### PR TITLE
docs(dm): record retired moderation key provenance and rotation checklist

### DIFF
--- a/mobile/docs/RETIRED_MODERATION_KEYS.md
+++ b/mobile/docs/RETIRED_MODERATION_KEYS.md
@@ -15,7 +15,7 @@ Read this before adding an entry.
 
 | Pubkey | Retired | Rotated by |
 |---|---|---|
-| `121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72` | 2026-03-15 | `divinevideo/divine-moderation-service#31` (`8dd56cbc9`), which unified signing on `NOSTR_PRIVATE_KEY` |
+| `121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72` | 2026-03-15 | An operational secret change, carrying no PR of its own — see below |
 
 ### `121b915b…`
 
@@ -25,13 +25,22 @@ moderation key is not one revocation:
 
 | Role | Revoked |
 |---|---|
-| Moderation DM + label signing identity | 2026-03-15, `divinevideo/divine-moderation-service#31` |
+| Moderation DM + label signing identity | 2026-03-15, the secret rotation itself |
 | Funnelcake `ADMIN_PUBKEYS`, in the relay and API overlays | 2026-03-17, `divinevideo/divine-iac-coreconfig#280`, across the poc, test, staging, and production overlays |
 | NIP-32 labeler this app subscribed to | 2026-03-20, `divinevideo/divine-mobile#2321` — plus `ModerationLabelService._migrateLegacyPubkey`, which unsubscribes it on every init |
 
 `divinevideo/divine-mobile#2321` is frequently cited as the retirement. It is
 not — it is the client catching up five days later. The key stopped being the
 moderation account on 2026-03-15.
+
+Neither is `divinevideo/divine-moderation-service#31` the retirement, and it is
+the easier mistake to make because it lands on the right date. The rotation was
+an operational secret change with no PR of its own. #31 (`8dd56cbc9`, merged
+the same day) is the cleanup *after* it: it removed the superseded
+`MODERATOR_NSEC` path and fixed the label publishing that the rotation had just
+broken. Its own summary dates the rotation to "today" and describes the
+breakage as running "since the key rotation". Cite #31 to date the rotation,
+never as the act that performed it.
 
 Do not read that middle row as the relay admin key. `divine-iac-coreconfig#280`
 uses "relay admin pubkey" for a *different* identity —

--- a/mobile/docs/RETIRED_MODERATION_KEYS.md
+++ b/mobile/docs/RETIRED_MODERATION_KEYS.md
@@ -120,8 +120,8 @@ The client half is small and belongs in one PR:
    not from the merge of whatever PR cleaned up after it, and expect that
    there may be no commit to name at all.
 2. Add a row to [the register](#the-register) above, including every role the
-   key held — check Funnelcake's `ADMIN_PUBKEYS` and the labeler roles, not
-   just DM signing.
+   key held — check Funnelcake's `RELAY_PUBKEY` and `ADMIN_PUBKEYS` and the
+   labeler roles, not just DM signing.
 3. Update `kModerationPubkeyHex` to the incoming shared support key. This is a
    mandatory routing change: the constant is the report target, pinned support
    row destination, protected-minor gate anchor, unread partition, retired
@@ -132,7 +132,8 @@ The client half is small and belongs in one PR:
    — it reads the list, so it does, but the test should say so.
 
 The service and infrastructure half — rotating the signing key, updating
-Funnelcake's `ADMIN_PUBKEYS` allowlist, republishing kind-0 and kind-10050,
+Funnelcake's `RELAY_PUBKEY` and its `ADMIN_PUBKEYS` allowlist (replacing only
+the outgoing entry), republishing kind-0 and kind-10050,
 repointing NIP-05, and auditing Funnelcake's `nostr.trusted_labelers` and
 `nostr.moderation_sources` — lives outside this repo. Do not assume those trust
 tables must use the user-facing support key: reconcile them with the approved

--- a/mobile/docs/RETIRED_MODERATION_KEYS.md
+++ b/mobile/docs/RETIRED_MODERATION_KEYS.md
@@ -51,8 +51,9 @@ the relay and API overlays. A rotation that goes looking for "the relay admin
 key" will find `81549bc0…` and rotate the wrong thing.
 
 Funnelcake's `nostr.trusted_labelers` and `nostr.moderation_sources` tables are
-a separate trust surface again, from both of those. Their configured identity
-currently differs from the user-facing moderation account; whether that is an
+a third trust surface, distinct from both of the above. Their configured
+identity differs from the user-facing moderation account — it is `81549bc0…`
+as well, so that key holds this role on top of relay admin. Whether that is an
 intentional automated role or drift is tracked in
 `divinevideo/divine-mobile#8253`. A rotation must audit and reconcile those
 tables with the intended labeler roles rather than assuming every moderation

--- a/mobile/docs/RETIRED_MODERATION_KEYS.md
+++ b/mobile/docs/RETIRED_MODERATION_KEYS.md
@@ -15,7 +15,7 @@ Read this before adding an entry.
 
 | Pubkey | Retired | Rotated by |
 |---|---|---|
-| `121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72` | 2026-03-15 | `divine-moderation-service#31` (`8dd56cbc9`), which unified signing on `NOSTR_PRIVATE_KEY` |
+| `121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72` | 2026-03-15 | `divinevideo/divine-moderation-service#31` (`8dd56cbc9`), which unified signing on `NOSTR_PRIVATE_KEY` |
 
 ### `121b915b…`
 
@@ -25,22 +25,34 @@ moderation key is not one revocation:
 
 | Role | Revoked |
 |---|---|
-| Moderation DM + label signing identity | 2026-03-15, by the rotation itself |
-| Relay admin pubkey | 2026-03-17, in the infrastructure config, across all four environments |
-| NIP-32 labeler this app subscribed to | 2026-03-20, `divine-mobile#2321` — plus `ModerationLabelService._migrateLegacyPubkey`, which unsubscribes it on every init |
+| Moderation DM + label signing identity | 2026-03-15, `divinevideo/divine-moderation-service#31` |
+| Relay admin pubkey | 2026-03-17, `divinevideo/divine-iac-coreconfig#280`, across the poc, test, staging, and production Funnelcake API and relay overlays |
+| NIP-32 labeler this app subscribed to | 2026-03-20, `divinevideo/divine-mobile#2321` — plus `ModerationLabelService._migrateLegacyPubkey`, which unsubscribes it on every init |
 
-`divine-mobile#2321` is frequently cited as the retirement. It is not — it is
-the client catching up five days later. The key stopped being the moderation
-account on 2026-03-15.
+`divinevideo/divine-mobile#2321` is frequently cited as the retirement. It is
+not — it is the client catching up five days later. The key stopped being the
+moderation account on 2026-03-15.
+
+Funnelcake's `nostr.trusted_labelers` and `nostr.moderation_sources` tables are
+a separate trust surface from the relay-admin list. Their configured identity
+currently differs from the user-facing moderation account; whether that is an
+intentional automated role or drift is tracked in
+`divinevideo/divine-mobile#8253`. A rotation must audit and reconcile those
+tables with the intended labeler roles rather than assuming every moderation
+role uses the shared support identity.
 
 ## What the client does with a retired key
 
 | Behaviour | Where |
 |---|---|
-| Recognised as moderation — official display name | `moderation_identity.dart`, via `isModerationAccount` |
+| Recognised as moderation — official display name and inbox search name | `dm_peer_identity.dart`, `moderation_identity.dart`, and `dm_peer_name.dart`, via `isModerationAccount` |
 | Recognised as moderation — bundled wordmark avatar | `conversation_tile.dart`, `request_tile.dart`, `request_preview_view.dart`, `empty_conversation.dart` |
-| Composer closed, thread labelled retired | `conversation_view.dart`, via `isRetiredModerationAccount` |
-| Outbound sends refused at the policy layer | `dmSendPolicyProvider` → `terminallyBlocked` |
+| Conversation and request rows labelled closed | `conversation_tile.dart` and `request_tile.dart`, via `isRetiredModerationAccount` |
+| Composer closed; banner routes replies to the current support key | `conversation_view.dart`, via `isRetiredModerationAccount` and `kModerationPubkeyHex` |
+| Pinned support row, unread partition, and retired predicates wired into list state | `inbox_page.dart`, `message_requests_page.dart`, `app_shell_badge_scope.dart`, and `ConversationListBloc` |
+| Destructive request action withheld for moderation threads | `request_preview_view.dart`, via `isModerationAccount` |
+| Outbound sends refused at the lowest repository send primitive | `dmSendPolicyProvider` → `DmSendPolicyDecision.terminallyBlocked` |
+| Pre-rotation threads excluded from pinned-support adoption | `DmRepository.extractPinnedSupport` |
 | Labeler subscription migrated to the current key | `ModerationLabelService._migrateLegacyPubkey` |
 
 `isModerationAccount` answers *"is this the moderation team"* and is true for
@@ -50,9 +62,13 @@ Anything picking a **send target** must use `kModerationPubkeyHex` and neither
 predicate.
 
 Recognition is keyed on the pubkey alone: it does not consider when a message
-arrived relative to the rotation, and the layers below the UI — `dm_repository`
-included — have no notion of a retired key at all. Whether that should change
-is an open product question, tracked with the custody work rather than here.
+arrived relative to the rotation. The repository layer is nevertheless
+retired-key-aware at the two delivery seams that matter: the injected
+`DmSendPolicy` blocks every outbound publisher at the lowest send primitive,
+and pinned-support extraction avoids adopting a pre-rotation thread whose
+participants would route replies to the retired key. The medium- and long-term
+policy for recognising newly discovered events from a retired shared identity
+is tracked in `divinevideo/divine-mobile#8355`.
 
 ## Rotating the moderation key
 
@@ -62,17 +78,23 @@ The client half is small and belongs in one PR:
    naming the rotation commit and date.
 2. Add a row to [the register](#the-register) above, including every role the
    key held — check for relay admin and labeler roles, not just DM signing.
-3. Update `kModerationPubkeyHex` to the incoming key. It is the NIP-05
-   fallback; live resolution of `moderation@divine.video` is the primary path,
-   so a stale constant fails quietly rather than loudly.
+3. Update `kModerationPubkeyHex` to the incoming shared support key. This is a
+   mandatory routing change: the constant is the report target, pinned support
+   row destination, protected-minor gate anchor, unread partition, retired
+   thread redirect target, and `ModerationLabelService`'s NIP-05 fallback. A
+   stale value silently routes support traffic to the retired account even
+   when live NIP-05 resolution succeeds elsewhere.
 4. Confirm `ModerationLabelService._migrateLegacyPubkey` covers the new entry
    — it reads the list, so it does, but the test should say so.
 
 The service and infrastructure half — rotating the signing key, updating the
-relay admin list, republishing kind-0 and kind-10050, repointing NIP-05 — lives
-outside this repo. No step-by-step procedure for it is written down anywhere;
-the March 2026 rotation had to be reconstructed from PR bodies after the fact.
-If you run the next one, write it down.
+relay admin list, republishing kind-0 and kind-10050, repointing NIP-05, and
+auditing Funnelcake's `nostr.trusted_labelers` and
+`nostr.moderation_sources` — lives outside this repo. Do not assume those trust
+tables must use the user-facing support key: reconcile them with the approved
+human-support and automated-labeler roles in `divinevideo/divine-mobile#8253`.
+No step-by-step service procedure is written down; the policy and procedure
+requirements are tracked in `divinevideo/divine-mobile#8355`.
 
 ### What a rotation cannot fix
 
@@ -96,5 +118,7 @@ there rather than inferring it from this repo.
 
 ## Open items
 
-- `divinevideo/divine-mobile#7851` — custody of `121b915b…`, and this register.
-- No written procedure for the service-side half of a rotation.
+- `divinevideo/divine-mobile#8355` — codify and validate the medium- and
+  long-term shared moderation identity, custody, and rotation policy.
+- `divinevideo/divine-mobile#8253` — decide whether the user-facing support
+  identity and Funnelcake's trusted labeler are intentionally separate roles.

--- a/mobile/docs/RETIRED_MODERATION_KEYS.md
+++ b/mobile/docs/RETIRED_MODERATION_KEYS.md
@@ -15,7 +15,7 @@ Read this before adding an entry.
 
 | Pubkey | Retired | Rotated by |
 |---|---|---|
-| `121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72` | 2026-03-15 | An operational secret change, carrying no PR of its own — see below |
+| `121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72` | 2026-03-12 | An operational secret change, carrying no PR of its own — see below |
 
 ### `121b915b…`
 
@@ -25,30 +25,53 @@ moderation key is not one revocation:
 
 | Role | Revoked |
 |---|---|
-| Moderation DM + label signing identity | 2026-03-15, the secret rotation itself |
-| Funnelcake `ADMIN_PUBKEYS`, in the relay and API overlays | 2026-03-17, `divinevideo/divine-iac-coreconfig#280`, across the poc, test, staging, and production overlays |
+| Moderation DM, label, and report signing identity | 2026-03-12 by the secret rotation itself — though only for labels and reports; the DM half is unverifiable, see below |
+| Funnelcake `RELAY_PUBKEY`, plus one of the two `ADMIN_PUBKEYS` entries | 2026-03-17, `divinevideo/divine-iac-coreconfig#280`, across the poc, test, staging, and production overlays |
 | NIP-32 labeler this app subscribed to | 2026-03-20, `divinevideo/divine-mobile#2321` — plus `ModerationLabelService._migrateLegacyPubkey`, which unsubscribes it on every init |
 
-`divinevideo/divine-mobile#2321` is frequently cited as the retirement. It is
-not — it is the client catching up five days later. The key stopped being the
-moderation account on 2026-03-15.
+#### Dating the rotation
 
-Neither is `divinevideo/divine-moderation-service#31` the retirement, and it is
-the easier mistake to make because it lands on the right date. The rotation was
-an operational secret change with no PR of its own. #31 (`8dd56cbc9`, merged
-the same day) is the cleanup *after* it: it removed the superseded
-`MODERATOR_NSEC` path and fixed the label publishing that the rotation had just
-broken. Its own summary dates the rotation to "today" and describes the
-breakage as running "since the key rotation". Cite #31 to date the rotation,
-never as the act that performed it.
+No PR performed it, so every PR this gets credited to is the wrong answer. The
+rotation was a secret change, and neither key appears anywhere in
+`divine-moderation-service`'s history — `git log --all -S<hex>` returns nothing
+for either. What *can* be dated, in UTC:
 
-Do not read that middle row as the relay admin key. `divine-iac-coreconfig#280`
-uses "relay admin pubkey" for a *different* identity —
-`81549bc0b5153b4b970fe4a3892ad185698b8b8b26ec69321a527d0644cd2898` — and says
-in the same breath that it is **unchanged** by the rotation. What `121b915b…`
-held was Funnelcake's `ADMIN_PUBKEYS` allowlist, which happens to be applied to
-the relay and API overlays. A rotation that goes looking for "the relay admin
-key" will find `81549bc0…` and rotate the wrong thing.
+| When | What |
+|---|---|
+| 2026-03-12 22:50:41 | The incoming key's kind-0 is signed and published to `relay.divine.video` (`17e11af3…`) |
+| 2026-03-12 22:54:42 | `divine-iac-coreconfig#280` is opened, recording NIP-05 as already repointed, kind-0 as published, and the incoming key as verified through moderation-service's debug endpoint — which derived its answer from `NOSTR_PRIVATE_KEY` alone |
+| 2026-03-13 01:57:35 | `divine-moderation-service#31` is authored, describing label publishing as broken "since the key rotation" |
+| 2026-03-15 15:39:37 | #31 merges |
+| 2026-03-17 15:32:10 | #280 merges |
+| 2026-03-20 14:54:11 | `divine-mobile#2321` merges |
+
+The signing secret therefore already resolved to the incoming key on
+**2026-03-12** — three days before the earliest PR this is usually credited to,
+and eight before the latest.
+
+Both of the usual citations name a merge date rather than the act:
+
+- `divine-mobile#2321` (2026-03-20) is the client catching up, eight days late.
+- `divine-moderation-service#31` (2026-03-15) is the cleanup. It removed the
+  superseded `MODERATOR_NSEC` path and fixed the label publishing the rotation
+  had just broken. Its own text dates the rotation to "today" — and it was
+  written on the 13th, not the 15th it merged on.
+
+One part is genuinely unrecoverable. DM signing read `MODERATOR_NSEC`, a secret
+with no git trace, so whether the DM role moved on the 12th with everything
+else or lingered until #31 removed that path on the 15th cannot be established
+from any repo. Labels and reports are pinned to the 12th; treat the DM half as
+"on or before 2026-03-15".
+
+Do not read that middle row as "the relay admin key", despite `RELAY_PUBKEY`.
+`divine-iac-coreconfig#280` uses the phrase *relay admin pubkey* for a
+different identity —
+`81549bc0b5153b4b970fe4a3892ad185698b8b8b26ec69321a527d0644cd2898` — and states
+in the same PR that it is **unchanged** by the rotation. `ADMIN_PUBKEYS` was a
+two-entry list holding both keys, and only the `121b915b…` entry was replaced;
+`81549bc0…` sits untouched on both sides of every edit. So a rotation that goes
+looking for "the relay admin key" finds `81549bc0…` and changes the wrong
+thing. Match on the variable name, not the prose.
 
 Funnelcake's `nostr.trusted_labelers` and `nostr.moderation_sources` tables are
 a third trust surface, distinct from both of the above. Their configured

--- a/mobile/docs/RETIRED_MODERATION_KEYS.md
+++ b/mobile/docs/RETIRED_MODERATION_KEYS.md
@@ -116,7 +116,9 @@ is tracked in `divinevideo/divine-mobile#8355`.
 The client half is small and belongs in one PR:
 
 1. Add the outgoing pubkey to `kLegacyModerationPubkeys`, with a comment
-   naming the rotation commit and date.
+   naming the date and what performed the rotation — date it from the act,
+   not from the merge of whatever PR cleaned up after it, and expect that
+   there may be no commit to name at all.
 2. Add a row to [the register](#the-register) above, including every role the
    key held — check Funnelcake's `ADMIN_PUBKEYS` and the labeler roles, not
    just DM signing.

--- a/mobile/docs/RETIRED_MODERATION_KEYS.md
+++ b/mobile/docs/RETIRED_MODERATION_KEYS.md
@@ -26,15 +26,23 @@ moderation key is not one revocation:
 | Role | Revoked |
 |---|---|
 | Moderation DM + label signing identity | 2026-03-15, `divinevideo/divine-moderation-service#31` |
-| Relay admin pubkey | 2026-03-17, `divinevideo/divine-iac-coreconfig#280`, across the poc, test, staging, and production Funnelcake API and relay overlays |
+| Funnelcake `ADMIN_PUBKEYS`, in the relay and API overlays | 2026-03-17, `divinevideo/divine-iac-coreconfig#280`, across the poc, test, staging, and production overlays |
 | NIP-32 labeler this app subscribed to | 2026-03-20, `divinevideo/divine-mobile#2321` — plus `ModerationLabelService._migrateLegacyPubkey`, which unsubscribes it on every init |
 
 `divinevideo/divine-mobile#2321` is frequently cited as the retirement. It is
 not — it is the client catching up five days later. The key stopped being the
 moderation account on 2026-03-15.
 
+Do not read that middle row as the relay admin key. `divine-iac-coreconfig#280`
+uses "relay admin pubkey" for a *different* identity —
+`81549bc0b5153b4b970fe4a3892ad185698b8b8b26ec69321a527d0644cd2898` — and says
+in the same breath that it is **unchanged** by the rotation. What `121b915b…`
+held was Funnelcake's `ADMIN_PUBKEYS` allowlist, which happens to be applied to
+the relay and API overlays. A rotation that goes looking for "the relay admin
+key" will find `81549bc0…` and rotate the wrong thing.
+
 Funnelcake's `nostr.trusted_labelers` and `nostr.moderation_sources` tables are
-a separate trust surface from the relay-admin list. Their configured identity
+a separate trust surface again, from both of those. Their configured identity
 currently differs from the user-facing moderation account; whether that is an
 intentional automated role or drift is tracked in
 `divinevideo/divine-mobile#8253`. A rotation must audit and reconcile those
@@ -77,7 +85,8 @@ The client half is small and belongs in one PR:
 1. Add the outgoing pubkey to `kLegacyModerationPubkeys`, with a comment
    naming the rotation commit and date.
 2. Add a row to [the register](#the-register) above, including every role the
-   key held — check for relay admin and labeler roles, not just DM signing.
+   key held — check Funnelcake's `ADMIN_PUBKEYS` and the labeler roles, not
+   just DM signing.
 3. Update `kModerationPubkeyHex` to the incoming shared support key. This is a
    mandatory routing change: the constant is the report target, pinned support
    row destination, protected-minor gate anchor, unread partition, retired
@@ -87,9 +96,9 @@ The client half is small and belongs in one PR:
 4. Confirm `ModerationLabelService._migrateLegacyPubkey` covers the new entry
    — it reads the list, so it does, but the test should say so.
 
-The service and infrastructure half — rotating the signing key, updating the
-relay admin list, republishing kind-0 and kind-10050, repointing NIP-05, and
-auditing Funnelcake's `nostr.trusted_labelers` and
+The service and infrastructure half — rotating the signing key, updating
+Funnelcake's `ADMIN_PUBKEYS` allowlist, republishing kind-0 and kind-10050,
+repointing NIP-05, and auditing Funnelcake's `nostr.trusted_labelers` and
 `nostr.moderation_sources` — lives outside this repo. Do not assume those trust
 tables must use the user-facing support key: reconcile them with the approved
 human-support and automated-labeler roles in `divinevideo/divine-mobile#8253`.

--- a/mobile/docs/RETIRED_MODERATION_KEYS.md
+++ b/mobile/docs/RETIRED_MODERATION_KEYS.md
@@ -1,0 +1,100 @@
+# Retired Moderation Keys
+
+Divine's moderation account is a Nostr identity, and it has rotated. A DM
+thread opened before a rotation stays keyed on the old pubkey forever — Nostr
+has no way to move a conversation to a new key — so the app has to keep
+recognising identities it will never talk to again.
+
+`kLegacyModerationPubkeys` in `mobile/lib/config/official_accounts.dart` is
+that recognition list. This file is its register: what each entry was, when it
+stopped being the moderation account, and what the client still does with it.
+
+Read this before adding an entry.
+
+## The register
+
+| Pubkey | Retired | Rotated by |
+|---|---|---|
+| `121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72` | 2026-03-15 | `divine-moderation-service#31` (`8dd56cbc9`), which unified signing on `NOSTR_PRIVATE_KEY` |
+
+### `121b915b…`
+
+Rotated because the service and the clients had drifted onto different keys.
+It held **three** roles, which is the part worth knowing — retiring a
+moderation key is not one revocation:
+
+| Role | Revoked |
+|---|---|
+| Moderation DM + label signing identity | 2026-03-15, by the rotation itself |
+| Relay admin pubkey | 2026-03-17, in the infrastructure config, across all four environments |
+| NIP-32 labeler this app subscribed to | 2026-03-20, `divine-mobile#2321` — plus `ModerationLabelService._migrateLegacyPubkey`, which unsubscribes it on every init |
+
+`divine-mobile#2321` is frequently cited as the retirement. It is not — it is
+the client catching up five days later. The key stopped being the moderation
+account on 2026-03-15.
+
+## What the client does with a retired key
+
+| Behaviour | Where |
+|---|---|
+| Recognised as moderation — official display name | `moderation_identity.dart`, via `isModerationAccount` |
+| Recognised as moderation — bundled wordmark avatar | `conversation_tile.dart`, `request_tile.dart`, `request_preview_view.dart`, `empty_conversation.dart` |
+| Composer closed, thread labelled retired | `conversation_view.dart`, via `isRetiredModerationAccount` |
+| Outbound sends refused at the policy layer | `dmSendPolicyProvider` → `terminallyBlocked` |
+| Labeler subscription migrated to the current key | `ModerationLabelService._migrateLegacyPubkey` |
+
+`isModerationAccount` answers *"is this the moderation team"* and is true for
+retired keys on purpose, so old threads still read correctly.
+`isRetiredModerationAccount` answers *"is this a key we can still talk to"*.
+Anything picking a **send target** must use `kModerationPubkeyHex` and neither
+predicate.
+
+Recognition is keyed on the pubkey alone: it does not consider when a message
+arrived relative to the rotation, and the layers below the UI — `dm_repository`
+included — have no notion of a retired key at all. Whether that should change
+is an open product question, tracked with the custody work rather than here.
+
+## Rotating the moderation key
+
+The client half is small and belongs in one PR:
+
+1. Add the outgoing pubkey to `kLegacyModerationPubkeys`, with a comment
+   naming the rotation commit and date.
+2. Add a row to [the register](#the-register) above, including every role the
+   key held — check for relay admin and labeler roles, not just DM signing.
+3. Update `kModerationPubkeyHex` to the incoming key. It is the NIP-05
+   fallback; live resolution of `moderation@divine.video` is the primary path,
+   so a stale constant fails quietly rather than loudly.
+4. Confirm `ModerationLabelService._migrateLegacyPubkey` covers the new entry
+   — it reads the list, so it does, but the test should say so.
+
+The service and infrastructure half — rotating the signing key, updating the
+relay admin list, republishing kind-0 and kind-10050, repointing NIP-05 — lives
+outside this repo. No step-by-step procedure for it is written down anywhere;
+the March 2026 rotation had to be reconstructed from PR bodies after the fact.
+If you run the next one, write it down.
+
+### What a rotation cannot fix
+
+Messages already sent to the outgoing key are unreachable. The DM reader
+derives its subscription from its own signing key
+(`divine-moderation-service`, `src/nostr/dm-reader.mjs`), so it watches exactly
+one pubkey and cannot be configured to watch a second. Anything addressed to a
+retired key is accepted by the relay and read by nobody — it does not error,
+bounce, or queue. This is why the composer is closed rather than optimistic.
+
+Retired keys also publish no kind-10050. Under NIP-17 that already signals "not
+ready to receive messages", so the protocol and the client agree.
+
+## Key custody
+
+No moderation key material has ever been committed to this repo, and none is
+recoverable from it. Custody of the signing keys themselves is owned by Trust &
+Safety and tracked on their private issue tracker, not here — including for
+retired keys. If you need the custody status of an entry in the register, ask
+there rather than inferring it from this repo.
+
+## Open items
+
+- `divinevideo/divine-mobile#7851` — custody of `121b915b…`, and this register.
+- No written procedure for the service-side half of a rotation.

--- a/mobile/lib/config/official_accounts.dart
+++ b/mobile/lib/config/official_accounts.dart
@@ -139,8 +139,9 @@ const Set<String> kDivineTeamPubkeys = {
 /// ([isRetiredModerationAccount]), and for the `ModerationLabelService`
 /// subscription migration.
 ///
-/// Every entry carries its rotation commit and date below. The register of
-/// what each key was, the roles it held, and what a rotation has to do is
+/// Every entry carries its rotation date and what performed it below — which
+/// may be no commit at all. The register of what each key was, the roles it
+/// held, and what a rotation has to do is
 /// `mobile/docs/RETIRED_MODERATION_KEYS.md` — read it before adding one.
 const List<String> kLegacyModerationPubkeys = [
   // Retired 2026-03-12 by an operational secret rotation, after the service

--- a/mobile/lib/config/official_accounts.dart
+++ b/mobile/lib/config/official_accounts.dart
@@ -143,12 +143,13 @@ const Set<String> kDivineTeamPubkeys = {
 /// what each key was, the roles it held, and what a rotation has to do is
 /// `mobile/docs/RETIRED_MODERATION_KEYS.md` — read it before adding one.
 const List<String> kLegacyModerationPubkeys = [
-  // Retired 2026-03-15 by divinevideo/divine-moderation-service#31
-  // (8dd56cbc9), which unified the service onto one signing key after it and
-  // the clients drifted apart — a mismatch, not a compromise. Also held relay
-  // admin and the NIP-32 labeler role that `ModerationLabelService` migrates
-  // away. divinevideo/divine-mobile#2321 (2026-03-20) was the client catching
-  // up, not the retirement itself.
+  // Retired 2026-03-15 by an operational secret rotation, after the service
+  // and the clients drifted onto different keys — a mismatch, not a
+  // compromise. Also held Funnelcake's ADMIN_PUBKEYS and the NIP-32 labeler
+  // role that `ModerationLabelService` migrates away. Neither
+  // divinevideo/divine-moderation-service#31 (8dd56cbc9, the same-day
+  // cleanup) nor divinevideo/divine-mobile#2321 (2026-03-20, the client
+  // catching up) is the retirement itself.
   '121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72',
 ];
 

--- a/mobile/lib/config/official_accounts.dart
+++ b/mobile/lib/config/official_accounts.dart
@@ -139,9 +139,15 @@ const Set<String> kDivineTeamPubkeys = {
 /// ([isRetiredModerationAccount]), and for the `ModerationLabelService`
 /// subscription migration.
 ///
-/// `121b915b…` was retired in #2321 (2026-03-20); `ModerationLabelService`
-/// carries the matching one-time migration for labeler subscriptions.
+/// Every entry carries its rotation commit and date below. The register of
+/// what each key was, the roles it held, and what a rotation has to do is
+/// `mobile/docs/RETIRED_MODERATION_KEYS.md` — read it before adding one.
 const List<String> kLegacyModerationPubkeys = [
+  // Retired 2026-03-15 by divine-moderation-service#31 (8dd56cbc9), which
+  // unified the service onto one signing key after it and the clients drifted
+  // apart — a mismatch, not a compromise. Also held relay admin and the NIP-32
+  // labeler role that `ModerationLabelService` migrates away. #2321
+  // (2026-03-20) was the client catching up, not the retirement itself.
   '121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72',
 ];
 
@@ -151,6 +157,10 @@ const List<String> kLegacyModerationPubkeys = [
 /// old pubkey, and it is the same team on the other end of it. Callers that
 /// need a *send target* must use [kModerationPubkeyHex] instead — this answers
 /// "is this the moderation team", not "where do replies go".
+///
+/// Keyed on the pubkey alone, with no freshness gate: a message a retired key
+/// signs today is recognised exactly like one predating the rotation. See
+/// `mobile/docs/RETIRED_MODERATION_KEYS.md`.
 bool isModerationAccount(String pubkeyHex) =>
     pubkeyHex == kModerationPubkeyHex ||
     kLegacyModerationPubkeys.contains(pubkeyHex);

--- a/mobile/lib/config/official_accounts.dart
+++ b/mobile/lib/config/official_accounts.dart
@@ -143,13 +143,14 @@ const Set<String> kDivineTeamPubkeys = {
 /// what each key was, the roles it held, and what a rotation has to do is
 /// `mobile/docs/RETIRED_MODERATION_KEYS.md` — read it before adding one.
 const List<String> kLegacyModerationPubkeys = [
-  // Retired 2026-03-15 by an operational secret rotation, after the service
+  // Retired 2026-03-12 by an operational secret rotation, after the service
   // and the clients drifted onto different keys — a mismatch, not a
-  // compromise. Also held Funnelcake's ADMIN_PUBKEYS and the NIP-32 labeler
-  // role that `ModerationLabelService` migrates away. Neither
-  // divinevideo/divine-moderation-service#31 (8dd56cbc9, the same-day
-  // cleanup) nor divinevideo/divine-mobile#2321 (2026-03-20, the client
-  // catching up) is the retirement itself.
+  // compromise. Also held Funnelcake's RELAY_PUBKEY and one ADMIN_PUBKEYS
+  // entry, plus the NIP-32 labeler role `ModerationLabelService` migrates
+  // away. No PR performed the rotation, so both usual citations are merge
+  // dates for something else: divinevideo/divine-moderation-service#31
+  // (2026-03-15) is the cleanup after it, and divinevideo/divine-mobile#2321
+  // (2026-03-20) is this client catching up eight days late.
   '121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72',
 ];
 

--- a/mobile/lib/config/official_accounts.dart
+++ b/mobile/lib/config/official_accounts.dart
@@ -143,11 +143,12 @@ const Set<String> kDivineTeamPubkeys = {
 /// what each key was, the roles it held, and what a rotation has to do is
 /// `mobile/docs/RETIRED_MODERATION_KEYS.md` — read it before adding one.
 const List<String> kLegacyModerationPubkeys = [
-  // Retired 2026-03-15 by divine-moderation-service#31 (8dd56cbc9), which
-  // unified the service onto one signing key after it and the clients drifted
-  // apart — a mismatch, not a compromise. Also held relay admin and the NIP-32
-  // labeler role that `ModerationLabelService` migrates away. #2321
-  // (2026-03-20) was the client catching up, not the retirement itself.
+  // Retired 2026-03-15 by divinevideo/divine-moderation-service#31
+  // (8dd56cbc9), which unified the service onto one signing key after it and
+  // the clients drifted apart — a mismatch, not a compromise. Also held relay
+  // admin and the NIP-32 labeler role that `ModerationLabelService` migrates
+  // away. divinevideo/divine-mobile#2321 (2026-03-20) was the client catching
+  // up, not the retirement itself.
   '121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72',
 ];
 


### PR DESCRIPTION
Part of #7851

## Summary

Completes the client-owned documentation work from #7851: per-entry provenance on `kLegacyModerationPubkeys`, and a written register plus a client-side rotation checklist.

Custody of the key material itself is not here — it belongs to Trust & Safety and is tracked privately. This repo has never held any moderation key material, and the register says so rather than duplicating a custody claim it cannot back. The medium- and long-term shared-account, custody, and rotation policy is tracked in #8355.

## What was wrong

`kLegacyModerationPubkeys` carried a single date, and it was the wrong event:

> `121b915b…` was retired in #2321 (2026-03-20)

#2321 is **this client repointing to NIP-05**, eight days after the fact. Anyone reading the list to answer "when did this stop being live" got an answer eight days late, in the direction that matters: it looked like the client was ahead of the rotation; it was behind it.

**No PR performed the rotation at all.** It was an operational secret change, and neither key appears anywhere in `divine-moderation-service`'s history (`git log --all -S<hex>` returns nothing for either). Every PR the rotation gets credited to is a merge date for something else, which is exactly why the wrong date is so easy to land on.

The rotation revoked three roles, and the dates come from PR *metadata* rather than PR prose:

| Role | Revoked |
|---|---|
| DM, label, and report signing identity | 2026-03-12 by the secret rotation itself — verifiable for labels and reports; the DM half is not (see below) |
| Funnelcake `RELAY_PUBKEY`, plus one of the two `ADMIN_PUBKEYS` entries | 2026-03-17, `divinevideo/divine-iac-coreconfig#280` |
| NIP-32 labeler this app subscribes to | 2026-03-20, #2321 + `ModerationLabelService._migrateLegacyPubkey` |

Funnelcake's trusted-labeler and moderation-source tables are a separate trust surface. Their current identity disagreement is tracked in #8253; the checklist requires auditing and reconciling those roles rather than assuming they must use the shared support identity.

## Changes

- **`official_accounts.dart`** — per-entry provenance comment with the rotation date, reason, and known roles; corrected attribution; and a pointer to the register.
- **`mobile/docs/RETIRED_MODERATION_KEYS.md`** — the register, a dated timeline, a complete inventory of the client behaviors tied to current and retired keys, and the client-side rotation checklist.
- The checklist treats `kModerationPubkeyHex` as the mandatory report/support routing key, not merely a NIP-05 fallback.
- The guide records the repository-level send refusal and pinned-support exclusion, and cites the relay-config rotation source.
- Remaining shared-account and labeler-role decisions point to #8355 and #8253.

## Corrections made after review

Verifying the takeover against primary sources turned up three factual errors, two of which I had introduced originally. All are fixed here.

**The retirement date was wrong by three days, in the same direction the file was written to correct.** It said 2026-03-15, which is the *merge date* of `divine-moderation-service#31`. The incoming key's kind-0 was signed at `2026-03-12T22:50:41Z` (`17e11af3…` on `relay.divine.video`), and `divine-iac-coreconfig#280` was **opened** four minutes later at `22:54:42Z` recording NIP-05 as already repointed and the incoming key as verified through moderation-service's debug endpoint — which derived its answer from `NOSTR_PRIVATE_KEY` alone. #280's body is a 03-12 statement; only its merge is 03-17. #31's commit was authored 03-13, so its "today's key rotation" is dated from then too. The correct date is **2026-03-12**.

**#31 was credited with performing the rotation.** It did not: it removed the superseded `MODERATOR_NSEC` path and fixed the label publishing the rotation had just broken.

**The Funnelcake role was named "relay admin pubkey".** `divine-iac-coreconfig#280` uses that exact phrase for a *different* identity, `81549bc0…`, and states in the same PR that it is unchanged by the rotation. `121b915b…` held `RELAY_PUBKEY` and one of two `ADMIN_PUBKEYS` entries; `81549bc0…` is the other and sits untouched on both sides of every edit. A register whose purpose is to tell a rotator which roles to revoke had named a role after the one key that must not be touched.

The register now carries the dated timeline so the next reader can check the reasoning rather than trust the conclusion, and scopes what is **not** recoverable: DM signing read `MODERATOR_NSEC`, a secret with no git trace, so whether the DM role moved on the 12th with everything else or lingered until #31 removed that path on the 15th cannot be established from any repo.

## Not in scope

- Custody of the retired private key — Trust & Safety, tracked privately.
- The approved medium- and long-term shared moderation account model — assigned to `mbradley` in #8355.
- Whether the Funnelcake labeler is intentionally distinct from the user-facing support identity — #8253.
- Implementing a service-side rotation procedure; #8355 requires the policy and procedure location to be defined.
- The exact NIP-05 repoint date. It is bounded at or before `2026-03-12T22:54:42Z` by #280's body, but no `.well-known/nostr.json` exists in any indexed repo, so it is not established here.

## Test plan

Comment-and-docs only; no behavior change.

- `flutter analyze lib test integration_test` — clean
- `flutter test test/config/official_accounts_test.dart test/services/moderation_label_service_test.dart` — 55 passing
- `dart format` (pinned toolchain) — no changes

Every claim in the register was re-verified against primary sources: all 11 cited files and all 9 cited symbols resolve in `lib/`; the `kModerationPubkeyHex` consumer list, `_migrateLegacyPubkey`'s idempotency, and the `dm-reader.mjs` single-pubkey subscription were each read rather than assumed; and the three cited PRs were checked against their own creation/merge metadata rather than their prose.
