### PR TITLE
fix(dm): refuse a self-addressed message and exclude the viewer from recipient pickers

### DIFF
--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -13,6 +13,7 @@ import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:nostr_sdk/nip19/nip19_tlv.dart';
+import 'package:nostr_sdk/nip19/pubkeys_equal.dart';
 import 'package:openvine/blocs/share_sheet/reportable_sites.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/video_clip_import_service.dart';
@@ -108,9 +109,11 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
       // contact list written by another Nostr client can self-follow, and
       // recents accumulate whoever a share was sent to.
       final recentUsers = _videoSharingService.recentlySharedWith
-          .where((user) => _isNotSelf(user.pubkey))
+          .where((user) => !_isSelf(user.pubkey))
           .toList();
-      final followList = _followRepository.followingPubkeys.where(_isNotSelf);
+      final followList = _followRepository.followingPubkeys.where(
+        (pubkey) => !_isSelf(pubkey),
+      );
       final recentPubkeys = recentUsers.map((u) => u.pubkey).toSet();
 
       final remainingFollows = followList
@@ -243,12 +246,11 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
     }
   }
 
-  /// Whether [pubkey] is somebody other than the viewer.
+  /// Whether [pubkey] addresses the viewer.
   ///
   /// Case-insensitive, because a pubkey that reaches Divine from another
   /// client may be upper-case hex.
-  bool _isNotSelf(String pubkey) =>
-      pubkey.toLowerCase() != _currentUserPubkey.toLowerCase();
+  bool _isSelf(String pubkey) => pubkeysEqual(pubkey, _currentUserPubkey);
 
   // --------------------------------------------------------------------------
   // Recipient selection
@@ -261,7 +263,7 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
     final recipient = event.recipient;
     // Find People searches all users, so it can surface the viewer even
     // though neither contact source offers them (#8351).
-    if (!_isNotSelf(recipient.pubkey)) return;
+    if (_isSelf(recipient.pubkey)) return;
 
     final updatedSelection = state.isSelected(recipient)
         ? [

--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -40,6 +40,7 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
     required VideoSharingService videoSharingService,
     required ProfileReader profileRepository,
     required FollowRepository followRepository,
+    required String currentUserPubkey,
     Future<BookmarksRepository?>? bookmarksRepositoryFuture,
     BaseCacheManager? cacheManager,
     VideoClipImportService? videoClipImportService,
@@ -48,6 +49,7 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
        _videoSharingService = videoSharingService,
        _profileRepository = profileRepository,
        _followRepository = followRepository,
+       _currentUserPubkey = currentUserPubkey,
        _bookmarksRepositoryFuture = bookmarksRepositoryFuture,
        _cacheManager = cacheManager,
        _videoClipImportService = videoClipImportService,
@@ -75,6 +77,7 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
   final VideoSharingService _videoSharingService;
   final ProfileReader _profileRepository;
   final FollowRepository _followRepository;
+  final String _currentUserPubkey;
   final Future<BookmarksRepository?>? _bookmarksRepositoryFuture;
   final BaseCacheManager? _cacheManager;
   final VideoClipImportService? _videoClipImportService;
@@ -100,8 +103,14 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
     );
 
     try {
-      final recentUsers = _videoSharingService.recentlySharedWith;
-      final followList = _followRepository.followingPubkeys;
+      // Divine does not support a self-addressed conversation (#8351), so
+      // the viewer is never a share target. Both sources can carry them: a
+      // contact list written by another Nostr client can self-follow, and
+      // recents accumulate whoever a share was sent to.
+      final recentUsers = _videoSharingService.recentlySharedWith
+          .where((user) => _isNotSelf(user.pubkey))
+          .toList();
+      final followList = _followRepository.followingPubkeys.where(_isNotSelf);
       final recentPubkeys = recentUsers.map((u) => u.pubkey).toSet();
 
       final remainingFollows = followList
@@ -234,6 +243,13 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
     }
   }
 
+  /// Whether [pubkey] is somebody other than the viewer.
+  ///
+  /// Case-insensitive, because a pubkey that reaches Divine from another
+  /// client may be upper-case hex.
+  bool _isNotSelf(String pubkey) =>
+      pubkey.toLowerCase() != _currentUserPubkey.toLowerCase();
+
   // --------------------------------------------------------------------------
   // Recipient selection
   // --------------------------------------------------------------------------
@@ -243,6 +259,10 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
     Emitter<ShareSheetState> emit,
   ) {
     final recipient = event.recipient;
+    // Find People searches all users, so it can surface the viewer even
+    // though neither contact source offers them (#8351).
+    if (!_isNotSelf(recipient.pubkey)) return;
+
     final updatedSelection = state.isSelected(recipient)
         ? [
             for (final r in state.selectedRecipients)

--- a/mobile/lib/blocs/user_search/user_search_bloc.dart
+++ b/mobile/lib/blocs/user_search/user_search_bloc.dart
@@ -8,6 +8,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart';
+import 'package:nostr_sdk/nip19/pubkeys_equal.dart';
 import 'package:openvine/constants/search_constants.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:profile_repository/profile_repository.dart';
@@ -32,6 +33,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
     FollowRepository? followRepository,
     this.hasVideos = false,
     this.searchTimeout = userSearchOuterTimeout,
+    this.excludedPubkey,
     FeedPerformanceTracker? feedTracker,
   }) : _profileRepository = profileRepository,
        _followRepository = followRepository,
@@ -61,6 +63,18 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
   /// Set to `null` to disable the timeout entirely, which is useful in widget
   /// tests that rely on `pumpAndSettle()` with internally created blocs.
   final Duration? searchTimeout;
+
+  /// A pubkey to omit from every result page, such as a recipient picker's
+  /// signed-in viewer.
+  final String? excludedPubkey;
+
+  List<UserProfile> _visibleProfiles(Iterable<UserProfile> profiles) {
+    final excluded = excludedPubkey;
+    if (excluded == null) return profiles.toList();
+    return profiles
+        .where((profile) => !pubkeysEqual(profile.pubkey, excluded))
+        .toList();
+  }
 
   Future<void> _onQueryChanged(
     UserSearchQueryChanged event,
@@ -92,6 +106,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
 
     _feedTracker?.startFeedLoad('user_search');
     var trackedFirst = false;
+    var latestUnfilteredCount = 0;
     var latestSourceOutcomes = _pendingSourceOutcomes();
     // Snapshot of sources whose terminal status has already been
     // forwarded to feedTracker — prevents duplicate events when a
@@ -118,11 +133,13 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
             ? searchStream
             : searchStream.timeout(searchTimeout!),
         onData: (result) {
-          if (!trackedFirst && result.profiles.isNotEmpty) {
+          latestUnfilteredCount = result.profiles.length;
+          final visibleProfiles = _visibleProfiles(result.profiles);
+          if (!trackedFirst && visibleProfiles.isNotEmpty) {
             trackedFirst = true;
             _feedTracker?.markFirstVideosReceived(
               'user_search',
-              result.profiles.length,
+              visibleProfiles.length,
             );
           }
           for (final entry in result.sources.entries) {
@@ -134,8 +151,8 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
           latestSourceOutcomes = result.sources;
           return state.copyWith(
             status: UserSearchStatus.loading,
-            results: result.profiles,
-            resultCount: result.profiles.length,
+            results: visibleProfiles,
+            resultCount: visibleProfiles.length,
             sourceOutcomes: result.sources,
           );
         },
@@ -144,8 +161,8 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
       emit(
         state.copyWith(
           status: UserSearchStatus.success,
-          offset: state.results.length,
-          hasMore: state.results.length == _pageSize,
+          offset: latestUnfilteredCount,
+          hasMore: latestUnfilteredCount == _pageSize,
           isLoadingMore: false,
         ),
       );
@@ -222,14 +239,15 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
       // counting the profiles in the terminal envelope (filter+boost
       // applied) against pagination state. The new page is the slice
       // that the repository computed for offset > 0.
-      final newPage = result.profiles;
+      final unfilteredPageCount = result.profiles.length;
+      final newPage = _visibleProfiles(result.profiles);
       final allResults = [...state.results, ...newPage];
 
       emit(
         state.copyWith(
           results: allResults,
-          offset: allResults.length,
-          hasMore: newPage.length == _pageSize,
+          offset: state.offset + unfilteredPageCount,
+          hasMore: unfilteredPageCount == _pageSize,
           isLoadingMore: false,
         ),
       );

--- a/mobile/lib/screens/inbox/bloc/new_message_search_bloc.dart
+++ b/mobile/lib/screens/inbox/bloc/new_message_search_bloc.dart
@@ -19,8 +19,10 @@ class NewMessageSearchBloc
   NewMessageSearchBloc({
     required ProfileRepository profileRepository,
     required FollowRepository followRepository,
+    required String currentUserPubkey,
   }) : _profileRepository = profileRepository,
        _followRepository = followRepository,
+       _currentUserPubkey = currentUserPubkey,
        super(const NewMessageSearchState()) {
     on<NewMessageSearchStarted>(_onStarted);
     on<NewMessageSearchQueryChanged>(
@@ -32,12 +34,13 @@ class NewMessageSearchBloc
 
   final ProfileRepository _profileRepository;
   final FollowRepository _followRepository;
+  final String _currentUserPubkey;
 
   Future<void> _onStarted(
     NewMessageSearchStarted event,
     Emitter<NewMessageSearchState> emit,
   ) async {
-    final pubkeys = _followRepository.followingPubkeys;
+    final pubkeys = _followRepository.followingPubkeys.where(_isNotSelf);
     final futures = pubkeys.map(
       (pk) => _profileRepository.getCachedProfile(pubkey: pk),
     );
@@ -83,11 +86,11 @@ class NewMessageSearchBloc
     );
 
     try {
-      final networkResults = await _profileRepository.searchUsers(
+      final networkResults = (await _profileRepository.searchUsers(
         query: query,
         limit: 50,
         sortBy: profileSearchSortFollowers,
-      );
+      )).where((profile) => _isNotSelf(profile.pubkey)).toList();
 
       Log.debug(
         'Query "$query": ${networkResults.length} network results',
@@ -121,6 +124,19 @@ class NewMessageSearchBloc
       ),
     );
   }
+
+  /// Whether [pubkey] is somebody other than the viewer.
+  ///
+  /// Divine does not support a self-addressed conversation (#8351, decided
+  /// on #8261), so the viewer is never a candidate recipient. Filtered here in
+  /// the picker rather than in the follow list: a contact list written by
+  /// another Nostr client can legitimately self-follow, and only the merge
+  /// path strips that — every other path assigns the list as received.
+  ///
+  /// Case-insensitive, because a pubkey that reaches Divine from another
+  /// client may be upper-case hex.
+  bool _isNotSelf(String pubkey) =>
+      pubkey.toLowerCase() != _currentUserPubkey.toLowerCase();
 
   /// Filters contacts by display name or NIP-05.
   static List<UserProfile> _filterContacts(

--- a/mobile/lib/screens/inbox/bloc/new_message_search_bloc.dart
+++ b/mobile/lib/screens/inbox/bloc/new_message_search_bloc.dart
@@ -5,6 +5,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart';
+import 'package:nostr_sdk/nip19/pubkeys_equal.dart';
 import 'package:openvine/constants/search_constants.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -40,7 +41,9 @@ class NewMessageSearchBloc
     NewMessageSearchStarted event,
     Emitter<NewMessageSearchState> emit,
   ) async {
-    final pubkeys = _followRepository.followingPubkeys.where(_isNotSelf);
+    final pubkeys = _followRepository.followingPubkeys.where(
+      (pubkey) => !_isSelf(pubkey),
+    );
     final futures = pubkeys.map(
       (pk) => _profileRepository.getCachedProfile(pubkey: pk),
     );
@@ -90,7 +93,7 @@ class NewMessageSearchBloc
         query: query,
         limit: 50,
         sortBy: profileSearchSortFollowers,
-      )).where((profile) => _isNotSelf(profile.pubkey)).toList();
+      )).where((profile) => !_isSelf(profile.pubkey)).toList();
 
       Log.debug(
         'Query "$query": ${networkResults.length} network results',
@@ -125,7 +128,7 @@ class NewMessageSearchBloc
     );
   }
 
-  /// Whether [pubkey] is somebody other than the viewer.
+  /// Whether [pubkey] addresses the viewer.
   ///
   /// Divine does not support a self-addressed conversation (#8351, decided
   /// on #8261), so the viewer is never a candidate recipient. Filtered here in
@@ -135,8 +138,7 @@ class NewMessageSearchBloc
   ///
   /// Case-insensitive, because a pubkey that reaches Divine from another
   /// client may be upper-case hex.
-  bool _isNotSelf(String pubkey) =>
-      pubkey.toLowerCase() != _currentUserPubkey.toLowerCase();
+  bool _isSelf(String pubkey) => pubkeysEqual(pubkey, _currentUserPubkey);
 
   /// Filters contacts by display name or NIP-05.
   static List<UserProfile> _filterContacts(

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -423,17 +423,20 @@ class _MessagesContent extends ConsumerWidget {
       return;
     }
 
+    // Read before opening the sheet: the picker needs it to exclude the
+    // viewer from its own candidate list (#8351), and with no signed-in
+    // pubkey there is nobody to message anyway.
+    final currentPubkey = ref.read(authServiceProvider).currentPublicKeyHex;
+    if (currentPubkey == null) return;
+
     final selectedUser = await NewMessageSheet.show(
       context,
       profileRepository: profileRepo,
       followRepository: ref.read(followRepositoryProvider),
+      currentUserPubkey: currentPubkey,
     );
 
     if (selectedUser == null || !context.mounted) return;
-
-    final authService = ref.read(authServiceProvider);
-    final currentPubkey = authService.currentPublicKeyHex;
-    if (currentPubkey == null) return;
 
     final conversationId = DmRepository.computeConversationId([
       currentPubkey,
@@ -672,6 +675,7 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
             child: _searchFocused
                 ? const SizedBox(width: double.infinity)
                 : FollowingBar(
+                    currentUserPubkey: widget.currentUserPubkey,
                     onUserTapped: (pubkey) {
                       Log.info(
                         '👤 User tapped in following bar: ${pubkeyForLogs(pubkey)}',

--- a/mobile/lib/screens/inbox/new_message_sheet.dart
+++ b/mobile/lib/screens/inbox/new_message_sheet.dart
@@ -21,11 +21,16 @@ class NewMessageSheet extends StatelessWidget {
   const NewMessageSheet({
     required this.profileRepository,
     required this.followRepository,
+    required this.currentUserPubkey,
     super.key,
   });
 
   final ProfileRepository profileRepository;
   final FollowRepository followRepository;
+
+  /// The signed-in user, excluded from the candidate list — Divine does not
+  /// support a self-addressed conversation (#8351).
+  final String currentUserPubkey;
 
   /// Shows the sheet and returns the selected [UserProfile], or null if
   /// the user dismissed without selecting.
@@ -33,6 +38,7 @@ class NewMessageSheet extends StatelessWidget {
     BuildContext context, {
     required ProfileRepository profileRepository,
     required FollowRepository followRepository,
+    required String currentUserPubkey,
   }) {
     return showModalBottomSheet<UserProfile>(
       context: context,
@@ -42,6 +48,7 @@ class NewMessageSheet extends StatelessWidget {
       builder: (context) => NewMessageSheet(
         profileRepository: profileRepository,
         followRepository: followRepository,
+        currentUserPubkey: currentUserPubkey,
       ),
     );
   }
@@ -52,6 +59,7 @@ class NewMessageSheet extends StatelessWidget {
       create: (_) => NewMessageSearchBloc(
         profileRepository: profileRepository,
         followRepository: followRepository,
+        currentUserPubkey: currentUserPubkey,
       )..add(const NewMessageSearchStarted()),
       child: const _NewMessageSheetView(),
     );

--- a/mobile/lib/screens/inbox/widgets/following_bar.dart
+++ b/mobile/lib/screens/inbox/widgets/following_bar.dart
@@ -16,15 +16,38 @@ import 'package:openvine/widgets/user_avatar.dart';
 /// Displays a row of avatars with display names from [MyFollowingBloc].
 /// Tapping a user triggers [onUserTapped] with their pubkey.
 class FollowingBar extends StatelessWidget {
-  const FollowingBar({required this.onUserTapped, super.key});
+  const FollowingBar({
+    required this.onUserTapped,
+    required this.currentUserPubkey,
+    super.key,
+  });
 
   final ValueChanged<String> onUserTapped;
+
+  /// The signed-in user, never offered as a conversation partner — Divine
+  /// does not support a self-addressed conversation (#8351).
+  final String currentUserPubkey;
 
   @override
   Widget build(BuildContext context) {
     return BlocSelector<MyFollowingBloc, MyFollowingState, List<String>>(
+      // Selects the list unchanged so its identity is stable across
+      // emissions — BlocSelector compares with `==`, and List does not
+      // override it, so filtering here would rebuild the bar on every
+      // MyFollowingState emission.
       selector: (state) => state.followingPubkeys,
-      builder: (context, followingPubkeys) {
+      builder: (context, allFollowingPubkeys) {
+        // Drop the viewer here rather than in [MyFollowingBloc], which nine
+        // other screens share and where following yourself is a legitimate
+        // thing to render. A contact list written by another Nostr client
+        // can self-follow, and only the merge path strips that — every other
+        // path assigns the list as received. Case-insensitive: a pubkey
+        // arriving from another client may be upper-case hex. See #8351.
+        final viewer = currentUserPubkey.toLowerCase();
+        final followingPubkeys = [
+          for (final pubkey in allFollowingPubkeys)
+            if (pubkey.toLowerCase() != viewer) pubkey,
+        ];
         if (followingPubkeys.isEmpty) return const SizedBox.shrink();
 
         return DecoratedBox(

--- a/mobile/lib/screens/inbox/widgets/following_bar.dart
+++ b/mobile/lib/screens/inbox/widgets/following_bar.dart
@@ -6,6 +6,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nostr_sdk/nip19/pubkeys_equal.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/widgets/dm_peer_identity.dart';
@@ -43,10 +44,9 @@ class FollowingBar extends StatelessWidget {
         // can self-follow, and only the merge path strips that — every other
         // path assigns the list as received. Case-insensitive: a pubkey
         // arriving from another client may be upper-case hex. See #8351.
-        final viewer = currentUserPubkey.toLowerCase();
         final followingPubkeys = [
           for (final pubkey in allFollowingPubkeys)
-            if (pubkey.toLowerCase() != viewer) pubkey,
+            if (!pubkeysEqual(pubkey, currentUserPubkey)) pubkey,
         ];
         if (followingPubkeys.isEmpty) return const SizedBox.shrink();
 

--- a/mobile/lib/widgets/find_people_sheet.dart
+++ b/mobile/lib/widgets/find_people_sheet.dart
@@ -20,6 +20,7 @@ import 'package:openvine/widgets/user_avatar.dart';
 class FindPeopleSheet extends ConsumerStatefulWidget {
   const FindPeopleSheet({
     required this.contacts,
+    required this.currentUserPubkey,
     this.scrollController,
     this.searchTimeout = const Duration(seconds: 20),
     super.key,
@@ -27,6 +28,9 @@ class FindPeopleSheet extends ConsumerStatefulWidget {
 
   /// Pre-loaded contacts from the parent share sheet BLoC.
   final List<ShareableUser> contacts;
+
+  /// The signed-in user, excluded from DM recipient search results.
+  final String currentUserPubkey;
 
   /// Scroll controller handed down by the enclosing [VineBottomSheet] so
   /// flinging the result list drags the sheet itself.
@@ -49,6 +53,7 @@ class FindPeopleSheet extends ConsumerStatefulWidget {
   /// need to load them independently.
   static Future<ShareableUser?> show(
     BuildContext context, {
+    required String currentUserPubkey,
     List<ShareableUser> contacts = const [],
   }) {
     return VineBottomSheet.show<ShareableUser>(
@@ -60,6 +65,7 @@ class FindPeopleSheet extends ConsumerStatefulWidget {
       minChildSize: VineTheme.bottomSheetDismissFloor,
       buildScrollBody: (scrollController) => FindPeopleSheet(
         contacts: contacts,
+        currentUserPubkey: currentUserPubkey,
         scrollController: scrollController,
       ),
     );
@@ -79,6 +85,7 @@ class _FindPeopleSheetState extends ConsumerState<FindPeopleSheet> {
       _searchBloc = UserSearchBloc(
         profileRepository: profileRepo,
         searchTimeout: widget.searchTimeout,
+        excludedPubkey: widget.currentUserPubkey,
       );
     }
   }

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -161,6 +161,10 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
             videoSharingService: widget.videoSharingService,
             profileRepository: widget.profileRepository,
             followRepository: ref.read(followRepositoryProvider),
+            // Empty when signed out: no viewer to exclude, and an empty
+            // string never matches a real pubkey (#8351).
+            currentUserPubkey:
+                ref.read(authServiceProvider).currentPublicKeyHex ?? '',
             bookmarksRepositoryFuture: ref.read(
               bookmarksRepositoryProvider.future,
             ),

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -421,6 +421,8 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
     final selectedUser = await FindPeopleSheet.show(
       context,
       contacts: _shareSheetBloc.state.contacts,
+      currentUserPubkey:
+          ref.read(authServiceProvider).currentPublicKeyHex ?? '',
     );
     if (selectedUser != null && mounted) {
       _shareSheetBloc.add(ShareSheetRecipientToggled(selectedUser));

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3607,6 +3607,9 @@ class DmRepository {
   /// Throws [ArgumentError] if [recipientPubkey] is not a 64-character
   /// hex string or if [content] is empty.
   ///
+  /// Returns a failure result, publishing nothing, when [recipientPubkey] is
+  /// the sender — see the refusal below.
+  ///
   /// When an [OutgoingDmsDao] is injected, the send goes through the
   /// durable queue: build the rumor, enqueue a `pending`/`pending` row
   /// keyed by the rumor's id, publish, then transition the queue row
@@ -3631,6 +3634,25 @@ class DmRepository {
     validatePubkey(recipientPubkey);
     if (content.trim().isEmpty) {
       throw ArgumentError.value(content, 'content', 'must not be empty');
+    }
+
+    // Divine does not support a self-addressed conversation (#8351, decided
+    // on #8261). Refused here rather than in the UI so every caller is covered —
+    // share-to-DM, collaborator invites, the retry paths, and whatever is
+    // added next. Returned rather than thrown because callers already branch
+    // on `success` and one of them, `CollaboratorInviteService.sendInvites`,
+    // loops without a catch: a throw would abort the remaining invites.
+    //
+    // A published self-send is not merely useless, it is permanent. The
+    // receive path drops a wrap whose participants collapse to a single
+    // pubkey (#2824), so the app cannot read its own message back; and a
+    // NIP-59 gift wrap is signed by a throwaway ephemeral key, which is the
+    // author funnelcake matches a kind-5 against, so the real sender is never
+    // authorized to delete it.
+    if (_isSelf(recipientPubkey)) {
+      return const NIP17SendResult.failure(
+        'refused: a message cannot be addressed to its own sender',
+      );
     }
 
     // Send gate (#176): block before building or enqueuing a doomed intent.
@@ -6003,6 +6025,14 @@ class DmRepository {
       throw ArgumentError.value(fileUrl, 'fileUrl', 'must not be empty');
     }
 
+    // Self-addressed sends are refused (#8351) — see [sendMessage] for why a
+    // published one cannot be read back or deleted.
+    if (_isSelf(recipientPubkey)) {
+      return const NIP17SendResult.failure(
+        'refused: a message cannot be addressed to its own sender',
+      );
+    }
+
     // Protected-minor gate (#176): the file path intentionally relies on the
     // single authoritative choke point in `sendRumor` (via sendPrivateMessage)
     // rather than adding its own pre-check like sendMessage/sendGroupMessage. A
@@ -7236,6 +7266,14 @@ class DmRepository {
       );
     }
   }
+
+  /// Whether [pubkey] addresses the signed-in user.
+  ///
+  /// Compared case-insensitively because [validatePubkey] accepts upper-case
+  /// hex (`[0-9a-fA-F]{64}`), so an exact `==` would let `A1B2…` through as a
+  /// different person from `a1b2…`.
+  bool _isSelf(String pubkey) =>
+      pubkey.toLowerCase() == _userPubkey.toLowerCase();
 
   Never _dummyRelay(String url) {
     throw UnimplementedError('Relay not needed for decryption');

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3637,11 +3637,12 @@ class DmRepository {
     }
 
     // Divine does not support a self-addressed conversation (#8351, decided
-    // on #8261). Refused here rather than in the UI so every caller is covered —
-    // share-to-DM, collaborator invites, the retry paths, and whatever is
-    // added next. Returned rather than thrown because callers already branch
-    // on `success` and one of them, `CollaboratorInviteService.sendInvites`,
-    // loops without a catch: a throw would abort the remaining invites.
+    // on #8261). Refused here rather than in the UI so every caller is
+    // covered — share-to-DM, collaborator invites, the retry paths, and
+    // whatever is added next. Returned rather than thrown because callers
+    // already branch on `success` and one of them,
+    // `CollaboratorInviteService.sendInvites`, loops without a catch: a
+    // throw would abort the remaining invites.
     //
     // A published self-send is not merely useless, it is permanent. The
     // receive path drops a wrap whose participants collapse to a single

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -32,6 +32,7 @@ import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
 import 'package:nostr_sdk/filter.dart' as nostr_filter;
 import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
+import 'package:nostr_sdk/nip19/pubkeys_equal.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_batch_unwrap.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
 import 'package:nostr_sdk/nostr.dart';
@@ -3638,8 +3639,8 @@ class DmRepository {
 
     // Divine does not support a self-addressed conversation (#8351, decided
     // on #8261). Refused here rather than in the UI so every caller is
-    // covered — share-to-DM, collaborator invites, the retry paths, and
-    // whatever is added next. Returned rather than thrown because callers
+    // covered — share-to-DM, collaborator invites, and whatever is added
+    // next. Returned rather than thrown because callers
     // already branch on `success` and one of them,
     // `CollaboratorInviteService.sendInvites`, loops without a catch: a
     // throw would abort the remaining invites.
@@ -7273,8 +7274,7 @@ class DmRepository {
   /// Compared case-insensitively because [validatePubkey] accepts upper-case
   /// hex (`[0-9a-fA-F]{64}`), so an exact `==` would let `A1B2…` through as a
   /// different person from `a1b2…`.
-  bool _isSelf(String pubkey) =>
-      pubkey.toLowerCase() == _userPubkey.toLowerCase();
+  bool _isSelf(String pubkey) => pubkeysEqual(pubkey, _userPubkey);
 
   Never _dummyRelay(String url) {
     throw UnimplementedError('Relay not needed for decryption');

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -1004,6 +1004,39 @@ void main() {
         );
       });
 
+      test('refuses a self-addressed recipient before any publish', () async {
+        final repository = createRepository();
+
+        final result = await repository.sendMessage(
+          recipientPubkey: _validPubkeyA,
+          content: 'Note to self',
+        );
+
+        expect(result.success, isFalse);
+        verifyNever(() => mockMessageService.canSendTo(any()));
+        verifyNever(
+          () => mockMessageService.sendRumor(
+            rumorEvent: any(named: 'rumorEvent'),
+            recipientPubkey: any(named: 'recipientPubkey'),
+            targetRelays: any(named: 'targetRelays'),
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
+            selfWrapOnSoftUnconfirmed: any(named: 'selfWrapOnSoftUnconfirmed'),
+          ),
+        );
+      });
+
+      test('refuses a self-addressed recipient in upper-case hex', () async {
+        final repository = createRepository();
+
+        final result = await repository.sendMessage(
+          recipientPubkey: _validPubkeyA.toUpperCase(),
+          content: 'Note to self',
+        );
+
+        expect(result.success, isFalse);
+        verifyNever(() => mockMessageService.canSendTo(any()));
+      });
+
       test('sendMessage forwards additional NIP-17 tags', () async {
         stubSendRumor(
           (rumorEvent, recipientPubkey) async =>
@@ -9579,6 +9612,26 @@ void main() {
             fileMetadata: testFileMetadata,
           ),
           throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('refuses a self-addressed recipient before any publish', () async {
+        final repository = createRepository();
+
+        final result = await repository.sendFileMessage(
+          recipientPubkey: _validPubkeyA,
+          fileUrl: 'https://blossom.example.com/file.enc',
+          fileMetadata: testFileMetadata,
+        );
+
+        expect(result.success, isFalse);
+        verifyNever(
+          () => mockMessageService.sendPrivateMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: any(named: 'content'),
+            eventKind: any(named: 'eventKind'),
+            additionalTags: any(named: 'additionalTags'),
+          ),
         );
       });
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -9635,6 +9635,26 @@ void main() {
         );
       });
 
+      test('refuses a self-addressed recipient in upper-case hex', () async {
+        final repository = createRepository();
+
+        final result = await repository.sendFileMessage(
+          recipientPubkey: _validPubkeyA.toUpperCase(),
+          fileUrl: 'https://blossom.example.com/file.enc',
+          fileMetadata: testFileMetadata,
+        );
+
+        expect(result.success, isFalse);
+        verifyNever(
+          () => mockMessageService.sendPrivateMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: any(named: 'content'),
+            eventKind: any(named: 'eventKind'),
+            additionalTags: any(named: 'additionalTags'),
+          ),
+        );
+      });
+
       test('sends kind 15 event and persists with file metadata', () async {
         when(
           () => mockMessageService.sendPrivateMessage(

--- a/mobile/packages/nostr_sdk/lib/nip19/pubkeys_equal.dart
+++ b/mobile/packages/nostr_sdk/lib/nip19/pubkeys_equal.dart
@@ -1,0 +1,9 @@
+// ABOUTME: Compares hexadecimal Nostr pubkeys in their canonical form.
+// ABOUTME: Keeps case-insensitive identity checks consistent across packages.
+
+/// Whether two hexadecimal Nostr pubkeys identify the same key.
+///
+/// Hex is case-insensitive. This comparison deliberately does not validate
+/// either value so callers can use it after their own boundary validation.
+bool pubkeysEqual(String first, String second) =>
+    first.toLowerCase() == second.toLowerCase();

--- a/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
@@ -22,6 +22,7 @@ export 'nip07/nip07_signer.dart';
 export 'nip19/hrps.dart';
 export 'nip19/nip19.dart';
 export 'nip19/pubkey_for_logs.dart';
+export 'nip19/pubkeys_equal.dart';
 export 'nip49/nip49.dart';
 export 'nip23/long_form_info.dart';
 export 'nip29/group_identifier.dart';

--- a/mobile/packages/nostr_sdk/test/nip19/pubkeys_equal_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip19/pubkeys_equal_test.dart
@@ -1,0 +1,17 @@
+// ABOUTME: Tests the shared case-insensitive Nostr pubkey comparison.
+// ABOUTME: Pins equal and unequal hexadecimal-key behavior.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nip19/pubkeys_equal.dart';
+
+void main() {
+  group('pubkeysEqual', () {
+    test('matches hexadecimal pubkeys case-insensitively', () {
+      expect(pubkeysEqual('a1b2', 'A1B2'), isTrue);
+    });
+
+    test('rejects different pubkeys', () {
+      expect(pubkeysEqual('a1b2', 'a1b3'), isFalse);
+    });
+  });
+}

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -92,6 +92,15 @@ void main() {
       picture: 'https://example.com/alice.png',
     );
 
+    const currentUserPubkey =
+        'facade00facade00facade00facade00facade00facade00facade00facade00';
+
+    const viewerAsRecipient = ShareableUser(
+      pubkey: currentUserPubkey,
+      displayName: 'Me',
+      picture: 'https://example.com/me.png',
+    );
+
     setUp(() {
       mockSharingService = _MockVideoSharingService();
       mockProfileRepository = _MockProfileRepository();
@@ -142,6 +151,7 @@ void main() {
       videoSharingService: mockSharingService,
       profileRepository: mockProfileRepository,
       followRepository: followRepository ?? mockFollowRepository,
+      currentUserPubkey: currentUserPubkey,
       bookmarksRepositoryFuture:
           bookmarksRepositoryFuture ?? Future.value(mockBookmarksRepository),
       cacheManager: cacheManager,
@@ -165,6 +175,76 @@ void main() {
     // -----------------------------------------------------------------------
     // Contact loading
     // -----------------------------------------------------------------------
+
+    group('excludes the current user (#8351)', () {
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'omits the viewer from contacts when their contact list self-follows',
+        setUp: () {
+          when(() => mockFollowRepository.followingPubkeys).thenReturn([
+            currentUserPubkey,
+            'bbbb456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          ]);
+          when(
+            () => mockProfileRepository.getCachedProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              UserProfile(
+                pubkey: currentUserPubkey,
+                createdAt: DateTime.now(),
+                eventId: 'event-self',
+                rawData: const {},
+                name: 'Me',
+              ),
+              UserProfile(
+                pubkey:
+                    'bbbb456789abcdef0123456789abcdef0123456789abcdef'
+                    '0123456789abcdef',
+                createdAt: DateTime.now(),
+                eventId: 'event-bob',
+                rawData: const {},
+                name: 'Bob',
+              ),
+            ],
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ShareSheetContactsLoadRequested()),
+        verify: (bloc) {
+          expect(
+            bloc.state.contacts.map((c) => c.pubkey),
+            isNot(contains(currentUserPubkey)),
+          );
+          expect(bloc.state.contacts, isNotEmpty);
+        },
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'omits the viewer from the recently-shared-with row',
+        setUp: () {
+          when(
+            () => mockSharingService.recentlySharedWith,
+          ).thenReturn([viewerAsRecipient, testRecipient]);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ShareSheetContactsLoadRequested()),
+        verify: (bloc) {
+          expect(
+            bloc.state.contacts.map((c) => c.pubkey),
+            [testRecipient.pubkey],
+          );
+        },
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'ignores a Find People selection that resolves to the viewer',
+        build: createBloc,
+        act: (bloc) =>
+            bloc.add(const ShareSheetRecipientToggled(viewerAsRecipient)),
+        expect: () => <ShareSheetState>[],
+      );
+    });
 
     group('ShareSheetContactsLoadRequested', () {
       const profiledFollow =
@@ -1908,6 +1988,7 @@ void main() {
           videoSharingService: mockSharingService,
           profileRepository: mockProfileRepository,
           followRepository: mockFollowRepository,
+          currentUserPubkey: currentUserPubkey,
         ),
         act: (bloc) => bloc.add(const ShareSheetCopyEventJsonRequested()),
         errors: () => [
@@ -1959,6 +2040,7 @@ void main() {
           videoSharingService: mockSharingService,
           profileRepository: mockProfileRepository,
           followRepository: mockFollowRepository,
+          currentUserPubkey: currentUserPubkey,
         ),
         act: (bloc) => bloc.add(const ShareSheetCopyEventIdRequested()),
         errors: () => [

--- a/mobile/test/blocs/user_search/user_search_bloc_test.dart
+++ b/mobile/test/blocs/user_search/user_search_bloc_test.dart
@@ -40,9 +40,11 @@ void main() {
 
     UserSearchBloc createBloc({
       Duration? searchTimeout = const Duration(seconds: 20),
+      String? excludedPubkey,
     }) => UserSearchBloc(
       profileRepository: mockProfileRepository,
       searchTimeout: searchTimeout,
+      excludedPubkey: excludedPubkey,
     );
 
     UserProfile createTestProfile(String pubkey, String displayName) {
@@ -83,6 +85,8 @@ void main() {
       );
     }
 
+    const debounceDuration = Duration(milliseconds: 400);
+
     test('initial state is correct', () {
       final bloc = createBloc();
       expect(bloc.state.status, UserSearchStatus.initial);
@@ -95,10 +99,32 @@ void main() {
       bloc.close();
     });
 
-    group('UserSearchQueryChanged', () {
-      // Debounce duration used in the BLoC
-      const debounceDuration = Duration(milliseconds: 400);
+    blocTest<UserSearchBloc, UserSearchState>(
+      'omits the excluded pubkey case-insensitively',
+      setUp: () {
+        when(
+          () => mockProfileRepository.searchUsersProgressive(
+            query: 'alice',
+            limit: 50,
+            sortBy: 'followers',
+          ),
+        ).thenAnswer(
+          (_) => progressive([
+            createTestProfile('a' * 64, 'Alice'),
+            createTestProfile('b' * 64, 'Bob'),
+          ]),
+        );
+      },
+      build: () => createBloc(excludedPubkey: ('a' * 64).toUpperCase()),
+      act: (bloc) => bloc.add(const UserSearchQueryChanged('alice')),
+      wait: debounceDuration,
+      verify: (bloc) {
+        expect(bloc.state.results.map((profile) => profile.pubkey), ['b' * 64]);
+        expect(bloc.state.offset, 2);
+      },
+    );
 
+    group('UserSearchQueryChanged', () {
       blocTest<UserSearchBloc, UserSearchState>(
         'emits [searching, searching(results), success] when search succeeds',
         setUp: () {

--- a/mobile/test/screens/inbox/bloc/new_message_search_bloc_test.dart
+++ b/mobile/test/screens/inbox/bloc/new_message_search_bloc_test.dart
@@ -19,6 +19,9 @@ void main() {
     late _MockFollowRepository mockFollowRepo;
 
     const debounceDuration = Duration(milliseconds: 400);
+    const currentUserPubkey =
+        'facade00facade00facade00facade00'
+        'facade00facade00facade00facade00';
 
     setUp(() {
       mockProfileRepo = _MockProfileRepository();
@@ -28,6 +31,7 @@ void main() {
     NewMessageSearchBloc createBloc() => NewMessageSearchBloc(
       profileRepository: mockProfileRepo,
       followRepository: mockFollowRepo,
+      currentUserPubkey: currentUserPubkey,
     );
 
     UserProfile createTestProfile(
@@ -53,6 +57,89 @@ void main() {
       expect(bloc.state.query, isEmpty);
       expect(bloc.state.results, isEmpty);
       bloc.close();
+    });
+
+    group('excludes the current user (#8351)', () {
+      blocTest<NewMessageSearchBloc, NewMessageSearchState>(
+        'omits the viewer from contacts when their contact list self-follows',
+        setUp: () {
+          when(
+            () => mockFollowRepo.followingPubkeys,
+          ).thenReturn([currentUserPubkey, 'a' * 64]);
+          when(
+            () => mockProfileRepo.getCachedProfile(pubkey: currentUserPubkey),
+          ).thenAnswer((_) async => createTestProfile(currentUserPubkey, 'Me'));
+          when(
+            () => mockProfileRepo.getCachedProfile(pubkey: 'a' * 64),
+          ).thenAnswer((_) async => createTestProfile('a' * 64, 'Alice'));
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const NewMessageSearchStarted()),
+        expect: () => [
+          isA<NewMessageSearchState>().having(
+            (s) => s.contacts.map((c) => c.pubkey),
+            'contact pubkeys',
+            ['a' * 64],
+          ),
+        ],
+      );
+
+      blocTest<NewMessageSearchBloc, NewMessageSearchState>(
+        'omits the viewer from network search results',
+        setUp: () {
+          when(() => mockFollowRepo.followingPubkeys).thenReturn([]);
+          when(
+            () => mockProfileRepo.searchUsers(
+              query: any(named: 'query'),
+              limit: any(named: 'limit'),
+              sortBy: any(named: 'sortBy'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              createTestProfile(currentUserPubkey, 'Me'),
+              createTestProfile('a' * 64, 'Alice'),
+            ],
+          );
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const NewMessageSearchStarted());
+          bloc.add(const NewMessageSearchQueryChanged('al'));
+        },
+        wait: debounceDuration,
+        verify: (bloc) {
+          expect(
+            bloc.state.results.map((r) => r.pubkey),
+            ['a' * 64],
+          );
+        },
+      );
+
+      blocTest<NewMessageSearchBloc, NewMessageSearchState>(
+        'omits the viewer when their contact list stores upper-case hex',
+        setUp: () {
+          when(
+            () => mockFollowRepo.followingPubkeys,
+          ).thenReturn([currentUserPubkey.toUpperCase()]);
+          when(
+            () => mockProfileRepo.getCachedProfile(
+              pubkey: currentUserPubkey.toUpperCase(),
+            ),
+          ).thenAnswer(
+            (_) async =>
+                createTestProfile(currentUserPubkey.toUpperCase(), 'Me'),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const NewMessageSearchStarted()),
+        expect: () => [
+          isA<NewMessageSearchState>().having(
+            (s) => s.contacts,
+            'contacts',
+            isEmpty,
+          ),
+        ],
+      );
     });
 
     group('NewMessageSearchStarted', () {

--- a/mobile/test/screens/inbox/widgets/following_bar_test.dart
+++ b/mobile/test/screens/inbox/widgets/following_bar_test.dart
@@ -22,6 +22,8 @@ void main() {
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
   const pubkey2 =
       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const currentUserPubkey =
+      'facade00facade00facade00facade00facade00facade00facade00facade00';
 
   final now = DateTime.now();
 
@@ -53,6 +55,7 @@ void main() {
       List<dynamic> additionalOverrides = const [],
       ValueChanged<String>? onUserTapped,
       Locale? locale,
+      String viewerPubkey = currentUserPubkey,
     }) {
       whenListen(
         mockFollowingBloc,
@@ -66,7 +69,10 @@ void main() {
         home: BlocProvider<MyFollowingBloc>.value(
           value: mockFollowingBloc,
           child: Scaffold(
-            body: FollowingBar(onUserTapped: onUserTapped ?? (_) {}),
+            body: FollowingBar(
+              onUserTapped: onUserTapped ?? (_) {},
+              currentUserPubkey: viewerPubkey,
+            ),
           ),
         ),
       );
@@ -80,6 +86,67 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(FollowingBar), findsOneWidget);
+        expect(find.byType(UserAvatar), findsNothing);
+        expect(find.byType(SizedBox), findsOneWidget);
+      });
+
+      testWidgets('omits the viewer when their contact list self-follows', (
+        tester,
+      ) async {
+        final profile1 = createTestProfile(
+          pubkey: pubkey1,
+          displayName: 'Alice',
+        );
+        final selfProfile = createTestProfile(
+          pubkey: currentUserPubkey,
+          displayName: 'Me',
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: const MyFollowingState(
+              status: MyFollowingStatus.success,
+              followingPubkeys: [pubkey1, currentUserPubkey],
+            ),
+            additionalOverrides: [
+              fetchUserProfileProvider(
+                pubkey1,
+              ).overrideWith((ref) async => profile1),
+              fetchUserProfileProvider(
+                currentUserPubkey,
+              ).overrideWith((ref) async => selfProfile),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(UserAvatar), findsOneWidget);
+        expect(find.text('Me'), findsNothing);
+      });
+
+      testWidgets('collapses when the viewer is the only followed pubkey', (
+        tester,
+      ) async {
+        final selfProfile = createTestProfile(
+          pubkey: currentUserPubkey,
+          displayName: 'Me',
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: const MyFollowingState(
+              status: MyFollowingStatus.success,
+              followingPubkeys: [currentUserPubkey],
+            ),
+            additionalOverrides: [
+              fetchUserProfileProvider(
+                currentUserPubkey,
+              ).overrideWith((ref) async => selfProfile),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
         expect(find.byType(UserAvatar), findsNothing);
         expect(find.byType(SizedBox), findsOneWidget);
       });

--- a/mobile/test/widgets/find_people_sheet_test.dart
+++ b/mobile/test/widgets/find_people_sheet_test.dart
@@ -20,6 +20,8 @@ class _MockProfileRepository extends Mock implements ProfileRepository {}
 
 void main() {
   group(FindPeopleSheet, () {
+    const currentUserPubkey =
+        'facade00facade00facade00facade00facade00facade00facade00facade00';
     late _MockProfileRepository mockProfileRepo;
 
     setUp(() {
@@ -49,6 +51,7 @@ void main() {
                       height: 600,
                       child: FindPeopleSheet(
                         contacts: contacts,
+                        currentUserPubkey: currentUserPubkey,
                         searchTimeout: searchTimeout,
                       ),
                     ),
@@ -221,6 +224,50 @@ void main() {
         await tester.pump(const Duration(milliseconds: 400));
         await tester.pumpAndSettle();
 
+        expect(find.text('Bob'), findsOneWidget);
+      });
+
+      testWidgets('does not offer the viewer in search results', (
+        tester,
+      ) async {
+        when(
+          () => mockProfileRepo.searchUsersProgressive(
+            query: any(named: 'query'),
+            limit: any(named: 'limit'),
+            sortBy: any(named: 'sortBy'),
+            hasVideos: any(named: 'hasVideos'),
+          ),
+        ).thenAnswer(
+          (_) => Stream.value(
+            ProgressiveSearchResult(
+              profiles: [
+                UserProfile(
+                  pubkey: currentUserPubkey.toUpperCase(),
+                  displayName: 'Me',
+                  createdAt: DateTime.now(),
+                  eventId: 'event-$currentUserPubkey',
+                  rawData: const {'display_name': 'Me'},
+                ),
+                UserProfile(
+                  pubkey: 'b' * 64,
+                  displayName: 'Bob',
+                  createdAt: DateTime.now(),
+                  eventId: 'event-${'b' * 64}',
+                  rawData: const {'display_name': 'Bob'},
+                ),
+              ],
+              sources: const {},
+              isComplete: true,
+            ),
+          ),
+        );
+
+        await openSheet(tester);
+        await tester.enterText(find.byType(TextField), 'me');
+        await tester.pump(const Duration(milliseconds: 400));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Me'), findsNothing);
         expect(find.text('Bob'), findsOneWidget);
       });
 
@@ -416,6 +463,7 @@ void main() {
                         result = await FindPeopleSheet.show(
                           context,
                           contacts: [contact],
+                          currentUserPubkey: currentUserPubkey,
                         );
                       },
                       child: const Text('Open Sheet'),
@@ -467,8 +515,11 @@ void main() {
             home: Builder(
               builder: (context) => Scaffold(
                 body: ElevatedButton(
-                  onPressed: () =>
-                      FindPeopleSheet.show(context, contacts: contacts),
+                  onPressed: () => FindPeopleSheet.show(
+                    context,
+                    contacts: contacts,
+                    currentUserPubkey: currentUserPubkey,
+                  ),
                   child: const Text('Open Sheet'),
                 ),
               ),


### PR DESCRIPTION
Implements Decision 1 of #8261 — **Divine does not support a self-addressed conversation** — as scoped by #8351.

Nothing in the send path compared recipient to sender, so a self-DM was built, gift-wrapped and published. The app then could not read it back: `_extractParticipants` builds a `Set`, so a self-send collapses to one participant and #2824's receive guard drops it. And it could not be retracted — a NIP-59 gift wrap is signed by a throwaway ephemeral key, and funnelcake authorizes a `kind:5` by matching the deleter against the target's author, so the real sender is never authorized to delete their own wrap.

The repository refusal and picker exclusions remain independently revertable. A takeover follow-up closes the Find People search gap and consolidates the new case-insensitive pubkey comparisons.

## 1. Refuse the send at the repository seam

`DmRepository.sendMessage` now refuses a recipient equal to the sender, before the send gate and before anything is built, enqueued or published. `sendFileMessage` carries the same guard.

Three choices worth calling out:

- **Repository, not UI** — so every caller is covered, including share-to-DM (`sendSharedVideo` delegates here) and collaborator invites.
- **Returned, not thrown.** Every caller already branches on `success`, and one of them — `CollaboratorInviteService.sendInvites` — loops without a `catch`, so a throw would abort the remaining invites of a batch.
- **Compared case-insensitively.** `validatePubkey` accepts `[0-9a-fA-F]{64}`, so an exact `==` would let upper-case hex through as a different person. There is a test for that.

The receive guards (`rawParticipants.length < 2`, the #2824 `toSet().length < 2` check) and the startup janitor are unchanged — under this decision they are the intended contract, and the janitor still has work to do, since self-wraps published by shipped versions are already on relays.

## 2. Exclude the viewer from every recipient picker

All three surfaces named in the issue, plus the Find People search that feeds the third:

| Surface | Where | What it filters |
|---|---|---|
| New-message sheet | `NewMessageSearchBloc` | seeded contacts **and** network search results |
| Inbox following bar | `FollowingBar` | the rendered list, and the bar collapses if the viewer was the only entry |
| Share-to-DM | `ShareSheetBloc` | the follow list, the recently-shared-with row, **and** `_onRecipientToggled`, so Find People cannot reintroduce the viewer |

**Filtered in the picker, not in the contact list**, per the issue. The current user can legitimately appear in their own following list — a contact list written by another Nostr client that self-follows surfaces the viewer to themselves, because only the merge path strips self while every other path assigns the list as received. `MyFollowingBloc` is also left alone: nine other screens share it, and rendering your own self-follow there is a different question from this one.

`FollowingBar` filters in the builder rather than the selector on purpose — `BlocSelector` compares with `==`, which `List` does not override, so filtering in the selector would return a fresh list every time and rebuild the bar on every `MyFollowingState` emission.

## Observed, deliberately not changed

`sendGroupMessage` does not compare its recipient list against the sender. It is not reachable with the viewer in it: the new-message sheet is single-select, and group participants otherwise come from the receive path, which dedups. A group carrying a redundant self `p` tag is a different defect with a different remedy (refuse the whole send, or strip the entry?) and it is not what #8261 decided. Flagging rather than guessing. Tracked in #8359.

## Observed follow-up

The collaborator picker has the same self-following edge case, but collaborator eligibility is outside this DM-picker issue. Tracked in #8360.

## Testing

Written test-first; each test was watched failing for the right reason before the guard existed.

- `dm_repository`: self-send refused before `canSendTo` is even consulted and without reaching `sendRumor`; the upper-case-hex variant; the same for `sendFileMessage`. Full package suite green (715 tests), with the package coverage gate passing in CI.
- `NewMessageSearchBloc`: viewer omitted from contacts when the contact list self-follows, from network search results, and when the contact list stores the viewer in upper-case hex.
- `FollowingBar`: viewer omitted from a self-following list; the bar collapses when the viewer is the only entry.
- `ShareSheetBloc`: viewer omitted from a self-following contact list and from the recents row; a Find People selection resolving to the viewer is ignored.
- `FindPeopleSheet` / `UserSearchBloc`: viewer omitted case-insensitively from global search results before the picker renders them.

The self-follow-in-contact-list case the issue calls out as the non-obvious one is covered in all three pickers.

App, `dm_repository`, and `nostr_sdk` analysis are clean; affected tests, package tests, formatting, and the Generated Files ratchets are green locally or in CI.

Closes #8351. Refs #8261, #8202, #2824.