### PR TITLE
fix(account): prevent signer failures from partially deleting accounts

### DIFF
--- a/mobile/lib/services/account_deletion_service.dart
+++ b/mobile/lib/services/account_deletion_service.dart
@@ -114,6 +114,32 @@ class _VanishPublishConfig {
   final List<Duration> retryDelays;
 }
 
+class _PreparedDeletionBatch {
+  const _PreparedDeletionBatch({
+    required this.event,
+    required this.deletedKind,
+    required this.deletedEventCount,
+  });
+
+  final Event event;
+  final int deletedKind;
+  final int deletedEventCount;
+}
+
+class _PreparedDeletionSweep {
+  const _PreparedDeletionSweep({
+    required this.batches,
+    required this.targetRelays,
+    required this.totalEventCount,
+    required this.incompleteWithoutPublishing,
+  });
+
+  final List<_PreparedDeletionBatch> batches;
+  final List<String> targetRelays;
+  final int totalEventCount;
+  final bool incompleteWithoutPublishing;
+}
+
 /// Service for deleting user's entire Nostr account via NIP-62
 class AccountDeletionService {
   AccountDeletionService({
@@ -228,10 +254,40 @@ class AccountDeletionService {
         category: LogCategory.system,
       );
 
+      _PreparedDeletionSweep? preparedSweep;
       if (allUserEvents.isNotEmpty) {
-        final deletion = await _publishDeletionEventsForAll(
+        preparedSweep = await _prepareDeletionEventsForAll(
           allUserEvents,
           reason,
+          expectedPubkey: expectedPubkey,
+        );
+        if (preparedSweep == null) {
+          return DeleteAccountResult.failure(
+            DeleteAccountFailureReason.signingFailed,
+            diagnosticError: 'Failed to prepare deletion events',
+          );
+        }
+      }
+
+      // Sign the network-wide vanish only after every kind-5 fallback event is
+      // signed. Its created_at must cover those earlier events, while preparing
+      // every signature up front ensures signing failure cannot follow an
+      // irreversible publish.
+      final event = await createNip62Event(
+        reason: reason,
+        expectedPubkey: expectedPubkey,
+      );
+
+      if (event == null) {
+        return DeleteAccountResult.failure(
+          DeleteAccountFailureReason.signingFailed,
+          diagnosticError: 'Failed to create deletion event',
+        );
+      }
+
+      if (preparedSweep != null) {
+        final deletion = await _publishPreparedDeletionSweep(
+          preparedSweep,
           expectedPubkey: expectedPubkey,
           onProgress: onProgress,
         );
@@ -242,18 +298,6 @@ class AccountDeletionService {
           'Published $deletedCount NIP-09 deletion requests',
           name: 'AccountDeletionService',
           category: LogCategory.system,
-        );
-      }
-
-      final event = await createNip62Event(
-        reason: reason,
-        expectedPubkey: expectedPubkey,
-      );
-
-      if (event == null) {
-        return DeleteAccountResult.failure(
-          DeleteAccountFailureReason.signingFailed,
-          diagnosticError: 'Failed to create deletion event',
         );
       }
 
@@ -485,14 +529,12 @@ class AccountDeletionService {
     }
   }
 
-  /// Publish NIP-09 kind 5 deletion events for all user events
-  Future<({int confirmedCount, bool incomplete})> _publishDeletionEventsForAll(
+  /// Sign every NIP-09 fallback event before any irreversible publish begins.
+  Future<_PreparedDeletionSweep?> _prepareDeletionEventsForAll(
     List<Event> events,
     String reason, {
     String? expectedPubkey,
-    void Function(int current, int total)? onProgress,
   }) async {
-    int successCount = 0;
     final total = events.length;
     final connectedRelays = _nostrService.connectedRelays;
     final kind5TargetRelays = connectedRelays
@@ -509,8 +551,12 @@ class AccountDeletionService {
         name: 'AccountDeletionService',
         category: LogCategory.system,
       );
-      onProgress?.call(total, total);
-      return (confirmedCount: 0, incomplete: true);
+      return _PreparedDeletionSweep(
+        batches: const [],
+        targetRelays: const [],
+        totalEventCount: total,
+        incompleteWithoutPublishing: true,
+      );
     }
 
     if (kind5TargetRelays.isEmpty) {
@@ -520,8 +566,12 @@ class AccountDeletionService {
         name: 'AccountDeletionService',
         category: LogCategory.system,
       );
-      onProgress?.call(total, total);
-      return (confirmedCount: 0, incomplete: false);
+      return _PreparedDeletionSweep(
+        batches: const [],
+        targetRelays: const [],
+        totalEventCount: total,
+        incompleteWithoutPublishing: false,
+      );
     }
 
     final eventsByKind = <int, List<Event>>{};
@@ -529,79 +579,114 @@ class AccountDeletionService {
       eventsByKind.putIfAbsent(event.kind, () => []).add(event);
     }
 
-    final batches = eventsByKind.entries.toList(growable: false);
-    for (var batchIndex = 0; batchIndex < batches.length; batchIndex++) {
-      final entry = batches[batchIndex];
+    final preparedBatches = <_PreparedDeletionBatch>[];
+    for (final entry in eventsByKind.entries) {
       final kind = entry.key;
       final kindEvents = entry.value;
-
-      Event? deleteEvent;
-      try {
-        deleteEvent = await _createBatchDeleteEvent(
-          events: kindEvents,
-          kind: kind,
-          reason: reason,
-          expectedPubkey: expectedPubkey,
+      final deleteEvent = await _createBatchDeleteEvent(
+        events: kindEvents,
+        kind: kind,
+        reason: reason,
+        expectedPubkey: expectedPubkey,
+      );
+      if (deleteEvent == null) {
+        Log.error(
+          'Failed to prepare batch deletion for kind $kind',
+          name: 'AccountDeletionService',
+          category: LogCategory.system,
         );
-      } on AccountChangedDuringDeletion {
-        if (successCount > 0) {
-          throw const AccountChangedAfterDeletion();
-        }
-        rethrow;
+        return null;
       }
+      preparedBatches.add(
+        _PreparedDeletionBatch(
+          event: deleteEvent,
+          deletedKind: kind,
+          deletedEventCount: kindEvents.length,
+        ),
+      );
+    }
 
-      if (deleteEvent != null) {
-        var outcome = await _nostrService.publishEventAwaitOk(
-          deleteEvent,
-          targetRelays: kind5TargetRelays,
-        );
-        if (isRateLimitedOutcome(outcome)) {
-          await _retryDelay(_rateLimitRetryDelay);
-          _assertSignerStillMatches(
-            expectedPubkey,
-            anyConfirmed: successCount > 0,
-          );
-          outcome = await _nostrService.publishEventAwaitOk(
-            deleteEvent,
-            targetRelays: kind5TargetRelays,
-          );
-        }
+    return _PreparedDeletionSweep(
+      batches: preparedBatches,
+      targetRelays: kind5TargetRelays,
+      totalEventCount: total,
+      incompleteWithoutPublishing: false,
+    );
+  }
+
+  /// Publish a fully signed NIP-09 sweep.
+  Future<({int confirmedCount, bool incomplete})> _publishPreparedDeletionSweep(
+    _PreparedDeletionSweep sweep, {
+    String? expectedPubkey,
+    void Function(int current, int total)? onProgress,
+  }) async {
+    var successCount = 0;
+    if (sweep.batches.isEmpty) {
+      onProgress?.call(sweep.totalEventCount, sweep.totalEventCount);
+      return (
+        confirmedCount: 0,
+        incomplete: sweep.incompleteWithoutPublishing,
+      );
+    }
+
+    for (var batchIndex = 0; batchIndex < sweep.batches.length; batchIndex++) {
+      final batch = sweep.batches[batchIndex];
+      _assertSignerStillMatches(
+        expectedPubkey,
+        anyConfirmed: successCount > 0,
+      );
+      var outcome = await _nostrService.publishEventAwaitOk(
+        batch.event,
+        targetRelays: sweep.targetRelays,
+      );
+      if (isRateLimitedOutcome(outcome)) {
+        await _retryDelay(_rateLimitRetryDelay);
         _assertSignerStillMatches(
           expectedPubkey,
-          anyConfirmed: outcome.confirmed || successCount > 0,
+          anyConfirmed: successCount > 0,
         );
-        if (isAccountRestrictedOutcome(
-          outcome,
-          trustedRelayUrl: _nostrService.defaultRelayUrl,
-        )) {
-          Log.warning(
-            'Stopping batch deletion after the configured relay reported an '
-            'account restriction',
-            name: 'AccountDeletionService',
-            category: LogCategory.system,
-          );
-          onProgress?.call(successCount, total);
-          return (confirmedCount: successCount, incomplete: true);
-        }
-        if (outcome.confirmed) {
-          successCount += kindEvents.length;
-          Log.debug(
-            'Batch deletion for ${kindEvents.length} kind $kind events '
-            'confirmed by ${outcome.acceptedBy}',
-            name: 'AccountDeletionService',
-            category: LogCategory.system,
-          );
-        } else {
-          Log.warning(
-            'Batch deletion for kind $kind not confirmed: ${outcome.summary}',
-            name: 'AccountDeletionService',
-            category: LogCategory.system,
-          );
-        }
+        outcome = await _nostrService.publishEventAwaitOk(
+          batch.event,
+          targetRelays: sweep.targetRelays,
+        );
+      }
+      _assertSignerStillMatches(
+        expectedPubkey,
+        anyConfirmed: outcome.confirmed || successCount > 0,
+      );
+      if (isAccountRestrictedOutcome(
+        outcome,
+        trustedRelayUrl: _nostrService.defaultRelayUrl,
+      )) {
+        Log.warning(
+          'Stopping batch deletion after the configured relay reported an '
+          'account restriction',
+          name: 'AccountDeletionService',
+          category: LogCategory.system,
+        );
+        onProgress?.call(successCount, sweep.totalEventCount);
+        return (confirmedCount: successCount, incomplete: true);
+      }
+      if (outcome.confirmed) {
+        successCount += batch.deletedEventCount;
+        Log.debug(
+          'Batch deletion for ${batch.deletedEventCount} events '
+          'of kind ${batch.deletedKind} '
+          'confirmed by ${outcome.acceptedBy}',
+          name: 'AccountDeletionService',
+          category: LogCategory.system,
+        );
+      } else {
+        Log.warning(
+          'Batch deletion for kind ${batch.deletedKind} not confirmed: '
+          '${outcome.summary}',
+          name: 'AccountDeletionService',
+          category: LogCategory.system,
+        );
       }
 
-      onProgress?.call(successCount, total);
-      if (batchIndex < batches.length - 1) {
+      onProgress?.call(successCount, sweep.totalEventCount);
+      if (batchIndex < sweep.batches.length - 1) {
         await _retryDelay(_interBatchDelay);
         _assertSignerStillMatches(
           expectedPubkey,
@@ -610,7 +695,10 @@ class AccountDeletionService {
       }
     }
 
-    return (confirmedCount: successCount, incomplete: successCount < total);
+    return (
+      confirmedCount: successCount,
+      incomplete: successCount < sweep.totalEventCount,
+    );
   }
 
   /// Create NIP-09 kind 5 deletion event for multiple events of the same kind

--- a/mobile/test/services/account_deletion_service_test.dart
+++ b/mobile/test/services/account_deletion_service_test.dart
@@ -118,13 +118,14 @@ void main() {
       required List<List<String>> tags,
       required String content,
       String? id,
+      int? createdAt,
     }) {
       final event = Event(
         pubkey,
         kind,
         tags,
         content,
-        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        createdAt: createdAt ?? DateTime.now().millisecondsSinceEpoch ~/ 1000,
       );
       event.id = id ?? 'test_event_${DateTime.now().millisecondsSinceEpoch}';
       event.sig = 'test_signature';
@@ -551,6 +552,187 @@ void main() {
 
         // Verify publishEvent was NOT called
         verifyNever(() => mockNostrService.publishEventAwaitOk(any()));
+      },
+    );
+
+    test(
+      'publishes nothing when kind 62 signing fails after preparing a sweep',
+      () async {
+        final contentEvent = createTestEvent(
+          pubkey: testPublicKey,
+          kind: 1,
+          tags: const [],
+          content: 'note',
+        );
+        final kind5Event = createTestEvent(
+          pubkey: testPublicKey,
+          kind: 5,
+          tags: [
+            ['e', contentEvent.id],
+            ['k', '1'],
+          ],
+          content: 'deletion',
+        );
+        when(
+          () => mockNostrService.queryEvents(any()),
+        ).thenAnswer((_) async => [contentEvent]);
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((invocation) async {
+          final kind = invocation.namedArguments[#kind] as int;
+          return kind == 5 ? kind5Event : null;
+        });
+
+        final result = await service.deleteAccount();
+
+        expect(result.success, isFalse);
+        expect(result.failureReason, DeleteAccountFailureReason.signingFailed);
+        verifyNever(
+          () => mockNostrService.publishEventAwaitOk(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+        verifyNever(
+          () => mockNostrService.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
+        );
+      },
+    );
+
+    test('publishes nothing when any sweep batch cannot be signed', () async {
+      final contentEvents = [
+        createTestEvent(
+          pubkey: testPublicKey,
+          kind: 1,
+          tags: const [],
+          content: 'note',
+        ),
+        createTestEvent(
+          pubkey: testPublicKey,
+          kind: 6,
+          tags: const [],
+          content: 'repost',
+        ),
+      ];
+      when(
+        () => mockNostrService.queryEvents(any()),
+      ).thenAnswer((_) async => contentEvents);
+      var kind5Signatures = 0;
+      when(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((_) async {
+        kind5Signatures++;
+        if (kind5Signatures == 2) return null;
+        return createTestEvent(
+          pubkey: testPublicKey,
+          kind: 5,
+          tags: const [],
+          content: 'deletion',
+        );
+      });
+
+      final result = await service.deleteAccount();
+
+      expect(result.success, isFalse);
+      expect(result.failureReason, DeleteAccountFailureReason.signingFailed);
+      verifyNever(
+        () => mockNostrService.publishEventAwaitOk(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      );
+      verifyNever(
+        () => mockNostrService.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      );
+    });
+
+    test(
+      'signs every sweep batch before vanish and publishes vanish last',
+      () async {
+        final contentEvents = [
+          createTestEvent(
+            pubkey: testPublicKey,
+            kind: 1,
+            tags: const [],
+            content: 'note',
+          ),
+          createTestEvent(
+            pubkey: testPublicKey,
+            kind: 6,
+            tags: const [],
+            content: 'repost',
+          ),
+        ];
+        when(
+          () => mockNostrService.queryEvents(any()),
+        ).thenAnswer((_) async => contentEvents);
+        final signedEvents = <Event>[];
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((invocation) async {
+          final kind = invocation.namedArguments[#kind] as int;
+          final event = createTestEvent(
+            pubkey: testPublicKey,
+            kind: kind,
+            tags: const [],
+            content: 'deletion',
+            createdAt: 100 + signedEvents.length,
+          );
+          signedEvents.add(event);
+          return event;
+        });
+        final publishedEvents = <Event>[];
+        when(
+          () => mockNostrService.publishEventAwaitOk(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          publishedEvents.add(invocation.positionalArguments.single as Event);
+          return _confirmed;
+        });
+        when(
+          () => mockNostrService.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((invocation) async {
+          publishedEvents.add(invocation.positionalArguments.single as Event);
+          return _confirmed;
+        });
+
+        final result = await service.deleteAccount();
+
+        expect(result.success, isTrue);
+        expect(signedEvents.map((event) => event.kind), [5, 5, 62]);
+        expect(publishedEvents.map((event) => event.kind), [5, 5, 62]);
+        expect(
+          signedEvents.last.createdAt,
+          greaterThanOrEqualTo(
+            signedEvents
+                .take(2)
+                .map((event) => event.createdAt)
+                .reduce((first, second) => first > second ? first : second),
+          ),
+        );
       },
     );
 

--- a/mobile/test/services/account_deletion_service_test.dart
+++ b/mobile/test/services/account_deletion_service_test.dart
@@ -118,14 +118,13 @@ void main() {
       required List<List<String>> tags,
       required String content,
       String? id,
-      int? createdAt,
     }) {
       final event = Event(
         pubkey,
         kind,
         tags,
         content,
-        createdAt: createdAt ?? DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
       );
       event.id = id ?? 'test_event_${DateTime.now().millisecondsSinceEpoch}';
       event.sig = 'test_signature';
@@ -680,7 +679,11 @@ void main() {
         when(
           () => mockNostrService.queryEvents(any()),
         ).thenAnswer((_) async => contentEvents);
-        final signedEvents = <Event>[];
+        // One interleaved timeline, not two per-phase lists: separate
+        // sign-order and publish-order lists are each satisfied by the
+        // sign/publish/sign/publish interleaving this change exists to
+        // remove, so only a merged timeline can fail on it.
+        final timeline = <String>[];
         when(
           () => mockAuthService.createAndSignEvent(
             kind: any(named: 'kind'),
@@ -689,24 +692,26 @@ void main() {
           ),
         ).thenAnswer((invocation) async {
           final kind = invocation.namedArguments[#kind] as int;
-          final event = createTestEvent(
+          timeline.add('sign:$kind');
+          return createTestEvent(
             pubkey: testPublicKey,
             kind: kind,
             tags: const [],
             content: 'deletion',
-            createdAt: 100 + signedEvents.length,
           );
-          signedEvents.add(event);
-          return event;
         });
-        final publishedEvents = <Event>[];
+        void recordPublish(Invocation invocation) {
+          final event = invocation.positionalArguments.single as Event;
+          timeline.add('publish:${event.kind}');
+        }
+
         when(
           () => mockNostrService.publishEventAwaitOk(
             any(),
             targetRelays: any(named: 'targetRelays'),
           ),
         ).thenAnswer((invocation) async {
-          publishedEvents.add(invocation.positionalArguments.single as Event);
+          recordPublish(invocation);
           return _confirmed;
         });
         when(
@@ -715,24 +720,21 @@ void main() {
             timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((invocation) async {
-          publishedEvents.add(invocation.positionalArguments.single as Event);
+          recordPublish(invocation);
           return _confirmed;
         });
 
         final result = await service.deleteAccount();
 
         expect(result.success, isTrue);
-        expect(signedEvents.map((event) => event.kind), [5, 5, 62]);
-        expect(publishedEvents.map((event) => event.kind), [5, 5, 62]);
-        expect(
-          signedEvents.last.createdAt,
-          greaterThanOrEqualTo(
-            signedEvents
-                .take(2)
-                .map((event) => event.createdAt)
-                .reduce((first, second) => first > second ? first : second),
-          ),
-        );
+        expect(timeline, [
+          'sign:5',
+          'sign:5',
+          'sign:62',
+          'publish:5',
+          'publish:5',
+          'publish:62',
+        ]);
       },
     );
 

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -767,6 +767,10 @@ void main() {
           find.text(_englishL10n().accountDeletionCancelAttemptBody),
           findsOneWidget,
         );
+        verifyNever(
+          () =>
+              authService.signOut(deleteKeys: true, deleteLocalUserData: true),
+        );
       },
     );
 
@@ -1157,6 +1161,9 @@ void main() {
           ).accountDeletionRecoveryBody,
         ),
         findsOneWidget,
+      );
+      verifyNever(
+        () => authService.signOut(deleteKeys: true, deleteLocalUserData: true),
       );
     });
 


### PR DESCRIPTION
Account deletion could publish irreversible per-content deletion requests and only afterward discover that the signer could not create the network-wide vanish request. That left content tombstoned while the account deletion itself failed.

This change prepares and signs every required kind-5 fallback request first, then signs the kind-62 vanish with an equal or later timestamp, and begins publishing only after all signatures exist. The existing publish order remains kind-5 followed by kind-62, so the vanish timestamp still covers the prepared fallback requests.

This deliberately changes signer-failure handling: if any fallback request cannot be signed, deletion stops before publishing anything and the user can retry. Relay confirmation, retries, account-switch guards, and partial-sweep reporting after publishing begins remain unchanged.

The kind-62 deletion boundary is fixed when signing completes, before the prepared sweep is published. A user-authored event published during an unusually long sweep could therefore fall after that boundary. The flow accepts that bounded window so signer failure can never follow an irreversible publish; it does not add a second signing dependency after publishing starts.

It also pins the recovery guarantee at the dialog boundary: an unconfirmed vanish never signs out with local-key deletion.

Verification:
- `flutter test test/services/account_deletion_service_test.dart test/widgets/delete_account_dialog_test.dart`
- `flutter analyze`
- service size, Nostr identifier logging, and pubkey logging ratchets
- repository pre-push checks

Closes #6215
