### PR TITLE
test: replace wall-clock budgets with assertions that measure the code

### DIFF
--- a/mobile/test/helpers/video_feed_builder_streaming_test.dart
+++ b/mobile/test/helpers/video_feed_builder_streaming_test.dart
@@ -4,11 +4,13 @@
 import 'dart:async';
 import 'dart:ui';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/helpers/video_feed_builder.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/state/video_feed_state.dart';
 
 class _MockVideoEventService extends Mock implements VideoEventService {}
 
@@ -35,7 +37,7 @@ void main() {
       builder = VideoFeedBuilder(mockService);
     });
 
-    test('buildFeed returns immediately with available videos', () async {
+    test('buildFeed returns immediately with available videos', () {
       final videos = [_createMockVideo(id: 'v1'), _createMockVideo(id: 'v2')];
       final config = VideoFeedConfig(
         subscriptionType: SubscriptionType.discovery,
@@ -44,14 +46,18 @@ void main() {
         sortVideos: (videos) => videos,
       );
 
-      final stopwatch = Stopwatch()..start();
-      final state = await builder.buildFeed(config: config);
-      stopwatch.stop();
+      VideoFeedState? state;
 
-      expect(state.videos.length, 2);
-      expect(state.isInitialLoad, isFalse);
-      // Should be nearly instant (no stability wait)
-      expect(stopwatch.elapsedMilliseconds, lessThan(100));
+      fakeAsync((async) {
+        builder.buildFeed(config: config).then((value) => state = value);
+        // Drains microtasks without advancing the clock, so a reintroduced
+        // stability wait leaves `state` null rather than merely slow.
+        async.flushMicrotasks();
+
+        expect(state, isNotNull, reason: 'buildFeed awaited a timer');
+        expect(state!.videos.length, 2);
+        expect(state!.isInitialLoad, isFalse);
+      });
     });
 
     test('buildFeed returns isInitialLoad state when no videos yet', () async {

--- a/mobile/test/helpers/video_feed_builder_test.dart
+++ b/mobile/test/helpers/video_feed_builder_test.dart
@@ -1,11 +1,13 @@
 // ABOUTME: Tests for VideoFeedBuilder helper class that encapsulates common feed logic
 // ABOUTME: Validates debouncing, streaming return, and state management patterns
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/helpers/video_feed_builder.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/state/video_feed_state.dart';
 
 class _MockVideoEventService extends Mock implements VideoEventService {}
 
@@ -77,7 +79,7 @@ void main() {
         },
       );
 
-      test('should return immediately without waiting for stability', () async {
+      test('should return immediately without waiting for stability', () {
         // Arrange - subscribe adds videos asynchronously but buildFeed
         // should NOT wait for them
         final config = VideoFeedConfig(
@@ -87,15 +89,20 @@ void main() {
           sortVideos: (videos) => videos,
         );
 
-        // Act
-        final stopwatch = Stopwatch()..start();
-        final state = await builder.buildFeed(config: config);
-        stopwatch.stop();
+        VideoFeedState? state;
 
-        // Assert - should return nearly instantly (no 300ms+ stability wait)
-        expect(stopwatch.elapsedMilliseconds, lessThan(100));
-        expect(state.videos, isEmpty);
-        expect(state.isInitialLoad, isTrue);
+        fakeAsync((async) {
+          // Act
+          builder.buildFeed(config: config).then((value) => state = value);
+          // Drains microtasks without advancing the clock, so a reintroduced
+          // stability wait leaves `state` null rather than merely slow.
+          async.flushMicrotasks();
+
+          // Assert - resolved with no elapsed time at all
+          expect(state, isNotNull, reason: 'buildFeed awaited a timer');
+          expect(state!.videos, isEmpty);
+          expect(state!.isInitialLoad, isTrue);
+        });
       });
 
       test('should set isInitialLoad true when no videos available', () async {

--- a/mobile/test/services/curated_list_service_initialization_test.dart
+++ b/mobile/test/services/curated_list_service_initialization_test.dart
@@ -284,12 +284,14 @@ void main() {
           prefs: prefs,
         );
 
-        // Initialize should complete quickly
-        final stopwatch = Stopwatch()..start();
-        await service.initialize();
-        stopwatch.stop();
+        // The property under test is that initialize() does not wait on the
+        // relay. Nothing completes relayResponseCompleter until further down,
+        // so a version that waited would hang here; the timeout turns that
+        // into a fast, attributable failure rather than a stalled suite. It
+        // is a liveness bound, not a performance budget — do not tighten it
+        // toward the observed runtime.
+        await service.initialize().timeout(const Duration(seconds: 5));
 
-        expect(stopwatch.elapsedMilliseconds, lessThan(100));
         expect(service.isInitialized, isTrue);
 
         // Now simulate relay returning a new list

--- a/mobile/test/services/curated_list_service_initialization_test.dart
+++ b/mobile/test/services/curated_list_service_initialization_test.dart
@@ -294,6 +294,19 @@ void main() {
 
         expect(service.isInitialized, isTrue);
 
+        final relayListMerged = Completer<void>();
+        void completeWhenRelayListIsMerged() {
+          if (!relayListMerged.isCompleted &&
+              service.lists.any((list) => list.id == 'relay_list_id')) {
+            relayListMerged.complete();
+          }
+        }
+
+        service.addListener(completeWhenRelayListIsMerged);
+        addTearDown(
+          () => service.removeListener(completeWhenRelayListIsMerged),
+        );
+
         // Now simulate relay returning a new list
         final relayEvent = Event.fromJson({
           'id': 'relay_event_id',
@@ -310,11 +323,11 @@ void main() {
 
         relayResponseCompleter.complete(relayEvent);
 
-        // Give time for background sync to process
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-
-        // The relay list should now be merged into local lists
-        // (This tests that background sync is working)
+        await relayListMerged.future.timeout(const Duration(seconds: 5));
+        expect(
+          service.lists.singleWhere((list) => list.id == 'relay_list_id').name,
+          'List From Relay',
+        );
       },
     );
   });

--- a/mobile/test/services/curated_list_service_query_test.dart
+++ b/mobile/test/services/curated_list_service_query_test.dart
@@ -510,8 +510,8 @@ void main() {
         expect(tags.contains(''), isTrue); // Service doesn't filter empty tags
       });
 
-      test('search performance with many lists', () async {
-        // Create 50 lists
+      test('matches on description across a large list set', () async {
+        // Create 50 lists; only the even-numbered ones are described 'even'.
         for (var i = 0; i < 50; i++) {
           await service.createList(
             name: 'List $i',
@@ -520,15 +520,13 @@ void main() {
           );
         }
 
-        final stopwatch = Stopwatch()..start();
         final results = service.searchLists('even');
-        stopwatch.stop();
 
+        // Exactly the 25 even-numbered lists, and none of the odd ones.
         expect(
-          results.length,
-          greaterThanOrEqualTo(25),
-        ); // Should find at least 25
-        expect(stopwatch.elapsedMilliseconds, lessThan(100)); // Should be fast
+          results.map((list) => list.name).toSet(),
+          {for (var i = 0; i < 50; i += 2) 'List $i'},
+        );
       });
     });
 

--- a/mobile/test/services/curated_list_service_query_test.dart
+++ b/mobile/test/services/curated_list_service_query_test.dart
@@ -523,10 +523,10 @@ void main() {
         final results = service.searchLists('even');
 
         // Exactly the 25 even-numbered lists, and none of the odd ones.
-        expect(
-          results.map((list) => list.name).toSet(),
-          {for (var i = 0; i < 50; i += 2) 'List $i'},
-        );
+        expect(results, hasLength(25));
+        expect(results.map((list) => list.name).toSet(), {
+          for (var i = 0; i < 50; i += 2) 'List $i',
+        });
       });
     });
 
@@ -534,9 +534,7 @@ void main() {
       test('finishes and releases the source subscription on EOSE', () async {
         void Function()? onEose;
         var canceled = false;
-        final source = StreamController<Event>(
-          onCancel: () => canceled = true,
-        );
+        final source = StreamController<Event>(onCancel: () => canceled = true);
         addTearDown(source.close);
         when(
           () => mockNostr.subscribe(


### PR DESCRIPTION
## Description

Four tests asserted a **hard wall-clock budget** — `expect(stopwatch.elapsedMilliseconds, lessThan(100))` — as a stand-in for a property that is not about elapsed time at all. Under `very_good test --optimization --concurrency=4` the whole suite shares four vCPUs, so those budgets measure the machine, not the code: correct code loses them under contention, and slow code passes them on an idle runner.

I hit exactly that while verifying #8354 — `curated_list_service_query_test` → `search performance with many lists` failed one merged run and passed the re-run at the identical seed. Same tree, same ordering, both outcomes. There is no tracking issue for any of these.

Each replacement states the real property, and each was **verified by mutation** — the assertion is only worth keeping if it can still fail.

**`video_feed_builder_test` and `video_feed_builder_streaming_test` → `fakeAsync`.**
Both exist to prove `buildFeed` returns without the 300ms+ stability wait it used to have. `fakeAsync`'s `flushMicrotasks()` drains microtasks without advancing the clock, so the future must resolve at zero elapsed virtual time. That is strictly stronger than the old bound — "no timer at all" rather than "under 100ms" — and contention cannot reach it.
*Mutation:* re-adding a 300ms delay to `VideoFeedBuilder.buildFeed` fails both, with the intended `buildFeed awaited a timer` reason.

**`curated_list_service_query_test` → assert the result set.**
`results.length >= 25` passes for any superset, including one where the filter stopped discriminating; the stopwatch added nothing on 50 in-memory items. `createList` defaults `isPublic: true` and only even-numbered lists are described `"even number"`, so the answer is exactly the 25 even-numbered lists. Renamed to match what it now checks.
*Mutation:* disabling the description branch of `searchLists` fails it.

**`curated_list_service_initialization_test` → a liveness bound.**
The property is that `initialize()` does not block on the relay, whose stream is a `Completer` nothing completes until later in the test — so a blocking version hangs. `.timeout(const Duration(seconds: 5))` expresses that with an unbounded margin instead of 6ms, and turns a regression into a fast attributable failure rather than a stalled suite.
*Mutation:* making `initialize()` await a never-completing future fails it in 5s with `TimeoutException ... Future not completed`, where it previously hung the whole file.

**Related Issue:** Relates to #8290

## Out of Scope

The two remaining `elapsedMilliseconds` assertions in `mobile/test/config/bug_report_config_test.dart` are **deliberately left alone**. They are ReDoS smoke thresholds, not performance budgets: 94ms against a 2000ms ceiling, ~0ms against 1000ms, guarding failures measured at 18.6s and ~17s. Their own comments say so and explicitly warn against tightening them toward the observed number. The margin is three orders of magnitude, so contention cannot trip them, and removing them would delete catastrophic-backtracking protection.

## Verification

- The four files: 53 tests pass.
- Three mutation tests, each applied to `lib/` and reverted, confirming every new assertion still fails for the right reason (details above).
- `flutter analyze lib test integration_test` → No issues found.
- `dart format` on changed files → 0 changed.
- `very_good test --optimization --concurrency=4 --exclude-tags "integration || golden"` at seed 2624071836 — the seed the old assertion flaked on.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
