### PR TITLE
fix(dm): derive the live DM since: window in the clock the relay filters

### DIFF
--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -605,8 +605,9 @@ Future<BookmarksRepository> bookmarksRepository(Ref ref) async {
 ///
 /// Cold-start cost is bounded by two existing mechanisms that landed with
 /// the original lazy-inbox work (#2766):
-/// - The `since: newestSyncedAt - 2d` filter in [DmRepository.startListening]
-///   limits the relay backlog to recent events on every open after the first.
+/// - The `(newestWireSyncedAt ?? newestSyncedAt) - 2d` filter in
+///   [DmRepository.startListening] limits the relay backlog to recent events
+///   on every open after the first.
 /// - Decryption is offloaded to a background isolate via
 ///   `dm_decryption_worker.dart`, keeping the UI thread responsive.
 ///
@@ -750,7 +751,8 @@ DmRepository dmRepository(Ref ref) {
         messageService: messageService,
       );
       // Open the gift-wrap subscription for the whole authenticated
-      // session. Bounded by `since: newestSyncedAt - 2d` and isolate
+      // session. Bounded by
+      // `since: (newestWireSyncedAt ?? newestSyncedAt) - 2d` and isolate
       // decrypt so cold start stays cheap regardless of lifetime DM count.
       unawaited(repository.startListening());
       // Self-advertise the user's NIP-17 kind-10050 DM inbox relay list once

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -845,8 +845,9 @@ String _$bookmarksRepositoryHash() =>
 ///
 /// Cold-start cost is bounded by two existing mechanisms that landed with
 /// the original lazy-inbox work (#2766):
-/// - The `since: newestSyncedAt - 2d` filter in [DmRepository.startListening]
-///   limits the relay backlog to recent events on every open after the first.
+/// - The `(newestWireSyncedAt ?? newestSyncedAt) - 2d` filter in
+///   [DmRepository.startListening] limits the relay backlog to recent events
+///   on every open after the first.
 /// - Decryption is offloaded to a background isolate via
 ///   `dm_decryption_worker.dart`, keeping the UI thread responsive.
 ///
@@ -872,8 +873,9 @@ final dmReactionsRepositoryProvider = DmReactionsRepositoryProvider._();
 ///
 /// Cold-start cost is bounded by two existing mechanisms that landed with
 /// the original lazy-inbox work (#2766):
-/// - The `since: newestSyncedAt - 2d` filter in [DmRepository.startListening]
-///   limits the relay backlog to recent events on every open after the first.
+/// - The `(newestWireSyncedAt ?? newestSyncedAt) - 2d` filter in
+///   [DmRepository.startListening] limits the relay backlog to recent events
+///   on every open after the first.
 /// - Decryption is offloaded to a background isolate via
 ///   `dm_decryption_worker.dart`, keeping the UI thread responsive.
 ///
@@ -904,8 +906,9 @@ final class DmReactionsRepositoryProvider
   ///
   /// Cold-start cost is bounded by two existing mechanisms that landed with
   /// the original lazy-inbox work (#2766):
-  /// - The `since: newestSyncedAt - 2d` filter in [DmRepository.startListening]
-  ///   limits the relay backlog to recent events on every open after the first.
+  /// - The `(newestWireSyncedAt ?? newestSyncedAt) - 2d` filter in
+  ///   [DmRepository.startListening] limits the relay backlog to recent events
+  ///   on every open after the first.
   /// - Decryption is offloaded to a background isolate via
   ///   `dm_decryption_worker.dart`, keeping the UI thread responsive.
   ///

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3223,9 +3223,16 @@ class DmRepository {
       // it advances both boundaries. The live subscription's `since:` covers
       // kinds [1059, 4, 5] with one filter, so the wire boundary has to track
       // whichever kind carried the newest wire stamp. See #8209.
-      await _syncState?.recordSeen(_userPubkey, createdAt: persistedCreatedAt);
+      // Scoped to the delivering account, not whichever is current after the
+      // decrypt and transaction return: this handler has no generation guard
+      // to abandon on, and a switch inside that window would import this
+      // stamp into the next account's maximum, narrowing its `since:`.
+      await _syncState?.recordSeen(
+        ownerPubkey,
+        createdAt: persistedCreatedAt,
+      );
       await _syncState?.recordWireSeen(
-        _userPubkey,
+        ownerPubkey,
         createdAt: nip04Event.createdAt,
       );
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3222,7 +3222,7 @@ class DmRepository {
       await _syncState?.recordSeen(_userPubkey, createdAt: persistedCreatedAt);
       await _syncState?.recordWireSeen(
         _userPubkey,
-        createdAt: persistedCreatedAt,
+        createdAt: nip04Event.createdAt,
       );
 
       Log.debug(

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2107,6 +2107,17 @@ class DmRepository {
     try {
       // Dedup: skip if already processed (message row or ledger). #5452.
       if (await _alreadyProcessed(giftWrapEvent.id)) {
+        // Still advance the wire boundary. A duplicate is by definition a
+        // wrap we have processed, so its outer stamp belongs in the maximum
+        // this boundary tracks, and without this an install that upgraded
+        // into the #8209 fix keeps the old eroded window until its next
+        // genuinely new message — every wrap already in the window returns
+        // here first. Monotonic, so the drain replaying old pages cannot
+        // drag it backwards.
+        await _syncState?.recordWireSeen(
+          ownerPubkey,
+          createdAt: giftWrapEvent.createdAt,
+        );
         // History drain pass 2 re-routes already-persisted wraps through this
         // handler (preDecrypted miss). Per-wrap debug would fill the 50k
         // capture ring and evict the persist lines that diagnose #7631.
@@ -2973,6 +2984,13 @@ class DmRepository {
       // suppressed by a removed-conversation tombstone, so replays skip
       // decryption entirely — matching the terminal NIP-17 behavior. #7804.
       if (await _alreadyProcessed(nip04Event.id)) {
+        // Advance the wire boundary for the same reason the gift-wrap dedup
+        // path does. A kind 4 is its own envelope, so the stamp the relay
+        // filtered to deliver this replay is the event's own `created_at`.
+        await _syncState?.recordWireSeen(
+          _userPubkey,
+          createdAt: nip04Event.createdAt,
+        );
         if (_historyDrain == null) {
           Log.debug(
             'Skipping already-processed NIP-04 event ${nip04Event.id}',

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2980,6 +2980,7 @@ class DmRepository {
   }
 
   Future<void> _handleNip04Event(Event nip04Event) async {
+    final ownerPubkey = _userPubkey;
     try {
       // Dedup: use event ID as giftWrapId for the unique index. The
       // processed-wraps ledger also carries NIP-04 event ids that were
@@ -2990,7 +2991,7 @@ class DmRepository {
         // path does. A kind 4 is its own envelope, so the stamp the relay
         // filtered to deliver this replay is the event's own `created_at`.
         await _syncState?.recordWireSeen(
-          _userPubkey,
+          ownerPubkey,
           createdAt: nip04Event.createdAt,
         );
         if (_historyDrain == null) {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -892,7 +892,27 @@ class DmRepository {
       // filter. The 2-day overlap absorbs NIP-17 randomized created_at
       // jitter (gift wraps tweak their outer created_at within a ~2 day
       // window). See docs/plans/2026-04-05-dm-scaling-fix-design.md.
+      //
+      // The boundary must come from the clock the relay filters in. A relay
+      // evaluates `since:` against the stamp on the event it stored — the
+      // outer kind-1059 wrap, never the inner rumor — and NIP-17 requires
+      // that outer stamp to be backdated by a random 0..2 days. Deriving the
+      // boundary from the rumor clock therefore consumes part of the 2-day
+      // overlap before the window opens, and a wrap whose backdate exceeds
+      // the remainder is dropped by the relay. Nothing asks for it again:
+      // `newestWireSyncedAt` only advances, so `since:` only rises, and the
+      // history drain that would otherwise repair the gap latches complete.
+      // The measured erosion equals the newest wrap's own backdate, which is
+      // uniform on [0, 2d) — half the intended margin, on average. See #8209.
+      //
+      // Falling back to the rumor boundary keeps the previous behavior for an
+      // install that has not processed an event since upgrading. The fallback
+      // can only ever widen: for any single event the wire stamp is at or
+      // below the rumor stamp, so `newestWireSyncedAt <= newestSyncedAt` and
+      // the derived `since:` never moves later than it does today.
       final newest = _syncState?.newestSyncedAt(_userPubkey);
+      final newestWire = _syncState?.newestWireSyncedAt(_userPubkey);
+      final sinceBoundary = newestWire ?? newest;
       final isFirstOpen = newest == null;
       final filter = nostr_filter.Filter(
         kinds: [
@@ -902,7 +922,7 @@ class DmRepository {
         ],
         p: [_userPubkey],
         limit: isFirstOpen ? 50 : null,
-        since: isFirstOpen ? null : (newest - 2 * 86400),
+        since: isFirstOpen ? null : (sinceBoundary! - 2 * 86400),
       );
 
       Log.info(
@@ -2502,10 +2522,18 @@ class DmRepository {
         return;
       }
 
-      // Advance sync boundaries from the bounded local timestamp. The outer
-      // gift wrap randomizes its own created_at within a ~2 day window
-      // (NIP-17) so it must not be used for boundary tracking.
+      // Advance sync boundaries in BOTH clocks, because they answer two
+      // different questions. The rumor timestamp is the honest send time the
+      // UI orders by, and its randomized outer wrap must not be used for
+      // that. But the relay indexes and filters the outer stamp, so the live
+      // subscription's `since:` has to be derived from that one instead —
+      // recording only the rumor clock is what made a backdated wrap fall
+      // outside the window and never be requested again. See #8209.
       await _syncState?.recordSeen(ownerPubkey, createdAt: persistedCreatedAt);
+      await _syncState?.recordWireSeen(
+        ownerPubkey,
+        createdAt: giftWrapEvent.createdAt,
+      );
 
       Log.debug(
         'Persisted NIP-17 DM ${rumor.id} (kind ${rumor.kind}) in conversation '
@@ -3169,8 +3197,16 @@ class DmRepository {
 
       // NIP-04 created_at values are not randomized (unlike NIP-17 gift
       // wraps), so this bounded timestamp is a real send time and safe to
-      // record as a cursor.
+      // record as a cursor. A kind 4 is its own envelope — the stamp the
+      // relay filters and the stamp the UI orders by are the same value — so
+      // it advances both boundaries. The live subscription's `since:` covers
+      // kinds [1059, 4, 5] with one filter, so the wire boundary has to track
+      // whichever kind carried the newest wire stamp. See #8209.
       await _syncState?.recordSeen(_userPubkey, createdAt: persistedCreatedAt);
+      await _syncState?.recordWireSeen(
+        _userPubkey,
+        createdAt: persistedCreatedAt,
+      );
 
       Log.debug(
         'Persisted NIP-04 DM ${nip04Event.id} '

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -720,7 +720,8 @@ class DmRepository {
   /// separately by the provider via [startListening] right after this
   /// returns, so DM ingestion runs for the whole authenticated session.
   /// Cold-start cost stays bounded thanks to the count-based windowing
-  /// (`since: newestSyncedAt - 2d`) and the isolate decryption worker.
+  /// (`since: (newestWireSyncedAt ?? newestSyncedAt) - 2d`) and the isolate
+  /// decryption worker.
   /// See docs/plans/2026-04-05-dm-scaling-fix-design.md and #2931.
   ///
   /// Safe to call multiple times — subsequent calls for the same user are

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -907,10 +907,12 @@ class DmRepository {
       // uniform on [0, 2d) — half the intended margin, on average. See #8209.
       //
       // Falling back to the rumor boundary keeps the previous behavior for an
-      // install that has not processed an event since upgrading. The fallback
-      // can only ever widen: for any single event the wire stamp is at or
-      // below the rumor stamp, so `newestWireSyncedAt <= newestSyncedAt` and
-      // the derived `since:` never moves later than it does today.
+      // install that has not processed an event since upgrading. A delayed
+      // retry may re-wrap an old rumor with a recent wire stamp, so switching
+      // to the wire boundary can narrow that fallback window. It still keeps
+      // the full required overlap in the relay's clock: a compliant wrap's
+      // wire stamp is at most its publication time, and every later compliant
+      // wrap is stamped no earlier than its publication time minus two days.
       final newest = _syncState?.newestSyncedAt(_userPubkey);
       final newestWire = _syncState?.newestWireSyncedAt(_userPubkey);
       final isFirstOpen = newest == null;

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -912,7 +912,6 @@ class DmRepository {
       // the derived `since:` never moves later than it does today.
       final newest = _syncState?.newestSyncedAt(_userPubkey);
       final newestWire = _syncState?.newestWireSyncedAt(_userPubkey);
-      final sinceBoundary = newestWire ?? newest;
       final isFirstOpen = newest == null;
       final filter = nostr_filter.Filter(
         kinds: [
@@ -922,7 +921,7 @@ class DmRepository {
         ],
         p: [_userPubkey],
         limit: isFirstOpen ? 50 : null,
-        since: isFirstOpen ? null : (sinceBoundary! - 2 * 86400),
+        since: newest == null ? null : (newestWire ?? newest) - 2 * 86400,
       );
 
       Log.info(

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -108,12 +108,12 @@ class DmSyncState {
   ///
   /// [newestSyncedAt] tracks the inner NIP-59 rumor instead, because that is
   /// the honest send time the UI orders by. The two clocks are not
-  /// interchangeable: NIP-17 requires the outer wrap to be backdated by a
-  /// random 0..2 day offset, so the wire stamp trails the rumor stamp by that
-  /// offset. Deriving `since:` from the rumor clock therefore spends part of
-  /// the intended 2-day overlap before the window even opens, and any wrap
-  /// whose backdate exceeds what is left is dropped by the relay and never
-  /// requested again. See #8209.
+  /// interchangeable: NIP-17 derives the outer wrap stamp from publication
+  /// time with a random 0..2 day backdate, independently of the rumor stamp.
+  /// Deriving `since:` from the rumor clock can therefore spend part of the
+  /// intended 2-day overlap before the window even opens, and any wrap whose
+  /// backdate exceeds what is left is dropped by the relay and never requested
+  /// again. See #8209.
   int? newestWireSyncedAt(String pubkey) =>
       _prefs.getInt('$_newestWirePrefix$pubkey');
 

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -2,8 +2,10 @@
 // ABOUTME: opens can fetch only new events via a `since:` filter.
 //
 // Stores per user pubkey in SharedPreferences:
-//   - newestSyncedAt: highest `created_at` successfully processed
-//   - oldestSyncedAt: lowest `created_at` successfully processed
+//   - newestSyncedAt: highest rumor `created_at` successfully processed
+//   - newestWireSyncedAt: highest ON-THE-WIRE `created_at` processed, which
+//     is the stamp relays actually filter `since:` against
+//   - oldestSyncedAt: lowest rumor `created_at` successfully processed
 //   - historyDrainComplete: whether the one-time full-history drain is done
 //   - historyDrainCursor: the drain's resumable pagination boundary
 //
@@ -21,6 +23,7 @@ class DmSyncState {
   final SharedPreferences _prefs;
 
   static const _newestPrefix = 'dm.newestSyncedAt.';
+  static const _newestWirePrefix = 'dm.newestWireSyncedAt.';
   static const _oldestPrefix = 'dm.oldestSyncedAt.';
   static const _drainCompletePrefix = 'dm.historyDrainComplete.';
   static const _drainCursorPrefix = 'dm.historyDrainCursor.';
@@ -94,6 +97,45 @@ class DmSyncState {
   /// processed yet.
   int? oldestSyncedAt(String pubkey) => _prefs.getInt('$_oldestPrefix$pubkey');
 
+  /// Returns the newest on-the-wire `created_at` we have processed for
+  /// [pubkey], or `null` if nothing has been processed under this key yet.
+  ///
+  /// "On the wire" means the `created_at` of the event the relay actually
+  /// stored and indexes: the outer kind-1059 gift wrap for NIP-17, and the
+  /// event's own stamp for an unwrapped NIP-04 kind 4. That is the only clock
+  /// a `since:` filter is evaluated in, which is why the live subscription
+  /// derives its boundary from this and not from [newestSyncedAt].
+  ///
+  /// [newestSyncedAt] tracks the inner NIP-59 rumor instead, because that is
+  /// the honest send time the UI orders by. The two clocks are not
+  /// interchangeable: NIP-17 requires the outer wrap to be backdated by a
+  /// random 0..2 day offset, so the wire stamp trails the rumor stamp by that
+  /// offset. Deriving `since:` from the rumor clock therefore spends part of
+  /// the intended 2-day overlap before the window even opens, and any wrap
+  /// whose backdate exceeds what is left is dropped by the relay and never
+  /// requested again. See #8209.
+  int? newestWireSyncedAt(String pubkey) =>
+      _prefs.getInt('$_newestWirePrefix$pubkey');
+
+  /// Records that an event carrying wire timestamp [createdAt] has been
+  /// successfully processed for [pubkey], advancing [newestWireSyncedAt]
+  /// monotonically upward.
+  ///
+  /// Clamped to now for the same reason [recordSeen] is. The outer wrap is
+  /// signed, but only by a throwaway NIP-59 ephemeral key, so the signature
+  /// proves who chose the stamp and not that the stamp is honest — a wrap
+  /// stamped in the future would otherwise push `since:` past every event a
+  /// relay could return and blackhole the inbox exactly as an unbounded rumor
+  /// timestamp once did.
+  Future<void> recordWireSeen(String pubkey, {required int createdAt}) async {
+    final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final capped = createdAt.clamp(minPlausibleCreatedAt, nowSec);
+    final newest = newestWireSyncedAt(pubkey);
+    if (newest == null || capped > newest) {
+      await _prefs.setInt('$_newestWirePrefix$pubkey', capped);
+    }
+  }
+
   /// Records that a DM with the given [createdAt] unix seconds has been
   /// successfully processed for [pubkey]. Advances `newestSyncedAt`
   /// upward and `oldestSyncedAt` downward monotonically — older events
@@ -145,6 +187,12 @@ class DmSyncState {
     final newest = newestSyncedAt(pubkey);
     if (newest != null && newest > nowSec) {
       await _prefs.setInt('$_newestPrefix$pubkey', nowSec);
+      repaired = true;
+    }
+
+    final newestWire = newestWireSyncedAt(pubkey);
+    if (newestWire != null && newestWire > nowSec) {
+      await _prefs.setInt('$_newestWirePrefix$pubkey', nowSec);
       repaired = true;
     }
 
@@ -250,6 +298,7 @@ class DmSyncState {
   /// Removes all sync state for [pubkey]. Called on account switch.
   Future<void> clear(String pubkey) async {
     await _prefs.remove('$_newestPrefix$pubkey');
+    await _prefs.remove('$_newestWirePrefix$pubkey');
     await _prefs.remove('$_oldestPrefix$pubkey');
     await _prefs.remove('$_drainCompletePrefix$pubkey');
     await _prefs.remove('$_drainCursorPrefix$pubkey');
@@ -267,6 +316,7 @@ class DmSyncState {
         .where(
           (key) =>
               key.startsWith(_newestPrefix) ||
+              key.startsWith(_newestWirePrefix) ||
               key.startsWith(_oldestPrefix) ||
               key.startsWith(_drainCompletePrefix) ||
               key.startsWith(_drainCursorPrefix) ||

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -2615,6 +2615,9 @@ void main() {
         expect(syncState.recorded, hasLength(1));
         expect(syncState.recorded.single.pubkey, _validPubkeyA);
         expect(syncState.recorded.single.createdAt, nip04CreatedAt);
+        expect(syncState.recordedWire, hasLength(1));
+        expect(syncState.recordedWire.single.pubkey, _validPubkeyA);
+        expect(syncState.recordedWire.single.createdAt, nip04CreatedAt);
 
         await controller.close();
         await repository.stopListening();
@@ -11000,7 +11003,7 @@ void main() {
         await repository.stopListening();
       });
 
-      test('skips duplicate NIP-04 events', () async {
+      test('duplicate NIP-04 events still advance the wire boundary', () async {
         final nip04Event = createNip04Event();
 
         when(
@@ -11015,8 +11018,10 @@ void main() {
           ),
         ).thenAnswer((_) => controller.stream);
 
+        final syncState = _FakeDmSyncState();
         final repository = createRepository(
           nip04Decryptor: (_, _) async => 'should not reach',
+          syncState: syncState,
         );
 
         await repository.startListening();
@@ -11049,6 +11054,10 @@ void main() {
             sendBatchId: any(named: 'sendBatchId'),
           ),
         );
+        expect(syncState.recordedWire, hasLength(1));
+        expect(syncState.recordedWire.single.pubkey, _validPubkeyA);
+        expect(syncState.recordedWire.single.createdAt, nip04Event.createdAt);
+        expect(syncState.recorded, isEmpty);
 
         await controller.close();
         await repository.stopListening();

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -4162,6 +4162,7 @@ void main() {
                     ),
                   ).captured.single
                   as List<nostr_filter.Filter>;
+          expect(captured.single.since, wireNewest - 2 * 86400);
           expect(captured.single.since, lessThanOrEqualTo(worstCaseOuter));
 
           await repository.stopListening();
@@ -11064,6 +11065,64 @@ void main() {
         await controller.close();
         await repository.stopListening();
       });
+
+      test(
+        'duplicate NIP-04 wire boundary stays scoped to the event owner during '
+        'an account switch',
+        () async {
+          final nip04Event = createNip04Event();
+          final dedupStarted = Completer<void>();
+          final dedupResult = Completer<bool>();
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(_rumorEventId),
+          ).thenAnswer((_) {
+            dedupStarted.complete();
+            return dedupResult.future;
+          });
+
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final syncState = _FakeDmSyncState();
+          final repository = createRepository(
+            nip04Decryptor: (_, _) async => 'should not reach',
+            syncState: syncState,
+          );
+
+          await repository.startListening();
+          controller.add(nip04Event);
+          await dedupStarted.future;
+
+          final nextUserSelfConversationId = DmRepository.computeConversationId(
+            [_validPubkeyB, _validPubkeyB],
+          );
+          when(
+            () => mockConversationsDao.getConversation(
+              nextUserSelfConversationId,
+              ownerPubkey: _validPubkeyB,
+            ),
+          ).thenAnswer((_) async => null);
+          repository.setCredentials(
+            userPubkey: _validPubkeyB,
+            signer: LocalNostrSigner(_validPrivateKey),
+            messageService: mockMessageService,
+          );
+          dedupResult.complete(true);
+          await Future<void>.delayed(Duration.zero);
+
+          expect(syncState.recordedWire, hasLength(1));
+          expect(syncState.recordedWire.single.pubkey, _validPubkeyA);
+          expect(syncState.recordedWire.single.createdAt, nip04Event.createdAt);
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
 
       test('skips NIP-04 events with no p tag', () async {
         final nip04Event = createNip04Event(tags: []);

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -390,6 +390,7 @@ class _GatedPubkeySigner implements NostrSigner {
 /// [recordSeen] calls for assertions.
 class _FakeDmSyncState implements DmSyncState {
   int? newestOverride;
+  int? newestWireOverride;
   int? oldestOverride;
   bool drainCompleteOverride = false;
   int? drainCursorOverride;
@@ -400,9 +401,14 @@ class _FakeDmSyncState implements DmSyncState {
   final List<String> repairedPubkeys = <String>[];
   final List<({String pubkey, int createdAt})> recorded =
       <({String pubkey, int createdAt})>[];
+  final List<({String pubkey, int createdAt})> recordedWire =
+      <({String pubkey, int createdAt})>[];
 
   @override
   int? newestSyncedAt(String pubkey) => newestOverride;
+
+  @override
+  int? newestWireSyncedAt(String pubkey) => newestWireOverride;
 
   @override
   int? oldestSyncedAt(String pubkey) => oldestOverride;
@@ -464,6 +470,14 @@ class _FakeDmSyncState implements DmSyncState {
   @override
   Future<void> markDmRelayListPublished(String pubkey) async {
     dmRelayListPublishedPubkeys.add(pubkey);
+  }
+
+  @override
+  Future<void> recordWireSeen(String pubkey, {required int createdAt}) async {
+    recordedWire.add((pubkey: pubkey, createdAt: createdAt));
+    if (newestWireOverride == null || createdAt > newestWireOverride!) {
+      newestWireOverride = createdAt;
+    }
   }
 
   @override
@@ -2465,6 +2479,58 @@ void main() {
         await repository.stopListening();
       });
 
+      test(
+        'gift-wrap persist records the OUTER wrap stamp as the wire '
+        'boundary, not the rumor stamp (#8209)',
+        () async {
+          // The fixture wrap is stamped 500s below its rumor, standing in for
+          // the NIP-17 backdate. `since:` is filtered by the relay against the
+          // outer stamp, so tracking only the rumor clock leaves the window
+          // starting 500s above the event it is meant to include.
+          const rumorCreatedAt = 1700000500;
+          const outerCreatedAt = 1700000000;
+          final giftWrap = createGiftWrapEvent();
+          expect(
+            giftWrap.createdAt,
+            outerCreatedAt,
+            reason: 'fixture must keep the outer stamp below the rumor',
+          );
+          final rumor = createRumorEvent(createdAt: rumorCreatedAt);
+
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(_giftWrapEventId),
+          ).thenAnswer((_) async => false);
+          stubDaoInserts();
+
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final syncState = _FakeDmSyncState();
+          final repository = createRepository(
+            rumorDecryptor: (_, _) async => rumor,
+            syncState: syncState,
+          );
+
+          await repository.startListening();
+          controller.add(giftWrap);
+          await Future<void>.delayed(Duration.zero);
+
+          expect(syncState.recordedWire, hasLength(1));
+          expect(syncState.recordedWire.single.pubkey, _validPubkeyA);
+          expect(syncState.recordedWire.single.createdAt, outerCreatedAt);
+          // The rumor boundary keeps the honest send time the UI orders by.
+          expect(syncState.recorded.single.createdAt, rumorCreatedAt);
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
+
       test('successful NIP-04 persist advances sync boundaries', () async {
         const nip04CreatedAt = 1700000600;
         final nip04Event = Event.fromJson({
@@ -3967,6 +4033,89 @@ void main() {
           expect(captured, hasLength(1));
           expect(captured.single.since, newest - 2 * 86400);
           expect(captured.single.limit, isNull);
+
+          await repository.stopListening();
+          await controller.close();
+        },
+      );
+
+      test(
+        'startListening derives since from the WIRE boundary, not the rumor '
+        'boundary, once one has been recorded (#8209)',
+        () async {
+          // One NIP-17 message: honest send time in the rumor, outer wrap
+          // backdated a day per NIP-17. A relay evaluates `since:` against the
+          // outer stamp, so deriving the window from the rumor clock starts it
+          // a day above the events it is supposed to admit.
+          const rumorNewest = 1700000000;
+          const wireNewest = rumorNewest - 86400;
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final syncState = _FakeDmSyncState()
+            ..newestOverride = rumorNewest
+            ..newestWireOverride = wireNewest;
+          final repository = createRepository(syncState: syncState);
+          await repository.startListening();
+
+          final captured =
+              verify(
+                    () => mockNostrClient.subscribe(
+                      captureAny(),
+                      subscriptionId: any(named: 'subscriptionId'),
+                    ),
+                  ).captured.single
+                  as List<nostr_filter.Filter>;
+          expect(captured.single.since, wireNewest - 2 * 86400);
+
+          await repository.stopListening();
+          await controller.close();
+        },
+      );
+
+      test(
+        'since leaves the whole 2-day overlap below the wire boundary, so a '
+        'wrap carrying the maximum NIP-17 backdate still matches (#8209)',
+        () async {
+          // The invariant the window has to hold: our newest processed wrap
+          // was stamped at or below the moment it was published, so any wrap
+          // published from that moment onward — even one backdated the full
+          // two days NIP-17 allows — is at or above `wire - 2d`. Deriving the
+          // boundary from the rumor clock breaks it, because the rumor stamp
+          // sits above the wire stamp by that wrap's own backdate.
+          const publishedAt = 1700000000;
+          const wireNewest = publishedAt - 3600;
+          const rumorNewest = publishedAt + 86400;
+          const worstCaseOuter = publishedAt - 2 * 86400;
+
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final syncState = _FakeDmSyncState()
+            ..newestOverride = rumorNewest
+            ..newestWireOverride = wireNewest;
+          final repository = createRepository(syncState: syncState);
+          await repository.startListening();
+
+          final captured =
+              verify(
+                    () => mockNostrClient.subscribe(
+                      captureAny(),
+                      subscriptionId: any(named: 'subscriptionId'),
+                    ),
+                  ).captured.single
+                  as List<nostr_filter.Filter>;
+          expect(captured.single.since, lessThanOrEqualTo(worstCaseOuter));
 
           await repository.stopListening();
           await controller.close();

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -11124,6 +11124,63 @@ void main() {
         },
       );
 
+      test(
+        'persisted NIP-04 boundaries stay scoped to the event owner during '
+        'an account switch',
+        () async {
+          final nip04Event = createNip04Event();
+          final decryptStarted = Completer<void>();
+          final decryptResult = Completer<String?>();
+
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(any()),
+          ).thenAnswer((_) async => false);
+          stubDaoInserts();
+
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final syncState = _FakeDmSyncState();
+          final repository = createRepository(
+            nip04Decryptor: (_, _) {
+              decryptStarted.complete();
+              return decryptResult.future;
+            },
+            syncState: syncState,
+          );
+
+          await repository.startListening();
+          controller.add(nip04Event);
+          await decryptStarted.future;
+
+          // The decrypt is a remote-signer round trip on the real path, so
+          // this is the widest window a switch can land in — wider than the
+          // dedup read the sibling test above covers. Unlike the NIP-17
+          // handler, this one has no generation guard to abandon on.
+          repository.setCredentials(
+            userPubkey: _validPubkeyC,
+            signer: LocalNostrSigner(_validPrivateKey),
+            messageService: mockMessageService,
+          );
+          decryptResult.complete('Hello over NIP-04');
+          await Future<void>.delayed(Duration.zero);
+
+          expect(syncState.recordedWire, hasLength(1));
+          expect(syncState.recordedWire.single.pubkey, _validPubkeyA);
+          expect(syncState.recordedWire.single.createdAt, nip04Event.createdAt);
+          expect(syncState.recorded, hasLength(1));
+          expect(syncState.recorded.single.pubkey, _validPubkeyA);
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
+
       test('skips NIP-04 events with no p tag', () async {
         final nip04Event = createNip04Event(tags: []);
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -2531,6 +2531,48 @@ void main() {
         },
       );
 
+      test(
+        'an already-processed gift wrap still advances the wire boundary so '
+        'an upgraded install does not keep the eroded window (#8209)',
+        () async {
+          // Every wrap already inside the window returns at the dedup guard,
+          // so if that path recorded nothing the wire boundary would stay
+          // null — and `since:` would keep falling back to the rumor clock —
+          // until the account received a genuinely new message. Confirmed on
+          // an iOS simulator before this branch existed.
+          const outerCreatedAt = 1700000000;
+          final giftWrap = createGiftWrapEvent();
+
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(_giftWrapEventId),
+          ).thenAnswer((_) async => true);
+
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final syncState = _FakeDmSyncState();
+          final repository = createRepository(syncState: syncState);
+
+          await repository.startListening();
+          controller.add(giftWrap);
+          await Future<void>.delayed(Duration.zero);
+
+          expect(syncState.recordedWire, hasLength(1));
+          expect(syncState.recordedWire.single.createdAt, outerCreatedAt);
+          // A duplicate persisted no message, so the rumor boundary — which
+          // tracks send times for ordering — must not move.
+          expect(syncState.recorded, isEmpty);
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
+
       test('successful NIP-04 persist advances sync boundaries', () async {
         const nip04CreatedAt = 1700000600;
         final nip04Event = Event.fromJson({

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -4130,13 +4130,15 @@ void main() {
           // The invariant the window has to hold: our newest processed wrap
           // was stamped at or below the moment it was published, so any wrap
           // published from that moment onward — even one backdated the full
-          // two days NIP-17 allows — is at or above `wire - 2d`. Deriving the
-          // boundary from the rumor clock breaks it, because the rumor stamp
-          // sits above the wire stamp by that wrap's own backdate.
+          // two days NIP-17 allows — is at or above `wire - 2d`. Use an old
+          // rumor re-wrapped recently (the retry behavior in GiftWrapUtil) to
+          // cover the case where the wire boundary narrows the rumor fallback.
           const publishedAt = 1700000000;
           const wireNewest = publishedAt - 3600;
-          const rumorNewest = publishedAt + 86400;
+          const rumorNewest = publishedAt - 86400;
           const worstCaseOuter = publishedAt - 2 * 86400;
+
+          expect(wireNewest, greaterThan(rumorNewest));
 
           final controller = StreamController<Event>();
           when(

--- a/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
@@ -467,5 +467,130 @@ void main() {
         },
       );
     });
+
+    group('newestWireSyncedAt (#8209)', () {
+      const year2100 = 4102444800;
+      int nowSec() => DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      test('defaults to null when nothing has been processed', () {
+        expect(state.newestWireSyncedAt(pkA), isNull);
+      });
+
+      test('recordWireSeen persists the wire stamp', () async {
+        await state.recordWireSeen(pkA, createdAt: tsMid);
+
+        expect(state.newestWireSyncedAt(pkA), equals(tsMid));
+      });
+
+      test(
+        'recordWireSeen advances monotonically — an older wire stamp does '
+        'not roll the boundary back',
+        () async {
+          await state.recordWireSeen(pkA, createdAt: tsNewer);
+          await state.recordWireSeen(pkA, createdAt: tsMid);
+
+          expect(state.newestWireSyncedAt(pkA), equals(tsNewer));
+        },
+      );
+
+      test(
+        'the wire boundary is independent of the rumor boundary, so a '
+        'backdated wrap cannot advance `since:` past its own stamp',
+        () async {
+          // One NIP-17 message: the rumor carries the honest send time, the
+          // outer wrap is backdated ~1 day per NIP-17. Recording only the
+          // rumor clock is what left `since:` a day ahead of the stamp the
+          // relay filters. See #8209.
+          const rumorAt = tsNewest;
+          const wireAt = tsNewest - 86400;
+
+          await state.recordSeen(pkA, createdAt: rumorAt);
+          await state.recordWireSeen(pkA, createdAt: wireAt);
+
+          expect(state.newestSyncedAt(pkA), equals(rumorAt));
+          expect(state.newestWireSyncedAt(pkA), equals(wireAt));
+        },
+      );
+
+      test('recordWireSeen is scoped per pubkey', () async {
+        await state.recordWireSeen(pkA, createdAt: tsMid);
+
+        expect(state.newestWireSyncedAt(pkB), isNull);
+      });
+
+      test(
+        'recordWireSeen clamps a future wire stamp to now — an ephemeral '
+        'key signs its own stamp, so the signature does not make it honest',
+        () async {
+          await state.recordWireSeen(pkA, createdAt: year2100);
+
+          final stored = state.newestWireSyncedAt(pkA);
+          expect(stored, isNotNull);
+          expect(stored, lessThan(year2100));
+          expect(stored, closeTo(nowSec(), 5));
+        },
+      );
+
+      test(
+        'recordWireSeen floors an implausibly old wire stamp',
+        () async {
+          await state.recordWireSeen(pkA, createdAt: 1);
+
+          expect(
+            state.newestWireSyncedAt(pkA),
+            equals(DmSyncState.minPlausibleCreatedAt),
+          );
+        },
+      );
+
+      test(
+        'repairPoisonedBoundaries heals a wire boundary poisoned by a build '
+        'without the clamp, and re-arms the drain',
+        () async {
+          await prefs.setInt('dm.newestWireSyncedAt.$pkA', year2100);
+          await state.markHistoryDrainComplete(pkA);
+          expect(state.historyDrainComplete(pkA), isTrue);
+
+          await state.repairPoisonedBoundaries(pkA);
+
+          expect(state.newestWireSyncedAt(pkA), closeTo(nowSec(), 5));
+          expect(state.historyDrainComplete(pkA), isFalse);
+        },
+      );
+
+      test(
+        'repairPoisonedBoundaries leaves a healthy wire boundary alone',
+        () async {
+          final honest = nowSec() - 3600;
+          await state.recordWireSeen(pkA, createdAt: honest);
+          await state.markHistoryDrainComplete(pkA);
+
+          await state.repairPoisonedBoundaries(pkA);
+
+          expect(state.newestWireSyncedAt(pkA), equals(honest));
+          expect(state.historyDrainComplete(pkA), isTrue);
+        },
+      );
+
+      test('clear removes the wire boundary for that pubkey only', () async {
+        await state.recordWireSeen(pkA, createdAt: tsMid);
+        await state.recordWireSeen(pkB, createdAt: tsNewer);
+
+        await state.clear(pkA);
+
+        expect(state.newestWireSyncedAt(pkA), isNull);
+        expect(state.newestWireSyncedAt(pkB), equals(tsNewer));
+      });
+
+      test('clearAll removes the wire boundary for every pubkey', () async {
+        await state.recordWireSeen(pkA, createdAt: tsMid);
+        await state.recordWireSeen(pkB, createdAt: tsNewer);
+
+        await state.clearAll();
+
+        expect(state.newestWireSyncedAt(pkA), isNull);
+        expect(state.newestWireSyncedAt(pkB), isNull);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Description

The live gift-wrap subscription derived `since:` in one clock and the relay applied it in another.

`newestSyncedAt` stores the **inner NIP-59 rumor** timestamp — both `recordSeen` call sites pass `clock.atMostNow(rumor.createdAt)`. A relay evaluates `since:` against the stamp on the event it actually stored, which is the **outer kind-1059 wrap**, and NIP-17 requires that outer stamp to be backdated by a CSPRNG offset of 0–2 days (`gift_wrap_util.dart:76`). So the boundary sat above the clock it was applied in, and the 2-day overlap that comment at `dm_repository.dart:895` describes as absorbing "NIP-17 randomized created_at jitter" was already partly spent when the window opened.

The erosion equals the newest wrap's own backdate, which is uniform on [0, 2d) — **half the intended margin, on average**. A wrap whose backdate exceeded the remainder was dropped by the relay, and nothing asked for it again: `newestSyncedAt` only advances, so `since:` only rises, and the history drain that would repair the gap has latched `historyDrainComplete`.

### What changed

`DmSyncState` gains `newestWireSyncedAt` / `recordWireSeen`, tracking the `created_at` the relay indexes — the outer wrap for NIP-17, the event's own stamp for an unwrapped NIP-04 kind 4, since one `since:` covers kinds `[1059, 4, 5]`. `newestSyncedAt` is untouched and still orders the UI.

Clamped and repaired exactly like the rumor boundary. The outer wrap is signed, but only by a throwaway NIP-59 ephemeral key, so the signature proves who chose the stamp and not that it is honest — a future-stamped wrap would otherwise blackhole the inbox the way an unbounded rumor timestamp once did (the failure `maxFutureSkewSeconds` and `repairPoisonedBoundaries` were written for).

**The wire boundary can move either direction relative to the rumor boundary.** A retry re-wraps the same rumor relative to the current time, so its wire stamp can be later and the new `since:` can narrow relative to the old fallback. The full 2-day overlap remains safe because a compliant wrap stamp is at or below its publication time.

Second commit: both dedup guards return before either boundary is recorded, so on an upgraded install every wrap already inside the window hits that early return and the new key stays null — the fix would not engage until the account received a genuinely new message. Confirmed on device before fixing it. A duplicate is by definition a wrap we processed, so its outer stamp belongs in the maximum this boundary tracks; the boundary is monotonic, so the drain replaying old pages cannot drag it backwards.

#8209 describes two independently composing mechanisms. The other one — the history drain latching complete on a page no relay answered — was already fixed by #8217, which deliberately left the issue open for this half.

**Related Issues:**
- Part of #8209
- Recovery follow-up: #8362

## Out of Scope

- **Recovering wraps already lost.** This is forward-only. It re-exposes a band of `newestSyncedAt - newestWireSyncedAt` seconds — measured at 51,807s and 8,273s on two staging accounts — and anything missed longer ago than that stays outside every future window. The drain is the only path below the live window and has already latched on established installs. Filed as a follow-up for a `currentDrainVersion` bump, deliberately separate so the two can be reverted independently.
- **#7320** (`targetRelays` subtracts the pool instead of adding) is untouched; it widens exposure to this bug but is a distinct defect.
- **A real-relay out-of-order round trip.** The package tests mutation-check the boundary derivation and dedup bootstrap path, but `FakeRelay` ignores REQ filters, so the current integration harness cannot prove that an older wrap lands through the actual `since:` filter.
- **NIP-77 negentropy**, which the issue names as the protocol-level answer, is unchanged.

## Verification

**On an iOS 26.5 simulator against staging**, two Keycast (`divineOAuth`) accounts.

Read the app's own boundary from its log, then published two gift wraps to the same account 90 seconds apart, from the same throwaway sender, identical in every respect except the outer `created_at` straddling it:

| wrap | outer `created_at` | vs `since` (1787838398) | stored on relay | delivered to app |
|---|---|---|---|---|
| victim | 1787834798 | −1h | yes | **never** — no decrypt, no persist |
| control | 1787841998 | +1h | yes | decrypted, `Persisted NIP-17 DM 19f29400…` |

Receiving the control advanced `newestSyncedAt` to 1788057144, so the next window opened at 1787884344 and the victim fell a further 13.8h outside it. A relay query with that filter confirms its absence. Permanent, and silent.

Independently, the watermark on one account led the outer stamp of *every* wrap the relay holds for it by 5,861s, leaving 166,939s of headroom against a 172,800s maximum backdate — a 3.4% miss rate for a wrap published at that moment, with no adversarial input at all.

**Then the same simulator on this branch recovered that exact message.** The build wrote `dm.newestWireSyncedAt = 1788005337` from wraps it had already processed, derived `since: 1787832537` — 2,261s below the victim — and persisted `NIP-17 DM 975a75ee…`. Recomputing the Nostr event id from the victim's rumor fields (sender pubkey, `created_at`, kind 14, p-tag, content) reproduces `975a75ee…` exactly, so this is the same message the unfixed build lost, not a lookalike; the same recomputation reproduces the control's id, which validates the method.

The window moves in two stages, which both accounts show. On the first launch after upgrading, the new key is absent and `since:` is the unchanged fallback; the dedup path then records the wire boundary from wraps already in the window, and the next launch opens the corrected window:

| | account A (iPhone 17 Pro) | account B (iPhone 17 Pro Max) |
|---|---|---|
| `newestSyncedAt` (rumor) | 1788057144 | 1788011189 |
| `newestWireSyncedAt` recorded | 1788005337 | 1788002916 |
| `since:` stage 1 (fallback) | 1787884344 | 1787838389 |
| `since:` stage 2 (observed) | 1787832537 | 1787830116 |
| window widened by | 51,807s | 8,273s |

Each recorded boundary equals the maximum outer stamp the relay independently reports for that account, and each stage-2 `since:` is exactly `that − 2d`. The widening is the newest wrap's own backdate — the margin that was silently missing.

**Automated:**
- `flutter test` in `packages/dm_repository` — 727 passing.
- `flutter analyze lib test` clean, in the package and at the app level.
- Every new test was mutation-checked: reverting each production change individually turns the corresponding test red.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)


