### PR TITLE
ci(tests): make shared-channel leaks fail the test that caused them

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -652,6 +652,9 @@ test, verifies each shared channel still carries its canonical handler
 going through `overrideSharedChannel`, the harness **heals** it (reinstalls
 canonical so the next suite is safe) and, under the `DIVINE_STRICT_CHANNELS`
 build flag (`--dart-define=DIVINE_STRICT_CHANNELS=true`), **fails** the
-perpetrating test with a fix recipe. Compliant tests never trip it. A static
+perpetrating test with a fix recipe. Compliant tests never trip it.
+**Mobile CI and `mise run test` both set that flag**, so a leak fails your PR
+rather than being healed into someone else's suite; a bare
+`flutter test <file>` leaves it off and heals silently. A static
 `check_shared_channel_overrides.sh` ratchet additionally freezes the set of
 files that raw-install a shared channel, so new ones must use the helper.

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -516,7 +516,17 @@ jobs:
         # AppDatabase "database is locked", no path_provider collisions (#3137).
         # concurrency=1 once pushed the job past 1 hour because each tagged file
         # pays a full Dart VM startup; a higher ceiling overlaps those startups.
-        run: very_good test --optimization --concurrency=4 --exclude-tags integration --test-randomize-ordering-seed random
+        #
+        # DIVINE_STRICT_CHANNELS makes the heal-and-blame tearDown in
+        # test/flutter_test_config.dart fail the test that left a shared
+        # MethodChannel handler replaced, instead of only healing it for the
+        # next suite (#5738). Without it the guard repairs the leak silently
+        # and nothing reports who caused it, so the next such regression is
+        # found the same way #5738 was: as an order-dependent failure
+        # cross-attributed to an innocent suite. Turned on once the full suite
+        # was proven clean under it, which the harness comment set as the
+        # condition.
+        run: very_good test --optimization --concurrency=4 --exclude-tags integration --dart-define=DIVINE_STRICT_CHANNELS=true --test-randomize-ordering-seed random
   vgv-tag-gate:
     name: VGV Tag Gate
     needs: changes

--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -128,9 +128,13 @@ if [ "$VERY_GOOD_CURRENT_VERSION" != "$VERY_GOOD_CLI_VERSION" ]; then
 fi
 
 flutter pub get
+# DIVINE_STRICT_CHANNELS matches Mobile CI: a test that leaves a shared
+# MethodChannel handler replaced fails here rather than being healed silently,
+# so the leak surfaces before the push instead of in someone else's suite.
 PATH="$PUB_CACHE_BIN:$PATH" "$VERY_GOOD_BIN" test \
   --optimization \
   --concurrency=4 \
   --exclude-tags "integration || golden" \
+  --dart-define=DIVINE_STRICT_CHANNELS=true \
   --test-randomize-ordering-seed random
 """

--- a/mobile/test/flutter_test_config.dart
+++ b/mobile/test/flutter_test_config.dart
@@ -16,8 +16,9 @@ const _runGoldenSetup = bool.fromEnvironment('DIVINE_GOLDEN_TESTS');
 
 /// When set (via `--dart-define=DIVINE_STRICT_CHANNELS=true`), the
 /// heal-and-blame tearDown also `fail()`s the test that leaked a shared
-/// channel. Off by default so the harness heals silently locally; CI can flip
-/// it on once the full suite is proven clean under it (#5738).
+/// channel. Mobile CI and `mise run test` both set it — the suite was proven
+/// clean under it, which was the condition for turning it on (#5738). It stays
+/// off for a bare `flutter test` so a single-file run still heals silently.
 const _strictChannels = bool.fromEnvironment('DIVINE_STRICT_CHANNELS');
 
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {


### PR DESCRIPTION
## Description

Turns on `DIVINE_STRICT_CHANNELS` in Mobile CI and in `mise run test`, so a test that leaves one of the five shared `MethodChannel` handlers replaced **fails** instead of being healed silently.

The heal-and-blame tearDown has been in `test/flutter_test_config.dart` since #5738. After every test it compares each shared channel against its canonical handler, reinstalls any that drifted, and — only under this flag — fails the test that caused it. **Nothing set the flag**, so only the healing half has ever run: CI repaired the leak and reported nothing.

That is the wrong half to keep on its own. Under `very_good test --optimization` the whole unit suite shares one isolate, so a replaced handler degrades every later suite. Healing keeps the run green while hiding the cause, which means the next regression of this class gets found the way #5738 was found — as an order-dependent failure cross-attributed to an innocent suite.

The harness comment already stated the condition for enabling it: *"CI can flip it on once the full suite is proven clean under it."* It is, so this flips it.

**Not set for a bare `flutter test <file>`** — a single-file run has no later suite to strand, and silent healing there stays convenient.

**Related Issue:** Relates to #8290, #5738

## Out of Scope

- The static `check_shared_channel_overrides.sh` ratchet is untouched; it freezes which files may raw-install a shared channel, which is the complementary compile-time half.
- Nothing about the `skip_very_good_optimization` baseline, which #8354 just moved to 15.

## Verification

- **The suite is clean under the flag** — two full merged runs, both `+18514 ~264 All tests passed!`, exit 0:
  - seed 424242, and seed 98765 on post-merge `main` (`709d45429`).
- **The flag is load-bearing, not inert.** A scratch test that replaces `plugins.flutter.io/device_info` without restoring:

  | | Result |
  |---|---|
  | without the flag (CI today) | `All tests passed!` — leak healed, nobody told |
  | with the flag | fails: *"This test replaced shared MethodChannel(s) `plugins.flutter.io/device_info` without restoring them … Use `overrideSharedChannel(channel, handler)`"* |

  So the change converts a silent repair into a named failure with a fix recipe. The probe was deleted, not committed.
- `flutter analyze lib test integration_test` → No issues found.
- `dart format` → 0 changed.
- `python3 -m unittest discover -s .github/scripts/tests` → 77 tests; the one error (`test_shorebird_provenance`, `git rev-parse HEAD^`) reproduces identically on a clean tree here and is an artifact of a shallow local clone — CI checks out with `fetch-depth: 0`.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
