### PR TITLE
fix(a11y): give the feed-mode selector a 48dp tap target

### DIFF
--- a/mobile/lib/screens/feed/feed_mode_switch.dart
+++ b/mobile/lib/screens/feed/feed_mode_switch.dart
@@ -202,22 +202,32 @@ class _FeedModeContent extends StatelessWidget {
               child: GestureDetector(
                 behavior: .opaque,
                 onTap: onTap,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  spacing: 12,
-                  children: [
-                    Flexible(
-                      child: Text(
-                        label,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: VineTheme.headlineSmallFont(
-                          color: VineTheme.whiteText,
-                        ).copyWith(shadows: VineTheme.buttonShadows),
+                // The label and caret are intrinsically 36dp tall, which fails
+                // androidTapTargetGuideline (48). Free to fix: the trailing
+                // settings button is already 48dp, so the header row does not
+                // grow. minHeight, not a fixed height, so it still grows with
+                // the system font scale (.claude/rules/accessibility.md).
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(
+                    minHeight: kMinInteractiveDimension,
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    spacing: 12,
+                    children: [
+                      Flexible(
+                        child: Text(
+                          label,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: VineTheme.headlineSmallFont(
+                            color: VineTheme.whiteText,
+                          ).copyWith(shadows: VineTheme.buttonShadows),
+                        ),
                       ),
-                    ),
-                    const _FeedModeCaret(),
-                  ],
+                      const _FeedModeCaret(),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/mobile/lib/screens/feed/feed_mode_switch.dart
+++ b/mobile/lib/screens/feed/feed_mode_switch.dart
@@ -202,14 +202,11 @@ class _FeedModeContent extends StatelessWidget {
               child: GestureDetector(
                 behavior: .opaque,
                 onTap: onTap,
-                // The label and caret are intrinsically 36dp tall, which fails
-                // androidTapTargetGuideline (48). Free to fix: the trailing
-                // settings button is already 48dp, so the header row does not
-                // grow. minHeight, not a fixed height, so it still grows with
-                // the system font scale (.claude/rules/accessibility.md).
+                // Interactive instances need a 48dp target. Preview instances
+                // have no onTap and retain their intrinsic height.
                 child: ConstrainedBox(
-                  constraints: const BoxConstraints(
-                    minHeight: kMinInteractiveDimension,
+                  constraints: BoxConstraints(
+                    minHeight: onTap == null ? 0 : kMinInteractiveDimension,
                   ),
                   child: Row(
                     mainAxisSize: MainAxisSize.min,

--- a/mobile/test/screens/feed/feed_mode_switch_test.dart
+++ b/mobile/test/screens/feed/feed_mode_switch_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/screens/feed/feed_immersive_cubit.dart';
 import 'package:openvine/screens/feed/feed_mode_switch.dart';
+import 'package:openvine/screens/feed/feed_settings_menu.dart';
 import 'package:openvine/widgets/video_feed_item/feed_immersive_chrome.dart';
 
 import '../../helpers/test_provider_overrides.dart';
@@ -117,15 +118,6 @@ void main() {
           )
           .first;
 
-      testWidgets('the feed-mode label clears the 48dp minimum', (
-        tester,
-      ) async {
-        await pumpDefault(tester);
-
-        // 36dp on device before this constraint — under both platform minimums.
-        expect(tester.getSize(labelTarget()).height, kMinInteractiveDimension);
-      });
-
       testWidgets('meets the Android tap target guideline', (tester) async {
         final handle = tester.ensureSemantics();
         await pumpDefault(tester);
@@ -134,18 +126,18 @@ void main() {
         handle.dispose();
       });
 
-      testWidgets('costs the header no height', (tester) async {
+      testWidgets('does not grow the live header beyond its settings target', (
+        tester,
+      ) async {
         await pumpDefault(tester);
 
-        // The trailing settings button is already 48dp, so constraining the
-        // label to match cannot push the header down. 16 + 48 + 16.
-        final header = find
+        final headerRow = find
             .ancestor(
-              of: find.text(l10n.feedModeForYou),
-              matching: find.byType(Padding),
+              of: find.byType(FeedSettingsMenu),
+              matching: find.byType(Row),
             )
             .first;
-        expect(tester.getSize(header).height, 80.0);
+        expect(tester.getSize(headerRow).height, kMinInteractiveDimension);
       });
 
       testWidgets('does not reserve a tap target in preview mode', (

--- a/mobile/test/screens/feed/feed_mode_switch_test.dart
+++ b/mobile/test/screens/feed/feed_mode_switch_test.dart
@@ -98,6 +98,54 @@ void main() {
       );
     }
 
+    group('Tap Target', () {
+      Future<void> pumpDefault(WidgetTester tester) async {
+        when(
+          () => mockBloc.state,
+        ).thenReturn(const VideoFeedBlocState(status: VideoFeedStatus.success));
+        await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+      }
+
+      Finder labelTarget() => find
+          .ancestor(
+            of: find.text(l10n.feedModeForYou),
+            matching: find.byType(GestureDetector),
+          )
+          .first;
+
+      testWidgets('the feed-mode label clears the 48dp minimum', (
+        tester,
+      ) async {
+        await pumpDefault(tester);
+
+        // 36dp on device before this constraint — under both platform minimums.
+        expect(tester.getSize(labelTarget()).height, kMinInteractiveDimension);
+      });
+
+      testWidgets('meets the Android tap target guideline', (tester) async {
+        final handle = tester.ensureSemantics();
+        await pumpDefault(tester);
+
+        await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+        handle.dispose();
+      });
+
+      testWidgets('costs the header no height', (tester) async {
+        await pumpDefault(tester);
+
+        // The trailing settings button is already 48dp, so constraining the
+        // label to match cannot push the header down. 16 + 48 + 16.
+        final header = find
+            .ancestor(
+              of: find.text(l10n.feedModeForYou),
+              matching: find.byType(Padding),
+            )
+            .first;
+        expect(tester.getSize(header).height, 80.0);
+      });
+    });
+
     group('Feed Source Labels', () {
       testWidgets('displays "For You" label for the default home source', (
         tester,

--- a/mobile/test/screens/feed/feed_mode_switch_test.dart
+++ b/mobile/test/screens/feed/feed_mode_switch_test.dart
@@ -49,8 +49,11 @@ void main() {
       mockVolumeCubit.close();
     });
 
-    // ignore: strict_raw_type
-    Widget createTestWidget({List overrides = const []}) {
+    Widget createTestWidget({
+      // ignore: strict_raw_type
+      List overrides = const [],
+      bool isPreviewMode = false,
+    }) {
       return ProviderScope(
         overrides: overrides.cast(),
         child: MaterialApp(
@@ -66,7 +69,7 @@ void main() {
                       value: mockVolumeCubit,
                     ),
                   ],
-                  child: const FeedModeSwitch(),
+                  child: FeedModeSwitch(isPreviewMode: isPreviewMode),
                 ),
               ],
             ),
@@ -143,6 +146,17 @@ void main() {
             )
             .first;
         expect(tester.getSize(header).height, 80.0);
+      });
+
+      testWidgets('does not reserve a tap target in preview mode', (
+        tester,
+      ) async {
+        await tester.pumpWidget(createTestWidget(isPreviewMode: true));
+
+        expect(
+          tester.getSize(labelTarget()).height,
+          lessThan(kMinInteractiveDimension),
+        );
       });
     });
 


### PR DESCRIPTION
Refs #8145

Second of the #8145 feed tap targets. Independent of #8366 (the follow badge) —
different screen, different file, no shared code.

The feed-mode label at the top of the feed measured **137.3 x 36** on device,
under both platform minimums (Android 48, iOS 44). Nothing constrained it: the
label and caret sit in a `Row(mainAxisSize: .min)` that hugs its content, inside
an `Align` that does not stretch, with no minimum anywhere in the chain. The
author row two layers below already carries an explicit
`ConstrainedBox(minWidth: kMinInteractiveDimension, ...)` for exactly this
reason; the header never got one.

## This one is free

The trailing settings button in the same header is already 48x48, so the header
row is 48dp tall whatever the label does. Constraining the label to match moves
nothing.

That is asserted rather than assumed — `does not grow the live header beyond its settings target` pins the live content row at 48dp independently of the outer padding, and fails if the constraint is raised past the
settings button's height.

`minHeight`, not a fixed height, so the target still grows with the system font
scale. The constraint only applies when `onTap` is present: preview-only uses in
the video editor and metadata screen remain non-interactive and keep their
intrinsic height.

## Tests

Three, all mutation-checked:

| test | mutation that turns it red |
|---|---|
| meets `androidTapTargetGuideline` | drop the `ConstrainedBox` |
| does not grow the live header beyond its settings target | raise the constraint to 96dp |
| does not reserve a tap target in preview mode | apply the constraint when `onTap` is null |

## Verification

- `flutter test test/screens/feed/` — 194 passing, 1 skipped
- `flutter analyze lib test integration_test tools` — clean
- `mobile/scripts/golden.sh verify` — 5 passing

## Still open on #8145

Two of the four targets in that issue are not simple fixes, and the issue has
been updated to say so rather than leaving them looking like pending work:

- **`OG Beta Tester` (19.6 x 15.6)** is deliberately undersized, with the
  reasoning already written into `og_beta_badge.dart` — padding the chit to
  48dp grows every inline name row that carries one, and the compliant
  affordance is the profile header, which renders the same explainer.
- **Hashtag links (102 x 26, 131 x 26)** cannot be fixed as written. They are
  `TextSpan`s with a `TapGestureRecognizer`, and an inline span has no padding,
  constraints or `HitTestBehavior` — its hit box is exactly its glyph run.
  Reaching 48dp needs a `WidgetSpan` per tag or moving tags out of the
  paragraph, both of which change how descriptions wrap.


---

## Device patrol

Measured on **iOS 26.5**, real signed-in account, against `main` @ `dda8cb2b8`
as a baseline in the same environment. These are the interactive feed path; they
predate the preview gating, which does not change it (`onTap` is non-null there,
so the constraint still resolves to 48dp).

| | baseline | with this branch |
|---|---|---|
| feed-mode label target | 89.4 x **32.0** @ (16, 86) | 89.4 x **48.0** @ (16, 78) |
| `_FeedModeContent` (the header row) | 412 x **48.0** | 412 x **48.0** — unchanged |
| `FeedSettingsMenu` | 48 x 48 | 48 x 48 |
| label box vertical centre | y = **102** | y = **102** |

The "free" claim holds on device: the header row is 412 x 48 before and after,
because the trailing settings button was already 48dp. And the label does not
move — its box grows from 32 to 48 but its centre stays at y = 102, so the text
sits exactly where it did.

The 32dp measured here is smaller than the 137.3 x 36 recorded on the issue;
the width tracks the label text and the height the text scale. The failing
dimension is the height either way, and it is under both minimums in both
readings.
