### PR TITLE
chore(legal): show Shorebird updater licenses in the app

### DIFF
--- a/mobile/assets/licenses/Shorebird-APACHE.txt
+++ b/mobile/assets/licenses/Shorebird-APACHE.txt
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/mobile/assets/licenses/Shorebird-MIT.txt
+++ b/mobile/assets/licenses/Shorebird-MIT.txt
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -89,6 +89,38 @@ return to stable updates in Developer Options.
 patch number in logs and Crashlytics custom keys. Use those values when
 triaging crashes that may be patch-specific.
 
+### Third-party attribution
+
+`shorebird release` statically links Shorebird's Rust updater into the Flutter
+engine. Flutter's license collector does not discover that native dependency:
+it assembles `NOTICES` from Flutter, `sky_engine`, and packages in the Dart
+package configuration. Divine therefore registers the updater's MIT and
+Apache-2.0 license choices from `assets/licenses/` during app startup so both
+appear under **Shorebird updater** in Settings → Legal → Open Source Licenses.
+The updater is offered under either license at the recipient's option; showing
+both documents records the available choices, rather than asserting that both
+licenses must be satisfied simultaneously.
+
+The bundled texts were copied from `shorebirdtech/updater` at commit
+`1f85c4ab1ee5b540269b9859c75e1bffbb9050c7` (license blob ids
+`6802bc4b80c0f8df1413d55b16267c0969e352c9` and
+`a7e77cb28d386ec6eddeaabf441f91473ddefa1e`). The store engine paired with the
+current Flutter 3.44.9 pin is `27bc060323bfdfe2f5b6732174d4e499e74eca70`.
+
+When Flutter or Shorebird changes, re-check attribution without producing a
+store artifact:
+
+1. Read `bin/internal/engine.version` from the Flutter SDK selected by
+   Shorebird.
+2. Compare the Shorebird fork's root `LICENSE` and cached
+   `bin/cache/pkg/sky_engine/LICENSE` with the corresponding stock Flutter
+   files.
+3. Search those files for `shorebird` and `updater`, and inspect the fork's
+   `flutter_tools` asset collector changes.
+4. Compare the immutable upstream updater license blobs above with the current
+   updater license files. Update the bundled assets and this provenance only
+   when the canonical texts change.
+
 ### Flutter version
 
 Shorebird ships its own Flutter, so `FLUTTER_VERSION` in `codemagic.yaml`

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -102,7 +102,8 @@ both documents records the available choices, rather than asserting that both
 licenses must be satisfied simultaneously.
 
 The bundled texts were copied from `shorebirdtech/updater` at commit
-`1f85c4ab1ee5b540269b9859c75e1bffbb9050c7` (license blob ids
+`1f85c4ab1ee5b540269b9859c75e1bffbb9050c7`, with one trailing newline added
+to each local text asset (upstream license blob ids
 `6802bc4b80c0f8df1413d55b16267c0969e352c9` and
 `a7e77cb28d386ec6eddeaabf441f91473ddefa1e`). The store engine paired with the
 current Flutter 3.44.9 pin is `27bc060323bfdfe2f5b6732174d4e499e74eca70`.

--- a/mobile/lib/bootstrap/bundled_licenses.dart
+++ b/mobile/lib/bootstrap/bundled_licenses.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// A license bundled as an app asset and the package names it covers.
+typedef BundledLicense = ({List<String> packages, String assetPath});
+
+/// Loads bundled license assets as entries understood by [LicenseRegistry].
+Stream<LicenseEntry> bundledLicenseEntries(
+  AssetBundle bundle,
+  Iterable<BundledLicense> licenses,
+) async* {
+  for (final license in licenses) {
+    final licenseText = await bundle.loadString(license.assetPath);
+    yield LicenseEntryWithLineBreaks(license.packages, licenseText);
+  }
+}

--- a/mobile/lib/bootstrap/font_licenses.dart
+++ b/mobile/lib/bootstrap/font_licenses.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show AssetBundle, rootBundle;
+import 'package:openvine/bootstrap/bundled_licenses.dart';
 
 /// A bundled OFL font: the family name shown on the license page and the asset
 /// path to its SIL Open Font License 1.1 text.
@@ -29,10 +30,12 @@ const _bundledFontLicenses = <_BundledFontLicense>[
 /// [bundle] is injectable so the entries can be exercised in tests without
 /// touching the global [LicenseRegistry].
 Stream<LicenseEntry> bundledFontLicenseEntries(AssetBundle bundle) async* {
-  for (final font in _bundledFontLicenses) {
-    final licenseText = await bundle.loadString(font.assetPath);
-    yield LicenseEntryWithLineBreaks(<String>[font.family], licenseText);
-  }
+  yield* bundledLicenseEntries(
+    bundle,
+    _bundledFontLicenses.map(
+      (font) => (packages: <String>[font.family], assetPath: font.assetPath),
+    ),
+  );
 }
 
 /// Registers the bundled fonts' OFL licenses with the global [LicenseRegistry].

--- a/mobile/lib/bootstrap/shorebird_licenses.dart
+++ b/mobile/lib/bootstrap/shorebird_licenses.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart' show AssetBundle, rootBundle;
+import 'package:openvine/bootstrap/bundled_licenses.dart';
+
+const _shorebirdUpdaterPackage = 'Shorebird updater';
+
+/// Shorebird offers its native updater under MIT or Apache-2.0, at the
+/// recipient's option. Both documents are shown under one package heading.
+const _shorebirdUpdaterLicenses = <BundledLicense>[
+  (
+    packages: <String>[_shorebirdUpdaterPackage],
+    assetPath: 'assets/licenses/Shorebird-MIT.txt',
+  ),
+  (
+    packages: <String>[_shorebirdUpdaterPackage],
+    assetPath: 'assets/licenses/Shorebird-APACHE.txt',
+  ),
+];
+
+/// Yields the license choices for the native updater linked into store builds.
+Stream<LicenseEntry> shorebirdLicenseEntries(AssetBundle bundle) =>
+    bundledLicenseEntries(bundle, _shorebirdUpdaterLicenses);
+
+/// Registers the native Shorebird updater with the global [LicenseRegistry].
+///
+/// Registration is lazy: the assets load only when the license page enumerates
+/// the registry.
+void registerShorebirdLicenses() {
+  LicenseRegistry.addLicense(() => shorebirdLicenseEntries(rootBundle));
+}

--- a/mobile/lib/startup/app_bootstrap.dart
+++ b/mobile/lib/startup/app_bootstrap.dart
@@ -18,6 +18,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:openvine/app/divine_app.dart';
 import 'package:openvine/bootstrap/font_licenses.dart';
+import 'package:openvine/bootstrap/shorebird_licenses.dart';
 import 'package:openvine/config/screenshot_mode.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/features/app/startup/startup_phase.dart';
@@ -153,6 +154,11 @@ Future<void> startOpenVineApp({
   // Register bundled OFL font licenses so they surface on the in-app
   // Open Source Licenses page (Settings → Legal). See #3659.
   registerBundledFontLicenses();
+
+  // Shorebird's Rust updater is linked into store engines but is outside
+  // Flutter's generated NOTICES asset. Register its licenses explicitly so
+  // they appear on the in-app Open Source Licenses page. See #7206.
+  registerShorebirdLicenses();
 
   // Give the in-memory image cache a larger byte budget than Flutter's 100 MB
   // default so thumbnails survive fast scrolling instead of being evicted and

--- a/mobile/test/bootstrap/shorebird_licenses_test.dart
+++ b/mobile/test/bootstrap/shorebird_licenses_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/bootstrap/shorebird_licenses.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('shorebirdLicenseEntries', () {
+    test('loads both license choices under one updater package', () async {
+      final entries = await shorebirdLicenseEntries(rootBundle).toList();
+
+      expect(entries, hasLength(2));
+      expect(
+        entries.expand((entry) => entry.packages),
+        everyElement('Shorebird updater'),
+      );
+
+      final texts = entries
+          .map(
+            (entry) =>
+                entry.paragraphs.map((paragraph) => paragraph.text).join('\n'),
+          )
+          .toList();
+      expect(texts, contains(contains('MIT License')));
+      expect(
+        texts,
+        contains(
+          allOf(
+            contains('Apache License'),
+            contains('Version 2.0, January 2004'),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('registerShorebirdLicenses', () {
+    tearDown(LicenseRegistry.reset);
+
+    test('adds the updater licenses to the global registry', () async {
+      registerShorebirdLicenses();
+
+      final entries = await LicenseRegistry.licenses
+          .where((entry) => entry.packages.contains('Shorebird updater'))
+          .toList();
+
+      expect(entries, hasLength(2));
+    });
+  });
+}


### PR DESCRIPTION
Store releases include Shorebird’s native updater, but Flutter’s generated license list does not discover native code linked into the engine. People opening Settings → Legal → Open Source Licenses therefore could not see the updater’s redistribution terms.

This registers the updater’s canonical MIT and Apache-2.0 license choices from bundled assets during startup. Both entries share one “Shorebird updater” heading, and the existing bundled-font loader now uses the same small asset-to-license helper. The Shorebird operations guide records the immutable upstream license blobs, current engine revision, and a repeatable offline re-check procedure.

This does not change Shorebird update behavior, Flutter’s generated NOTICES asset, or the attribution of the updater’s Rust dependency tree. The latter remains a separate, broader upstream-audit question.

Verification:
- `flutter test test/bootstrap/font_licenses_test.dart test/bootstrap/shorebird_licenses_test.dart test/startup/main_startup_registration_test.dart`
- `flutter analyze`
- repository pre-push analyzer and changed-file tests

Closes #7206