### PR TITLE
fix(account): stop failed signer recovery from delaying startup

### DIFF
--- a/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart
+++ b/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart
@@ -80,17 +80,29 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
     }
   }
 
-  Future<void> retry() {
+  Future<void> retry() async {
     if (_authService.signerReadiness == SignerReadiness.unavailable) {
-      signerUnavailable();
-      return Future.value();
+      final generation = _beginOperation();
+      emitIfOpen(
+        const AccountDeletionRecoveryState(
+          status: AccountDeletionRecoveryStatus.loading,
+        ),
+      );
+      final refreshed = await _authService.tryRefreshExpiredSession();
+      if (!_isCurrent(generation)) return;
+      if (refreshed) {
+        await load();
+      } else {
+        signerUnavailable();
+      }
+      return;
     }
     return load();
   }
 
   void signerUnavailable() {
     _beginOperation();
-    emit(
+    emitIfOpen(
       const AccountDeletionRecoveryState(
         status: AccountDeletionRecoveryStatus.loadFailed,
         failure: AccountDeletionRecoveryFailure.signerUnavailable,

--- a/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart
+++ b/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart
@@ -9,6 +9,7 @@ import 'package:nostr_key_manager/nostr_key_manager.dart'
     show SecureKeyStorageException;
 import 'package:openvine/blocs/close_guard.dart';
 import 'package:openvine/models/account_deletion_attempt.dart';
+import 'package:openvine/models/signer_readiness.dart';
 import 'package:openvine/repositories/account_deletion_recovery_repository.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
@@ -79,7 +80,23 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
     }
   }
 
-  Future<void> retry() => load();
+  Future<void> retry() {
+    if (_authService.signerReadiness == SignerReadiness.unavailable) {
+      signerUnavailable();
+      return Future.value();
+    }
+    return load();
+  }
+
+  void signerUnavailable() {
+    _beginOperation();
+    emit(
+      const AccountDeletionRecoveryState(
+        status: AccountDeletionRecoveryStatus.loadFailed,
+        failure: AccountDeletionRecoveryFailure.signerUnavailable,
+      ),
+    );
+  }
 
   Future<void> cancel() async {
     final attempt = state.attempt;

--- a/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_state.dart
+++ b/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_state.dart
@@ -16,6 +16,7 @@ enum AccountDeletionRecoveryStatus {
 }
 
 enum AccountDeletionRecoveryFailure {
+  signerUnavailable,
   statusLookup,
   usernameRestore,
   keychainCleanup,

--- a/mobile/lib/models/signer_readiness.dart
+++ b/mobile/lib/models/signer_readiness.dart
@@ -1,0 +1,4 @@
+// ABOUTME: Models whether the active identity can sign now or may sign later.
+// ABOUTME: Distinguishes signer warm-up from permanent unavailability.
+
+enum SignerReadiness { pending, ready, unavailable }

--- a/mobile/lib/providers/account_deletion_recovery_providers.dart
+++ b/mobile/lib/providers/account_deletion_recovery_providers.dart
@@ -28,29 +28,34 @@ final accountDeletionRecoveryRepositoryProvider =
     });
 
 final currentAccountDeletionAttemptProvider =
-    FutureProvider<AccountDeletionAttempt?>((ref) async {
-      if (ref.watch(currentAuthStateProvider) != AuthState.authenticated) {
-        return null;
-      }
-      final authService = ref.watch(authServiceProvider);
-      ref.watch(currentAuthRpcCapabilityProvider);
-      switch (authService.signerReadiness) {
-        case SignerReadiness.pending:
-          final waitingForReadiness = Completer<AccountDeletionAttempt?>();
-          ref.onDispose(
-            () => waitingForReadiness.completeError(
-              const _SignerReadinessWaitCancelled(),
-            ),
-          );
-          return waitingForReadiness.future;
-        case SignerReadiness.unavailable:
-          throw const AccountDeletionStatusUnavailable();
-        case SignerReadiness.ready:
-          return ref
-              .watch(accountDeletionRecoveryRepositoryProvider)
-              .fetchCurrent();
-      }
-    }, retry: (_, _) => null);
+    FutureProvider<AccountDeletionAttempt?>(
+      (ref) async {
+        if (ref.watch(currentAuthStateProvider) != AuthState.authenticated) {
+          return null;
+        }
+        final authService = ref.watch(authServiceProvider);
+        ref.watch(currentAuthRpcCapabilityProvider);
+        switch (authService.signerReadiness) {
+          case SignerReadiness.pending:
+            final waitingForReadiness = Completer<AccountDeletionAttempt?>();
+            ref.onDispose(
+              () => waitingForReadiness.completeError(
+                const _SignerReadinessWaitCancelled(),
+              ),
+            );
+            return waitingForReadiness.future;
+          case SignerReadiness.unavailable:
+            throw const AccountDeletionStatusUnavailable();
+          case SignerReadiness.ready:
+            return ref
+                .watch(accountDeletionRecoveryRepositoryProvider)
+                .fetchCurrent();
+        }
+      },
+      retry: (retryCount, error) => error is AccountDeletionStatusUnavailable
+          ? null
+          : ProviderContainer.defaultRetry(retryCount, error),
+    );
 
 class AccountDeletionStatusUnavailable implements Exception {
   const AccountDeletionStatusUnavailable();
@@ -61,4 +66,7 @@ class AccountDeletionStatusUnavailable implements Exception {
 
 class _SignerReadinessWaitCancelled implements Exception {
   const _SignerReadinessWaitCancelled();
+
+  @override
+  String toString() => '_SignerReadinessWaitCancelled';
 }

--- a/mobile/lib/providers/account_deletion_recovery_providers.dart
+++ b/mobile/lib/providers/account_deletion_recovery_providers.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/models/account_deletion_attempt.dart';
+import 'package:openvine/models/signer_readiness.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/service_providers.dart';
@@ -33,12 +34,31 @@ final currentAccountDeletionAttemptProvider =
       }
       final authService = ref.watch(authServiceProvider);
       ref.watch(currentAuthRpcCapabilityProvider);
-      if (!authService.canPublishNostrWritesNow) {
-        final waitingForReadiness = Completer<AccountDeletionAttempt?>();
-        ref.onDispose(waitingForReadiness.complete);
-        return waitingForReadiness.future;
+      switch (authService.signerReadiness) {
+        case SignerReadiness.pending:
+          final waitingForReadiness = Completer<AccountDeletionAttempt?>();
+          ref.onDispose(
+            () => waitingForReadiness.completeError(
+              const _SignerReadinessWaitCancelled(),
+            ),
+          );
+          return waitingForReadiness.future;
+        case SignerReadiness.unavailable:
+          throw const AccountDeletionStatusUnavailable();
+        case SignerReadiness.ready:
+          return ref
+              .watch(accountDeletionRecoveryRepositoryProvider)
+              .fetchCurrent();
       }
-      return ref
-          .watch(accountDeletionRecoveryRepositoryProvider)
-          .fetchCurrent();
-    });
+    }, retry: (_, _) => null);
+
+class AccountDeletionStatusUnavailable implements Exception {
+  const AccountDeletionStatusUnavailable();
+
+  @override
+  String toString() => 'AccountDeletionStatusUnavailable';
+}
+
+class _SignerReadinessWaitCancelled implements Exception {
+  const _SignerReadinessWaitCancelled();
+}

--- a/mobile/lib/screens/account_deletion_recovery_screen.dart
+++ b/mobile/lib/screens/account_deletion_recovery_screen.dart
@@ -9,9 +9,9 @@ import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/account_deletion_attempt.dart';
+import 'package:openvine/models/signer_readiness.dart';
 import 'package:openvine/providers/account_deletion_recovery_providers.dart';
 import 'package:openvine/providers/auth_providers.dart';
-import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/router/route_paths.dart';
 
 class AccountDeletionRecoveryScreen extends ConsumerWidget {
@@ -24,10 +24,11 @@ class AccountDeletionRecoveryScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final repository = ref.watch(accountDeletionRecoveryRepositoryProvider);
     final authService = ref.watch(authServiceProvider);
-    final isReady = ref.watch(nostrSessionProvider).isReadyForActiveClient;
+    ref.watch(currentAuthRpcCapabilityProvider);
+    final signerReadiness = authService.signerReadiness;
 
     return BlocProvider<AccountDeletionRecoveryCubit>(
-      key: ValueKey((repository, authService, isReady)),
+      key: ValueKey((repository, authService, signerReadiness)),
       create: (_) {
         final cubit = AccountDeletionRecoveryCubit(
           repository: repository,
@@ -36,7 +37,14 @@ class AccountDeletionRecoveryScreen extends ConsumerWidget {
             ref.invalidate(currentAccountDeletionAttemptProvider);
           },
         );
-        if (isReady) cubit.load();
+        switch (signerReadiness) {
+          case SignerReadiness.ready:
+            cubit.load();
+          case SignerReadiness.unavailable:
+            cubit.signerUnavailable();
+          case SignerReadiness.pending:
+            break;
+        }
         return cubit;
       },
       child: const AccountDeletionRecoveryView(),
@@ -99,7 +107,9 @@ class _RecoveryStateContent extends StatelessWidget {
         child: CircularProgressIndicator(),
       ),
       AccountDeletionRecoveryStatus.loadFailed => _RecoveryContent(
-        body: context.l10n.authUnexpectedError,
+        body: state.failure == AccountDeletionRecoveryFailure.signerUnavailable
+            ? context.l10n.authSessionExpired
+            : context.l10n.authUnexpectedError,
         actionLabel: context.l10n.commonRetry,
         onPressed: cubit.retry,
         secondaryActionLabel: context.l10n.accountDeletionSignOut,

--- a/mobile/lib/services/auth/signer_readiness_resolver.dart
+++ b/mobile/lib/services/auth/signer_readiness_resolver.dart
@@ -1,0 +1,30 @@
+// ABOUTME: Resolves signer readiness from identity and observable RPC state.
+// ABOUTME: Keeps temporary warm-up distinct from permanent unavailability.
+
+import 'package:openvine/models/auth_rpc_capability.dart';
+import 'package:openvine/models/signer_readiness.dart';
+import 'package:openvine/services/auth/nostr_identity.dart';
+
+SignerReadiness resolveSignerReadiness(
+  NostrIdentity? identity,
+  AuthRpcCapability rpcCapability,
+) => switch (identity) {
+  null => SignerReadiness.pending,
+  LocalNostrIdentity() => SignerReadiness.ready,
+  KeycastNostrIdentity(:final signsWithLocalKey) =>
+    signsWithLocalKey
+        ? SignerReadiness.ready
+        : switch (rpcCapability) {
+            AuthRpcCapability.rpcReady => SignerReadiness.ready,
+            AuthRpcCapability.upgrading => SignerReadiness.pending,
+            AuthRpcCapability.unavailable => SignerReadiness.unavailable,
+          },
+  PubkeyOnlyNostrIdentity() => switch (rpcCapability) {
+    AuthRpcCapability.upgrading => SignerReadiness.pending,
+    AuthRpcCapability.unavailable ||
+    AuthRpcCapability.rpcReady => SignerReadiness.unavailable,
+  },
+  AmberNostrIdentity() ||
+  BunkerNostrIdentity() ||
+  Nip07NostrIdentity() => SignerReadiness.ready,
+};

--- a/mobile/lib/services/auth/signer_readiness_resolver.dart
+++ b/mobile/lib/services/auth/signer_readiness_resolver.dart
@@ -7,23 +7,29 @@ import 'package:openvine/services/auth/nostr_identity.dart';
 
 SignerReadiness resolveSignerReadiness(
   NostrIdentity? identity,
-  AuthRpcCapability rpcCapability,
-) => switch (identity) {
+  AuthRpcCapability rpcCapability, {
+  bool rpcCapabilityInitialized = true,
+}) => switch (identity) {
   null => SignerReadiness.pending,
   LocalNostrIdentity() => SignerReadiness.ready,
   KeycastNostrIdentity(:final signsWithLocalKey) =>
     signsWithLocalKey
         ? SignerReadiness.ready
+        : !rpcCapabilityInitialized
+        ? SignerReadiness.pending
         : switch (rpcCapability) {
             AuthRpcCapability.rpcReady => SignerReadiness.ready,
             AuthRpcCapability.upgrading => SignerReadiness.pending,
             AuthRpcCapability.unavailable => SignerReadiness.unavailable,
           },
-  PubkeyOnlyNostrIdentity() => switch (rpcCapability) {
-    AuthRpcCapability.upgrading => SignerReadiness.pending,
-    AuthRpcCapability.unavailable ||
-    AuthRpcCapability.rpcReady => SignerReadiness.unavailable,
-  },
+  PubkeyOnlyNostrIdentity() =>
+    !rpcCapabilityInitialized
+        ? SignerReadiness.pending
+        : switch (rpcCapability) {
+            AuthRpcCapability.upgrading => SignerReadiness.pending,
+            AuthRpcCapability.unavailable ||
+            AuthRpcCapability.rpcReady => SignerReadiness.unavailable,
+          },
   AmberNostrIdentity() ||
   BunkerNostrIdentity() ||
   Nip07NostrIdentity() => SignerReadiness.ready,

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -22,12 +22,14 @@ import 'package:openvine/models/auth_state.dart';
 import 'package:openvine/models/auth_user_profile.dart';
 import 'package:openvine/models/authentication_source.dart';
 import 'package:openvine/models/known_account.dart';
+import 'package:openvine/models/signer_readiness.dart';
 import 'package:openvine/services/auth/known_accounts_registry.dart';
 import 'package:openvine/services/auth/nostr_connect_coordinator.dart';
 import 'package:openvine/services/auth/nostr_identity.dart';
 import 'package:openvine/services/auth/oauth_session_coordinator.dart';
 import 'package:openvine/services/auth/relay_discovery_orchestrator.dart';
 import 'package:openvine/services/auth/signer_factory.dart';
+import 'package:openvine/services/auth/signer_readiness_resolver.dart';
 import 'package:openvine/services/auth/signer_secure_store.dart';
 import 'package:openvine/services/background_activity_manager.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
@@ -420,28 +422,15 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   Stream<AuthRpcCapability> get authRpcCapabilityStream =>
       _rpcCapabilityController.stream;
 
-  /// Whether this identity can publish Nostr writes right now.
+  /// Whether signing is ready, still warming up, or permanently unavailable.
   ///
-  /// True when the identity has a local private key (can sign locally)
-  /// OR when RPC is fully ready. False for pubkey-only identities that
-  /// are still waiting for RPC warmup.
-  ///
-  /// This answers "is this identity *capable* of signing", not "is the
-  /// signer-backed client ready". It has no direct stream, so it is safe to
-  /// sample at the moment of use. Push consumers that wait for this to flip must
-  /// also watch a rebuild trigger such as `currentAuthRpcCapabilityProvider`.
-  bool get canPublishNostrWritesNow {
-    return switch (_currentIdentity) {
-      null => false,
-      LocalNostrIdentity() => true,
-      KeycastNostrIdentity(:final signsWithLocalKey) =>
-        signsWithLocalKey || _authRpcCapability == AuthRpcCapability.rpcReady,
-      PubkeyOnlyNostrIdentity() => false,
-      AmberNostrIdentity() => true,
-      BunkerNostrIdentity() => true,
-      Nip07NostrIdentity() => true,
-    };
-  }
+  /// This deliberately ignores [isRpcUpgradeInProgress]. That flag does not
+  /// emit on every transition, while identity changes and [authRpcCapability]
+  /// together provide the complete observable state.
+  SignerReadiness get signerReadiness =>
+      resolveSignerReadiness(_currentIdentity, _authRpcCapability);
+
+  bool get canPublishNostrWritesNow => signerReadiness == SignerReadiness.ready;
 
   /// True when a divineOAuth user's session expired and refresh failed.
   /// The user's identity is intact but remote signing is unavailable.

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -427,9 +427,16 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// This deliberately ignores [isRpcUpgradeInProgress]. That flag does not
   /// emit on every transition, while identity changes and [authRpcCapability]
   /// together provide the complete observable state.
+  ///
+  /// No stream carries this value, so sample it at the moment of use. A push
+  /// consumer that waits for it to change must also watch a rebuild trigger
+  /// such as `currentAuthRpcCapabilityProvider` (#6977).
   SignerReadiness get signerReadiness =>
       resolveSignerReadiness(_currentIdentity, _authRpcCapability);
 
+  /// Whether this identity can publish Nostr writes right now.
+  ///
+  /// Shorthand for [signerReadiness] being ready; same sampling contract.
   bool get canPublishNostrWritesNow => signerReadiness == SignerReadiness.ready;
 
   /// True when a divineOAuth user's session expired and refresh failed.

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -254,6 +254,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   // RPC capability state — separate from AuthState so the router doesn't
   // need to know about remote signer warmup.
   AuthRpcCapability _authRpcCapability = AuthRpcCapability.unavailable;
+  bool _authRpcCapabilityInitialized = false;
 
   // NIP-46 bunker signer state
   NostrRemoteSigner? _bunkerSigner;
@@ -431,8 +432,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// No stream carries this value, so sample it at the moment of use. A push
   /// consumer that waits for it to change must also watch a rebuild trigger
   /// such as `currentAuthRpcCapabilityProvider` (#6977).
-  SignerReadiness get signerReadiness =>
-      resolveSignerReadiness(_currentIdentity, _authRpcCapability);
+  SignerReadiness get signerReadiness => resolveSignerReadiness(
+    _currentIdentity,
+    _authRpcCapability,
+    rpcCapabilityInitialized: _authRpcCapabilityInitialized,
+  );
 
   /// Whether this identity can publish Nostr writes right now.
   ///
@@ -2722,6 +2726,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     _setAuthState(AuthState.authenticating);
     _lastError = null;
     _hasExpiredOAuthSession = false;
+    _authRpcCapabilityInitialized = false;
 
     try {
       // Unbound session: pubkey unknown here, treat as same — a wrong close
@@ -4376,6 +4381,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   }
 
   void _setRpcCapability(AuthRpcCapability capability) {
+    _authRpcCapabilityInitialized = true;
     if (_authRpcCapability != capability) {
       final previous = _authRpcCapability;
       _authRpcCapability = capability;

--- a/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_cubit_test.dart
+++ b/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_cubit_test.dart
@@ -124,21 +124,29 @@ void main() {
       verifyNever(repository.fetchCurrent);
     });
 
-    test('retry remains deterministic while signer is unavailable', () async {
-      when(
-        () => authService.signerReadiness,
-      ).thenReturn(SignerReadiness.unavailable);
-      final cubit = buildCubit();
-      addTearDown(cubit.close);
+    test(
+      'retry refreshes an expired session while signer is unavailable',
+      () async {
+        when(
+          () => authService.signerReadiness,
+        ).thenReturn(SignerReadiness.unavailable);
+        when(
+          () => authService.tryRefreshExpiredSession(),
+        ).thenAnswer((_) async => false);
+        final cubit = buildCubit();
+        cubit.signerUnavailable();
+        addTearDown(cubit.close);
 
-      await cubit.retry();
+        await cubit.retry();
 
-      expect(
-        cubit.state.failure,
-        AccountDeletionRecoveryFailure.signerUnavailable,
-      );
-      verifyNever(repository.fetchCurrent);
-    });
+        verify(authService.tryRefreshExpiredSession).called(1);
+        expect(
+          cubit.state.failure,
+          AccountDeletionRecoveryFailure.signerUnavailable,
+        );
+        verifyNever(repository.fetchCurrent);
+      },
+    );
   });
 
   group('load', () {
@@ -435,5 +443,31 @@ void main() {
 
       expect(cubit.state.status, AccountDeletionRecoveryStatus.loading);
     });
+
+    test(
+      'close while waiting for signer refresh drops the resumed emit',
+      () async {
+        final refresh = Completer<bool>();
+        when(
+          () => authService.signerReadiness,
+        ).thenReturn(SignerReadiness.unavailable);
+        when(
+          () => authService.tryRefreshExpiredSession(),
+        ).thenAnswer((_) => refresh.future);
+        final cubit = buildCubit();
+        cubit.signerUnavailable();
+
+        final retry = cubit.retry();
+        await Future<void>.delayed(Duration.zero);
+        await cubit.close();
+        refresh.complete(false);
+        await retry;
+
+        expect(
+          cubit.state.status,
+          AccountDeletionRecoveryStatus.loading,
+        );
+      },
+    );
   });
 }

--- a/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_cubit_test.dart
+++ b/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_cubit_test.dart
@@ -8,6 +8,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:openvine/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart';
 import 'package:openvine/models/account_deletion_attempt.dart';
+import 'package:openvine/models/signer_readiness.dart';
 import 'package:openvine/repositories/account_deletion_recovery_repository.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
@@ -105,6 +106,39 @@ void main() {
     authService = _MockAuthService();
     timers = _ManualTimers();
     resolvedCalls = 0;
+    when(() => authService.signerReadiness).thenReturn(SignerReadiness.ready);
+  });
+
+  group('signer readiness', () {
+    test('unavailable signer enters a typed load failure', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      cubit.signerUnavailable();
+
+      expect(cubit.state.status, AccountDeletionRecoveryStatus.loadFailed);
+      expect(
+        cubit.state.failure,
+        AccountDeletionRecoveryFailure.signerUnavailable,
+      );
+      verifyNever(repository.fetchCurrent);
+    });
+
+    test('retry remains deterministic while signer is unavailable', () async {
+      when(
+        () => authService.signerReadiness,
+      ).thenReturn(SignerReadiness.unavailable);
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      await cubit.retry();
+
+      expect(
+        cubit.state.failure,
+        AccountDeletionRecoveryFailure.signerUnavailable,
+      );
+      verifyNever(repository.fetchCurrent);
+    });
   });
 
   group('load', () {

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -15,6 +15,8 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/auth_rpc_capability.dart';
+import 'package:openvine/models/signer_readiness.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/app_version_provider.dart';
 import 'package:openvine/providers/documents_path_provider.dart';
@@ -123,6 +125,13 @@ MockAuthService createMockAuthService() {
   ).thenReturn(AuthenticationSource.none);
   when(() => mockAuth.currentPublicKeyHex).thenReturn(null);
   when(() => mockAuth.isNip07Available).thenReturn(false);
+  when(() => mockAuth.signerReadiness).thenReturn(SignerReadiness.pending);
+  when(
+    () => mockAuth.authRpcCapability,
+  ).thenReturn(AuthRpcCapability.unavailable);
+  when(
+    () => mockAuth.authRpcCapabilityStream,
+  ).thenAnswer((_) => const Stream<AuthRpcCapability>.empty());
 
   // Stub authState and authStateStream so currentAuthStateProvider does not
   // crash with type 'Null' is not a subtype of type 'Stream<AuthState>'

--- a/mobile/test/providers/account_deletion_recovery_providers_test.dart
+++ b/mobile/test/providers/account_deletion_recovery_providers_test.dart
@@ -1,10 +1,14 @@
 // ABOUTME: Tests the account-deletion recovery providers used by routing.
 // ABOUTME: Verifies lookup readiness remains fail-closed until signing works.
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openvine/models/account_deletion_attempt.dart';
 import 'package:openvine/models/auth_rpc_capability.dart';
+import 'package:openvine/models/signer_readiness.dart';
 import 'package:openvine/providers/account_deletion_recovery_providers.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -30,7 +34,9 @@ void main() {
         final repository = _MockDeletionRepository();
         final authService = _MockAuthService();
         when(repository.fetchCurrent).thenAnswer((_) async => null);
-        when(() => authService.canPublishNostrWritesNow).thenReturn(true);
+        when(
+          () => authService.signerReadiness,
+        ).thenReturn(SignerReadiness.ready);
         final container = ProviderContainer(
           overrides: [
             authServiceProvider.overrideWithValue(authService),
@@ -65,7 +71,9 @@ void main() {
     test('lookup stays fail-closed while signing is unavailable', () async {
       final repository = _MockDeletionRepository();
       final authService = _MockAuthService();
-      when(() => authService.canPublishNostrWritesNow).thenReturn(false);
+      when(
+        () => authService.signerReadiness,
+      ).thenReturn(SignerReadiness.pending);
       final container = ProviderContainer(
         overrides: [
           authServiceProvider.overrideWithValue(authService),
@@ -92,6 +100,44 @@ void main() {
         container.read(currentAccountDeletionAttemptProvider).isLoading,
         true,
       );
+      verifyNever(repository.fetchCurrent);
+    });
+
+    test('permanent signer failure settles as a typed error', () async {
+      final repository = _MockDeletionRepository();
+      final authService = _MockAuthService();
+      when(
+        () => authService.signerReadiness,
+      ).thenReturn(SignerReadiness.unavailable);
+      final container = ProviderContainer(
+        overrides: [
+          authServiceProvider.overrideWithValue(authService),
+          currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+          currentAuthRpcCapabilityProvider.overrideWithValue(
+            AuthRpcCapability.unavailable,
+          ),
+          accountDeletionRecoveryRepositoryProvider.overrideWithValue(
+            repository,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final settled = Completer<AsyncValue<AccountDeletionAttempt?>>();
+      final subscription = container.listen(
+        currentAccountDeletionAttemptProvider,
+        (_, next) {
+          if (next.hasError && !next.isLoading && !settled.isCompleted) {
+            settled.complete(next);
+          }
+        },
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+
+      final result = await settled.future;
+      expect(result.isLoading, isFalse);
+      expect(result.error, isA<AccountDeletionStatusUnavailable>());
       verifyNever(repository.fetchCurrent);
     });
   });

--- a/mobile/test/providers/account_deletion_recovery_providers_test.dart
+++ b/mobile/test/providers/account_deletion_recovery_providers_test.dart
@@ -68,7 +68,7 @@ void main() {
       },
     );
 
-    test('lookup stays fail-closed while signing is unavailable', () async {
+    test('lookup stays fail-closed while signing warms up', () async {
       final repository = _MockDeletionRepository();
       final authService = _MockAuthService();
       when(

--- a/mobile/test/router/minor_account_review_router_test.dart
+++ b/mobile/test/router/minor_account_review_router_test.dart
@@ -8,6 +8,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/account_deletion_attempt.dart';
 import 'package:openvine/models/minor_account_review_status.dart';
+import 'package:openvine/models/signer_readiness.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/repositories/account_deletion_recovery_repository.dart';
@@ -56,6 +57,24 @@ Future<AsyncValue<AccountDeletionAttempt?>> _retainedNullRefetch() async {
   return container.read(lookup);
 }
 
+Future<AsyncValue<AccountDeletionAttempt?>> _retainedRecoveryError() async {
+  var shouldFail = false;
+  final lookup = FutureProvider<AccountDeletionAttempt?>((ref) async {
+    if (shouldFail) throw StateError('signer unavailable');
+    return const AccountDeletionAttempt(
+      id: 'attempt-id',
+      status: AccountDeletionAttemptStatus.recoverable,
+    );
+  }, retry: (_, _) => null);
+  final container = ProviderContainer();
+  addTearDown(container.dispose);
+  await container.read(lookup.future);
+  shouldFail = true;
+  container.invalidate(lookup);
+  await expectLater(container.read(lookup.future), throwsStateError);
+  return container.read(lookup);
+}
+
 void main() {
   group('Account deletion recovery gate', () {
     test('stays inactive while the attempt is loading', () {
@@ -76,6 +95,13 @@ void main() {
           ),
         ),
         isFalse,
+      );
+    });
+
+    test('retains a confirmed recovery gate when a refresh errors', () async {
+      expect(
+        accountDeletionRecoveryGateActive(await _retainedRecoveryError()),
+        isTrue,
       );
     });
 
@@ -158,6 +184,16 @@ void main() {
           ),
           isTrue,
         );
+        expect(
+          authenticatedDeletionLookupSettled(
+            AuthState.authenticated,
+            AsyncError<AccountDeletionAttempt?>(
+              StateError('signer unavailable'),
+              StackTrace.empty,
+            ),
+          ),
+          isTrue,
+        );
       },
     );
   });
@@ -180,6 +216,9 @@ void main() {
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
       when(() => mockAuthService.authState).thenReturn(AuthState.authenticated);
       when(() => mockAuthService.currentPublicKeyHex).thenReturn('user-pubkey');
+      when(
+        () => mockAuthService.signerReadiness,
+      ).thenReturn(SignerReadiness.ready);
       when(
         () => mockAuthService.authStateStream,
       ).thenAnswer((_) => const Stream<AuthState>.empty());

--- a/mobile/test/screens/account_deletion_recovery_screen_test.dart
+++ b/mobile/test/screens/account_deletion_recovery_screen_test.dart
@@ -247,6 +247,30 @@ void main() {
       );
     });
 
+    testWidgets('signer failure asks the user to sign in again', (
+      tester,
+    ) async {
+      when(() => cubit.state).thenReturn(
+        const AccountDeletionRecoveryState(
+          status: AccountDeletionRecoveryStatus.loadFailed,
+          failure: AccountDeletionRecoveryFailure.signerUnavailable,
+        ),
+      );
+      await tester.pumpWidget(_app(cubit));
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.authSessionExpired), findsOneWidget);
+      expect(find.text(l10n.authUnexpectedError), findsNothing);
+      expect(
+        find.widgetWithText(DivineButton, l10n.commonRetry),
+        findsOneWidget,
+      );
+      expect(
+        find.widgetWithText(DivineButton, l10n.accountDeletionSignOut),
+        findsOneWidget,
+      );
+    });
+
     testWidgets(
       'sign-out failure offers one sign-out retry with generic copy',
       (tester) async {

--- a/mobile/test/screens/account_deletion_recovery_screen_test.dart
+++ b/mobile/test/screens/account_deletion_recovery_screen_test.dart
@@ -245,6 +245,8 @@ void main() {
         find.widgetWithText(DivineButton, l10n.accountDeletionSignOut),
         findsOneWidget,
       );
+      await tester.tap(find.widgetWithText(DivineButton, l10n.commonRetry));
+      verify(cubit.retry).called(1);
     });
 
     testWidgets('signer failure asks the user to sign in again', (

--- a/mobile/test/services/auth/signer_readiness_resolver_test.dart
+++ b/mobile/test/services/auth/signer_readiness_resolver_test.dart
@@ -1,0 +1,89 @@
+// ABOUTME: Tests signer readiness across identity and RPC capability states.
+// ABOUTME: Pins terminal signer failure separately from temporary warm-up.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_key_manager/nostr_key_manager.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/models/auth_rpc_capability.dart';
+import 'package:openvine/models/signer_readiness.dart';
+import 'package:openvine/services/auth/nostr_identity.dart';
+import 'package:openvine/services/auth/signer_readiness_resolver.dart';
+import 'package:openvine/services/local_key_signer.dart';
+
+class _MockSigner extends Mock implements NostrSigner {}
+
+class _MockKeyContainer extends Mock implements SecureKeyContainer {}
+
+class _MockLocalKeySigner extends Mock implements LocalKeySigner {}
+
+void main() {
+  group('resolveSignerReadiness', () {
+    const pubkey =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    test('no identity remains pending', () {
+      expect(
+        resolveSignerReadiness(null, AuthRpcCapability.unavailable),
+        SignerReadiness.pending,
+      );
+    });
+
+    test('pubkey-only identity waits only while RPC is upgrading', () {
+      final identity = PubkeyOnlyNostrIdentity(pubkey: pubkey);
+
+      expect(
+        resolveSignerReadiness(identity, AuthRpcCapability.upgrading),
+        SignerReadiness.pending,
+      );
+      expect(
+        resolveSignerReadiness(identity, AuthRpcCapability.unavailable),
+        SignerReadiness.unavailable,
+      );
+    });
+
+    test('remote Keycast identity follows RPC capability', () {
+      final identity = KeycastNostrIdentity(
+        pubkey: pubkey,
+        rpcSigner: _MockSigner(),
+      );
+
+      expect(
+        resolveSignerReadiness(identity, AuthRpcCapability.upgrading),
+        SignerReadiness.pending,
+      );
+      expect(
+        resolveSignerReadiness(identity, AuthRpcCapability.unavailable),
+        SignerReadiness.unavailable,
+      );
+      expect(
+        resolveSignerReadiness(identity, AuthRpcCapability.rpcReady),
+        SignerReadiness.ready,
+      );
+    });
+
+    test('local and interactive identities are always ready', () {
+      final keyContainer = _MockKeyContainer();
+      when(() => keyContainer.publicKeyHex).thenReturn(pubkey);
+      final signer = _MockSigner();
+      final identities = <NostrIdentity>[
+        LocalNostrIdentity(keyContainer: keyContainer),
+        KeycastNostrIdentity(
+          pubkey: pubkey,
+          rpcSigner: signer,
+          localSigner: _MockLocalKeySigner(),
+        ),
+        BunkerNostrIdentity(pubkey: pubkey, remoteSigner: signer),
+        AmberNostrIdentity(pubkey: pubkey, amberSigner: signer),
+        Nip07NostrIdentity(pubkey: pubkey, nip07Signer: signer),
+      ];
+
+      for (final identity in identities) {
+        expect(
+          resolveSignerReadiness(identity, AuthRpcCapability.unavailable),
+          SignerReadiness.ready,
+        );
+      }
+    });
+  });
+}

--- a/mobile/test/services/auth/signer_readiness_resolver_test.dart
+++ b/mobile/test/services/auth/signer_readiness_resolver_test.dart
@@ -62,6 +62,36 @@ void main() {
       );
     });
 
+    test(
+      'remote Keycast identity stays pending before capability sampling',
+      () {
+        final identity = KeycastNostrIdentity(
+          pubkey: pubkey,
+          rpcSigner: _MockSigner(),
+        );
+
+        expect(
+          resolveSignerReadiness(
+            identity,
+            AuthRpcCapability.unavailable,
+            rpcCapabilityInitialized: false,
+          ),
+          SignerReadiness.pending,
+        );
+      },
+    );
+
+    test('pubkey-only identity stays pending before capability sampling', () {
+      expect(
+        resolveSignerReadiness(
+          PubkeyOnlyNostrIdentity(pubkey: pubkey),
+          AuthRpcCapability.unavailable,
+          rpcCapabilityInitialized: false,
+        ),
+        SignerReadiness.pending,
+      );
+    });
+
     test('local and interactive identities are always ready', () {
       final keyContainer = _MockKeyContainer();
       when(() => keyContainer.publicKeyHex).thenReturn(pubkey);


### PR DESCRIPTION
## Problem

An authenticated OAuth restore can retain the user's public key after remote signing becomes permanently unavailable. Account-deletion recovery treated that terminal state as temporary warm-up, so its status lookup never settled and startup remained behind the native splash timeout. A user already routed to deletion recovery could also remain on an endless spinner.

## Fix

Model signer readiness as pending, ready, or unavailable from the active identity and observable RPC capability. Deletion-status lookup now waits only while signing can still become ready, reports a typed terminal error when it cannot, and preserves Riverpod's normal retries for transport failures while disabling retries for the terminal signer-unavailable error.

The recovery screen uses the same signer readiness signal and shows the existing expired-session guidance with Retry and Sign Out when signing is unavailable. Retry now attempts the expired-session refresh. Disposal of a pending lookup now cancels with an internal error, preventing a late completion from surfacing after the lookup is invalidated.

## Deliberately unchanged

Routing still requires evidence of an interrupted deletion. A signer error with no prior deletion attempt does not send the user to the recovery screen; an error that retains a previously confirmed recovery attempt remains gated there.

The retry-policy change is intentionally scoped: terminal signer failure settles immediately, while transient lookup failures retain Riverpod's default retry behavior.

## Verification

- flutter analyze
- Focused provider, Cubit, recovery-screen, router, and signer-readiness tests
- Service-size and untested-service ratchets
- Repository pre-push analyzer and changed-file test gate

Closes #8060