### PR TITLE
ci(tests): keep unrelated test files in stable shards

### DIFF
--- a/mobile/scripts/ci/select_test_shard.sh
+++ b/mobile/scripts/ci/select_test_shard.sh
@@ -14,9 +14,11 @@
 # builders, flutter_test_config.dart — is left in place, because the tests that
 # remain still import it.
 #
-# Assignment is round-robin over the lexicographically sorted file list: it is
-# deterministic, needs no stored baseline that could drift, and (because sorted
-# order groups by directory) spreads each directory's cost across all shards.
+# Assignment hashes each relative path into a bucket. Unlike assigning by the
+# path's position in a sorted list, this keeps every existing file in the same
+# shard when another test is added, removed, or renamed. File counts are only a
+# rough proxy for runtime cost, so the small loss of round-robin count balance
+# is preferable to unrelated pull requests reshuffling merged-isolate peers.
 #
 # This DELETES files. It refuses to run outside CI without --force.
 
@@ -78,7 +80,8 @@ cd "$PROJECT_ROOT"
 
 all_tests_file="$(mktemp)"
 golden_tests_file="$(mktemp)"
-trap 'rm -f "$all_tests_file" "$golden_tests_file"' EXIT
+shard_assignments_file="$(mktemp)"
+trap 'rm -f "$all_tests_file" "$golden_tests_file" "$shard_assignments_file"' EXIT
 
 # test/goldens/ belongs to the dedicated `goldens` job, not to any shard.
 # Image goldens cannot survive this job: `very_good test --optimization`
@@ -104,9 +107,24 @@ fi
 
 kept=0
 removed=0
-i=0
-while IFS= read -r file; do
-  if [ $((i % TOTAL)) -eq "$INDEX" ]; then
+LC_ALL=C awk -v total="$TOTAL" '
+  BEGIN { alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_./-" }
+  {
+    bucket = 0
+    for (i = 1; i <= length($0); i++) {
+      value = index(alphabet, substr($0, i, 1))
+      if (value == 0) {
+        print "Unsupported character in test path: " $0 > "/dev/stderr"
+        exit 2
+      }
+      bucket = (bucket * 33 + value) % total
+    }
+    print bucket, $0
+  }
+' "$all_tests_file" > "$shard_assignments_file"
+
+while read -r bucket file; do
+  if [ "$bucket" -eq "$INDEX" ]; then
     kept=$((kept + 1))
   else
     removed=$((removed + 1))
@@ -114,8 +132,7 @@ while IFS= read -r file; do
       rm -f "$file"
     fi
   fi
-  i=$((i + 1))
-done < "$all_tests_file"
+done < "$shard_assignments_file"
 
 if [ "$kept" -eq 0 ]; then
   echo "❌ Shard ${INDEX}/${TOTAL} selected 0 test files. Refusing to report a vacuous pass." >&2

--- a/mobile/test/flutter_test_config.dart
+++ b/mobile/test/flutter_test_config.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:alchemist/alchemist.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:golden_toolkit/golden_toolkit.dart';
@@ -23,6 +24,15 @@ const _strictChannels = bool.fromEnvironment('DIVINE_STRICT_CHANNELS');
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   // Set up test environment with plugin mocks (secure_storage, path_provider, etc.)
   setupTestEnvironment();
+
+  if (!kIsWeb) {
+    // ThemeData captures defaultTargetPlatform when it is built, while these
+    // app themes are lazy process-cached values. Build both at flutter_test's
+    // Android baseline before a test-scoped platform override can permanently
+    // determine page transitions for every later test in the merged isolate.
+    final _ = VineTheme.theme;
+    final _ = VineTheme.lightTheme;
+  }
 
   // Under `very_good test --optimization` the whole unit suite runs in one
   // isolate and flutter_test auto-restores nothing, so a test that replaces a

--- a/mobile/test/screens/settings/content_preferences_music_mode_test.dart
+++ b/mobile/test/screens/settings/content_preferences_music_mode_test.dart
@@ -99,6 +99,14 @@ void main() {
           widget.title == l10n.contentPreferencesMusicMode,
     );
 
+    test('an iOS override cannot determine the process-cached app theme', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      final cachedPlatform = VineTheme.theme.platform;
+      debugDefaultTargetPlatformOverride = null;
+
+      expect(cachedPlatform, TargetPlatform.android);
+    });
+
     testWidgets('shows the toggle on iOS with its trade-off subtitle', (
       tester,
     ) async {

--- a/mobile/test/screens/settings/content_preferences_music_mode_test.dart
+++ b/mobile/test/screens/settings/content_preferences_music_mode_test.dart
@@ -99,12 +99,14 @@ void main() {
           widget.title == l10n.contentPreferencesMusicMode,
     );
 
-    test('an iOS override cannot determine the process-cached app theme', () {
+    test('an iOS override cannot determine the process-cached app themes', () {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-      final cachedPlatform = VineTheme.theme.platform;
+      final cachedDarkPlatform = VineTheme.theme.platform;
+      final cachedLightPlatform = VineTheme.lightTheme.platform;
       debugDefaultTargetPlatformOverride = null;
 
-      expect(cachedPlatform, TargetPlatform.android);
+      expect(cachedDarkPlatform, TargetPlatform.android);
+      expect(cachedLightPlatform, TargetPlatform.android);
     });
 
     testWidgets('shows the toggle on iOS with its trade-off subtitle', (

--- a/mobile/test/tools/select_test_shard_test.dart
+++ b/mobile/test/tools/select_test_shard_test.dart
@@ -71,6 +71,22 @@ void main() {
         ..sort();
     }
 
+    Map<String, int> shardAssignments(List<String> testFiles, int total) {
+      final assignments = <String, int>{};
+      for (var index = 0; index < total; index++) {
+        sandbox.deleteSync(recursive: true);
+        sandbox = Directory.systemTemp.createTempSync('select_test_shard_');
+        createSandbox(testFiles: testFiles);
+
+        final result = runShard(index, total);
+        expect(result.exitCode, 0, reason: '${result.stderr}');
+        for (final file in survivingTestFiles()) {
+          assignments[file] = index;
+        }
+      }
+      return assignments;
+    }
+
     setUp(() {
       sandbox = Directory.systemTemp.createTempSync('select_test_shard_');
     });
@@ -81,8 +97,15 @@ void main() {
 
     test('shards partition every test file exactly once', () {
       final allTests = [
-        for (var i = 0; i < 17; i++)
-          p.join('test', 'group_${i % 4}', 'a${i}_test.dart'),
+        p.join('test', 'android', 'crossposting_callback_manifest_test.dart'),
+        p.join('test', 'app', 'background_launch_downloads_test.dart'),
+        p.join('test', 'app_update', 'bloc', 'app_update_bloc_test.dart'),
+        p.join(
+          'test',
+          'blocs',
+          'account_content_labels',
+          'account_content_labels_cubit_test.dart',
+        ),
       ]..sort();
       const total = 4;
 
@@ -106,6 +129,23 @@ void main() {
       );
     });
 
+    test('adding a test file does not move existing files between shards', () {
+      final originalTests = [
+        for (var i = 0; i < 12; i++)
+          p.join('test', 'widgets', 'b${i}_test.dart'),
+      ];
+      const insertedTest = 'test/widgets/a_inserted_test.dart';
+      const total = 4;
+
+      final before = shardAssignments(originalTests, total);
+      final after = shardAssignments([...originalTests, insertedTest], total);
+
+      expect({
+        for (final file in originalTests) file: after[file],
+      }, equals(before));
+      expect(after, contains(insertedTest));
+    });
+
     test(
       'leaves non-test sources in place so surviving tests still import them',
       () {
@@ -121,7 +161,7 @@ void main() {
           ],
         );
 
-        expect(runShard(0, 2).exitCode, 0);
+        expect(runShard(0, 1).exitCode, 0);
 
         for (final kept in [
           p.join('test', 'helpers', 'test_helpers.dart'),
@@ -145,7 +185,7 @@ void main() {
       const golden = 'test/goldens/widgets/a_golden_test.dart';
       final shardable = [
         p.join('test', 'a_test.dart'),
-        p.join('test', 'b_test.dart'),
+        p.join('test', 'only_test.dart'),
       ];
       const total = 2;
 
@@ -191,7 +231,7 @@ void main() {
       final result = Process.runSync('bash', [
         scriptPath,
         '--total',
-        '2',
+        '1',
         '--index',
         '0',
         '--dry-run',
@@ -213,8 +253,8 @@ void main() {
     test(
       'fails rather than reporting a vacuous pass when a shard is empty',
       () {
-        // One file, four shards: shards 1..3 select nothing. A silent success
-        // there would mean a green CI leg that ran no tests at all.
+        // One file cannot populate four shards. A silent success from an empty
+        // one would mean a green CI leg that ran no tests at all.
         createSandbox(testFiles: [p.join('test', 'only_test.dart')]);
 
         final result = runShard(3, 4);


### PR DESCRIPTION
Adding or renaming a test file currently reshuffles hundreds of later files across CI shards. Because each shard is merged into one test isolate, that exposes unrelated pull requests to different process-global neighbours and can surface failures their diffs did not cause.

This change assigns each test path to a stable hash bucket, so changing one path no longer moves existing tests. The current 1,558 shardable files remain closely balanced at 380 / 388 / 392 / 398 across four shards.

It also prevents the concrete pollution behind #8320: the process-cached dark and light themes could capture a temporary platform override on first access and preserve iOS page transitions for every later test in the isolate. Non-web tests now initialize both themes at Flutter test’s Android baseline before test bodies run.

This deliberately does not sweep positional widget finders or change random-seed reporting; those are independent prevention and diagnostics work. #6880 remains the occurrence log for other cross-file pollution mechanisms.

Verification:
- `flutter test test/tools/select_test_shard_test.dart test/screens/settings/content_preferences_music_mode_test.dart`
- `flutter analyze lib test integration_test`
- all four `scripts/ci/select_test_shard.sh --total 4 --index N --dry-run` selections
- process-global, ungrouped-test, placeholder-test, and Codex configuration guards

Closes #8330
Refs #6880