### PR TITLE
feat(dm): publish the kind-10050 DM inbox list so NIP-17 senders can reach divine users

### DIFF
--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -39,13 +39,6 @@ enum FeatureFlag {
         'Changing relays can break publishing and discovery — only turn '
         'this on if you know what you are doing.',
   ),
-  publishDmRelayList(
-    'Publish DM Relay List',
-    'Self-advertise your NIP-17 kind-10050 DM inbox relays on login so '
-        'compliant senders deliver where divine reads. Keep off until the '
-        'backend relay accepts kind-10050.',
-    audience: FeatureFlagAudience.internal,
-  ),
   feedTuning(
     'Feed Tuning Swipes',
     'Swipe left/right on the fullscreen feed to send "less/more like this" '

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -34,9 +34,6 @@ class BuildConfiguration {
         );
       case FeatureFlag.advancedRelaySettings:
         return const bool.fromEnvironment('FF_ADVANCED_RELAY_SETTINGS');
-      case FeatureFlag.publishDmRelayList:
-        // Default OFF until the backend relay accepts kind-10050 (#4974 RC3).
-        return const bool.fromEnvironment('FF_PUBLISH_DM_RELAY_LIST');
       case FeatureFlag.feedTuning:
         // TODO(#6649): Re-promote after divine-funnelcake#691 ships.
         return const bool.fromEnvironment('FF_FEED_TUNING');
@@ -100,8 +97,6 @@ class BuildConfiguration {
         return 'FF_VIDEO_REPLIES';
       case FeatureFlag.advancedRelaySettings:
         return 'FF_ADVANCED_RELAY_SETTINGS';
-      case FeatureFlag.publishDmRelayList:
-        return 'FF_PUBLISH_DM_RELAY_LIST';
       case FeatureFlag.feedTuning:
         return 'FF_FEED_TUNING';
       case FeatureFlag.profileMonetizationLinks:

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -24,8 +24,6 @@ import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/constants/hive_box_names.dart';
-import 'package:openvine/features/feature_flags/models/feature_flag.dart';
-import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/bookmark_signer_adapter.dart';
@@ -45,6 +43,7 @@ import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/curated_list_service.dart';
 import 'package:openvine/services/immediate_completion_helper.dart';
 import 'package:openvine/services/pending_action_service.dart';
+import 'package:openvine/services/relay_discovery_service.dart';
 import 'package:openvine/utils/search_utils.dart';
 import 'package:people_lists_repository/people_lists_repository.dart';
 import 'package:profile_repository/profile_repository.dart';
@@ -694,15 +693,8 @@ DmRepository dmRepository(Ref ref) {
   final prefs = ref.watch(sharedPreferencesProvider);
   final reactionsRepository = ref.watch(dmReactionsRepositoryProvider);
 
-  // #4974 RC3: gate self-publishing the user's kind-10050 behind the feature
-  // flag (default OFF until the backend relay accepts the kind), and advertise
-  // the environment's stable DM relay (same source as the kind-10002
-  // bootstrap), not the volatile connected-relay getter. Read, not watch, so a
-  // flag flip doesn't churn the live DM subscription — the provider body
-  // re-runs (and re-reads the flag) on each auth change.
-  final publishDmRelayListEnabled = ref.read(
-    isFeatureEnabledProvider(FeatureFlag.publishDmRelayList),
-  );
+  // Advertise the environment's stable DM relay (same source as the
+  // kind-10002 bootstrap), not the volatile connected-relay getter. #4974.
   final dmInboxRelayUrl = ref.read(currentEnvironmentProvider).relayUrl;
 
   final repository = DmRepository(
@@ -720,8 +712,8 @@ DmRepository dmRepository(Ref ref) {
     // this repository, so putting the policy here is what stops a caller
     // inheriting nothing (#8391). Current AND retired keys, matching #8302.
     removalPolicy: isModerationAccount,
-    publishDmRelayListEnabled: publishDmRelayListEnabled,
     dmInboxRelayUrl: dmInboxRelayUrl,
+    dmInboxDiscoveryRelays: IndexerRelayConfig.dmInboxDiscoveryRelays,
     errorReporter: (error, stackTrace, {required site}) {
       unawaited(
         CrashReportingService.instance.recordError(

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -713,6 +713,7 @@ DmRepository dmRepository(Ref ref) {
     // inheriting nothing (#8391). Current AND retired keys, matching #8302.
     removalPolicy: isModerationAccount,
     dmInboxRelayUrl: dmInboxRelayUrl,
+    dmInboxTaggedRelays: IndexerRelayConfig.dmInboxTaggedRelays,
     dmInboxDiscoveryRelays: IndexerRelayConfig.dmInboxDiscoveryRelays,
     errorReporter: (error, stackTrace, {required site}) {
       unawaited(

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -1068,7 +1068,7 @@ final class DmRepositoryProvider
   }
 }
 
-String _$dmRepositoryHash() => r'd4380a101f8c96787c9a3036ffb610ca3fd56e16';
+String _$dmRepositoryHash() => r'b34dab2b6c4bf6f66645aca04f737ef5a8d010f2';
 
 /// Provider for CommentsRepository instance
 ///

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -1068,7 +1068,7 @@ final class DmRepositoryProvider
   }
 }
 
-String _$dmRepositoryHash() => r'8b8a652ac6190a1ea6dace64f4cd9ed492dd8bf2';
+String _$dmRepositoryHash() => r'd4380a101f8c96787c9a3036ffb610ca3fd56e16';
 
 /// Provider for CommentsRepository instance
 ///

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -1068,7 +1068,7 @@ final class DmRepositoryProvider
   }
 }
 
-String _$dmRepositoryHash() => r'b34dab2b6c4bf6f66645aca04f737ef5a8d010f2';
+String _$dmRepositoryHash() => r'639c33f88161f512cae32548e75f18303a690c9e';
 
 /// Provider for CommentsRepository instance
 ///

--- a/mobile/lib/services/auth/relay_discovery_orchestrator.dart
+++ b/mobile/lib/services/auth/relay_discovery_orchestrator.dart
@@ -91,6 +91,9 @@ class RelayDiscoveryOrchestrator {
   /// Always runs discovery (with 24h cache to avoid redundant indexer queries).
   /// Discovered relays are ADDED to the main client's existing connections,
   /// so user's manual relay edits are preserved (addRelay skips duplicates).
+  /// The relays Divine advertises in its kind-10050 inbox list are also added
+  /// when discovery succeeds, because the active session must read every relay
+  /// it promises to senders. They are not reported through [onUserRelays].
   ///
   /// When discovery returns empty or fails (e.g. imported account that
   /// never published a kind 10002 list), [IndexerRelayConfig.safeFallbackRelays]
@@ -133,6 +136,7 @@ class RelayDiscoveryOrchestrator {
         // Notify NostrService so it can add these relays to the current client
         final urls = result.relays.map((r) => r.url).toList();
         _userRelaysDiscoveredCallback()?.call(targetPubkey ?? npub, urls);
+        connectToDmInboxRelays(targetPubkey ?? npub);
       } else {
         _onUserRelays([]);
 
@@ -299,6 +303,16 @@ class RelayDiscoveryOrchestrator {
     _userRelaysDiscoveredCallback()?.call(
       targetPubkey,
       IndexerRelayConfig.safeFallbackRelays,
+    );
+  }
+
+  /// Adds the relays Divine advertises in its kind-10050 inbox list to the
+  /// active pool even when the user has a separate kind-10002 list. These are
+  /// automatic reachability connections, not the user's published relay list.
+  void connectToDmInboxRelays(String targetPubkey) {
+    _userRelaysDiscoveredCallback()?.call(
+      targetPubkey,
+      IndexerRelayConfig.dmInboxTaggedRelays,
     );
   }
 

--- a/mobile/lib/services/relay_discovery_service.dart
+++ b/mobile/lib/services/relay_discovery_service.dart
@@ -24,21 +24,30 @@ class IndexerRelayConfig {
     'wss://relay.nos.social',
   ];
 
+  /// Additional relays named in the user's NIP-17 kind-10050 DM inbox list,
+  /// on top of divine's own relay, so DM writes retain redundancy.
+  static const List<String> dmInboxTaggedRelays = [
+    'wss://nos.lol',
+    'wss://relay.primal.net',
+  ];
+
   /// Relays the user's NIP-17 kind-10050 DM inbox list is published to, on
   /// top of divine's own relay, so a third-party sender can find it.
   ///
   /// NIP-17 §Relays: clients "SHOULD spread them to as many relays as
-  /// viable". Viable is measured, not assumed — of [defaultIndexers], only
-  /// purplepag.es accepts the kind today; `user.kindpag.es` answers `blocked:
-  /// the event doesn't match the allowed filters` and `relay.nos.social`
-  /// answers `blocked: kind not allowed`. purplepag.es is also the indexer
-  /// outbox-model clients query for a user's lists, so it is the entry that
-  /// buys the discoverability.
+  /// viable". Viable is measured, not assumed — [dmInboxDiscoveryRelays]
+  /// includes the two DM-capable fallback relays plus purplepag.es, the indexer
+  /// outbox-model clients query for a user's lists. `user.kindpag.es` and
+  /// `relay.nos.social` are intentionally not used as discovery-only targets
+  /// because they reject kind 10050 in the current relay measurements.
   ///
   /// Publishing here is best-effort and never gates the publish; see
   /// `DmRepository.ensureDmRelayListPublished`. Adding an entry means having
   /// checked it accepts kind 10050.
-  static const List<String> dmInboxDiscoveryRelays = ['wss://purplepag.es'];
+  static const List<String> dmInboxDiscoveryRelays = [
+    ...dmInboxTaggedRelays,
+    'wss://purplepag.es',
+  ];
 
   /// Safe fallback relay set for users without a discoverable NIP-65 relay
   /// list (kind 10002).

--- a/mobile/lib/services/relay_discovery_service.dart
+++ b/mobile/lib/services/relay_discovery_service.dart
@@ -24,6 +24,22 @@ class IndexerRelayConfig {
     'wss://relay.nos.social',
   ];
 
+  /// Relays the user's NIP-17 kind-10050 DM inbox list is published to, on
+  /// top of divine's own relay, so a third-party sender can find it.
+  ///
+  /// NIP-17 §Relays: clients "SHOULD spread them to as many relays as
+  /// viable". Viable is measured, not assumed — of [defaultIndexers], only
+  /// purplepag.es accepts the kind today; `user.kindpag.es` answers `blocked:
+  /// the event doesn't match the allowed filters` and `relay.nos.social`
+  /// answers `blocked: kind not allowed`. purplepag.es is also the indexer
+  /// outbox-model clients query for a user's lists, so it is the entry that
+  /// buys the discoverability.
+  ///
+  /// Publishing here is best-effort and never gates the publish; see
+  /// `DmRepository.ensureDmRelayListPublished`. Adding an entry means having
+  /// checked it accepts kind 10050.
+  static const List<String> dmInboxDiscoveryRelays = ['wss://purplepag.es'];
+
   /// Safe fallback relay set for users without a discoverable NIP-65 relay
   /// list (kind 10002).
   ///

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -948,18 +948,26 @@ class DmRepository {
         category: LogCategory.system,
       );
 
-      // Resolve the user's OWN kind-10050 inbox relays and target the live
-      // subscription at them — as BOTH tempRelays (to add connections outside
-      // the default pool) AND targetRelays — so gift wraps a NIP-17 sender
-      // delivered to relays outside divine's default pool are read. A `null`
-      // result (no kind-10050 / resolve failure) preserves the prior
-      // default-pool behavior. Memoized per session, so the resolve (bounded
-      // by the queryEvents ~5s timeout) only delays the FIRST open. See #4974.
+      // Resolve the user's OWN kind-10050 inbox relays and dial them as
+      // `tempRelays`, so gift wraps a NIP-17 sender delivered outside divine's
+      // default pool are read. `tempRelays` ADDS those connections; the pool
+      // keeps its own subscription. A `null` result (no kind-10050 / resolve
+      // failure) is the plain default-pool read. Memoized per session, so the
+      // resolve (bounded by the queryEvents ~5s timeout) only delays the FIRST
+      // open. See #4974.
+      //
+      // Deliberately NOT `targetRelays`: that parameter is a filter over the
+      // pool, not an addition — `RelayPool.subscribe` skips every pooled relay
+      // the list does not name. Passing the own-inbox list there subtracted
+      // divine's own relay and the four `safeFallbackRelays` that #2931 added
+      // precisely so DMs written to other relays stay visible, which is the
+      // opposite of the intent above. See #7320.
+      //
       // Capture the session token before the await: `filter` was built with
       // the current `_userPubkey`, so if an account switch lands during the
       // resolve we must NOT open a subscription targeting the previous user.
       final gen = _resetGeneration;
-      final ownInbox = await _ownInboxTargetRelays();
+      final ownInbox = await _ownInboxRelays();
       // A teardown (stopListening), account switch (generation bumped), or a
       // competing call may have run during the await — bail rather than open
       // a stale or duplicate subscription.
@@ -975,7 +983,6 @@ class DmRepository {
         [filter],
         subscriptionId: _subscriptionId,
         tempRelays: ownInbox,
-        targetRelays: ownInbox,
       );
 
       _giftWrapSubscription = stream.listen(
@@ -1060,9 +1067,15 @@ class DmRepository {
     return future;
   }
 
-  /// The relays to target the live read at: the user's own kind-10050 relays
-  /// when `found`, else `null` (default pool) on `absent`/`failed`.
-  Future<List<String>?> _ownInboxTargetRelays() async {
+  /// The user's own kind-10050 relays when `found`, else `null` on
+  /// `absent`/`failed`.
+  ///
+  /// Every reader treats a non-null result as relays to reach IN ADDITION to
+  /// the pool — `tempRelays` on the live subscription and on each drain page,
+  /// and publish targets on the read marker (where `NostrClient.publishEvent`
+  /// forwards them as temp relays too). None of them narrows the pool: see the
+  /// `targetRelays` note in [startListening] and #7320.
+  Future<List<String>?> _ownInboxRelays() async {
     final res = await _resolveOwnDmInbox();
     return res.state == _OwnDmInboxState.found ? res.relays : null;
   }
@@ -1574,10 +1587,11 @@ class DmRepository {
           DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
       // Resolve the user's OWN kind-10050 inbox relays once for the whole
-      // drain (memoized, shared with the live subscription) and target every
-      // page at them so the backfill reads gift wraps delivered outside the
-      // default pool. `null` keeps default-pool-only behavior. See #4974.
-      final ownInbox = await _ownInboxTargetRelays();
+      // drain (memoized, shared with the live subscription) and dial every
+      // page at them as well as the pool, so the backfill reads gift wraps
+      // delivered outside the default pool. `null` keeps default-pool-only
+      // behavior. See #4974.
+      final ownInbox = await _ownInboxRelays();
       if (_ingestSessionEnded(pubkey, gen)) return;
 
       var reachedEnd = false;
@@ -6539,7 +6553,7 @@ class DmRepository {
         'v': _readMarkerPayloadVersion,
         'read': readMap,
       });
-      final ownInbox = await _ownInboxTargetRelays();
+      final ownInbox = await _ownInboxRelays();
       if (_disposed || _resetGeneration != gen) return;
       await service.publishSelfApplicationMarker(
         content: content,

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -427,17 +427,17 @@ class DmRepository {
   /// `null` in fixtures that don't exercise the publish; when `null`,
   /// [ensureDmRelayListPublished] is a no-op (nothing to advertise).
   ///
-  /// This is both the sole `relay` tag in the published list and the relay
-  /// whose `OK` decides success — it is where divine actually reads.
+  /// This is the primary `relay` tag in the published list and the relay whose
+  /// `OK` decides success — it is where Divine always reads.
   final String? _dmInboxRelayUrl;
 
   /// Extra relays the kind-10050 EVENT is published to so third-party senders
-  /// can discover it. They are publish targets only and never appear as
-  /// `relay` tags: the list's contents stay at one relay, per NIP-17's
-  /// "keep kind:10050 lists small (1-3 relays)", while NIP-17's "SHOULD spread
-  /// them to as many relays as viable" is satisfied by where the event lands.
+  /// can discover it. The tagged subset also belongs in Divine's active pool
+  /// so the session reads every relay it advertises; discovery-only relays
+  /// receive the event but are not advertised.
   ///
-  /// Best-effort by construction. A relay here that refuses kind 10050 is
+  /// Discovery publication is best-effort by construction. A relay here that
+  /// refuses kind 10050 is
   /// logged once and otherwise ignored: it neither fails the publish nor
   /// blocks the idempotence flag, so it can never cause a republish loop.
   final List<String> _dmInboxDiscoveryRelays;
@@ -1082,9 +1082,9 @@ class DmRepository {
   ///
   /// Every reader treats a non-null result as relays to reach IN ADDITION to
   /// the pool — `tempRelays` on the live subscription and on each drain page.
-  /// Read markers deliberately publish through the normal pool because the
-  /// publish API's `targetRelays` parameter filters that pool rather than
-  /// adding to it. See the `targetRelays` note in [startListening] and #7320.
+  /// Read markers deliberately publish through the normal pool so they retain
+  /// the pool's write redundancy; the publish API can also open temporary
+  /// connections for explicit targets, unlike subscription/query filtering.
   Future<List<String>?> _ownInboxRelays() async {
     final res = await _resolveOwnDmInbox();
     return res.state == _OwnDmInboxState.found ? res.relays : null;
@@ -3574,7 +3574,7 @@ class DmRepository {
       final taggedRelays = <String>[
         relayUrl,
         ..._dmInboxTaggedRelays
-            .where(isRelayUrlAllowed)
+            .where(_nostrClient.isRelayAllowed)
             .where((relay) => relay != relayUrl),
       ];
       final unsigned = Event(
@@ -3604,7 +3604,7 @@ class DmRepository {
       // env-locked build drops the latter in `NostrClient._allowedRelays`, so
       // a LOCAL run still targets only its own relay.
       final discoveryTargets = _dmInboxDiscoveryRelays
-          .where(isRelayUrlAllowed)
+          .where(_nostrClient.isRelayAllowed)
           .toList();
       final outcome = await _nostrClient.publishEventAwaitOk(
         signed,

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -327,8 +327,8 @@ class DmRepository {
     DmRepositoryErrorReporter? errorReporter,
     DmReactionsRepository? reactionsRepository,
     DmConversationRemovalPolicy? removalPolicy,
-    bool publishDmRelayListEnabled = false,
     String? dmInboxRelayUrl,
+    List<String> dmInboxDiscoveryRelays = const <String>[],
     Duration readMarkerDebounceDelay = _defaultReadMarkerDebounceDelay,
     String Function()? sendBatchIdGenerator,
   }) : _nostrClient = nostrClient,
@@ -350,8 +350,8 @@ class DmRepository {
        _errorReporter = errorReporter,
        _reactionsRepository = reactionsRepository,
        _removalPolicy = removalPolicy ?? allowAllConversationRemoval,
-       _publishDmRelayListEnabled = publishDmRelayListEnabled,
        _dmInboxRelayUrl = dmInboxRelayUrl,
+       _dmInboxDiscoveryRelays = dmInboxDiscoveryRelays,
        _newSendBatchId = sendBatchIdGenerator ?? _defaultSendBatchId;
 
   final NostrClient _nostrClient;
@@ -420,18 +420,25 @@ class DmRepository {
   /// identities via `dmRepositoryProvider`.
   final DmConversationRemovalPolicy _removalPolicy;
 
-  /// Feature gate for #4974 RC3 (self-publishing the user's own kind-10050 DM
-  /// inbox relay list on login). Defaults to `false` so the publish stays
-  /// inert until the backend relay accepts the kind; the app flips it on via
-  /// `FeatureFlag.publishDmRelayList`. While `false`,
-  /// [ensureDmRelayListPublished] is a no-op — no signer round-trip fires.
-  final bool _publishDmRelayListEnabled;
-
-  /// The stable relay URL advertised by the RC3 kind-10050 publish (the
+  /// The stable relay URL advertised by the kind-10050 publish (the
   /// environment's canonical DM relay, mirroring the kind-10002 bootstrap).
-  /// `null` in fixtures that don't exercise RC3; when `null`,
+  /// `null` in fixtures that don't exercise the publish; when `null`,
   /// [ensureDmRelayListPublished] is a no-op (nothing to advertise).
+  ///
+  /// This is both the sole `relay` tag in the published list and the relay
+  /// whose `OK` decides success — it is where divine actually reads.
   final String? _dmInboxRelayUrl;
+
+  /// Extra relays the kind-10050 EVENT is published to so third-party senders
+  /// can discover it. They are publish targets only and never appear as
+  /// `relay` tags: the list's contents stay at one relay, per NIP-17's
+  /// "keep kind:10050 lists small (1-3 relays)", while NIP-17's "SHOULD spread
+  /// them to as many relays as viable" is satisfied by where the event lands.
+  ///
+  /// Best-effort by construction. A relay here that refuses kind 10050 is
+  /// logged once and otherwise ignored: it neither fails the publish nor
+  /// blocks the idempotence flag, so it can never cause a republish loop.
+  final List<String> _dmInboxDiscoveryRelays;
 
   /// Mints the durable, collision-proof identity for one send invocation.
   /// Group sends share it across the fan-out. Injected so tests can pin a
@@ -3492,11 +3499,17 @@ class DmRepository {
   /// Publishes a minimal NIP-17 kind-10050 DM inbox relay list for the
   /// current user when they don't already advertise one, so compliant
   /// senders deliver gift-wrapped DMs to the relay where divine receives
-  /// them (#4974 RC3).
+  /// them (#4974, #7336).
   ///
-  /// Gated behind the injected `publishDmRelayListEnabled` flag: while it is
-  /// off (the default, until the backend relay accepts kind-10050) this is a
-  /// no-op — no signer round-trip fires on login.
+  /// Without this, NIP-17 §Publishing makes a divine account undeliverable to
+  /// any spec-following sender: "If such a list is not found that indicates
+  /// the user is not ready to receive messages and clients shouldn't try."
+  /// Absence is a positive signal of unreadiness, not "unknown, try the
+  /// defaults" — and the sender sees nothing worth surfacing, so the divine
+  /// user never learns a message was withheld.
+  ///
+  /// Published to [_dmInboxRelayUrl] plus [_dmInboxDiscoveryRelays]; only the
+  /// first is tagged, and only its `OK` counts as success.
   ///
   /// Publish-when-absent: a kind-10050 the user advertised from any client is
   /// left untouched. The own-inbox lookup distinguishes `found` / `absent` /
@@ -3512,15 +3525,15 @@ class DmRepository {
   /// bounded: this method returns early once `dmRelayListPublished` is set, so
   /// it runs at most once per (device, pubkey), and it is never awaited by
   /// login. Idempotent per (device, pubkey) via
-  /// `DmSyncState.dmRelayListPublished`, with the flag set ONLY on a confirmed
-  /// relay `OK`. A relay that rejects kind-10050 or a slow/failed signer
-  /// leaves the flag unset and the next login retries — the publish never
-  /// blocks login and self-heals once the backend accepts the kind.
+  /// `DmSyncState.dmRelayListPublished`, with the flag set ONLY once
+  /// [_dmInboxRelayUrl] itself confirms `OK`. A rejection there, or a
+  /// slow/failed signer, leaves the flag unset and the next login retries —
+  /// the publish never blocks login and self-heals.
   ///
-  /// No-op when the feature is off, when uninitialized, when no signer / sync
-  /// state is wired, or when no valid advertised relay URL is configured.
+  /// No-op when uninitialized, when no signer / sync state is wired, or when
+  /// no valid advertised relay URL is configured.
   Future<void> ensureDmRelayListPublished() async {
-    if (!_publishDmRelayListEnabled || !isInitialized) return;
+    if (!isInitialized) return;
     final syncState = _syncState;
     final signer = _signer;
     final relayUrl = _dmInboxRelayUrl;
@@ -3574,17 +3587,39 @@ class DmRepository {
       if (signed == null || signed.sig.isEmpty) return;
       if (_disposed || _resetGeneration != gen) return;
 
+      // Publish to the advertised relay AND the discovery relays. An
+      // env-locked build drops the latter in `NostrClient._allowedRelays`, so
+      // a LOCAL run still targets only its own relay.
+      final discoveryTargets = _dmInboxDiscoveryRelays
+          .where(isRelayUrlAllowed)
+          .toList();
       final outcome = await _nostrClient.publishEventAwaitOk(
         signed,
-        targetRelays: <String>[relayUrl],
+        targetRelays: <String>[relayUrl, ...discoveryTargets],
       );
       if (_disposed || _resetGeneration != gen) return;
-      if (outcome.acceptedBy.isEmpty) {
+      // Success is the advertised relay's own `OK`, not "something accepted".
+      // A discovery relay accepting while divine's relay refused would mark
+      // the list published and stop retrying, leaving the one relay divine
+      // reads from without it.
+      if (!outcome.acceptedBy.contains(relayUrl)) {
         Log.warning(
-          'kind-10050 publish: no relay accepted — will retry next login',
+          'kind-10050 publish: $relayUrl did not accept '
+          '(${outcome.rejectedBy[relayUrl] ?? 'no response'}) — will retry '
+          'next login',
           category: LogCategory.system,
         );
         return;
+      }
+      for (final url in discoveryTargets) {
+        if (outcome.acceptedBy.contains(url)) continue;
+        // Best-effort by design: discoverability only. Logged so a relay
+        // changing its kind policy is visible in a bug report, never retried.
+        Log.warning(
+          'kind-10050 discovery publish to $url did not land '
+          '(${outcome.rejectedBy[url] ?? 'no response'}) — not retried',
+          category: LogCategory.system,
+        );
       }
 
       await syncState.markDmRelayListPublished(pubkey);

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -329,6 +329,7 @@ class DmRepository {
     DmConversationRemovalPolicy? removalPolicy,
     String? dmInboxRelayUrl,
     List<String> dmInboxDiscoveryRelays = const <String>[],
+    List<String> dmInboxTaggedRelays = const <String>[],
     Duration readMarkerDebounceDelay = _defaultReadMarkerDebounceDelay,
     String Function()? sendBatchIdGenerator,
   }) : _nostrClient = nostrClient,
@@ -352,6 +353,7 @@ class DmRepository {
        _removalPolicy = removalPolicy ?? allowAllConversationRemoval,
        _dmInboxRelayUrl = dmInboxRelayUrl,
        _dmInboxDiscoveryRelays = dmInboxDiscoveryRelays,
+       _dmInboxTaggedRelays = dmInboxTaggedRelays,
        _newSendBatchId = sendBatchIdGenerator ?? _defaultSendBatchId;
 
   final NostrClient _nostrClient;
@@ -439,6 +441,7 @@ class DmRepository {
   /// logged once and otherwise ignored: it neither fails the publish nor
   /// blocks the idempotence flag, so it can never cause a republish loop.
   final List<String> _dmInboxDiscoveryRelays;
+  final List<String> _dmInboxTaggedRelays;
 
   /// Mints the durable, collision-proof identity for one send invocation.
   /// Group sends share it across the fan-out. Injected so tests can pin a
@@ -1036,7 +1039,7 @@ class DmRepository {
   /// Resolves and memoizes the CURRENT user's own kind-10050 DM inbox
   /// resolution for the session (#4974 RC2).
   ///
-  /// Shared by the live subscription, history drain, and read-marker publish.
+  /// Shared by the live subscription and history drain.
   /// The RC3 existence check deliberately performs its own authoritative read.
   /// A `found`/`absent` outcome is cached; a `failed` (transient) outcome is NOT
   /// — the memo clears itself once it resolves `failed` so the next caller
@@ -1049,7 +1052,7 @@ class DmRepository {
     final future = _queryOwnDmInbox(
       _userPubkey,
       // Deliberately NOT authoritative. Every consumer of this memo — the live
-      // gift-wrap subscription, the history drain, the read-marker publish —
+      // gift-wrap subscription and the history drain —
       // falls back to the default pool on `absent` and `failed` alike, and
       // `startListening` awaits it before opening the subscription. Making it
       // strict would put a full timeout in front of DM delivery on every login
@@ -1078,10 +1081,10 @@ class DmRepository {
   /// `absent`/`failed`.
   ///
   /// Every reader treats a non-null result as relays to reach IN ADDITION to
-  /// the pool — `tempRelays` on the live subscription and on each drain page,
-  /// and publish targets on the read marker (where `NostrClient.publishEvent`
-  /// forwards them as temp relays too). None of them narrows the pool: see the
-  /// `targetRelays` note in [startListening] and #7320.
+  /// the pool — `tempRelays` on the live subscription and on each drain page.
+  /// Read markers deliberately publish through the normal pool because the
+  /// publish API's `targetRelays` parameter filters that pool rather than
+  /// adding to it. See the `targetRelays` note in [startListening] and #7320.
   Future<List<String>?> _ownInboxRelays() async {
     final res = await _resolveOwnDmInbox();
     return res.state == _OwnDmInboxState.found ? res.relays : null;
@@ -3508,8 +3511,9 @@ class DmRepository {
   /// defaults" — and the sender sees nothing worth surfacing, so the divine
   /// user never learns a message was withheld.
   ///
-  /// Published to [_dmInboxRelayUrl] plus [_dmInboxDiscoveryRelays]; only the
-  /// first is tagged, and only its `OK` counts as success.
+  /// Published to [_dmInboxRelayUrl] plus [_dmInboxDiscoveryRelays]. The
+  /// advertised relay and [_dmInboxTaggedRelays] are tagged as DM inboxes;
+  /// discovery-only relays receive the event but are not advertised.
   ///
   /// Publish-when-absent: a kind-10050 the user advertised from any client is
   /// left untouched. The own-inbox lookup distinguishes `found` / `absent` /
@@ -3567,9 +3571,18 @@ class DmRepository {
       }
       // _OwnDmInboxState.absent — safe to self-advertise.
 
-      final unsigned = Event(pubkey, EventKind.dmRelaysList, <List<String>>[
-        <String>['relay', relayUrl],
-      ], '');
+      final taggedRelays = <String>[
+        relayUrl,
+        ..._dmInboxTaggedRelays
+            .where(isRelayUrlAllowed)
+            .where((relay) => relay != relayUrl),
+      ];
+      final unsigned = Event(
+        pubkey,
+        EventKind.dmRelaysList,
+        taggedRelays.map((relay) => <String>['relay', relay]).toList(),
+        '',
+      );
 
       final Event? signed;
       try {
@@ -6562,9 +6575,9 @@ class DmRepository {
   /// self-addressed, NIP-44-sealed kind-30078 marker (#4977 v1).
   ///
   /// Best-effort: a failed publish just means read state syncs on the next
-  /// read. Published to the user's own DM inbox relays (or the default pool) —
-  /// the same set the history drain reads — so other devices and a reinstall
-  /// recover it.
+  /// read. Published through the normal pool so the marker keeps the pool's
+  /// write redundancy; other devices and a reinstall recover it from the
+  /// same pool that receives Divine's DM traffic.
   Future<void> _publishReadMarker() async {
     final service = _messageService;
     if (service == null || !isInitialized) return;
@@ -6588,14 +6601,11 @@ class DmRepository {
         'v': _readMarkerPayloadVersion,
         'read': readMap,
       });
-      final ownInbox = await _ownInboxRelays();
-      if (_disposed || _resetGeneration != gen) return;
       await service.publishSelfApplicationMarker(
         content: content,
         tags: const [
           ['d', _readMarkerDTag],
         ],
-        targetRelays: ownInbox,
       );
     } on Object catch (e, stackTrace) {
       Log.error(

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -1063,9 +1063,8 @@ class NIP17MessageService {
   }
 
   /// Build a kind-[eventKind] rumor with [content] + [tags] and publish it as
-  /// a **self-addressed** NIP-59 gift wrap (never to a counterparty) to
-  /// [targetRelays] — the user's own DM inbox relays, or the default pool when
-  /// `null`/empty. Returns `true` when the wrap reached at least one relay.
+  /// a **self-addressed** NIP-59 gift wrap (never to a counterparty) to the
+  /// default pool. Returns `true` when the wrap reached at least one relay.
   ///
   /// Used for the DM read-state cursor marker (#4977): a kind-30078
   /// application-data rumor whose `content` is the read map. The gift-wrap seal
@@ -1077,7 +1076,6 @@ class NIP17MessageService {
     required String content,
     required List<List<String>> tags,
     int eventKind = EventKind.appSpecificData,
-    List<String>? targetRelays,
   }) async {
     try {
       final nostr = Nostr(_signer, [], _dummyRelayGenerator);
@@ -1089,12 +1087,7 @@ class NIP17MessageService {
         receiverPublicKey: _senderPublicKey,
       ).timeout(DmSendBudget.selfWrapUncappedBuild, onTimeout: () => null);
       if (selfWrapEvent == null) return false;
-      final published = (targetRelays != null && targetRelays.isNotEmpty)
-          ? await _nostrService.publishEvent(
-              selfWrapEvent,
-              targetRelays: targetRelays,
-            )
-          : await _nostrService.publishEvent(selfWrapEvent);
+      final published = await _nostrService.publishEvent(selfWrapEvent);
       return published is PublishSuccess;
     } on Object catch (e, stackTrace) {
       Log.error(

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -823,6 +823,7 @@ void main() {
       // the real path; tests that assert the unconfigured no-op pass null.
       String? dmInboxRelayUrl = 'wss://relay.divine.video',
       List<String> dmInboxDiscoveryRelays = const <String>[],
+      List<String> dmInboxTaggedRelays = const <String>[],
       Duration readMarkerDebounceDelay = const Duration(seconds: 3),
       String Function()? sendBatchIdGenerator,
     }) {
@@ -849,6 +850,7 @@ void main() {
         syncState: syncState,
         reactionsRepository: reactionsRepository,
         dmInboxRelayUrl: dmInboxRelayUrl,
+        dmInboxTaggedRelays: dmInboxTaggedRelays,
         dmInboxDiscoveryRelays: dmInboxDiscoveryRelays,
         readMarkerDebounceDelay: readMarkerDebounceDelay,
         sendBatchIdGenerator: sendBatchIdGenerator,
@@ -4798,11 +4800,13 @@ void main() {
 
       group('discovery relays (#7336)', () {
         const divine = 'wss://relay.divine.video';
+        const dmFallback1 = 'wss://nos.lol';
+        const dmFallback2 = 'wss://relay.primal.net';
         const discovery = 'wss://purplepag.es';
 
         test(
-          'publishes to the advertised relay AND the discovery relays, but '
-          'tags only the advertised one',
+          'publishes to the advertised and discovery relays, while tagging '
+          'the three DM relays only',
           () async {
             when(
               () => mockNostrClient.publishEventAwaitOk(
@@ -4811,15 +4815,30 @@ void main() {
               ),
             ).thenAnswer(
               (_) async => partialOutcome(
-                targets: const [divine, discovery],
-                acceptedBy: const [divine, discovery],
+                targets: const [
+                  divine,
+                  dmFallback1,
+                  dmFallback2,
+                  discovery,
+                ],
+                acceptedBy: const [
+                  divine,
+                  dmFallback1,
+                  dmFallback2,
+                  discovery,
+                ],
               ),
             );
 
             final syncState = _FakeDmSyncState();
             final repository = createRepository(
               syncState: syncState,
-              dmInboxDiscoveryRelays: const [discovery],
+              dmInboxDiscoveryRelays: const [
+                dmFallback1,
+                dmFallback2,
+                discovery,
+              ],
+              dmInboxTaggedRelays: const [dmFallback1, dmFallback2],
             );
             await repository.ensureDmRelayListPublished();
 
@@ -4829,15 +4848,19 @@ void main() {
                 targetRelays: captureAny(named: 'targetRelays'),
               ),
             ).captured;
-            // Where the EVENT lands is wide (NIP-17: "SHOULD spread them to as
-            // many relays as viable"); what the LIST names stays at one
-            // ("keep kind:10050 lists small (1-3 relays)"). A discovery relay
-            // is not somewhere divine reads, so tagging it would send senders
-            // to a relay nothing drains.
+            // The EVENT is copied to the discovery indexer, but the list names
+            // only relays Divine actually drains for incoming DMs.
             expect((captured[0] as Event).tags, [
               ['relay', divine],
+              ['relay', dmFallback1],
+              ['relay', dmFallback2],
             ]);
-            expect(captured[1], [divine, discovery]);
+            expect(captured[1], [
+              divine,
+              dmFallback1,
+              dmFallback2,
+              discovery,
+            ]);
             expect(
               syncState.dmRelayListPublishedPubkeys,
               contains(_validPubkeyA),
@@ -8594,7 +8617,7 @@ void main() {
               content: captureAny(named: 'content'),
               tags: captureAny(named: 'tags'),
               eventKind: any(named: 'eventKind'),
-              targetRelays: any(named: 'targetRelays'),
+              targetRelays: captureAny(named: 'targetRelays'),
             ),
           ).captured;
           expect(captured, isNotEmpty);
@@ -8603,6 +8626,7 @@ void main() {
           expect(payload['v'], 1);
           expect((payload['read'] as Map)[tupleKey], 1700000200);
           expect(tags, contains(equals(['d', 'divine/dm-read/v1'])));
+          expect(captured[2], isNull);
 
           // Self-only: a read marker never goes out as a counterparty message.
           verifyNever(

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -819,10 +819,10 @@ void main() {
       NostrSigner? signer,
       DmDecryptIsolateSpawner? decryptIsolateSpawner,
       DmVerifyIsolateSpawner? verifyIsolateSpawner,
-      // #4974 RC3: default the feature on + inject a stable relay so the
-      // existing RC3 tests exercise the publish path; gating tests override.
-      bool publishDmRelayListEnabled = true,
+      // #4974: inject a stable advertised relay so the publish tests exercise
+      // the real path; tests that assert the unconfigured no-op pass null.
       String? dmInboxRelayUrl = 'wss://relay.divine.video',
+      List<String> dmInboxDiscoveryRelays = const <String>[],
       Duration readMarkerDebounceDelay = const Duration(seconds: 3),
       String Function()? sendBatchIdGenerator,
     }) {
@@ -848,8 +848,8 @@ void main() {
             verifyIsolateSpawner ?? () async => _RecordingVerifyWorker(),
         syncState: syncState,
         reactionsRepository: reactionsRepository,
-        publishDmRelayListEnabled: publishDmRelayListEnabled,
         dmInboxRelayUrl: dmInboxRelayUrl,
+        dmInboxDiscoveryRelays: dmInboxDiscoveryRelays,
         readMarkerDebounceDelay: readMarkerDebounceDelay,
         sendBatchIdGenerator: sendBatchIdGenerator,
         errorReporter: (error, stackTrace, {required site}) {
@@ -4745,6 +4745,22 @@ void main() {
         noResponseFrom: const [],
       );
 
+      /// An outcome where each of [acceptedBy] said `OK true` and every other
+      /// target rejected with a kind-policy message, the way `relay.nos.social`
+      /// and `user.kindpag.es` answer a kind-10050 today.
+      PublishOutcome partialOutcome({
+        required List<String> targets,
+        required List<String> acceptedBy,
+      }) => PublishOutcome(
+        eventId: 'eid',
+        acceptedBy: acceptedBy,
+        rejectedBy: {
+          for (final url in targets)
+            if (!acceptedBy.contains(url)) url: 'blocked: kind not allowed',
+        },
+        noResponseFrom: const [],
+      );
+
       test(
         'publishes a kind-10050 advertising the injected stable relay when '
         'absent and records the flag on a confirmed OK',
@@ -4779,6 +4795,148 @@ void main() {
           );
         },
       );
+
+      group('discovery relays (#7336)', () {
+        const divine = 'wss://relay.divine.video';
+        const discovery = 'wss://purplepag.es';
+
+        test(
+          'publishes to the advertised relay AND the discovery relays, but '
+          'tags only the advertised one',
+          () async {
+            when(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            ).thenAnswer(
+              (_) async => partialOutcome(
+                targets: const [divine, discovery],
+                acceptedBy: const [divine, discovery],
+              ),
+            );
+
+            final syncState = _FakeDmSyncState();
+            final repository = createRepository(
+              syncState: syncState,
+              dmInboxDiscoveryRelays: const [discovery],
+            );
+            await repository.ensureDmRelayListPublished();
+
+            final captured = verify(
+              () => mockNostrClient.publishEventAwaitOk(
+                captureAny(),
+                targetRelays: captureAny(named: 'targetRelays'),
+              ),
+            ).captured;
+            // Where the EVENT lands is wide (NIP-17: "SHOULD spread them to as
+            // many relays as viable"); what the LIST names stays at one
+            // ("keep kind:10050 lists small (1-3 relays)"). A discovery relay
+            // is not somewhere divine reads, so tagging it would send senders
+            // to a relay nothing drains.
+            expect((captured[0] as Event).tags, [
+              ['relay', divine],
+            ]);
+            expect(captured[1], [divine, discovery]);
+            expect(
+              syncState.dmRelayListPublishedPubkeys,
+              contains(_validPubkeyA),
+            );
+          },
+        );
+
+        test(
+          'a discovery relay refusing the kind is best-effort — the list is '
+          'still published',
+          () async {
+            when(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            ).thenAnswer(
+              (_) async => partialOutcome(
+                targets: const [divine, discovery],
+                acceptedBy: const [divine],
+              ),
+            );
+
+            final syncState = _FakeDmSyncState();
+            final repository = createRepository(
+              syncState: syncState,
+              dmInboxDiscoveryRelays: const [discovery],
+            );
+            await repository.ensureDmRelayListPublished();
+
+            // Discovery is a bonus, not a precondition: a third-party relay
+            // changing its kind policy must never put every account into a
+            // republish loop on each login.
+            expect(
+              syncState.dmRelayListPublishedPubkeys,
+              contains(_validPubkeyA),
+            );
+          },
+        );
+
+        test(
+          'a discovery relay accepting does NOT stand in for the advertised '
+          'relay refusing — retries next login',
+          () async {
+            when(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            ).thenAnswer(
+              (_) async => partialOutcome(
+                targets: const [divine, discovery],
+                acceptedBy: const [discovery],
+              ),
+            );
+
+            final syncState = _FakeDmSyncState();
+            final repository = createRepository(
+              syncState: syncState,
+              dmInboxDiscoveryRelays: const [discovery],
+            );
+            await repository.ensureDmRelayListPublished();
+
+            // "Something accepted" is the wrong bar. The advertised relay is
+            // the one divine drains, so a list that never reached it leaves
+            // the account undeliverable while the flag says it is done.
+            expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
+          },
+        );
+
+        test(
+          'drops a discovery relay whose URL is not a usable relay',
+          () async {
+            when(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            ).thenAnswer((_) async => outcome(accepted: true));
+
+            final repository = createRepository(
+              syncState: _FakeDmSyncState(),
+              dmInboxDiscoveryRelays: const [
+                'http://not-a-relay.example',
+                discovery,
+              ],
+            );
+            await repository.ensureDmRelayListPublished();
+
+            final captured = verify(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: captureAny(named: 'targetRelays'),
+              ),
+            ).captured;
+            expect(captured.single, [divine, discovery]);
+          },
+        );
+      });
 
       test(
         'does NOT record the flag when no relay accepts — retries next login',
@@ -4889,11 +5047,11 @@ void main() {
         );
       });
 
-      test('is a no-op when the feature flag is off', () async {
+      test('is a no-op when no advertised relay is configured', () async {
         final syncState = _FakeDmSyncState();
         final repository = createRepository(
           syncState: syncState,
-          publishDmRelayListEnabled: false,
+          dmInboxRelayUrl: null,
         );
         await repository.ensureDmRelayListPublished();
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -4462,8 +4462,8 @@ void main() {
       );
 
       test(
-        'live subscription targets the own kind-10050 inbox relays as BOTH '
-        'tempRelays and targetRelays',
+        'live subscription ADDS the own kind-10050 inbox relays as tempRelays '
+        'and never narrows the pool with targetRelays',
         () async {
           when(
             () => mockNostrClient.queryEventsDetailed(
@@ -4500,9 +4500,13 @@ void main() {
               targetRelays: captureAny(named: 'targetRelays'),
             ),
           ).captured;
+          // tempRelays dials the advertised inbox in ADDITION to the pool.
+          // targetRelays must stay null: it is a filter over the pool, so a
+          // non-null value there drops divine's own relay and the four
+          // safeFallbackRelays #2931 added for exactly this read. See #7320.
           expect(captured, [
             ['wss://own.example'],
-            ['wss://own.example'],
+            null,
           ]);
 
           await repository.stopListening();

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -573,6 +573,7 @@ void main() {
       // Stub relay properties used by startListening() log.
       when(() => mockNostrClient.connectedRelayCount).thenReturn(3);
       when(() => mockNostrClient.configuredRelayCount).thenReturn(3);
+      when(() => mockNostrClient.isRelayAllowed(any())).thenReturn(true);
 
       // Stub getNewestMessageTimestamp for startListening() windowing.
       when(
@@ -725,7 +726,6 @@ void main() {
           content: any(named: 'content'),
           tags: any(named: 'tags'),
           eventKind: any(named: 'eventKind'),
-          targetRelays: any(named: 'targetRelays'),
         ),
       ).thenAnswer((_) async => true);
 
@@ -4935,6 +4935,10 @@ void main() {
           'drops a discovery relay whose URL is not a usable relay',
           () async {
             when(
+              () =>
+                  mockNostrClient.isRelayAllowed('http://not-a-relay.example'),
+            ).thenReturn(false);
+            when(
               () => mockNostrClient.publishEventAwaitOk(
                 any(),
                 targetRelays: any(named: 'targetRelays'),
@@ -8617,7 +8621,6 @@ void main() {
               content: captureAny(named: 'content'),
               tags: captureAny(named: 'tags'),
               eventKind: any(named: 'eventKind'),
-              targetRelays: captureAny(named: 'targetRelays'),
             ),
           ).captured;
           expect(captured, isNotEmpty);
@@ -8626,8 +8629,6 @@ void main() {
           expect(payload['v'], 1);
           expect((payload['read'] as Map)[tupleKey], 1700000200);
           expect(tags, contains(equals(['d', 'divine/dm-read/v1'])));
-          expect(captured[2], isNull);
-
           // Self-only: a read marker never goes out as a counterparty message.
           verifyNever(
             () => mockMessageService.sendRumor(
@@ -8663,7 +8664,6 @@ void main() {
               content: any(named: 'content'),
               tags: any(named: 'tags'),
               eventKind: any(named: 'eventKind'),
-              targetRelays: any(named: 'targetRelays'),
             ),
           );
         },
@@ -8689,7 +8689,6 @@ void main() {
             content: any(named: 'content'),
             tags: any(named: 'tags'),
             eventKind: any(named: 'eventKind'),
-            targetRelays: any(named: 'targetRelays'),
           ),
         ).called(1);
       });
@@ -8812,7 +8811,6 @@ void main() {
               content: any(named: 'content'),
               tags: any(named: 'tags'),
               eventKind: any(named: 'eventKind'),
-              targetRelays: any(named: 'targetRelays'),
             ),
           ).called(1);
         },
@@ -8836,7 +8834,6 @@ void main() {
             content: any(named: 'content'),
             tags: any(named: 'tags'),
             eventKind: any(named: 'eventKind'),
-            targetRelays: any(named: 'targetRelays'),
           ),
         );
       });
@@ -8878,7 +8875,6 @@ void main() {
               content: any(named: 'content'),
               tags: any(named: 'tags'),
               eventKind: any(named: 'eventKind'),
-              targetRelays: any(named: 'targetRelays'),
             ),
           );
         },
@@ -8903,7 +8899,6 @@ void main() {
             content: any(named: 'content'),
             tags: any(named: 'tags'),
             eventKind: any(named: 'eventKind'),
-            targetRelays: any(named: 'targetRelays'),
           ),
         );
       });

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -834,31 +834,7 @@ void main() {
         );
       });
 
-      test('routes the self marker to the provided targetRelays', () async {
-        List<String>? routedTo;
-        when(
-          () => mockNostrClient.publishEvent(
-            any(),
-            targetRelays: any(named: 'targetRelays'),
-          ),
-        ).thenAnswer((inv) async {
-          routedTo = inv.namedArguments[#targetRelays] as List<String>?;
-          return PublishSuccess(event: inv.positionalArguments[0] as Event);
-        });
-
-        final ok = await service.publishSelfApplicationMarker(
-          content: '{"v":1,"read":{}}',
-          tags: const [
-            ['d', 'divine/dm-read/v1'],
-          ],
-          targetRelays: const ['wss://inbox.example.com'],
-        );
-
-        expect(ok, isTrue);
-        expect(routedTo, const ['wss://inbox.example.com']);
-      });
-
-      test('falls back to the default pool when no targetRelays', () async {
+      test('publishes through the default pool', () async {
         var bareCalls = 0;
         when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
           bareCalls++;

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -362,6 +362,15 @@ class RelayPool {
   List<MapEntry<String, Relay>> _cacheRelayEntriesSnapshot() =>
       _cacheRelays.entries.toList(growable: false);
 
+  /// RelayManager stores pooled URLs without a trailing slash, while
+  /// [RelayAddrUtil.handle] adds one for temporary relay addresses. Keep the
+  /// wire address unchanged, but use one identity for pool/temp comparisons.
+  String _relayIdentity(String url) =>
+      url.endsWith('/') ? url.substring(0, url.length - 1) : url;
+
+  Relay? _pooledRelayForTempAddr(String addr) =>
+      _relays[addr] ?? _relays[_relayIdentity(addr)];
+
   bool _isExplicitAuthRequiredReason(String message) {
     final lower = message.trim().toLowerCase();
     return lower.startsWith('auth-required');
@@ -1869,7 +1878,7 @@ class RelayPool {
         relayTypes.contains(RelayType.temp)) {
       for (var tempRelayAddr in tempRelays) {
         // check if normal relays has this temp relay, try to get relay from normal relays
-        Relay? relay = _relays[tempRelayAddr];
+        Relay? relay = _pooledRelayForTempAddr(tempRelayAddr);
         relay ??= checkAndGenTempRelay(tempRelayAddr);
 
         relayDoSubscribe(
@@ -2119,7 +2128,7 @@ class RelayPool {
         relayTypes.contains(RelayType.temp)) {
       for (var tempRelayAddr in tempRelays) {
         // check if normal relays has this temp relay, try to get relay from normal relays
-        Relay? relay = _relays[tempRelayAddr];
+        Relay? relay = _pooledRelayForTempAddr(tempRelayAddr);
         relay ??= checkAndGenTempRelay(tempRelayAddr);
 
         queryFutures.add(sendQueryTo(relay, runBeforeConnected: true));
@@ -2365,7 +2374,9 @@ class RelayPool {
 
     if (tempRelays != null) {
       for (var tempRelayAddr in tempRelays) {
-        if (attemptedRelayUrls.contains(tempRelayAddr)) {
+        if (attemptedRelayUrls.any(
+          (url) => _relayIdentity(url) == _relayIdentity(tempRelayAddr),
+        )) {
           continue;
         }
         attemptedRelayUrls.add(tempRelayAddr);

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -3001,7 +3001,7 @@ class RelayPool {
         tempRelays.isNotEmpty &&
         relayTypes.contains(RelayType.temp)) {
       for (var tempRelayAddr in tempRelays) {
-        Relay? relay = _relays[tempRelayAddr];
+        Relay? relay = _pooledRelayForTempAddr(tempRelayAddr);
         relay ??= checkAndGenTempRelay(tempRelayAddr);
         relaysToTry.add(relay);
       }

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_targeting_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_targeting_test.dart
@@ -8,12 +8,14 @@ import 'package:nostr_sdk/nostr_sdk.dart';
 
 import '../support/fake_web_socket.dart';
 
-/// Lets every pending microtask and short timer drain so the pool has finished
-/// connecting and fanning the REQ out.
-Future<void> _settle() async {
-  for (var i = 0; i < 60; i++) {
-    await Future<void>.delayed(const Duration(milliseconds: 2));
+/// Waits for the fake socket to observe a specific REQ without relying on
+/// wall-clock settling.
+Future<void> _waitForReq(FakeWebSocketChannelFactory factory, String id) async {
+  for (var i = 0; i < 100; i++) {
+    if (_reqIds(factory).contains(id)) return;
+    await Future<void>.delayed(Duration.zero);
   }
+  fail('REQ $id was not written');
 }
 
 /// Subscription ids of every `REQ` frame [factory]'s sockets were asked to send.
@@ -78,12 +80,12 @@ void main() {
           channelFactory: fallbackFactory,
         ),
       );
-      await _settle();
     });
 
     test('untargeted subscribe reaches every pooled relay', () async {
       nostr.relayPool.subscribe(filters, (_) {}, id: 'untargeted');
-      await _settle();
+      await _waitForReq(primaryFactory, 'untargeted');
+      await _waitForReq(fallbackFactory, 'untargeted');
 
       expect(_reqIds(primaryFactory), contains('untargeted'));
       expect(_reqIds(fallbackFactory), contains('untargeted'));
@@ -100,7 +102,9 @@ void main() {
           id: 'temp-only',
           tempRelays: const ['wss://inbox.example'],
         );
-        await _settle();
+        await _waitForReq(primaryFactory, 'temp-only');
+        await _waitForReq(fallbackFactory, 'temp-only');
+        await _waitForReq(tempFactory, 'temp-only');
 
         expect(_reqIds(primaryFactory), contains('temp-only'));
         expect(_reqIds(fallbackFactory), contains('temp-only'));
@@ -111,21 +115,10 @@ void main() {
 
     test('targetRelays narrows the pool away, even when it names a pooled '
         'relay verbatim', () async {
-      // Two separate reasons the pooled relays drop out, and the test asserts
-      // the outcome rather than either mechanism:
-      //
-      //   1. `targetRelays` is a filter over the pool, not an addition —
-      //      subscribe() skips every pooled relay the list does not name.
-      //   2. The two sides are not even comparable. Pool keys come from
-      //      `normalizeRelayUrl` (nostr_client), which STRIPS a trailing
-      //      slash; `targetRelays` is run through `RelayAddrUtil.handle`,
-      //      which ADDS one. So `targetRelays.contains(relayAddr)` is false
-      //      for every pooled relay, and naming one verbatim does not help.
-      //
-      // Reason 2 is why the named relay below is re-dialed as a *temp* relay
-      // instead of reusing the pooled socket. It is tracked separately; this
-      // test exists so the DM live subscription can never quietly regress to
-      // passing `targetRelays` again.
+      // `targetRelays` is a filter over the pool, not an addition — the
+      // fallback pooled relay is skipped. The named pooled relay is supplied
+      // through tempRelays too, but must reuse the existing pooled socket
+      // rather than opening a duplicate connection.
       nostr.relayPool.subscribe(
         filters,
         (_) {},
@@ -133,11 +126,11 @@ void main() {
         tempRelays: const [pooledPrimary],
         targetRelays: const [pooledPrimary],
       );
-      await _settle();
+      await _waitForReq(primaryFactory, 'targeted');
 
-      expect(_reqIds(primaryFactory), isNot(contains('targeted')));
+      expect(_reqIds(primaryFactory), contains('targeted'));
       expect(_reqIds(fallbackFactory), isNot(contains('targeted')));
-      expect(tempRelaysGenerated, contains('$pooledPrimary/'));
+      expect(tempRelaysGenerated, isEmpty);
     });
   });
 }

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_targeting_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_targeting_test.dart
@@ -1,0 +1,143 @@
+// ABOUTME: Pins how RelayPool.subscribe routes a REQ when tempRelays and
+// ABOUTME: targetRelays are supplied, over real sockets rather than mocks.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+import '../support/fake_web_socket.dart';
+
+/// Lets every pending microtask and short timer drain so the pool has finished
+/// connecting and fanning the REQ out.
+Future<void> _settle() async {
+  for (var i = 0; i < 60; i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 2));
+  }
+}
+
+/// Subscription ids of every `REQ` frame [factory]'s sockets were asked to send.
+List<String> _reqIds(FakeWebSocketChannelFactory factory) {
+  return [
+    for (final channel in factory.createdChannels)
+      for (final message in channel.sentMessages)
+        if ((jsonDecode(message as String) as List<dynamic>).first == 'REQ')
+          (jsonDecode(message) as List<dynamic>)[1] as String,
+  ];
+}
+
+void main() {
+  group('RelayPool.subscribe relay routing', () {
+    // The production shape this guards: divine's own relay plus one of the
+    // four IndexerRelayConfig.safeFallbackRelays that #2931 connects so DMs
+    // written to other relays stay visible.
+    const pooledPrimary = 'wss://relay.divine.video';
+    const pooledFallback = 'wss://relay.nos.social';
+    final filters = [
+      {
+        'kinds': [1059],
+        '#p': ['a' * 64],
+      },
+    ];
+
+    late FakeWebSocketChannelFactory primaryFactory;
+    late FakeWebSocketChannelFactory fallbackFactory;
+    late FakeWebSocketChannelFactory tempFactory;
+    late List<String> tempRelaysGenerated;
+    late Nostr nostr;
+
+    setUp(() async {
+      primaryFactory = FakeWebSocketChannelFactory();
+      fallbackFactory = FakeWebSocketChannelFactory();
+      tempFactory = FakeWebSocketChannelFactory();
+      tempRelaysGenerated = <String>[];
+
+      nostr = Nostr(
+        LocalNostrSigner(
+          '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+        ),
+        [],
+        (url) {
+          tempRelaysGenerated.add(url);
+          return RelayBase(url, RelayStatus(url), channelFactory: tempFactory);
+        },
+      );
+      await nostr.refreshPublicKey();
+
+      await nostr.relayPool.add(
+        RelayBase(
+          pooledPrimary,
+          RelayStatus(pooledPrimary),
+          channelFactory: primaryFactory,
+        ),
+      );
+      await nostr.relayPool.add(
+        RelayBase(
+          pooledFallback,
+          RelayStatus(pooledFallback),
+          channelFactory: fallbackFactory,
+        ),
+      );
+      await _settle();
+    });
+
+    test('untargeted subscribe reaches every pooled relay', () async {
+      nostr.relayPool.subscribe(filters, (_) {}, id: 'untargeted');
+      await _settle();
+
+      expect(_reqIds(primaryFactory), contains('untargeted'));
+      expect(_reqIds(fallbackFactory), contains('untargeted'));
+    });
+
+    test(
+      'tempRelays ADDS the named relay and leaves the pool subscribed',
+      () async {
+        // The shape DmRepository.startListening uses for the live gift-wrap
+        // read once the user advertises a kind-10050 (#4974, #7320).
+        nostr.relayPool.subscribe(
+          filters,
+          (_) {},
+          id: 'temp-only',
+          tempRelays: const ['wss://inbox.example'],
+        );
+        await _settle();
+
+        expect(_reqIds(primaryFactory), contains('temp-only'));
+        expect(_reqIds(fallbackFactory), contains('temp-only'));
+        expect(tempRelaysGenerated, contains('wss://inbox.example/'));
+        expect(_reqIds(tempFactory), contains('temp-only'));
+      },
+    );
+
+    test('targetRelays narrows the pool away, even when it names a pooled '
+        'relay verbatim', () async {
+      // Two separate reasons the pooled relays drop out, and the test asserts
+      // the outcome rather than either mechanism:
+      //
+      //   1. `targetRelays` is a filter over the pool, not an addition —
+      //      subscribe() skips every pooled relay the list does not name.
+      //   2. The two sides are not even comparable. Pool keys come from
+      //      `normalizeRelayUrl` (nostr_client), which STRIPS a trailing
+      //      slash; `targetRelays` is run through `RelayAddrUtil.handle`,
+      //      which ADDS one. So `targetRelays.contains(relayAddr)` is false
+      //      for every pooled relay, and naming one verbatim does not help.
+      //
+      // Reason 2 is why the named relay below is re-dialed as a *temp* relay
+      // instead of reusing the pooled socket. It is tracked separately; this
+      // test exists so the DM live subscription can never quietly regress to
+      // passing `targetRelays` again.
+      nostr.relayPool.subscribe(
+        filters,
+        (_) {},
+        id: 'targeted',
+        tempRelays: const [pooledPrimary],
+        targetRelays: const [pooledPrimary],
+      );
+      await _settle();
+
+      expect(_reqIds(primaryFactory), isNot(contains('targeted')));
+      expect(_reqIds(fallbackFactory), isNot(contains('targeted')));
+      expect(tempRelaysGenerated, contains('$pooledPrimary/'));
+    });
+  });
+}

--- a/mobile/test/core/feature_flag_test.dart
+++ b/mobile/test/core/feature_flag_test.dart
@@ -63,10 +63,6 @@ void main() {
         FeatureFlag.communityContentWarnings.audience,
         FeatureFlagAudience.internal,
       );
-      expect(
-        FeatureFlag.publishDmRelayList.audience,
-        FeatureFlagAudience.internal,
-      );
       expect(FeatureFlag.feedTuning.audience, FeatureFlagAudience.internal);
       expect(
         FeatureFlag.postPublishConfirmationExperiment.audience,

--- a/mobile/test/screens/feature_flag_screen_test.dart
+++ b/mobile/test/screens/feature_flag_screen_test.dart
@@ -92,10 +92,6 @@ void main() {
         find.text(FeatureFlag.communityContentWarnings.displayName),
         findsNothing,
       );
-      expect(
-        find.text(FeatureFlag.publishDmRelayList.displayName),
-        findsNothing,
-      );
       expect(find.text(FeatureFlag.feedTuning.displayName), findsNothing);
     });
 
@@ -116,10 +112,6 @@ void main() {
       );
       expect(
         find.text(FeatureFlag.communityContentWarnings.displayName),
-        findsOneWidget,
-      );
-      expect(
-        find.text(FeatureFlag.publishDmRelayList.displayName),
         findsOneWidget,
       );
       expect(find.text(FeatureFlag.feedTuning.displayName), findsOneWidget);

--- a/mobile/test/services/auth/relay_discovery_orchestrator_test.dart
+++ b/mobile/test/services/auth/relay_discovery_orchestrator_test.dart
@@ -155,11 +155,16 @@ void main() {
         await buildOrchestrator().discoverUserRelays(testNpub, testPubkey);
 
         expect(userRelaysWrites, equals([relays]));
-        expect(externalRelayCalls, hasLength(1));
-        expect(externalRelayCalls.single.$1, equals(testPubkey));
+        expect(externalRelayCalls, hasLength(2));
+        expect(externalRelayCalls.first.$1, equals(testPubkey));
         expect(
-          externalRelayCalls.single.$2,
+          externalRelayCalls.first.$2,
           equals(['wss://a.example', 'wss://b.example']),
+        );
+        expect(externalRelayCalls.last.$1, equals(testPubkey));
+        expect(
+          externalRelayCalls.last.$2,
+          equals(IndexerRelayConfig.dmInboxTaggedRelays),
         );
       });
 
@@ -400,6 +405,21 @@ void main() {
           equals(IndexerRelayConfig.safeFallbackRelays),
         );
       });
+
+      test(
+        'pushes the tagged DM inbox relays without reporting user relays',
+        () {
+          buildOrchestrator().connectToDmInboxRelays(testPubkey);
+
+          expect(externalRelayCalls, hasLength(1));
+          expect(externalRelayCalls.single.$1, equals(testPubkey));
+          expect(
+            externalRelayCalls.single.$2,
+            equals(IndexerRelayConfig.dmInboxTaggedRelays),
+          );
+          expect(userRelaysWrites, isEmpty);
+        },
+      );
     });
   });
 }

--- a/mobile/test/services/auth_service_relay_fallback_test.dart
+++ b/mobile/test/services/auth_service_relay_fallback_test.dart
@@ -130,9 +130,9 @@ void main() {
         );
         final authService = buildAuthService(discovery);
 
-        List<String>? capturedRelayUrls;
+        final capturedRelayUrls = <List<String>>[];
         authService.registerUserRelaysDiscoveredCallback(
-          (_, urls) => capturedRelayUrls = urls,
+          (_, urls) => capturedRelayUrls.add(urls),
         );
 
         // ACT
@@ -142,10 +142,13 @@ void main() {
         // fallback set.
         expect(
           capturedRelayUrls,
-          equals(['wss://relay.example.com', 'wss://relay.user-chosen.org']),
+          equals([
+            ['wss://relay.example.com', 'wss://relay.user-chosen.org'],
+            IndexerRelayConfig.dmInboxTaggedRelays,
+          ]),
         );
         expect(
-          capturedRelayUrls,
+          capturedRelayUrls.first,
           isNot(equals(IndexerRelayConfig.safeFallbackRelays)),
         );
 


### PR DESCRIPTION
## Description

Divine now publishes a NIP-17 kind-10050 DM inbox relay list so spec-following third-party senders can discover where to deliver gift wraps.

### What changed

- Removed `targetRelays` from the live DM subscription. `RelayPool.subscribe` treats it as a pool filter, so passing the user's inbox list could silently exclude Divine's fallback relays. `tempRelays` remains additive.
- Enabled kind-10050 publication for all builds now that the relay accepts the event kind; removed the obsolete feature flag.
- The published list tags three DM inbox relays: `relay.divine.video`, `nos.lol`, and `relay.primal.net`. `purplepag.es` remains a discovery-only publication target.
- The tagged DM relays are also added to the active relay pool, including for accounts with a separate kind-10002 list. The relay manager uses `autoSubscribe`, so an existing DM subscription is resent to newly connected relays and the current session can read every advertised relay.
- Both published tags and discovery targets honor the client's environment relay allowlist. The advertised relay's own `OK` determines publish success; discovery relays remain best-effort.
- Read markers use the normal pool to preserve write redundancy.
- Removed the unused self-marker `targetRelays` API and fixed trailing-slash pooled relay matching in `RelayPool.count` as well as subscription/query paths.

**Related Issue:** Closes #7336, Closes #7320

## Out of Scope

- The broader `targetRelays` semantics remain unchanged. This PR fixes trailing-slash pooled identity at the subscribe, query, and count call sites; changing filter semantics is separate work.
- The kind-10002 bootstrap target set is unchanged.

## Verification

- Focused `dm_repository`, NIP-17, relay discovery, fallback, and relay-pool tests pass (`+534`).
- `flutter analyze` passes for the affected app files.
- `dart analyze lib test` passes in both `dm_repository` and `nostr_sdk`.
- Existing publish-path coverage verifies that a target already present in the pool is not retried through a duplicate temporary relay.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
