### PR TITLE
fix(dm): bind an incoming reaction to the last e/p tag per NIP-25

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -825,13 +825,15 @@ class DmReactionsRepository {
     }
     String? targetMessageId;
     String? targetAuthor;
+    // Last tag wins in each family. NIP-25 puts the reaction's target last
+    // when a client includes extras ("the target event `id` should be last
+    // of the `e` tags", likewise the pubkey "last the `p` tags"), so a peer
+    // that leads with the thread root would otherwise bind the reaction to
+    // the wrong message. #7333.
     for (final tag in rumorEvent.tags) {
-      if (tag.length >= 2) {
-        if (tag[0] == 'e' && targetMessageId == null) {
-          targetMessageId = tag[1];
-        }
-        if (tag[0] == 'p' && targetAuthor == null) targetAuthor = tag[1];
-      }
+      if (tag.length < 2) continue;
+      if (tag[0] == 'e') targetMessageId = tag[1];
+      if (tag[0] == 'p') targetAuthor = tag[1];
     }
     if (targetMessageId == null ||
         targetMessageId.isEmpty ||

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -36,6 +36,14 @@ const _reactionRumorId =
 const _giftWrapId =
     'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
 
+/// A thread-root `e` tag a peer client may place AHEAD of the target,
+/// and a mentioned `p` tag ahead of the target's author. NIP-25 puts the
+/// real target last in each family, so these two exist to be ignored.
+const _threadRootId =
+    'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+const _mentionedPubkey =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+
 void main() {
   setUpAll(() {
     registerFallbackValue(_FakeEvent());
@@ -1236,6 +1244,58 @@ void main() {
       final repository = createRepository();
       final outcome = await repository.persistIncoming(
         rumorEvent: reactionRumor(),
+        giftWrapId: _giftWrapId,
+      );
+
+      expect(outcome, DmWrapOutcome.processed);
+      verify(
+        () => mockDao.upsertIncoming(
+          id: _reactionRumorId,
+          conversationId: any(named: 'conversationId'),
+          targetMessageId: _targetMessageId,
+          targetMessageAuthor: _otherPubkey,
+          reactorPubkey: _ownerPubkey,
+          emoji: '🔥',
+          createdAt: 1_700_000_000,
+          giftWrapId: _giftWrapId,
+          ownerPubkey: _ownerPubkey,
+        ),
+      ).called(1);
+    });
+
+    test('persistIncoming binds the LAST e and p tag per NIP-25', () async {
+      // NIP-25: "If a client decides to include other `e`, which not
+      // recommended, the target event `id` should be last of the `e` tags",
+      // and likewise the target pubkey "should be last the `p` tags". A peer
+      // that threads its reaction puts the root first, so first-wins binds
+      // the reaction to the wrong message — painted on the wrong bubble, or
+      // written against no bubble at all and then cemented in the dedup
+      // ledger as `processed`, which no later launch re-derives. #7333.
+      when(
+        () => mockDao.upsertIncoming(
+          id: any(named: 'id'),
+          conversationId: any(named: 'conversationId'),
+          targetMessageId: any(named: 'targetMessageId'),
+          targetMessageAuthor: any(named: 'targetMessageAuthor'),
+          reactorPubkey: any(named: 'reactorPubkey'),
+          emoji: any(named: 'emoji'),
+          createdAt: any(named: 'createdAt'),
+          giftWrapId: any(named: 'giftWrapId'),
+          ownerPubkey: any(named: 'ownerPubkey'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final repository = createRepository();
+      final outcome = await repository.persistIncoming(
+        rumorEvent: reactionRumor(
+          tags: [
+            ['e', _threadRootId],
+            ['e', _targetMessageId],
+            ['p', _mentionedPubkey],
+            ['p', _otherPubkey],
+            ['k', EventKind.privateDirectMessage.toString()],
+          ],
+        ),
         giftWrapId: _giftWrapId,
       );
 


### PR DESCRIPTION
## What

`DmReactionsRepository.persistIncoming` resolved an incoming kind-7 reaction's target by latching the **first** `e` and `p` tag. NIP-25 puts the target **last** when a client includes extras. Dropping the two null guards makes the loop last-wins.

## Why it matters

A peer that threads its reaction puts the root `e` tag first, so the reaction bound to the wrong message. Two outcomes, both silent:

1. The wrong id resolves to a real local row — the reaction is painted on a bubble nobody reacted to.
2. It resolves to nothing — but the 1:1 inference fallback still returns a conversation id, so a row is written whose `targetMessageId` matches no rendered bubble.

Either way `persistIncoming` returns `processed`, so the caller records the gift wrap in the dedup ledger and the wrap is never re-decrypted. The reaction cannot land correctly on any later launch.

The `p` tag had the same bug, and the latched value was written to `targetMessageAuthor`.

## Spec

NIP-25, Tags — verified against the NIP text, not paraphrased:

> If a client decides to include other `e`, which not recommended, the target event `id` should be last of the `e` tags.

> If a client decides to include other `p` tags, which not recommended, the target event `pubkey` should be last the `p` tags.

## Blast radius

None for reactions Divine emits: `publish` builds exactly one `e` and one `p` tag, so first and last are the same tag. Reaching the defect requires a peer client that includes extras — the case NIP-25 anticipates and specifies ordering for.

## Scope deliberately not widened

- The kind-5 arm in `_routeWrappedDeletion` iterates **every** `e` tag. That is correct under NIP-09, where one deletion may name several targets, and is not this rule.
- `_extractTargetEventId` in `likes_repository` (the **public** reaction path) has the same first-wins defect while its own dartdoc cites NIP-25. It is intentionally left out because it belongs to a different package and follow-up work. Its sibling `_resolveVoteTarget` already iterates `event.tags.reversed` correctly.

New regression test feeds a rumor with two `e` and two `p` tags and asserts the row is keyed on the second of each. Confirmed RED before the fix — it bound the thread root and the mentioned pubkey:

```
targetMessageId: eeee…   (thread root, wrong)
targetMessageAuthor: 1111…  (mentioned party, wrong)
```

- `flutter test` in `packages/dm_repository` — **716 passed**
- `flutter analyze` in `packages/dm_repository` — clean
- `flutter analyze lib test integration_test` from `mobile/` — clean
- `dart format` — no changes

Fixes #7333