### PR TITLE
test(helpers): keep auth fixture state consistent

### DIFF
--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -112,21 +112,26 @@ MockSharedPreferences createMockSharedPreferences() {
 }
 
 /// Creates a properly stubbed MockAuthService for testing
-MockAuthService createMockAuthService() {
+MockAuthService createMockAuthService({
+  AuthState authState = AuthState.unauthenticated,
+  String? currentPublicKeyHex,
+}) {
   final mockAuth = MockAuthService();
 
   // Stub common auth methods with sensible defaults
-  when(() => mockAuth.isAuthenticated).thenReturn(false);
+  when(
+    () => mockAuth.isAuthenticated,
+  ).thenReturn(authState == AuthState.authenticated);
   when(() => mockAuth.canExportLocalNsec).thenReturn(false);
   when(
     () => mockAuth.authenticationSource,
   ).thenReturn(AuthenticationSource.none);
-  when(() => mockAuth.currentPublicKeyHex).thenReturn(null);
+  when(() => mockAuth.currentPublicKeyHex).thenReturn(currentPublicKeyHex);
   when(() => mockAuth.isNip07Available).thenReturn(false);
 
   // Stub authState and authStateStream so currentAuthStateProvider does not
   // crash with type 'Null' is not a subtype of type 'Stream<AuthState>'
-  when(() => mockAuth.authState).thenReturn(AuthState.unauthenticated);
+  when(() => mockAuth.authState).thenReturn(authState);
   when(
     () => mockAuth.authStateStream,
   ).thenAnswer((_) => const Stream<AuthState>.empty());

--- a/mobile/test/helpers/test_provider_overrides_test.dart
+++ b/mobile/test/helpers/test_provider_overrides_test.dart
@@ -12,6 +12,37 @@ import 'test_provider_overrides.dart';
 class _FakeAuthService extends Fake implements AuthService {}
 
 void main() {
+  group('createMockAuthService', () {
+    for (final authState in AuthState.values) {
+      test('keeps isAuthenticated consistent with $authState', () {
+        final auth = createMockAuthService(authState: authState);
+
+        expect(auth.authState, authState);
+        expect(auth.isAuthenticated, authState == AuthState.authenticated);
+      });
+    }
+
+    test('defaults to an unauthenticated session without a public key', () {
+      final auth = createMockAuthService();
+
+      expect(auth.authState, AuthState.unauthenticated);
+      expect(auth.isAuthenticated, isFalse);
+      expect(auth.currentPublicKeyHex, isNull);
+    });
+
+    test('accepts an authenticated state and public key together', () {
+      final publicKeyHex = 'a' * 64;
+      final auth = createMockAuthService(
+        authState: AuthState.authenticated,
+        currentPublicKeyHex: publicKeyHex,
+      );
+
+      expect(auth.authState, AuthState.authenticated);
+      expect(auth.isAuthenticated, isTrue);
+      expect(auth.currentPublicKeyHex, publicKeyHex);
+    });
+  });
+
   group('getStandardTestOverrides', () {
     test('standard overrides give auth mocks a session-cleanup callback', () {
       final auth = MockAuthService();

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -29,6 +29,7 @@ import 'package:openvine/blocs/video_playback_status/video_playback_status_state
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/auth_state.dart';
 import 'package:openvine/models/view_traffic_source.dart';
 import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -699,9 +700,9 @@ void main() {
                 videos: [video],
               ),
               additionalOverrides: [
-                userProfileReactiveProvider(testPubkey).overrideWith(
-                  (ref) => Stream<UserProfile?>.value(null),
-                ),
+                userProfileReactiveProvider(
+                  testPubkey,
+                ).overrideWith((ref) => Stream<UserProfile?>.value(null)),
               ],
             ),
           );
@@ -820,11 +821,10 @@ void main() {
         'resizes for the keyboard only while its OWN composer is focused — '
         'not for a modal (e.g. the share sheet) on top (#5758)',
         (tester) async {
-          final mockAuth = createMockAuthService();
-          when(() => mockAuth.isAuthenticated).thenReturn(true);
-          when(
-            () => mockAuth.currentPublicKeyHex,
-          ).thenReturn('a' * 64);
+          final mockAuth = createMockAuthService(
+            authState: AuthState.authenticated,
+            currentPublicKeyHex: 'a' * 64,
+          );
 
           final videos = createTestVideos();
 
@@ -1035,66 +1035,63 @@ void main() {
         },
       );
 
-      testWidgets(
-        'hands back to onBack instead of popping when status becomes '
-        'emptyAfterRemoval in embedded video mode',
-        (tester) async {
-          final videos = createTestVideos(count: 1);
-          final initialState = FullscreenFeedState(
-            status: FullscreenFeedStatus.ready,
-            videos: videos,
-          );
-          final emptyState = FullscreenFeedState(
-            status: FullscreenFeedStatus.emptyAfterRemoval,
-            removedVideoIds: {videos.first.id},
-          );
-          final controller = StreamController<FullscreenFeedState>();
-          addTearDown(controller.close);
-          whenListen(mockBloc, controller.stream, initialState: initialState);
+      testWidgets('hands back to onBack instead of popping when status becomes '
+          'emptyAfterRemoval in embedded video mode', (tester) async {
+        final videos = createTestVideos(count: 1);
+        final initialState = FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: videos,
+        );
+        final emptyState = FullscreenFeedState(
+          status: FullscreenFeedStatus.emptyAfterRemoval,
+          removedVideoIds: {videos.first.id},
+        );
+        final controller = StreamController<FullscreenFeedState>();
+        addTearDown(controller.close);
+        whenListen(mockBloc, controller.stream, initialState: initialState);
 
-          var onBackCalls = 0;
-          var popCount = 0;
-          final observer = _PopCountingObserver(onPop: () => popCount++);
+        var onBackCalls = 0;
+        var popCount = 0;
+        final observer = _PopCountingObserver(onPop: () => popCount++);
 
-          await tester.pumpWidget(
-            testProviderScope(
-              mockProfileRepository: mockProfileRepository,
-              mockNip05VerificationService: mockNip05VerificationService,
-              child: MaterialApp(
-                localizationsDelegates: AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                navigatorObservers: [observer],
-                home: Builder(
-                  builder: (context) => Scaffold(
-                    body: ElevatedButton(
-                      onPressed: () => Navigator.of(context).push(
-                        MaterialPageRoute<void>(
-                          builder: (_) => buildContent(
-                            contextTitle: 'Embedded',
-                            onBack: () => onBackCalls++,
-                          ),
+        await tester.pumpWidget(
+          testProviderScope(
+            mockProfileRepository: mockProfileRepository,
+            mockNip05VerificationService: mockNip05VerificationService,
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              navigatorObservers: [observer],
+              home: Builder(
+                builder: (context) => Scaffold(
+                  body: ElevatedButton(
+                    onPressed: () => Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) => buildContent(
+                          contextTitle: 'Embedded',
+                          onBack: () => onBackCalls++,
                         ),
                       ),
-                      child: const Text('open'),
                     ),
+                    child: const Text('open'),
                   ),
                 ),
               ),
             ),
-          );
+          ),
+        );
 
-          await tester.tap(find.text('open'));
-          await tester.pump();
-          await tester.pump(const Duration(milliseconds: 400));
+        await tester.tap(find.text('open'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
 
-          controller.add(emptyState);
-          await tester.pump();
+        controller.add(emptyState);
+        await tester.pump();
 
-          expect(onBackCalls, 1);
-          // Auto-empty must return to the parent grid, not pop the route.
-          expect(popCount, 0);
-        },
-      );
+        expect(onBackCalls, 1);
+        // Auto-empty must return to the parent grid, not pop the route.
+        expect(popCount, 0);
+      });
 
       testWidgets(
         'shows the category title in the fullscreen app bar when provided',
@@ -1161,28 +1158,25 @@ void main() {
         ).called(1);
       });
 
-      testWidgets(
-        'does not dispatch FullscreenFeedLoadMoreRequested when '
-        'canLoadMore is false',
-        (tester) async {
-          final videos = createTestVideos();
+      testWidgets('does not dispatch FullscreenFeedLoadMoreRequested when '
+          'canLoadMore is false', (tester) async {
+        final videos = createTestVideos();
 
-          await tester.pumpWidget(
-            buildSubject(
-              state: FullscreenFeedState(
-                status: FullscreenFeedStatus.ready,
-                videos: videos,
-              ),
+        await tester.pumpWidget(
+          buildSubject(
+            state: FullscreenFeedState(
+              status: FullscreenFeedStatus.ready,
+              videos: videos,
             ),
-          );
+          ),
+        );
 
-          nativeFeed(tester).onNearEnd?.call();
+        nativeFeed(tester).onNearEnd?.call();
 
-          verifyNever(
-            () => mockBloc.add(const FullscreenFeedLoadMoreRequested()),
-          );
-        },
-      );
+        verifyNever(
+          () => mockBloc.add(const FullscreenFeedLoadMoreRequested()),
+        );
+      });
 
       testWidgets('passes nearEndThreshold of 10 to InfiniteVideoFeed', (
         tester,
@@ -1227,52 +1221,50 @@ void main() {
         },
       );
 
-      testWidgets(
-        'hides LoadingMorePill when isLoadingMore is false',
-        (tester) async {
-          final videos = createTestVideos();
+      testWidgets('hides LoadingMorePill when isLoadingMore is false', (
+        tester,
+      ) async {
+        final videos = createTestVideos();
 
-          await tester.pumpWidget(
-            buildSubject(
-              state: FullscreenFeedState(
-                status: FullscreenFeedStatus.ready,
-                videos: videos,
-                currentIndex: videos.length - 1,
-              ),
+        await tester.pumpWidget(
+          buildSubject(
+            state: FullscreenFeedState(
+              status: FullscreenFeedStatus.ready,
+              videos: videos,
+              currentIndex: videos.length - 1,
             ),
-          );
-          await tester.pump();
+          ),
+        );
+        await tester.pump();
 
-          final pill = tester.widget<LoadingMorePill>(
-            find.byType(LoadingMorePill),
-          );
-          expect(pill.isVisible, isFalse);
-        },
-      );
+        final pill = tester.widget<LoadingMorePill>(
+          find.byType(LoadingMorePill),
+        );
+        expect(pill.isVisible, isFalse);
+      });
 
-      testWidgets(
-        'hides LoadingMorePill when not on the last video',
-        (tester) async {
-          final videos = createTestVideos();
+      testWidgets('hides LoadingMorePill when not on the last video', (
+        tester,
+      ) async {
+        final videos = createTestVideos();
 
-          await tester.pumpWidget(
-            buildSubject(
-              state: FullscreenFeedState(
-                status: FullscreenFeedStatus.ready,
-                videos: videos,
-                isLoadingMore: true,
-                canLoadMore: true,
-              ),
+        await tester.pumpWidget(
+          buildSubject(
+            state: FullscreenFeedState(
+              status: FullscreenFeedStatus.ready,
+              videos: videos,
+              isLoadingMore: true,
+              canLoadMore: true,
             ),
-          );
-          await tester.pump();
+          ),
+        );
+        await tester.pump();
 
-          final pill = tester.widget<LoadingMorePill>(
-            find.byType(LoadingMorePill),
-          );
-          expect(pill.isVisible, isFalse);
-        },
-      );
+        final pill = tester.widget<LoadingMorePill>(
+          find.byType(LoadingMorePill),
+        );
+        expect(pill.isVisible, isFalse);
+      });
 
       testWidgets(
         'LoadingMorePill renders localized feedLoadingMore copy when visible',
@@ -1543,94 +1535,90 @@ void main() {
         },
       );
 
-      testWidgets(
-        'verify age retries playback with viewer auth headers',
-        (tester) async {
-          const sha256 =
-              'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
-          const videoUrl = 'https://media.divine.video/$sha256/720p.mp4';
-          const headers = {'Authorization': 'Nostr fullscreen-token'};
-          final nativePlayer = _NativePlayerHarness(tester)..install();
-          addTearDown(nativePlayer.dispose);
-          final mockMediaAuthInterceptor = MockMediaAuthInterceptor();
-          final video = createTestVideoEvent(
-            id: testVideoId1,
-            pubkey: testPubkey,
-            videoUrl: videoUrl,
-            sha256: sha256,
-          );
+      testWidgets('verify age retries playback with viewer auth headers', (
+        tester,
+      ) async {
+        const sha256 =
+            'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+        const videoUrl = 'https://media.divine.video/$sha256/720p.mp4';
+        const headers = {'Authorization': 'Nostr fullscreen-token'};
+        final nativePlayer = _NativePlayerHarness(tester)..install();
+        addTearDown(nativePlayer.dispose);
+        final mockMediaAuthInterceptor = MockMediaAuthInterceptor();
+        final video = createTestVideoEvent(
+          id: testVideoId1,
+          pubkey: testPubkey,
+          videoUrl: videoUrl,
+          sha256: sha256,
+        );
 
-          when(
-            () => mockMediaAuthInterceptor.handleUnauthorizedMedia(
-              context: any(named: 'context'),
-              sha256Hash: sha256,
-              url: videoUrl,
-              serverUrl: 'https://media.divine.video',
-              category: 'video',
+        when(
+          () => mockMediaAuthInterceptor.handleUnauthorizedMedia(
+            context: any(named: 'context'),
+            sha256Hash: sha256,
+            url: videoUrl,
+            serverUrl: 'https://media.divine.video',
+            category: 'video',
+          ),
+        ).thenAnswer((_) async => const ViewerAuthAuthorized(headers));
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: FullscreenFeedState(
+              status: FullscreenFeedStatus.ready,
+              videos: [video],
             ),
-          ).thenAnswer((_) async => const ViewerAuthAuthorized(headers));
-
-          await tester.pumpWidget(
-            buildSubject(
-              state: FullscreenFeedState(
-                status: FullscreenFeedStatus.ready,
-                videos: [video],
+            additionalOverrides: [
+              mediaAuthInterceptorProvider.overrideWithValue(
+                mockMediaAuthInterceptor,
               ),
-              additionalOverrides: [
-                mediaAuthInterceptorProvider.overrideWithValue(
-                  mockMediaAuthInterceptor,
-                ),
-              ],
-            ),
-          );
-          await tester.pump();
+            ],
+          ),
+        );
+        await tester.pump();
 
-          final cubit = BlocProvider.of<VideoPlaybackStatusCubit>(
-            tester.element(find.byType(FullscreenFeedContent)),
-          );
-          cubit.report(video.id, PlaybackStatus.ageRestricted);
-          await tester.pump();
+        final cubit = BlocProvider.of<VideoPlaybackStatusCubit>(
+          tester.element(find.byType(FullscreenFeedContent)),
+        );
+        cubit.report(video.id, PlaybackStatus.ageRestricted);
+        await tester.pump();
 
-          final l10n = lookupAppLocalizations(const Locale('en'));
+        final l10n = lookupAppLocalizations(const Locale('en'));
 
-          expect(find.byType(ModeratedContentOverlay), findsOneWidget);
-          expect(
-            find.text(l10n.videoErrorVerifyAgeButton),
-            findsOneWidget,
-          );
+        expect(find.byType(ModeratedContentOverlay), findsOneWidget);
+        expect(find.text(l10n.videoErrorVerifyAgeButton), findsOneWidget);
 
-          await tester.tap(find.text(l10n.videoErrorVerifyAgeButton));
-          await tester.pump();
-          await tester.pump();
+        await tester.tap(find.text(l10n.videoErrorVerifyAgeButton));
+        await tester.pump();
+        await tester.pump();
 
-          verify(
-            () => mockMediaAuthInterceptor.handleUnauthorizedMedia(
-              context: any(named: 'context'),
-              sha256Hash: sha256,
-              url: videoUrl,
-              serverUrl: 'https://media.divine.video',
-              category: 'video',
-            ),
-          ).called(1);
-          expect(cubit.state.statusFor(video.id), PlaybackStatus.ready);
-          expect(
-            nativePlayer.setClipsArguments,
-            contains(
-              predicate<Map<Object?, Object?>>((arguments) {
-                final clips = arguments['clips'];
-                if (clips is! List || clips.isEmpty) return false;
-                final clip = clips.first;
-                if (clip is! Map || clip['uri'] != videoUrl) {
-                  return false;
-                }
-                final httpHeaders = clip['httpHeaders'];
-                return httpHeaders is Map &&
-                    httpHeaders['Authorization'] == headers['Authorization'];
-              }),
-            ),
-          );
-        },
-      );
+        verify(
+          () => mockMediaAuthInterceptor.handleUnauthorizedMedia(
+            context: any(named: 'context'),
+            sha256Hash: sha256,
+            url: videoUrl,
+            serverUrl: 'https://media.divine.video',
+            category: 'video',
+          ),
+        ).called(1);
+        expect(cubit.state.statusFor(video.id), PlaybackStatus.ready);
+        expect(
+          nativePlayer.setClipsArguments,
+          contains(
+            predicate<Map<Object?, Object?>>((arguments) {
+              final clips = arguments['clips'];
+              if (clips is! List || clips.isEmpty) return false;
+              final clip = clips.first;
+              if (clip is! Map || clip['uri'] != videoUrl) {
+                return false;
+              }
+              final httpHeaders = clip['httpHeaders'];
+              return httpHeaders is Map &&
+                  httpHeaders['Authorization'] == headers['Authorization'];
+            }),
+          ),
+        );
+      });
 
       testWidgets(
         'verify age authenticates the optimized source for a bare-hash URL',
@@ -1736,9 +1724,10 @@ void main() {
         tester,
       ) async {
         final videos = createTestVideos();
-        final mockAuth = createMockAuthService();
-        when(() => mockAuth.isAuthenticated).thenReturn(true);
-        when(() => mockAuth.currentPublicKeyHex).thenReturn(testPubkey);
+        final mockAuth = createMockAuthService(
+          authState: AuthState.authenticated,
+          currentPublicKeyHex: testPubkey,
+        );
 
         await tester.pumpWidget(
           buildSubject(
@@ -1767,9 +1756,10 @@ void main() {
         'hides owner edit and delete actions for non-owned videos in the more menu',
         (tester) async {
           final videos = createTestVideos();
-          final mockAuth = createMockAuthService();
-          when(() => mockAuth.isAuthenticated).thenReturn(true);
-          when(() => mockAuth.currentPublicKeyHex).thenReturn(otherPubkey);
+          final mockAuth = createMockAuthService(
+            authState: AuthState.authenticated,
+            currentPublicKeyHex: otherPubkey,
+          );
 
           await tester.pumpWidget(
             buildSubject(
@@ -1851,9 +1841,7 @@ void main() {
         nativeFeed(tester).onVideoLoopCompleted?.call(0);
         await tester.pump();
 
-        verifyNever(
-          () => mockBloc.add(const FullscreenFeedIndexChanged(1)),
-        );
+        verifyNever(() => mockBloc.add(const FullscreenFeedIndexChanged(1)));
       });
     });
 

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -700,9 +700,9 @@ void main() {
                 videos: [video],
               ),
               additionalOverrides: [
-                userProfileReactiveProvider(
-                  testPubkey,
-                ).overrideWith((ref) => Stream<UserProfile?>.value(null)),
+                userProfileReactiveProvider(testPubkey).overrideWith(
+                  (ref) => Stream<UserProfile?>.value(null),
+                ),
               ],
             ),
           );
@@ -1035,63 +1035,66 @@ void main() {
         },
       );
 
-      testWidgets('hands back to onBack instead of popping when status becomes '
-          'emptyAfterRemoval in embedded video mode', (tester) async {
-        final videos = createTestVideos(count: 1);
-        final initialState = FullscreenFeedState(
-          status: FullscreenFeedStatus.ready,
-          videos: videos,
-        );
-        final emptyState = FullscreenFeedState(
-          status: FullscreenFeedStatus.emptyAfterRemoval,
-          removedVideoIds: {videos.first.id},
-        );
-        final controller = StreamController<FullscreenFeedState>();
-        addTearDown(controller.close);
-        whenListen(mockBloc, controller.stream, initialState: initialState);
+      testWidgets(
+        'hands back to onBack instead of popping when status becomes '
+        'emptyAfterRemoval in embedded video mode',
+        (tester) async {
+          final videos = createTestVideos(count: 1);
+          final initialState = FullscreenFeedState(
+            status: FullscreenFeedStatus.ready,
+            videos: videos,
+          );
+          final emptyState = FullscreenFeedState(
+            status: FullscreenFeedStatus.emptyAfterRemoval,
+            removedVideoIds: {videos.first.id},
+          );
+          final controller = StreamController<FullscreenFeedState>();
+          addTearDown(controller.close);
+          whenListen(mockBloc, controller.stream, initialState: initialState);
 
-        var onBackCalls = 0;
-        var popCount = 0;
-        final observer = _PopCountingObserver(onPop: () => popCount++);
+          var onBackCalls = 0;
+          var popCount = 0;
+          final observer = _PopCountingObserver(onPop: () => popCount++);
 
-        await tester.pumpWidget(
-          testProviderScope(
-            mockProfileRepository: mockProfileRepository,
-            mockNip05VerificationService: mockNip05VerificationService,
-            child: MaterialApp(
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              navigatorObservers: [observer],
-              home: Builder(
-                builder: (context) => Scaffold(
-                  body: ElevatedButton(
-                    onPressed: () => Navigator.of(context).push(
-                      MaterialPageRoute<void>(
-                        builder: (_) => buildContent(
-                          contextTitle: 'Embedded',
-                          onBack: () => onBackCalls++,
+          await tester.pumpWidget(
+            testProviderScope(
+              mockProfileRepository: mockProfileRepository,
+              mockNip05VerificationService: mockNip05VerificationService,
+              child: MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                navigatorObservers: [observer],
+                home: Builder(
+                  builder: (context) => Scaffold(
+                    body: ElevatedButton(
+                      onPressed: () => Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => buildContent(
+                            contextTitle: 'Embedded',
+                            onBack: () => onBackCalls++,
+                          ),
                         ),
                       ),
+                      child: const Text('open'),
                     ),
-                    child: const Text('open'),
                   ),
                 ),
               ),
             ),
-          ),
-        );
+          );
 
-        await tester.tap(find.text('open'));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 400));
+          await tester.tap(find.text('open'));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 400));
 
-        controller.add(emptyState);
-        await tester.pump();
+          controller.add(emptyState);
+          await tester.pump();
 
-        expect(onBackCalls, 1);
-        // Auto-empty must return to the parent grid, not pop the route.
-        expect(popCount, 0);
-      });
+          expect(onBackCalls, 1);
+          // Auto-empty must return to the parent grid, not pop the route.
+          expect(popCount, 0);
+        },
+      );
 
       testWidgets(
         'shows the category title in the fullscreen app bar when provided',
@@ -1158,25 +1161,28 @@ void main() {
         ).called(1);
       });
 
-      testWidgets('does not dispatch FullscreenFeedLoadMoreRequested when '
-          'canLoadMore is false', (tester) async {
-        final videos = createTestVideos();
+      testWidgets(
+        'does not dispatch FullscreenFeedLoadMoreRequested when '
+        'canLoadMore is false',
+        (tester) async {
+          final videos = createTestVideos();
 
-        await tester.pumpWidget(
-          buildSubject(
-            state: FullscreenFeedState(
-              status: FullscreenFeedStatus.ready,
-              videos: videos,
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: videos,
+              ),
             ),
-          ),
-        );
+          );
 
-        nativeFeed(tester).onNearEnd?.call();
+          nativeFeed(tester).onNearEnd?.call();
 
-        verifyNever(
-          () => mockBloc.add(const FullscreenFeedLoadMoreRequested()),
-        );
-      });
+          verifyNever(
+            () => mockBloc.add(const FullscreenFeedLoadMoreRequested()),
+          );
+        },
+      );
 
       testWidgets('passes nearEndThreshold of 10 to InfiniteVideoFeed', (
         tester,
@@ -1221,50 +1227,52 @@ void main() {
         },
       );
 
-      testWidgets('hides LoadingMorePill when isLoadingMore is false', (
-        tester,
-      ) async {
-        final videos = createTestVideos();
+      testWidgets(
+        'hides LoadingMorePill when isLoadingMore is false',
+        (tester) async {
+          final videos = createTestVideos();
 
-        await tester.pumpWidget(
-          buildSubject(
-            state: FullscreenFeedState(
-              status: FullscreenFeedStatus.ready,
-              videos: videos,
-              currentIndex: videos.length - 1,
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: videos,
+                currentIndex: videos.length - 1,
+              ),
             ),
-          ),
-        );
-        await tester.pump();
+          );
+          await tester.pump();
 
-        final pill = tester.widget<LoadingMorePill>(
-          find.byType(LoadingMorePill),
-        );
-        expect(pill.isVisible, isFalse);
-      });
+          final pill = tester.widget<LoadingMorePill>(
+            find.byType(LoadingMorePill),
+          );
+          expect(pill.isVisible, isFalse);
+        },
+      );
 
-      testWidgets('hides LoadingMorePill when not on the last video', (
-        tester,
-      ) async {
-        final videos = createTestVideos();
+      testWidgets(
+        'hides LoadingMorePill when not on the last video',
+        (tester) async {
+          final videos = createTestVideos();
 
-        await tester.pumpWidget(
-          buildSubject(
-            state: FullscreenFeedState(
-              status: FullscreenFeedStatus.ready,
-              videos: videos,
-              isLoadingMore: true,
-              canLoadMore: true,
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: videos,
+                isLoadingMore: true,
+                canLoadMore: true,
+              ),
             ),
-          ),
-        );
-        await tester.pump();
+          );
+          await tester.pump();
 
-        final pill = tester.widget<LoadingMorePill>(
-          find.byType(LoadingMorePill),
-        );
-        expect(pill.isVisible, isFalse);
-      });
+          final pill = tester.widget<LoadingMorePill>(
+            find.byType(LoadingMorePill),
+          );
+          expect(pill.isVisible, isFalse);
+        },
+      );
 
       testWidgets(
         'LoadingMorePill renders localized feedLoadingMore copy when visible',
@@ -1535,90 +1543,94 @@ void main() {
         },
       );
 
-      testWidgets('verify age retries playback with viewer auth headers', (
-        tester,
-      ) async {
-        const sha256 =
-            'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
-        const videoUrl = 'https://media.divine.video/$sha256/720p.mp4';
-        const headers = {'Authorization': 'Nostr fullscreen-token'};
-        final nativePlayer = _NativePlayerHarness(tester)..install();
-        addTearDown(nativePlayer.dispose);
-        final mockMediaAuthInterceptor = MockMediaAuthInterceptor();
-        final video = createTestVideoEvent(
-          id: testVideoId1,
-          pubkey: testPubkey,
-          videoUrl: videoUrl,
-          sha256: sha256,
-        );
+      testWidgets(
+        'verify age retries playback with viewer auth headers',
+        (tester) async {
+          const sha256 =
+              'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+          const videoUrl = 'https://media.divine.video/$sha256/720p.mp4';
+          const headers = {'Authorization': 'Nostr fullscreen-token'};
+          final nativePlayer = _NativePlayerHarness(tester)..install();
+          addTearDown(nativePlayer.dispose);
+          final mockMediaAuthInterceptor = MockMediaAuthInterceptor();
+          final video = createTestVideoEvent(
+            id: testVideoId1,
+            pubkey: testPubkey,
+            videoUrl: videoUrl,
+            sha256: sha256,
+          );
 
-        when(
-          () => mockMediaAuthInterceptor.handleUnauthorizedMedia(
-            context: any(named: 'context'),
-            sha256Hash: sha256,
-            url: videoUrl,
-            serverUrl: 'https://media.divine.video',
-            category: 'video',
-          ),
-        ).thenAnswer((_) async => const ViewerAuthAuthorized(headers));
-
-        await tester.pumpWidget(
-          buildSubject(
-            state: FullscreenFeedState(
-              status: FullscreenFeedStatus.ready,
-              videos: [video],
+          when(
+            () => mockMediaAuthInterceptor.handleUnauthorizedMedia(
+              context: any(named: 'context'),
+              sha256Hash: sha256,
+              url: videoUrl,
+              serverUrl: 'https://media.divine.video',
+              category: 'video',
             ),
-            additionalOverrides: [
-              mediaAuthInterceptorProvider.overrideWithValue(
-                mockMediaAuthInterceptor,
+          ).thenAnswer((_) async => const ViewerAuthAuthorized(headers));
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: [video],
               ),
-            ],
-          ),
-        );
-        await tester.pump();
+              additionalOverrides: [
+                mediaAuthInterceptorProvider.overrideWithValue(
+                  mockMediaAuthInterceptor,
+                ),
+              ],
+            ),
+          );
+          await tester.pump();
 
-        final cubit = BlocProvider.of<VideoPlaybackStatusCubit>(
-          tester.element(find.byType(FullscreenFeedContent)),
-        );
-        cubit.report(video.id, PlaybackStatus.ageRestricted);
-        await tester.pump();
+          final cubit = BlocProvider.of<VideoPlaybackStatusCubit>(
+            tester.element(find.byType(FullscreenFeedContent)),
+          );
+          cubit.report(video.id, PlaybackStatus.ageRestricted);
+          await tester.pump();
 
-        final l10n = lookupAppLocalizations(const Locale('en'));
+          final l10n = lookupAppLocalizations(const Locale('en'));
 
-        expect(find.byType(ModeratedContentOverlay), findsOneWidget);
-        expect(find.text(l10n.videoErrorVerifyAgeButton), findsOneWidget);
+          expect(find.byType(ModeratedContentOverlay), findsOneWidget);
+          expect(
+            find.text(l10n.videoErrorVerifyAgeButton),
+            findsOneWidget,
+          );
 
-        await tester.tap(find.text(l10n.videoErrorVerifyAgeButton));
-        await tester.pump();
-        await tester.pump();
+          await tester.tap(find.text(l10n.videoErrorVerifyAgeButton));
+          await tester.pump();
+          await tester.pump();
 
-        verify(
-          () => mockMediaAuthInterceptor.handleUnauthorizedMedia(
-            context: any(named: 'context'),
-            sha256Hash: sha256,
-            url: videoUrl,
-            serverUrl: 'https://media.divine.video',
-            category: 'video',
-          ),
-        ).called(1);
-        expect(cubit.state.statusFor(video.id), PlaybackStatus.ready);
-        expect(
-          nativePlayer.setClipsArguments,
-          contains(
-            predicate<Map<Object?, Object?>>((arguments) {
-              final clips = arguments['clips'];
-              if (clips is! List || clips.isEmpty) return false;
-              final clip = clips.first;
-              if (clip is! Map || clip['uri'] != videoUrl) {
-                return false;
-              }
-              final httpHeaders = clip['httpHeaders'];
-              return httpHeaders is Map &&
-                  httpHeaders['Authorization'] == headers['Authorization'];
-            }),
-          ),
-        );
-      });
+          verify(
+            () => mockMediaAuthInterceptor.handleUnauthorizedMedia(
+              context: any(named: 'context'),
+              sha256Hash: sha256,
+              url: videoUrl,
+              serverUrl: 'https://media.divine.video',
+              category: 'video',
+            ),
+          ).called(1);
+          expect(cubit.state.statusFor(video.id), PlaybackStatus.ready);
+          expect(
+            nativePlayer.setClipsArguments,
+            contains(
+              predicate<Map<Object?, Object?>>((arguments) {
+                final clips = arguments['clips'];
+                if (clips is! List || clips.isEmpty) return false;
+                final clip = clips.first;
+                if (clip is! Map || clip['uri'] != videoUrl) {
+                  return false;
+                }
+                final httpHeaders = clip['httpHeaders'];
+                return httpHeaders is Map &&
+                    httpHeaders['Authorization'] == headers['Authorization'];
+              }),
+            ),
+          );
+        },
+      );
 
       testWidgets(
         'verify age authenticates the optimized source for a bare-hash URL',
@@ -1841,7 +1853,9 @@ void main() {
         nativeFeed(tester).onVideoLoopCompleted?.call(0);
         await tester.pump();
 
-        verifyNever(() => mockBloc.add(const FullscreenFeedIndexChanged(1)));
+        verifyNever(
+          () => mockBloc.add(const FullscreenFeedIndexChanged(1)),
+        );
       });
     });
 

--- a/mobile/test/screens/profile_setup_screen_test.dart
+++ b/mobile/test/screens/profile_setup_screen_test.dart
@@ -195,7 +195,10 @@ void main() {
         ),
       );
 
-      expect(find.text(l10n.profileSetupUsernameInvalidFormat), findsOneWidget);
+      expect(
+        find.text(l10n.profileSetupUsernameInvalidFormat),
+        findsOneWidget,
+      );
     });
 
     testWidgets('shows the localized edge-hyphen error', (tester) async {
@@ -240,7 +243,10 @@ void main() {
         ),
       );
 
-      expect(find.text(l10n.profileSetupUsernameInvalidLength), findsOneWidget);
+      expect(
+        find.text(l10n.profileSetupUsernameInvalidLength),
+        findsOneWidget,
+      );
     });
   });
 
@@ -295,7 +301,9 @@ void main() {
         home: Scaffold(
           body: TextField(
             controller: controller,
-            inputFormatters: const [LowercaseTextInputFormatter()],
+            inputFormatters: const [
+              LowercaseTextInputFormatter(),
+            ],
           ),
         ),
       );
@@ -777,13 +785,15 @@ void main() {
           ),
           GoRoute(
             path: '/profile/:npub',
-            builder: (context, state) =>
-                const Scaffold(body: Text('Profile destination')),
+            builder: (context, state) => const Scaffold(
+              body: Text('Profile destination'),
+            ),
           ),
           GoRoute(
             path: '/home/:tab',
-            builder: (context, state) =>
-                const Scaffold(body: Text('Home destination')),
+            builder: (context, state) => const Scaffold(
+              body: Text('Home destination'),
+            ),
           ),
         ],
       );
@@ -1023,7 +1033,9 @@ void main() {
 
       testWidgets(
         'a fresher Divine handle refreshes an untouched cached handle',
-        (tester) async {
+        (
+          tester,
+        ) async {
           final controller = StreamController<MyProfileState>();
           addTearDown(controller.close);
           whenListen(
@@ -1070,7 +1082,9 @@ void main() {
 
           await pumpScreen(tester);
           controller.add(
-            MyProfileLoading(profile: cachedProfile(banner: '0x33ccbf')),
+            MyProfileLoading(
+              profile: cachedProfile(banner: '0x33ccbf'),
+            ),
           );
           await tester.pump();
 
@@ -1177,7 +1191,10 @@ void main() {
         await tester.pumpAndSettle();
 
         final l10n = lookupAppLocalizations(const Locale('en'));
-        expect(find.text(l10n.profileSetupUnsavedChangesTitle), findsOneWidget);
+        expect(
+          find.text(l10n.profileSetupUnsavedChangesTitle),
+          findsOneWidget,
+        );
         expect(find.text('Profile destination'), findsNothing);
       });
 
@@ -1196,7 +1213,10 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text(l10n.profileSetupUnsavedChangesTitle), findsNothing);
+        expect(
+          find.text(l10n.profileSetupUnsavedChangesTitle),
+          findsNothing,
+        );
         expect(find.byType(ProfileSetupScreenView), findsOneWidget);
       });
 
@@ -1265,12 +1285,17 @@ void main() {
         await tester.pumpAndSettle();
 
         final l10n = lookupAppLocalizations(const Locale('en'));
-        expect(find.text(l10n.profileSetupUnsavedChangesTitle), findsOneWidget);
+        expect(
+          find.text(l10n.profileSetupUnsavedChangesTitle),
+          findsOneWidget,
+        );
         expect(
           find.text(l10n.profileSetupUnsavedChangesSaveButton),
           findsNothing,
         );
-        verifyNever(() => mockEditorBloc.add(any(that: isA<ProfileSaved>())));
+        verifyNever(
+          () => mockEditorBloc.add(any(that: isA<ProfileSaved>())),
+        );
       });
 
       testWidgets('clean cancel leaves without showing prompt', (tester) async {
@@ -1283,7 +1308,10 @@ void main() {
         await tester.tap(find.text(l10n.commonCancel));
         await tester.pumpAndSettle();
 
-        expect(find.text(l10n.profileSetupUnsavedChangesTitle), findsNothing);
+        expect(
+          find.text(l10n.profileSetupUnsavedChangesTitle),
+          findsNothing,
+        );
         expect(find.text('Profile destination'), findsOneWidget);
       });
 
@@ -1327,7 +1355,9 @@ void main() {
                 fetchUserProfileProvider(
                   testPubkeyHex,
                 ).overrideWith((ref) async => null),
-                userProfileReactiveProvider(testPubkeyHex).overrideWith(
+                userProfileReactiveProvider(
+                  testPubkeyHex,
+                ).overrideWith(
                   (ref) => Stream<models.UserProfile?>.value(null),
                 ),
               ],
@@ -1423,85 +1453,95 @@ void main() {
         await tester.pumpAndSettle();
       }
 
-      testWidgets('pre-filled hex banner shows color preview', (tester) async {
-        when(() => mockEditorBloc.state).thenReturn(
-          const ProfileEditorState(
-            persistedBanner: '0x33ccbf',
-            pendingBannerColor: Color(0xFF33CCBF),
-          ),
-        );
+      testWidgets(
+        'pre-filled hex banner shows color preview',
+        (tester) async {
+          when(() => mockEditorBloc.state).thenReturn(
+            const ProfileEditorState(
+              persistedBanner: '0x33ccbf',
+              pendingBannerColor: Color(0xFF33CCBF),
+            ),
+          );
 
-        await pumpScreen(tester);
-        await tester.pumpAndSettle();
+          await pumpScreen(tester);
+          await tester.pumpAndSettle();
 
-        expect(
-          find.byKey(const ValueKey('profile_banner_color_preview')),
-          findsOneWidget,
-        );
-        expect(
-          find.byKey(const ValueKey('profile_banner_image_preview')),
-          findsNothing,
-        );
-      });
+          expect(
+            find.byKey(const ValueKey('profile_banner_color_preview')),
+            findsOneWidget,
+          );
+          expect(
+            find.byKey(const ValueKey('profile_banner_image_preview')),
+            findsNothing,
+          );
+        },
+      );
 
-      testWidgets('pre-filled URL banner shows image preview', (tester) async {
-        when(() => mockEditorBloc.state).thenReturn(
-          const ProfileEditorState(
-            persistedBanner: 'https://cdn.example.com/banner.jpg',
-          ),
-        );
+      testWidgets(
+        'pre-filled URL banner shows image preview',
+        (tester) async {
+          when(() => mockEditorBloc.state).thenReturn(
+            const ProfileEditorState(
+              persistedBanner: 'https://cdn.example.com/banner.jpg',
+            ),
+          );
 
-        await pumpScreen(tester);
-        await tester.pumpAndSettle();
+          await pumpScreen(tester);
+          await tester.pumpAndSettle();
 
-        expect(
-          find.byKey(const ValueKey('profile_banner_image_preview')),
-          findsOneWidget,
-        );
-        expect(
-          find.byKey(const ValueKey('profile_banner_color_preview')),
-          findsNothing,
-        );
-      });
+          expect(
+            find.byKey(const ValueKey('profile_banner_image_preview')),
+            findsOneWidget,
+          );
+          expect(
+            find.byKey(const ValueKey('profile_banner_color_preview')),
+            findsNothing,
+          );
+        },
+      );
 
-      testWidgets('staged pendingBannerUrl shows image preview from that URL', (
-        tester,
-      ) async {
-        when(() => mockEditorBloc.state).thenReturn(
-          const ProfileEditorState(
-            pendingBannerStatus: PendingBannerStatus.staged,
-            pendingBannerUrl: 'https://cdn.example.com/uploaded.jpg',
-          ),
-        );
+      testWidgets(
+        'staged pendingBannerUrl shows image preview from that URL',
+        (tester) async {
+          when(() => mockEditorBloc.state).thenReturn(
+            const ProfileEditorState(
+              pendingBannerStatus: PendingBannerStatus.staged,
+              pendingBannerUrl: 'https://cdn.example.com/uploaded.jpg',
+            ),
+          );
 
-        await pumpScreen(tester);
-        await tester.pumpAndSettle();
+          await pumpScreen(tester);
+          await tester.pumpAndSettle();
 
-        expect(
-          find.byKey(const ValueKey('profile_banner_image_preview')),
-          findsOneWidget,
-        );
-      });
+          expect(
+            find.byKey(const ValueKey('profile_banner_image_preview')),
+            findsOneWidget,
+          );
+        },
+      );
 
-      testWidgets('staged pendingBannerColor shows color preview, no image', (
-        tester,
-      ) async {
-        when(() => mockEditorBloc.state).thenReturn(
-          const ProfileEditorState(pendingBannerColor: Color(0xFFFF0000)),
-        );
+      testWidgets(
+        'staged pendingBannerColor shows color preview, no image',
+        (tester) async {
+          when(() => mockEditorBloc.state).thenReturn(
+            const ProfileEditorState(
+              pendingBannerColor: Color(0xFFFF0000),
+            ),
+          );
 
-        await pumpScreen(tester);
-        await tester.pumpAndSettle();
+          await pumpScreen(tester);
+          await tester.pumpAndSettle();
 
-        expect(
-          find.byKey(const ValueKey('profile_banner_color_preview')),
-          findsOneWidget,
-        );
-        expect(
-          find.byKey(const ValueKey('profile_banner_image_preview')),
-          findsNothing,
-        );
-      });
+          expect(
+            find.byKey(const ValueKey('profile_banner_color_preview')),
+            findsOneWidget,
+          );
+          expect(
+            find.byKey(const ValueKey('profile_banner_image_preview')),
+            findsNothing,
+          );
+        },
+      );
 
       testWidgets('the banner sheet offers an image link', (tester) async {
         await pumpScreen(tester);
@@ -1562,7 +1602,10 @@ void main() {
         await tester.tap(find.text(l10n.profileSetupImagePasteLink));
         await tester.pumpAndSettle();
 
-        expect(find.text('https://cdn.example.com/banner.jpg'), findsOneWidget);
+        expect(
+          find.text('https://cdn.example.com/banner.jpg'),
+          findsOneWidget,
+        );
       });
 
       testWidgets('the link sheet opens empty on a persisted colour', (
@@ -1658,54 +1701,66 @@ void main() {
               captureAny(that: isA<ProfileBannerColorSelected>()),
             ),
           ).captured;
-          expect(captured.whereType<ProfileBannerColorSelected>(), isNotEmpty);
+          expect(
+            captured.whereType<ProfileBannerColorSelected>(),
+            isNotEmpty,
+          );
         },
       );
 
-      testWidgets('tapping Clear when a banner is staged dispatches '
-          '$ProfileBannerCleared', (tester) async {
-        when(() => mockEditorBloc.state).thenReturn(
-          const ProfileEditorState(
-            pendingBannerStatus: PendingBannerStatus.staged,
-            pendingBannerUrl: 'https://cdn.example.com/uploaded.jpg',
-          ),
-        );
+      testWidgets(
+        'tapping Clear when a banner is staged dispatches '
+        '$ProfileBannerCleared',
+        (tester) async {
+          when(() => mockEditorBloc.state).thenReturn(
+            const ProfileEditorState(
+              pendingBannerStatus: PendingBannerStatus.staged,
+              pendingBannerUrl: 'https://cdn.example.com/uploaded.jpg',
+            ),
+          );
 
-        await pumpScreen(tester);
-        await tester.pumpAndSettle();
+          await pumpScreen(tester);
+          await tester.pumpAndSettle();
 
-        final l10n = lookupAppLocalizations(const Locale('en'));
-        await tester.tap(find.byTooltip(l10n.profileSetupEditBannerLabel));
-        await tester.pumpAndSettle();
-        final clearButton = find.text(l10n.profileSetupBannerClearButton);
-        await tester.ensureVisible(clearButton);
-        await tester.tap(clearButton);
-        await tester.pumpAndSettle();
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          await tester.tap(find.byTooltip(l10n.profileSetupEditBannerLabel));
+          await tester.pumpAndSettle();
+          final clearButton = find.text(l10n.profileSetupBannerClearButton);
+          await tester.ensureVisible(clearButton);
+          await tester.tap(clearButton);
+          await tester.pumpAndSettle();
 
-        verify(
-          () => mockEditorBloc.add(const ProfileBannerCleared()),
-        ).called(1);
-      });
+          verify(
+            () => mockEditorBloc.add(const ProfileBannerCleared()),
+          ).called(1);
+        },
+      );
 
-      testWidgets('Save dispatches $ProfileSaved without legacy banner field — '
-          'bloc resolves it from state.effectiveBanner', (tester) async {
-        await pumpScreen(tester);
-        await tester.pumpAndSettle();
+      testWidgets(
+        'Save dispatches $ProfileSaved without legacy banner field — '
+        'bloc resolves it from state.effectiveBanner',
+        (tester) async {
+          await pumpScreen(tester);
+          await tester.pumpAndSettle();
 
-        // Provide a display name so the save proceeds.
-        await tester.enterText(find.byType(TextField).first, 'Test User');
-        await tester.pumpAndSettle();
+          // Provide a display name so the save proceeds.
+          await tester.enterText(find.byType(TextField).first, 'Test User');
+          await tester.pumpAndSettle();
 
-        final l10n = lookupAppLocalizations(const Locale('en'));
-        await tester.tap(find.text(l10n.profileSetupSaveButton));
-        await tester.pumpAndSettle();
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          await tester.tap(find.text(l10n.profileSetupSaveButton));
+          await tester.pumpAndSettle();
 
-        final captured = verify(
-          () => mockEditorBloc.add(captureAny(that: isA<ProfileSaved>())),
-        ).captured;
-        expect(captured.whereType<ProfileSaved>(), isNotEmpty);
-        expect(captured.whereType<ProfileSaved>().last.banner, isNull);
-      });
+          final captured = verify(
+            () => mockEditorBloc.add(captureAny(that: isA<ProfileSaved>())),
+          ).captured;
+          expect(captured.whereType<ProfileSaved>(), isNotEmpty);
+          expect(
+            captured.whereType<ProfileSaved>().last.banner,
+            isNull,
+          );
+        },
+      );
     });
   });
 }

--- a/mobile/test/screens/profile_setup_screen_test.dart
+++ b/mobile/test/screens/profile_setup_screen_test.dart
@@ -16,6 +16,7 @@ import 'package:models/models.dart' as models;
 import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/auth_state.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/profile_setup/profile_setup.dart';
@@ -194,10 +195,7 @@ void main() {
         ),
       );
 
-      expect(
-        find.text(l10n.profileSetupUsernameInvalidFormat),
-        findsOneWidget,
-      );
+      expect(find.text(l10n.profileSetupUsernameInvalidFormat), findsOneWidget);
     });
 
     testWidgets('shows the localized edge-hyphen error', (tester) async {
@@ -242,10 +240,7 @@ void main() {
         ),
       );
 
-      expect(
-        find.text(l10n.profileSetupUsernameInvalidLength),
-        findsOneWidget,
-      );
+      expect(find.text(l10n.profileSetupUsernameInvalidLength), findsOneWidget);
     });
   });
 
@@ -300,9 +295,7 @@ void main() {
         home: Scaffold(
           body: TextField(
             controller: controller,
-            inputFormatters: const [
-              LowercaseTextInputFormatter(),
-            ],
+            inputFormatters: const [LowercaseTextInputFormatter()],
           ),
         ),
       );
@@ -601,9 +594,10 @@ void main() {
     late MockProfileRepository mockProfileRepository;
 
     setUp(() {
-      mockAuthService = createMockAuthService();
-      when(() => mockAuthService.isAuthenticated).thenReturn(true);
-      when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkeyHex);
+      mockAuthService = createMockAuthService(
+        authState: AuthState.authenticated,
+        currentPublicKeyHex: testPubkeyHex,
+      );
       when(() => mockAuthService.currentNpub).thenReturn(testNpub);
       when(() => mockAuthService.hasExistingProfile).thenReturn(true);
 
@@ -712,9 +706,10 @@ void main() {
     late _MockMyProfileBloc mockMyProfileBloc;
 
     setUp(() {
-      mockAuthService = createMockAuthService();
-      when(() => mockAuthService.isAuthenticated).thenReturn(true);
-      when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkeyHex);
+      mockAuthService = createMockAuthService(
+        authState: AuthState.authenticated,
+        currentPublicKeyHex: testPubkeyHex,
+      );
       when(() => mockAuthService.currentNpub).thenReturn('npub-test-profile');
       when(() => mockAuthService.hasExistingProfile).thenReturn(true);
 
@@ -782,15 +777,13 @@ void main() {
           ),
           GoRoute(
             path: '/profile/:npub',
-            builder: (context, state) => const Scaffold(
-              body: Text('Profile destination'),
-            ),
+            builder: (context, state) =>
+                const Scaffold(body: Text('Profile destination')),
           ),
           GoRoute(
             path: '/home/:tab',
-            builder: (context, state) => const Scaffold(
-              body: Text('Home destination'),
-            ),
+            builder: (context, state) =>
+                const Scaffold(body: Text('Home destination')),
           ),
         ],
       );
@@ -1030,9 +1023,7 @@ void main() {
 
       testWidgets(
         'a fresher Divine handle refreshes an untouched cached handle',
-        (
-          tester,
-        ) async {
+        (tester) async {
           final controller = StreamController<MyProfileState>();
           addTearDown(controller.close);
           whenListen(
@@ -1079,9 +1070,7 @@ void main() {
 
           await pumpScreen(tester);
           controller.add(
-            MyProfileLoading(
-              profile: cachedProfile(banner: '0x33ccbf'),
-            ),
+            MyProfileLoading(profile: cachedProfile(banner: '0x33ccbf')),
           );
           await tester.pump();
 
@@ -1188,10 +1177,7 @@ void main() {
         await tester.pumpAndSettle();
 
         final l10n = lookupAppLocalizations(const Locale('en'));
-        expect(
-          find.text(l10n.profileSetupUnsavedChangesTitle),
-          findsOneWidget,
-        );
+        expect(find.text(l10n.profileSetupUnsavedChangesTitle), findsOneWidget);
         expect(find.text('Profile destination'), findsNothing);
       });
 
@@ -1210,10 +1196,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(
-          find.text(l10n.profileSetupUnsavedChangesTitle),
-          findsNothing,
-        );
+        expect(find.text(l10n.profileSetupUnsavedChangesTitle), findsNothing);
         expect(find.byType(ProfileSetupScreenView), findsOneWidget);
       });
 
@@ -1282,17 +1265,12 @@ void main() {
         await tester.pumpAndSettle();
 
         final l10n = lookupAppLocalizations(const Locale('en'));
-        expect(
-          find.text(l10n.profileSetupUnsavedChangesTitle),
-          findsOneWidget,
-        );
+        expect(find.text(l10n.profileSetupUnsavedChangesTitle), findsOneWidget);
         expect(
           find.text(l10n.profileSetupUnsavedChangesSaveButton),
           findsNothing,
         );
-        verifyNever(
-          () => mockEditorBloc.add(any(that: isA<ProfileSaved>())),
-        );
+        verifyNever(() => mockEditorBloc.add(any(that: isA<ProfileSaved>())));
       });
 
       testWidgets('clean cancel leaves without showing prompt', (tester) async {
@@ -1305,10 +1283,7 @@ void main() {
         await tester.tap(find.text(l10n.commonCancel));
         await tester.pumpAndSettle();
 
-        expect(
-          find.text(l10n.profileSetupUnsavedChangesTitle),
-          findsNothing,
-        );
+        expect(find.text(l10n.profileSetupUnsavedChangesTitle), findsNothing);
         expect(find.text('Profile destination'), findsOneWidget);
       });
 
@@ -1352,9 +1327,7 @@ void main() {
                 fetchUserProfileProvider(
                   testPubkeyHex,
                 ).overrideWith((ref) async => null),
-                userProfileReactiveProvider(
-                  testPubkeyHex,
-                ).overrideWith(
+                userProfileReactiveProvider(testPubkeyHex).overrideWith(
                   (ref) => Stream<models.UserProfile?>.value(null),
                 ),
               ],
@@ -1450,95 +1423,85 @@ void main() {
         await tester.pumpAndSettle();
       }
 
-      testWidgets(
-        'pre-filled hex banner shows color preview',
-        (tester) async {
-          when(() => mockEditorBloc.state).thenReturn(
-            const ProfileEditorState(
-              persistedBanner: '0x33ccbf',
-              pendingBannerColor: Color(0xFF33CCBF),
-            ),
-          );
+      testWidgets('pre-filled hex banner shows color preview', (tester) async {
+        when(() => mockEditorBloc.state).thenReturn(
+          const ProfileEditorState(
+            persistedBanner: '0x33ccbf',
+            pendingBannerColor: Color(0xFF33CCBF),
+          ),
+        );
 
-          await pumpScreen(tester);
-          await tester.pumpAndSettle();
+        await pumpScreen(tester);
+        await tester.pumpAndSettle();
 
-          expect(
-            find.byKey(const ValueKey('profile_banner_color_preview')),
-            findsOneWidget,
-          );
-          expect(
-            find.byKey(const ValueKey('profile_banner_image_preview')),
-            findsNothing,
-          );
-        },
-      );
+        expect(
+          find.byKey(const ValueKey('profile_banner_color_preview')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const ValueKey('profile_banner_image_preview')),
+          findsNothing,
+        );
+      });
 
-      testWidgets(
-        'pre-filled URL banner shows image preview',
-        (tester) async {
-          when(() => mockEditorBloc.state).thenReturn(
-            const ProfileEditorState(
-              persistedBanner: 'https://cdn.example.com/banner.jpg',
-            ),
-          );
+      testWidgets('pre-filled URL banner shows image preview', (tester) async {
+        when(() => mockEditorBloc.state).thenReturn(
+          const ProfileEditorState(
+            persistedBanner: 'https://cdn.example.com/banner.jpg',
+          ),
+        );
 
-          await pumpScreen(tester);
-          await tester.pumpAndSettle();
+        await pumpScreen(tester);
+        await tester.pumpAndSettle();
 
-          expect(
-            find.byKey(const ValueKey('profile_banner_image_preview')),
-            findsOneWidget,
-          );
-          expect(
-            find.byKey(const ValueKey('profile_banner_color_preview')),
-            findsNothing,
-          );
-        },
-      );
+        expect(
+          find.byKey(const ValueKey('profile_banner_image_preview')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const ValueKey('profile_banner_color_preview')),
+          findsNothing,
+        );
+      });
 
-      testWidgets(
-        'staged pendingBannerUrl shows image preview from that URL',
-        (tester) async {
-          when(() => mockEditorBloc.state).thenReturn(
-            const ProfileEditorState(
-              pendingBannerStatus: PendingBannerStatus.staged,
-              pendingBannerUrl: 'https://cdn.example.com/uploaded.jpg',
-            ),
-          );
+      testWidgets('staged pendingBannerUrl shows image preview from that URL', (
+        tester,
+      ) async {
+        when(() => mockEditorBloc.state).thenReturn(
+          const ProfileEditorState(
+            pendingBannerStatus: PendingBannerStatus.staged,
+            pendingBannerUrl: 'https://cdn.example.com/uploaded.jpg',
+          ),
+        );
 
-          await pumpScreen(tester);
-          await tester.pumpAndSettle();
+        await pumpScreen(tester);
+        await tester.pumpAndSettle();
 
-          expect(
-            find.byKey(const ValueKey('profile_banner_image_preview')),
-            findsOneWidget,
-          );
-        },
-      );
+        expect(
+          find.byKey(const ValueKey('profile_banner_image_preview')),
+          findsOneWidget,
+        );
+      });
 
-      testWidgets(
-        'staged pendingBannerColor shows color preview, no image',
-        (tester) async {
-          when(() => mockEditorBloc.state).thenReturn(
-            const ProfileEditorState(
-              pendingBannerColor: Color(0xFFFF0000),
-            ),
-          );
+      testWidgets('staged pendingBannerColor shows color preview, no image', (
+        tester,
+      ) async {
+        when(() => mockEditorBloc.state).thenReturn(
+          const ProfileEditorState(pendingBannerColor: Color(0xFFFF0000)),
+        );
 
-          await pumpScreen(tester);
-          await tester.pumpAndSettle();
+        await pumpScreen(tester);
+        await tester.pumpAndSettle();
 
-          expect(
-            find.byKey(const ValueKey('profile_banner_color_preview')),
-            findsOneWidget,
-          );
-          expect(
-            find.byKey(const ValueKey('profile_banner_image_preview')),
-            findsNothing,
-          );
-        },
-      );
+        expect(
+          find.byKey(const ValueKey('profile_banner_color_preview')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const ValueKey('profile_banner_image_preview')),
+          findsNothing,
+        );
+      });
 
       testWidgets('the banner sheet offers an image link', (tester) async {
         await pumpScreen(tester);
@@ -1599,10 +1562,7 @@ void main() {
         await tester.tap(find.text(l10n.profileSetupImagePasteLink));
         await tester.pumpAndSettle();
 
-        expect(
-          find.text('https://cdn.example.com/banner.jpg'),
-          findsOneWidget,
-        );
+        expect(find.text('https://cdn.example.com/banner.jpg'), findsOneWidget);
       });
 
       testWidgets('the link sheet opens empty on a persisted colour', (
@@ -1698,66 +1658,54 @@ void main() {
               captureAny(that: isA<ProfileBannerColorSelected>()),
             ),
           ).captured;
-          expect(
-            captured.whereType<ProfileBannerColorSelected>(),
-            isNotEmpty,
-          );
+          expect(captured.whereType<ProfileBannerColorSelected>(), isNotEmpty);
         },
       );
 
-      testWidgets(
-        'tapping Clear when a banner is staged dispatches '
-        '$ProfileBannerCleared',
-        (tester) async {
-          when(() => mockEditorBloc.state).thenReturn(
-            const ProfileEditorState(
-              pendingBannerStatus: PendingBannerStatus.staged,
-              pendingBannerUrl: 'https://cdn.example.com/uploaded.jpg',
-            ),
-          );
+      testWidgets('tapping Clear when a banner is staged dispatches '
+          '$ProfileBannerCleared', (tester) async {
+        when(() => mockEditorBloc.state).thenReturn(
+          const ProfileEditorState(
+            pendingBannerStatus: PendingBannerStatus.staged,
+            pendingBannerUrl: 'https://cdn.example.com/uploaded.jpg',
+          ),
+        );
 
-          await pumpScreen(tester);
-          await tester.pumpAndSettle();
+        await pumpScreen(tester);
+        await tester.pumpAndSettle();
 
-          final l10n = lookupAppLocalizations(const Locale('en'));
-          await tester.tap(find.byTooltip(l10n.profileSetupEditBannerLabel));
-          await tester.pumpAndSettle();
-          final clearButton = find.text(l10n.profileSetupBannerClearButton);
-          await tester.ensureVisible(clearButton);
-          await tester.tap(clearButton);
-          await tester.pumpAndSettle();
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.byTooltip(l10n.profileSetupEditBannerLabel));
+        await tester.pumpAndSettle();
+        final clearButton = find.text(l10n.profileSetupBannerClearButton);
+        await tester.ensureVisible(clearButton);
+        await tester.tap(clearButton);
+        await tester.pumpAndSettle();
 
-          verify(
-            () => mockEditorBloc.add(const ProfileBannerCleared()),
-          ).called(1);
-        },
-      );
+        verify(
+          () => mockEditorBloc.add(const ProfileBannerCleared()),
+        ).called(1);
+      });
 
-      testWidgets(
-        'Save dispatches $ProfileSaved without legacy banner field — '
-        'bloc resolves it from state.effectiveBanner',
-        (tester) async {
-          await pumpScreen(tester);
-          await tester.pumpAndSettle();
+      testWidgets('Save dispatches $ProfileSaved without legacy banner field — '
+          'bloc resolves it from state.effectiveBanner', (tester) async {
+        await pumpScreen(tester);
+        await tester.pumpAndSettle();
 
-          // Provide a display name so the save proceeds.
-          await tester.enterText(find.byType(TextField).first, 'Test User');
-          await tester.pumpAndSettle();
+        // Provide a display name so the save proceeds.
+        await tester.enterText(find.byType(TextField).first, 'Test User');
+        await tester.pumpAndSettle();
 
-          final l10n = lookupAppLocalizations(const Locale('en'));
-          await tester.tap(find.text(l10n.profileSetupSaveButton));
-          await tester.pumpAndSettle();
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.profileSetupSaveButton));
+        await tester.pumpAndSettle();
 
-          final captured = verify(
-            () => mockEditorBloc.add(captureAny(that: isA<ProfileSaved>())),
-          ).captured;
-          expect(captured.whereType<ProfileSaved>(), isNotEmpty);
-          expect(
-            captured.whereType<ProfileSaved>().last.banner,
-            isNull,
-          );
-        },
-      );
+        final captured = verify(
+          () => mockEditorBloc.add(captureAny(that: isA<ProfileSaved>())),
+        ).captured;
+        expect(captured.whereType<ProfileSaved>(), isNotEmpty);
+        expect(captured.whereType<ProfileSaved>().last.banner, isNull);
+      });
     });
   });
 }

--- a/mobile/test/services/video_metadata_update_service_test.dart
+++ b/mobile/test/services/video_metadata_update_service_test.dart
@@ -14,6 +14,7 @@ import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/auth_state.dart';
 import 'package:openvine/models/content_label.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_metadata_update_error.dart';
@@ -80,7 +81,10 @@ void main() {
   });
 
   setUp(() {
-    mockAuthService = createMockAuthService();
+    mockAuthService = createMockAuthService(
+      authState: AuthState.authenticated,
+      currentPublicKeyHex: _ownerPubkey,
+    );
     mockNostrService = createMockNostrService();
     mockBlossomUploadService = _MockBlossomUploadService();
     mockDmRepository = _MockDmRepository();
@@ -88,9 +92,6 @@ void main() {
     mockVideoEventService = _MockVideoEventService();
     capturedTags = [];
     capturedCreatedAt = 0;
-
-    when(() => mockAuthService.isAuthenticated).thenReturn(true);
-    when(() => mockAuthService.currentPublicKeyHex).thenReturn(_ownerPubkey);
 
     late Event signedEvent;
     when(
@@ -765,10 +766,7 @@ void main() {
 
         expect(result, isA<VideoUpdateSuccess>());
         expect(capturedTags.where((tag) => tag.first == 't'), isEmpty);
-        expect(
-          capturedTags,
-          contains(equals(['proofmode', 'proof-manifest'])),
-        );
+        expect(capturedTags, contains(equals(['proofmode', 'proof-manifest'])));
       });
 
       test(

--- a/mobile/test/services/video_metadata_update_service_test.dart
+++ b/mobile/test/services/video_metadata_update_service_test.dart
@@ -769,7 +769,10 @@ void main() {
 
         expect(result, isA<VideoUpdateSuccess>());
         expect(capturedTags.where((tag) => tag.first == 't'), isEmpty);
-        expect(capturedTags, contains(equals(['proofmode', 'proof-manifest'])));
+        expect(
+          capturedTags,
+          contains(equals(['proofmode', 'proof-manifest'])),
+        );
       });
 
       test(

--- a/mobile/test/services/video_metadata_update_service_test.dart
+++ b/mobile/test/services/video_metadata_update_service_test.dart
@@ -141,6 +141,9 @@ void main() {
     group('auth guard', () {
       test('returns VideoUpdateFailure when not authenticated', () async {
         when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(
+          () => mockAuthService.authState,
+        ).thenReturn(AuthState.unauthenticated);
 
         final result = await service.updateVideo(
           originalVideo: _testVideo(),

--- a/mobile/test/widgets/profile/profile_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_grid_test.dart
@@ -160,7 +160,9 @@ void main() {
       when(
         () => videosRepository.removedVideoIds,
       ).thenAnswer((_) => const Stream<String>.empty());
-      when(() => videosRepository.isVideoKnownDeleted(any())).thenReturn(false);
+      when(
+        () => videosRepository.isVideoKnownDeleted(any()),
+      ).thenReturn(false);
       when(() => blocklistRepository.isBlocked(any())).thenReturn(false);
       when(() => blocklistRepository.hasMutedUs(any())).thenReturn(false);
       when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(false);
@@ -467,45 +469,46 @@ void main() {
       },
     );
 
-    testWidgets('pull-to-refresh completes after a viewed tab settled empty', (
-      tester,
-    ) async {
-      final curatedListService = _MockCuratedListService();
-      when(() => curatedListService.lists).thenReturn(const []);
-      when(() => curatedListService.myLists).thenReturn(const []);
-      when(
-        () => curatedListService.fetchUserListsFromRelays(
-          force: any(named: 'force'),
-        ),
-      ).thenAnswer((_) async {});
+    testWidgets(
+      'pull-to-refresh completes after a viewed tab settled empty',
+      (tester) async {
+        final curatedListService = _MockCuratedListService();
+        when(() => curatedListService.lists).thenReturn(const []);
+        when(() => curatedListService.myLists).thenReturn(const []);
+        when(
+          () => curatedListService.fetchUserListsFromRelays(
+            force: any(named: 'force'),
+          ),
+        ).thenAnswer((_) async {});
 
-      await tester.pumpWidget(
-        buildSubject(
-          isOwnProfile: true,
-          curatedListService: curatedListService,
-        ),
-      );
-      await tester.pump();
+        await tester.pumpWidget(
+          buildSubject(
+            isOwnProfile: true,
+            curatedListService: curatedListService,
+          ),
+        );
+        await tester.pump();
 
-      // View Lists so it joins the set of tabs a refresh re-syncs, and let
-      // it settle on the empty list collection.
-      final tabBar = tester.widget<TabBar>(find.byType(TabBar));
-      tabBar.controller!.animateTo(
-        profileTabKinds(isOwnProfile: true).indexOf(ProfileTabKind.lists),
-      );
-      await tester.pumpAndSettle();
+        // View Lists so it joins the set of tabs a refresh re-syncs, and let
+        // it settle on the empty list collection.
+        final tabBar = tester.widget<TabBar>(find.byType(TabBar));
+        tabBar.controller!.animateTo(
+          profileTabKinds(isOwnProfile: true).indexOf(ProfileTabKind.lists),
+        );
+        await tester.pumpAndSettle();
 
-      final refreshIndicator = tester.widget<RefreshIndicator>(
-        find.byType(RefreshIndicator),
-      );
-      var refreshed = false;
-      unawaited(refreshIndicator.onRefresh().then((_) => refreshed = true));
-      await tester.pumpAndSettle();
+        final refreshIndicator = tester.widget<RefreshIndicator>(
+          find.byType(RefreshIndicator),
+        );
+        var refreshed = false;
+        unawaited(refreshIndicator.onRefresh().then((_) => refreshed = true));
+        await tester.pumpAndSettle();
 
-      // The spinner runs until this future resolves, so a tab that reports
-      // no state change leaves the user stuck on it forever.
-      expect(refreshed, isTrue);
-    });
+        // The spinner runs until this future resolves, so a tab that reports
+        // no state change leaves the user stuck on it forever.
+        expect(refreshed, isTrue);
+      },
+    );
 
     testWidgets(
       "pull-to-refresh completes when the next pull lands during a tab's "

--- a/mobile/test/widgets/profile/profile_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_grid_test.dart
@@ -19,6 +19,7 @@ import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/auth_state.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/curated_list_service.dart';
 import 'package:openvine/widgets/profile/profile_grid.dart';
@@ -159,9 +160,7 @@ void main() {
       when(
         () => videosRepository.removedVideoIds,
       ).thenAnswer((_) => const Stream<String>.empty());
-      when(
-        () => videosRepository.isVideoKnownDeleted(any()),
-      ).thenReturn(false);
+      when(() => videosRepository.isVideoKnownDeleted(any())).thenReturn(false);
       when(() => blocklistRepository.isBlocked(any())).thenReturn(false);
       when(() => blocklistRepository.hasMutedUs(any())).thenReturn(false);
       when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(false);
@@ -400,11 +399,12 @@ void main() {
         const viewerB =
             '2222222222222222222222222222222222222222222222222222222222222222';
         var currentViewer = viewerA;
-        final authService = createMockAuthService();
+        final authService = createMockAuthService(
+          authState: AuthState.authenticated,
+        );
         when(
           () => authService.currentPublicKeyHex,
         ).thenAnswer((_) => currentViewer);
-        when(() => authService.isAuthenticated).thenReturn(true);
         when(() => authService.isAnonymous).thenReturn(false);
         when(() => authService.hasExpiredOAuthSession).thenReturn(false);
         when(() => authService.isRpcUpgradeInProgress).thenReturn(false);
@@ -467,46 +467,45 @@ void main() {
       },
     );
 
-    testWidgets(
-      'pull-to-refresh completes after a viewed tab settled empty',
-      (tester) async {
-        final curatedListService = _MockCuratedListService();
-        when(() => curatedListService.lists).thenReturn(const []);
-        when(() => curatedListService.myLists).thenReturn(const []);
-        when(
-          () => curatedListService.fetchUserListsFromRelays(
-            force: any(named: 'force'),
-          ),
-        ).thenAnswer((_) async {});
+    testWidgets('pull-to-refresh completes after a viewed tab settled empty', (
+      tester,
+    ) async {
+      final curatedListService = _MockCuratedListService();
+      when(() => curatedListService.lists).thenReturn(const []);
+      when(() => curatedListService.myLists).thenReturn(const []);
+      when(
+        () => curatedListService.fetchUserListsFromRelays(
+          force: any(named: 'force'),
+        ),
+      ).thenAnswer((_) async {});
 
-        await tester.pumpWidget(
-          buildSubject(
-            isOwnProfile: true,
-            curatedListService: curatedListService,
-          ),
-        );
-        await tester.pump();
+      await tester.pumpWidget(
+        buildSubject(
+          isOwnProfile: true,
+          curatedListService: curatedListService,
+        ),
+      );
+      await tester.pump();
 
-        // View Lists so it joins the set of tabs a refresh re-syncs, and let
-        // it settle on the empty list collection.
-        final tabBar = tester.widget<TabBar>(find.byType(TabBar));
-        tabBar.controller!.animateTo(
-          profileTabKinds(isOwnProfile: true).indexOf(ProfileTabKind.lists),
-        );
-        await tester.pumpAndSettle();
+      // View Lists so it joins the set of tabs a refresh re-syncs, and let
+      // it settle on the empty list collection.
+      final tabBar = tester.widget<TabBar>(find.byType(TabBar));
+      tabBar.controller!.animateTo(
+        profileTabKinds(isOwnProfile: true).indexOf(ProfileTabKind.lists),
+      );
+      await tester.pumpAndSettle();
 
-        final refreshIndicator = tester.widget<RefreshIndicator>(
-          find.byType(RefreshIndicator),
-        );
-        var refreshed = false;
-        unawaited(refreshIndicator.onRefresh().then((_) => refreshed = true));
-        await tester.pumpAndSettle();
+      final refreshIndicator = tester.widget<RefreshIndicator>(
+        find.byType(RefreshIndicator),
+      );
+      var refreshed = false;
+      unawaited(refreshIndicator.onRefresh().then((_) => refreshed = true));
+      await tester.pumpAndSettle();
 
-        // The spinner runs until this future resolves, so a tab that reports
-        // no state change leaves the user stuck on it forever.
-        expect(refreshed, isTrue);
-      },
-    );
+      // The spinner runs until this future resolves, so a tab that reports
+      // no state change leaves the user stuck on it forever.
+      expect(refreshed, isTrue);
+    });
 
     testWidgets(
       "pull-to-refresh completes when the next pull lands during a tab's "

--- a/mobile/test/widgets/share_video_menu_comprehensive_test.dart
+++ b/mobile/test/widgets/share_video_menu_comprehensive_test.dart
@@ -15,6 +15,7 @@ import 'package:models/models.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/auth_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/creator_delete_enforcement_providers.dart';
@@ -347,11 +348,10 @@ void main() {
     testWidgets(
       'More actions row prompts for a clip title and confirms saved title for owned videos',
       (tester) async {
-        final authService = createMockAuthService();
-        when(() => authService.isAuthenticated).thenReturn(true);
-        when(
-          () => authService.currentPublicKeyHex,
-        ).thenReturn(testVideo.pubkey);
+        final authService = createMockAuthService(
+          authState: AuthState.authenticated,
+          currentPublicKeyHex: testVideo.pubkey,
+        );
 
         await tester.pumpWidget(buildSubject(mockAuthService: authService));
         await tester.tap(find.byType(ShareActionButton));
@@ -385,9 +385,10 @@ void main() {
     testWidgets('More actions row shows owner edit and delete actions', (
       tester,
     ) async {
-      final authService = createMockAuthService();
-      when(() => authService.isAuthenticated).thenReturn(true);
-      when(() => authService.currentPublicKeyHex).thenReturn(testVideo.pubkey);
+      final authService = createMockAuthService(
+        authState: AuthState.authenticated,
+        currentPublicKeyHex: testVideo.pubkey,
+      );
 
       await tester.pumpWidget(buildSubject(mockAuthService: authService));
       await tester.tap(find.byType(ShareActionButton));
@@ -400,14 +401,15 @@ void main() {
     testWidgets('More actions row disables Edit during relay deletion', (
       tester,
     ) async {
-      final authService = createMockAuthService();
+      final authService = createMockAuthService(
+        authState: AuthState.authenticated,
+        currentPublicKeyHex: testVideo.pubkey,
+      );
       final deletionService = _MockContentDeletionService();
       final enforcementRepository = _MockEnforcementRepository();
       final videoEventService = _MockVideoEventService();
       final relayCompleter = Completer<DeleteResult>();
       final l10n = lookupAppLocalizations(const Locale('en'));
-      when(() => authService.isAuthenticated).thenReturn(true);
-      when(() => authService.currentPublicKeyHex).thenReturn(testVideo.pubkey);
       when(
         () => deletionService.quickDelete(
           video: testVideo,

--- a/mobile/test/widgets/share_video_menu_edit_collaborator_tags_test.dart
+++ b/mobile/test/widgets/share_video_menu_edit_collaborator_tags_test.dart
@@ -12,6 +12,7 @@ import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/auth_state.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/personal_event_cache_service.dart';
@@ -75,16 +76,16 @@ void main() {
   });
 
   setUp(() {
-    mockAuthService = createMockAuthService();
+    mockAuthService = createMockAuthService(
+      authState: AuthState.authenticated,
+      currentPublicKeyHex: ownerPubkey,
+    );
     mockNostrService = createMockNostrService();
     mockBlossomUploadService = _MockBlossomUploadService();
     mockDmRepository = _MockDmRepository();
     mockPersonalEventCacheService = _MockPersonalEventCacheService();
     mockVideoEventService = _MockVideoEventService();
     capturedTags = [];
-
-    when(() => mockAuthService.isAuthenticated).thenReturn(true);
-    when(() => mockAuthService.currentPublicKeyHex).thenReturn(ownerPubkey);
 
     late Event signedEvent;
     when(

--- a/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
@@ -229,7 +229,9 @@ void main() {
               home: StatefulBuilder(
                 builder: (context, setState) {
                   rebuildHost = setState;
-                  return Scaffold(body: ShareActionButton(video: testVideo));
+                  return Scaffold(
+                    body: ShareActionButton(video: testVideo),
+                  );
                 },
               ),
               additionalOverrides: [
@@ -563,7 +565,10 @@ void main() {
             await tester.pumpAndSettle();
 
             expect(find.text('Share with'), findsNothing);
-            expect(find.text(l10n.sharePostSharedWithCount(2)), findsOneWidget);
+            expect(
+              find.text(l10n.sharePostSharedWithCount(2)),
+              findsOneWidget,
+            );
             expect(find.text(l10n.dmReelReplyViewChat), findsNothing);
           },
         );

--- a/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
@@ -13,6 +13,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/share_sheet/share_sheet_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/auth_state.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/video_sharing_service.dart';
 import 'package:openvine/widgets/video_feed_item/actions/share_action_button.dart';
@@ -228,9 +229,7 @@ void main() {
               home: StatefulBuilder(
                 builder: (context, setState) {
                   rebuildHost = setState;
-                  return Scaffold(
-                    body: ShareActionButton(video: testVideo),
-                  );
+                  return Scaffold(body: ShareActionButton(video: testVideo));
                 },
               ),
               additionalOverrides: [
@@ -331,10 +330,10 @@ void main() {
       testWidgets('shows own-video download actions for owned content', (
         tester,
       ) async {
-        final mockAuth = createMockAuthService();
-
-        when(() => mockAuth.isAuthenticated).thenReturn(true);
-        when(() => mockAuth.currentPublicKeyHex).thenReturn(ownPubkey);
+        final mockAuth = createMockAuthService(
+          authState: AuthState.authenticated,
+          currentPublicKeyHex: ownPubkey,
+        );
 
         await tester.pumpWidget(
           testMaterialApp(
@@ -564,10 +563,7 @@ void main() {
             await tester.pumpAndSettle();
 
             expect(find.text('Share with'), findsNothing);
-            expect(
-              find.text(l10n.sharePostSharedWithCount(2)),
-              findsOneWidget,
-            );
+            expect(find.text(l10n.sharePostSharedWithCount(2)), findsOneWidget);
             expect(find.text(l10n.dmReelReplyViewChat), findsNothing);
           },
         );


### PR DESCRIPTION
## Summary

Fixes #8327.

Test auth fixtures now model the same authentication state across the enum, derived boolean, and current public key. Authenticated fixtures in the seven affected tests use the helper parameters instead of independently stubbing `isAuthenticated`.

## Verification

- `flutter analyze test`
- `flutter test test/helpers/test_provider_overrides_test.dart`
- Seven affected test files: 239 tests passed

## Deliberately unchanged

Hand-written `MockAuthService` fixtures remain unchanged; they continue to fail loudly on unstubbed getters.