### PR TITLE
fix(dm): keep vanished accounts from flashing generated handles

### DIFF
--- a/mobile/lib/providers/database_provider.dart
+++ b/mobile/lib/providers/database_provider.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Provides singleton AppDatabase instance with proper lifecycle management
 // ABOUTME: Database auto-closes when provider container is disposed
+// ABOUTME: Also hosts the durable vanished-profile pubkey stream read off Drift
 import 'package:db_client/db_client.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/providers/database_corruption_provider.dart';
 import 'package:openvine/providers/db_cipher_key_provider.dart';
 import 'package:openvine/services/database_corruption_service.dart';
@@ -61,3 +63,16 @@ AppDbClient appDbClient(Ref ref) {
   final dbClient = DbClient(generatedDatabase: db);
   return AppDbClient(dbClient, db);
 }
+
+/// Live view of the durable NIP-62 `vanished_profiles` table.
+///
+/// Housed with the database handle rather than with either consumer: building
+/// the profile repository primes it and `profileVanishedProvider` derives from
+/// it, so a home owned by either of those files would close an import cycle.
+final vanishedProfilePubkeysProvider = StreamProvider<Set<String>>((ref) {
+  return ref
+      .watch(databaseProvider)
+      .vanishedProfilesDao
+      .watchAllPubkeys()
+      .map((pubkeys) => pubkeys.toSet());
+});

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -440,9 +440,11 @@ ProfileRepository _buildProfileRepository(Ref ref, {required bool warmCache}) {
   // needs them — a relay Kind 0 can resurrect an evicted account regardless of
   // whether this instance warms the cache.
   unawaited(repo.loadVanishedPubkeys());
-  // Prime the keep-alive source used by profileVanishedProvider before DM
-  // surfaces mount, so its synchronous derived value does not sample the
-  // source during its one initial AsyncLoading state.
+  // Prime the vanish source before DM surfaces mount, so the synchronous
+  // derived value does not sample it during its initial AsyncLoading state.
+  // This one line is what orders the vanish signal ahead of
+  // profileIdentityResolvingProvider; nothing in the graph couples them.
+  // Pinned by test/providers/repository_providers_test.dart.
   ref.listen(vanishedProfilePubkeysProvider, (_, _) {});
 
   if (warmCache) {

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -38,6 +38,7 @@ import 'package:openvine/providers/relay_providers.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/social_providers.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/curated_list_service.dart';
@@ -440,6 +441,10 @@ ProfileRepository _buildProfileRepository(Ref ref, {required bool warmCache}) {
   // needs them — a relay Kind 0 can resurrect an evicted account regardless of
   // whether this instance warms the cache.
   unawaited(repo.loadVanishedPubkeys());
+  // Prime the keep-alive source used by profileVanishedProvider before DM
+  // surfaces mount, so its synchronous derived value does not sample the
+  // source during its one initial AsyncLoading state.
+  ref.listen(vanishedProfilePubkeysProvider, (_, _) {});
 
   if (warmCache) {
     // Pre-load known cached pubkeys and wire into SubscriptionManager

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -38,7 +38,6 @@ import 'package:openvine/providers/relay_providers.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/social_providers.dart';
-import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/curated_list_service.dart';

--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -32,8 +32,12 @@ final profileIdentityResolvingProvider = Provider.autoDispose
     });
 
 /// One-shot durable vanish lookup for imperative paths that must resolve the
-/// state before acting instead of treating [profileVanishedProvider]'s loading
-/// placeholder as a live account.
+/// state before acting.
+///
+/// [profileVanishedProvider] reports `false` until its shared Drift stream
+/// first emits — right for a widget that repaints on the next tick, wrong for
+/// a read-once caller, which would commit to the live-account branch and
+/// never revisit it.
 // ignore: specify_nonobvious_property_types
 final profileVanishedSnapshotProvider = FutureProvider.autoDispose
     .family<bool, String>((ref, pubkey) {
@@ -178,9 +182,13 @@ Future<UserProfile?> fetchUserProfile(Ref ref, String pubkey) async {
 /// new deletion. This — not the profile provider — drives the deleted-account
 /// treatment in the inbox and the following bar.
 ///
-/// This is deliberately synchronous: the keep-alive pubkey stream is primed
-/// when the profile repository is built, so wrapping this derived value in a
-/// stream would only manufacture an `AsyncLoading` state for consumers.
+/// Reports `false` until [vanishedProfilePubkeysProvider] first emits. That
+/// window belongs to the source stream, so returning a `Stream<bool>` would
+/// not shorten it — only wrap it in a second, per-pubkey `AsyncLoading`.
+/// Building the profile repository subscribes the source, so the wait starts
+/// no later than the moment the profile graph can leave `isLoading`; that
+/// ordering is what keeps a vanished account from rendering a generated name
+/// first (#8208), and `repository_providers_test.dart` pins it.
 @riverpod
 bool profileVanished(Ref ref, String pubkey) {
   final pubkeys =

--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -14,14 +14,6 @@ part 'user_profile_providers.g.dart';
 
 const _blockedProfileFetchChunkSize = 50;
 
-final vanishedProfilePubkeysProvider = StreamProvider<Set<String>>((ref) {
-  return ref
-      .watch(databaseProvider)
-      .vanishedProfilesDao
-      .watchAllPubkeys()
-      .map((pubkeys) => pubkeys.toSet());
-});
-
 /// Whether a peer's profile identity is still being resolved.
 ///
 /// The reactive profile stream intentionally emits `null` while the read

--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -14,7 +14,7 @@ part 'user_profile_providers.g.dart';
 
 const _blockedProfileFetchChunkSize = 50;
 
-final _vanishedProfilePubkeysProvider = StreamProvider<Set<String>>((ref) {
+final vanishedProfilePubkeysProvider = StreamProvider<Set<String>>((ref) {
   return ref
       .watch(databaseProvider)
       .vanishedProfilesDao
@@ -185,9 +185,13 @@ Future<UserProfile?> fetchUserProfile(Ref ref, String pubkey) async {
 /// without a network round trip, and it flips live when a fetch discovers a
 /// new deletion. This — not the profile provider — drives the deleted-account
 /// treatment in the inbox and the following bar.
+///
+/// This is deliberately synchronous: the keep-alive pubkey stream is primed
+/// when the profile repository is built, so wrapping this derived value in a
+/// stream would only manufacture an `AsyncLoading` state for consumers.
 @riverpod
-Stream<bool> profileVanished(Ref ref, String pubkey) {
+bool profileVanished(Ref ref, String pubkey) {
   final pubkeys =
-      ref.watch(_vanishedProfilePubkeysProvider).value ?? const <String>{};
-  return Stream.value(pubkeys.contains(pubkey));
+      ref.watch(vanishedProfilePubkeysProvider).value ?? const <String>{};
+  return pubkeys.contains(pubkey);
 }

--- a/mobile/lib/providers/user_profile_providers.g.dart
+++ b/mobile/lib/providers/user_profile_providers.g.dart
@@ -479,6 +479,10 @@ final class FetchUserProfileFamily extends $Family
 /// without a network round trip, and it flips live when a fetch discovers a
 /// new deletion. This — not the profile provider — drives the deleted-account
 /// treatment in the inbox and the following bar.
+///
+/// This is deliberately synchronous: the keep-alive pubkey stream is primed
+/// when the profile repository is built, so wrapping this derived value in a
+/// stream would only manufacture an `AsyncLoading` state for consumers.
 
 @ProviderFor(profileVanished)
 final profileVanishedProvider = ProfileVanishedFamily._();
@@ -489,16 +493,24 @@ final profileVanishedProvider = ProfileVanishedFamily._();
 /// without a network round trip, and it flips live when a fetch discovers a
 /// new deletion. This — not the profile provider — drives the deleted-account
 /// treatment in the inbox and the following bar.
+///
+/// This is deliberately synchronous: the keep-alive pubkey stream is primed
+/// when the profile repository is built, so wrapping this derived value in a
+/// stream would only manufacture an `AsyncLoading` state for consumers.
 
 final class ProfileVanishedProvider
-    extends $FunctionalProvider<AsyncValue<bool>, bool, Stream<bool>>
-    with $FutureModifier<bool>, $StreamProvider<bool> {
+    extends $FunctionalProvider<bool, bool, bool>
+    with $Provider<bool> {
   /// Whether the account behind [pubkey] has requested NIP-62 deletion.
   ///
   /// Backed by the durable `vanished_profiles` table, so a cold start resolves
   /// without a network round trip, and it flips live when a fetch discovers a
   /// new deletion. This — not the profile provider — drives the deleted-account
   /// treatment in the inbox and the following bar.
+  ///
+  /// This is deliberately synchronous: the keep-alive pubkey stream is primed
+  /// when the profile repository is built, so wrapping this derived value in a
+  /// stream would only manufacture an `AsyncLoading` state for consumers.
   ProfileVanishedProvider._({
     required ProfileVanishedFamily super.from,
     required String super.argument,
@@ -522,13 +534,21 @@ final class ProfileVanishedProvider
 
   @$internal
   @override
-  $StreamProviderElement<bool> $createElement($ProviderPointer pointer) =>
-      $StreamProviderElement(pointer);
+  $ProviderElement<bool> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
 
   @override
-  Stream<bool> create(Ref ref) {
+  bool create(Ref ref) {
     final argument = this.argument as String;
     return profileVanished(ref, argument);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
   }
 
   @override
@@ -542,7 +562,7 @@ final class ProfileVanishedProvider
   }
 }
 
-String _$profileVanishedHash() => r'9c15d7c790f73dd872f1cf8e8c690ef0f411ba17';
+String _$profileVanishedHash() => r'29720937045a4363d508c27d1a2bf503d6f41bf7';
 
 /// Whether the account behind [pubkey] has requested NIP-62 deletion.
 ///
@@ -550,9 +570,13 @@ String _$profileVanishedHash() => r'9c15d7c790f73dd872f1cf8e8c690ef0f411ba17';
 /// without a network round trip, and it flips live when a fetch discovers a
 /// new deletion. This — not the profile provider — drives the deleted-account
 /// treatment in the inbox and the following bar.
+///
+/// This is deliberately synchronous: the keep-alive pubkey stream is primed
+/// when the profile repository is built, so wrapping this derived value in a
+/// stream would only manufacture an `AsyncLoading` state for consumers.
 
 final class ProfileVanishedFamily extends $Family
-    with $FunctionalFamilyOverride<Stream<bool>, String> {
+    with $FunctionalFamilyOverride<bool, String> {
   ProfileVanishedFamily._()
     : super(
         retry: null,
@@ -568,6 +592,10 @@ final class ProfileVanishedFamily extends $Family
   /// without a network round trip, and it flips live when a fetch discovers a
   /// new deletion. This — not the profile provider — drives the deleted-account
   /// treatment in the inbox and the following bar.
+  ///
+  /// This is deliberately synchronous: the keep-alive pubkey stream is primed
+  /// when the profile repository is built, so wrapping this derived value in a
+  /// stream would only manufacture an `AsyncLoading` state for consumers.
 
   ProfileVanishedProvider call(String pubkey) =>
       ProfileVanishedProvider._(argument: pubkey, from: this);

--- a/mobile/lib/providers/user_profile_providers.g.dart
+++ b/mobile/lib/providers/user_profile_providers.g.dart
@@ -480,9 +480,13 @@ final class FetchUserProfileFamily extends $Family
 /// new deletion. This — not the profile provider — drives the deleted-account
 /// treatment in the inbox and the following bar.
 ///
-/// This is deliberately synchronous: the keep-alive pubkey stream is primed
-/// when the profile repository is built, so wrapping this derived value in a
-/// stream would only manufacture an `AsyncLoading` state for consumers.
+/// Reports `false` until [vanishedProfilePubkeysProvider] first emits. That
+/// window belongs to the source stream, so returning a `Stream<bool>` would
+/// not shorten it — only wrap it in a second, per-pubkey `AsyncLoading`.
+/// Building the profile repository subscribes the source, so the wait starts
+/// no later than the moment the profile graph can leave `isLoading`; that
+/// ordering is what keeps a vanished account from rendering a generated name
+/// first (#8208), and `repository_providers_test.dart` pins it.
 
 @ProviderFor(profileVanished)
 final profileVanishedProvider = ProfileVanishedFamily._();
@@ -494,9 +498,13 @@ final profileVanishedProvider = ProfileVanishedFamily._();
 /// new deletion. This — not the profile provider — drives the deleted-account
 /// treatment in the inbox and the following bar.
 ///
-/// This is deliberately synchronous: the keep-alive pubkey stream is primed
-/// when the profile repository is built, so wrapping this derived value in a
-/// stream would only manufacture an `AsyncLoading` state for consumers.
+/// Reports `false` until [vanishedProfilePubkeysProvider] first emits. That
+/// window belongs to the source stream, so returning a `Stream<bool>` would
+/// not shorten it — only wrap it in a second, per-pubkey `AsyncLoading`.
+/// Building the profile repository subscribes the source, so the wait starts
+/// no later than the moment the profile graph can leave `isLoading`; that
+/// ordering is what keeps a vanished account from rendering a generated name
+/// first (#8208), and `repository_providers_test.dart` pins it.
 
 final class ProfileVanishedProvider
     extends $FunctionalProvider<bool, bool, bool>
@@ -508,9 +516,13 @@ final class ProfileVanishedProvider
   /// new deletion. This — not the profile provider — drives the deleted-account
   /// treatment in the inbox and the following bar.
   ///
-  /// This is deliberately synchronous: the keep-alive pubkey stream is primed
-  /// when the profile repository is built, so wrapping this derived value in a
-  /// stream would only manufacture an `AsyncLoading` state for consumers.
+  /// Reports `false` until [vanishedProfilePubkeysProvider] first emits. That
+  /// window belongs to the source stream, so returning a `Stream<bool>` would
+  /// not shorten it — only wrap it in a second, per-pubkey `AsyncLoading`.
+  /// Building the profile repository subscribes the source, so the wait starts
+  /// no later than the moment the profile graph can leave `isLoading`; that
+  /// ordering is what keeps a vanished account from rendering a generated name
+  /// first (#8208), and `repository_providers_test.dart` pins it.
   ProfileVanishedProvider._({
     required ProfileVanishedFamily super.from,
     required String super.argument,
@@ -571,9 +583,13 @@ String _$profileVanishedHash() => r'29720937045a4363d508c27d1a2bf503d6f41bf7';
 /// new deletion. This — not the profile provider — drives the deleted-account
 /// treatment in the inbox and the following bar.
 ///
-/// This is deliberately synchronous: the keep-alive pubkey stream is primed
-/// when the profile repository is built, so wrapping this derived value in a
-/// stream would only manufacture an `AsyncLoading` state for consumers.
+/// Reports `false` until [vanishedProfilePubkeysProvider] first emits. That
+/// window belongs to the source stream, so returning a `Stream<bool>` would
+/// not shorten it — only wrap it in a second, per-pubkey `AsyncLoading`.
+/// Building the profile repository subscribes the source, so the wait starts
+/// no later than the moment the profile graph can leave `isLoading`; that
+/// ordering is what keeps a vanished account from rendering a generated name
+/// first (#8208), and `repository_providers_test.dart` pins it.
 
 final class ProfileVanishedFamily extends $Family
     with $FunctionalFamilyOverride<bool, String> {
@@ -593,9 +609,13 @@ final class ProfileVanishedFamily extends $Family
   /// new deletion. This — not the profile provider — drives the deleted-account
   /// treatment in the inbox and the following bar.
   ///
-  /// This is deliberately synchronous: the keep-alive pubkey stream is primed
-  /// when the profile repository is built, so wrapping this derived value in a
-  /// stream would only manufacture an `AsyncLoading` state for consumers.
+  /// Reports `false` until [vanishedProfilePubkeysProvider] first emits. That
+  /// window belongs to the source stream, so returning a `Stream<bool>` would
+  /// not shorten it — only wrap it in a second, per-pubkey `AsyncLoading`.
+  /// Building the profile repository subscribes the source, so the wait starts
+  /// no later than the moment the profile graph can leave `isLoading`; that
+  /// ordering is what keeps a vanished account from rendering a generated name
+  /// first (#8208), and `repository_providers_test.dart` pins it.
 
   ProfileVanishedProvider call(String pubkey) =>
       ProfileVanishedProvider._(argument: pubkey, from: this);

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -246,9 +246,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
     // The conversation and its history remain readable — they are the viewer's
     // own copy of messages a NIP-62 vanish cannot retract. Only the header
     // identity changes.
-    final isDeleted = ref
-        .watch(profileVanishedProvider(otherPubkey))
-        .maybeWhen(data: (vanished) => vanished, orElse: () => false);
+    final isDeleted = ref.watch(profileVanishedProvider(otherPubkey));
     final displayName = dmPeerDisplayName(
       context,
       pubkeyHex: otherPubkey,

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
@@ -152,9 +152,9 @@ class _ReactorRow extends ConsumerWidget {
     // "Deleted account" thread can open names its reactors a different way.
     // In a group thread the reactor need not be the counterparty at all, so
     // this is the only DM surface that can name a third participant.
-    final isVanished = ref
-        .watch(profileVanishedProvider(reaction.reactorPubkey))
-        .maybeWhen(data: (vanished) => vanished, orElse: () => false);
+    final isVanished = ref.watch(
+      profileVanishedProvider(reaction.reactorPubkey),
+    );
 
     final name = dmPeerDisplayName(
       context,

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
@@ -306,10 +306,10 @@ class _PoppingEmojiState extends State<_PoppingEmoji>
     duration: _emojiPopDuration,
   );
 
-  late final Animation<double> _scale = Tween<double>(begin: 0.6, end: 1)
-      .animate(
-        CurvedAnimation(parent: _controller, curve: Curves.easeOutCubic),
-      );
+  late final Animation<double> _scale = Tween<double>(
+    begin: 0.6,
+    end: 1,
+  ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOutCubic));
 
   @override
   void initState() {
@@ -410,9 +410,7 @@ class _PillAvatar extends ConsumerWidget {
     // The pill is what opens the reactor sheet, so it resolves the vanish the
     // same way: a peer whose photo is still on the pill and whose sheet row
     // reads "Deleted account" is the divergence this pill would introduce.
-    final isVanished = ref
-        .watch(profileVanishedProvider(pubkey))
-        .maybeWhen(data: (vanished) => vanished, orElse: () => false);
+    final isVanished = ref.watch(profileVanishedProvider(pubkey));
 
     // cornerRadius == diameter / 2 makes UserAvatar a true circle whose own
     // border is circular too. Clipping the default rounded-square avatar to a

--- a/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
@@ -114,9 +114,7 @@ class RequestPreviewView extends ConsumerWidget {
     // through to [OtherProfileScreen], which already names a vanished account
     // for the state — so without this the same tap sequence showed a generated
     // handle and then "Deleted account" (#8185).
-    final isDeleted = ref
-        .watch(profileVanishedProvider(otherPubkey))
-        .maybeWhen(data: (vanished) => vanished, orElse: () => false);
+    final isDeleted = ref.watch(profileVanishedProvider(otherPubkey));
 
     // Suppressing the profile object as well as the name matches
     // [OtherProfileScreen], which nulls its own header profile on a vanish

--- a/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
+++ b/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
@@ -46,9 +46,7 @@ class RequestTile extends ConsumerWidget {
     // Same treatment as [ConversationTile]: a request from an account that
     // later vanished is named for the state, not for the generated handle the
     // eviction leaves behind (#8185).
-    final isDeleted = ref
-        .watch(profileVanishedProvider(otherPubkey))
-        .maybeWhen(data: (vanished) => vanished, orElse: () => false);
+    final isDeleted = ref.watch(profileVanishedProvider(otherPubkey));
 
     final peerName = dmPeerDisplayName(
       context,

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -74,9 +74,7 @@ class ConversationTile extends ConsumerWidget {
     // The thread and its history stay — the messages are the viewer's own copy
     // and a NIP-62 vanish cannot retract them. Only the counterparty's identity
     // is replaced.
-    final isDeleted = ref
-        .watch(profileVanishedProvider(otherPubkey))
-        .maybeWhen(data: (vanished) => vanished, orElse: () => false);
+    final isDeleted = ref.watch(profileVanishedProvider(otherPubkey));
 
     final peerName = dmPeerDisplayName(
       context,

--- a/mobile/lib/screens/inbox/widgets/following_bar.dart
+++ b/mobile/lib/screens/inbox/widgets/following_bar.dart
@@ -90,9 +90,7 @@ class _FollowingUserButton extends ConsumerWidget {
 
     // A vanish cannot rewrite the viewer's own contact list, so the account
     // stays in this bar. Show it as deleted rather than under a stale name.
-    final isDeleted = ref
-        .watch(profileVanishedProvider(pubkey))
-        .maybeWhen(data: (vanished) => vanished, orElse: () => false);
+    final isDeleted = ref.watch(profileVanishedProvider(pubkey));
 
     final displayName = dmPeerDisplayName(
       context,

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -446,9 +446,9 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
               // Name the state rather than pass a deleted account's identity
               // downstream. ProfileHeaderWidget applies the same rule to the
               // avatar and the route hints, which it resolves itself.
-              final isVanished =
-                  ref.watch(profileVanishedProvider(widget.pubkey)).value ??
-                  false;
+              final isVanished = ref.watch(
+                profileVanishedProvider(widget.pubkey),
+              );
               final headerProfile = isVanished
                   ? null
                   : switch (state) {

--- a/mobile/lib/widgets/profile/profile_banner_layer.dart
+++ b/mobile/lib/widgets/profile/profile_banner_layer.dart
@@ -50,7 +50,7 @@ class _ProfileBannerLayerState extends ConsumerState<ProfileBannerLayer> {
   Widget build(BuildContext context) {
     final isVanished =
         !widget.isOwnProfile &&
-        (ref.watch(profileVanishedProvider(widget.userIdHex)).value ?? false);
+        ref.watch(profileVanishedProvider(widget.userIdHex));
 
     // Resolve effective profile (same logic as ProfileHeaderWidget).
     final UserProfile? effectiveProfile;

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -183,8 +183,7 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
     // fetchUserProfileProvider, and the route hints — so evicting the cached
     // row is not enough on its own: the hints are supplied by whoever
     // navigated here and outlive the cache entirely.
-    final isVanished =
-        ref.watch(profileVanishedProvider(widget.userIdHex)).value ?? false;
+    final isVanished = ref.watch(profileVanishedProvider(widget.userIdHex));
 
     final UserProfile? effectiveProfile;
     final bool isLoadingIdentity;

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -451,7 +451,7 @@ List<dynamic> getStandardTestOverrides({
     // which widget tests do not wire, and the inbox surfaces watch it on every
     // build. Tests that exercise the deleted-account treatment override it
     // again with `additionalOverrides`.
-    profileVanishedProvider.overrideWith((ref, pubkey) => Stream.value(false)),
+    profileVanishedProvider.overrideWith((ref, pubkey) => false),
     profileVanishedSnapshotProvider.overrideWith((ref, pubkey) async => false),
     // Existing widget fixtures provide profiles through their original
     // reactive/one-shot provider. Keep the new derived loading signal settled

--- a/mobile/test/providers/repository_providers_test.dart
+++ b/mobile/test/providers/repository_providers_test.dart
@@ -1,0 +1,155 @@
+// ABOUTME: Tests for the repository Riverpod providers.
+// ABOUTME: Pins the vanish-source priming that keeps #8208 from regressing.
+
+import 'package:db_client/db_client.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/providers/curation_providers.dart';
+import 'package:openvine/providers/database_provider.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAppDatabase extends Mock implements AppDatabase {}
+
+class _MockUserProfilesDao extends Mock implements UserProfilesDao {}
+
+class _MockProfileStatsDao extends Mock implements ProfileStatsDao {}
+
+class _MockPendingProfileSavesDao extends Mock
+    implements PendingProfileSavesDao {}
+
+class _MockIdentityEventsDao extends Mock implements IdentityEventsDao {}
+
+class _MockVanishedProfilesDao extends Mock implements VanishedProfilesDao {}
+
+class _TestNostrSession extends NostrSession {
+  _TestNostrSession(this._readiness);
+
+  final NostrSessionReadiness _readiness;
+
+  @override
+  NostrSessionReadiness build() => _readiness;
+}
+
+void main() {
+  const pubkey =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+  group('profileReadRepositoryProvider vanish priming (#8208)', () {
+    // Builds a container wired for the REAL _buildProfileRepository. Overriding
+    // profileReadRepositoryProvider itself — what every test in
+    // user_profile_providers_test.dart does — skips the factory entirely and
+    // would make these assertions vacuous, so only its leaf dependencies are
+    // replaced here.
+    //
+    // Deliberately a helper called from the test bodies rather than a shared
+    // setUp: stubs registered in a shared setUp are inherited invisibly by
+    // every descendant test (#8399).
+    Future<(ProviderContainer, _MockVanishedProfilesDao)> buildContainer({
+      required List<String> vanished,
+    }) async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final database = _MockAppDatabase();
+      final vanishedProfilesDao = _MockVanishedProfilesDao();
+
+      when(() => database.userProfilesDao).thenReturn(_MockUserProfilesDao());
+      when(() => database.profileStatsDao).thenReturn(_MockProfileStatsDao());
+      when(
+        () => database.pendingProfileSavesDao,
+      ).thenReturn(_MockPendingProfileSavesDao());
+      when(
+        () => database.identityEventsDao,
+      ).thenReturn(_MockIdentityEventsDao());
+      when(() => database.vanishedProfilesDao).thenReturn(vanishedProfilesDao);
+      // ProfileRepository hydrates its in-memory vanish mirror on construction,
+      // so this has to resolve or the provider throws before returning.
+      when(
+        vanishedProfilesDao.getAllPubkeys,
+      ).thenAnswer((_) async => <String>[]);
+      // The durable table's live view — the source the priming subscribes.
+      when(
+        vanishedProfilesDao.watchAllPubkeys,
+      ).thenAnswer((_) => Stream.value(vanished));
+
+      final container = ProviderContainer(
+        overrides: [
+          // identity-known is the cheapest gate that yields a repository: it
+          // needs no NostrClient in the readiness, and it takes the
+          // warmCache: false branch of _buildProfileRepository.
+          nostrSessionProvider.overrideWith(
+            () => _TestNostrSession(
+              const NostrSessionReadiness.identityKnown(pubkey: pubkey),
+            ),
+          ),
+          nostrServiceProvider.overrideWithValue(_MockNostrClient()),
+          databaseProvider.overrideWithValue(database),
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          funnelcakeApiClientProvider.overrideWithValue(
+            FunnelcakeApiClient(baseUrl: 'https://api.divine.video'),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      return (container, vanishedProfilesDao);
+    }
+
+    test('building the read repository subscribes the durable vanish source '
+        'without anyone reading profileVanished', () async {
+      final (container, vanishedProfilesDao) = await buildContainer(
+        vanished: const [],
+      );
+
+      expect(
+        container.exists(vanishedProfilePubkeysProvider),
+        isFalse,
+        reason: 'precondition: nothing has touched the source yet',
+      );
+
+      expect(container.read(profileReadRepositoryProvider), isNotNull);
+
+      // The priming ref.listen in _buildProfileRepository is the only thing
+      // that can have mounted this. Delete that line and both fail.
+      expect(container.exists(vanishedProfilePubkeysProvider), isTrue);
+      verify(vanishedProfilesDao.watchAllPubkeys).called(1);
+      expect(
+        container.exists(profileVanishedProvider(pubkey)),
+        isFalse,
+        reason: 'the derived provider must not be what mounted the source',
+      );
+    });
+
+    test(
+      'a vanished account reads true once the primed source emits',
+      () async {
+        final (container, _) = await buildContainer(vanished: const [pubkey]);
+
+        // Hold a live listener, as production does: zendeskIdentitySync watches
+        // a repository provider (auth_providers.dart) and AppRootSideEffects
+        // watches that, above the router. Riverpod buffers events into a
+        // provider nothing is listening to, so a bare read() would leave the
+        // primed stream's first row undelivered and this would stay
+        // AsyncLoading forever — which is a property of the harness, not of the
+        // priming.
+        final repository = container.listen(
+          profileReadRepositoryProvider,
+          (_, _) {},
+          fireImmediately: true,
+        );
+        addTearDown(repository.close);
+        expect(repository.read(), isNotNull);
+        await pumpEventQueue();
+
+        expect(container.read(profileVanishedProvider(pubkey)), isTrue);
+      },
+    );
+  });
+}

--- a/mobile/test/providers/user_profile_providers_test.dart
+++ b/mobile/test/providers/user_profile_providers_test.dart
@@ -46,6 +46,11 @@ class _TestNostrSession extends NostrSession {
   NostrSessionReadiness build() => _readiness;
 }
 
+void _ignoreVanishedPubkeysChange(
+  AsyncValue<Set<String>>? previous,
+  AsyncValue<Set<String>> next,
+) {}
+
 void main() {
   const pubkey =
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
@@ -207,6 +212,72 @@ void main() {
         container.exists(profileIdentityResolvingProvider(pubkey)),
         isFalse,
       );
+    });
+  });
+
+  group('profileVanishedProvider', () {
+    test(
+      'returns the durable value synchronously after the source resolves',
+      () async {
+        final database = _MockAppDatabase();
+        final vanishedProfilesDao = _MockVanishedProfilesDao();
+        when(
+          () => database.vanishedProfilesDao,
+        ).thenReturn(vanishedProfilesDao);
+        when(
+          vanishedProfilesDao.watchAllPubkeys,
+        ).thenAnswer((_) => Stream.value([pubkey]));
+        final container = ProviderContainer(
+          overrides: [databaseProvider.overrideWithValue(database)],
+        );
+        addTearDown(container.dispose);
+
+        final sourceSub = container.listen(
+          vanishedProfilePubkeysProvider,
+          _ignoreVanishedPubkeysChange,
+          fireImmediately: true,
+        );
+        addTearDown(sourceSub.close);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(container.read(profileVanishedProvider(pubkey)), isTrue);
+      },
+    );
+
+    test('updates directly when the durable source changes', () async {
+      final database = _MockAppDatabase();
+      final vanishedProfilesDao = _MockVanishedProfilesDao();
+      final pubkeys = StreamController<List<String>>();
+      addTearDown(pubkeys.close);
+      when(() => database.vanishedProfilesDao).thenReturn(vanishedProfilesDao);
+      when(
+        vanishedProfilesDao.watchAllPubkeys,
+      ).thenAnswer((_) => pubkeys.stream);
+      final container = ProviderContainer(
+        overrides: [databaseProvider.overrideWithValue(database)],
+      );
+      addTearDown(container.dispose);
+
+      final sourceSub = container.listen(
+        vanishedProfilePubkeysProvider,
+        _ignoreVanishedPubkeysChange,
+        fireImmediately: true,
+      );
+      addTearDown(sourceSub.close);
+      final values = <bool>[];
+      final profileSub = container.listen(
+        profileVanishedProvider(pubkey),
+        (_, value) => values.add(value),
+        fireImmediately: true,
+      );
+      addTearDown(profileSub.close);
+
+      pubkeys.add(const []);
+      await Future<void>.delayed(Duration.zero);
+      pubkeys.add([pubkey]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(values, [false, true]);
     });
   });
 

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -233,7 +233,7 @@ void main() {
           ).overrideWith((ref) => Stream.value(otherStats)),
           profileVanishedProvider(
             counterparty,
-          ).overrideWith((ref) => Stream.value(otherProfileVanished)),
+          ).overrideWith((ref) => otherProfileVanished),
           profileVanishedSnapshotProvider(
             counterparty,
           ).overrideWith(

--- a/mobile/test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart
@@ -372,7 +372,7 @@ void main() {
               ).overrideWith((ref) => Stream.value(aliceProfile())),
               profileVanishedProvider(
                 otherPubkey,
-              ).overrideWith((ref) => Stream.value(vanished)),
+              ).overrideWith((ref) => vanished),
             ],
           ),
         );
@@ -408,9 +408,7 @@ void main() {
 
       testWidgets(
         'names the vanished reactor for the state in the a11y label',
-        (
-          tester,
-        ) async {
+        (tester) async {
           await openWith(tester, vanished: true);
 
           // The row's label is the only place the reactor's name reaches

--- a/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
@@ -195,9 +195,7 @@ void main() {
 
     testWidgets(
       'filters reactions from blockedPubkeys out of the pill (#5418)',
-      (
-        tester,
-      ) async {
+      (tester) async {
         primeState(
           stateWith([
             makeReaction(id: '1', reactorPubkey: ownerPubkey, emoji: '🔥'),
@@ -513,7 +511,7 @@ void main() {
               ),
               profileVanishedProvider(
                 otherPubkey,
-              ).overrideWith((ref) => Stream.value(vanished)),
+              ).overrideWith((ref) => vanished),
             ],
           ),
         );

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -1854,9 +1854,7 @@ void main() {
             hasMore: false,
           ),
           additionalOverrides: [
-            profileVanishedProvider(
-              otherPubkey,
-            ).overrideWith((ref) => Stream.value(true)),
+            profileVanishedProvider(otherPubkey).overrideWith((ref) => true),
             profileVanishedSnapshotProvider(
               otherPubkey,
             ).overrideWith((ref) async => true),

--- a/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
+++ b/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
@@ -651,7 +651,7 @@ void main() {
             ).overrideWith((ref) => Stream.value(testProfile)),
             profileVanishedProvider(
               otherPubkey,
-            ).overrideWith((ref) => Stream.value(vanished)),
+            ).overrideWith((ref) => vanished),
           ],
           home: MockGoRouterProvider(
             goRouter: mockGoRouter,

--- a/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
+++ b/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
@@ -198,7 +198,7 @@ void main() {
             ).overrideWith((ref) => Stream.value(stats)),
             profileVanishedProvider(
               otherPubkey,
-            ).overrideWith((ref) => Stream.value(vanished)),
+            ).overrideWith((ref) => vanished),
           ],
           home: MockGoRouterProvider(
             goRouter: mockGoRouter,

--- a/mobile/test/screens/inbox/message_requests/widgets/request_tile_test.dart
+++ b/mobile/test/screens/inbox/message_requests/widgets/request_tile_test.dart
@@ -389,7 +389,7 @@ void main() {
               ),
               profileVanishedProvider(
                 otherPubkey,
-              ).overrideWith((ref) => Stream.value(vanished)),
+              ).overrideWith((ref) => vanished),
             ],
             home: Scaffold(
               body: RequestTile(

--- a/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
+++ b/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
@@ -1164,7 +1164,7 @@ void main() {
               ),
               profileVanishedProvider(
                 otherPubkey,
-              ).overrideWith((ref) => Stream.value(vanished)),
+              ).overrideWith((ref) => vanished),
               profileIdentityResolvingProvider(
                 otherPubkey,
               ).overrideWithValue(identityResolving),

--- a/mobile/test/screens/inbox/widgets/following_bar_test.dart
+++ b/mobile/test/screens/inbox/widgets/following_bar_test.dart
@@ -242,9 +242,7 @@ void main() {
                 (ref) async =>
                     createTestProfile(pubkey: pubkey1, displayName: 'Alice'),
               ),
-              profileVanishedProvider(
-                pubkey1,
-              ).overrideWith((ref) => Stream.value(vanished)),
+              profileVanishedProvider(pubkey1).overrideWith((ref) => vanished),
             ],
           ),
         );

--- a/mobile/test/screens/other_profile_screen_test.dart
+++ b/mobile/test/screens/other_profile_screen_test.dart
@@ -159,9 +159,7 @@ void main() {
     when(
       () => videosRepository.removedVideoIds,
     ).thenAnswer((_) => const Stream<String>.empty());
-    when(
-      () => videosRepository.isVideoKnownDeleted(any()),
-    ).thenReturn(false);
+    when(() => videosRepository.isVideoKnownDeleted(any())).thenReturn(false);
 
     when(
       () => videoEventService.authorVideos(any()),
@@ -278,9 +276,7 @@ void main() {
         // Element-level, since the standard overrides already claim the
         // family and Riverpod rejects a second family override.
         if (isVanished)
-          profileVanishedProvider(
-            targetPubkey,
-          ).overrideWith((ref) => Stream.value(true)),
+          profileVanishedProvider(targetPubkey).overrideWith((ref) => true),
       ],
     );
   }

--- a/mobile/test/widgets/profile/profile_banner_layer_test.dart
+++ b/mobile/test/widgets/profile/profile_banner_layer_test.dart
@@ -66,7 +66,7 @@ void main() {
           ).overrideWith((ref) async => riverpodProfile),
           profileVanishedProvider(
             _testUserHex,
-          ).overrideWith((ref) => Stream.value(isVanished)),
+          ).overrideWith((ref) => isVanished),
         ],
         child: MaterialApp(home: Scaffold(body: layer)),
       );

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -456,9 +456,7 @@ void main() {
             mockNip05VerificationService: createMockNip05VerificationService(),
             mockFollowRepository: mockFollowRepository,
           ),
-          profileVanishedProvider(
-            userIdHex,
-          ).overrideWith((ref) => Stream.value(isVanished)),
+          profileVanishedProvider(userIdHex).overrideWith((ref) => isVanished),
           fetchUserProfileProvider(userIdHex).overrideWith(
             profileIsLoading
                 ? (ref) => Completer<UserProfile?>().future


### PR DESCRIPTION
Closes #8208

## Problem

When a vanished account appeared in a Direct Message surface, its row could briefly show a generated handle such as “Adjective Animal N” before correcting to “Deleted account.” The same flash could recur when a tile, inbox, or sheet remounted, and could reappear during a live vanish update.

## Fix

The vanish lookup now exposes a synchronous derived boolean from the durable pubkey stream instead of wrapping that value in `Stream.value`, which had created an intermediate loading state. The durable stream is also primed when the profile repository is built. All DM and profile consumers now read the boolean directly, so loading cannot be interpreted as “live account.”

The family is `autoDispose` and `AsyncValue.maybeWhen` defaults `skipLoadingOnReload = false`, so before this change *every* remount and every dependency-driven reload restarted at `AsyncLoading` and painted one generated-handle frame. A recycled `ListView` tile hit it each time.

## Scope against #8208

This closes the issue. The provider still reads `false` if its Drift source has not emitted, but that state is not reachable on a rendered frame: the priming `ref.listen` lives inside `_buildProfileRepository`, which is what `profileReadRepositoryProvider` returns, and `profileIdentityResolvingProvider` (#8394) reports `true` for as long as that is null. So the vanish signal resolves no later than the moment the identity skeleton is allowed to come down. Sampling both signals every event-loop turn for 200 ms across eight cold-start shapes — including the production background-isolate Drift connection — produced no frame where a vanished account could render a generated handle.

That ordering was previously incidental: nothing in the provider graph or the types couples the two signals, and deleting the one `ref.listen` left the entire suite green. `test/providers/repository_providers_test.dart` now pins it.

## Deliberately unchanged

This does not change profile-loading behavior for non-vanished accounts; their generated-name fallback remains covered by the existing profile loading UX.

## Verification

- Rebased onto current `main`. Note for anyone rebasing this branch again: #8405 added a *second* `profileVanishedProvider` override to `request_preview_view_test.dart` in a region this diff never touches, so git merges it in with **no conflict reported** and it fails only at analyze time.
- `flutter analyze lib test integration_test` — no issues
- `flutter test` over the affected DM/profile surface (`test/providers/`, `test/screens/inbox/`, `test/screens/other_profile_screen_test.dart`, `test/widgets/profile/`) — 928 tests passed
- The new priming test was mutation-checked: both cases fail with the `ref.listen` removed, pass with it restored
- Commit/push hooks — generated files, analyzer, and changed-file tests passed

Review team requested: `@divinevideo/reviewers`.
