### PR TITLE
fix(dm): stop offline sweeps burning the reaction retry budget

### DIFF
--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -54,9 +54,13 @@ part 'social_providers.g.dart';
 /// `connectivity_plus` reports any non-`none` result, so work queued during a
 /// brief network drop is re-driven the moment connectivity returns — without
 /// waiting for an app-foreground transition. The sweep short-circuits when
-/// nothing is retryable. `→ none` transitions are filtered out because
-/// [DmReactionRetryService] has no offline gate of its own — an offline pass
-/// would burn each row's retry budget on attempts that deterministically fail.
+/// nothing is retryable. `→ none` transitions are filtered out because a
+/// sweep fired on going offline has nothing to do: since #7319
+/// [DmReactionRetryService] carries its own offline gate and would skip the
+/// pass anyway. The filter is a cheap short-circuit, not the safety property
+/// — the gate is, and it also covers the unfiltered foreground trigger
+/// below, which is the path that actually burned retry budgets in airplane
+/// mode.
 Stream<void> _dmRetryConnectivityTriggerStream() => Connectivity()
     .onConnectivityChanged
     .where((results) => results.any((r) => r != ConnectivityResult.none))
@@ -474,6 +478,7 @@ DmReactionRetryService? dmReactionRetryService(Ref ref) {
     reactionsRepository: reactionsRepository,
     appForegroundStream: foregroundController.stream,
     retryTriggerStream: retryTriggerStream,
+    isOffline: dmSendConnectivityIsOffline,
   );
 
   service.initialize().catchError((e) {

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -54,13 +54,12 @@ part 'social_providers.g.dart';
 /// `connectivity_plus` reports any non-`none` result, so work queued during a
 /// brief network drop is re-driven the moment connectivity returns — without
 /// waiting for an app-foreground transition. The sweep short-circuits when
-/// nothing is retryable. `→ none` transitions are filtered out because a
-/// sweep fired on going offline has nothing to do: since #7319
-/// [DmReactionRetryService] carries its own offline gate and would skip the
-/// pass anyway. The filter is a cheap short-circuit, not the safety property
-/// — the gate is, and it also covers the unfiltered foreground trigger
-/// below, which is the path that actually burned retry budgets in airplane
-/// mode.
+/// nothing is retryable. For [DmReactionRetryService], `→ none` transitions
+/// are filtered out because a sweep fired on going offline has nothing to do:
+/// its own offline gate skips the pass anyway. The filter is a cheap
+/// short-circuit for the reaction consumer; the profile-save consumer also
+/// shares this stream and relies on the filter to avoid a futile offline
+/// trigger until it gains the same guard.
 Stream<void> _dmRetryConnectivityTriggerStream() => Connectivity()
     .onConnectivityChanged
     .where((results) => results.any((r) => r != ConnectivityResult.none))

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -249,7 +249,7 @@ final class DmReactionRetryServiceProvider
 }
 
 String _$dmReactionRetryServiceHash() =>
-    r'85a3937752ef569dce502ec14bff303e2b84e46c';
+    r'e6617b1b4b2af0e0f4c8ad7cc1196cfbddad4cd5';
 
 /// Auto-sweep service for the durable `pending_view_events` queue.
 

--- a/mobile/lib/services/dm_reaction_retry_service.dart
+++ b/mobile/lib/services/dm_reaction_retry_service.dart
@@ -103,12 +103,14 @@ class DmReactionRetryService {
     required DmReactionsRepository reactionsRepository,
     required Stream<bool> appForegroundStream,
     Stream<void>? retryTriggerStream,
+    OfflineProbe? isOffline,
     DmReactionRetryConfig retryConfig = const DmReactionRetryConfig(),
     DateTime Function() now = DateTime.now,
     CrashReportingService? crashReporting,
   }) : _repository = reactionsRepository,
        _appForegroundStream = appForegroundStream,
        _retryTriggerStream = retryTriggerStream,
+       _isOffline = isOffline,
        _config = retryConfig,
        _now = now,
        _crashReporting = crashReporting ?? CrashReportingService.instance;
@@ -121,6 +123,17 @@ class DmReactionRetryService {
   /// during a brief network drop is re-driven the moment the network returns —
   /// without waiting for the user to background and re-foreground the app.
   final Stream<void>? _retryTriggerStream;
+
+  /// Connectivity probe (same contract as `NIP17MessageService`'s). When it
+  /// reports offline the pass is skipped entirely: every dispatch would
+  /// deterministically hit the send path's own offline fail-fast, and
+  /// [_driveTargets] charges a target's budget on any non-success result. So
+  /// five foreground transitions in airplane mode would otherwise exhaust a
+  /// pending removal, after which the sweep skips it for the rest of the
+  /// process and the kind-5 never publishes — invisibly, because the chip is
+  /// already filtered out of the thread. [_retryTriggerStream] re-fires the
+  /// sweep when the network returns. Mirrors `OutgoingDmRetryService`. #7319.
+  final OfflineProbe? _isOffline;
 
   final DmReactionRetryConfig _config;
   final DateTime Function() _now;
@@ -203,6 +216,20 @@ class DmReactionRetryService {
     _isSweeping = true;
 
     try {
+      // Offline: every dispatch would deterministically hit the send path's
+      // own offline fail-fast, and _driveTargets charges the budget on any
+      // non-success result. Gate the whole pass rather than the dispatch, so
+      // no target is charged for a network outage. _retryTriggerStream
+      // re-fires the sweep when connectivity returns. #7319.
+      if (await _isOfflineSafely()) {
+        Log.debug(
+          'device offline; skipping sweep without charging retry budgets',
+          name: 'DmReactionRetryService',
+          category: LogCategory.system,
+        );
+        return;
+      }
+
       final reactionTargets = await _repository.retryableReactions();
       final deletionTargets = await _repository.retryableDeletions();
       _pruneTracking(<String>{
@@ -361,6 +388,26 @@ class DmReactionRetryService {
       skippedExhausted: skippedExhausted,
       skippedTooYoung: skippedTooYoung,
     );
+  }
+
+  /// Probe connectivity, treating a broken probe as online.
+  ///
+  /// A probe that throws must never disable retries outright — that would
+  /// turn a transient platform-channel error into a permanently stalled
+  /// queue. Mirrors `OutgoingDmRetryService._isOfflineSafely`.
+  Future<bool> _isOfflineSafely() async {
+    final probe = _isOffline;
+    if (probe == null) return false;
+    try {
+      return await probe();
+    } on Object catch (e) {
+      Log.warning(
+        'offline probe failed; assuming online: $e',
+        name: 'DmReactionRetryService',
+        category: LogCategory.system,
+      );
+      return false;
+    }
   }
 
   void _pruneTracking(Set<String> liveIds) {

--- a/mobile/test/services/dm_reaction_retry_service_test.dart
+++ b/mobile/test/services/dm_reaction_retry_service_test.dart
@@ -138,7 +138,7 @@ void main() {
           ),
         ).called(1);
 
-        service.dispose();
+        await service.dispose();
       },
     );
 
@@ -162,7 +162,7 @@ void main() {
         ),
       ).called(1);
 
-      service.dispose();
+      await service.dispose();
     });
 
     test(

--- a/mobile/test/services/dm_reaction_retry_service_test.dart
+++ b/mobile/test/services/dm_reaction_retry_service_test.dart
@@ -74,17 +74,97 @@ void main() {
     DmReactionRetryConfig retryConfig = const DmReactionRetryConfig(),
     DateTime Function()? now,
     Stream<void>? retryTriggerStream,
+    OfflineProbe? isOffline,
   }) {
     return DmReactionRetryService(
       reactionsRepository: repository,
       appForegroundStream: foregroundController.stream,
       retryTriggerStream: retryTriggerStream,
+      isOffline: isOffline,
       retryConfig: retryConfig,
       now: now ?? () => DateTime.utc(2026, 5, 10, 12),
     );
   }
 
   group(DmReactionRetryService, () {
+    test(
+      'offline sweeps do not charge a pending removal its retry budget',
+      () async {
+        // #7319. retryDeletion would hit NIP17MessageService's offline
+        // fail-fast and return a plain (non-blocked) failure, which
+        // _driveTargets charges unconditionally. maxRetries foreground
+        // transitions in airplane mode therefore exhausted the row, and the
+        // sweep skipped it for the rest of the process — so the kind-5 never
+        // published even after the network returned. The removal is
+        // invisible in the thread (watchForConversation filters
+        // is_deleted = 1), so unlike the add path there is no chip to re-tap.
+        const rumorId = 'deletion-offline';
+        var offline = true;
+        var clock = DateTime.utc(2026, 5, 10, 12);
+
+        when(
+          repository.retryableDeletions,
+        ).thenAnswer((_) async => [_target(rumorId: rumorId)]);
+
+        final service = buildService(
+          now: () => clock,
+          isOffline: () async => offline,
+        );
+
+        // Burn more passes than the budget allows, advancing well past the
+        // backoff each time so nothing is skipped for being too young.
+        const config = DmReactionRetryConfig();
+        for (var i = 0; i < config.maxRetries + 1; i++) {
+          await service.sweep();
+          clock = clock.add(const Duration(minutes: 5));
+        }
+
+        verifyNever(
+          () => repository.retryDeletion(
+            rumorId: any(named: 'rumorId'),
+            targetMessageAuthor: any(named: 'targetMessageAuthor'),
+          ),
+        );
+
+        // The budget survived the offline session: the row is still driven
+        // once the network returns.
+        offline = false;
+        await service.sweep();
+
+        verify(
+          () => repository.retryDeletion(
+            rumorId: rumorId,
+            targetMessageAuthor: _authorPubkey,
+          ),
+        ).called(1);
+
+        service.dispose();
+      },
+    );
+
+    test('a throwing offline probe is treated as online', () async {
+      // A broken probe must never disable retries outright.
+      const rumorId = 'deletion-probe-throws';
+      when(
+        repository.retryableDeletions,
+      ).thenAnswer((_) async => [_target(rumorId: rumorId)]);
+
+      final service = buildService(
+        isOffline: () async => throw StateError('probe exploded'),
+      );
+
+      await service.sweep();
+
+      verify(
+        () => repository.retryDeletion(
+          rumorId: rumorId,
+          targetMessageAuthor: _authorPubkey,
+        ),
+      ).called(1);
+
+      service.dispose();
+    });
+
     test(
       'initialize subscribes to the foreground stream, dispose cancels',
       () async {


### PR DESCRIPTION
## What

DM reaction retry sweeps now probe connectivity before driving queued reaction
adds or removals. When offline, the pass returns without dispatching a publish,
so an outage cannot consume the in-memory retry budget. The existing reconnect
trigger retries the durable queue when connectivity returns.

## Why

The foreground trigger fires on every app resume, including airplane mode.
Previously, a pending kind-5 reaction removal reached the send path's offline
fail-fast, which returned a non-blocked failure. The retry service charged that
failure against the row, and five foreground transitions could strand the
removal for the rest of the process. The local deletion remains durable and is
now retried after reconnect.

The gate is inside the sweep `try`, after the re-entrancy flag is set, so the
flag is cleared by `finally` even on the early return. A throwing probe is
treated as online so a broken platform channel cannot disable retries.

## Behavior and scope

- The offline gate covers both reaction-add and reaction-removal phases. An
  interrupted `pending` add remains pending while offline; it is not surfaced
  as failed by this service. This differs from the outgoing-message retry
  service and is intentional for this focused fix.
- A removal that ultimately fails for a genuine non-offline reason still needs
  a visible, manual retryable state rather than remaining silently hidden. That
  product/UI work is tracked in #8390 and is deliberately separate from this
  transport fix.
- The shared connectivity stream is also consumed by profile-save retries.
  Its `→ none` filter remains an important short-circuit for that consumer;
  adding the profile-save offline gate is tracked in #8389.

## Testing

- `flutter test test/services/dm_reaction_retry_service_test.dart`
- `flutter test test/services/outgoing_dm_retry_service_test.dart test/services/app_side_effects_test.dart`
- `flutter analyze lib test integration_test`
- `dart format`
- `dart run build_runner build --delete-conflicting-outputs`

Fixes #7319
