### PR TITLE
fix(dm): avoid generated handles while profiles load

### DIFF
--- a/mobile/lib/blocs/dm/dm_peer_name.dart
+++ b/mobile/lib/blocs/dm/dm_peer_name.dart
@@ -88,6 +88,7 @@ String dmPeerName({
     displayNameOverride: displayNameOverride,
   );
   if (substitute != null) return substitute;
+  if (profileName != null) return profileName;
   if (isResolving) return '';
-  return profileName ?? UserProfile.defaultDisplayNameFor(pubkeyHex);
+  return UserProfile.defaultDisplayNameFor(pubkeyHex);
 }

--- a/mobile/lib/blocs/dm/dm_peer_name.dart
+++ b/mobile/lib/blocs/dm/dm_peer_name.dart
@@ -69,6 +69,9 @@ String? dmPeerSubstituteName({
 /// [profileName] is the caller's already-resolved step-4 value: the widget
 /// chain passes `profile?.bestDisplayName`, and the BLoC passes its cached
 /// entry. Both may be null, and the generated fallback answers for them.
+///
+/// While [isResolving] is true, the generated fallback is withheld so a
+/// deterministic placeholder is not presented as the peer's real identity.
 String dmPeerName({
   required String pubkeyHex,
   required bool isVanished,
@@ -76,6 +79,7 @@ String dmPeerName({
   required DmPeerLabels labels,
   String? profileName,
   String? displayNameOverride,
+  bool isResolving = false,
 }) {
   final substitute = dmPeerSubstituteName(
     isVanished: isVanished,
@@ -84,5 +88,6 @@ String dmPeerName({
     displayNameOverride: displayNameOverride,
   );
   if (substitute != null) return substitute;
+  if (isResolving) return '';
   return profileName ?? UserProfile.defaultDisplayNameFor(pubkeyHex);
 }

--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -27,20 +27,17 @@ final _vanishedProfilePubkeysProvider = StreamProvider<Set<String>>((ref) {
 /// The reactive profile stream intentionally emits `null` while the read
 /// repository is unavailable, so its value alone cannot distinguish that
 /// cold-start state from a settled account with no profile. The one-shot
-/// provider owns the cache lookup and fresh fetch, which gives this derived
-/// provider a settled loading boundary without widening [ProfileReader].
+/// provider owns the cache lookup and fresh fetch. Waiting for both paths keeps
+/// the signal aligned with widgets that consume either one, and auto-disposal
+/// releases their per-pubkey watchers when the surface unmounts.
 // ignore: specify_nonobvious_property_types
-final profileIdentityResolvingProvider = Provider.family<bool, String>((
-  ref,
-  pubkey,
-) {
-  if (ref.watch(profileReadRepositoryProvider) == null) return true;
-  final fetched = ref.watch(fetchUserProfileProvider(pubkey));
-  if (fetched.hasValue) return false;
-  final reactive = ref.watch(userProfileReactiveProvider(pubkey));
-  if (reactive.hasValue && reactive.value != null) return false;
-  return fetched.isLoading || reactive.isLoading;
-});
+final profileIdentityResolvingProvider = Provider.autoDispose
+    .family<bool, String>((ref, pubkey) {
+      if (ref.watch(profileReadRepositoryProvider) == null) return true;
+      final fetched = ref.watch(fetchUserProfileProvider(pubkey));
+      final reactive = ref.watch(userProfileReactiveProvider(pubkey));
+      return fetched.isLoading || reactive.isLoading;
+    });
 
 /// One-shot durable vanish lookup for imperative paths that must resolve the
 /// state before acting instead of treating [profileVanishedProvider]'s loading

--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -22,6 +22,26 @@ final _vanishedProfilePubkeysProvider = StreamProvider<Set<String>>((ref) {
       .map((pubkeys) => pubkeys.toSet());
 });
 
+/// Whether a peer's profile identity is still being resolved.
+///
+/// The reactive profile stream intentionally emits `null` while the read
+/// repository is unavailable, so its value alone cannot distinguish that
+/// cold-start state from a settled account with no profile. The one-shot
+/// provider owns the cache lookup and fresh fetch, which gives this derived
+/// provider a settled loading boundary without widening [ProfileReader].
+// ignore: specify_nonobvious_property_types
+final profileIdentityResolvingProvider = Provider.family<bool, String>((
+  ref,
+  pubkey,
+) {
+  if (ref.watch(profileReadRepositoryProvider) == null) return true;
+  final fetched = ref.watch(fetchUserProfileProvider(pubkey));
+  if (fetched.hasValue) return false;
+  final reactive = ref.watch(userProfileReactiveProvider(pubkey));
+  if (reactive.hasValue && reactive.value != null) return false;
+  return fetched.isLoading || reactive.isLoading;
+});
+
 /// One-shot durable vanish lookup for imperative paths that must resolve the
 /// state before acting instead of treating [profileVanishedProvider]'s loading
 /// placeholder as a live account.

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -160,6 +160,9 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
     final isRetiredModerationThread = isRetiredModerationAccount(otherPubkey);
     final profileAsync = ref.watch(fetchUserProfileProvider(otherPubkey));
     final profile = profileAsync.asData?.value;
+    final isResolving = ref.watch(
+      profileIdentityResolvingProvider(otherPubkey),
+    );
     // The conversation and its history remain readable — they are the viewer's
     // own copy of messages a NIP-62 vanish cannot retract. Only the header
     // identity changes.
@@ -171,7 +174,11 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
       pubkeyHex: otherPubkey,
       isVanished: isDeleted,
       profile: profile,
+      isResolving: isResolving,
     );
+    final visualDisplayName = displayName.isEmpty
+        ? UserProfile.defaultDisplayNameFor(otherPubkey)
+        : displayName;
     final claimedNip05 = profile?.shortDisplayNip05;
     final verificationStatus = claimedNip05 != null && claimedNip05.isNotEmpty
         ? ref
@@ -251,6 +258,8 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                       children: [
                         ConversationAppBar(
                           displayName: displayName,
+                          isResolving: isResolving,
+                          loadingDisplayName: visualDisplayName,
                           handle: handle,
                           onBack: () => context.pop(),
                           onTitleTap: otherPubkey.isNotEmpty
@@ -280,6 +289,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                                   participantPubkeys: widget.participantPubkeys,
                                   blockedPubkeys: blockedReactors,
                                   displayName: displayName,
+                                  isResolving: isResolving,
                                   reactionsEnabled:
                                       !isRetiredModerationThread &&
                                       !isBlockedByUs,
@@ -613,6 +623,7 @@ class _ConversationContent extends StatelessWidget {
     required this.participantPubkeys,
     required this.blockedPubkeys,
     required this.displayName,
+    required this.isResolving,
     required this.reactionsEnabled,
     required this.sendRecoveryEnabled,
     this.imageUrl,
@@ -627,6 +638,7 @@ class _ConversationContent extends StatelessWidget {
   /// Effective block/mute set; reactions from these pubkeys are hidden.
   final Set<String> blockedPubkeys;
   final String displayName;
+  final bool isResolving;
   final bool reactionsEnabled;
 
   /// Whether tapping a failed own bubble may offer to resend it.
@@ -662,11 +674,14 @@ class _ConversationContent extends StatelessWidget {
           ConversationStatus.loaded =>
             selected.messages.isEmpty
                 ? EmptyConversation(
-                    displayName: displayName,
+                    displayName: isResolving
+                        ? UserProfile.defaultDisplayNameFor(otherPubkey)
+                        : displayName,
                     pubkey: otherPubkey,
                     imageUrl: imageUrl,
                     nip05: nip05,
                     onViewProfile: onViewProfile,
+                    isIdentityResolving: isResolving,
                     mayBeIncomplete: context.select<DmRestoreStatusCubit, bool>(
                       (cubit) => cubit.state.mayBeIncomplete,
                     ),

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -176,6 +176,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
       profile: profile,
       isResolving: isResolving,
     );
+    final isIdentityResolving = isResolving && displayName.isEmpty;
     final visualDisplayName = displayName.isEmpty
         ? UserProfile.defaultDisplayNameFor(otherPubkey)
         : displayName;
@@ -258,7 +259,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                       children: [
                         ConversationAppBar(
                           displayName: displayName,
-                          isResolving: isResolving,
+                          isResolving: isIdentityResolving,
                           loadingDisplayName: visualDisplayName,
                           handle: handle,
                           onBack: () => context.pop(),
@@ -289,7 +290,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                                   participantPubkeys: widget.participantPubkeys,
                                   blockedPubkeys: blockedReactors,
                                   displayName: displayName,
-                                  isResolving: isResolving,
+                                  isResolving: isIdentityResolving,
                                   reactionsEnabled:
                                       !isRetiredModerationThread &&
                                       !isBlockedByUs,

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -40,6 +40,7 @@ import 'package:openvine/widgets/profile/more_sheet/more_sheet_result.dart';
 import 'package:openvine/widgets/report_content_dialog.dart';
 import 'package:openvine/widgets/save_original_progress_sheet.dart';
 import 'package:openvine/widgets/watermark_download_progress_sheet.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 /// View for a single DM conversation.
 ///
@@ -63,6 +64,8 @@ class ConversationView extends ConsumerStatefulWidget {
 enum _FailedMessageAction { resend, delete }
 
 class _ConversationViewState extends ConsumerState<ConversationView> {
+  bool _isOpeningOptions = false;
+
   /// The account this thread addresses. The route passes `participantPubkeys`
   /// as the counterparty list, so self is already excluded.
   String get _otherPubkey => widget.participantPubkeys.isNotEmpty
@@ -81,67 +84,109 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
   }
 
   Future<void> _onOptions(String otherPubkey) async {
-    if (otherPubkey.isEmpty) return;
-
-    final profileFuture = ref.read(
-      fetchUserProfileProvider(otherPubkey).future,
-    );
-    final vanishedFuture = ref.read(
-      profileVanishedSnapshotProvider(otherPubkey).future,
-    );
-    final profile = await profileFuture;
-    final isVanished = await vanishedFuture;
-    if (!mounted) return;
-    final displayName = dmPeerDisplayName(
-      context,
-      pubkeyHex: otherPubkey,
-      isVanished: isVanished,
-      profile: profile,
-    );
-
-    final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
-    final followRepository = ref.read(followRepositoryProvider);
-    final isBlocked = blocklistRepository.isBlocked(otherPubkey);
-    final isFollowing = followRepository.isFollowing(otherPubkey);
-
-    final result = await VineBottomSheet.show<MoreSheetResult>(
-      context: context,
-      expanded: false,
-      scrollable: false,
-      isScrollControlled: true,
-      body: MoreSheetContent(
-        userIdHex: otherPubkey,
-        displayName: displayName,
-        isFollowing: isFollowing,
-        isBlocked: isBlocked,
-        showReport: true,
-      ),
-      children: const [],
-    );
-
-    if (!mounted || result == null) return;
-
-    switch (result) {
-      case MoreSheetResult.copy:
-        final npub = NostrKeyUtils.encodePubKey(otherPubkey);
-        await ClipboardUtils.copyPubkey(context, npub);
-      case MoreSheetResult.unfollow:
-        await followRepository.toggleFollow(otherPubkey);
-      case MoreSheetResult.report:
-        if (!mounted) return;
-        await ReportContentDialog.showForUser(context, userPubkey: otherPubkey);
-      case MoreSheetResult.blockConfirmed:
-        await blocklistRepository.blockUser(
-          otherPubkey,
-          ourPubkey: ref.read(authServiceProvider).currentPublicKeyHex ?? '',
+    if (otherPubkey.isEmpty || _isOpeningOptions) return;
+    _isOpeningOptions = true;
+    try {
+      bool isVanished;
+      try {
+        isVanished = await ref.read(
+          profileVanishedSnapshotProvider(otherPubkey).future,
         );
-        if (mounted) context.pop();
-      case MoreSheetResult.unblockConfirmed:
-        await blocklistRepository.unblockUser(otherPubkey);
-      case MoreSheetResult.addToList:
-        // addToList is not surfaced from this caller (showAddToList defaults
-        // to false on MoreSheetContent here), so this branch is unreachable.
-        break;
+      } catch (error, stackTrace) {
+        Log.warning(
+          'Could not read durable vanish state; opening conversation options '
+          'with the live-account identity fallback',
+          name: 'ConversationView',
+          category: LogCategory.ui,
+          error: error,
+          stackTrace: stackTrace,
+        );
+        isVanished = false;
+      }
+      if (!mounted) return;
+
+      final String displayName;
+      final knownName = dmPeerNameWithoutProfile(
+        context,
+        pubkeyHex: otherPubkey,
+        isVanished: isVanished,
+      );
+      if (knownName != null) {
+        displayName = knownName;
+      } else {
+        UserProfile? profile;
+        try {
+          profile = await ref.read(
+            fetchUserProfileProvider(otherPubkey).future,
+          );
+        } catch (error, stackTrace) {
+          Log.warning(
+            'Could not read the conversation peer profile; opening '
+            'conversation options with the generated identity fallback',
+            name: 'ConversationView',
+            category: LogCategory.ui,
+            error: error,
+            stackTrace: stackTrace,
+          );
+        }
+        if (!mounted) return;
+        displayName = dmPeerDisplayName(
+          context,
+          pubkeyHex: otherPubkey,
+          isVanished: isVanished,
+          profile: profile,
+        );
+      }
+
+      final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
+      final followRepository = ref.read(followRepositoryProvider);
+      final isBlocked = blocklistRepository.isBlocked(otherPubkey);
+      final isFollowing = followRepository.isFollowing(otherPubkey);
+
+      final result = await VineBottomSheet.show<MoreSheetResult>(
+        context: context,
+        expanded: false,
+        scrollable: false,
+        isScrollControlled: true,
+        body: MoreSheetContent(
+          userIdHex: otherPubkey,
+          displayName: displayName,
+          isFollowing: isFollowing,
+          isBlocked: isBlocked,
+          showReport: true,
+        ),
+        children: const [],
+      );
+
+      if (!mounted || result == null) return;
+
+      switch (result) {
+        case MoreSheetResult.copy:
+          final npub = NostrKeyUtils.encodePubKey(otherPubkey);
+          await ClipboardUtils.copyPubkey(context, npub);
+        case MoreSheetResult.unfollow:
+          await followRepository.toggleFollow(otherPubkey);
+        case MoreSheetResult.report:
+          if (!mounted) return;
+          await ReportContentDialog.showForUser(
+            context,
+            userPubkey: otherPubkey,
+          );
+        case MoreSheetResult.blockConfirmed:
+          await blocklistRepository.blockUser(
+            otherPubkey,
+            ourPubkey: ref.read(authServiceProvider).currentPublicKeyHex ?? '',
+          );
+          if (mounted) context.pop();
+        case MoreSheetResult.unblockConfirmed:
+          await blocklistRepository.unblockUser(otherPubkey);
+        case MoreSheetResult.addToList:
+          // addToList is not surfaced from this caller (showAddToList defaults
+          // to false on MoreSheetContent here), so this branch is unreachable.
+          break;
+      }
+    } finally {
+      _isOpeningOptions = false;
     }
   }
 

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -268,7 +268,9 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                                   '${OtherProfileScreen.path}/${NostrKeyUtils.encodePubKey(otherPubkey)}',
                                 )
                               : null,
-                          onOptions: () => _onOptions(otherPubkey, displayName),
+                          onOptions: isIdentityResolving
+                              ? null
+                              : () => _onOptions(otherPubkey, displayName),
                         ),
                         Expanded(
                           // Force the messages card to fill the available width

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -80,8 +80,24 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
     );
   }
 
-  Future<void> _onOptions(String otherPubkey, String displayName) async {
+  Future<void> _onOptions(String otherPubkey) async {
     if (otherPubkey.isEmpty) return;
+
+    final profileFuture = ref.read(
+      fetchUserProfileProvider(otherPubkey).future,
+    );
+    final vanishedFuture = ref.read(
+      profileVanishedSnapshotProvider(otherPubkey).future,
+    );
+    final profile = await profileFuture;
+    final isVanished = await vanishedFuture;
+    if (!mounted) return;
+    final displayName = dmPeerDisplayName(
+      context,
+      pubkeyHex: otherPubkey,
+      isVanished: isVanished,
+      profile: profile,
+    );
 
     final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
     final followRepository = ref.read(followRepositoryProvider);
@@ -268,9 +284,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                                   '${OtherProfileScreen.path}/${NostrKeyUtils.encodePubKey(otherPubkey)}',
                                 )
                               : null,
-                          onOptions: isIdentityResolving
-                              ? null
-                              : () => _onOptions(otherPubkey, displayName),
+                          onOptions: () => _onOptions(otherPubkey),
                         ),
                         Expanded(
                           // Force the messages card to fill the available width

--- a/mobile/lib/screens/inbox/conversation/widgets/conversation_app_bar.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/conversation_app_bar.dart
@@ -16,6 +16,8 @@ class ConversationAppBar extends StatelessWidget
     required this.handle,
     required this.onBack,
     required this.onOptions,
+    this.isResolving = false,
+    this.loadingDisplayName,
     this.onTitleTap,
     super.key,
   });
@@ -24,6 +26,8 @@ class ConversationAppBar extends StatelessWidget
   final String handle;
   final VoidCallback onBack;
   final VoidCallback onOptions;
+  final bool isResolving;
+  final String? loadingDisplayName;
 
   /// Called when the user taps the name/handle in the app bar.
   final VoidCallback? onTitleTap;
@@ -34,7 +38,20 @@ class ConversationAppBar extends StatelessWidget
   @override
   Widget build(BuildContext context) {
     return DiVineAppBar(
-      title: displayName,
+      title: isResolving ? null : displayName,
+      titleWidget: isResolving
+          ? IdentitySkeletonizer(
+              isLoading: true,
+              child: Text(
+                loadingDisplayName ?? context.l10n.commonLoading,
+                style: VineTheme.titleMediumFont(
+                  color: context.vineColors.primaryText,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            )
+          : null,
       subtitle: handle.isNotEmpty ? handle : null,
       titleMode: onTitleTap != null
           ? DiVineAppBarTitleMode.tappable

--- a/mobile/lib/screens/inbox/conversation/widgets/conversation_app_bar.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/conversation_app_bar.dart
@@ -25,7 +25,7 @@ class ConversationAppBar extends StatelessWidget
   final String displayName;
   final String handle;
   final VoidCallback onBack;
-  final VoidCallback? onOptions;
+  final VoidCallback onOptions;
   final bool isResolving;
   final String? loadingDisplayName;
 
@@ -42,6 +42,7 @@ class ConversationAppBar extends StatelessWidget
       titleWidget: isResolving
           ? IdentitySkeletonizer(
               isLoading: true,
+              excludeSemantics: true,
               child: Text(
                 loadingDisplayName ?? context.l10n.commonLoading,
                 style: VineTheme.titleMediumFont(

--- a/mobile/lib/screens/inbox/conversation/widgets/conversation_app_bar.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/conversation_app_bar.dart
@@ -40,16 +40,19 @@ class ConversationAppBar extends StatelessWidget
     return DiVineAppBar(
       title: isResolving ? null : displayName,
       titleWidget: isResolving
-          ? IdentitySkeletonizer(
-              isLoading: true,
-              excludeSemantics: true,
-              child: Text(
-                loadingDisplayName ?? context.l10n.commonLoading,
-                style: VineTheme.titleMediumFont(
-                  color: context.vineColors.primaryText,
+          ? Semantics(
+              label: context.l10n.commonLoading,
+              child: IdentitySkeletonizer(
+                isLoading: true,
+                excludeSemantics: true,
+                child: Text(
+                  loadingDisplayName ?? context.l10n.commonLoading,
+                  style: VineTheme.titleMediumFont(
+                    color: context.vineColors.primaryText,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
               ),
             )
           : null,

--- a/mobile/lib/screens/inbox/conversation/widgets/conversation_app_bar.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/conversation_app_bar.dart
@@ -25,7 +25,7 @@ class ConversationAppBar extends StatelessWidget
   final String displayName;
   final String handle;
   final VoidCallback onBack;
-  final VoidCallback onOptions;
+  final VoidCallback? onOptions;
   final bool isResolving;
   final String? loadingDisplayName;
 

--- a/mobile/lib/screens/inbox/conversation/widgets/empty_conversation.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/empty_conversation.dart
@@ -51,17 +51,20 @@ class EmptyConversation extends StatelessWidget {
       child: Column(
         children: [
           // Avatar
-          IdentitySkeletonizer(
-            isLoading: isIdentityResolving,
-            excludeSemantics: true,
-            child: UserAvatar(
-              imageUrl: imageUrl,
-              name: displayName,
-              placeholderSeed: pubkey,
-              size: 96,
-              contentOverride: isModerationAccount(pubkey)
-                  ? const ModerationAvatar()
-                  : null,
+          Semantics(
+            label: isIdentityResolving ? context.l10n.commonLoading : null,
+            child: IdentitySkeletonizer(
+              isLoading: isIdentityResolving,
+              excludeSemantics: true,
+              child: UserAvatar(
+                imageUrl: imageUrl,
+                name: displayName,
+                placeholderSeed: pubkey,
+                size: 96,
+                contentOverride: isModerationAccount(pubkey)
+                    ? const ModerationAvatar()
+                    : null,
+              ),
             ),
           ),
           const SizedBox(height: 32),

--- a/mobile/lib/screens/inbox/conversation/widgets/empty_conversation.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/empty_conversation.dart
@@ -53,6 +53,7 @@ class EmptyConversation extends StatelessWidget {
           // Avatar
           IdentitySkeletonizer(
             isLoading: isIdentityResolving,
+            excludeSemantics: true,
             child: UserAvatar(
               imageUrl: imageUrl,
               name: displayName,
@@ -67,6 +68,7 @@ class EmptyConversation extends StatelessWidget {
           // User info
           IdentitySkeletonizer(
             isLoading: isIdentityResolving,
+            excludeSemantics: true,
             child: Text(
               displayName,
               style: VineTheme.titleLargeFont(

--- a/mobile/lib/screens/inbox/conversation/widgets/empty_conversation.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/empty_conversation.dart
@@ -21,6 +21,7 @@ class EmptyConversation extends StatelessWidget {
     this.nip05,
     this.onViewProfile,
     this.mayBeIncomplete = false,
+    this.isIdentityResolving = false,
     super.key,
   });
 
@@ -39,6 +40,10 @@ class EmptyConversation extends StatelessWidget {
   /// line instead of silently asserting the conversation is empty.
   final bool mayBeIncomplete;
 
+  /// Whether the participant avatar and name should use the identity loading
+  /// treatment while their profile is being resolved.
+  final bool isIdentityResolving;
+
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
@@ -46,25 +51,31 @@ class EmptyConversation extends StatelessWidget {
       child: Column(
         children: [
           // Avatar
-          UserAvatar(
-            imageUrl: imageUrl,
-            name: displayName,
-            placeholderSeed: pubkey,
-            size: 96,
-            contentOverride: isModerationAccount(pubkey)
-                ? const ModerationAvatar()
-                : null,
+          IdentitySkeletonizer(
+            isLoading: isIdentityResolving,
+            child: UserAvatar(
+              imageUrl: imageUrl,
+              name: displayName,
+              placeholderSeed: pubkey,
+              size: 96,
+              contentOverride: isModerationAccount(pubkey)
+                  ? const ModerationAvatar()
+                  : null,
+            ),
           ),
           const SizedBox(height: 32),
           // User info
-          Text(
-            displayName,
-            style: VineTheme.titleLargeFont(
-              color: context.vineColors.primaryText,
+          IdentitySkeletonizer(
+            isLoading: isIdentityResolving,
+            child: Text(
+              displayName,
+              style: VineTheme.titleLargeFont(
+                color: context.vineColors.primaryText,
+              ),
+              textAlign: TextAlign.center,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
             ),
-            textAlign: TextAlign.center,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
           ),
           if (nip05 != null && nip05!.isNotEmpty) ...[
             const SizedBox(height: 4),

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
@@ -163,6 +163,7 @@ class _ReactorRow extends ConsumerWidget {
       profile: profile,
       isResolving: isResolving,
     );
+    final isIdentityResolving = isResolving && name.isEmpty;
     final visualName = name.isEmpty
         ? UserProfile.defaultDisplayNameFor(reaction.reactorPubkey)
         : name;
@@ -179,7 +180,7 @@ class _ReactorRow extends ConsumerWidget {
             _ => context.l10n.dmReactionChipOwnA11yLabel(reaction.emoji),
           }
         : context.l10n.dmReactionChipOtherA11yLabel(
-            isResolving ? context.l10n.commonLoading : name,
+            isIdentityResolving ? context.l10n.commonLoading : name,
             reaction.emoji,
           );
 
@@ -197,7 +198,7 @@ class _ReactorRow extends ConsumerWidget {
           // also circular. Wrapping the rounded-square UserAvatar in ClipOval
           // would slice its border into arcs (the "cut border" artifact).
           leading: IdentitySkeletonizer(
-            isLoading: isResolving,
+            isLoading: isIdentityResolving,
             child: UserAvatar(
               // `watchProfile` is an ungated `select(userProfiles)`, so a row
               // that outlived its tombstone still streams a picture here.
@@ -208,7 +209,7 @@ class _ReactorRow extends ConsumerWidget {
             ),
           ),
           title: IdentitySkeletonizer(
-            isLoading: isResolving,
+            isLoading: isIdentityResolving,
             child: Text(
               visualName,
               maxLines: 1,

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
@@ -199,6 +199,7 @@ class _ReactorRow extends ConsumerWidget {
           // would slice its border into arcs (the "cut border" artifact).
           leading: IdentitySkeletonizer(
             isLoading: isIdentityResolving,
+            excludeSemantics: true,
             child: UserAvatar(
               // `watchProfile` is an ungated `select(userProfiles)`, so a row
               // that outlived its tombstone still streams a picture here.
@@ -210,6 +211,7 @@ class _ReactorRow extends ConsumerWidget {
           ),
           title: IdentitySkeletonizer(
             isLoading: isIdentityResolving,
+            excludeSemantics: true,
             child: Text(
               visualName,
               maxLines: 1,

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
@@ -143,6 +143,9 @@ class _ReactorRow extends ConsumerWidget {
       userProfileReactiveProvider(reaction.reactorPubkey),
     );
     final profile = profileAsync.asData?.value;
+    final isResolving = ref.watch(
+      profileIdentityResolvingProvider(reaction.reactorPubkey),
+    );
 
     // A reactor is a DM peer, so it resolves through the same chain as the
     // conversation header and the inbox row — otherwise the one sheet a
@@ -158,7 +161,11 @@ class _ReactorRow extends ConsumerWidget {
       pubkeyHex: reaction.reactorPubkey,
       isVanished: isVanished,
       profile: profile,
+      isResolving: isResolving,
     );
+    final visualName = name.isEmpty
+        ? UserProfile.defaultDisplayNameFor(reaction.reactorPubkey)
+        : name;
 
     final isFailed = reaction.publishStatus == DmReactionPublishStatus.failed;
     final isPending = reaction.publishStatus == DmReactionPublishStatus.pending;
@@ -171,7 +178,10 @@ class _ReactorRow extends ConsumerWidget {
               context.l10n.dmReactionChipFailedA11yLabel,
             _ => context.l10n.dmReactionChipOwnA11yLabel(reaction.emoji),
           }
-        : context.l10n.dmReactionChipOtherA11yLabel(name, reaction.emoji);
+        : context.l10n.dmReactionChipOtherA11yLabel(
+            isResolving ? context.l10n.commonLoading : name,
+            reaction.emoji,
+          );
 
     return Semantics(
       button: isOwn && !isPending,
@@ -186,20 +196,26 @@ class _ReactorRow extends ConsumerWidget {
           // cornerRadius == size / 2 renders a true circle whose border is
           // also circular. Wrapping the rounded-square UserAvatar in ClipOval
           // would slice its border into arcs (the "cut border" artifact).
-          leading: UserAvatar(
-            // `watchProfile` is an ungated `select(userProfiles)`, so a row
-            // that outlived its tombstone still streams a picture here.
-            imageUrl: isVanished ? null : profile?.picture,
-            name: name,
-            size: _avatarSize,
-            cornerRadius: _avatarSize / 2,
+          leading: IdentitySkeletonizer(
+            isLoading: isResolving,
+            child: UserAvatar(
+              // `watchProfile` is an ungated `select(userProfiles)`, so a row
+              // that outlived its tombstone still streams a picture here.
+              imageUrl: isVanished ? null : profile?.picture,
+              name: visualName,
+              size: _avatarSize,
+              cornerRadius: _avatarSize / 2,
+            ),
           ),
-          title: Text(
-            name,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: VineTheme.titleSmallFont(
-              color: context.vineColors.onSurface,
+          title: IdentitySkeletonizer(
+            isLoading: isResolving,
+            child: Text(
+              visualName,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: VineTheme.titleSmallFont(
+                color: context.vineColors.onSurface,
+              ),
             ),
           ),
           trailing: _Trailing(

--- a/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
@@ -125,6 +125,7 @@ class RequestPreviewView extends ConsumerWidget {
       profile: visibleProfile,
       isResolving: isResolving,
     );
+    final isIdentityResolving = isResolving && displayName.isEmpty;
     final visualDisplayName = displayName.isEmpty
         ? UserProfile.defaultDisplayNameFor(otherPubkey)
         : displayName;
@@ -132,8 +133,8 @@ class RequestPreviewView extends ConsumerWidget {
     return Scaffold(
       backgroundColor: context.vineColors.surface,
       appBar: DiVineAppBar(
-        title: isResolving ? null : displayName,
-        titleWidget: isResolving
+        title: isIdentityResolving ? null : displayName,
+        titleWidget: isIdentityResolving
             ? IdentitySkeletonizer(
                 isLoading: true,
                 child: Text(
@@ -163,7 +164,7 @@ class RequestPreviewView extends ConsumerWidget {
                 currentPubkey: currentPubkey,
                 messageCount: messageCount,
                 messages: messages,
-                isResolving: isResolving,
+                isResolving: isIdentityResolving,
               ),
             ),
             _ActionButtons(

--- a/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
@@ -100,6 +100,9 @@ class RequestPreviewView extends ConsumerWidget {
     final profileAsync = ref.watch(userProfileReactiveProvider(otherPubkey));
 
     final profile = profileAsync.asData?.value;
+    final isResolving = ref.watch(
+      profileIdentityResolvingProvider(otherPubkey),
+    );
 
     // Same treatment as [ConversationTile]. This screen also links straight
     // through to [OtherProfileScreen], which already names a vanished account
@@ -120,12 +123,29 @@ class RequestPreviewView extends ConsumerWidget {
       pubkeyHex: otherPubkey,
       isVanished: isDeleted,
       profile: visibleProfile,
+      isResolving: isResolving,
     );
+    final visualDisplayName = displayName.isEmpty
+        ? UserProfile.defaultDisplayNameFor(otherPubkey)
+        : displayName;
 
     return Scaffold(
       backgroundColor: context.vineColors.surface,
       appBar: DiVineAppBar(
-        title: displayName,
+        title: isResolving ? null : displayName,
+        titleWidget: isResolving
+            ? IdentitySkeletonizer(
+                isLoading: true,
+                child: Text(
+                  visualDisplayName,
+                  style: VineTheme.titleMediumFont(
+                    color: context.vineColors.primaryText,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              )
+            : null,
         showBackButton: true,
         // Same one-entry-stack exposure as the unresolved states below:
         // `loading` is only the first frame of a cold deep-link entry, and
@@ -143,6 +163,7 @@ class RequestPreviewView extends ConsumerWidget {
                 currentPubkey: currentPubkey,
                 messageCount: messageCount,
                 messages: messages,
+                isResolving: isResolving,
               ),
             ),
             _ActionButtons(
@@ -256,6 +277,7 @@ class _ProfileContent extends StatelessWidget {
     required this.currentPubkey,
     required this.messageCount,
     required this.messages,
+    required this.isResolving,
   });
 
   final String displayName;
@@ -264,9 +286,13 @@ class _ProfileContent extends StatelessWidget {
   final String currentPubkey;
   final int messageCount;
   final List<DmMessage> messages;
+  final bool isResolving;
 
   @override
   Widget build(BuildContext context) {
+    final visualDisplayName = displayName.isEmpty
+        ? UserProfile.defaultDisplayNameFor(otherPubkey)
+        : displayName;
     final imageUrl = profile?.picture;
     final nip05 = profile?.shortDisplayNip05;
     final followerCount = profile?.followerCount;
@@ -280,24 +306,30 @@ class _ProfileContent extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              UserAvatar(
-                imageUrl: imageUrl,
-                name: displayName,
-                placeholderSeed: otherPubkey,
-                size: 96,
-                contentOverride: isModerationAccount(otherPubkey)
-                    ? const ModerationAvatar()
-                    : null,
+              IdentitySkeletonizer(
+                isLoading: isResolving,
+                child: UserAvatar(
+                  imageUrl: imageUrl,
+                  name: visualDisplayName,
+                  placeholderSeed: otherPubkey,
+                  size: 96,
+                  contentOverride: isModerationAccount(otherPubkey)
+                      ? const ModerationAvatar()
+                      : null,
+                ),
               ),
               const SizedBox(height: 32),
-              Text(
-                displayName,
-                style: VineTheme.titleLargeFont(
-                  color: context.vineColors.primaryText,
+              IdentitySkeletonizer(
+                isLoading: isResolving,
+                child: Text(
+                  visualDisplayName,
+                  style: VineTheme.titleLargeFont(
+                    color: context.vineColors.primaryText,
+                  ),
+                  textAlign: TextAlign.center,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
                 ),
-                textAlign: TextAlign.center,
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
               ),
               if (nip05 != null && nip05.isNotEmpty) ...[
                 const SizedBox(height: 4),

--- a/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
@@ -137,6 +137,7 @@ class RequestPreviewView extends ConsumerWidget {
         titleWidget: isIdentityResolving
             ? IdentitySkeletonizer(
                 isLoading: true,
+                excludeSemantics: true,
                 child: Text(
                   visualDisplayName,
                   style: VineTheme.titleMediumFont(
@@ -309,6 +310,7 @@ class _ProfileContent extends StatelessWidget {
             children: [
               IdentitySkeletonizer(
                 isLoading: isResolving,
+                excludeSemantics: true,
                 child: UserAvatar(
                   imageUrl: imageUrl,
                   name: visualDisplayName,
@@ -322,6 +324,7 @@ class _ProfileContent extends StatelessWidget {
               const SizedBox(height: 32),
               IdentitySkeletonizer(
                 isLoading: isResolving,
+                excludeSemantics: true,
                 child: Text(
                   visualDisplayName,
                   style: VineTheme.titleLargeFont(

--- a/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
@@ -135,16 +135,19 @@ class RequestPreviewView extends ConsumerWidget {
       appBar: DiVineAppBar(
         title: isIdentityResolving ? null : displayName,
         titleWidget: isIdentityResolving
-            ? IdentitySkeletonizer(
-                isLoading: true,
-                excludeSemantics: true,
-                child: Text(
-                  visualDisplayName,
-                  style: VineTheme.titleMediumFont(
-                    color: context.vineColors.primaryText,
+            ? Semantics(
+                label: context.l10n.commonLoading,
+                child: IdentitySkeletonizer(
+                  isLoading: true,
+                  excludeSemantics: true,
+                  child: Text(
+                    visualDisplayName,
+                    style: VineTheme.titleMediumFont(
+                      color: context.vineColors.primaryText,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
                 ),
               )
             : null,
@@ -308,17 +311,20 @@ class _ProfileContent extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              IdentitySkeletonizer(
-                isLoading: isResolving,
-                excludeSemantics: true,
-                child: UserAvatar(
-                  imageUrl: imageUrl,
-                  name: visualDisplayName,
-                  placeholderSeed: otherPubkey,
-                  size: 96,
-                  contentOverride: isModerationAccount(otherPubkey)
-                      ? const ModerationAvatar()
-                      : null,
+              Semantics(
+                label: isResolving ? context.l10n.commonLoading : null,
+                child: IdentitySkeletonizer(
+                  isLoading: isResolving,
+                  excludeSemantics: true,
+                  child: UserAvatar(
+                    imageUrl: imageUrl,
+                    name: visualDisplayName,
+                    placeholderSeed: otherPubkey,
+                    size: 96,
+                    contentOverride: isModerationAccount(otherPubkey)
+                        ? const ModerationAvatar()
+                        : null,
+                  ),
                 ),
               ),
               const SizedBox(height: 32),

--- a/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
+++ b/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
@@ -106,6 +106,7 @@ class RequestTile extends ConsumerWidget {
               children: [
                 IdentitySkeletonizer(
                   isLoading: isIdentityResolving,
+                  excludeSemantics: true,
                   child: Padding(
                     padding: const EdgeInsets.symmetric(vertical: 4),
                     child: UserAvatar(
@@ -128,6 +129,7 @@ class RequestTile extends ConsumerWidget {
                           Expanded(
                             child: IdentitySkeletonizer(
                               isLoading: isIdentityResolving,
+                              excludeSemantics: true,
                               child: Text(
                                 visualDisplayName,
                                 style: VineTheme.titleMediumFont(

--- a/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
+++ b/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
@@ -57,6 +57,7 @@ class RequestTile extends ConsumerWidget {
       profile: profileAsync.asData?.value,
       isResolving: isResolving,
     );
+    final isIdentityResolving = isResolving && displayName.isEmpty;
     final visualDisplayName = displayName.isEmpty
         ? UserProfile.defaultDisplayNameFor(otherPubkey)
         : displayName;
@@ -80,7 +81,7 @@ class RequestTile extends ConsumerWidget {
     return Semantics(
       button: true,
       label: context.l10n.inboxRequestTileLabel(
-        isResolving ? context.l10n.commonLoading : displayName,
+        isIdentityResolving ? context.l10n.commonLoading : displayName,
       ),
       child: GestureDetector(
         onTap: () {
@@ -104,7 +105,7 @@ class RequestTile extends ConsumerWidget {
               spacing: 20,
               children: [
                 IdentitySkeletonizer(
-                  isLoading: isResolving,
+                  isLoading: isIdentityResolving,
                   child: Padding(
                     padding: const EdgeInsets.symmetric(vertical: 4),
                     child: UserAvatar(
@@ -126,7 +127,7 @@ class RequestTile extends ConsumerWidget {
                         children: [
                           Expanded(
                             child: IdentitySkeletonizer(
-                              isLoading: isResolving,
+                              isLoading: isIdentityResolving,
                               child: Text(
                                 visualDisplayName,
                                 style: VineTheme.titleMediumFont(

--- a/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
+++ b/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
@@ -39,6 +39,9 @@ class RequestTile extends ConsumerWidget {
     );
 
     final profileAsync = ref.watch(userProfileReactiveProvider(otherPubkey));
+    final isResolving = ref.watch(
+      profileIdentityResolvingProvider(otherPubkey),
+    );
 
     // Same treatment as [ConversationTile]: a request from an account that
     // later vanished is named for the state, not for the generated handle the
@@ -52,7 +55,11 @@ class RequestTile extends ConsumerWidget {
       pubkeyHex: otherPubkey,
       isVanished: isDeleted,
       profile: profileAsync.asData?.value,
+      isResolving: isResolving,
     );
+    final visualDisplayName = displayName.isEmpty
+        ? UserProfile.defaultDisplayNameFor(otherPubkey)
+        : displayName;
 
     final imageUrl = isDeleted
         ? null
@@ -72,7 +79,9 @@ class RequestTile extends ConsumerWidget {
 
     return Semantics(
       button: true,
-      label: context.l10n.inboxRequestTileLabel(displayName),
+      label: context.l10n.inboxRequestTileLabel(
+        isResolving ? context.l10n.commonLoading : displayName,
+      ),
       child: GestureDetector(
         onTap: () {
           Log.debug(
@@ -94,16 +103,19 @@ class RequestTile extends ConsumerWidget {
             child: Row(
               spacing: 20,
               children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 4),
-                  child: UserAvatar(
-                    imageUrl: imageUrl,
-                    name: displayName,
-                    placeholderSeed: otherPubkey,
-                    size: 40,
-                    contentOverride: isModerationAccount(otherPubkey)
-                        ? const ModerationAvatar()
-                        : null,
+                IdentitySkeletonizer(
+                  isLoading: isResolving,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: UserAvatar(
+                      imageUrl: imageUrl,
+                      name: visualDisplayName,
+                      placeholderSeed: otherPubkey,
+                      size: 40,
+                      contentOverride: isModerationAccount(otherPubkey)
+                          ? const ModerationAvatar()
+                          : null,
+                    ),
                   ),
                 ),
                 Expanded(
@@ -113,13 +125,16 @@ class RequestTile extends ConsumerWidget {
                       Row(
                         children: [
                           Expanded(
-                            child: Text(
-                              displayName,
-                              style: VineTheme.titleMediumFont(
-                                color: context.vineColors.primaryText,
+                            child: IdentitySkeletonizer(
+                              isLoading: isResolving,
+                              child: Text(
+                                visualDisplayName,
+                                style: VineTheme.titleMediumFont(
+                                  color: context.vineColors.primaryText,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
                               ),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
                             ),
                           ),
                           if (relativeTime.isNotEmpty) ...[

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -86,7 +86,8 @@ class ConversationTile extends ConsumerWidget {
       profile: profileAsync.asData?.value,
       isResolving: isResolving,
     );
-    final accessibilityName = isResolving
+    final isIdentityResolving = isResolving && displayName.isEmpty;
+    final accessibilityName = isIdentityResolving
         ? context.l10n.commonLoading
         : displayName;
     final visualDisplayName = displayName.isEmpty
@@ -152,7 +153,7 @@ class ConversationTile extends ConsumerWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 IdentitySkeletonizer(
-                  isLoading: isResolving,
+                  isLoading: isIdentityResolving,
                   child: Padding(
                     padding: const EdgeInsets.symmetric(vertical: 4),
                     child: UserAvatar(
@@ -178,7 +179,7 @@ class ConversationTile extends ConsumerWidget {
                         children: [
                           Expanded(
                             child: IdentitySkeletonizer(
-                              isLoading: isResolving,
+                              isLoading: isIdentityResolving,
                               child: DivineHeartText(
                                 visualDisplayName,
                                 style: VineTheme.titleMediumFont(

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -67,6 +67,9 @@ class ConversationTile extends ConsumerWidget {
     );
 
     final profileAsync = ref.watch(fetchUserProfileProvider(otherPubkey));
+    final isResolving = ref.watch(
+      profileIdentityResolvingProvider(otherPubkey),
+    );
 
     // The thread and its history stay — the messages are the viewer's own copy
     // and a NIP-62 vanish cannot retract them. Only the counterparty's identity
@@ -81,7 +84,14 @@ class ConversationTile extends ConsumerWidget {
       isVanished: isDeleted,
       displayNameOverride: displayNameOverride,
       profile: profileAsync.asData?.value,
+      isResolving: isResolving,
     );
+    final accessibilityName = isResolving
+        ? context.l10n.commonLoading
+        : displayName;
+    final visualDisplayName = displayName.isEmpty
+        ? UserProfile.defaultDisplayNameFor(otherPubkey)
+        : displayName;
 
     final imageUrl = isDeleted
         ? null
@@ -105,8 +115,8 @@ class ConversationTile extends ConsumerWidget {
       // preview; mirror it for assistive tech by prefixing the unread status
       // to the row label (same pattern as the notification rows).
       label: conversation.isRead
-          ? context.l10n.inboxConversationTileLabel(displayName)
-          : context.l10n.inboxConversationTileLabelUnread(displayName),
+          ? context.l10n.inboxConversationTileLabel(accessibilityName)
+          : context.l10n.inboxConversationTileLabelUnread(accessibilityName),
       // Only advertise the long-press affordance when there is one: the hint
       // is a promise to assistive tech, and rows built without a handler
       // (the pinned support row) have no action sheet to open.
@@ -141,18 +151,21 @@ class ConversationTile extends ConsumerWidget {
               // not, instead of drifting down with a centered column.
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 4),
-                  child: UserAvatar(
-                    imageUrl: imageUrl,
-                    name: displayName,
-                    placeholderSeed: otherPubkey,
-                    size: 40,
-                    // Bundled artwork for the moderation account, whose kind-0
-                    // picture does not survive the SVG parser.
-                    contentOverride: isModerationAccount(otherPubkey)
-                        ? const ModerationAvatar()
-                        : null,
+                IdentitySkeletonizer(
+                  isLoading: isResolving,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: UserAvatar(
+                      imageUrl: imageUrl,
+                      name: visualDisplayName,
+                      placeholderSeed: otherPubkey,
+                      size: 40,
+                      // Bundled artwork for the moderation account, whose kind-0
+                      // picture does not survive the SVG parser.
+                      contentOverride: isModerationAccount(otherPubkey)
+                          ? const ModerationAvatar()
+                          : null,
+                    ),
                   ),
                 ),
                 const SizedBox(width: 20),
@@ -164,13 +177,16 @@ class ConversationTile extends ConsumerWidget {
                       Row(
                         children: [
                           Expanded(
-                            child: DivineHeartText(
-                              displayName,
-                              style: VineTheme.titleMediumFont(
-                                color: context.vineColors.primaryText,
+                            child: IdentitySkeletonizer(
+                              isLoading: isResolving,
+                              child: DivineHeartText(
+                                visualDisplayName,
+                                style: VineTheme.titleMediumFont(
+                                  color: context.vineColors.primaryText,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
                               ),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
                             ),
                           ),
                           if (relativeTime.isNotEmpty) ...[

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -154,6 +154,7 @@ class ConversationTile extends ConsumerWidget {
               children: [
                 IdentitySkeletonizer(
                   isLoading: isIdentityResolving,
+                  excludeSemantics: true,
                   child: Padding(
                     padding: const EdgeInsets.symmetric(vertical: 4),
                     child: UserAvatar(
@@ -180,6 +181,7 @@ class ConversationTile extends ConsumerWidget {
                           Expanded(
                             child: IdentitySkeletonizer(
                               isLoading: isIdentityResolving,
+                              excludeSemantics: true,
                               child: DivineHeartText(
                                 visualDisplayName,
                                 style: VineTheme.titleMediumFont(

--- a/mobile/lib/screens/inbox/widgets/dm_peer_identity.dart
+++ b/mobile/lib/screens/inbox/widgets/dm_peer_identity.dart
@@ -57,6 +57,7 @@ String dmPeerDisplayName(
   required bool isVanished,
   UserProfile? profile,
   String? displayNameOverride,
+  bool isResolving = false,
 }) => dmPeerName(
   pubkeyHex: pubkeyHex,
   isVanished: isVanished,
@@ -64,4 +65,5 @@ String dmPeerDisplayName(
   labels: dmPeerLabels(context),
   profileName: profile?.bestDisplayName,
   displayNameOverride: displayNameOverride,
+  isResolving: isResolving,
 );

--- a/mobile/lib/screens/inbox/widgets/dm_peer_identity.dart
+++ b/mobile/lib/screens/inbox/widgets/dm_peer_identity.dart
@@ -63,7 +63,13 @@ String dmPeerDisplayName(
   isVanished: isVanished,
   isModeration: isModerationAccount(pubkeyHex),
   labels: dmPeerLabels(context),
-  profileName: profile?.bestDisplayName,
+  profileName: switch (profile) {
+    UserProfile(displayName: final name?) when name.isNotEmpty =>
+      UserProfile.sanitizeDisplayName(name),
+    UserProfile(name: final name?) when name.isNotEmpty =>
+      UserProfile.sanitizeDisplayName(name),
+    _ => null,
+  },
   displayNameOverride: displayNameOverride,
   isResolving: isResolving,
 );

--- a/mobile/lib/screens/inbox/widgets/following_bar.dart
+++ b/mobile/lib/screens/inbox/widgets/following_bar.dart
@@ -6,6 +6,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:models/models.dart';
 import 'package:nostr_sdk/nip19/pubkeys_equal.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
@@ -84,6 +85,7 @@ class _FollowingUserButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final profileAsync = ref.watch(fetchUserProfileProvider(pubkey));
+    final isResolving = ref.watch(profileIdentityResolvingProvider(pubkey));
 
     // A vanish cannot rewrite the viewer's own contact list, so the account
     // stays in this bar. Show it as deleted rather than under a stale name.
@@ -96,7 +98,11 @@ class _FollowingUserButton extends ConsumerWidget {
       pubkeyHex: pubkey,
       isVanished: isDeleted,
       profile: profileAsync.asData?.value,
+      isResolving: isResolving,
     );
+    final visualDisplayName = displayName.isEmpty
+        ? UserProfile.defaultDisplayNameFor(pubkey)
+        : displayName;
 
     final imageUrl = isDeleted
         ? null
@@ -113,33 +119,36 @@ class _FollowingUserButton extends ConsumerWidget {
           mainAxisSize: MainAxisSize.min,
           spacing: 8,
           children: [
-            UserAvatar(
-              imageUrl: imageUrl,
-              name: displayName,
-              placeholderSeed: pubkey,
-              size: 48,
+            IdentitySkeletonizer(
+              isLoading: isResolving,
+              child: UserAvatar(
+                imageUrl: imageUrl,
+                name: visualDisplayName,
+                placeholderSeed: pubkey,
+                size: 48,
+              ),
             ),
-            Text(
-              displayName,
-              textScaler: TextScaler.noScaling,
-              style:
-                  VineTheme.bodySmallFont(
-                    color: context.vineColors.onSurfaceVariant,
-                  ).copyWith(
-                    fontSize:
-                        MediaQuery.textScalerOf(
-                              context,
-                            )
-                            .scale(
-                              VineTheme.bodySmallFont(
-                                color: context.vineColors.primaryText,
-                              ).fontSize!,
-                            )
-                            .clamp(0, 18),
-                  ),
-              textAlign: TextAlign.center,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
+            IdentitySkeletonizer(
+              isLoading: isResolving,
+              child: Text(
+                visualDisplayName,
+                textScaler: TextScaler.noScaling,
+                style:
+                    VineTheme.bodySmallFont(
+                      color: context.vineColors.onSurfaceVariant,
+                    ).copyWith(
+                      fontSize: MediaQuery.textScalerOf(context)
+                          .scale(
+                            VineTheme.bodySmallFont(
+                              color: context.vineColors.primaryText,
+                            ).fontSize!,
+                          )
+                          .clamp(0, 18),
+                    ),
+                textAlign: TextAlign.center,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
           ],
         ),

--- a/mobile/lib/screens/inbox/widgets/following_bar.dart
+++ b/mobile/lib/screens/inbox/widgets/following_bar.dart
@@ -100,6 +100,7 @@ class _FollowingUserButton extends ConsumerWidget {
       profile: profileAsync.asData?.value,
       isResolving: isResolving,
     );
+    final isIdentityResolving = isResolving && displayName.isEmpty;
     final visualDisplayName = displayName.isEmpty
         ? UserProfile.defaultDisplayNameFor(pubkey)
         : displayName;
@@ -120,7 +121,7 @@ class _FollowingUserButton extends ConsumerWidget {
           spacing: 8,
           children: [
             IdentitySkeletonizer(
-              isLoading: isResolving,
+              isLoading: isIdentityResolving,
               child: UserAvatar(
                 imageUrl: imageUrl,
                 name: visualDisplayName,
@@ -129,7 +130,7 @@ class _FollowingUserButton extends ConsumerWidget {
               ),
             ),
             IdentitySkeletonizer(
-              isLoading: isResolving,
+              isLoading: isIdentityResolving,
               child: Text(
                 visualDisplayName,
                 textScaler: TextScaler.noScaling,

--- a/mobile/lib/screens/inbox/widgets/following_bar.dart
+++ b/mobile/lib/screens/inbox/widgets/following_bar.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
 import 'package:nostr_sdk/nip19/pubkeys_equal.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/widgets/dm_peer_identity.dart';
 import 'package:openvine/widgets/user_avatar.dart';
@@ -112,48 +113,52 @@ class _FollowingUserButton extends ConsumerWidget {
             orElse: () => null,
           );
 
-    return GestureDetector(
-      onTap: onTap,
-      child: SizedBox(
-        width: 72,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          spacing: 8,
-          children: [
-            IdentitySkeletonizer(
-              isLoading: isIdentityResolving,
-              excludeSemantics: true,
-              child: UserAvatar(
-                imageUrl: imageUrl,
-                name: visualDisplayName,
-                placeholderSeed: pubkey,
-                size: 48,
+    return Semantics(
+      button: true,
+      label: isIdentityResolving ? context.l10n.commonLoading : displayName,
+      child: GestureDetector(
+        onTap: onTap,
+        child: SizedBox(
+          width: 72,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            spacing: 8,
+            children: [
+              IdentitySkeletonizer(
+                isLoading: isIdentityResolving,
+                excludeSemantics: true,
+                child: UserAvatar(
+                  imageUrl: imageUrl,
+                  name: visualDisplayName,
+                  placeholderSeed: pubkey,
+                  size: 48,
+                ),
               ),
-            ),
-            IdentitySkeletonizer(
-              isLoading: isIdentityResolving,
-              excludeSemantics: true,
-              child: Text(
-                visualDisplayName,
-                textScaler: TextScaler.noScaling,
-                style:
-                    VineTheme.bodySmallFont(
-                      color: context.vineColors.onSurfaceVariant,
-                    ).copyWith(
-                      fontSize: MediaQuery.textScalerOf(context)
-                          .scale(
-                            VineTheme.bodySmallFont(
-                              color: context.vineColors.primaryText,
-                            ).fontSize!,
-                          )
-                          .clamp(0, 18),
-                    ),
-                textAlign: TextAlign.center,
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
+              IdentitySkeletonizer(
+                isLoading: isIdentityResolving,
+                excludeSemantics: true,
+                child: Text(
+                  visualDisplayName,
+                  textScaler: TextScaler.noScaling,
+                  style:
+                      VineTheme.bodySmallFont(
+                        color: context.vineColors.onSurfaceVariant,
+                      ).copyWith(
+                        fontSize: MediaQuery.textScalerOf(context)
+                            .scale(
+                              VineTheme.bodySmallFont(
+                                color: context.vineColors.primaryText,
+                              ).fontSize!,
+                            )
+                            .clamp(0, 18),
+                      ),
+                  textAlign: TextAlign.center,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/screens/inbox/widgets/following_bar.dart
+++ b/mobile/lib/screens/inbox/widgets/following_bar.dart
@@ -122,6 +122,7 @@ class _FollowingUserButton extends ConsumerWidget {
           children: [
             IdentitySkeletonizer(
               isLoading: isIdentityResolving,
+              excludeSemantics: true,
               child: UserAvatar(
                 imageUrl: imageUrl,
                 name: visualDisplayName,
@@ -131,6 +132,7 @@ class _FollowingUserButton extends ConsumerWidget {
             ),
             IdentitySkeletonizer(
               isLoading: isIdentityResolving,
+              excludeSemantics: true,
               child: Text(
                 visualDisplayName,
                 textScaler: TextScaler.noScaling,

--- a/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
@@ -503,9 +503,13 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
     );
   }
 
-  String get _composerHint => _ctx.isOwnMessage
-      ? context.l10n.dmReelReplyComposerHintSelf
-      : context.l10n.dmReelReplyComposerHint(_ctx.hintName);
+  String get _composerHint {
+    if (_ctx.isOwnMessage) return context.l10n.dmReelReplyComposerHintSelf;
+    if (_ctx.hintName.isEmpty) {
+      return context.l10n.dmReelReplyComposerSemanticLabel;
+    }
+    return context.l10n.dmReelReplyComposerHint(_ctx.hintName);
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/packages/divine_ui/lib/src/skeleton/identity_skeletonizer.dart
+++ b/mobile/packages/divine_ui/lib/src/skeleton/identity_skeletonizer.dart
@@ -28,6 +28,7 @@ class IdentitySkeletonizer extends StatefulWidget {
     required this.isLoading,
     required this.child,
     this.fallthroughTimeout = const Duration(seconds: 7),
+    this.excludeSemantics = false,
     super.key,
   });
 
@@ -41,6 +42,12 @@ class IdentitySkeletonizer extends StatefulWidget {
   /// who genuinely has no Kind 0 sees the underlying generated-name
   /// fallback instead of an infinite shimmer.
   final Duration fallthroughTimeout;
+
+  /// Hides placeholder identity semantics while the shimmer is active.
+  ///
+  /// Opt in only when the child is wholly placeholder content. Interactive
+  /// [Skeleton.keep] descendants must remain available to assistive tech.
+  final bool excludeSemantics;
 
   /// The avatar + name subtree to skeletonize.
   final Widget child;
@@ -87,14 +94,13 @@ class _IdentitySkeletonizerState extends State<IdentitySkeletonizer> {
   @override
   Widget build(BuildContext context) {
     final isSkeletonized = widget.isLoading && !_timeoutExpired;
-    return ExcludeSemantics(
-      excluding: isSkeletonized,
-      child: Skeletonizer(
-        enabled: isSkeletonized,
-        enableSwitchAnimation: true,
-        effect: vineSkeletonEffectOf(context),
-        child: widget.child,
-      ),
+    final skeleton = Skeletonizer(
+      enabled: isSkeletonized,
+      enableSwitchAnimation: true,
+      effect: vineSkeletonEffectOf(context),
+      child: widget.child,
     );
+    if (!widget.excludeSemantics) return skeleton;
+    return ExcludeSemantics(excluding: isSkeletonized, child: skeleton);
   }
 }

--- a/mobile/packages/divine_ui/lib/src/skeleton/identity_skeletonizer.dart
+++ b/mobile/packages/divine_ui/lib/src/skeleton/identity_skeletonizer.dart
@@ -86,11 +86,15 @@ class _IdentitySkeletonizerState extends State<IdentitySkeletonizer> {
 
   @override
   Widget build(BuildContext context) {
-    return Skeletonizer(
-      enabled: widget.isLoading && !_timeoutExpired,
-      enableSwitchAnimation: true,
-      effect: vineSkeletonEffectOf(context),
-      child: widget.child,
+    final isSkeletonized = widget.isLoading && !_timeoutExpired;
+    return ExcludeSemantics(
+      excluding: isSkeletonized,
+      child: Skeletonizer(
+        enabled: isSkeletonized,
+        enableSwitchAnimation: true,
+        effect: vineSkeletonEffectOf(context),
+        child: widget.child,
+      ),
     );
   }
 }

--- a/mobile/packages/divine_ui/test/src/skeleton/identity_skeletonizer_test.dart
+++ b/mobile/packages/divine_ui/test/src/skeleton/identity_skeletonizer_test.dart
@@ -8,12 +8,14 @@ void main() {
     Widget buildSubject({
       required bool isLoading,
       Duration fallthroughTimeout = const Duration(seconds: 7),
+      bool excludeSemantics = false,
     }) {
       return MaterialApp(
         home: Scaffold(
           body: IdentitySkeletonizer(
             isLoading: isLoading,
             fallthroughTimeout: fallthroughTimeout,
+            excludeSemantics: excludeSemantics,
             child: Semantics(
               label: 'Identity',
               child: const SizedBox.square(dimension: 64, key: Key('child')),
@@ -47,7 +49,15 @@ void main() {
       expect(findSkeletonizer(tester).enabled, isTrue);
     });
 
-    testWidgets('hides placeholder semantics only while shimmering', (
+    testWidgets('keeps semantics by default while shimmering', (tester) async {
+      final semantics = tester.ensureSemantics();
+      await tester.pumpWidget(buildSubject(isLoading: true));
+
+      expect(find.bySemanticsLabel('Identity'), findsOneWidget);
+      semantics.dispose();
+    });
+
+    testWidgets('can hide placeholder semantics only while shimmering', (
       tester,
     ) async {
       final semantics = tester.ensureSemantics();
@@ -55,6 +65,7 @@ void main() {
         buildSubject(
           isLoading: true,
           fallthroughTimeout: const Duration(seconds: 3),
+          excludeSemantics: true,
         ),
       );
 

--- a/mobile/packages/divine_ui/test/src/skeleton/identity_skeletonizer_test.dart
+++ b/mobile/packages/divine_ui/test/src/skeleton/identity_skeletonizer_test.dart
@@ -14,7 +14,10 @@ void main() {
           body: IdentitySkeletonizer(
             isLoading: isLoading,
             fallthroughTimeout: fallthroughTimeout,
-            child: const SizedBox.square(dimension: 64, key: Key('child')),
+            child: Semantics(
+              label: 'Identity',
+              child: const SizedBox.square(dimension: 64, key: Key('child')),
+            ),
           ),
         ),
       );
@@ -42,6 +45,26 @@ void main() {
       await tester.pumpWidget(buildSubject(isLoading: true));
 
       expect(findSkeletonizer(tester).enabled, isTrue);
+    });
+
+    testWidgets('hides placeholder semantics only while shimmering', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+      await tester.pumpWidget(
+        buildSubject(
+          isLoading: true,
+          fallthroughTimeout: const Duration(seconds: 3),
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Identity'), findsNothing);
+
+      await tester.pump(const Duration(seconds: 4));
+
+      expect(find.bySemanticsLabel('Identity'), findsOneWidget);
+      await tester.pumpAndSettle();
+      semantics.dispose();
     });
 
     testWidgets(

--- a/mobile/test/blocs/dm/dm_peer_name_test.dart
+++ b/mobile/test/blocs/dm/dm_peer_name_test.dart
@@ -72,6 +72,23 @@ void main() {
         );
       });
 
+      test(
+        'a resolved profile name remains visible while other reads load',
+        () {
+          expect(
+            dmPeerName(
+              pubkeyHex: _ordinaryPubkey,
+              isVanished: false,
+              isModeration: false,
+              labels: _labels,
+              profileName: 'Kind Zero Name',
+              isResolving: true,
+            ),
+            equals('Kind Zero Name'),
+          );
+        },
+      );
+
       test('the generated fallback answers when nothing else does', () {
         expect(
           dmPeerName(

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -433,6 +433,10 @@ List<dynamic> getStandardTestOverrides({
     // again with `additionalOverrides`.
     profileVanishedProvider.overrideWith((ref, pubkey) => Stream.value(false)),
     profileVanishedSnapshotProvider.overrideWith((ref, pubkey) async => false),
+    // Existing widget fixtures provide profiles through their original
+    // reactive/one-shot provider. Keep the new derived loading signal settled
+    // by default; loading-specific tests override this provider explicitly.
+    profileIdentityResolvingProvider.overrideWith((ref, pubkey) => false),
 
     // ONLY override other service providers if explicitly requested
     if (mockAuthService != null)

--- a/mobile/test/providers/user_profile_providers_test.dart
+++ b/mobile/test/providers/user_profile_providers_test.dart
@@ -99,6 +99,9 @@ void main() {
       when(
         () => profileRepository.fetchFreshProfile(pubkey: pubkey),
       ).thenAnswer((_) => fetch.future);
+      when(
+        () => profileRepository.watchProfile(pubkey: pubkey),
+      ).thenAnswer((_) => Stream.value(null));
 
       final container = ProviderContainer(
         overrides: [
@@ -106,17 +109,102 @@ void main() {
         ],
       );
       addTearDown(container.dispose);
-
-      expect(
-        container.read(profileIdentityResolvingProvider(pubkey)),
-        isTrue,
+      final subscription = container.listen(
+        profileIdentityResolvingProvider(pubkey),
+        (_, _) {},
+        fireImmediately: true,
       );
+      addTearDown(subscription.close);
+
+      expect(subscription.read(), isTrue);
 
       fetch.complete(null);
       await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(subscription.read(), isFalse);
+    });
+
+    test(
+      'stays resolving until the one-shot and reactive reads both settle',
+      () async {
+        final profileRepository = _MockProfileRepository();
+        final fetch = Completer<UserProfile?>();
+        final profiles = StreamController<UserProfile?>();
+        addTearDown(profiles.close);
+        when(
+          () => profileRepository.getCachedProfile(pubkey: pubkey),
+        ).thenAnswer((_) async => null);
+        when(
+          () => profileRepository.fetchFreshProfile(pubkey: pubkey),
+        ).thenAnswer((_) => fetch.future);
+        when(
+          () => profileRepository.watchProfile(pubkey: pubkey),
+        ).thenAnswer((_) => profiles.stream);
+
+        final container = ProviderContainer(
+          overrides: [
+            profileReadRepositoryProvider.overrideWithValue(profileRepository),
+          ],
+        );
+        addTearDown(container.dispose);
+        final subscription = container.listen(
+          profileIdentityResolvingProvider(pubkey),
+          (_, _) {},
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+
+        fetch.complete(null);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(subscription.read(), isTrue);
+
+        profiles.add(null);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(subscription.read(), isFalse);
+      },
+    );
+
+    test('releases profile watchers after the last listener closes', () async {
+      final profileRepository = _MockProfileRepository();
+      final profiles = StreamController<UserProfile?>();
+      addTearDown(profiles.close);
+      when(
+        () => profileRepository.getCachedProfile(pubkey: pubkey),
+      ).thenAnswer((_) async => null);
+      when(
+        () => profileRepository.fetchFreshProfile(pubkey: pubkey),
+      ).thenAnswer((_) async => null);
+      when(
+        () => profileRepository.watchProfile(pubkey: pubkey),
+      ).thenAnswer((_) => profiles.stream);
+
+      final container = ProviderContainer(
+        overrides: [
+          profileReadRepositoryProvider.overrideWithValue(profileRepository),
+        ],
+      );
+      addTearDown(container.dispose);
+      final subscription = container.listen(
+        profileIdentityResolvingProvider(pubkey),
+        (_, _) {},
+        fireImmediately: true,
+      );
 
       expect(
-        container.read(profileIdentityResolvingProvider(pubkey)),
+        container.exists(profileIdentityResolvingProvider(pubkey)),
+        isTrue,
+      );
+
+      subscription.close();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        container.exists(profileIdentityResolvingProvider(pubkey)),
         isFalse,
       );
     });

--- a/mobile/test/providers/user_profile_providers_test.dart
+++ b/mobile/test/providers/user_profile_providers_test.dart
@@ -77,6 +77,51 @@ void main() {
     });
   });
 
+  group('profileIdentityResolvingProvider', () {
+    test('stays resolving while the read repository is unavailable', () {
+      final container = ProviderContainer(
+        overrides: [profileReadRepositoryProvider.overrideWithValue(null)],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(profileIdentityResolvingProvider(pubkey)),
+        isTrue,
+      );
+    });
+
+    test('stops resolving after a fresh profile fetch settles', () async {
+      final profileRepository = _MockProfileRepository();
+      final fetch = Completer<UserProfile?>();
+      when(
+        () => profileRepository.getCachedProfile(pubkey: pubkey),
+      ).thenAnswer((_) async => null);
+      when(
+        () => profileRepository.fetchFreshProfile(pubkey: pubkey),
+      ).thenAnswer((_) => fetch.future);
+
+      final container = ProviderContainer(
+        overrides: [
+          profileReadRepositoryProvider.overrideWithValue(profileRepository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(profileIdentityResolvingProvider(pubkey)),
+        isTrue,
+      );
+
+      fetch.complete(null);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        container.read(profileIdentityResolvingProvider(pubkey)),
+        isFalse,
+      );
+    });
+  });
+
   group('userProfileReactiveProvider', () {
     late _MockProfileRepository profileRepository;
     late ProviderContainer container;

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -186,6 +186,7 @@ void main() {
       DmRestoreStatusState? restoreStatus,
       String counterparty = otherPubkey,
       ConversationState? previousState,
+      bool isIdentityResolving = false,
     }) {
       final effectiveState = state ?? const ConversationState();
       if (restoreStatus != null) {
@@ -221,6 +222,9 @@ void main() {
           profileVanishedProvider(
             counterparty,
           ).overrideWith((ref) => Stream.value(otherProfileVanished)),
+          profileIdentityResolvingProvider(
+            counterparty,
+          ).overrideWithValue(isIdentityResolving),
           // The view now reads the blocklist eagerly in build() to filter
           // reaction reactors, so every pump needs a stubbed repository.
           contentBlocklistRepositoryProvider.overrideWithValue(mockBlocklist),
@@ -668,6 +672,20 @@ void main() {
         await tester.pump();
 
         expect(find.byType(ConversationAppBar), findsOneWidget);
+      });
+
+      testWidgets('disables profile options while the peer name resolves', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildSubject(isIdentityResolving: true));
+        await tester.pump();
+
+        expect(
+          tester
+              .widget<ConversationAppBar>(find.byType(ConversationAppBar))
+              .onOptions,
+          isNull,
+        );
       });
 
       testWidgets('renders $MessageInputBar', (tester) async {

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -34,6 +34,7 @@ import 'package:openvine/screens/inbox/conversation/conversation_view.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/widgets.dart';
 import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/services/watermark_download_service.dart';
+import 'package:openvine/widgets/profile/more_sheet/more_sheet_content.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:videos_repository/videos_repository.dart';
 import 'package:visibility_detector/visibility_detector.dart';
@@ -186,6 +187,7 @@ void main() {
       DmRestoreStatusState? restoreStatus,
       String counterparty = otherPubkey,
       ConversationState? previousState,
+      Future<UserProfile?>? otherProfileFuture,
       bool isIdentityResolving = false,
     }) {
       final effectiveState = state ?? const ConversationState();
@@ -218,10 +220,15 @@ void main() {
           profileReadRepositoryProvider.overrideWithValue(null),
           fetchUserProfileProvider(
             counterparty,
-          ).overrideWith((ref) async => otherProfile),
+          ).overrideWith(
+            (ref) => otherProfileFuture ?? Future.value(otherProfile),
+          ),
           profileVanishedProvider(
             counterparty,
           ).overrideWith((ref) => Stream.value(otherProfileVanished)),
+          profileVanishedSnapshotProvider(
+            counterparty,
+          ).overrideWith((ref) async => otherProfileVanished),
           profileIdentityResolvingProvider(
             counterparty,
           ).overrideWithValue(isIdentityResolving),
@@ -674,19 +681,34 @@ void main() {
         expect(find.byType(ConversationAppBar), findsOneWidget);
       });
 
-      testWidgets('disables profile options while the peer name resolves', (
-        tester,
-      ) async {
-        await tester.pumpWidget(buildSubject(isIdentityResolving: true));
-        await tester.pump();
+      testWidgets(
+        'waits for the peer identity before opening profile options',
+        (
+          tester,
+        ) async {
+          final profileCompleter = Completer<UserProfile?>();
+          await tester.pumpWidget(
+            buildSubject(
+              otherProfileFuture: profileCompleter.future,
+              isIdentityResolving: true,
+            ),
+          );
+          await tester.pump();
 
-        expect(
-          tester
-              .widget<ConversationAppBar>(find.byType(ConversationAppBar))
-              .onOptions,
-          isNull,
-        );
-      });
+          await tester.tap(
+            find.bySemanticsLabel(l10n.inboxConversationOptionsLabel),
+          );
+          await tester.pump();
+
+          expect(find.byType(MoreSheetContent), findsNothing);
+
+          profileCompleter.complete(null);
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 400));
+
+          expect(find.byType(MoreSheetContent), findsOneWidget);
+        },
+      );
 
       testWidgets('renders $MessageInputBar', (tester) async {
         await tester.pumpWidget(buildSubject());

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -188,6 +188,7 @@ void main() {
       String counterparty = otherPubkey,
       ConversationState? previousState,
       Future<UserProfile?>? otherProfileFuture,
+      Future<bool>? otherProfileVanishedFuture,
       bool isIdentityResolving = false,
     }) {
       final effectiveState = state ?? const ConversationState();
@@ -228,7 +229,11 @@ void main() {
           ).overrideWith((ref) => Stream.value(otherProfileVanished)),
           profileVanishedSnapshotProvider(
             counterparty,
-          ).overrideWith((ref) async => otherProfileVanished),
+          ).overrideWith(
+            (ref) =>
+                otherProfileVanishedFuture ??
+                Future.value(otherProfileVanished),
+          ),
           profileIdentityResolvingProvider(
             counterparty,
           ).overrideWithValue(isIdentityResolving),
@@ -698,6 +703,9 @@ void main() {
           await tester.tap(
             find.bySemanticsLabel(l10n.inboxConversationOptionsLabel),
           );
+          await tester.tap(
+            find.bySemanticsLabel(l10n.inboxConversationOptionsLabel),
+          );
           await tester.pump();
 
           expect(find.byType(MoreSheetContent), findsNothing);
@@ -709,6 +717,54 @@ void main() {
           expect(find.byType(MoreSheetContent), findsOneWidget);
         },
       );
+
+      testWidgets('opens profile options when identity lookups fail', (
+        tester,
+      ) async {
+        final profileCompleter = Completer<UserProfile?>();
+        final vanishedCompleter = Completer<bool>();
+        await tester.pumpWidget(
+          buildSubject(
+            otherProfileFuture: profileCompleter.future,
+            otherProfileVanishedFuture: vanishedCompleter.future,
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(
+          find.bySemanticsLabel(l10n.inboxConversationOptionsLabel),
+        );
+        await tester.pump();
+        vanishedCompleter.completeError(StateError('vanish read failed'));
+        await tester.pump();
+        profileCompleter.completeError(StateError('profile read failed'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.byType(MoreSheetContent), findsOneWidget);
+      });
+
+      testWidgets('opens known moderation options without awaiting a profile', (
+        tester,
+      ) async {
+        final profileCompleter = Completer<UserProfile?>();
+        await tester.pumpWidget(
+          buildSubject(
+            counterparty: kModerationPubkeyHex,
+            otherProfileFuture: profileCompleter.future,
+            isIdentityResolving: true,
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(
+          find.bySemanticsLabel(l10n.inboxConversationOptionsLabel),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.byType(MoreSheetContent), findsOneWidget);
+      });
 
       testWidgets('renders $MessageInputBar', (tester) async {
         await tester.pumpWidget(buildSubject());

--- a/mobile/test/screens/inbox/conversation/widgets/conversation_app_bar_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/conversation_app_bar_test.dart
@@ -11,6 +11,7 @@ void main() {
       String handle = '@alice',
       VoidCallback? onBack,
       VoidCallback? onOptions,
+      bool isResolving = false,
     }) {
       return MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -21,6 +22,8 @@ void main() {
             handle: handle,
             onBack: onBack ?? () {},
             onOptions: onOptions ?? () {},
+            isResolving: isResolving,
+            loadingDisplayName: 'Generated Name',
           ),
         ),
       );
@@ -50,6 +53,17 @@ void main() {
 
         expect(find.text('Alice'), findsOneWidget);
         expect(find.text(''), findsNothing);
+      });
+
+      testWidgets('announces loading instead of the placeholder identity', (
+        tester,
+      ) async {
+        final semantics = tester.ensureSemantics();
+        await tester.pumpWidget(buildSubject(isResolving: true));
+
+        expect(find.bySemanticsLabel('Loading'), findsOneWidget);
+        expect(find.bySemanticsLabel('Generated Name'), findsNothing);
+        semantics.dispose();
       });
     });
 

--- a/mobile/test/screens/inbox/conversation/widgets/empty_conversation_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/empty_conversation_test.dart
@@ -100,6 +100,29 @@ void main() {
 
         expect(find.text('View profile'), findsOneWidget);
       });
+
+      testWidgets('announces loading instead of the placeholder identity', (
+        tester,
+      ) async {
+        final semantics = tester.ensureSemantics();
+        await tester.pumpWidget(
+          const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: EmptyConversation(
+                displayName: 'Generated Name',
+                pubkey: 'pk1',
+                isIdentityResolving: true,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.bySemanticsLabel('Loading'), findsOneWidget);
+        expect(find.bySemanticsLabel('Generated Name'), findsNothing);
+        semantics.dispose();
+      });
     });
 
     group('interactions', () {

--- a/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
+++ b/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
@@ -12,6 +12,7 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/widgets/conversation_tile.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 import '../../../helpers/test_provider_overrides.dart';
 
@@ -121,6 +122,54 @@ void main() {
 
         expect(find.text('Alice'), findsOneWidget);
       });
+
+      testWidgets(
+        'uses a loading identity before revealing the generated fallback',
+        (tester) async {
+          final testConversation = createTestConversation();
+          final generatedName = UserProfile.defaultDisplayNameFor(otherPubkey);
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              additionalOverrides: [
+                fetchUserProfileProvider(
+                  otherPubkey,
+                ).overrideWith((ref) async => null),
+                profileIdentityResolvingProvider(
+                  otherPubkey,
+                ).overrideWithValue(true),
+              ],
+              home: Scaffold(
+                body: ConversationTile(
+                  conversation: testConversation,
+                  currentUserPubkey: currentPubkey,
+                  onTap: () {},
+                ),
+              ),
+            ),
+          );
+          await tester.pump();
+
+          expect(tileSemantics(tester).label, contains('Loading'));
+          expect(
+            tester
+                .widgetList<Skeletonizer>(find.bySubtype<Skeletonizer>())
+                .every((skeletonizer) => skeletonizer.enabled),
+            isTrue,
+          );
+
+          await tester.pump(const Duration(seconds: 8));
+          await tester.pumpAndSettle();
+
+          expect(find.text(generatedName), findsOneWidget);
+          expect(
+            tester
+                .widgetList<Skeletonizer>(find.bySubtype<Skeletonizer>())
+                .every((skeletonizer) => !skeletonizer.enabled),
+            isTrue,
+          );
+        },
+      );
 
       testWidgets('paints a brand-green heart in a display name', (
         tester,

--- a/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
+++ b/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
@@ -1146,6 +1146,8 @@ void main() {
         WidgetTester tester, {
         required bool vanished,
         Locale? locale,
+        bool identityResolving = false,
+        bool settle = true,
       }) async {
         await tester.pumpWidget(
           testMaterialApp(
@@ -1157,6 +1159,9 @@ void main() {
               profileVanishedProvider(
                 otherPubkey,
               ).overrideWith((ref) => Stream.value(vanished)),
+              profileIdentityResolvingProvider(
+                otherPubkey,
+              ).overrideWithValue(identityResolving),
             ],
             home: Scaffold(
               body: ConversationTile(
@@ -1170,7 +1175,12 @@ void main() {
             ),
           ),
         );
-        await tester.pumpAndSettle();
+        if (settle) {
+          await tester.pumpAndSettle();
+        } else {
+          await tester.pump();
+          await tester.pump();
+        }
       }
 
       testWidgets('replaces the display name for a deleted account', (
@@ -1197,6 +1207,30 @@ void main() {
         await pumpTile(tester, vanished: true);
 
         expect(find.byType(VineCachedImage), findsNothing);
+      });
+
+      testWidgets('does not hide a deleted identity behind profile loading', (
+        tester,
+      ) async {
+        await pumpTile(
+          tester,
+          vanished: true,
+          identityResolving: true,
+          settle: false,
+        );
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.profileDeletedAccountName), findsOneWidget);
+        expect(
+          tileSemantics(tester).label,
+          contains(l10n.profileDeletedAccountName),
+        );
+        expect(
+          tester
+              .widgetList<Skeletonizer>(find.bySubtype<Skeletonizer>())
+              .every((skeletonizer) => !skeletonizer.enabled),
+          isTrue,
+        );
       });
 
       testWidgets('leaves a live account untouched', (tester) async {

--- a/mobile/test/screens/inbox/widgets/dm_peer_identity_test.dart
+++ b/mobile/test/screens/inbox/widgets/dm_peer_identity_test.dart
@@ -86,6 +86,28 @@ void main() {
       expect(find.text('Profile'), findsOneWidget);
     });
 
+    testWidgets('withholds a generated profile fallback while resolving', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildSubject(
+          (context) => dmPeerDisplayName(
+            context,
+            pubkeyHex: pubkey,
+            isVanished: false,
+            profile: _profile(pubkey, ''),
+            isResolving: true,
+          ),
+        ),
+      );
+
+      expect(
+        find.text(UserProfile.defaultDisplayNameFor(pubkey)),
+        findsNothing,
+      );
+      expect(find.text(''), findsOneWidget);
+    });
+
     testWidgets('generates a name when no identity is available', (
       tester,
     ) async {

--- a/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
@@ -30,15 +30,16 @@ const _peer =
 const _reelId =
     'rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr';
 
-DmReplyContext context({bool isOwn = false}) => DmReplyContext(
-  conversationId: 'convo-id',
-  participantPubkeys: const [_peer],
-  isGroup: false,
-  sharedReelMessageId: _reelId,
-  messageAuthorPubkey: _peer,
-  hintName: 'Alice',
-  isOwnMessage: isOwn,
-);
+DmReplyContext context({bool isOwn = false, String hintName = 'Alice'}) =>
+    DmReplyContext(
+      conversationId: 'convo-id',
+      participantPubkeys: const [_peer],
+      isGroup: false,
+      sharedReelMessageId: _reelId,
+      messageAuthorPubkey: _peer,
+      hintName: hintName,
+      isOwnMessage: isOwn,
+    );
 
 void main() {
   late _MockDmRepository dmRepo;
@@ -149,6 +150,18 @@ void main() {
       await tester.pump();
       final l10n = lookupAppLocalizations(const Locale('en'));
       expect(find.text(l10n.dmReelReplyComposerHint('Alice')), findsOneWidget);
+    });
+
+    testWidgets('shows a generic hint while the peer name resolves', (
+      tester,
+    ) async {
+      await tester.pumpWidget(wrap(context(hintName: '')));
+      await tester.pump();
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(
+        find.text(l10n.dmReelReplyComposerSemanticLabel),
+        findsOneWidget,
+      );
     });
 
     testWidgets('shows "reply to yourself" hint on own reel', (tester) async {


### PR DESCRIPTION
## Problem
DM surfaces briefly showed deterministic generated handles such as Adjective Animal N while a peer profile was still unresolved. That made a loading state look like a real identity.

## Fix
- Add a synchronous profile identity resolving signal that covers the repository cold-start window as well as in-flight profile fetches.
- Carry that state through the DM naming chain while preserving vanished-account, moderation, and explicit display-name precedence.
- Use the existing IdentitySkeletonizer treatment for avatar/name slots and announce the localized loading label to assistive technology.
- Keep generated names as the visual skeleton fallback and in the conversation search index, so the 7-second fallthrough remains consistent with the rendered row.

## Scope
The conversation options path now resolves identity before opening, skips unnecessary profile fetches for known identities, and falls back without hiding safety actions when lookup fails. Snackbar behavior is unchanged. No new localization key or generated code was needed; the existing common loading label is reused.

## Verification
- Full `flutter analyze`
- Focused DM naming/provider tests
- Affected inbox, conversation, and reply widget suites (261 tests in pre-push verification)
- `divine_ui` identity skeletonizer tests
- Repository pre-commit and pre-push checks

Fixes #8385
