### PR TITLE
fix(likes): bind a reaction to the last e tag per NIP-25

### DIFF
--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -1436,13 +1436,9 @@ class LikesRepository {
     }
 
     for (final event in eventsByE) {
-      for (final tag in event.tags) {
-        if (tag.isNotEmpty && tag[0] == 'e' && tag.length > 1) {
-          final targetId = tag[1];
-          if (uncachedIdSet.contains(targetId)) {
-            counts[targetId] = (counts[targetId] ?? 0) + 1;
-          }
-        }
+      final targetId = _extractTargetEventId(event);
+      if (targetId != null && uncachedIdSet.contains(targetId)) {
+        counts[targetId] = (counts[targetId] ?? 0) + 1;
       }
     }
 
@@ -2397,14 +2393,17 @@ class LikesRepository {
     required Set<String> eventIdSet,
     required Map<String, String> aTagToEventId,
   }) {
+    final targetEventId = _extractTargetEventId(event);
+    if (targetEventId != null && eventIdSet.contains(targetEventId)) {
+      return {targetEventId};
+    }
+
     final targetIds = <String>{};
     for (final tag in event.tags) {
       if (tag.length <= 1) continue;
       final marker = tag[0];
       final value = tag[1];
-      if (marker == 'e' && eventIdSet.contains(value)) {
-        targetIds.add(value);
-      } else if (marker == 'a') {
+      if (marker == 'a') {
         final eventId = aTagToEventId[value];
         if (eventId != null) targetIds.add(eventId);
       }
@@ -2773,8 +2772,9 @@ class LikesRepository {
   /// Scans the `e` tags last-first: NIP-25 says that when a reaction carries
   /// more than one, "the target event `id` should be last of the `e` tags".
   /// Reading forwards credits a copied ancestor tag instead of the real
-  /// target — Divine's own writer emits a single `e` tag, so this only
-  /// affects reactions from other clients, which [fetchUserLikes] parses.
+  /// target. Divine's own writer emits a single `e` tag, so the ordering
+  /// matters when ingesting reactions from clients that include extras,
+  /// including another client using the same account key.
   String? _extractTargetEventId(Event event) {
     for (final tag in event.tags.reversed) {
       if (tag.isNotEmpty && tag[0] == 'e' && tag.length > 1) {

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -2770,9 +2770,13 @@ class LikesRepository {
 
   /// Extracts the target event ID from a reaction event's 'e' tag.
   ///
-  /// According to NIP-25, the 'e' tag contains the event ID being reacted to.
+  /// Scans the `e` tags last-first: NIP-25 says that when a reaction carries
+  /// more than one, "the target event `id` should be last of the `e` tags".
+  /// Reading forwards credits a copied ancestor tag instead of the real
+  /// target — Divine's own writer emits a single `e` tag, so this only
+  /// affects reactions from other clients, which [fetchUserLikes] parses.
   String? _extractTargetEventId(Event event) {
-    for (final tag in event.tags) {
+    for (final tag in event.tags.reversed) {
       if (tag.isNotEmpty && tag[0] == 'e' && tag.length > 1) {
         return tag[1];
       }
@@ -2788,6 +2792,11 @@ class LikesRepository {
   /// addressable targets like comments, or reactions published before this
   /// tag was added). Used to keep own-like state resolvable by coordinate
   /// across a target edit that mints a new event id (#6020).
+  ///
+  /// Deliberately scans forwards, unlike [_extractTargetEventId]. NIP-25
+  /// states the last-wins rule for `e` and `p` tags only; for `a` it says
+  /// just that one SHOULD accompany the `e` tag, so there is no specified
+  /// ordering to honour and reversing would invent a convention.
   String? _extractAddressableId(Event event) {
     for (final tag in event.tags) {
       if (tag.isNotEmpty && tag[0] == 'a' && tag.length > 1) {

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -3823,6 +3823,31 @@ void main() {
         expect(await repository.fetchUserLikes(otherUserPubkey), [targetId]);
       });
 
+      test(
+        'binds to the last e tag when a peer threads its reaction',
+        () async {
+          const threadRoot = 'thread_root_event_1234567890abcdef';
+          const reactedTo = 'reacted_to_event_abcdef1234567890';
+
+          // NIP-25: "If a client decides to include other `e`, which not
+          // recommended, the target event `id` should be last of the `e` tags."
+          final mockReaction = MockEvent();
+          when(() => mockReaction.content).thenReturn('+');
+          when(() => mockReaction.createdAt).thenReturn(defaultTimestamp);
+          when(() => mockReaction.tags).thenReturn([
+            ['e', threadRoot],
+            ['e', reactedTo],
+          ]);
+
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [mockReaction]);
+
+          repository = createRepository();
+          expect(await repository.fetchUserLikes(otherUserPubkey), [reactedTo]);
+        },
+      );
+
       test('returns likes ordered by recency', () async {
         const olderId = 'older_target_1234567890abcdef';
         const newerId = 'newer_target_1234567890abcdef';

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -3046,17 +3046,15 @@ void main() {
         },
       );
 
-      test('counts a reaction spanning two chunks once', () async {
+      test('deduplicates a reaction returned from two chunks', () async {
         // Each chunk is its own queryEvents call with its own dedup box, so a
-        // reaction that e-tags a target in chunk 0 and one in chunk 1 comes
-        // back from both. The count loop adds per e-tag occurrence, so
-        // without a dedup across chunks both targets score 2.
+        // reaction targeting an event in chunk 1 can come back from both.
+        // _queryChunked must deduplicate it before counting.
         final eventIds = [for (var i = 0; i < 600; i++) 'event_id_$i'];
         final reaction = createMockReaction(
           id: 'reaction_spanning_chunks',
           targetEventId: 'event_id_0',
           tags: [
-            ['e', 'event_id_0'],
             ['e', 'event_id_500'],
           ],
         );
@@ -3067,8 +3065,30 @@ void main() {
         repository = createRepository();
         final counts = await repository.getLikeCounts(eventIds);
 
-        expect(counts['event_id_0'], 1);
+        expect(counts['event_id_0'], 0);
         expect(counts['event_id_500'], 1);
+      });
+
+      test('counts a reaction only for its last e tag', () async {
+        const threadRoot = 'thread_root_event_1234567890abcdef';
+        const reactedTo = 'reacted_to_event_abcdef1234567890';
+        final reaction = createMockReaction(
+          id: 'reaction_with_thread_context',
+          targetEventId: threadRoot,
+          tags: [
+            ['e', threadRoot],
+            ['e', reactedTo],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [reaction]);
+
+        repository = createRepository();
+        final counts = await repository.getLikeCounts([threadRoot, reactedTo]);
+
+        expect(counts, {threadRoot: 0, reactedTo: 1});
       });
 
       test('handles events with non-list or empty tags', () async {
@@ -4028,6 +4048,28 @@ void main() {
 
         expect(likers, hasLength(2));
         expect(likers, [likerB, likerA]);
+      });
+
+      test('attributes a multi-e reaction only to its last e tag', () async {
+        const threadRoot = 'thread_root_event_1234567890abcdef';
+        final reaction = createReaction(
+          id: 'reaction_with_thread_context',
+          authorPubkey: likerA,
+          tags: [
+            ['e', threadRoot],
+            ['e', targetEventId],
+          ],
+        );
+
+        mockQueryEventsSequence([
+          [reaction],
+          <Event>[],
+        ]);
+
+        repository = createRepository();
+        expect(await repository.fetchEventLikers(eventId: targetEventId), [
+          likerA,
+        ]);
       });
 
       test(


### PR DESCRIPTION
## Description

`_extractTargetEventId` returned on the first `e` tag it saw. NIP-25 puts the target last when a client includes extras, so a peer that threads its reaction had it credited to the thread root instead of the event actually reacted to. Scanning `event.tags.reversed` fixes it.

The same target-selection rule is now applied to the feed-facing like-count and liker-resolution paths, so a multi-`e` reaction is attributed to one event rather than inflating every referenced event. `_resolveVoteTarget` already scanned reversed, so this brings the sibling reaction parsers in line.

### Spec

NIP-25, Tags — quoted, not paraphrased:

> There MUST be always an `e` tag set to the `id` of the event that is being reacted to. […] If a client decides to include other `e`, which not recommended, the target event `id` should be last of the `e` tags.

### Call sites and blast radius

The change applies to reactions with multiple `e` tags, including reactions received from another client using the same account key. Divine's own writer emits exactly one `e` tag, so its reactions are unchanged.

- `_processIncomingReaction`, `syncUserReactions`, and `_resolveRemoteDownvoteRecord` use the shared last-wins parser for current-user reactions.
- `fetchUserLikes`, `getLikeCounts`, and `fetchEventLikers` now consistently attribute peer reactions to the last `e` tag.
- The `a`-tag fallback remains unchanged when the selected `e` target is not in the queried set.

### Out of Scope

- `_extractAddressableId` stays forward-scanning deliberately. NIP-25 states the last-wins rule for `e` and `p` tags only; for `a` it says merely that one SHOULD accompany the `e` tag, with no multiplicity or ordering rule.
- No `p` tag change is needed here because `likes_repository` does not parse `p` tags. The corresponding DM path was fixed in #8379.

**Related Issue:** Closes #8382

## Verification

- Regression tests cover `fetchUserLikes`, `getLikeCounts`, and `fetchEventLikers` with multiple `e` tags.
- `flutter test --coverage` in `mobile/packages/likes_repository` — **253 passed**
- `flutter analyze` in `mobile/packages/likes_repository` — no issues
- Repo-pinned formatter — **3410 files, 0 changed**
- Pre-push analyzer and changed-file tests — passed

