### PR TITLE
fix(dm): enforce moderation-notice removal at the repository boundary

### DIFF
--- a/mobile/lib/blocs/dm/conversation_actions/conversation_actions_cubit.dart
+++ b/mobile/lib/blocs/dm/conversation_actions/conversation_actions_cubit.dart
@@ -5,11 +5,28 @@ import 'package:bloc/bloc.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:equatable/equatable.dart';
+import 'package:models/models.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/content_moderation_types.dart';
 import 'package:openvine/services/content_reporting_service.dart';
 
 enum ConversationActionsStatus { idle, processing, success, failure }
+
+/// What [ConversationActionsCubit.removeConversation] actually did.
+///
+/// Three-valued rather than a `bool` for the reason given on
+/// `DeclineRequestOutcome`: a refusal is not a failure, and the caller must
+/// not report an error for a conversation the policy protects (#8391).
+enum RemoveConversationOutcome {
+  /// The conversation was removed.
+  removed,
+
+  /// The repository's removal policy protects it. Nothing was deleted.
+  refused,
+
+  /// The removal threw.
+  failed,
+}
 
 class ConversationActionsState extends Equatable {
   const ConversationActionsState({
@@ -126,17 +143,36 @@ class ConversationActionsCubit extends Cubit<ConversationActionsState> {
     }
   }
 
+  /// Whether [conversation] is one the repository refuses to remove.
+  ///
+  /// Synchronous, so the caller can withdraw the destructive action before
+  /// offering it rather than letting the user meet a refusal. Symmetric with
+  /// [isBlocked], which the same action sheet already consults.
+  bool isRemovalProtected(DmConversation conversation) =>
+      _dmRepository.isRemovalProtected(conversation);
+
   /// Remove a conversation locally.
   ///
-  /// Returns `true` if the conversation was removed successfully.
-  Future<bool> removeConversation(String conversationId) async {
+  /// Three-valued for the same reason `declineRequest` is: a refusal is not a
+  /// failure, so reporting `commonSomethingWentWrong` for a conversation the
+  /// policy deliberately protects would be wrong (#8391). The repository owns
+  /// the policy; this only translates its answer.
+  Future<RemoveConversationOutcome> removeConversation(
+    String conversationId,
+  ) async {
     emit(state.copyWith(status: ConversationActionsStatus.processing));
     try {
-      await _dmRepository.removeConversation(conversationId);
+      final outcome = await _dmRepository.removeConversation(conversationId);
+      if (outcome == ConversationRemovalOutcome.refused) {
+        if (!isClosed) {
+          emit(state.copyWith(status: ConversationActionsStatus.idle));
+        }
+        return RemoveConversationOutcome.refused;
+      }
       if (!isClosed) {
         emit(state.copyWith(status: ConversationActionsStatus.success));
       }
-      return true;
+      return RemoveConversationOutcome.removed;
     } catch (e, stackTrace) {
       // Drift write failures are expected. Per
       // .claude/rules/error_handling.md they are NOT Reportable.
@@ -144,7 +180,7 @@ class ConversationActionsCubit extends Cubit<ConversationActionsState> {
       if (!isClosed) {
         emit(state.copyWith(status: ConversationActionsStatus.failure));
       }
-      return false;
+      return RemoveConversationOutcome.failed;
     }
   }
 }

--- a/mobile/lib/blocs/dm/message_requests/message_request_actions_cubit.dart
+++ b/mobile/lib/blocs/dm/message_requests/message_request_actions_cubit.dart
@@ -5,7 +5,6 @@ import 'package:bloc/bloc.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:models/models.dart';
-import 'package:openvine/blocs/dm/dm_peer_account_predicate.dart';
 
 enum MessageRequestActionsStatus { idle, processing, success, error }
 
@@ -42,39 +41,11 @@ class MessageRequestActionsState extends Equatable {
 }
 
 class MessageRequestActionsCubit extends Cubit<MessageRequestActionsState> {
-  MessageRequestActionsCubit({
-    required DmRepository dmRepository,
-    DmPeerAccountPredicate moderationAccount = neverDmPeerAccount,
-  }) : _dmRepository = dmRepository,
-       _moderationAccount = moderationAccount,
-       super(const MessageRequestActionsState());
+  MessageRequestActionsCubit({required DmRepository dmRepository})
+    : _dmRepository = dmRepository,
+      super(const MessageRequestActionsState());
 
   final DmRepository _dmRepository;
-
-  /// Whether a peer is a Divine moderation identity, current or retired.
-  ///
-  /// Injected so this cubit never learns Divine's own pubkeys — same seam as
-  /// `ConversationListBloc`'s. Defaults permissive, so a fixture that injects
-  /// nothing keeps the pre-policy behaviour.
-  final DmPeerAccountPredicate _moderationAccount;
-
-  /// Whether [conversation] is one this cubit refuses to remove.
-  ///
-  /// An enforcement notice is the user's only copy of why they were actioned:
-  /// there is no reason field on the account-status API and no appeals
-  /// workflow behind it, while removal here is permanent — `removeConversation`
-  /// writes a tombstone that suppresses relay replay for the account's
-  /// lifetime. So the row stays (#6971).
-  ///
-  /// Self is excluded, so a signed-in moderation account can still clear its
-  /// own request list. Any *other* moderation participant is enough, which
-  /// covers a group that happens to include one.
-  bool _isProtected(DmConversation conversation) {
-    final me = _dmRepository.userPubkey;
-    return conversation.participantPubkeys.any(
-      (pubkey) => pubkey != me && _moderationAccount(pubkey),
-    );
-  }
 
   /// Decline and remove a single message request.
   ///
@@ -86,24 +57,21 @@ class MessageRequestActionsCubit extends Cubit<MessageRequestActionsState> {
   /// `success` emit even though the removal succeeded, so a state read would
   /// report a false failure.
   ///
-  /// The guard is here rather than only in the widget because the request
+  /// The refusal itself comes from the repository, which owns the policy for
+  /// every removal path (#8391). This cubit only translates it: the request
   /// preview renders its decline button in states where the counterparty is
-  /// not resolved yet — a conversation id is a hash of the participants, so
-  /// the widget cannot always answer the question this cubit can.
+  /// not resolved yet, so the widget could not answer the question anyway.
   Future<DeclineRequestOutcome> declineRequest(String conversationId) async {
     emit(state.copyWith(status: MessageRequestActionsStatus.processing));
     try {
-      // A missing row fails OPEN: a stale id must not become an undeletable
-      // request.
-      final conversation = await _dmRepository.getConversation(conversationId);
-      if (conversation != null && _isProtected(conversation)) {
+      final outcome = await _dmRepository.removeConversation(conversationId);
+      if (outcome == ConversationRemovalOutcome.refused) {
         if (!isClosed) {
           emit(state.copyWith(status: MessageRequestActionsStatus.idle));
         }
         return DeclineRequestOutcome.refused;
       }
 
-      await _dmRepository.removeConversation(conversationId);
       if (!isClosed) {
         emit(state.copyWith(status: MessageRequestActionsStatus.success));
       }
@@ -140,10 +108,10 @@ class MessageRequestActionsCubit extends Cubit<MessageRequestActionsState> {
 
   /// Remove every removable conversation in [conversations].
   ///
-  /// Takes conversations rather than ids so the filter can read participants
-  /// without a lookup per row, and so the caller can keep passing its whole
-  /// list — the decision about what "all requests" excludes lives here, not in
-  /// the view, and a new caller cannot forget it.
+  /// Takes conversations rather than ids so the caller can keep passing its
+  /// whole list. The decision about what "all requests" excludes lives in the
+  /// repository (#8391), so every removal path inherits it rather than each
+  /// cubit re-implementing it.
   ///
   /// Protected conversations are skipped and remain in the request list.
   ///
@@ -163,15 +131,14 @@ class MessageRequestActionsCubit extends Cubit<MessageRequestActionsState> {
   Future<({bool withheld, bool failed})> removeAllRequests(
     List<DmConversation> conversations,
   ) async {
-    final removable = [
-      for (final conversation in conversations)
-        if (!_isProtected(conversation)) conversation.id,
-    ];
-    final withheld = removable.length != conversations.length;
-    if (removable.isEmpty) return (withheld: withheld, failed: false);
+    if (conversations.isEmpty) return (withheld: false, failed: false);
     emit(state.copyWith(status: MessageRequestActionsStatus.processing));
+    var withheld = false;
     try {
-      await _dmRepository.removeConversations(removable);
+      final outcome = await _dmRepository.removeConversations([
+        for (final conversation in conversations) conversation.id,
+      ]);
+      withheld = outcome.refused > 0;
       if (!isClosed) {
         emit(state.copyWith(status: MessageRequestActionsStatus.success));
       }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3532,7 +3532,7 @@
   },
   "messageRequestModerationNoticeCannotBeRemoved": "This Divine Moderation notice can't be removed.",
   "@messageRequestModerationNoticeCannotBeRemoved": {
-    "description": "SnackBar shown when a user tries to decline and remove a message request that resolves to a protected Divine Moderation notice (#6971)."
+    "description": "SnackBar shown when a user tries to remove a conversation that resolves to a protected Divine Moderation notice. Used on the request-preview decline, the Message Requests bulk sweep, and the inbox long-press remove (#6971, #8347, #8391)."
   },
   "dmRetiredThreadClosedBody": "We moved Divine Moderation to a new account. Nobody reads this one anymore.",
   "@dmRetiredThreadClosedBody": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9845,7 +9845,7 @@ abstract class AppLocalizations {
   /// **'This conversation is closed.'**
   String get dmRetiredThreadClosedTitle;
 
-  /// SnackBar shown when a user tries to decline and remove a message request that resolves to a protected Divine Moderation notice (#6971).
+  /// SnackBar shown when a user tries to remove a conversation that resolves to a protected Divine Moderation notice. Used on the request-preview decline, the Message Requests bulk sweep, and the inbox long-press remove (#6971, #8347, #8391).
   ///
   /// In en, this message translates to:
   /// **'This Divine Moderation notice can\'t be removed.'**

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -21,6 +21,7 @@ import 'package:follow_repository/follow_repository.dart';
 import 'package:hashtag_repository/hashtag_repository.dart';
 import 'package:hive_ce/hive_ce.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/constants/hive_box_names.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
@@ -714,6 +715,11 @@ DmRepository dmRepository(Ref ref) {
     removedConversationsDao: db.removedConversationsDao,
     syncState: DmSyncState(prefs),
     reactionsRepository: reactionsRepository,
+    // The single chokepoint for "this thread may not be deleted". Both the
+    // message-request cubit and the inbox long-press reach removal through
+    // this repository, so putting the policy here is what stops a caller
+    // inheriting nothing (#8391). Current AND retired keys, matching #8302.
+    removalPolicy: isModerationAccount,
     publishDmRelayListEnabled: publishDmRelayListEnabled,
     dmInboxRelayUrl: dmInboxRelayUrl,
     errorReporter: (error, stackTrace, {required site}) {

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -1068,7 +1068,7 @@ final class DmRepositoryProvider
   }
 }
 
-String _$dmRepositoryHash() => r'cae15093229ab33a95b5f2eade1016306eca26d5';
+String _$dmRepositoryHash() => r'8b8a652ac6190a1ea6dace64f4cd9ed492dd8bf2';
 
 /// Provider for CommentsRepository instance
 ///

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -1095,6 +1095,9 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
         isVanished: isVanished,
         isMuted: isMuted,
         isBlocked: isBlocked,
+        // Covers the pinned support row AND an ordinary row, which is the
+        // same moderation thread whenever a filter or search drops the pin.
+        canRemove: !actionsCubit.isRemovalProtected(conversation),
       );
 
       if (action == null || !context.mounted) return;
@@ -1154,13 +1157,27 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
             isVanished: isVanished,
           );
           if (confirmed && context.mounted) {
-            final removed = await actionsCubit.removeConversation(
+            final messenger = ScaffoldMessenger.of(context);
+            final removedText = context.l10n.inboxRemovedConversation;
+            // Not an error: the repository protects a Divine Moderation
+            // thread. Only reachable if the action was offered anyway, since
+            // the sheet drops it for a protected peer (#8391).
+            final refusedText =
+                context.l10n.messageRequestModerationNoticeCannotBeRemoved;
+            final outcome = await actionsCubit.removeConversation(
               conversation.id,
             );
-            if (context.mounted && removed) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text(context.l10n.inboxRemovedConversation)),
-              );
+            switch (outcome) {
+              case RemoveConversationOutcome.removed:
+                messenger.showSnackBar(
+                  SnackBar(content: Text(removedText)),
+                );
+              case RemoveConversationOutcome.refused:
+                messenger.showSnackBar(
+                  SnackBar(content: Text(refusedText)),
+                );
+              case RemoveConversationOutcome.failed:
+                break;
             }
           }
       }

--- a/mobile/lib/screens/inbox/message_requests/message_requests_page.dart
+++ b/mobile/lib/screens/inbox/message_requests/message_requests_page.dart
@@ -59,14 +59,12 @@ class MessageRequestsPage extends ConsumerWidget {
             // read" / "remove all" sweep a conversation the user is not
             // looking at.
             supportRowPubkey: kModerationPubkeyHex,
-            moderationAccount: isModerationAccount,
             retiredModerationAccount: isRetiredModerationAccount,
           )..add(const ConversationListStarted()),
         ),
         BlocProvider(
           create: (_) => MessageRequestActionsCubit(
             dmRepository: dmRepository,
-            moderationAccount: isModerationAccount,
           ),
         ),
       ],

--- a/mobile/lib/screens/inbox/message_requests/message_requests_page.dart
+++ b/mobile/lib/screens/inbox/message_requests/message_requests_page.dart
@@ -59,13 +59,12 @@ class MessageRequestsPage extends ConsumerWidget {
             // read" / "remove all" sweep a conversation the user is not
             // looking at.
             supportRowPubkey: kModerationPubkeyHex,
+            moderationAccount: isModerationAccount,
             retiredModerationAccount: isRetiredModerationAccount,
           )..add(const ConversationListStarted()),
         ),
         BlocProvider(
-          create: (_) => MessageRequestActionsCubit(
-            dmRepository: dmRepository,
-          ),
+          create: (_) => MessageRequestActionsCubit(dmRepository: dmRepository),
         ),
       ],
       child: const MessageRequestsView(),

--- a/mobile/lib/screens/inbox/message_requests/message_requests_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/message_requests_view.dart
@@ -75,10 +75,10 @@ class MessageRequestsView extends ConsumerWidget {
         final withheldText =
             context.l10n.messageRequestModerationNoticeCannotBeRemoved;
         final errorText = context.l10n.commonSomethingWentWrong;
-        // Whole list, not ids: the cubit decides what "all requests" excludes,
-        // so a Divine moderation notice cannot be swept away by a gesture
-        // aimed at spam (#6971). Keeping the filter there rather than here
-        // means a future caller inherits it.
+        // Whole list, not ids: the repository decides what "all requests"
+        // excludes, so a Divine moderation notice cannot be swept away by a
+        // gesture aimed at spam (#6971). Keeping the policy there means every
+        // removal caller inherits it.
         final outcome = await actionsCubit.removeAllRequests(requests);
         if (context.mounted) context.pop();
         // Silence reads as a broken button: a list holding nothing but a

--- a/mobile/lib/screens/inbox/message_requests/request_preview_page.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_page.dart
@@ -7,7 +7,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/dm/conversation/collaborator_invite_actions_cubit.dart';
 import 'package:openvine/blocs/dm/message_requests/message_request_actions_cubit.dart';
 import 'package:openvine/blocs/dm/message_requests/request_preview_cubit.dart';
-import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/official_accounts_providers.dart';
 import 'package:openvine/providers/protected_minor_providers.dart';
@@ -66,7 +65,6 @@ class RequestPreviewPage extends ConsumerWidget {
           key: ValueKey(dmRepository),
           create: (_) => MessageRequestActionsCubit(
             dmRepository: dmRepository,
-            moderationAccount: isModerationAccount,
           ),
         ),
         BlocProvider(

--- a/mobile/lib/screens/inbox/widgets/conversation_actions_sheet.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_actions_sheet.dart
@@ -31,6 +31,7 @@ class ConversationActionsSheet {
     required bool isVanished,
     required bool isMuted,
     required bool isBlocked,
+    bool canRemove = true,
   }) {
     // A vanished peer can publish again under the same key, and their DMs
     // remain in the recipient's history. Keep Report and Block available for
@@ -67,15 +68,23 @@ class ConversationActionsSheet {
               icon: DivineIconName.eyeSlash,
               label: blockLabel,
               isDestructive: !isBlocked,
+              // Block becomes the last row when Remove is withdrawn, so it
+              // owns the missing divider rather than leaving a trailing rule.
+              showDivider: canRemove,
               result: ConversationAction.block,
             ),
-            _ActionTile(
-              icon: DivineIconName.trash,
-              label: context.l10n.inboxActionRemove,
-              isDestructive: true,
-              showDivider: false,
-              result: ConversationAction.remove,
-            ),
+            // Withdrawn for a Divine Moderation thread: removal is permanent
+            // and the notice is the user's only copy of why they were actioned
+            // (#8391). The repository refuses it either way; not offering it
+            // beats a dead-end refusal.
+            if (canRemove)
+              _ActionTile(
+                icon: DivineIconName.trash,
+                label: context.l10n.inboxActionRemove,
+                isDestructive: true,
+                showDivider: false,
+                result: ConversationAction.remove,
+              ),
           ],
         ),
       ),

--- a/mobile/packages/dm_repository/lib/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/dm_repository.dart
@@ -4,6 +4,7 @@ export 'src/dm_decrypt_isolate.dart';
 export 'src/dm_decryption_worker.dart';
 export 'src/dm_reactions_repository.dart';
 export 'src/dm_reactions_repository_reportable_sites.dart';
+export 'src/dm_removal_policy.dart';
 export 'src/dm_repository.dart';
 export 'src/dm_repository_reportable_sites.dart';
 export 'src/dm_send_budget.dart';

--- a/mobile/packages/dm_repository/lib/src/dm_removal_policy.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_removal_policy.dart
@@ -1,0 +1,40 @@
+// ABOUTME: Injectable conversation-removal policy for DmRepository (#8391). The
+// ABOUTME: DM package can't reach app config, so "which peers hold a thread the
+// ABOUTME: user may not delete" is injected as a predicate the removal
+// ABOUTME: primitives consult.
+
+/// What `DmRepository.removeConversation` did to one conversation.
+///
+/// Two-valued rather than a `bool`, and returned rather than thrown, because a
+/// refusal is not a failure: per `.claude/rules/error_handling.md` a policy
+/// refusal must not reach the error path, and the caller must be able to say
+/// "this one is protected" without reporting that something went wrong. Drift
+/// failures still throw.
+enum ConversationRemovalOutcome {
+  /// The conversation was removed (or was already absent — see the fail-open
+  /// note on `DmRepository.removeConversation`).
+  removed,
+
+  /// The policy protects this conversation. Nothing was deleted.
+  refused,
+}
+
+/// Whether a conversation with [peerPubkeyHex] is one the user may not remove.
+///
+/// Injected rather than imported so this package never learns Divine's own
+/// pubkeys: `official_accounts.dart` is app config and this package is reusable
+/// without it. Same reasoning as `DmSendPolicy` alongside it, and as the
+/// `supportPubkey` parameter on `DmRepository.extractPinnedSupport`.
+///
+/// Synchronous, unlike `DmSendPolicy`: removal protection is pure set
+/// membership over shipped identities, with no account state to await.
+///
+/// The predicate answers about a *peer*. `DmRepository` owns excluding self and
+/// scanning every participant, so a group is judged by all of its members and
+/// no caller can get that wrong.
+typedef DmConversationRemovalPolicy = bool Function(String peerPubkeyHex);
+
+/// Default policy: nothing is protected. Preserves existing behaviour wherever
+/// no policy is injected, so a fixture that wires nothing behaves exactly as it
+/// did before the policy existed.
+bool allowAllConversationRemoval(String peerPubkeyHex) => false;

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -19,6 +19,7 @@ import 'package:dm_repository/src/dm_clock.dart';
 import 'package:dm_repository/src/dm_decrypt_isolate.dart';
 import 'package:dm_repository/src/dm_decryption_worker.dart';
 import 'package:dm_repository/src/dm_reactions_repository.dart';
+import 'package:dm_repository/src/dm_removal_policy.dart';
 import 'package:dm_repository/src/dm_repository_reportable_sites.dart';
 import 'package:dm_repository/src/dm_send_budget.dart';
 import 'package:dm_repository/src/dm_shared_video_citation.dart';
@@ -325,6 +326,7 @@ class DmRepository {
     DmVerifyIsolateSpawner? verifyIsolateSpawner,
     DmRepositoryErrorReporter? errorReporter,
     DmReactionsRepository? reactionsRepository,
+    DmConversationRemovalPolicy? removalPolicy,
     bool publishDmRelayListEnabled = false,
     String? dmInboxRelayUrl,
     Duration readMarkerDebounceDelay = _defaultReadMarkerDebounceDelay,
@@ -347,6 +349,7 @@ class DmRepository {
        _verifyIsolateSpawner = verifyIsolateSpawner ?? DmVerifyIsolate.spawn,
        _errorReporter = errorReporter,
        _reactionsRepository = reactionsRepository,
+       _removalPolicy = removalPolicy ?? allowAllConversationRemoval,
        _publishDmRelayListEnabled = publishDmRelayListEnabled,
        _dmInboxRelayUrl = dmInboxRelayUrl,
        _newSendBatchId = sendBatchIdGenerator ?? _defaultSendBatchId;
@@ -408,6 +411,14 @@ class DmRepository {
   /// persisting them as DMs. Nullable to keep existing tests working
   /// without rewiring; production injects it via `dmRepositoryProvider`.
   final DmReactionsRepository? _reactionsRepository;
+
+  /// Which peers hold a conversation this repository refuses to remove.
+  ///
+  /// Injected so the package never learns Divine's own pubkeys. Defaults to
+  /// [allowAllConversationRemoval], so a fixture that wires nothing behaves as
+  /// it did before the policy existed; production injects the moderation
+  /// identities via `dmRepositoryProvider`.
+  final DmConversationRemovalPolicy _removalPolicy;
 
   /// Feature gate for #4974 RC3 (self-publishing the user's own kind-10050 DM
   /// inbox relay list on login). Defaults to `false` so the publish stays
@@ -6672,6 +6683,31 @@ class DmRepository {
     }
   }
 
+  /// Whether [conversation] is one the injected policy refuses to remove.
+  ///
+  /// Exposed so a caller can withdraw a destructive affordance before offering
+  /// it, rather than letting the user meet a refusal. The enforcement itself is
+  /// in [removeConversation] / [removeConversations]; this is the cheap,
+  /// synchronous question the UI asks.
+  ///
+  /// Self is excluded, so a signed-in moderation account can still clear its
+  /// own threads. **Any** other participant is enough, which covers a group
+  /// that happens to include one — `.any`, never `.first`.
+  bool isRemovalProtected(DmConversation conversation) {
+    final me = _userPubkey;
+    return conversation.participantPubkeys.any(
+      (pubkey) => pubkey != me && _removalPolicy(pubkey),
+    );
+  }
+
+  /// [isRemovalProtected] for an id the caller has not already resolved.
+  ///
+  /// A missing row is NOT protected: removal of a stale id must fail open.
+  Future<bool> _isRemovalProtectedById(String conversationId) async {
+    final conversation = await getConversation(conversationId);
+    return conversation != null && isRemovalProtected(conversation);
+  }
+
   /// Remove a conversation, its messages, its queued sends, and its queued
   /// reactions atomically.
   ///
@@ -6686,11 +6722,25 @@ class DmRepository {
   /// the sweep publishes a gift wrap into a conversation the user removed
   /// (#7857) — the reaction counterpart of the `outgoing_dms` delete above.
   ///
+  /// Returns [ConversationRemovalOutcome.refused] without deleting anything
+  /// when the injected [DmConversationRemovalPolicy] protects the peer — the
+  /// single chokepoint every removal path inherits, so a new caller cannot
+  /// forget it (#8391).
+  ///
+  /// A conversation that is **absent** fails OPEN and reports
+  /// [ConversationRemovalOutcome.removed]: a stale id must never become an
+  /// undeletable row.
+  ///
   /// Throws:
   ///
   /// * `InvalidDataException` if a database constraint is violated.
-  Future<void> removeConversation(String conversationId) {
-    return _conversationsDao.runInTransaction(() async {
+  Future<ConversationRemovalOutcome> removeConversation(
+    String conversationId,
+  ) async {
+    if (await _isRemovalProtectedById(conversationId)) {
+      return ConversationRemovalOutcome.refused;
+    }
+    await _conversationsDao.runInTransaction<void>(() async {
       // Snapshot the owner for the whole transaction: an account switch
       // mid-flight must not mix one account's reads with another's writes.
       final owner = _userPubkey;
@@ -6717,6 +6767,7 @@ class DmRepository {
         conversationId,
       ], ownerPubkey: owner);
     });
+    return ConversationRemovalOutcome.removed;
   }
 
   /// Remove multiple conversations, their messages, their queued sends, and
@@ -6725,40 +6776,59 @@ class DmRepository {
   ///
   /// No-op when [conversationIds] is empty.
   ///
+  /// **Filters rather than refusing the batch.** Protected conversations are
+  /// skipped and counted in `refused`; the rest are removed. Refusing the whole
+  /// batch would break the shipped "sweep the spam, keep the notice" behaviour
+  /// (#6971), so the caller gets counts and decides what to say (#8391). The
+  /// transaction still covers every row it does remove.
+  ///
   /// Throws:
   ///
   /// * `InvalidDataException` if a database constraint is violated.
-  Future<void> removeConversations(List<String> conversationIds) {
-    if (conversationIds.isEmpty) return Future.value();
+  Future<({int removed, int refused})> removeConversations(
+    List<String> conversationIds,
+  ) async {
+    if (conversationIds.isEmpty) return (removed: 0, refused: 0);
 
-    return _conversationsDao.runInTransaction(() async {
+    final removable = <String>[];
+    var refused = 0;
+    for (final conversationId in conversationIds) {
+      if (await _isRemovalProtectedById(conversationId)) {
+        refused++;
+      } else {
+        removable.add(conversationId);
+      }
+    }
+    if (removable.isEmpty) return (removed: 0, refused: refused);
+    await _conversationsDao.runInTransaction<void>(() async {
       // Snapshot the owner for the whole transaction: an account switch
       // mid-flight must not mix one account's reads with another's writes.
       final owner = _userPubkey;
       final ownerOrNull = owner.isEmpty ? null : owner;
       final removedAt = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       await _removedConversationsDao?.recordAll(
-        conversationIds: conversationIds,
+        conversationIds: removable,
         ownerPubkey: owner,
         removedAt: removedAt,
       );
       await _directMessagesDao.deleteMultipleConversationMessages(
-        conversationIds,
+        removable,
         ownerPubkey: ownerOrNull,
       );
       await _conversationsDao.deleteMultiple(
-        conversationIds,
+        removable,
         ownerPubkey: ownerOrNull,
       );
       await _outgoingDmsDao?.deleteForConversations(
-        conversationIds: conversationIds,
+        conversationIds: removable,
         ownerPubkey: owner,
       );
       await _reactionsRepository?.deleteForConversations(
-        conversationIds,
+        removable,
         ownerPubkey: owner,
       );
     });
+    return (removed: removable.length, refused: refused);
   }
 
   /// Count the total number of messages in a conversation.

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -6800,6 +6800,7 @@ class DmRepository {
       }
     }
     if (removable.isEmpty) return (removed: 0, refused: refused);
+    var removed = 0;
     await _conversationsDao.runInTransaction<void>(() async {
       // Snapshot the owner for the whole transaction: an account switch
       // mid-flight must not mix one account's reads with another's writes.
@@ -6815,7 +6816,7 @@ class DmRepository {
         removable,
         ownerPubkey: ownerOrNull,
       );
-      await _conversationsDao.deleteMultiple(
+      removed = await _conversationsDao.deleteMultiple(
         removable,
         ownerPubkey: ownerOrNull,
       );
@@ -6828,7 +6829,7 @@ class DmRepository {
         ownerPubkey: owner,
       );
     });
-    return (removed: removable.length, refused: refused);
+    return (removed: removed, refused: refused);
   }
 
   /// Count the total number of messages in a conversation.

--- a/mobile/packages/dm_repository/test/src/dm_removal_policy_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_removal_policy_test.dart
@@ -1,0 +1,221 @@
+// ABOUTME: Coverage for the injected conversation-removal policy (#8391) — the
+// ABOUTME: repository-level guard that stops any caller destroying a protected
+// ABOUTME: thread, which #8302 had guarded in one cubit only.
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+const _owner =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+const _protectedPeer =
+    '2222222222222222222222222222222222222222222222222222222222222222';
+const _ordinaryPeer =
+    '3333333333333333333333333333333333333333333333333333333333333333';
+const _otherPeer =
+    '4444444444444444444444444444444444444444444444444444444444444444';
+
+bool _protectsTheProtectedPeer(String pubkeyHex) => pubkeyHex == _protectedPeer;
+
+void main() {
+  group('DmRepository removal policy', () {
+    late AppDatabase db;
+    late ConversationsDao conversationsDao;
+    late DirectMessagesDao messagesDao;
+
+    setUp(() {
+      db = AppDatabase.test(NativeDatabase.memory());
+      conversationsDao = ConversationsDao(db);
+      messagesDao = DirectMessagesDao(db);
+    });
+
+    tearDown(() => db.close());
+
+    DmRepository buildRepository({
+      DmConversationRemovalPolicy? removalPolicy,
+      String owner = _owner,
+    }) => DmRepository(
+      nostrClient: _MockNostrClient(),
+      directMessagesDao: messagesDao,
+      conversationsDao: conversationsDao,
+      removedConversationsDao: db.removedConversationsDao,
+      userPubkey: owner,
+      removalPolicy: removalPolicy,
+    );
+
+    Future<String> seedConversation(
+      List<String> participants, {
+      String owner = _owner,
+    }) async {
+      final conversationId = DmRepository.computeConversationId(participants);
+      await conversationsDao.upsertConversation(
+        id: conversationId,
+        participantPubkeys: '["${participants.join('","')}"]',
+        isGroup: participants.length > 2,
+        createdAt: 1700000000,
+        ownerPubkey: owner,
+      );
+      return conversationId;
+    }
+
+    group('removeConversation', () {
+      test('refuses a protected peer and leaves the row on disk', () async {
+        final repository = buildRepository(
+          removalPolicy: _protectsTheProtectedPeer,
+        );
+        final conversationId = await seedConversation([_owner, _protectedPeer]);
+
+        final outcome = await repository.removeConversation(conversationId);
+
+        expect(outcome, equals(ConversationRemovalOutcome.refused));
+        expect(await repository.getConversation(conversationId), isNotNull);
+      });
+
+      test('removes an ordinary conversation', () async {
+        final repository = buildRepository(
+          removalPolicy: _protectsTheProtectedPeer,
+        );
+        final conversationId = await seedConversation([_owner, _ordinaryPeer]);
+
+        final outcome = await repository.removeConversation(conversationId);
+
+        expect(outcome, equals(ConversationRemovalOutcome.removed));
+        expect(await repository.getConversation(conversationId), isNull);
+      });
+
+      test('refuses a group that merely includes a protected peer', () async {
+        // `.any`, never `.first` — a group has more than one peer, and the
+        // protected one need not be the first (#8302 review, 739349d45).
+        final repository = buildRepository(
+          removalPolicy: _protectsTheProtectedPeer,
+        );
+        final conversationId = await seedConversation([
+          _owner,
+          _ordinaryPeer,
+          _protectedPeer,
+        ]);
+
+        final outcome = await repository.removeConversation(conversationId);
+
+        expect(outcome, equals(ConversationRemovalOutcome.refused));
+        expect(await repository.getConversation(conversationId), isNotNull);
+      });
+
+      test('excludes self, so a protected account can clear its own '
+          'threads', () async {
+        // Signed in AS the protected identity: its own threads stay removable.
+        final repository = buildRepository(
+          removalPolicy: _protectsTheProtectedPeer,
+          owner: _protectedPeer,
+        );
+        final conversationId = await seedConversation([
+          _protectedPeer,
+          _ordinaryPeer,
+        ], owner: _protectedPeer);
+
+        final outcome = await repository.removeConversation(conversationId);
+
+        expect(outcome, equals(ConversationRemovalOutcome.removed));
+      });
+
+      test('fails open for a conversation that is not on disk', () async {
+        // A stale id must never become an undeletable row.
+        final repository = buildRepository(
+          removalPolicy: _protectsTheProtectedPeer,
+        );
+
+        final outcome = await repository.removeConversation('no-such-id');
+
+        expect(outcome, equals(ConversationRemovalOutcome.removed));
+      });
+
+      test('removes a protected peer when no policy is injected', () async {
+        // The default is permissive, so a fixture wiring nothing behaves
+        // exactly as it did before the policy existed.
+        final repository = buildRepository();
+        final conversationId = await seedConversation([_owner, _protectedPeer]);
+
+        final outcome = await repository.removeConversation(conversationId);
+
+        expect(outcome, equals(ConversationRemovalOutcome.removed));
+        expect(await repository.getConversation(conversationId), isNull);
+      });
+    });
+
+    group('removeConversations', () {
+      test('sweeps the ordinary rows and keeps the protected one', () async {
+        final repository = buildRepository(
+          removalPolicy: _protectsTheProtectedPeer,
+        );
+        final protectedId = await seedConversation([_owner, _protectedPeer]);
+        final ordinaryId = await seedConversation([_owner, _ordinaryPeer]);
+        final otherId = await seedConversation([_owner, _otherPeer]);
+
+        final outcome = await repository.removeConversations([
+          protectedId,
+          ordinaryId,
+          otherId,
+        ]);
+
+        expect(outcome.removed, equals(2));
+        expect(outcome.refused, equals(1));
+        expect(await repository.getConversation(protectedId), isNotNull);
+        expect(await repository.getConversation(ordinaryId), isNull);
+        expect(await repository.getConversation(otherId), isNull);
+      });
+
+      test('reports the refusal when every row is protected', () async {
+        // The path that read as a broken button before #8347: nothing to
+        // remove, so the caller needs a signal rather than silence.
+        final repository = buildRepository(
+          removalPolicy: _protectsTheProtectedPeer,
+        );
+        final protectedId = await seedConversation([_owner, _protectedPeer]);
+
+        final outcome = await repository.removeConversations([protectedId]);
+
+        expect(outcome.removed, equals(0));
+        expect(outcome.refused, equals(1));
+        expect(await repository.getConversation(protectedId), isNotNull);
+      });
+
+      test('returns zero counts for an empty list', () async {
+        final repository = buildRepository(
+          removalPolicy: _protectsTheProtectedPeer,
+        );
+
+        final outcome = await repository.removeConversations([]);
+
+        expect(outcome.removed, equals(0));
+        expect(outcome.refused, equals(0));
+      });
+    });
+
+    group('isRemovalProtected', () {
+      test('answers for a peer the policy protects', () async {
+        final repository = buildRepository(
+          removalPolicy: _protectsTheProtectedPeer,
+        );
+        final conversationId = await seedConversation([_owner, _protectedPeer]);
+        final conversation = await repository.getConversation(conversationId);
+
+        expect(repository.isRemovalProtected(conversation!), isTrue);
+      });
+
+      test('answers false for an ordinary peer', () async {
+        final repository = buildRepository(
+          removalPolicy: _protectsTheProtectedPeer,
+        );
+        final conversationId = await seedConversation([_owner, _ordinaryPeer]);
+        final conversation = await repository.getConversation(conversationId);
+
+        expect(repository.isRemovalProtected(conversation!), isFalse);
+      });
+    });
+  });
+}

--- a/mobile/packages/dm_repository/test/src/dm_removal_policy_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_removal_policy_test.dart
@@ -155,11 +155,13 @@ void main() {
         final protectedId = await seedConversation([_owner, _protectedPeer]);
         final ordinaryId = await seedConversation([_owner, _ordinaryPeer]);
         final otherId = await seedConversation([_owner, _otherPeer]);
+        const missingId = 'missing-conversation';
 
         final outcome = await repository.removeConversations([
           protectedId,
           ordinaryId,
           otherId,
+          missingId,
         ]);
 
         expect(outcome.removed, equals(2));

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -9023,6 +9023,18 @@ void main() {
     // -----------------------------------------------------------------
 
     group('removeConversation', () {
+      // The removal policy resolves each conversation before deleting it
+      // (#8391). These pure-mock tests care about the delete ordering, so the
+      // lookup returns null — absent rows fail open and removal proceeds.
+      setUp(() {
+        when(
+          () => mockConversationsDao.getConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+      });
+
       test(
         'deletes messages then conversation in a transaction',
         () async {
@@ -9131,6 +9143,18 @@ void main() {
     });
 
     group('removeConversations', () {
+      // The removal policy resolves each conversation before deleting it
+      // (#8391). These pure-mock tests care about the delete ordering, so the
+      // lookup returns null — absent rows fail open and removal proceeds.
+      setUp(() {
+        when(
+          () => mockConversationsDao.getConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+      });
+
       const convIdA =
           'aabb00112233445566778899aabbccddeeff0011223344556677889900aabb00';
       const convIdB =

--- a/mobile/test/blocs/dm/conversation_actions/conversation_actions_cubit_test.dart
+++ b/mobile/test/blocs/dm/conversation_actions/conversation_actions_cubit_test.dart
@@ -8,6 +8,7 @@ import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation_actions/conversation_actions_cubit.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/content_moderation_types.dart';
@@ -306,16 +307,16 @@ void main() {
 
     group('removeConversation', () {
       blocTest<ConversationActionsCubit, ConversationActionsState>(
-        'returns true on success',
+        'reports removed on success',
         setUp: () {
           when(
             () => mockDmRepo.removeConversation(any()),
-          ).thenAnswer((_) async {});
+          ).thenAnswer((_) async => ConversationRemovalOutcome.removed);
         },
         build: createCubit,
         act: (cubit) async {
           final result = await cubit.removeConversation(conversationId);
-          expect(result, isTrue);
+          expect(result, equals(RemoveConversationOutcome.removed));
         },
         expect: () => [
           const ConversationActionsState(
@@ -331,7 +332,7 @@ void main() {
       );
 
       blocTest<ConversationActionsCubit, ConversationActionsState>(
-        'returns false and calls addError on failure',
+        'reports failed and calls addError on failure',
         setUp: () {
           when(
             () => mockDmRepo.removeConversation(any()),
@@ -340,7 +341,7 @@ void main() {
         build: createCubit,
         act: (cubit) async {
           final result = await cubit.removeConversation(conversationId);
-          expect(result, isFalse);
+          expect(result, equals(RemoveConversationOutcome.failed));
         },
         expect: () => [
           const ConversationActionsState(
@@ -352,6 +353,51 @@ void main() {
         ],
         errors: () => [isA<Exception>()],
       );
+
+      // #8391: the inbox long-press could destroy a Divine Moderation
+      // enforcement notice — the user's only copy of why they were actioned —
+      // because the guard #8302 added lived in MessageRequestActionsCubit
+      // only. A refusal is not a failure, so it must not emit `failure` and
+      // must not reach addError.
+      blocTest<ConversationActionsCubit, ConversationActionsState>(
+        'reports refused without erroring when the repository protects it',
+        setUp: () {
+          when(
+            () => mockDmRepo.removeConversation(any()),
+          ).thenAnswer((_) async => ConversationRemovalOutcome.refused);
+        },
+        build: createCubit,
+        act: (cubit) async {
+          final result = await cubit.removeConversation(conversationId);
+          expect(result, equals(RemoveConversationOutcome.refused));
+        },
+        expect: () => [
+          const ConversationActionsState(
+            status: ConversationActionsStatus.processing,
+          ),
+          // Back to idle: a refusal is not a failure.
+          const ConversationActionsState(),
+        ],
+        errors: () => <Object>[],
+      );
+    });
+
+    group('isRemovalProtected', () {
+      test('delegates to the repository rather than re-deciding', () {
+        final conversation = DmConversation(
+          id: conversationId,
+          participantPubkeys: const [currentUserPubkey, pubkey],
+          isGroup: false,
+          createdAt: 1700000000,
+          lastMessageTimestamp: 1700000000,
+        );
+        when(
+          () => mockDmRepo.isRemovalProtected(conversation),
+        ).thenReturn(true);
+
+        expect(createCubit().isRemovalProtected(conversation), isTrue);
+        verify(() => mockDmRepo.isRemovalProtected(conversation)).called(1);
+      });
     });
   });
 }

--- a/mobile/test/blocs/dm/message_requests/message_request_actions_cubit_test.dart
+++ b/mobile/test/blocs/dm/message_requests/message_request_actions_cubit_test.dart
@@ -159,7 +159,7 @@ void main() {
         setUp: () {
           when(
             () => mockDmRepository.markConversationsAsRead(any()),
-          ).thenAnswer((_) async => ConversationRemovalOutcome.removed);
+          ).thenAnswer((_) async {});
         },
         build: createCubit,
         act: (cubit) => cubit.markAllRequestsAsRead([

--- a/mobile/test/blocs/dm/message_requests/message_request_actions_cubit_test.dart
+++ b/mobile/test/blocs/dm/message_requests/message_request_actions_cubit_test.dart
@@ -23,8 +23,6 @@ const _stranger =
 const _moderation =
     '3333333333333333333333333333333333333333333333333333333333333333';
 
-bool _isModeration(String pubkeyHex) => pubkeyHex == _moderation;
-
 DmConversation _conversation(String id, {required String peer}) =>
     DmConversation(
       id: id,
@@ -48,13 +46,11 @@ void main() {
       );
     });
 
-    MessageRequestActionsCubit createCubit() => MessageRequestActionsCubit(
-      dmRepository: mockDmRepository,
-      moderationAccount: _isModeration,
-    );
+    MessageRequestActionsCubit createCubit() =>
+        MessageRequestActionsCubit(dmRepository: mockDmRepository);
 
     test('reports removed but does not emit when closed mid-decline', () async {
-      final completer = Completer<void>();
+      final completer = Completer<ConversationRemovalOutcome>();
       when(
         () => mockDmRepository.removeConversation(_testConversationId1),
       ).thenAnswer((_) => completer.future);
@@ -63,7 +59,7 @@ void main() {
       final future = cubit.declineRequest(_testConversationId1);
       // processing emitted synchronously; close before the delete resolves.
       await cubit.close();
-      completer.complete();
+      completer.complete(ConversationRemovalOutcome.removed);
 
       // The removal completed, so the caller sees `removed` even though the
       // guarded `success` emit was skipped. A state read would still show
@@ -84,7 +80,7 @@ void main() {
       test('reports removed when removeConversation succeeds', () async {
         when(
           () => mockDmRepository.removeConversation(_testConversationId1),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => ConversationRemovalOutcome.removed);
 
         final cubit = createCubit();
         expect(
@@ -117,7 +113,7 @@ void main() {
         setUp: () {
           when(
             () => mockDmRepository.removeConversation(_testConversationId1),
-          ).thenAnswer((_) async {});
+          ).thenAnswer((_) async => ConversationRemovalOutcome.removed);
         },
         build: createCubit,
         act: (cubit) => cubit.declineRequest(_testConversationId1),
@@ -163,7 +159,7 @@ void main() {
         setUp: () {
           when(
             () => mockDmRepository.markConversationsAsRead(any()),
-          ).thenAnswer((_) async {});
+          ).thenAnswer((_) async => ConversationRemovalOutcome.removed);
         },
         build: createCubit,
         act: (cubit) => cubit.markAllRequestsAsRead([
@@ -222,7 +218,7 @@ void main() {
         setUp: () {
           when(
             () => mockDmRepository.removeConversations(any()),
-          ).thenAnswer((_) async {});
+          ).thenAnswer((_) async => (removed: 2, refused: 0));
         },
         build: createCubit,
         act: (cubit) => cubit.removeAllRequests([
@@ -277,70 +273,33 @@ void main() {
       );
     });
 
+    // The policy itself now lives in DmRepository, so every removal path
+    // inherits it rather than each cubit re-deciding (#8391). What is left to
+    // pin here is the translation: a refusal must not read as a failure, and
+    // a withheld row must still be reported to the caller (#8347).
     group('moderation protection', () {
-      test('refuses to decline a Divine moderation request', () async {
-        when(
-          () => mockDmRepository.getConversation(_testConversationId1),
-        ).thenAnswer(
-          (_) async => _conversation(_testConversationId1, peer: _moderation),
-        );
-
-        final cubit = createCubit();
-
-        expect(
-          await cubit.declineRequest(_testConversationId1),
-          DeclineRequestOutcome.refused,
-        );
-        // The assertion that matters: an enforcement notice is the user's only
-        // copy of why they were actioned, and removal is permanent (#6971).
-        verifyNever(() => mockDmRepository.removeConversation(any()));
-
-        await cubit.close();
-      });
-
-      test('refuses when any group participant is moderation', () async {
-        when(
-          () => mockDmRepository.getConversation(_testConversationId1),
-        ).thenAnswer(
-          (_) async => DmConversation(
-            id: _testConversationId1,
-            participantPubkeys: const [_me, _stranger, _moderation],
-            isGroup: true,
-            createdAt: 0,
-          ),
-        );
-
-        final cubit = createCubit();
-
-        expect(
-          await cubit.declineRequest(_testConversationId1),
-          DeclineRequestOutcome.refused,
-        );
-        verifyNever(() => mockDmRepository.removeConversation(any()));
-
-        await cubit.close();
-      });
-
-      test('still declines when the signed-in user IS moderation', () async {
-        when(() => mockDmRepository.userPubkey).thenReturn(_moderation);
-        when(
-          () => mockDmRepository.getConversation(_testConversationId1),
-        ).thenAnswer(
-          (_) async => DmConversation(
-            id: _testConversationId1,
-            participantPubkeys: const [_moderation, _stranger],
-            isGroup: false,
-            createdAt: 0,
-          ),
-        );
+      test('reports refused when the repository protects the row', () async {
         when(
           () => mockDmRepository.removeConversation(_testConversationId1),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => ConversationRemovalOutcome.refused);
 
         final cubit = createCubit();
 
-        // Self is excluded from the predicate, so the moderation account can
-        // still clear its own request list.
+        expect(
+          await cubit.declineRequest(_testConversationId1),
+          DeclineRequestOutcome.refused,
+        );
+
+        await cubit.close();
+      });
+
+      test('reports removed when the repository allows it', () async {
+        when(
+          () => mockDmRepository.removeConversation(_testConversationId1),
+        ).thenAnswer((_) async => ConversationRemovalOutcome.removed);
+
+        final cubit = createCubit();
+
         expect(
           await cubit.declineRequest(_testConversationId1),
           DeclineRequestOutcome.removed,
@@ -349,64 +308,37 @@ void main() {
         await cubit.close();
       });
 
-      test('fails open when the conversation row is gone', () async {
+      test('passes every id to the repository and lets it filter', () async {
+        // The cubit must NOT pre-filter: doing so is what let the inbox path
+        // inherit no guard at all (#8391).
         when(
-          () => mockDmRepository.getConversation(_testConversationId1),
-        ).thenAnswer((_) async => null);
-        when(
-          () => mockDmRepository.removeConversation(_testConversationId1),
-        ).thenAnswer((_) async {});
+          () => mockDmRepository.removeConversations(any()),
+        ).thenAnswer((_) async => (removed: 1, refused: 1));
 
         final cubit = createCubit();
 
-        // A stale id must not become an undeletable request.
-        expect(
-          await cubit.declineRequest(_testConversationId1),
-          DeclineRequestOutcome.removed,
-        );
-
-        await cubit.close();
-      });
-
-      blocTest<MessageRequestActionsCubit, MessageRequestActionsState>(
-        'removeAllRequests sweeps only the unprotected conversations',
-        setUp: () {
-          when(
-            () => mockDmRepository.removeConversations(any()),
-          ).thenAnswer((_) async {});
-        },
-        build: createCubit,
-        act: (cubit) => cubit.removeAllRequests([
+        await cubit.removeAllRequests([
           _conversation(_testConversationId1, peer: _stranger),
           _conversation(_testConversationId2, peer: _moderation),
-        ]),
-        verify: (_) {
-          verify(
-            () => mockDmRepository.removeConversations([_testConversationId1]),
-          ).called(1);
-        },
-      );
+        ]);
 
-      blocTest<MessageRequestActionsCubit, MessageRequestActionsState>(
-        'removeAllRequests does not emit when every row is protected',
-        build: createCubit,
-        act: (cubit) => cubit.removeAllRequests([
-          _conversation(_testConversationId1, peer: _moderation),
-        ]),
-        expect: () => const <MessageRequestActionsState>[],
-        verify: (_) {
-          verifyNever(() => mockDmRepository.removeConversations(any()));
-        },
-      );
+        verify(
+          () => mockDmRepository.removeConversations([
+            _testConversationId1,
+            _testConversationId2,
+          ]),
+        ).called(1);
 
-      // The sweep is silent about what it kept, so the guard is invisible in
-      // the bulk path: with only a notice in the list it removes nothing,
-      // emits nothing, and the button looks broken. The caller needs to know a
-      // row was withheld so it can say so (#8347).
+        await cubit.close();
+      });
+
+      // The sweep was silent about what it kept, so the guard was invisible in
+      // the bulk path: with only a notice in the list it removed nothing,
+      // emitted nothing, and the button looked broken (#8347).
       test('removeAllRequests reports the notice it withheld', () async {
         when(
           () => mockDmRepository.removeConversations(any()),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => (removed: 1, refused: 1));
 
         final cubit = createCubit();
 
@@ -417,15 +349,16 @@ void main() {
           ]),
           (withheld: true, failed: false),
         );
-        verify(
-          () => mockDmRepository.removeConversations([_testConversationId1]),
-        ).called(1);
 
         await cubit.close();
       });
 
-      test('removeAllRequests reports a withheld row it could not sweep at '
-          'all', () async {
+      test('removeAllRequests reports a sweep that removed nothing '
+          'at all', () async {
+        when(
+          () => mockDmRepository.removeConversations(any()),
+        ).thenAnswer((_) async => (removed: 0, refused: 1));
+
         final cubit = createCubit();
 
         expect(
@@ -434,7 +367,6 @@ void main() {
           ]),
           (withheld: true, failed: false),
         );
-        verifyNever(() => mockDmRepository.removeConversations(any()));
 
         await cubit.close();
       });
@@ -444,7 +376,7 @@ void main() {
         () async {
           when(
             () => mockDmRepository.removeConversations(any()),
-          ).thenAnswer((_) async {});
+          ).thenAnswer((_) async => (removed: 1, refused: 0));
 
           final cubit = createCubit();
 
@@ -475,26 +407,6 @@ void main() {
             await cubit.removeAllRequests([
               _conversation(_testConversationId1, peer: _stranger),
               _conversation(_testConversationId2, peer: _moderation),
-            ]),
-            (withheld: true, failed: true),
-          );
-
-          await cubit.close();
-        },
-      );
-
-      test(
-        'removeAllRequests reports a failure with nothing withheld',
-        () async {
-          when(
-            () => mockDmRepository.removeConversations(any()),
-          ).thenThrow(Exception('drift is down'));
-
-          final cubit = createCubit();
-
-          expect(
-            await cubit.removeAllRequests([
-              _conversation(_testConversationId1, peer: _stranger),
             ]),
             (withheld: false, failed: true),
           );

--- a/mobile/test/providers/dm_repository_provider_test.dart
+++ b/mobile/test/providers/dm_repository_provider_test.dart
@@ -9,10 +9,12 @@ import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart' as nostr_filter;
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -34,6 +36,9 @@ class _TestNostrSession extends NostrSession {
   @override
   NostrSessionReadiness build() => _readiness;
 }
+
+const _ordinaryPeerPubkey =
+    'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 
 void main() {
   // 64-character hex pubkey for tests.
@@ -135,6 +140,65 @@ void main() {
       ).called(1);
       expect(repository.isInitialized, isTrue);
       expect(repository.userPubkey, equals(testPubkey));
+    });
+
+    // #8391: the removal policy is what stops ANY caller destroying a Divine
+    // Moderation enforcement notice. The repository default is permissive, so
+    // a forgotten injection here would silently reopen the hole this fixed —
+    // which is exactly how the bug arose, one layer up.
+    test('injects a removal policy that protects a moderation thread', () {
+      final container = createContainer(
+        readiness: NostrSessionReadiness.nostrReady(
+          pubkey: testPubkey,
+          client: mockNostrClient,
+        ),
+      );
+      addTearDown(container.dispose);
+
+      final repository = container.read(dmRepositoryProvider);
+
+      expect(
+        repository.isRemovalProtected(
+          DmConversation(
+            id: 'moderation-thread',
+            participantPubkeys: const [testPubkey, kModerationPubkeyHex],
+            isGroup: false,
+            createdAt: 0,
+          ),
+        ),
+        isTrue,
+        reason: 'the current moderation key must be protected',
+      );
+      expect(
+        repository.isRemovalProtected(
+          DmConversation(
+            id: 'retired-moderation-thread',
+            participantPubkeys: [
+              testPubkey,
+              kLegacyModerationPubkeys.first,
+            ],
+            isGroup: false,
+            createdAt: 0,
+          ),
+        ),
+        isTrue,
+        reason: 'a retired key still carries enforcement history (#8302)',
+      );
+      expect(
+        repository.isRemovalProtected(
+          DmConversation(
+            id: 'ordinary-thread',
+            participantPubkeys: const [
+              testPubkey,
+              _ordinaryPeerPubkey,
+            ],
+            isGroup: false,
+            createdAt: 0,
+          ),
+        ),
+        isFalse,
+        reason: 'an ordinary peer stays removable',
+      );
     });
 
     test('does NOT open subscription before Nostr session is ready', () async {

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -81,6 +81,17 @@ class _MockAuthService extends MockAuthService {
 }
 
 void main() {
+  setUpAll(
+    () => registerFallbackValue(
+      DmConversation(
+        id: 'fallback',
+        participantPubkeys: const [],
+        isGroup: false,
+        createdAt: 0,
+      ),
+    ),
+  );
+
   const currentPubkey =
       'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
   const otherPubkey =
@@ -168,6 +179,9 @@ void main() {
         () => mockActionsCubit.state,
       ).thenReturn(const ConversationActionsState());
       when(() => mockActionsCubit.isBlocked(any())).thenReturn(false);
+      when(
+        () => mockActionsCubit.isRemovalProtected(any()),
+      ).thenReturn(false);
       whenListen(
         mockActionsCubit,
         const Stream<ConversationActionsState>.empty(),
@@ -2512,7 +2526,7 @@ void main() {
 
           // The pin replaced an ordinary row that had these actions; losing
           // them on adoption is the regression this guards (#6388 review).
-          expect(find.text(l10n.inboxActionRemove), findsOneWidget);
+          // Remove is the deliberate exception — see the sibling test below.
           expect(
             find.text(l10n.inboxActionBlock(l10n.inboxSupportRowTitle)),
             findsOneWidget,
@@ -2529,6 +2543,94 @@ void main() {
           );
         },
       );
+
+      // #8391: the arc #6971 -> #8302 made an enforcement notice unremovable
+      // in Message Requests, but the CURRENT-key notice never goes there — it
+      // is lifted into the pinned row, whose long-press offered "Remove
+      // conversation" through a cubit with no policy at all. Withdrawing the
+      // action is the deliberate reversal of the #6388-review expectation
+      // above: Mute / Report / Block still survive adoption, Remove does not,
+      // because removal is permanent and the notice is the user's only copy
+      // of why they were actioned.
+      testWidgets(
+        'withdraws Remove from the sheet for a protected moderation thread',
+        (tester) async {
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          final actionsCubit = _MockConversationActionsCubit();
+
+          await tester.pumpWidget(
+            buildSubject(
+              actionsCubit: actionsCubit,
+              state: ConversationListState(
+                status: ConversationListStatus.loaded,
+                pinnedSupport: supportPin(
+                  isPersisted: true,
+                  lastMessageContent: 'We looked into your report',
+                ),
+              ),
+            ),
+          );
+          when(
+            () => actionsCubit.isRemovalProtected(any()),
+          ).thenReturn(true);
+          await openMessages(tester);
+
+          await tester.longPress(find.text(l10n.inboxSupportRowTitle));
+          await tester.pumpAndSettle();
+
+          expect(find.text(l10n.inboxActionRemove), findsNothing);
+          // The safety actions the pin inherited are untouched.
+          expect(
+            find.text(l10n.inboxActionBlock(l10n.inboxSupportRowTitle)),
+            findsOneWidget,
+          );
+          expect(
+            find.text(l10n.inboxActionReport(l10n.inboxSupportRowTitle)),
+            findsOneWidget,
+          );
+        },
+      );
+
+      // Defence in depth: if the action is reached anyway, the repository
+      // still refuses, and a refusal must read as an explanation rather than
+      // as an error or a false success.
+      testWidgets('explains a refusal instead of reporting success', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final actionsCubit = _MockConversationActionsCubit();
+
+        await tester.pumpWidget(
+          buildSubject(
+            actionsCubit: actionsCubit,
+            wrapInScaffold: true,
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              pinnedSupport: supportPin(
+                isPersisted: true,
+                lastMessageContent: 'We looked into your report',
+              ),
+            ),
+          ),
+        );
+        when(
+          () => actionsCubit.removeConversation(any()),
+        ).thenAnswer((_) async => RemoveConversationOutcome.refused);
+        await openMessages(tester);
+
+        await tester.longPress(find.text(l10n.inboxSupportRowTitle));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(l10n.inboxActionRemove));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(l10n.inboxRemoveConfirmConfirm));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text(l10n.messageRequestModerationNoticeCannotBeRemoved),
+          findsOneWidget,
+        );
+        expect(find.text(l10n.inboxRemovedConversation), findsNothing);
+      });
 
       testWidgets(
         'keeps moderation safety actions named when the vanish lookup fails',


### PR DESCRIPTION
## Description

#6971 → #8302 made a Divine Moderation enforcement notice unremovable, because it is the user's only copy of why they were actioned — the account-status API has no reason field, no appeals workflow exists, and removal is permanent (one transaction writes an owner-scoped tombstone that suppresses relay replay for the account's lifetime).

**That guard went into `MessageRequestActionsCubit` only, and in the common case the notice never travels through it.** `DmRepository.extractPinnedSupport` lifts the current-key thread out of Message Requests and into the pinned support row, whose long-press offered **Remove conversation** through `ConversationActionsCubit` — a cubit that takes no policy at all. Found while validating #8347 and reproduced on a device build of `main`: the notice was destroyed and the app reported success.

`PinnedSupport.isPersisted` does not save us. It is true exactly when the conversation **exists**, so it enables the destructive action precisely for users who hold a real notice and disables it only for users with nothing to lose.

Adding the same predicate to a second cubit would reproduce the structure that caused this, so the policy moves to the boundary both destructive paths share. `DmRepository` takes an injected `DmConversationRemovalPolicy` and enforces it in `removeConversation` / `removeConversations`. Every current and future caller inherits it.

This follows two seams the package already has: an injected policy (`DmSendPolicy`) and an identity passed as a parameter rather than imported (`extractPinnedSupport`'s `supportPubkey`). The package stays free of Divine's own pubkeys.

Shape decisions worth a reviewer's attention:

- **`removeConversations` filters and reports counts** rather than refusing the batch. Refusing the batch would break #8302's "sweep the spam, keep the notice" and #8347's `(withheld, failed)` contract — both of which are unchanged, and #8347's three view tests are untouched and still green.
- **A refusal returns, it does not throw.** Per `.claude/rules/error_handling.md` a refusal is not a failure and must stay out of the Crashlytics path — the same reasoning behind `DeclineRequestOutcome`.
- **An absent row fails open**, so a stale id can never become undeletable. That semantic moved down from the cubit rather than being dropped.
- **Self is excluded and every participant is scanned** (`.any`, never `.first`), so a signed-in moderation account can still clear its own threads and a group is judged by all of its members — the bug caught in #8302 review (`739349d45`) cannot recur, because there is now one place that does it.
- **The sheet withdraws Remove for a protected peer**, so nobody meets a dead-end refusal. The repository still refuses either way; the UI change is politeness, not the guard. One call site covers both surfaces, which matters because the same moderation thread renders as an *ordinary* row whenever a filter or search drops the pin.

**No new ARB keys.** `messageRequestModerationNoticeCannotBeRemoved` already ships in 22 locales and is already the refusal snackbar on the single-request path; only its `@description` gained a note about the new call site.

**Related Issue:** Closes #8391. Part of #8228. Context: #6971, #8302, #8347.

## Deliberate behaviour change, flagged rather than buried

`inbox_view_test.dart` asserted that **Remove survives pin adoption**, guarding a #6388-review concern that adopting the pin must not silently strip the actions an ordinary row had. That reasoning still holds for Mute / Report / Block and those assertions are unchanged. It does not extend to Remove once Remove is known to destroy the user's only record of an enforcement reason. The single assertion is narrowed and a sibling test now pins the new expectation with the why in its comment.

## Out of Scope

- The confirmation copy. It currently reads *"If they message you again, a new conversation starts"* — reassuring and true, while saying nothing about the reason being destroyed. Withdrawing Remove makes it unreachable for this case, and copy changes touch 22 locales and belong with product. Filed as #8406.
- `MessageRequestActionsCubit`'s own `_isProtected` is deleted rather than kept alongside the repository's: one source of truth was the point.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `dart format --set-exit-if-changed lib test packages` — clean
- `flutter test test/screens/inbox/ test/blocs/dm/ test/providers/dm_repository_provider_test.dart test/l10n/arb_consistency_test.dart` — **915 passed**
- `mobile/packages/dm_repository` — **744 passed**, coverage **94.47%** against the package's 93% gate
- Ratchets: post-close emit, ungrouped tests, skip, placeholder, orphaned ARB, l10n delegates, test/unit structure — all pass

**Every new test was mutated at the production boundary to prove it can fail**, not merely watched go green:

| Mutation | Result |
|---|---|
| `_isRemovalProtected` neutered | 5 of 11 package tests fail |
| `canRemove: true` forced in `inbox_view` | the withdrawal test fails |
| refusal snackbar branch removed | the refusal test fails |
| `withheld` pinned to `false` (earlier, on #8347's code) | 3 cubit tests fail |

The device reproduction that found this is the inverse assertion: calling `removeConversation` on a moderation thread previously returned with the row gone (`PATROL_VERDICT moderation_conversation=DESTROYED`); it now returns `refused` with the row intact.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

