### PR TITLE
fix(dm): stop the startup dedup pass from erasing a group conversation

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -594,22 +594,6 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
         .go();
   }
 
-  /// Move all messages from one conversation to another.
-  Future<int> reassignConversation({
-    required String fromConversationId,
-    required String toConversationId,
-    String? ownerPubkey,
-  }) {
-    return (update(directMessages)..where(
-          (t) =>
-              t.conversationId.equals(fromConversationId) &
-              _ownedOrLegacy(t.ownerPubkey, ownerPubkey),
-        ))
-        .write(
-          DirectMessagesCompanion(conversationId: Value(toConversationId)),
-        );
-  }
-
   /// Count messages in a conversation.
   Future<int> countMessages(
     String conversationId, {

--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -595,8 +595,6 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
   }
 
   /// Move all messages from one conversation to another.
-  ///
-  /// Used when merging duplicate conversations into a canonical one.
   Future<int> reassignConversation({
     required String fromConversationId,
     required String toConversationId,

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -763,7 +763,7 @@ class DmRepository {
     }
 
     // Run post-auth maintenance sequentially so each step operates on the
-    // final state of the previous one (e.g. backfill runs after merge).
+    // final state of the previous one.
     _postAuthMaintenance = _runPostAuthMaintenance();
     unawaited(_postAuthMaintenance);
   }
@@ -6897,8 +6897,7 @@ class DmRepository {
   }
 
   /// Runs post-auth cleanup and migration tasks sequentially so each step
-  /// operates on the final state of the previous one (e.g. backfill runs
-  /// after merge creates canonical conversation rows).
+  /// operates on the final state of the previous one.
   Future<void> _runPostAuthMaintenance() async {
     await _cleanupSelfConversations();
     await _backfillCurrentUserHasSent();

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -6858,93 +6858,6 @@ class DmRepository {
   // Helpers
   // -------------------------------------------------------------------------
 
-  /// Merges duplicate conversations where the same 1:1 peer appears as
-  /// multiple conversations due to extra p-tags in NIP-17 events.
-  ///
-  /// For each peer that has more than one conversation with the current user,
-  /// keeps the canonical 1:1 conversation and merges the rest into it.
-  /// Idempotent and safe to run on every startup.
-  Future<void> _mergeDuplicateConversations() async {
-    try {
-      final allConversations = await _conversationsDao.getAllConversations(
-        ownerPubkey: _ownerPubkey,
-      );
-
-      // Group conversations by peer pubkey to find duplicates.
-      final peerGroups = <String, List<ConversationRow>>{};
-      for (final conv in allConversations) {
-        final participants = (jsonDecode(conv.participantPubkeys) as List)
-            .cast<String>();
-        final peers = participants.where((pk) => pk != _userPubkey).toList()
-          ..sort();
-        if (peers.isEmpty) continue;
-
-        // Use the first peer as the grouping key.
-        final peerKey = peers.first;
-        peerGroups.putIfAbsent(peerKey, () => []).add(conv);
-      }
-
-      for (final entry in peerGroups.entries) {
-        if (entry.value.length <= 1) continue;
-
-        final canonical1to1Participants = [_userPubkey, entry.key]..sort();
-        final canonicalId = computeConversationId(canonical1to1Participants);
-
-        // Check if the canonical 1:1 row already exists.
-        final hasCanonicalRow = entry.value.any((c) => c.id == canonicalId);
-
-        // Merge all conversations into the canonical 1:1 ID.
-        await _conversationsDao.runInTransaction(() async {
-          for (final conv in entry.value) {
-            if (conv.id == canonicalId) continue;
-
-            await _directMessagesDao.reassignConversation(
-              fromConversationId: conv.id,
-              toConversationId: canonicalId,
-              ownerPubkey: _userPubkey,
-            );
-            await _conversationsDao.deleteConversation(
-              conv.id,
-              ownerPubkey: _ownerPubkey,
-            );
-          }
-
-          // If the canonical 1:1 row didn't exist, create it from the most
-          // recent duplicate's metadata. Read state is the conservative
-          // merge — unread if ANY merged duplicate is unread — so
-          // canonicalization never silently drops a real unread signal from
-          // an older duplicate.
-          if (!hasCanonicalRow) {
-            final source = entry.value.first;
-            await _conversationsDao.upsertConversation(
-              id: canonicalId,
-              participantPubkeys: jsonEncode(canonical1to1Participants),
-              isGroup: false,
-              createdAt: source.createdAt,
-              lastMessageContent: source.lastMessageContent,
-              lastMessageTimestamp: source.lastMessageTimestamp,
-              lastMessageSenderPubkey: source.lastMessageSenderPubkey,
-              isRead: entry.value.every((c) => c.isRead),
-              currentUserHasSent: source.currentUserHasSent,
-              ownerPubkey: source.ownerPubkey,
-              dmProtocol: source.dmProtocol,
-            );
-          }
-        });
-
-        // Refresh preview from actual messages.
-        await _refreshConversationPreview(canonicalId);
-      }
-    } on Object catch (e, stackTrace) {
-      Log.error(
-        'Failed to merge duplicate conversations: $e',
-        category: LogCategory.system,
-        error: e,
-        stackTrace: stackTrace,
-      );
-    }
-  }
-
   /// Removes phantom self-conversations created by the self-wrap bug where
   /// `_resolveConversationParticipants` produced `[self, self]`.
   ///
@@ -6987,7 +6900,6 @@ class DmRepository {
   /// operates on the final state of the previous one (e.g. backfill runs
   /// after merge creates canonical conversation rows).
   Future<void> _runPostAuthMaintenance() async {
-    await _mergeDuplicateConversations();
     await _cleanupSelfConversations();
     await _backfillCurrentUserHasSent();
     await _backfillConversationPreviews();

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -16240,13 +16240,6 @@ void main() {
         );
 
         when(
-          () => mockDirectMessagesDao.reassignConversation(
-            fromConversationId: any(named: 'fromConversationId'),
-            toConversationId: any(named: 'toConversationId'),
-            ownerPubkey: any(named: 'ownerPubkey'),
-          ),
-        ).thenAnswer((_) async => 1);
-        when(
           () => mockConversationsDao.deleteConversation(
             any(),
             ownerPubkey: any(named: 'ownerPubkey'),
@@ -16276,13 +16269,6 @@ void main() {
         verifyNever(
           () => mockConversationsDao.deleteConversation(
             groupId,
-            ownerPubkey: any(named: 'ownerPubkey'),
-          ),
-        );
-        verifyNever(
-          () => mockDirectMessagesDao.reassignConversation(
-            fromConversationId: groupId,
-            toConversationId: any(named: 'toConversationId'),
             ownerPubkey: any(named: 'ownerPubkey'),
           ),
         );

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -16187,6 +16187,102 @@ void main() {
       );
     });
 
+    // #8270 / #8203. `_mergeDuplicateConversations` used to run here and
+    // bucketed every row by its alphabetically-first peer, so a group was
+    // folded into the 1:1 sharing that peer — messages reassigned, row
+    // deleted, other participants erased. The pass is gone; this pins the
+    // outcome rather than its absence, so re-adding any peer-keyed merge
+    // fails here.
+    group('post-auth maintenance leaves a group conversation intact', () {
+      test('does not reassign or delete a group sharing a 1:1 peer', () async {
+        final oneToOne = [_validPubkeyA, _validPubkeyB]..sort();
+        final groupParticipants = [
+          _validPubkeyA,
+          _validPubkeyB,
+          _validPubkeyC,
+        ]..sort();
+        final groupId = DmRepository.computeConversationId(groupParticipants);
+
+        when(
+          () => mockConversationsDao.getAllConversations(
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            ConversationRow(
+              id: DmRepository.computeConversationId(oneToOne),
+              participantPubkeys: jsonEncode(oneToOne),
+              isGroup: false,
+              isRead: true,
+              currentUserHasSent: true,
+              createdAt: 1700000000,
+              lastMessageContent: '1:1 msg',
+              lastMessageTimestamp: 1700000000,
+              lastMessageSenderPubkey: _validPubkeyB,
+            ),
+            ConversationRow(
+              id: groupId,
+              participantPubkeys: jsonEncode(groupParticipants),
+              isGroup: true,
+              isRead: true,
+              currentUserHasSent: true,
+              createdAt: 1699999000,
+              lastMessageContent: 'Group msg',
+              lastMessageTimestamp: 1699999000,
+              lastMessageSenderPubkey: _validPubkeyB,
+            ),
+          ],
+        );
+
+        when(
+          () => mockDirectMessagesDao.reassignConversation(
+            fromConversationId: any(named: 'fromConversationId'),
+            toConversationId: any(named: 'toConversationId'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => 1);
+        when(
+          () => mockConversationsDao.deleteConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => 1);
+        when(
+          () => mockConversationsDao.getConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+        when(() => mockNostrClient.unsubscribe(any())).thenAnswer((_) async {});
+
+        DmRepository(
+          nostrClient: mockNostrClient,
+          directMessagesDao: mockDirectMessagesDao,
+          conversationsDao: mockConversationsDao,
+        ).setCredentials(
+          userPubkey: _validPubkeyA,
+          signer: LocalNostrSigner(_validPrivateKey),
+          messageService: mockMessageService,
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        verifyNever(
+          () => mockConversationsDao.deleteConversation(
+            groupId,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+        verifyNever(
+          () => mockDirectMessagesDao.reassignConversation(
+            fromConversationId: groupId,
+            toConversationId: any(named: 'toConversationId'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      });
+    });
+
     group('_cleanupSelfConversations', () {
       test(
         'deletes self-conversation when it exists',
@@ -16916,309 +17012,6 @@ void main() {
           );
         },
       );
-    });
-
-    group('_mergeDuplicateConversations', () {
-      test(
-        'merges duplicate conversations into canonical 1:1 ID',
-        () async {
-          final canonical = [_validPubkeyA, _validPubkeyB]..sort();
-          final canonicalId = DmRepository.computeConversationId(canonical);
-
-          // Two conversations exist for the same peer: one canonical, one
-          // phantom from extra p-tags.
-          final phantomParticipants = [
-            _validPubkeyA,
-            _validPubkeyB,
-            _validPubkeyC,
-          ]..sort();
-          final phantomId = DmRepository.computeConversationId(
-            phantomParticipants,
-          );
-
-          when(
-            () => mockConversationsDao.getAllConversations(
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          ).thenAnswer(
-            (_) async => [
-              ConversationRow(
-                id: canonicalId,
-                participantPubkeys: jsonEncode(canonical),
-                isGroup: false,
-                isRead: true,
-                currentUserHasSent: true,
-                createdAt: 1700000000,
-                lastMessageContent: 'Canonical msg',
-                lastMessageTimestamp: 1700000000,
-                lastMessageSenderPubkey: _validPubkeyB,
-              ),
-              ConversationRow(
-                id: phantomId,
-                participantPubkeys: jsonEncode(phantomParticipants),
-                isGroup: false,
-                isRead: true,
-                currentUserHasSent: false,
-                createdAt: 1699999000,
-                lastMessageContent: 'Phantom msg',
-                lastMessageTimestamp: 1699999000,
-                lastMessageSenderPubkey: _validPubkeyB,
-              ),
-            ],
-          );
-
-          when(
-            () => mockDirectMessagesDao.reassignConversation(
-              fromConversationId: any(named: 'fromConversationId'),
-              toConversationId: any(named: 'toConversationId'),
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          ).thenAnswer((_) async => 1);
-
-          when(
-            () => mockConversationsDao.deleteConversation(
-              phantomId,
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          ).thenAnswer((_) async => 1);
-
-          // Stub for _refreshConversationPreview
-          when(
-            () => mockDirectMessagesDao.getMessagesForConversation(
-              canonicalId,
-              limit: 1,
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          ).thenAnswer((_) async => []);
-
-          when(
-            () => mockConversationsDao.getConversation(
-              canonicalId,
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          ).thenAnswer((_) async => null);
-
-          when(
-            () => mockConversationsDao.upsertConversation(
-              id: any(named: 'id'),
-              participantPubkeys: any(named: 'participantPubkeys'),
-              isGroup: any(named: 'isGroup'),
-              createdAt: any(named: 'createdAt'),
-              lastMessageContent: any(named: 'lastMessageContent'),
-              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
-              lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
-              currentUserHasSent: any(named: 'currentUserHasSent'),
-              ownerPubkey: any(named: 'ownerPubkey'),
-              dmProtocol: any(named: 'dmProtocol'),
-            ),
-          ).thenAnswer((_) async {});
-
-          // Stub self-conversation for _cleanupSelfConversations
-          final selfConvId = DmRepository.computeConversationId(
-            [_validPubkeyA, _validPubkeyA],
-          );
-          when(
-            () => mockConversationsDao.getConversation(
-              selfConvId,
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          ).thenAnswer((_) async => null);
-
-          when(
-            () => mockNostrClient.unsubscribe(any()),
-          ).thenAnswer((_) async {});
-
-          DmRepository(
-            nostrClient: mockNostrClient,
-            directMessagesDao: mockDirectMessagesDao,
-            conversationsDao: mockConversationsDao,
-          ).setCredentials(
-            userPubkey: _validPubkeyA,
-            signer: LocalNostrSigner(_validPrivateKey),
-            messageService: mockMessageService,
-          );
-
-          await Future<void>.delayed(const Duration(milliseconds: 50));
-
-          // Phantom messages should be reassigned to canonical ID.
-          verify(
-            () => mockDirectMessagesDao.reassignConversation(
-              fromConversationId: phantomId,
-              toConversationId: canonicalId,
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          ).called(1);
-
-          // Phantom conversation should be deleted.
-          verify(
-            () => mockConversationsDao.deleteConversation(
-              phantomId,
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          ).called(1);
-        },
-      );
-
-      test(
-        'creates canonical row when it does not exist',
-        () async {
-          // Only the phantom exists, not the canonical row.
-          final phantomParticipants = [
-            _validPubkeyA,
-            _validPubkeyB,
-            _validPubkeyC,
-          ]..sort();
-          final phantomId = DmRepository.computeConversationId(
-            phantomParticipants,
-          );
-
-          when(
-            () => mockConversationsDao.getAllConversations(
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          ).thenAnswer(
-            (_) async => [
-              ConversationRow(
-                id: phantomId,
-                participantPubkeys: jsonEncode(phantomParticipants),
-                isGroup: false,
-                isRead: true,
-                currentUserHasSent: false,
-                createdAt: 1699999000,
-                lastMessageContent: 'Phantom',
-                lastMessageTimestamp: 1699999000,
-                lastMessageSenderPubkey: _validPubkeyB,
-                ownerPubkey: _validPubkeyA,
-                dmProtocol: 'nip17',
-              ),
-            ],
-          );
-
-          when(
-            () => mockDirectMessagesDao.reassignConversation(
-              fromConversationId: any(named: 'fromConversationId'),
-              toConversationId: any(named: 'toConversationId'),
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          ).thenAnswer((_) async => 0);
-
-          when(
-            () => mockConversationsDao.deleteConversation(
-              any(),
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          ).thenAnswer((_) async => 0);
-
-          when(
-            () => mockConversationsDao.upsertConversation(
-              id: any(named: 'id'),
-              participantPubkeys: any(named: 'participantPubkeys'),
-              isGroup: any(named: 'isGroup'),
-              createdAt: any(named: 'createdAt'),
-              lastMessageContent: any(named: 'lastMessageContent'),
-              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
-              lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
-              currentUserHasSent: any(named: 'currentUserHasSent'),
-              ownerPubkey: any(named: 'ownerPubkey'),
-              dmProtocol: any(named: 'dmProtocol'),
-            ),
-          ).thenAnswer((_) async {});
-
-          when(
-            () => mockDirectMessagesDao.getMessagesForConversation(
-              any(),
-              limit: 1,
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          ).thenAnswer((_) async => []);
-
-          when(
-            () => mockConversationsDao.getConversation(
-              any(),
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          ).thenAnswer((_) async => null);
-
-          when(
-            () => mockNostrClient.unsubscribe(any()),
-          ).thenAnswer((_) async {});
-
-          DmRepository(
-            nostrClient: mockNostrClient,
-            directMessagesDao: mockDirectMessagesDao,
-            conversationsDao: mockConversationsDao,
-          ).setCredentials(
-            userPubkey: _validPubkeyA,
-            signer: LocalNostrSigner(_validPrivateKey),
-            messageService: mockMessageService,
-          );
-
-          await Future<void>.delayed(const Duration(milliseconds: 50));
-
-          // Only 1 conversation → no duplicates to merge (peerGroups
-          // will have a single entry), so no reassignment.
-          verifyNever(
-            () => mockDirectMessagesDao.reassignConversation(
-              fromConversationId: any(named: 'fromConversationId'),
-              toConversationId: any(named: 'toConversationId'),
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          );
-        },
-      );
-
-      test('single conversation per peer is a no-op', () async {
-        final participants = [_validPubkeyA, _validPubkeyB]..sort();
-        final convId = DmRepository.computeConversationId(participants);
-
-        when(
-          () => mockConversationsDao.getAllConversations(
-            ownerPubkey: any(named: 'ownerPubkey'),
-          ),
-        ).thenAnswer(
-          (_) async => [
-            ConversationRow(
-              id: convId,
-              participantPubkeys: jsonEncode(participants),
-              isGroup: false,
-              isRead: true,
-              currentUserHasSent: true,
-              createdAt: 1700000000,
-            ),
-          ],
-        );
-
-        when(
-          () => mockConversationsDao.getConversation(
-            any(),
-            ownerPubkey: any(named: 'ownerPubkey'),
-          ),
-        ).thenAnswer((_) async => null);
-
-        when(
-          () => mockNostrClient.unsubscribe(any()),
-        ).thenAnswer((_) async {});
-
-        DmRepository(
-          nostrClient: mockNostrClient,
-          directMessagesDao: mockDirectMessagesDao,
-          conversationsDao: mockConversationsDao,
-        ).setCredentials(
-          userPubkey: _validPubkeyA,
-          signer: LocalNostrSigner(_validPrivateKey),
-          messageService: mockMessageService,
-        );
-
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-
-        verifyNever(
-          () => mockDirectMessagesDao.reassignConversation(
-            fromConversationId: any(named: 'fromConversationId'),
-            toConversationId: any(named: 'toConversationId'),
-            ownerPubkey: any(named: 'ownerPubkey'),
-          ),
-        );
-      });
     });
 
     group('setCredentials with custom decryptors', () {
@@ -23334,495 +23127,6 @@ void main() {
           () => repository.cancelOutgoingBatch(rumorId: winnerRumorId),
           throwsStateError,
         );
-      });
-    });
-
-    group(
-      '_mergeDuplicateConversations creates canonical row from phantoms',
-      () {
-        test(
-          'creates canonical row when only phantom rows exist',
-          () async {
-            // Two phantom conversations for the same peer (B), but
-            // with different extra participants — neither has the
-            // canonical 1:1 ID.
-            final phantomParticipants1 = [
-              _validPubkeyA,
-              _validPubkeyB,
-              _validPubkeyC,
-            ]..sort();
-            final phantomId1 = DmRepository.computeConversationId(
-              phantomParticipants1,
-            );
-            final phantomParticipants2 = [
-              _validPubkeyA,
-              _validPubkeyB,
-              _validPubkeyD,
-            ]..sort();
-            final phantomId2 = DmRepository.computeConversationId(
-              phantomParticipants2,
-            );
-            final canonical = [_validPubkeyA, _validPubkeyB]..sort();
-            final canonicalId = DmRepository.computeConversationId(canonical);
-
-            when(
-              () => mockConversationsDao.getAllConversations(
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).thenAnswer(
-              (_) async => [
-                ConversationRow(
-                  id: phantomId1,
-                  participantPubkeys: jsonEncode(phantomParticipants1),
-                  isGroup: false,
-                  isRead: false,
-                  currentUserHasSent: false,
-                  createdAt: 1699999000,
-                  lastMessageContent: 'Phantom 1',
-                  lastMessageTimestamp: 1699999000,
-                  lastMessageSenderPubkey: _validPubkeyB,
-                  ownerPubkey: _validPubkeyA,
-                  dmProtocol: 'nip17',
-                ),
-                ConversationRow(
-                  id: phantomId2,
-                  participantPubkeys: jsonEncode(phantomParticipants2),
-                  isGroup: false,
-                  isRead: true,
-                  currentUserHasSent: true,
-                  createdAt: 1699998000,
-                  lastMessageContent: 'Phantom 2',
-                  lastMessageTimestamp: 1699998000,
-                  lastMessageSenderPubkey: _validPubkeyA,
-                  ownerPubkey: _validPubkeyA,
-                ),
-              ],
-            );
-
-            when(
-              () => mockDirectMessagesDao.reassignConversation(
-                fromConversationId: any(named: 'fromConversationId'),
-                toConversationId: any(named: 'toConversationId'),
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).thenAnswer((_) async => 1);
-
-            when(
-              () => mockConversationsDao.deleteConversation(
-                any(),
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).thenAnswer((_) async => 1);
-
-            when(
-              () => mockConversationsDao.upsertConversation(
-                id: any(named: 'id'),
-                participantPubkeys: any(named: 'participantPubkeys'),
-                isGroup: any(named: 'isGroup'),
-                createdAt: any(named: 'createdAt'),
-                lastMessageContent: any(named: 'lastMessageContent'),
-                lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
-                lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
-                isRead: any(named: 'isRead'),
-                currentUserHasSent: any(named: 'currentUserHasSent'),
-                ownerPubkey: any(named: 'ownerPubkey'),
-                dmProtocol: any(named: 'dmProtocol'),
-                forceUpdateLastMessage: any(named: 'forceUpdateLastMessage'),
-              ),
-            ).thenAnswer((_) async {});
-
-            when(
-              () => mockDirectMessagesDao.getMessagesForConversation(
-                any(),
-                limit: 1,
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).thenAnswer((_) async => []);
-
-            when(
-              () => mockConversationsDao.getConversation(
-                any(),
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).thenAnswer((_) async => null);
-
-            when(
-              () => mockNostrClient.unsubscribe(any()),
-            ).thenAnswer((_) async {});
-
-            DmRepository(
-              nostrClient: mockNostrClient,
-              directMessagesDao: mockDirectMessagesDao,
-              conversationsDao: mockConversationsDao,
-            ).setCredentials(
-              userPubkey: _validPubkeyA,
-              signer: LocalNostrSigner(_validPrivateKey),
-              messageService: mockMessageService,
-            );
-
-            await Future<void>.delayed(const Duration(milliseconds: 50));
-
-            // Both phantoms should be reassigned to the canonical ID.
-            verify(
-              () => mockDirectMessagesDao.reassignConversation(
-                fromConversationId: phantomId1,
-                toConversationId: canonicalId,
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).called(1);
-            verify(
-              () => mockDirectMessagesDao.reassignConversation(
-                fromConversationId: phantomId2,
-                toConversationId: canonicalId,
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).called(1);
-
-            // Canonical row should be created from the first phantom's
-            // metadata since no canonical existed.
-            verify(
-              () => mockConversationsDao.upsertConversation(
-                id: canonicalId,
-                participantPubkeys: jsonEncode(canonical),
-                isGroup: false,
-                createdAt: 1699999000,
-                lastMessageContent: 'Phantom 1',
-                lastMessageTimestamp: 1699999000,
-                lastMessageSenderPubkey: _validPubkeyB,
-                isRead: false,
-                ownerPubkey: _validPubkeyA,
-                dmProtocol: 'nip17',
-              ),
-            ).called(1);
-          },
-        );
-
-        test(
-          'creates the canonical row unread when an older duplicate is '
-          'unread, even though the newest duplicate is read',
-          () async {
-            // Conservative read-state merge (#5515 review): the newest
-            // (source) duplicate is READ but an older duplicate is UNREAD,
-            // so the canonical row must be created UNREAD. Read state follows
-            // "unread if any duplicate is unread", not just the newest —
-            // `source.isRead` alone would have dropped the unread signal.
-            final phantomParticipants1 = [
-              _validPubkeyA,
-              _validPubkeyB,
-              _validPubkeyC,
-            ]..sort();
-            final phantomId1 = DmRepository.computeConversationId(
-              phantomParticipants1,
-            );
-            final phantomParticipants2 = [
-              _validPubkeyA,
-              _validPubkeyB,
-              _validPubkeyD,
-            ]..sort();
-            final phantomId2 = DmRepository.computeConversationId(
-              phantomParticipants2,
-            );
-            final canonical = [_validPubkeyA, _validPubkeyB]..sort();
-            final canonicalId = DmRepository.computeConversationId(canonical);
-
-            when(
-              () => mockConversationsDao.getAllConversations(
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).thenAnswer(
-              (_) async => [
-                // Newest duplicate (the source) is READ...
-                ConversationRow(
-                  id: phantomId1,
-                  participantPubkeys: jsonEncode(phantomParticipants1),
-                  isGroup: false,
-                  isRead: true,
-                  currentUserHasSent: false,
-                  createdAt: 1699999000,
-                  lastMessageContent: 'Phantom 1',
-                  lastMessageTimestamp: 1699999000,
-                  lastMessageSenderPubkey: _validPubkeyB,
-                  ownerPubkey: _validPubkeyA,
-                  dmProtocol: 'nip17',
-                ),
-                // ...but an OLDER duplicate is UNREAD.
-                ConversationRow(
-                  id: phantomId2,
-                  participantPubkeys: jsonEncode(phantomParticipants2),
-                  isGroup: false,
-                  isRead: false,
-                  currentUserHasSent: false,
-                  createdAt: 1699998000,
-                  lastMessageContent: 'Phantom 2',
-                  lastMessageTimestamp: 1699998000,
-                  lastMessageSenderPubkey: _validPubkeyB,
-                  ownerPubkey: _validPubkeyA,
-                ),
-              ],
-            );
-            when(
-              () => mockDirectMessagesDao.reassignConversation(
-                fromConversationId: any(named: 'fromConversationId'),
-                toConversationId: any(named: 'toConversationId'),
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).thenAnswer((_) async => 1);
-            when(
-              () => mockConversationsDao.deleteConversation(
-                any(),
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).thenAnswer((_) async => 1);
-            when(
-              () => mockConversationsDao.upsertConversation(
-                id: any(named: 'id'),
-                participantPubkeys: any(named: 'participantPubkeys'),
-                isGroup: any(named: 'isGroup'),
-                createdAt: any(named: 'createdAt'),
-                lastMessageContent: any(named: 'lastMessageContent'),
-                lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
-                lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
-                isRead: any(named: 'isRead'),
-                currentUserHasSent: any(named: 'currentUserHasSent'),
-                ownerPubkey: any(named: 'ownerPubkey'),
-                dmProtocol: any(named: 'dmProtocol'),
-                forceUpdateLastMessage: any(named: 'forceUpdateLastMessage'),
-              ),
-            ).thenAnswer((_) async {});
-            when(
-              () => mockDirectMessagesDao.getMessagesForConversation(
-                any(),
-                limit: 1,
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).thenAnswer((_) async => []);
-            when(
-              () => mockConversationsDao.getConversation(
-                any(),
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).thenAnswer((_) async => null);
-            when(
-              () => mockNostrClient.unsubscribe(any()),
-            ).thenAnswer((_) async {});
-
-            DmRepository(
-              nostrClient: mockNostrClient,
-              directMessagesDao: mockDirectMessagesDao,
-              conversationsDao: mockConversationsDao,
-            ).setCredentials(
-              userPubkey: _validPubkeyA,
-              signer: LocalNostrSigner(_validPrivateKey),
-              messageService: mockMessageService,
-            );
-
-            await Future<void>.delayed(const Duration(milliseconds: 50));
-
-            // every([read, unread]) == false → canonical created UNREAD,
-            // even though the source (Phantom 1) is read.
-            verify(
-              () => mockConversationsDao.upsertConversation(
-                id: canonicalId,
-                participantPubkeys: jsonEncode(canonical),
-                isGroup: false,
-                createdAt: 1699999000,
-                lastMessageContent: 'Phantom 1',
-                lastMessageTimestamp: 1699999000,
-                lastMessageSenderPubkey: _validPubkeyB,
-                isRead: false,
-                ownerPubkey: _validPubkeyA,
-                dmProtocol: 'nip17',
-              ),
-            ).called(1);
-          },
-        );
-
-        test(
-          'preview refresh after merge preserves an unread canonical '
-          'conversation when the refreshed message is newer',
-          () async {
-            // #5515 review note 1: the canonical row already exists and is
-            // UNREAD with a stale preview timestamp; merging a duplicate
-            // triggers _refreshConversationPreview with a strictly-newer
-            // message. The forced preview update must NOT flip the
-            // conversation read — read state is preserved explicitly.
-            final phantomParticipants = [
-              _validPubkeyA,
-              _validPubkeyB,
-              _validPubkeyC,
-            ]..sort();
-            final phantomId = DmRepository.computeConversationId(
-              phantomParticipants,
-            );
-            final canonical = [_validPubkeyA, _validPubkeyB]..sort();
-            final canonicalId = DmRepository.computeConversationId(canonical);
-
-            final canonicalRow = ConversationRow(
-              id: canonicalId,
-              participantPubkeys: jsonEncode(canonical),
-              isGroup: false,
-              isRead: false,
-              currentUserHasSent: false,
-              createdAt: 1000,
-              lastMessageContent: 'stale preview',
-              lastMessageTimestamp: 1000,
-              lastMessageSenderPubkey: _validPubkeyB,
-              ownerPubkey: _validPubkeyA,
-              dmProtocol: 'nip17',
-            );
-
-            when(
-              () => mockConversationsDao.getAllConversations(
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).thenAnswer(
-              (_) async => [
-                canonicalRow,
-                ConversationRow(
-                  id: phantomId,
-                  participantPubkeys: jsonEncode(phantomParticipants),
-                  isGroup: false,
-                  isRead: true,
-                  currentUserHasSent: false,
-                  createdAt: 900,
-                  lastMessageContent: 'phantom',
-                  lastMessageTimestamp: 900,
-                  lastMessageSenderPubkey: _validPubkeyB,
-                  ownerPubkey: _validPubkeyA,
-                ),
-              ],
-            );
-            when(
-              () => mockDirectMessagesDao.reassignConversation(
-                fromConversationId: any(named: 'fromConversationId'),
-                toConversationId: any(named: 'toConversationId'),
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).thenAnswer((_) async => 1);
-            when(
-              () => mockConversationsDao.deleteConversation(
-                any(),
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).thenAnswer((_) async => 1);
-            when(
-              () => mockConversationsDao.upsertConversation(
-                id: any(named: 'id'),
-                participantPubkeys: any(named: 'participantPubkeys'),
-                isGroup: any(named: 'isGroup'),
-                createdAt: any(named: 'createdAt'),
-                lastMessageContent: any(named: 'lastMessageContent'),
-                lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
-                lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
-                isRead: any(named: 'isRead'),
-                currentUserHasSent: any(named: 'currentUserHasSent'),
-                ownerPubkey: any(named: 'ownerPubkey'),
-                dmProtocol: any(named: 'dmProtocol'),
-                forceUpdateLastMessage: any(named: 'forceUpdateLastMessage'),
-              ),
-            ).thenAnswer((_) async {});
-            // A strictly-newer message than the canonical row's stale
-            // preview timestamp (1000) — this makes incomingIsNewer fire.
-            when(
-              () => mockDirectMessagesDao.getMessagesForConversation(
-                any(),
-                limit: 1,
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).thenAnswer(
-              (_) async => [
-                DirectMessageRow(
-                  id: _rumorEventId,
-                  conversationId: canonicalId,
-                  senderPubkey: _validPubkeyB,
-                  content: 'newer message',
-                  createdAt: 2000,
-                  giftWrapId: _giftWrapEventId,
-                  messageKind: 14,
-                  isDeleted: false,
-                  twinCollapsed: false,
-                ),
-              ],
-            );
-            when(
-              () => mockConversationsDao.getConversation(
-                any(),
-                ownerPubkey: any(named: 'ownerPubkey'),
-              ),
-            ).thenAnswer((_) async => canonicalRow);
-            when(
-              () => mockNostrClient.unsubscribe(any()),
-            ).thenAnswer((_) async {});
-
-            DmRepository(
-              nostrClient: mockNostrClient,
-              directMessagesDao: mockDirectMessagesDao,
-              conversationsDao: mockConversationsDao,
-            ).setCredentials(
-              userPubkey: _validPubkeyA,
-              signer: LocalNostrSigner(_validPrivateKey),
-              messageService: mockMessageService,
-            );
-
-            await Future<void>.delayed(const Duration(milliseconds: 50));
-
-            // The forced preview refresh advances the preview to the newer
-            // message but keeps the conversation unread (isRead: false).
-            verify(
-              () => mockConversationsDao.upsertConversation(
-                id: canonicalId,
-                participantPubkeys: any(named: 'participantPubkeys'),
-                isGroup: false,
-                createdAt: any(named: 'createdAt'),
-                lastMessageContent: 'newer message',
-                lastMessageTimestamp: 2000,
-                lastMessageSenderPubkey: _validPubkeyB,
-                isRead: false,
-                currentUserHasSent: any(named: 'currentUserHasSent'),
-                ownerPubkey: any(named: 'ownerPubkey'),
-                dmProtocol: any(named: 'dmProtocol'),
-                forceUpdateLastMessage: true,
-              ),
-            ).called(1);
-          },
-        );
-      },
-    );
-
-    group('_backfillCurrentUserHasSent', () {
-      test('logs when conversations are updated', () async {
-        when(
-          () => mockConversationsDao.backfillCurrentUserHasSent(any()),
-        ).thenAnswer((_) async => 3);
-
-        when(
-          () => mockConversationsDao.getConversation(
-            any(),
-            ownerPubkey: any(named: 'ownerPubkey'),
-          ),
-        ).thenAnswer((_) async => null);
-
-        when(
-          () => mockNostrClient.unsubscribe(any()),
-        ).thenAnswer((_) async {});
-
-        DmRepository(
-          nostrClient: mockNostrClient,
-          directMessagesDao: mockDirectMessagesDao,
-          conversationsDao: mockConversationsDao,
-        ).setCredentials(
-          userPubkey: _validPubkeyA,
-          signer: LocalNostrSigner(_validPrivateKey),
-          messageService: mockMessageService,
-        );
-
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-
-        verify(
-          () => mockConversationsDao.backfillCurrentUserHasSent(
-            _validPubkeyA,
-          ),
-        ).called(1);
       });
     });
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -16201,6 +16201,11 @@ void main() {
           _validPubkeyB,
           _validPubkeyC,
         ]..sort();
+        expect(
+          groupParticipants.firstWhere((pubkey) => pubkey != _validPubkeyA),
+          _validPubkeyB,
+          reason: 'the group must collide with the 1:1 peer',
+        );
         final groupId = DmRepository.computeConversationId(groupParticipants);
 
         when(

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -581,7 +581,7 @@ void main() {
         ),
       ).thenAnswer((_) async => null);
 
-      // Stub getAllConversations for _mergeDuplicateConversations().
+      // Default conversation-list read for tests that trigger maintenance.
       when(
         () => mockConversationsDao.getAllConversations(
           ownerPubkey: any(named: 'ownerPubkey'),
@@ -16255,17 +16255,18 @@ void main() {
         ).thenAnswer((_) async => null);
         when(() => mockNostrClient.unsubscribe(any())).thenAnswer((_) async {});
 
-        DmRepository(
-          nostrClient: mockNostrClient,
-          directMessagesDao: mockDirectMessagesDao,
-          conversationsDao: mockConversationsDao,
-        ).setCredentials(
-          userPubkey: _validPubkeyA,
-          signer: LocalNostrSigner(_validPrivateKey),
-          messageService: mockMessageService,
-        );
+        final repository =
+            DmRepository(
+              nostrClient: mockNostrClient,
+              directMessagesDao: mockDirectMessagesDao,
+              conversationsDao: mockConversationsDao,
+            )..setCredentials(
+              userPubkey: _validPubkeyA,
+              signer: LocalNostrSigner(_validPrivateKey),
+              messageService: mockMessageService,
+            );
 
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await repository.getConversations();
 
         verifyNever(
           () => mockConversationsDao.deleteConversation(
@@ -16496,7 +16497,7 @@ void main() {
     });
 
     // -----------------------------------------------------------------
-    // Phase 3: sendGroupMessage success, _mergeDuplicateConversations
+    // Phase 3: sendGroupMessage success
     // -----------------------------------------------------------------
 
     group('sendGroupMessage - success', () {
@@ -23127,6 +23128,47 @@ void main() {
           () => repository.cancelOutgoingBatch(rumorId: winnerRumorId),
           throwsStateError,
         );
+      });
+    });
+
+    group('_backfillCurrentUserHasSent', () {
+      test('logs when conversations are updated', () async {
+        when(
+          () => mockConversationsDao.backfillCurrentUserHasSent(any()),
+        ).thenAnswer((_) async => 3);
+
+        when(
+          () => mockConversationsDao.getConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        when(
+          () => mockNostrClient.unsubscribe(any()),
+        ).thenAnswer((_) async {});
+
+        DmRepository(
+          nostrClient: mockNostrClient,
+          directMessagesDao: mockDirectMessagesDao,
+          conversationsDao: mockConversationsDao,
+        ).setCredentials(
+          userPubkey: _validPubkeyA,
+          signer: LocalNostrSigner(_validPrivateKey),
+          messageService: mockMessageService,
+        );
+
+        await untilCalled(
+          () => mockConversationsDao.backfillCurrentUserHasSent(
+            _validPubkeyA,
+          ),
+        );
+
+        verify(
+          () => mockConversationsDao.backfillCurrentUserHasSent(
+            _validPubkeyA,
+          ),
+        ).called(1);
       });
     });
 

--- a/mobile/test/widgets/app_shell_badge_scope_account_switch_test.dart
+++ b/mobile/test/widgets/app_shell_badge_scope_account_switch_test.dart
@@ -192,10 +192,6 @@ void main() {
       /// 'identity_change')` -> `ConversationsDao.clearForAccountSwitch`), so
       /// at most one account's rows exist on a device. Keeping both here
       /// proves the badge counts by owner rather than by row count.
-      ///
-      /// Each conversation needs a distinct [peer]: post-auth maintenance runs
-      /// `_mergeDuplicateConversations`, which collapses two rows that share a
-      /// peer into one canonical 1:1.
       Future<void> seedUnreadConversation({
         required String id,
         required String owner,


### PR DESCRIPTION
## Summary

`_mergeDuplicateConversations` bucketed every conversation by its alphabetically-first non-self peer, with no group filter:

```dart
final peers = participants.where((pk) => pk != _userPubkey).toList()..sort();
final peerKey = peers.first;                 // a group and a 1:1 collide here
```

So a group landed in the same bucket as the 1:1 sharing that peer, and the loop reassigned the group's messages to the 1:1 and **deleted the group row**, erasing every other participant. It ran unconditionally from `_runPostAuthMaintenance`, so a group did not survive the next launch whenever such a 1:1 existed.

**The pass is deleted, not guarded** — it can no longer do either job it was written for.

## Why deletion rather than a filter

*(This replaces an earlier `isGroup` guard whose stated premise was wrong. Review established the correct history; the record is in the thread.)*

**It cannot repair the legacy inflated rows it targeted.** Those are 1:1 threads a non-compliant client widened with an extra `p` tag before `_resolveConversationParticipants` existed, and they are stored **`is_group = true`** — the receive path co-writes `is_group = participants.length > 2` from a `Set`-clean participant list, so a received inflated row is indistinguishable from a real group by that flag. Separating them needs the message-sender count (an inflated 1:1 has exactly one non-self sender), which only the **unmerged** #5478 ever proposed and which is not in the tree.

**It cannot find present-day 1:1 duplicates either.** `computeConversationId` is a pure function of the sorted participant set, and every current writer of a non-group row builds exactly two participants — so two rows for one peer hash to the same id and *are* the same row. The only reachable multi-row peer bucket was a group/1:1 collision: the destructive case this PR removes.

What remained was the destructive case. The now-vestigial `hasCanonicalRow` branch and the unreferenced DAO reassignment primitive go with it; `getAllConversations` keeps two other callers.

## Testing

The replacement test pins the **outcome** — a group sharing a 1:1's first peer is not deleted by post-auth maintenance — rather than the absence of a method, so re-adding a destructive peer-keyed merge fails it.

Mutation-checked against a peer-keyed merge re-introduced on the DAO as it exists after this PR: the test turns red with `deleteConversation(<groupId>)` among the unexpected calls, and stays red when the `getConversations()` maintenance await is removed alongside it.

One limitation, corrected from an earlier revision of this description: restoring the *historical* pass verbatim from `origin/main` leaves the test **green**. That pass calls `reassignConversation` before `deleteConversation`, and this PR deletes that DAO method, so the restored call lands on an unstubbed mock, throws `type 'Null' is not a subtype of type 'Future<int>'`, and the pass's own `on Object catch` swallows it before the delete is reached. The earlier mutation claim was taken before `d5a8fa6b6` removed the method and its stubs, and did not survive it. The test guards the reachable regression — a peer-keyed merge written against today's DAO — not the resurrection of a method this PR removes.

```
flutter analyze lib test   → No issues found
flutter test               → +728 All tests passed
flutter test --coverage    → 2626/2783 = 94.36%   (gate: 93)
```

The DB client package also passes analysis and all 1,033 tests after removing the obsolete reassignment primitive.

## Existing corruption

`Refs #8203` rather than `Fixes`, because this prevents recurrence and restores nothing. Recovery is filed as **#8407**: on a damaged install the messages survive (they were re-parented onto the 1:1, not deleted) but the participant list does not, and nothing repairs it today. That issue records the two candidate signals — per-message `tagsJson`, and relay re-ingest — and notes both are unverified.

`Fixes #8270`.

