### PR TITLE
fix(analytics): stop leaking into the background activity registry

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -667,6 +667,35 @@ dead letter — the `vgv-tag-gate` CI job enforces this.
 | A `<Platform>.instance` singleton (`PathProviderPlatform`, `WebViewPlatform`, …) | Snapshot in `setUp`/`setUpAll`, restore in the matching `tearDown`/`tearDownAll` (`check_process_global_mutations.sh` enforces). |
 | `HttpOverrides.global` | Not allowed in a merged test — tag the file `['skip_very_good_optimization', 'integration']` (`check_http_overrides_isolation.sh` enforces). |
 | View config (`tester.view.physicalSize` / `devicePixelRatio` / `setSurfaceSize`) | Pair every override with an `addTearDown` reset (`resetPhysicalSize`, `resetDevicePixelRatio`, `setSurfaceSize(null)`). |
+| A service you registered with `BackgroundActivityManager` (`AuthService`, `UploadManager`, `AnalyticsService`) | Dispose it — all three unregister in `dispose()`. If a test drives the manager directly, `addTearDown(BackgroundActivityManager().resetForTesting)`. Enforced at runtime under `DIVINE_STRICT_GLOBALS`. |
+
+### Heal-and-blame harness (BackgroundActivityManager)
+
+`BackgroundActivityManager` is a process-global singleton whose registry only
+ever grows. Services join it in `initialize()` and leave in `dispose()`, and
+nothing else clears it — so a registration that outlives its test keeps
+receiving lifecycle callbacks for the rest of the merged isolate. The bill
+comes due at whichever later suite drives a lifecycle transition through a
+mounted `AppLifecycleHandler`: `_restoreServices()` calls `onAppResumed()` on
+every stranger in the list, inside the *current* test's zone, and
+`_verifyInvariants` blames whatever that leaves behind on a test that never
+asked for it (#6880).
+
+Its `isAppInForeground` flag leaks the same way and is the trigger half —
+`resumed` only fans out when the manager currently believes it is
+backgrounded, so a stale `false` from an earlier test is what arms it.
+
+So `flutter_test_config.dart` registers a root `tearDown` that resets the
+manager and, under `DIVINE_STRICT_GLOBALS`, fails the test that dirtied it.
+`resetForTesting()` — not `dispose()` — is the correct reset: `dispose()`
+leaves `_isInitialized` set, so a later `initialize()` silently no-ops, and it
+leaves the foreground flag wherever the last lifecycle event put it.
+
+This shape is invisible to `check_process_global_mutations.sh`, which matches
+**assignments** to a known list of globals. A registry that accumulates through
+a method call (`registerService(this)`) is neither an assignment nor a settable
+global, so the runtime tearDown is the guard — and it is the stronger one, since
+it sees every registrant rather than a hard-coded list.
 
 ### Heal-and-blame harness (the 5 shared channels)
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -667,7 +667,7 @@ dead letter — the `vgv-tag-gate` CI job enforces this.
 | A `<Platform>.instance` singleton (`PathProviderPlatform`, `WebViewPlatform`, …) | Snapshot in `setUp`/`setUpAll`, restore in the matching `tearDown`/`tearDownAll` (`check_process_global_mutations.sh` enforces). |
 | `HttpOverrides.global` | Not allowed in a merged test — tag the file `['skip_very_good_optimization', 'integration']` (`check_http_overrides_isolation.sh` enforces). |
 | View config (`tester.view.physicalSize` / `devicePixelRatio` / `setSurfaceSize`) | Pair every override with an `addTearDown` reset (`resetPhysicalSize`, `resetDevicePixelRatio`, `setSurfaceSize(null)`). |
-| A service you registered with `BackgroundActivityManager` (`AuthService`, `UploadManager`, `AnalyticsService`) | Dispose it — all three unregister in `dispose()`. If a test drives the manager directly, `addTearDown(BackgroundActivityManager().resetForTesting)`. Enforced at runtime under `DIVINE_STRICT_GLOBALS`. |
+| A service you registered with `BackgroundActivityManager` (`AuthService`, `UploadManager`, `AnalyticsService`) | Dispose it — all three unregister in `dispose()`. If a test drives the manager directly, `addTearDown(BackgroundActivityManager().resetForTesting)`. Enforced at runtime under `DIVINE_STRICT_GLOBALS`. `UploadManager` can still register *after* dispose if `initialize()` is in flight when it happens (#8413), so the runtime guard is what catches that, not the call site. |
 
 ### Heal-and-blame harness (BackgroundActivityManager)
 

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -545,6 +545,11 @@ jobs:
         # was proven clean under it, which the harness comment set as the
         # condition.
         #
+        # DIVINE_STRICT_GLOBALS does the same for BackgroundActivityManager,
+        # whose registry only grows: a service that outlives its test keeps
+        # receiving lifecycle callbacks, so a later suite driving `resumed`
+        # fans out over strangers and wears the result (#6880).
+        #
         # The seed is drawn here rather than left as `random`. very_good
         # resolves `random` once and forwards the result to every sub-process,
         # so a shard already has exactly one seed — but it only ever reaches
@@ -556,7 +561,7 @@ jobs:
         # instead of a copy that can drift from them.
         run: |
           SEED=$(( (RANDOM << 15) | RANDOM ))
-          FLAGS="--optimization --concurrency=4 --exclude-tags integration --dart-define=DIVINE_STRICT_CHANNELS=true"
+          FLAGS="--optimization --concurrency=4 --exclude-tags integration --dart-define=DIVINE_STRICT_CHANNELS=true --dart-define=DIVINE_STRICT_GLOBALS=true"
           {
             echo "TEST_SEED=$SEED"
             echo "TEST_FLAGS=$FLAGS"

--- a/mobile/lib/services/analytics_service.dart
+++ b/mobile/lib/services/analytics_service.dart
@@ -102,6 +102,11 @@ class AnalyticsService implements BackgroundAwareService {
   // Track disposal state
   bool _isDisposed = false;
 
+  /// Whether this instance is in [BackgroundActivityManager]'s registry.
+  /// Registration is best-effort (see [initialize]), so the flag records
+  /// whether it actually succeeded rather than whether it was attempted.
+  bool _isBackgroundRegistered = false;
+
   /// Update the view event publisher (e.g. when Nostr client reconnects).
   void updateViewEventPublisher(ViewEventPublisher? publisher) {
     _viewEventPublisher = publisher;
@@ -109,6 +114,10 @@ class AnalyticsService implements BackgroundAwareService {
 
   /// Initialize the analytics service.
   Future<void> initialize() async {
+    // A disposed instance must not come back. `analyticsServiceProvider`
+    // defers this call onto a microtask, so a container torn down before that
+    // microtask lands calls dispose() first (#8398).
+    if (_isDisposed) return;
     if (_isInitialized) return;
 
     try {
@@ -138,6 +147,12 @@ class AnalyticsService implements BackgroundAwareService {
         _recoverQueuedProductEvents();
       }
 
+      // The guard above is not enough on its own: dispose() may have run while
+      // the awaits above were in flight. Re-check before the two side effects
+      // it can no longer undo — the periodic timer, and joining the
+      // process-global registry that has no owner left to leave it (#8398).
+      if (_isDisposed) return;
+
       // Set up periodic cleanup of tracked views
       _cleanupTimer = Timer.periodic(const Duration(minutes: 5), (_) {
         _recentlyTrackedViews.clear();
@@ -146,6 +161,7 @@ class AnalyticsService implements BackgroundAwareService {
       // Register with background activity manager
       try {
         BackgroundActivityManager().registerService(this);
+        _isBackgroundRegistered = true;
       } catch (e) {
         Log.warning(
           'Could not register with background activity manager: $e',
@@ -826,6 +842,14 @@ class AnalyticsService implements BackgroundAwareService {
   }
 
   void dispose() {
+    // Unregister before tearing down. The manager is a process-global
+    // singleton, so an instance left in its registry keeps receiving
+    // lifecycle callbacks forever — across provider rebuilds in the app, and
+    // across every later suite in the merged test isolate (#6880).
+    if (_isBackgroundRegistered) {
+      BackgroundActivityManager().unregisterService(this);
+      _isBackgroundRegistered = false;
+    }
     _isDisposed = true;
     _cleanupTimer?.cancel();
   }

--- a/mobile/lib/services/background_activity_manager.dart
+++ b/mobile/lib/services/background_activity_manager.dart
@@ -287,6 +287,24 @@ class BackgroundActivityManager {
     _periodicCleanupTimer?.cancel();
     _registeredServices.clear();
   }
+
+  /// Restores this process-global singleton to its construction state.
+  ///
+  /// [dispose] is not a substitute: it leaves [_isInitialized] set, so a later
+  /// [initialize] silently no-ops and never re-arms the periodic cleanup, and
+  /// it leaves [_isAppInForeground] wherever the last lifecycle event put it.
+  /// A stale `false` there is what turns a later `resumed` into a fan-out over
+  /// whatever is still registered (#6880).
+  @visibleForTesting
+  void resetForTesting() {
+    _backgroundSuspensionTimer?.cancel();
+    _backgroundSuspensionTimer = null;
+    _periodicCleanupTimer?.cancel();
+    _periodicCleanupTimer = null;
+    _registeredServices.clear();
+    _isAppInForeground = true;
+    _isInitialized = false;
+  }
 }
 
 /// Interface for services that need background state awareness

--- a/mobile/lib/services/background_activity_manager.dart
+++ b/mobile/lib/services/background_activity_manager.dart
@@ -277,6 +277,11 @@ class BackgroundActivityManager {
   Map<String, dynamic> getStatus() {
     return {
       'isAppInForeground': _isAppInForeground,
+      // Reported because it gates [initialize] and owns the periodic cleanup
+      // timer: an instance left initialized keeps a 5-minute Timer.periodic
+      // alive, which in the merged test isolate outlives the test that armed
+      // it (#8398).
+      'isInitialized': _isInitialized,
       'registeredServices': _registeredServices.length,
       'serviceNames': _registeredServices.map((s) => s.serviceName).toList(),
     };

--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -128,13 +128,16 @@ if [ "$VERY_GOOD_CURRENT_VERSION" != "$VERY_GOOD_CLI_VERSION" ]; then
 fi
 
 flutter pub get
-# DIVINE_STRICT_CHANNELS matches Mobile CI: a test that leaves a shared
-# MethodChannel handler replaced fails here rather than being healed silently,
-# so the leak surfaces before the push instead of in someone else's suite.
+# DIVINE_STRICT_CHANNELS and DIVINE_STRICT_GLOBALS match Mobile CI: a test that
+# leaves a shared MethodChannel handler replaced, or leaves a service in
+# BackgroundActivityManager's process-global registry, fails here rather than
+# being healed silently — so the leak surfaces before the push instead of in
+# someone else's suite.
 PATH="$PUB_CACHE_BIN:$PATH" "$VERY_GOOD_BIN" test \
   --optimization \
   --concurrency=4 \
   --exclude-tags "integration || golden" \
   --dart-define=DIVINE_STRICT_CHANNELS=true \
+  --dart-define=DIVINE_STRICT_GLOBALS=true \
   --test-randomize-ordering-seed random
 """

--- a/mobile/test/flutter_test_config.dart
+++ b/mobile/test/flutter_test_config.dart
@@ -10,6 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:golden_toolkit/golden_toolkit.dart';
 import 'package:openvine/widgets/avatar_failure_cache.dart';
 
+import 'helpers/background_activity_reset.dart';
 import 'helpers/shared_channel_override.dart';
 import 'test_setup.dart';
 
@@ -21,6 +22,12 @@ const _runGoldenSetup = bool.fromEnvironment('DIVINE_GOLDEN_TESTS');
 /// clean under it, which was the condition for turning it on (#5738). It stays
 /// off for a bare `flutter test` so a single-file run still heals silently.
 const _strictChannels = bool.fromEnvironment('DIVINE_STRICT_CHANNELS');
+
+/// When set (via `--dart-define=DIVINE_STRICT_GLOBALS=true`), the
+/// heal-and-blame tearDown for process-global singletons also `fail()`s the
+/// test that dirtied one. Mobile CI and `mise run test` both set it; a bare
+/// `flutter test` leaves it off so a single-file run still heals silently.
+const _strictGlobals = bool.fromEnvironment('DIVINE_STRICT_GLOBALS');
 
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   // Set up test environment with plugin mocks (secure_storage, path_provider, etc.)
@@ -43,6 +50,15 @@ Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   // from its canonical handler, and — under DIVINE_STRICT_CHANNELS — blames
   // the perpetrating test. Compliant tests never trip it.
   tearDown(() => healAndBlameSharedChannels(strict: _strictChannels));
+
+  // BackgroundActivityManager is a process-global singleton whose registry
+  // only ever grows: services join it in initialize() and leave in dispose(),
+  // and nothing else clears it. A registration that outlives its test keeps
+  // receiving lifecycle callbacks for the rest of the isolate, so a later
+  // suite driving `resumed` fans out over strangers and is blamed for what
+  // they do (#6880). Its foreground flag leaks the same way, and a stale
+  // `false` is what arms that fan-out.
+  tearDown(() => healAndBlameBackgroundActivity(strict: _strictGlobals));
 
   // UserAvatar records broken image URLs in a process-global negative cache.
   // In the merged optimizer isolate that state would otherwise leak a failed

--- a/mobile/test/helpers/background_activity_reset.dart
+++ b/mobile/test/helpers/background_activity_reset.dart
@@ -15,11 +15,14 @@ String? findBackgroundActivityViolation() {
   final status = manager.getStatus();
   final services = (status['serviceNames']! as List).cast<String>();
   final backgrounded = status['isAppInForeground'] == false;
-  if (services.isEmpty && !backgrounded) return null;
+  final initialized = status['isInitialized'] == true;
+  if (services.isEmpty && !backgrounded && !initialized) return null;
 
   final parts = <String>[
     if (services.isNotEmpty) 'left ${services.join(', ')} registered',
     if (backgrounded) 'left the app in the background state',
+    if (initialized)
+      'left the manager initialized, with its periodic cleanup timer armed',
   ];
   return parts.join(' and ');
 }

--- a/mobile/test/helpers/background_activity_reset.dart
+++ b/mobile/test/helpers/background_activity_reset.dart
@@ -1,0 +1,48 @@
+// ABOUTME: Heals and blames leaks of the process-global BackgroundActivityManager.
+// ABOUTME: Registrations and the foreground flag survive a test unless reset.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/background_activity_manager.dart';
+
+/// Describes how a test left [BackgroundActivityManager], or `null` when it
+/// left it at its resting state.
+///
+/// The manager is a process-global singleton and `flutter_test` restores
+/// nothing between tests, so under `very_good test --optimization` both halves
+/// below persist for the remainder of the merged isolate.
+String? findBackgroundActivityViolation() {
+  final manager = BackgroundActivityManager();
+  final status = manager.getStatus();
+  final services = (status['serviceNames']! as List).cast<String>();
+  final backgrounded = status['isAppInForeground'] == false;
+  if (services.isEmpty && !backgrounded) return null;
+
+  final parts = <String>[
+    if (services.isNotEmpty) 'left ${services.join(', ')} registered',
+    if (backgrounded) 'left the app in the background state',
+  ];
+  return parts.join(' and ');
+}
+
+/// Restores the manager and, under [strict], fails the test that dirtied it.
+///
+/// Healing runs first so each test is blamed only for its own leak instead of
+/// every later test inheriting the first one's. Compliant tests never trip it.
+void healAndBlameBackgroundActivity({required bool strict}) {
+  final violation = findBackgroundActivityViolation();
+  if (violation == null) return;
+  BackgroundActivityManager().resetForTesting();
+  if (strict) {
+    fail(
+      'This test $violation. BackgroundActivityManager is a process-global '
+      'singleton, so under very_good --optimization every later suite in the '
+      'isolate inherits it: a registered service keeps receiving lifecycle '
+      'callbacks, and a stale background state turns the next `resumed` into '
+      'a fan-out over all of them, cross-attributing the result to an '
+      'unrelated test (#6880). Dispose the service you created (services '
+      'unregister in dispose()), or addTearDown '
+      '(BackgroundActivityManager().resetForTesting). '
+      'See .claude/rules/testing.md (VGV merged isolate).',
+    );
+  }
+}

--- a/mobile/test/helpers/background_activity_reset.dart
+++ b/mobile/test/helpers/background_activity_reset.dart
@@ -33,8 +33,14 @@ String? findBackgroundActivityViolation() {
 /// every later test inheriting the first one's. Compliant tests never trip it.
 void healAndBlameBackgroundActivity({required bool strict}) {
   final violation = findBackgroundActivityViolation();
-  if (violation == null) return;
+  // Heal unconditionally. [findBackgroundActivityViolation] reads getStatus(),
+  // which reports three of the five fields resetForTesting() restores — both
+  // timers are missing from it — so a clean status is not proof the manager is
+  // at rest. No such state is reachable through the public API today, but
+  // making the heal conditional on an incomplete observation is what would
+  // hide the next one. Blame is unaffected: the violation is read first.
   BackgroundActivityManager().resetForTesting();
+  if (violation == null) return;
   if (strict) {
     fail(
       'This test $violation. BackgroundActivityManager is a process-global '

--- a/mobile/test/helpers/background_activity_reset_test.dart
+++ b/mobile/test/helpers/background_activity_reset_test.dart
@@ -1,0 +1,154 @@
+// ABOUTME: Tests the heal-and-blame reset for BackgroundActivityManager.
+// ABOUTME: Covers the fan-out mechanism, the heal, the blame, and the no-op.
+
+import 'package:flutter/widgets.dart' show AppLifecycleState;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/background_activity_manager.dart';
+
+import 'background_activity_reset.dart';
+
+class _RecordingService implements BackgroundAwareService {
+  int resumeCount = 0;
+
+  @override
+  String get serviceName => 'RecordingService';
+
+  @override
+  void onAppBackgrounded() {}
+
+  @override
+  void onExtendedBackground() {}
+
+  @override
+  void onAppResumed() => resumeCount++;
+
+  @override
+  void onPeriodicCleanup() {}
+}
+
+void main() {
+  group('healAndBlameBackgroundActivity', () {
+    late BackgroundActivityManager manager;
+
+    setUp(() {
+      manager = BackgroundActivityManager()..resetForTesting();
+    });
+
+    // Every test here dirties the singleton on purpose, so each one restores
+    // it before the root tearDown in flutter_test_config.dart inspects it.
+    // addTearDown runs at the test's own scope, which is inside that root.
+    tearDown(() => manager.resetForTesting());
+
+    group('the mechanism it exists to close', () {
+      // A committed cross-test version of this is not possible: deliberately
+      // leaking into a later test would itself be blamed under
+      // DIVINE_STRICT_GLOBALS. The out-of-isolate proof is in #6880.
+      test('resumed fans out to every service still registered', () {
+        final probe = _RecordingService();
+        manager.registerService(probe);
+
+        manager
+          ..onAppLifecycleStateChanged(AppLifecycleState.paused)
+          ..onAppLifecycleStateChanged(AppLifecycleState.resumed);
+
+        expect(probe.resumeCount, 1);
+      });
+
+      test('a service the reset removed receives no later callback', () {
+        final probe = _RecordingService();
+        manager.registerService(probe);
+
+        healAndBlameBackgroundActivity(strict: false);
+
+        manager
+          ..onAppLifecycleStateChanged(AppLifecycleState.paused)
+          ..onAppLifecycleStateChanged(AppLifecycleState.resumed);
+
+        expect(probe.resumeCount, 0);
+      });
+    });
+
+    group('healing', () {
+      test('clears a registration the test left behind', () {
+        manager.registerService(_RecordingService());
+
+        healAndBlameBackgroundActivity(strict: false);
+
+        expect(manager.getStatus()['registeredServices'], 0);
+      });
+
+      test('restores a background state the test left behind', () {
+        manager.onAppLifecycleStateChanged(AppLifecycleState.paused);
+        expect(manager.isAppInForeground, isFalse);
+
+        healAndBlameBackgroundActivity(strict: false);
+
+        expect(manager.isAppInForeground, isTrue);
+      });
+    });
+
+    group('blaming', () {
+      test('names the leaked service', () {
+        manager.registerService(_RecordingService());
+
+        expect(
+          () => healAndBlameBackgroundActivity(strict: true),
+          throwsA(
+            isA<TestFailure>().having(
+              (f) => f.message,
+              'message',
+              allOf(contains('RecordingService'), contains('#6880')),
+            ),
+          ),
+        );
+      });
+
+      test('names a leaked background state', () {
+        manager.onAppLifecycleStateChanged(AppLifecycleState.paused);
+
+        expect(
+          () => healAndBlameBackgroundActivity(strict: true),
+          throwsA(
+            isA<TestFailure>().having(
+              (f) => f.message,
+              'message',
+              contains('left the app in the background state'),
+            ),
+          ),
+        );
+      });
+
+      test('heals even when it blames, so the next test starts clean', () {
+        manager.registerService(_RecordingService());
+
+        expect(
+          () => healAndBlameBackgroundActivity(strict: true),
+          throwsA(isA<TestFailure>()),
+        );
+
+        expect(manager.getStatus()['registeredServices'], 0);
+      });
+    });
+
+    group('compliant tests', () {
+      test('a clean manager is never blamed', () {
+        expect(
+          () => healAndBlameBackgroundActivity(strict: true),
+          returnsNormally,
+        );
+      });
+
+      test('a service that unregisters itself is never blamed', () {
+        final probe = _RecordingService();
+        manager
+          ..registerService(probe)
+          ..unregisterService(probe);
+
+        expect(
+          () => healAndBlameBackgroundActivity(strict: true),
+          returnsNormally,
+        );
+      });
+    });
+  });
+}

--- a/mobile/test/helpers/background_activity_reset_test.dart
+++ b/mobile/test/helpers/background_activity_reset_test.dart
@@ -77,6 +77,15 @@ void main() {
         expect(manager.getStatus()['registeredServices'], 0);
       });
 
+      test('clears an initialized manager, and its periodic timer', () async {
+        await manager.initialize();
+        expect(manager.getStatus()['isInitialized'], isTrue);
+
+        healAndBlameBackgroundActivity(strict: false);
+
+        expect(manager.getStatus()['isInitialized'], isFalse);
+      });
+
       test('restores a background state the test left behind', () {
         manager.onAppLifecycleStateChanged(AppLifecycleState.paused);
         expect(manager.isAppInForeground, isFalse);
@@ -98,6 +107,21 @@ void main() {
               (f) => f.message,
               'message',
               allOf(contains('RecordingService'), contains('#6880')),
+            ),
+          ),
+        );
+      });
+
+      test('names a manager left initialized', () async {
+        await manager.initialize();
+
+        expect(
+          () => healAndBlameBackgroundActivity(strict: true),
+          throwsA(
+            isA<TestFailure>().having(
+              (f) => f.message,
+              'message',
+              contains('left the manager initialized'),
             ),
           ),
         );

--- a/mobile/test/services/analytics_service_test.dart
+++ b/mobile/test/services/analytics_service_test.dart
@@ -11,6 +11,7 @@ import 'package:models/models.dart';
 import 'package:openvine/generated/product_analytics.dart';
 import 'package:openvine/models/view_traffic_source.dart';
 import 'package:openvine/services/analytics_service.dart';
+import 'package:openvine/services/background_activity_manager.dart';
 import 'package:openvine/services/product_event_queue.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -38,6 +39,65 @@ void main() {
     setUp(() {
       SharedPreferences.setMockInitialValues({});
       analyticsService = AnalyticsService(disableNostrPublishing: true);
+    });
+
+    group('background activity registration', () {
+      List<String> registeredServiceNames() =>
+          (BackgroundActivityManager().getStatus()['serviceNames']! as List)
+              .cast<String>();
+
+      test(
+        'initialize registers with the background activity manager',
+        () async {
+          await analyticsService.initialize();
+
+          expect(registeredServiceNames(), contains('AnalyticsService'));
+        },
+      );
+
+      test('dispose unregisters from the background activity manager', () async {
+        await analyticsService.initialize();
+        expect(registeredServiceNames(), contains('AnalyticsService'));
+
+        analyticsService.dispose();
+
+        // The manager is a process-global singleton, so an instance left in
+        // its registry keeps receiving lifecycle callbacks for the life of the
+        // process — across provider rebuilds in the app, and across every
+        // later suite in the merged test isolate (#6880).
+        expect(registeredServiceNames(), isNot(contains('AnalyticsService')));
+      });
+
+      test('dispose is safe when initialize never ran', () {
+        expect(analyticsService.dispose, returnsNormally);
+        expect(registeredServiceNames(), isEmpty);
+      });
+
+      test('a deferred initialize cannot re-register after dispose', () async {
+        // analyticsServiceProvider defers initialize onto a microtask, so a
+        // container torn down before that microtask lands calls dispose()
+        // first. Without the guard the late initialize re-registers a dead
+        // instance that nothing can ever unregister (#8398).
+        final pending = Future.microtask(analyticsService.initialize);
+        analyticsService.dispose();
+        await pending;
+
+        expect(registeredServiceNames(), isNot(contains('AnalyticsService')));
+      });
+
+      test(
+        'dispose while initialize is awaiting prevents registration',
+        () async {
+          // initialize() runs synchronously up to its first await, so
+          // disposing here lands between that suspension point and the
+          // registration. An entry guard alone would not catch this (#8398).
+          final pending = analyticsService.initialize();
+          analyticsService.dispose();
+          await pending;
+
+          expect(registeredServiceNames(), isNot(contains('AnalyticsService')));
+        },
+      );
     });
 
     tearDown(() async {

--- a/mobile/test/services/analytics_service_test.dart
+++ b/mobile/test/services/analytics_service_test.dart
@@ -70,7 +70,10 @@ void main() {
 
       test('dispose is safe when initialize never ran', () {
         expect(analyticsService.dispose, returnsNormally);
-        expect(registeredServiceNames(), isEmpty);
+        // Scoped to this service rather than asserting the whole registry is
+        // empty: it is a process-global shared by every suite in the merged
+        // isolate, so `isEmpty` would fail here for another test's leak.
+        expect(registeredServiceNames(), isNot(contains('AnalyticsService')));
       });
 
       test('a deferred initialize cannot re-register after dispose', () async {

--- a/mobile/test/services/background_activity_manager_test.dart
+++ b/mobile/test/services/background_activity_manager_test.dart
@@ -1,7 +1,10 @@
-// Test for BackgroundActivityManager functionality
-// Permanent: exercises process-wide WidgetsBinding lifecycle notifications and
-// BackgroundActivityManager singleton state; keep isolated until the manager is
-// injectable/resettable per test.
+// ABOUTME: Tests BackgroundActivityManager's lifecycle fan-out and reset.
+// ABOUTME: Drives the process-global singleton directly through every state.
+// Isolated because this suite walks the singleton through background, resumed
+// and terminating states and asserts on the shared instance between steps. It
+// no longer needs isolation for lack of a reset — resetForTesting() exists as
+// of #8398, and setUp/tearDown use it — so untagging is a live candidate, but
+// that belongs to its own change with its own merged-isolate verification.
 @Tags(['skip_very_good_optimization'])
 library;
 
@@ -104,16 +107,17 @@ void main() {
         expect(manager.isAppInForeground, isTrue);
       });
 
-      test('clears the initialized latch so initialize runs again', () async {
+      test('clears the initialized latch', () async {
         await manager.initialize();
+        // Asserting the pre-state is what makes the post-state meaningful:
+        // without it the test passes whether or not reset clears the latch.
+        expect(manager.getStatus()['isInitialized'], isTrue);
 
         manager.resetForTesting();
-        await manager.initialize();
 
-        // dispose() leaves the latch set, so a second initialize would no-op
-        // and never re-arm the periodic cleanup. reset must not.
-        expect(manager.isAppInForeground, isTrue);
-        expect(manager.getStatus()['registeredServices'], 0);
+        // dispose() leaves this set, so a later initialize() would no-op and
+        // never re-arm the periodic cleanup. reset must not.
+        expect(manager.getStatus()['isInitialized'], isFalse);
       });
     });
 

--- a/mobile/test/services/background_activity_manager_test.dart
+++ b/mobile/test/services/background_activity_manager_test.dart
@@ -70,16 +70,51 @@ void main() {
 
     setUp(() async {
       manager = BackgroundActivityManager();
-      manager.dispose();
       testService = TestBackgroundService();
 
       // BackgroundActivityManager is a process-wide singleton. Tests in this
-      // file share the same instance and run in random order, so clear any
-      // prior registrations/timers, reset its state to foreground, and drain
-      // pending lifecycle notifications before each test. Otherwise a prior
-      // test can leak services or stale background state into the next case.
-      manager.onAppLifecycleStateChanged(AppLifecycleState.resumed);
+      // file share the same instance and run in random order, so restore it to
+      // its construction state and drain pending lifecycle notifications
+      // before each test. Otherwise a prior test can leak services or stale
+      // background state into the next case.
+      manager.resetForTesting();
       await pumpEventQueue();
+    });
+
+    // Several cases below deliberately end in the background state. Restore
+    // the singleton so it is not left that way for the rest of the process —
+    // a stale `false` turns the next `resumed` anywhere into a fan-out (#6880).
+    tearDown(() => manager.resetForTesting());
+
+    group('resetForTesting', () {
+      test('clears registrations', () {
+        manager.registerService(testService);
+
+        manager.resetForTesting();
+
+        expect(manager.getStatus()['registeredServices'], 0);
+      });
+
+      test('restores the foreground state', () {
+        manager.onAppLifecycleStateChanged(AppLifecycleState.paused);
+        expect(manager.isAppInForeground, isFalse);
+
+        manager.resetForTesting();
+
+        expect(manager.isAppInForeground, isTrue);
+      });
+
+      test('clears the initialized latch so initialize runs again', () async {
+        await manager.initialize();
+
+        manager.resetForTesting();
+        await manager.initialize();
+
+        // dispose() leaves the latch set, so a second initialize would no-op
+        // and never re-arm the periodic cleanup. reset must not.
+        expect(manager.isAppInForeground, isTrue);
+        expect(manager.getStatus()['registeredServices'], 0);
+      });
     });
 
     test('should start in foreground state', () {


### PR DESCRIPTION
## Description

`BackgroundActivityManager` is a process-global singleton whose registry only ever grows. Services join it in `initialize()` and leave in `dispose()`, and nothing else clears it — so under `very_good test --optimization`, where the whole unit suite shares one isolate and `flutter_test` auto-restores nothing, a registration that outlives its test keeps receiving lifecycle callbacks for the rest of the run. `_restoreServices()` then calls `onAppResumed()` on every stranger in the list, inside whichever test is currently running, and `_verifyInvariants` blames what that leaves behind on a test that never asked for it.

Three changes, one per commit.

**`AnalyticsService` leaves the registry on dispose.** It was the only asymmetric registrant in the codebase — `AuthService` and `UploadManager` both unregister — and it has no injection seam, so a test could not substitute a fake manager either. This is a production leak, not only a test one: `analyticsServiceProvider` is `keepAlive` but rebuilds whenever any of its six dependencies do, and every rebuild stranded a dead instance permanently subscribed to lifecycle callbacks.

Registration was also reachable *after* dispose. The provider defers `initialize` onto a microtask, so a container torn down before that microtask lands calls `dispose()` first, and `initialize()` then re-registered a dead service that nothing could remove. An entry guard alone does not close it — `initialize()` awaits `SharedPreferences` before it registers, so `dispose()` can land mid-flight. Both the entry and the post-await paths are guarded. The guard before the suspension point is not the fix; the one after it is.

**A real reset for the singleton.** `dispose()` is not one: it leaves `_isInitialized` set, so a later `initialize()` silently no-ops and never re-arms the periodic cleanup, and it leaves `_isAppInForeground` wherever the last lifecycle event put it. That flag is the trigger half — `resumed` only fans out when the manager currently believes it is backgrounded, so a stale `false` from an earlier test is what arms it. `resetForTesting()` restores every field.

**A heal-and-blame root `tearDown`.** Same shape as the shared-channel harness whose strict half CI turned on in #8364, behind a sibling `DIVINE_STRICT_GLOBALS` so one noisy class cannot force the other off. Healing runs first, so each test is blamed only for its own leak rather than every later test inheriting the first one's.

A runtime tearDown rather than a static ratchet: `check_process_global_mutations.sh` matches **assignments** against a fixed list of globals, and a registry that accumulates through `registerService(this)` is neither an assignment nor a settable global. The tearDown is also the stronger guard, since it sees every registrant instead of a hard-coded list.

### What this does not claim

**It fixes none of the occurrences logged in #6880.** That mechanism is dormant, and the [measurements are on the issue](https://github.com/divinevideo/divine-mobile/issues/6880#issuecomment-5470850253) — including a correction to my own earlier comment there, which had the registration site wrong. A full merged run leaks 35 `AnalyticsService` instances and zero `AuthService`, and `AnalyticsService.onAppResumed()` arms nothing, so it cannot produce the pending-timer failures in that thread.

What it fixes is one real production leak, and it makes the class unable to come back silently. That matters because the split holding today — the two registrants whose resume callbacks are dangerous are disposed everywhere, the one that leaks is inert — is enforced by nothing. The day anyone adds a `.timeout()` to `AnalyticsService.onAppResumed()`, `app_lifecycle_handler_test.dart:253` goes red and blames whoever touched analytics.

**Related Issue:** Closes #8398, Refs #6880, #8413

## Out of Scope

- **UploadManager has the same post-dispose registration race (#8413).** The guard and its regression test were written and mutation-verified here, then reverted: `upload_manager.dart` is one of the six files frozen by `check_service_god_file_ceiling.sh` (1964 lines) and the three-line guard grows it, with no sanctioned raise path. It needs an epic #4338 extraction to pay for itself.
- The positional-widget-finder sweep and random-seed reporting from #8330 — #8376 declined both deliberately and they remain independent work.
- `AuthService` and `UploadManager` call sites: both are already symmetric and measured clean, so there is nothing to sweep.
- No static ratchet for this shape, for the reason above.

## Verification

- **Full merged suite, both strict flags, from a clean build cache:** `+18587 ~264`, **exit 0**, seed `553311` — `very_good test --optimization --concurrency=4 --exclude-tags "integration || golden" --dart-define=DIVINE_STRICT_CHANNELS=true --dart-define=DIVINE_STRICT_GLOBALS=true`. Zero registry leaks, zero channel leaks.
- **The guard is not inert.** Before these fixes the same run reported 35 blamed tests. It also caught the post-dispose re-registration path on its first full run, which is how that second bug was found.
- **Every new test was mutation-tested against the production boundary.** Reverting `unregisterService` from `dispose()` fails `dispose unregisters from the background activity manager`; reverting the entry guard fails `a deferred initialize cannot re-register after dispose`; reverting the post-await guard fails `dispose while initialize is awaiting prevents registration`. Each was confirmed red without its fix and green with it.
- `flutter analyze lib test integration_test` → No issues found.
- `dart format --set-exit-if-changed lib test` → 0 changed.
- Ratchets: `check_process_global_mutations`, `check_ungrouped_tests`, `check_placeholder_tests`, `check_test_unit_structure`, `check_skip_ceiling`, `check_shared_channel_overrides`, `check_untested_services_floor`, `check_l10n_delegates_ceiling`, `check_post_close_emit_ceiling` — all exit 0.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
