### PR TITLE
test(dm): drop two inherited stubs and strengthen account-switch coverage

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
@@ -555,15 +555,4 @@ LIMIT 1
       updateKind: UpdateKind.update,
     );
   }
-
-  /// Returns the newest `last_message_timestamp` across all conversations
-  /// for the given owner, or `null` if no conversations exist.
-  Future<int?> getNewestMessageTimestamp({String? ownerPubkey}) async {
-    final maxCol = conversations.lastMessageTimestamp.max();
-    final query = selectOnly(conversations)
-      ..where(_ownedOrLegacy(conversations.ownerPubkey, ownerPubkey))
-      ..addColumns([maxCol]);
-    final result = await query.getSingleOrNull();
-    return result?.read(maxCol);
-  }
 }

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -588,16 +588,6 @@ void main() {
         () => mockDirectMessagesDao.giftWrapIdsPresent(any()),
       ).thenAnswer((_) async => const <String>{});
 
-      // Default for the history drain's paged reads, which still go through
-      // queryEvents.
-      when(
-        () => mockNostrClient.queryEvents(
-          any(),
-          subscriptionId: any(named: 'subscriptionId'),
-          useCache: any(named: 'useCache'),
-        ),
-      ).thenAnswer((_) async => <Event>[]);
-
       // Default for every queryEventsDetailed read — the kind-10050 lookups
       // (resolveDmInboxRelays() on the send path, the memoized own-inbox
       // resolve, the RC3 publish check) and the history drain's paged reads.

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -698,6 +698,12 @@ void main() {
         ),
       ).thenAnswer((_) async => true);
       when(
+        () => mockConversationsDao.lastSentTimestampsByConversation(
+          any(),
+          ownerPubkey: any(named: 'ownerPubkey'),
+        ),
+      ).thenAnswer((_) async => <String, int>{});
+      when(
         () => mockMessageService.publishSelfApplicationMarker(
           content: any(named: 'content'),
           tags: any(named: 'tags'),

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -4630,14 +4630,23 @@ void main() {
         'an account switch during the own-inbox resolve bails the old '
         "user's subscription and frees the new user to subscribe",
         () async {
-          final resolveA = Completer<List<Event>>();
-          final resolveB = Completer<List<Event>>();
+          // The own-inbox resolve reads through `queryEventsDetailed` (#8212).
+          // Stubbing `queryEvents` here held nothing in flight: production
+          // stopped calling it, so the read fell through to the shared
+          // answered-empty default and returned before the switch.
+          final resolveA =
+              Completer<({List<Event> events, bool timedOut, bool noRelays})>();
+          final resolveB =
+              Completer<({List<Event> events, bool timedOut, bool noRelays})>();
           var resolveCalls = 0;
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenAnswer((_) {
             resolveCalls++;
@@ -4666,7 +4675,12 @@ void main() {
             messageService: mockMessageService,
           );
 
-          resolveA.complete(const <Event>[]);
+          // A's resolve must genuinely be in flight at the moment of the
+          // switch, or this test proves nothing about the race it names.
+          await pumpEventQueue();
+          expect(resolveCalls, 1);
+
+          resolveA.complete(answeredList(const <Event>[]));
           await pendingA;
 
           // A's continuation bailed — no subscription opened under A's id.
@@ -4681,7 +4695,7 @@ void main() {
 
           // _subscribing was released, so B opens its own subscription.
           final pendingB = repository.startListening();
-          resolveB.complete(const <Event>[]);
+          resolveB.complete(answeredList(const <Event>[]));
           await pendingB;
           verify(
             () => mockNostrClient.subscribe(

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -4224,7 +4224,7 @@ void main() {
       });
 
       test('returns null when no kind-10050 event exists', () async {
-        // setUp already stubs queryEvents -> [].
+        // setUp already stubs queryEventsDetailed -> [].
         final repository = createRepository();
         expect(await repository.resolveDmInboxRelays(_validPubkeyB), isNull);
       });
@@ -4491,7 +4491,7 @@ void main() {
         'live subscription falls back to the default pool (null targeting) '
         'when the user has no kind-10050',
         () async {
-          // setUp default queryEvents -> [] : no kind-10050.
+          // setUp default queryEventsDetailed -> [] : no kind-10050.
           final controller = StreamController<Event>();
           when(
             () => mockNostrClient.subscribe(
@@ -4666,7 +4666,12 @@ void main() {
           ).thenAnswer((_) async {});
 
           final repository = createRepository(); // user A
-          final pendingA = repository.startListening(); // suspends at resolve
+          final pendingA = repository.startListening();
+
+          // A's resolve must genuinely be in flight at the moment of the
+          // switch, or this test proves nothing about the race it names.
+          await pumpEventQueue();
+          expect(resolveCalls, 1);
 
           // Switch A -> B while A's resolve is still in flight.
           repository.setCredentials(
@@ -4675,11 +4680,13 @@ void main() {
             messageService: mockMessageService,
           );
 
-          // A's resolve must genuinely be in flight at the moment of the
-          // switch, or this test proves nothing about the race it names.
+          // B can begin its own resolve without waiting for A's stale one.
+          final pendingB = repository.startListening();
           await pumpEventQueue();
-          expect(resolveCalls, 1);
+          expect(resolveCalls, 2);
 
+          // Resume A first so the generation guard, rather than B's completed
+          // subscription, is what prevents A from opening a stale stream.
           resolveA.complete(answeredList(const <Event>[]));
           await pendingA;
 
@@ -4693,18 +4700,19 @@ void main() {
             ),
           );
 
-          // _subscribing was released, so B opens its own subscription.
-          final pendingB = repository.startListening();
           resolveB.complete(answeredList(const <Event>[]));
           await pendingB;
-          verify(
-            () => mockNostrClient.subscribe(
-              any(),
-              subscriptionId: 'dm_inbox_$_validPubkeyB',
-              tempRelays: any(named: 'tempRelays'),
-              targetRelays: any(named: 'targetRelays'),
-            ),
-          ).called(1);
+          final filter =
+              verify(
+                    () => mockNostrClient.subscribe(
+                      captureAny(),
+                      subscriptionId: 'dm_inbox_$_validPubkeyB',
+                      tempRelays: any(named: 'tempRelays'),
+                      targetRelays: any(named: 'targetRelays'),
+                    ),
+                  ).captured.single
+                  as List<nostr_filter.Filter>;
+          expect(filter.single.p, [_validPubkeyB]);
 
           await repository.stopListening();
           await controller.close();
@@ -4736,7 +4744,7 @@ void main() {
         'publishes a kind-10050 advertising the injected stable relay when '
         'absent and records the flag on a confirmed OK',
         () async {
-          // setUp default queryEvents -> [] : user has no existing kind-10050.
+          // setUp default queryEventsDetailed -> [] : no existing kind-10050.
           when(
             () => mockNostrClient.publishEventAwaitOk(
               any(),

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -574,13 +574,6 @@ void main() {
       when(() => mockNostrClient.connectedRelayCount).thenReturn(3);
       when(() => mockNostrClient.configuredRelayCount).thenReturn(3);
 
-      // Stub getNewestMessageTimestamp for startListening() windowing.
-      when(
-        () => mockConversationsDao.getNewestMessageTimestamp(
-          ownerPubkey: any(named: 'ownerPubkey'),
-        ),
-      ).thenAnswer((_) async => null);
-
       // Stub getAllConversations for _mergeDuplicateConversations().
       when(
         () => mockConversationsDao.getAllConversations(

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -698,12 +698,6 @@ void main() {
         ),
       ).thenAnswer((_) async => true);
       when(
-        () => mockConversationsDao.lastSentTimestampsByConversation(
-          any(),
-          ownerPubkey: any(named: 'ownerPubkey'),
-        ),
-      ).thenAnswer((_) async => <String, int>{});
-      when(
         () => mockMessageService.publishSelfApplicationMarker(
           content: any(named: 'content'),
           tags: any(named: 'tags'),


### PR DESCRIPTION
## Description

First slice of #8399. `dm_repository_test.dart` has a shared `setUp` whose stubs every test in the
file inherits without declaring, which is the shape that let #7324 stay green. This removes the
registrations that no test depends on and strengthens one test that could not fail for the race it
named.

**Shared `setUp`: 21 stub registrations -> 19.** No product code changed; 421 tests in the file,
744 in the package, and 1,033 in `db_client` remain green.

Deliberately narrow: it touches only lines 565–807 and the account-switch regression test. None of
the four in-flight PRs on this file modify those areas, so #8206 / #8378 / #8401 need no rebase.

### 1. `getNewestMessageTimestamp` was dead in both packages (`729a0076bd`)

Three references repo-wide: the DAO declaration and the two stub lines. Nothing in `mobile/lib` or
any `mobile/packages/*/lib` called it, so it was never "already covered in isolation". There was
nothing to cover. The stub's comment claimed it served `startListening()` windowing, a call that
does not exist. Stub and method go together. The method has no `db_client` test, so that package's
coverage can only rise.

### 2. `queryEvents` no longer reached (`caab7d117c`)

#8212 moved the drain's paged reads and every kind-10050 lookup to `queryEventsDetailed`. No
`.queryEvents(` call site remains in `dm_repository/lib`. The `verifyNever(queryEvents)` migration
guard is unaffected because mocktail records calls on an unstubbed mock.

### 3. The remaining shared defaults are throw-guards

Five defaults each show "0 tests break" when removed, and removing all five together also leaves
421 green. Only the two above are actually removable. The other defaults answer calls whose thrown
mocktail errors are caught by production, so deleting them silently moves tests onto error paths.
For example, removing `lastSentTimestampsByConversation` leaves the suite green while emitting 33
read-state restore failures.

**A test-failure count is necessary but not sufficient evidence for removing a stub. The run's
logs have to be diffed against the baseline too.** That rule is what the rest of #8399 will be
worked under.

### 4. The account-switch regression now discriminates the generation guard (`2c238711dc`, `a744cefc91`)

`an account switch during the own-inbox resolve bails the old user's subscription` used to wire
two completers to `queryEvents`, but #8212 moved that read to `queryEventsDetailed`. The resolve
therefore returned from the shared answered-empty default before the switch. Replacing the stub
body with an unconditional `throw` left the test green, confirming that it could not fail for the
race it named.

The test now blocks account A's real resolve, starts account B's resolve while A remains suspended,
and resumes A first. It verifies that A opens no stale stream, then verifies that B's subscription
filter contains only B. Removing the `_resetGeneration != gen` guard makes the test fail. This also
confirms that B re-resolves its own inbox after the switch. Refs #8411.

## Out of Scope

- **Relocating the remaining decision stubs into the groups that need them**: the substance of
  #8399, and the next slice. Measured cost per stub: `canSendTo` 64 tests,
  `claimCrossProtocolTwin` 48, `hasMessageWithSendBatchId` 13, `giftWrapIdsPresent` 6,
  `hasMatchingMessage` 4, `queryEventsDetailed` 2, `applyReadCursor` 1.
- **A physical split of the file.** Extracting one real group measured 1,798 lines to host an
  813-line group, or 985 lines of carried scaffolding, so about 10 files would add roughly 9,850
  duplicated lines. Deferred because the goal is that no stub is inherited invisibly, not a line
  count.
- **`runInTransaction` atomicity**: #8408.

## Verification

- `dm_repository` **744 pass**, `db_client` **1,033 pass**
- `very_good test --optimization --coverage --min-coverage 93 --test-randomize-ordering-seed random`
  green on two consecutive runs (the merged isolate randomizes order, so one green run is not
  evidence)
- `flutter analyze lib test` clean in both packages
- Ratchets re-run green: ungrouped-tests, placeholder-tests, skip-ceiling, package-coverage-floor,
  untested-services-floor
- Each removal was measured by deleting it and running all 421, then re-checking the run's logs
  against the baseline for newly swallowed exceptions
- The final 421-test run emitted zero read-state restore failures

## Type of Change

- [x] 🧹 Chore (test infrastructure; no product behaviour change)

**Related Issue:** Relates to #8399

Refs #8229
