### PR TITLE
test(dm): declare each DM decision stub where its decision is made

### DIFF
--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -582,32 +582,6 @@ void main() {
         ),
       ).thenAnswer((_) async => []);
 
-      // Default for the batched drain dedup probe (#13): nothing already
-      // persisted. The drain group overrides this with a stateful version so
-      // its inclusive-`until` boundary re-request is deduped.
-      when(
-        () => mockDirectMessagesDao.giftWrapIdsPresent(any()),
-      ).thenAnswer((_) async => const <String>{});
-
-      // Default for every queryEventsDetailed read — the kind-10050 lookups
-      // (resolveDmInboxRelays() on the send path, the memoized own-inbox
-      // resolve, the RC3 publish check) and the history drain's paged reads.
-      // ANSWERED and empty: the relays replied and there is genuinely nothing,
-      // which is what every test that cares about neither read assumed when
-      // both went through queryEvents. An UNANSWERED empty is a different
-      // outcome — absence the RC3 publisher must not act on (#8212), a page the
-      // drain must not read as exhaustion (#8209) — and is stubbed explicitly.
-      when(
-        () => mockNostrClient.queryEventsDetailed(
-          any(),
-          subscriptionId: any(named: 'subscriptionId'),
-          useCache: any(named: 'useCache'),
-          tempRelays: any(named: 'tempRelays'),
-          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
-          timeout: any(named: 'timeout'),
-        ),
-      ).thenAnswer((_) async => answeredList(const <Event>[]));
-
       // Stub backfillCurrentUserHasSent for _backfillCurrentUserHasSent().
       when(
         () => mockConversationsDao.backfillCurrentUserHasSent(any()),
@@ -666,18 +640,6 @@ void main() {
         ),
       ).thenAnswer((_) async => false);
 
-      // Global stub for the durable batch-id dedup probe: the send + recovery
-      // paths now match a group send's persisted local message by its stamped
-      // sendBatchId (not the collision-prone content/timestamp window). Default
-      // to "not yet persisted" so happy-path group send + recovery insert
-      // normally; dedup tests restub this to true.
-      when(
-        () => mockDirectMessagesDao.hasMessageWithSendBatchId(
-          batchId: any(named: 'batchId'),
-          ownerPubkey: any(named: 'ownerPubkey'),
-        ),
-      ).thenAnswer((_) async => false);
-
       // Global stub for markAsRead — every live-send path now marks the
       // conversation read in the same transaction (#5515: sending implies
       // read). Default to a successful flip so send tests don't restub it.
@@ -691,13 +653,6 @@ void main() {
       // Global stubs for the #4977 read-state cursor surface so any path that
       // touches the marker reconcile / debounced publish / drain floor has a
       // default. Tests that assert on these restub or verify as needed.
-      when(
-        () => mockConversationsDao.applyReadCursor(
-          any(),
-          any(),
-          ownerPubkey: any(named: 'ownerPubkey'),
-        ),
-      ).thenAnswer((_) async => true);
       when(
         () => mockConversationsDao.lastSentTimestampsByConversation(
           any(),
@@ -883,6 +838,40 @@ void main() {
     // -----------------------------------------------------------------
     // Static helpers
     // -----------------------------------------------------------------
+
+    // Decision stubs, declared by the groups that depend on them rather than
+    // inherited from the shared setUp. Each replaces a branch production takes,
+    // so a test that needs one should say so (#8399).
+
+    void stubNoStoredReadCursorRow() => when(
+      () => mockConversationsDao.applyReadCursor(
+        any(),
+        any(),
+        ownerPubkey: any(named: 'ownerPubkey'),
+      ),
+    ).thenAnswer((_) async => true);
+
+    void stubRelayReadAnsweredEmpty() => when(
+      () => mockNostrClient.queryEventsDetailed(
+        any(),
+        subscriptionId: any(named: 'subscriptionId'),
+        useCache: any(named: 'useCache'),
+        tempRelays: any(named: 'tempRelays'),
+        requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        timeout: any(named: 'timeout'),
+      ),
+    ).thenAnswer((_) async => answeredList(const <Event>[]));
+
+    void stubNoPersistedGiftWrapIds() => when(
+      () => mockDirectMessagesDao.giftWrapIdsPresent(any()),
+    ).thenAnswer((_) async => const <String>{});
+
+    void stubNoMessageForSendBatch() => when(
+      () => mockDirectMessagesDao.hasMessageWithSendBatchId(
+        batchId: any(named: 'batchId'),
+        ownerPubkey: any(named: 'ownerPubkey'),
+      ),
+    ).thenAnswer((_) async => false);
 
     group('computeConversationId', () {
       test('returns same hash regardless of order', () {
@@ -1667,6 +1656,11 @@ void main() {
     // -----------------------------------------------------------------
 
     group('receive pipeline', () {
+      setUp(stubNoPersistedGiftWrapIds);
+      // The drain's read-state restore calls applyReadCursor; unstubbed it
+      // throws into a catch, which no test failure would show.
+      setUp(stubNoStoredReadCursorRow);
+
       Event createGiftWrapEvent({String? id}) {
         return Event.fromJson({
           'id': id ?? _giftWrapEventId,
@@ -4733,6 +4727,8 @@ void main() {
     });
 
     group('ensureDmRelayListPublished (#4974 RC3)', () {
+      setUp(stubRelayReadAnsweredEmpty);
+
       Event existingInbox(List<String> relays) => Event(
         _validPubkeyA,
         EventKind.dmRelaysList,
@@ -5496,6 +5492,8 @@ void main() {
     });
 
     group('backfillHistoryIfNeeded', () {
+      setUp(stubNoStoredReadCursorRow);
+
       // Kind-5 deletions with no tags flow through _handleIncomingEvent
       // with zero decryption / DAO side effects, so they exercise the
       // drain's pagination control flow in isolation.
@@ -8581,6 +8579,8 @@ void main() {
     });
 
     group('read-state marker (#4977)', () {
+      setUp(stubNoStoredReadCursorRow);
+
       final tupleKey = (<String>[
         _validPubkeyA,
         _validPubkeyB,
@@ -9097,6 +9097,8 @@ void main() {
     // needed: the `_validPubkey*` fixtures are arbitrary hex, not keypairs,
     // so they cannot produce a seal whose signature verifies. #7343.
     group('read-state marker forgery, real NIP-59 crypto (#7343)', () {
+      setUp(stubNoStoredReadCursorRow);
+
       const victimPrivate =
           '5c0c523f52a5b6fad39ed2403092df8cebc36318b39383bca6c00808626fab3a';
       const attackerPrivate =
@@ -19321,6 +19323,8 @@ void main() {
     });
 
     group('sendGroupMessage with outgoing_dms queue wired in', () {
+      setUp(stubNoMessageForSendBatch);
+
       late _MockOutgoingDmsDao mockOutgoingDmsDao;
 
       setUp(() {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -608,21 +608,6 @@ void main() {
         await callback();
       });
 
-      // Same default for the cross-protocol twin claim, which the peer receive
-      // paths use instead of hasMatchingMessage (#8211): no twin is available,
-      // so an arrival persists. Dedup tests restub this to true.
-      when(
-        () => mockDirectMessagesDao.claimCrossProtocolTwin(
-          counterpart: any(named: 'counterpart'),
-          conversationId: any(named: 'conversationId'),
-          senderPubkey: any(named: 'senderPubkey'),
-          content: any(named: 'content'),
-          createdAt: any(named: 'createdAt'),
-          windowSeconds: any(named: 'windowSeconds'),
-          ownerPubkey: any(named: 'ownerPubkey'),
-        ),
-      ).thenAnswer((_) async => false);
-
       // Global stub for markAsRead — every live-send path now marks the
       // conversation read in the same transaction (#5515: sending implies
       // read). Default to a successful flip so send tests don't restub it.
@@ -861,6 +846,20 @@ void main() {
     // groups that lean on it say so.
     void stubNoMatchingStoredMessage() => when(
       () => mockDirectMessagesDao.hasMatchingMessage(
+        counterpart: any(named: 'counterpart'),
+        conversationId: any(named: 'conversationId'),
+        senderPubkey: any(named: 'senderPubkey'),
+        content: any(named: 'content'),
+        createdAt: any(named: 'createdAt'),
+        windowSeconds: any(named: 'windowSeconds'),
+        ownerPubkey: any(named: 'ownerPubkey'),
+      ),
+    ).thenAnswer((_) async => false);
+
+    // #8211's claim: a stored cross-protocol twin may absorb exactly one
+    // arrival. `false` means no twin is available, so an arrival persists.
+    void stubNoCrossProtocolTwinAvailable() => when(
+      () => mockDirectMessagesDao.claimCrossProtocolTwin(
         counterpart: any(named: 'counterpart'),
         conversationId: any(named: 'conversationId'),
         senderPubkey: any(named: 'senderPubkey'),
@@ -1654,6 +1653,8 @@ void main() {
     // -----------------------------------------------------------------
 
     group('receive pipeline', () {
+      setUp(stubNoCrossProtocolTwinAvailable);
+
       setUp(stubNoPersistedGiftWrapIds);
       // The drain's read-state restore calls applyReadCursor; unstubbed it
       // throws into a catch, which no test failure would show.
@@ -7072,6 +7073,8 @@ void main() {
     // -----------------------------------------------------------------
 
     group('history drain batch decryption (#5391)', () {
+      setUp(stubNoCrossProtocolTwinAvailable);
+
       // A new recipient keypair per test so the real NIP-44 unwrap in the
       // batched decrypt worker succeeds (the shared _validPubkey* constants
       // are not a real keypair).
@@ -9499,6 +9502,8 @@ void main() {
     });
 
     group('_handleGiftWrapEvent preserves existing state', () {
+      setUp(stubNoCrossProtocolTwinAvailable);
+
       void stubDaoInserts() {
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
@@ -9667,6 +9672,8 @@ void main() {
     // -----------------------------------------------------------------
 
     group('Kind 15 receive pipeline', () {
+      setUp(stubNoCrossProtocolTwinAvailable);
+
       void stubDaoInserts() {
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
@@ -10252,6 +10259,8 @@ void main() {
     // -----------------------------------------------------------------
 
     group('moderation DM scenarios', () {
+      setUp(stubNoCrossProtocolTwinAvailable);
+
       /// The fallback moderation pubkey (inlined from ModerationLabelService).
       const moderationPubkey =
           '8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e';
@@ -10601,6 +10610,8 @@ void main() {
     // -----------------------------------------------------------------
 
     group('NIP-04 receive pipeline', () {
+      setUp(stubNoCrossProtocolTwinAvailable);
+
       /// Helper to create a NIP-04 (kind 4) event.
       Event createNip04Event({
         String? id,
@@ -12882,6 +12893,8 @@ void main() {
     // Canonicalization: extra p-tags routing
     // -----------------------------------------------------------------
     group('canonicalize 1:1 participants', () {
+      setUp(stubNoCrossProtocolTwinAvailable);
+
       Event createGiftWrapEvent({String? id}) {
         return Event.fromJson({
           'id': id ?? _giftWrapEventId,
@@ -15204,6 +15217,8 @@ void main() {
     });
 
     group('receive pipeline - processed-wrap dedup ledger (#5452)', () {
+      setUp(stubNoCrossProtocolTwinAvailable);
+
       Event giftWrap() => Event.fromJson({
         'id': _giftWrapEventId,
         'pubkey': _validPubkeyC,

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -608,23 +608,6 @@ void main() {
         await callback();
       });
 
-      // Global stub for the recovery path's group-sibling dedup probe: by
-      // default no batch sibling is persisted yet, so recoverFullSend
-      // inserts normally. Group-recovery tests that exercise the dedup
-      // restub this to true. Still used by the cross-protocol receive dedup
-      // and by the legacy null-batch fallback in group recovery.
-      when(
-        () => mockDirectMessagesDao.hasMatchingMessage(
-          counterpart: any(named: 'counterpart'),
-          conversationId: any(named: 'conversationId'),
-          senderPubkey: any(named: 'senderPubkey'),
-          content: any(named: 'content'),
-          createdAt: any(named: 'createdAt'),
-          windowSeconds: any(named: 'windowSeconds'),
-          ownerPubkey: any(named: 'ownerPubkey'),
-        ),
-      ).thenAnswer((_) async => false);
-
       // Same default for the cross-protocol twin claim, which the peer receive
       // paths use instead of hasMatchingMessage (#8211): no twin is available,
       // so an arrival persists. Dedup tests restub this to true.
@@ -869,6 +852,21 @@ void main() {
     void stubNoMessageForSendBatch() => when(
       () => mockDirectMessagesDao.hasMessageWithSendBatchId(
         batchId: any(named: 'batchId'),
+        ownerPubkey: any(named: 'ownerPubkey'),
+      ),
+    ).thenAnswer((_) async => false);
+
+    // #7324's stub: whether a same-protocol row already matches. Constant
+    // `false` here is what let the collapsed-duplicate bug stay green, so the
+    // groups that lean on it say so.
+    void stubNoMatchingStoredMessage() => when(
+      () => mockDirectMessagesDao.hasMatchingMessage(
+        counterpart: any(named: 'counterpart'),
+        conversationId: any(named: 'conversationId'),
+        senderPubkey: any(named: 'senderPubkey'),
+        content: any(named: 'content'),
+        createdAt: any(named: 'createdAt'),
+        windowSeconds: any(named: 'windowSeconds'),
         ownerPubkey: any(named: 'ownerPubkey'),
       ),
     ).thenAnswer((_) async => false);
@@ -21666,6 +21664,8 @@ void main() {
     });
 
     group('recoverFullSend', () {
+      setUp(stubNoMatchingStoredMessage);
+
       late _MockOutgoingDmsDao mockOutgoingDmsDao;
 
       // A fixed rumor JSON that Event.fromJson can parse — the

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -562,6 +562,32 @@ void main() {
       registerFallbackValue(Duration.zero);
     });
 
+    // Everything registered below is a THROW-GUARD, not a decision.
+    //
+    // The distinction is what #8399 turns on. A *decision* stub stands in for a
+    // branch production takes, so inheriting one invisibly can make a class of
+    // bug unobservable -- that is how #7324 stayed green here for months. Those
+    // have been moved to the groups that depend on them and are declared there
+    // by name -- `stubSendPolicyPermitsEveryone`,
+    // `stubNoCrossProtocolTwinAvailable` and friends, defined just below
+    // `createRepository`.
+    //
+    // What is left exists only because an unstubbed mocktail member *throws*.
+    // No branch reads these values:
+    //
+    //   * relay counters      -- interpolated into a log line
+    //   * runInTransaction    -- runs the callback inline; on 11 persist paths
+    //   * markAsRead          -- both production call sites are a bare `await`
+    //   * getAllConversations, both backfills, publishSelfApplicationMarker
+    //                         -- production CATCHES their throw and logs it, so
+    //                            removing them keeps the suite green while
+    //                            silently running it against an error branch
+    //   * buildRumor/buildGroupRumor -- faithful fakes, not constants; they
+    //                            compute real event ids from their arguments
+    //
+    // Before removing anything here, check the run's logs as well as the test
+    // count: grep for `type 'Null' is not a subtype of type '` and compare
+    // against the baseline. A green suite is necessary but not sufficient.
     setUp(() {
       mockNostrClient = _MockNostrClient();
       mockMessageService = _MockNIP17MessageService();

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -578,6 +578,9 @@ void main() {
     //   * relay counters      -- interpolated into a log line
     //   * runInTransaction    -- runs the callback inline; on 11 persist paths
     //   * markAsRead          -- both production call sites are a bare `await`
+    //   * queryEventsDetailed -- send/listener inbox resolution catches its
+    //                            throw; RC3 re-declares the answered-empty
+    //                            decision explicitly in its own group
     //   * getAllConversations, both backfills, publishSelfApplicationMarker
     //                         -- production CATCHES their throw and logs it, so
     //                            removing them keeps the suite green while
@@ -607,6 +610,20 @@ void main() {
           ownerPubkey: any(named: 'ownerPubkey'),
         ),
       ).thenAnswer((_) async => []);
+
+      // Catch guard for the broad send/listener kind-10050 lookup surface.
+      // Without this, those tests stay green but silently exercise the failed
+      // lookup branch. RC3 re-declares the answered-empty decision by name.
+      when(
+        () => mockNostrClient.queryEventsDetailed(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+          tempRelays: any(named: 'tempRelays'),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer((_) async => answeredList(const <Event>[]));
 
       // Stub backfillCurrentUserHasSent for _backfillCurrentUserHasSent().
       when(
@@ -981,7 +998,6 @@ void main() {
 
     group('sendMessage', () {
       setUp(stubSendPolicyPermitsEveryone);
-      setUp(stubRelayReadAnsweredEmpty);
 
       test('throws $ArgumentError for invalid pubkey', () {
         final repository = createRepository();
@@ -10290,7 +10306,6 @@ void main() {
 
     group('moderation DM scenarios', () {
       setUp(stubSendPolicyPermitsEveryone);
-      setUp(stubRelayReadAnsweredEmpty);
 
       setUp(stubNoCrossProtocolTwinAvailable);
 
@@ -11897,7 +11912,6 @@ void main() {
 
     group('dual-send NIP-04 fallback', () {
       setUp(stubSendPolicyPermitsEveryone);
-      setUp(stubRelayReadAnsweredEmpty);
 
       void stubDaoInserts() {
         when(
@@ -16564,7 +16578,6 @@ void main() {
 
     group('sendMessage - replyToId', () {
       setUp(stubSendPolicyPermitsEveryone);
-      setUp(stubRelayReadAnsweredEmpty);
 
       test('includes reply-to tag when replyToId is provided', () async {
         stubSendRumor(
@@ -16669,7 +16682,6 @@ void main() {
 
     group('sendGroupMessage - success', () {
       setUp(stubSendPolicyPermitsEveryone);
-      setUp(stubRelayReadAnsweredEmpty);
 
       void stubDaoInserts() {
         when(
@@ -17002,7 +17014,6 @@ void main() {
 
     group('sendSharedVideoGroup', () {
       setUp(stubSendPolicyPermitsEveryone);
-      setUp(stubRelayReadAnsweredEmpty);
 
       void stubDaoInserts() {
         when(
@@ -17607,7 +17618,6 @@ void main() {
 
     group('_sendNip04Message failure paths', () {
       setUp(stubSendPolicyPermitsEveryone);
-      setUp(stubRelayReadAnsweredEmpty);
 
       test(
         'returns failure when signer is null',
@@ -18015,7 +18025,6 @@ void main() {
 
     group('sendMessage preserves existing conversation metadata', () {
       setUp(stubSendPolicyPermitsEveryone);
-      setUp(stubRelayReadAnsweredEmpty);
 
       test(
         'uses existing createdAt and dmProtocol from conversation',
@@ -18131,7 +18140,6 @@ void main() {
 
     group('sendMessage with outgoing_dms queue wired in', () {
       setUp(stubSendPolicyPermitsEveryone);
-      setUp(stubRelayReadAnsweredEmpty);
 
       late _MockOutgoingDmsDao mockOutgoingDmsDao;
 
@@ -19391,7 +19399,6 @@ void main() {
 
     group('sendGroupMessage with outgoing_dms queue wired in', () {
       setUp(stubSendPolicyPermitsEveryone);
-      setUp(stubRelayReadAnsweredEmpty);
 
       setUp(stubNoMessageForSendBatch);
 
@@ -21736,7 +21743,6 @@ void main() {
     });
 
     group('recoverFullSend', () {
-      setUp(stubRelayReadAnsweredEmpty);
       setUp(stubNoMatchingStoredMessage);
 
       late _MockOutgoingDmsDao mockOutgoingDmsDao;

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -831,7 +831,7 @@ void main() {
     // inherited from the shared setUp. Each replaces a branch production takes,
     // so a test that needs one should say so (#8399).
 
-    void stubNoStoredReadCursorRow() => when(
+    void stubReadCursorRowMatched() => when(
       () => mockConversationsDao.applyReadCursor(
         any(),
         any(),
@@ -981,6 +981,7 @@ void main() {
 
     group('sendMessage', () {
       setUp(stubSendPolicyPermitsEveryone);
+      setUp(stubRelayReadAnsweredEmpty);
 
       test('throws $ArgumentError for invalid pubkey', () {
         final repository = createRepository();
@@ -1687,7 +1688,7 @@ void main() {
       setUp(stubNoPersistedGiftWrapIds);
       // The drain's read-state restore calls applyReadCursor; unstubbed it
       // throws into a catch, which no test failure would show.
-      setUp(stubNoStoredReadCursorRow);
+      setUp(stubReadCursorRowMatched);
 
       Event createGiftWrapEvent({String? id}) {
         return Event.fromJson({
@@ -5520,7 +5521,7 @@ void main() {
     });
 
     group('backfillHistoryIfNeeded', () {
-      setUp(stubNoStoredReadCursorRow);
+      setUp(stubReadCursorRowMatched);
 
       // Kind-5 deletions with no tags flow through _handleIncomingEvent
       // with zero decryption / DAO side effects, so they exercise the
@@ -8609,7 +8610,7 @@ void main() {
     });
 
     group('read-state marker (#4977)', () {
-      setUp(stubNoStoredReadCursorRow);
+      setUp(stubReadCursorRowMatched);
 
       final tupleKey = (<String>[
         _validPubkeyA,
@@ -9127,7 +9128,7 @@ void main() {
     // needed: the `_validPubkey*` fixtures are arbitrary hex, not keypairs,
     // so they cannot produce a seal whose signature verifies. #7343.
     group('read-state marker forgery, real NIP-59 crypto (#7343)', () {
-      setUp(stubNoStoredReadCursorRow);
+      setUp(stubReadCursorRowMatched);
 
       const victimPrivate =
           '5c0c523f52a5b6fad39ed2403092df8cebc36318b39383bca6c00808626fab3a';
@@ -10289,6 +10290,7 @@ void main() {
 
     group('moderation DM scenarios', () {
       setUp(stubSendPolicyPermitsEveryone);
+      setUp(stubRelayReadAnsweredEmpty);
 
       setUp(stubNoCrossProtocolTwinAvailable);
 
@@ -11895,6 +11897,7 @@ void main() {
 
     group('dual-send NIP-04 fallback', () {
       setUp(stubSendPolicyPermitsEveryone);
+      setUp(stubRelayReadAnsweredEmpty);
 
       void stubDaoInserts() {
         when(
@@ -16561,6 +16564,7 @@ void main() {
 
     group('sendMessage - replyToId', () {
       setUp(stubSendPolicyPermitsEveryone);
+      setUp(stubRelayReadAnsweredEmpty);
 
       test('includes reply-to tag when replyToId is provided', () async {
         stubSendRumor(
@@ -16665,6 +16669,7 @@ void main() {
 
     group('sendGroupMessage - success', () {
       setUp(stubSendPolicyPermitsEveryone);
+      setUp(stubRelayReadAnsweredEmpty);
 
       void stubDaoInserts() {
         when(
@@ -16997,6 +17002,7 @@ void main() {
 
     group('sendSharedVideoGroup', () {
       setUp(stubSendPolicyPermitsEveryone);
+      setUp(stubRelayReadAnsweredEmpty);
 
       void stubDaoInserts() {
         when(
@@ -17601,6 +17607,7 @@ void main() {
 
     group('_sendNip04Message failure paths', () {
       setUp(stubSendPolicyPermitsEveryone);
+      setUp(stubRelayReadAnsweredEmpty);
 
       test(
         'returns failure when signer is null',
@@ -18008,6 +18015,7 @@ void main() {
 
     group('sendMessage preserves existing conversation metadata', () {
       setUp(stubSendPolicyPermitsEveryone);
+      setUp(stubRelayReadAnsweredEmpty);
 
       test(
         'uses existing createdAt and dmProtocol from conversation',
@@ -18123,6 +18131,7 @@ void main() {
 
     group('sendMessage with outgoing_dms queue wired in', () {
       setUp(stubSendPolicyPermitsEveryone);
+      setUp(stubRelayReadAnsweredEmpty);
 
       late _MockOutgoingDmsDao mockOutgoingDmsDao;
 
@@ -19382,6 +19391,7 @@ void main() {
 
     group('sendGroupMessage with outgoing_dms queue wired in', () {
       setUp(stubSendPolicyPermitsEveryone);
+      setUp(stubRelayReadAnsweredEmpty);
 
       setUp(stubNoMessageForSendBatch);
 
@@ -21726,6 +21736,7 @@ void main() {
     });
 
     group('recoverFullSend', () {
+      setUp(stubRelayReadAnsweredEmpty);
       setUp(stubNoMatchingStoredMessage);
 
       late _MockOutgoingDmsDao mockOutgoingDmsDao;

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -704,12 +704,6 @@ void main() {
           createdAt: createdAt,
         );
       });
-
-      // Default: the send policy permits everyone (behavior preserved). The
-      // protected-minor gate tests override this per-recipient. (#176)
-      when(
-        () => mockMessageService.canSendTo(any()),
-      ).thenAnswer((_) async => true);
     });
 
     DmRepository createRepository({
@@ -870,6 +864,13 @@ void main() {
       ),
     ).thenAnswer((_) async => false);
 
+    // #176's protected-minor gate: whether this recipient may be messaged.
+    // The gate tests override it per-recipient; every other send group needs
+    // the permissive default stated rather than inherited.
+    void stubSendPolicyPermitsEveryone() => when(
+      () => mockMessageService.canSendTo(any()),
+    ).thenAnswer((_) async => true);
+
     group('computeConversationId', () {
       test('returns same hash regardless of order', () {
         final resultAB = DmRepository.computeConversationId(
@@ -953,6 +954,8 @@ void main() {
     // -----------------------------------------------------------------
 
     group('sendMessage', () {
+      setUp(stubSendPolicyPermitsEveryone);
+
       test('throws $ArgumentError for invalid pubkey', () {
         final repository = createRepository();
 
@@ -10259,6 +10262,8 @@ void main() {
     // -----------------------------------------------------------------
 
     group('moderation DM scenarios', () {
+      setUp(stubSendPolicyPermitsEveryone);
+
       setUp(stubNoCrossProtocolTwinAvailable);
 
       /// The fallback moderation pubkey (inlined from ModerationLabelService).
@@ -11863,6 +11868,8 @@ void main() {
     // -----------------------------------------------------------------
 
     group('dual-send NIP-04 fallback', () {
+      setUp(stubSendPolicyPermitsEveryone);
+
       void stubDaoInserts() {
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
@@ -16527,6 +16534,8 @@ void main() {
     });
 
     group('sendMessage - replyToId', () {
+      setUp(stubSendPolicyPermitsEveryone);
+
       test('includes reply-to tag when replyToId is provided', () async {
         stubSendRumor(
           (_, recipientPubkey) async => NIP17SendResult.success(
@@ -16629,6 +16638,8 @@ void main() {
     // -----------------------------------------------------------------
 
     group('sendGroupMessage - success', () {
+      setUp(stubSendPolicyPermitsEveryone);
+
       void stubDaoInserts() {
         when(
           () => mockDirectMessagesDao.insertMessage(
@@ -16959,6 +16970,8 @@ void main() {
     });
 
     group('sendSharedVideoGroup', () {
+      setUp(stubSendPolicyPermitsEveryone);
+
       void stubDaoInserts() {
         when(
           () => mockDirectMessagesDao.insertMessage(
@@ -17561,6 +17574,8 @@ void main() {
     });
 
     group('_sendNip04Message failure paths', () {
+      setUp(stubSendPolicyPermitsEveryone);
+
       test(
         'returns failure when signer is null',
         () async {
@@ -17966,6 +17981,8 @@ void main() {
     });
 
     group('sendMessage preserves existing conversation metadata', () {
+      setUp(stubSendPolicyPermitsEveryone);
+
       test(
         'uses existing createdAt and dmProtocol from conversation',
         () async {
@@ -18079,6 +18096,8 @@ void main() {
     });
 
     group('sendMessage with outgoing_dms queue wired in', () {
+      setUp(stubSendPolicyPermitsEveryone);
+
       late _MockOutgoingDmsDao mockOutgoingDmsDao;
 
       setUp(() {
@@ -19336,6 +19355,8 @@ void main() {
     });
 
     group('sendGroupMessage with outgoing_dms queue wired in', () {
+      setUp(stubSendPolicyPermitsEveryone);
+
       setUp(stubNoMessageForSendBatch);
 
       late _MockOutgoingDmsDao mockOutgoingDmsDao;


### PR DESCRIPTION
## Description

Second slice of #8399, and the substance of it. Every stub in
`dm_repository_test.dart`'s shared `setUp` that exists only to select a production decision now
sits in the groups that depend on it, declared by name. What remains is either a throw-guard or a
faithful fake.

**Shared `setUp`: 21 -> 15 registrations.** 421 tests in the file and 744 in the package are
unchanged; this is wiring, not product behaviour.

**Related Issue:** Relates to #8399

### The distinction this is built on

- A **decision stub** replaces a branch production takes. Inheriting one invisibly is how #7324
  stayed green here for months, and why #8169's regression test had to be written in a separate
  file against a real DAO.
- A **throw-guard** exists because an unstubbed member throws into production code that catches or
  otherwise cannot usefully proceed from that throw.

Six decision defaults moved fully out of the shared setup. Each is a named helper defined once
below `createRepository`, so a group states its dependency in a line
(`setUp(stubSendPolicyPermitsEveryone);`) instead of repeating a fifteen-line `when(...)` block.

`queryEventsDetailed` needs both roles kept distinct: the broad send/listener kind-10050 lookup
surface retains an answered-empty shared catch guard because production catches an unstubbed
Mocktail throw and silently reports a failed lookup; the RC3 group re-declares the answered-empty
decision by name because absent versus failed controls whether it publishes.

| Stub | Declared on | Commit |
|---|---|---|
| `applyReadCursor` | 4 groups | `d5a5983f0d` |
| `queryEventsDetailed` | shared send/listener catch guard and `ensureDmRelayListPublished (#4974 RC3)` decision | `d5a5983f0d`, `d8a54a3f9` |
| `giftWrapIdsPresent` | `receive pipeline` | `d5a5983f0d` |
| `hasMessageWithSendBatchId` | `sendGroupMessage with outgoing_dms queue wired in` | `d5a5983f0d` |
| `hasMatchingMessage` (#7324) | `recoverFullSend` | `f100ac82d6` |
| `claimCrossProtocolTwin` (#8211) | 8 receive/canonicalisation groups | `81bbfe6f68` |
| `canSendTo` (#176 gate) | 10 send groups | `a2dcf22a2f` |

The final comments label what stays and say why each registration is a throw-guard or faithful
fake rather than a hidden decision default.

### The check that made this safe

A green test count is not sufficient evidence that a stub was unused. Where production **catches**
an unstubbed member's throw, removing the stub keeps every test green while silently running the
rest of the file against an error branch. So each relocation was verified two ways: 421 green,
**and** the run's swallowed-exception counts matched the baseline exactly.

That caught two misses. `applyReadCursor` breaks exactly one test when removed, but three further
groups call it through the drain's read-state restore. `queryEventsDetailed` initially looked like
an RC3-only decision, but its broad send/listener use also needs the shared catch guard: without
it, the suite stayed green while adding 41 swallowed Mocktail null errors relative to the PR base.

## Out of Scope

- **#8410** removes three further registrations (two dead stubs and one redundant default). It is a
  separate PR to `main`, not stacked on this one — the two sets do not intersect, so they are
  content-independent. Both edit the same `setUp` block, so whichever merges second takes a
  mechanical rebase. Together they leave the block at 12 registrations.
- **A physical split of the file** — measured at +985 scaffolding lines per extracted file, so it
  would grow the codebase rather than shrink it. Not planned.
- **`runInTransaction` atomicity** — #8408. It stays here as a throw-guard.
- Consolidating the existing hand-written `hasMatchingMessage` stubs. The new helper makes that
  cleanup possible, but it is not required for this relocation slice.
- A ratchet freezing the shared `setUp` so it cannot regrow — next slice.

## Verification

- `dm_repository` **744 pass**, file **421 pass**
- `flutter analyze packages/dm_repository/lib packages/dm_repository/test` clean
- Pre-push analyzer and changed-file test suite green
- Swallowed-exception counts compared with the PR merge base: identical (`queryEventsDetailed`
  Mocktail null errors **1 -> 1**, all Mocktail null subtype errors **4 -> 4**)

## Type of Change

- [x] 🧹 Code refactor (test wiring; no product behaviour change)

Refs #8229
