### PR TITLE
fix(dm): source the conversation header's follower count from ProfileStats

### DIFF
--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -247,6 +247,20 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
               .watch(nip05VerificationProvider(otherPubkey))
               .whenOrNull(data: (status) => status)
         : null;
+    // Counts live in the `profile_statistics` store, not on the profile.
+    // `UserProfile.restFollowerCount` reads `rawData['follower_count']`, which
+    // only the people-search shape ever writes and which is never persisted to
+    // the cache this screen reads — so it was permanently null here and the
+    // social-proof fallback never fired (#8403). The repository routes
+    // `GET /api/users/{pubkey}`'s `social` block into `profile_statistics`
+    // instead. A vanished account takes the branch below and never reaches the
+    // resolver; `fetchFreshProfile` short-circuits for it in any case.
+    final followerCount = ref
+        .watch(userProfileStatsReactiveProvider(otherPubkey))
+        .asData
+        ?.value
+        ?.followers;
+
     // Prefer the profile's NIP-05 / divine handle when set, otherwise the
     // follow relationship — which tells the viewer which of several
     // same-named people they are messaging, as a truncated npub never did.
@@ -260,7 +274,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                 relationship:
                     ref.watch(followRelationshipProvider(otherPubkey)).value ??
                     FollowRelationship.none,
-                followerCount: profile?.restFollowerCount,
+                followerCount: followerCount,
               ) ??
               '';
 

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -770,7 +770,13 @@ class ProfileRepository implements ProfileReader {
       followingCount: (social?.followingCount ?? 0) > 0
           ? social!.followingCount
           : null,
-      videoCount: stats?.videoCount,
+      // Same reasoning as the two counts above, and the same collapse:
+      // `get_user_stats` maps both a miss and a ClickHouse failure to a
+      // default, so funnelcake answers 200 with `video_count: 0` when the
+      // summary table is down. Withholding it lets `upsertStats` keep the
+      // previous real count instead of overwriting it with an ambiguous zero
+      // (#8403).
+      videoCount: (stats?.videoCount ?? 0) > 0 ? stats!.videoCount : null,
       totalLikes: engagement?.totalReactions,
       totalViews: publicViewCount,
     );

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -1401,6 +1401,41 @@ void main() {
           ).called(1);
         });
 
+        test('does not cache an ambiguous zero video count', () async {
+          // `get_user_stats` maps both a miss and a ClickHouse failure to a
+          // default, so funnelcake answers 200 with `video_count: 0` when the
+          // summary table is down — the same ambiguity the social counts
+          // already withhold. Writing it would overwrite a good baseline
+          // with a zero (#8403).
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getUserProfile(testPubkey),
+          ).thenAnswer(
+            (_) async => UserProfileNotPublished(
+              pubkey: testPubkey,
+              social: ProfileSocialData.fromJson(const {
+                'follower_count': 1976,
+                'following_count': 12,
+              }),
+              stats: ProfileStatsData.fromJson(const {'video_count': 0}),
+            ),
+          );
+
+          await repoWithFunnelcake.fetchFreshProfile(pubkey: testPubkey);
+
+          // The social counts are real and cached; the zero video count is
+          // withheld, so the DAO keeps whatever baseline the row already has.
+          verify(
+            () => mockProfileStatsDao.upsertStats(
+              pubkey: testPubkey,
+              followerCount: 1976,
+              followingCount: 12,
+              totalLikes: any(named: 'totalLikes'),
+              totalViews: any(named: 'totalViews'),
+            ),
+          ).called(1);
+        });
+
         test('caches mixed social responses per field', () async {
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
           when(

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -6,7 +6,9 @@ import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
-import 'package:db_client/db_client.dart';
+// `ProfileStats` here is the domain model from `models`, not the Drift
+// table class of the same name — the repository hides it the same way.
+import 'package:db_client/db_client.dart' hide ProfileStats;
 import 'package:divine_ui/divine_ui.dart';
 import 'package:dm_repository/dm_repository.dart' show DmRepository;
 import 'package:flutter/material.dart';
@@ -182,6 +184,7 @@ void main() {
     Widget buildSubject({
       ConversationState? state,
       UserProfile? otherProfile,
+      ProfileStats? otherStats,
       bool otherProfileVanished = false,
       MockGoRouter? goRouter,
       DmRestoreStatusState? restoreStatus,
@@ -224,6 +227,9 @@ void main() {
           ).overrideWith(
             (ref) => otherProfileFuture ?? Future.value(otherProfile),
           ),
+          userProfileStatsReactiveProvider(
+            counterparty,
+          ).overrideWith((ref) => Stream.value(otherStats)),
           profileVanishedProvider(
             counterparty,
           ).overrideWith((ref) => Stream.value(otherProfileVanished)),
@@ -1030,13 +1036,21 @@ void main() {
         final profile = UserProfile(
           pubkey: otherPubkey,
           name: 'Jack',
-          rawData: const {'follower_count': 2100},
+          rawData: const {},
           createdAt: now,
           eventId:
               'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
         );
 
-        await tester.pumpWidget(buildSubject(otherProfile: profile));
+        await tester.pumpWidget(
+          buildSubject(
+            otherProfile: profile,
+            otherStats: const ProfileStats(
+              pubkey: otherPubkey,
+              followers: 2100,
+            ),
+          ),
+        );
         await tester.pump();
         await tester.pump();
 
@@ -1051,13 +1065,18 @@ void main() {
         );
       });
 
-      testWidgets('does not render a self-reported Vine follower count', (
+      // The line's count comes from the `profile_statistics` store, never from
+      // the profile object. Both keys below are shapes this screen's cache can
+      // never produce anyway — `follower_count` is written only by the
+      // people-search path, and `vine_followers` is a Kind 0 *tag* the getter
+      // reads out of *content* — so neither may reach the line (#8403).
+      testWidgets('ignores follower counts carried on the profile', (
         tester,
       ) async {
         final profile = UserProfile(
           pubkey: otherPubkey,
           name: 'Jack',
-          rawData: const {'vine_followers': 430},
+          rawData: const {'follower_count': 2100, 'vine_followers': 430},
           createdAt: now,
           eventId:
               'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
@@ -1067,10 +1086,37 @@ void main() {
         await tester.pump();
         await tester.pump();
 
-        // vine_followers is the account's own kind-0 claim; only an
-        // authoritative follower_count earns a spot on the line.
         expect(find.text(l10n.socialProofMutual), findsOneWidget);
+        expect(find.textContaining('2.1K'), findsNothing);
         expect(find.textContaining('430'), findsNothing);
+      });
+
+      // A zero is indistinguishable from a stats outage: funnelcake answers
+      // 200 with `{0, 0}` when the summary table is down.
+      testWidgets('omits a zero follower count', (tester) async {
+        final profile = UserProfile(
+          pubkey: otherPubkey,
+          name: 'Jack',
+          rawData: const {},
+          createdAt: now,
+          eventId:
+              'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            otherProfile: profile,
+            otherStats: const ProfileStats(pubkey: otherPubkey, followers: 0),
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text(l10n.socialProofMutual), findsOneWidget);
+        expect(
+          find.textContaining(l10n.socialProofFollowerCount(0, '0')),
+          findsNothing,
+        );
       });
 
       testWidgets(


### PR DESCRIPTION
## Description

Follow-up to #8405, which fixed the same defect class on the message-request preview.

`resolveUserIdentifierLine` falls back to social proof when an account has no usable NIP-05 — the line that answers "which of several same-named people am I messaging?". The conversation header fed it `profile?.restFollowerCount`, which is **structurally null on this screen**, so the follower half of that fallback had never rendered.

`restFollowerCount` reads `rawData['follower_count']`. The only producer of that key is `ProfileSearchResult.toUserProfile()`, and it is never persisted to the Drift `user_profiles` cache the header reads. `GET /api/users/{pubkey}` nests its counts under `social`/`stats`, which `_cacheProfileStatsFromResult` routes into the separate `profile_statistics` table. The header now reads that store.

**Related Issue:** Relates to #8403

## Also in here: the writer's missing zero-guard

`_cacheProfileStatsFromResult` zero-guarded `followerCount` and `followingCount` but wrote `videoCount` verbatim. The guard exists because funnelcake collapses a stats failure into zeros behind an HTTP 200 — and `video_count` collapses the same way: `get_user_stats` maps **both** a miss and an error to a default (`handlers.rs:6183-6190`), while `get_social_stats` never surfaces an error at all (`client.rs:13694-13701`). So a zero is indistinguishable from "never indexed" and from "the summary table is down" on all three fields, and only two were guarded.

Withholding it lets `upsertStats` keep the row's previous real count (`videoCount ?? existing?.videoCount`) instead of overwriting it with an ambiguous zero. This benefits every `ProfileStats` consumer, not just this screen.

## Out of Scope — the nine `UserProfileTile` surfaces (#8415)

#8403 named nine further surfaces reached through `user_profile_tile.dart:109`. **They are deliberately not fixed here**, because the one-line fix that works for a single-pubkey screen would be a scroll-performance regression on unbounded follower lists. Per unique pubkey scrolled it would cost:

- **A REST fetch that does not happen today.** `_watchProfileStats` fires `unawaited(fetchFreshProfile)` unconditionally, unlike `_watchUserProfile`, which only fetches on a cache miss. `fetchFreshProfile` dedupes only in-flight calls; there is no TTL.
- **A subscription that is never released.** `userProfileStatsReactiveProvider` is a plain `StreamProvider.family`; every sibling in that file is generated `isAutoDispose: true`.
- **No batched path.** `_cacheProfileStatsFromResult` is only called from the two single-profile fetches, so the bulk endpoint never caches stats.

The payoff there is smaller too — the resolver prefers NIP-05, then the relationship label, and only *appends* the count. #8415 tracks fixing the provider first, then wiring those surfaces.

## Note for reviewers

The resolver already zero-guards internally (`followerCount != null && followerCount > 0`), so unlike #8405 this call site needs no guard of its own. Worth knowing if #8415 gets picked up — don't copy #8405's pattern here.

## Verification

- `flutter analyze lib test` — clean
- `cd mobile/packages/profile_repository && flutter analyze` — clean, **449 tests pass**
- `flutter test test/screens/inbox/ test/widgets/profile/ test/features/app_review/ test/screens/other_profile_screen_test.dart` — **901 pass** (every `ProfileStats` consumer)
- `dart format --set-exit-if-changed` on all changed files — clean
- 13 CI ratchets green

**Both fixes are mutation-tested.** Reverting only the lib file while keeping its test:
- `conversation_view.dart` reverted → *"uses social proof instead of kind-0 name as handle"* fails.
- `profile_repository.dart` reverted → *"does not cache an ambiguous zero video count"* fails.

The two pre-existing header tests asserted on `rawData` shapes this screen's cache cannot produce (`{'follower_count': 2100}`, `{'vine_followers': 430}`) — which is exactly why nothing went red while the feature was dead. They now drive `ProfileStats`, and a third pins that a count carried on the profile object is ignored.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
