### PR TITLE
fix(nostr_sdk): send reads only to requested relays

### DIFF
--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1882,6 +1882,7 @@ class RelayPool {
     );
     _subscriptions[subscription.id] = subscription;
     _subscriptionSentAt[subscription.id] = DateTime.now();
+    final subscribedRelayIdentities = <String>{};
     log(
       '📋 subscribe: id=${subscription.id}, '
       'relays=${_relays.length}, filters=$filters',
@@ -1894,6 +1895,9 @@ class RelayPool {
         // check if normal relays has this temp relay, try to get relay from normal relays
         Relay? relay = _pooledRelayForTempAddr(tempRelayAddr);
         relay ??= checkAndGenTempRelay(tempRelayAddr);
+        if (!subscribedRelayIdentities.add(_relayIdentity(relay.url))) {
+          continue;
+        }
 
         relayDoSubscribe(
           relay,
@@ -1911,6 +1915,9 @@ class RelayPool {
         var relay = entry.value;
 
         if (targetRelays != null && !_namesRelay(targetRelays, relayAddr)) {
+          continue;
+        }
+        if (!subscribedRelayIdentities.add(_relayIdentity(relay.url))) {
           continue;
         }
 
@@ -2123,6 +2130,7 @@ class RelayPool {
     // to the relay's url when it took the REQ, so the fan-out can report who
     // is actually able to answer.
     final queryFutures = <Future<String?>>[];
+    final queriedRelayIdentities = <String>{};
 
     Future<String?> sendQueryTo(
       Relay relay, {
@@ -2142,6 +2150,9 @@ class RelayPool {
         // check if normal relays has this temp relay, try to get relay from normal relays
         Relay? relay = _pooledRelayForTempAddr(tempRelayAddr);
         relay ??= checkAndGenTempRelay(tempRelayAddr);
+        if (!queriedRelayIdentities.add(_relayIdentity(relay.url))) {
+          continue;
+        }
 
         queryFutures.add(sendQueryTo(relay, runBeforeConnected: true));
       }
@@ -2154,6 +2165,9 @@ class RelayPool {
         var relay = entry.value;
 
         if (targetRelays != null && !_namesRelay(targetRelays, relayAddr)) {
+          continue;
+        }
+        if (!queriedRelayIdentities.add(_relayIdentity(relay.url))) {
           continue;
         }
 

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -371,6 +371,20 @@ class RelayPool {
   Relay? _pooledRelayForTempAddr(String addr) =>
       _relays[addr] ?? _relays[_relayIdentity(addr)];
 
+  /// Whether [addrs] names [url], comparing on [_relayIdentity] rather than
+  /// raw strings. `subscribe`/`query` run their `targetRelays` through
+  /// [handleAddrList] (which ADDS a trailing slash) but compare against pool
+  /// keys from `normalizeRelayUrl` (which STRIPS one), so a raw `contains`
+  /// matched no pooled relay and turned the filter into a universal
+  /// exclusion. #8377.
+  bool _namesRelay(List<String> addrs, String url) {
+    final wanted = _relayIdentity(url);
+    for (final addr in addrs) {
+      if (_relayIdentity(addr) == wanted) return true;
+    }
+    return false;
+  }
+
   bool _isExplicitAuthRequiredReason(String message) {
     final lower = message.trim().toLowerCase();
     return lower.startsWith('auth-required');
@@ -1896,10 +1910,8 @@ class RelayPool {
         var relayAddr = entry.key;
         var relay = entry.value;
 
-        if (targetRelays != null) {
-          if (!targetRelays.contains(relayAddr)) {
-            continue;
-          }
+        if (targetRelays != null && !_namesRelay(targetRelays, relayAddr)) {
+          continue;
         }
 
         relayDoSubscribe(relay, subscription, sendAfterAuth);
@@ -2141,10 +2153,8 @@ class RelayPool {
         var relayAddr = entry.key;
         var relay = entry.value;
 
-        if (targetRelays != null) {
-          if (!targetRelays.contains(relayAddr)) {
-            continue;
-          }
+        if (targetRelays != null && !_namesRelay(targetRelays, relayAddr)) {
+          continue;
         }
 
         queryFutures.add(sendQueryTo(relay));

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_targeting_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_targeting_test.dart
@@ -171,6 +171,18 @@ void main() {
       expect(result.sentTo, isNot(contains(pooledFallback)));
     });
 
+    test('query targetRelays accepts the trailing-slash form', () async {
+      final result = await nostr.relayPool.query(
+        filters,
+        (_) {},
+        id: 'query-target-slashed',
+        targetRelays: const ['$pooledPrimary/'],
+      );
+
+      expect(result.sentTo, [pooledPrimary]);
+      expect(_reqIds(fallbackFactory), isNot(contains('query-target-slashed')));
+    });
+
     test(
       'targetRelays and tempRelays naming one pooled relay share its socket',
       () async {
@@ -186,8 +198,32 @@ void main() {
         );
         await _waitForReq(primaryFactory, 'targeted');
 
-        expect(_reqIds(primaryFactory), contains('targeted'));
+        expect(
+          _reqIds(primaryFactory).where((id) => id == 'targeted'),
+          hasLength(1),
+        );
         expect(_reqIds(fallbackFactory), isNot(contains('targeted')));
+        expect(tempRelaysGenerated, isEmpty);
+      },
+    );
+
+    test(
+      'query sends one REQ when targetRelays and tempRelays name one pool relay',
+      () async {
+        final result = await nostr.relayPool.query(
+          filters,
+          (_) {},
+          id: 'query-targeted',
+          tempRelays: const [pooledPrimary],
+          targetRelays: const [pooledPrimary],
+        );
+
+        expect(
+          _reqIds(primaryFactory).where((id) => id == 'query-targeted'),
+          hasLength(1),
+        );
+        expect(result.sentTo, [pooledPrimary]);
+        expect(_reqIds(fallbackFactory), isNot(contains('query-targeted')));
         expect(tempRelaysGenerated, isEmpty);
       },
     );

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_targeting_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_targeting_test.dart
@@ -1,5 +1,6 @@
-// ABOUTME: Pins how RelayPool.subscribe routes a REQ when tempRelays and
-// ABOUTME: targetRelays are supplied, over real sockets rather than mocks.
+// ABOUTME: Pins how RelayPool.subscribe and .query route a REQ when
+// ABOUTME: tempRelays and targetRelays are supplied, over real sockets
+// ABOUTME: rather than mocks.
 
 import 'dart:convert';
 
@@ -29,7 +30,7 @@ List<String> _reqIds(FakeWebSocketChannelFactory factory) {
 }
 
 void main() {
-  group('RelayPool.subscribe relay routing', () {
+  group('RelayPool relay routing', () {
     // The production shape this guards: divine's own relay plus one of the
     // four IndexerRelayConfig.safeFallbackRelays that #2931 connects so DMs
     // written to other relays stay visible.
@@ -113,24 +114,82 @@ void main() {
       },
     );
 
-    test('targetRelays narrows the pool away, even when it names a pooled '
-        'relay verbatim', () async {
-      // `targetRelays` is a filter over the pool, not an addition — the
-      // fallback pooled relay is skipped. The named pooled relay is supplied
-      // through tempRelays too, but must reuse the existing pooled socket
-      // rather than opening a duplicate connection.
-      nostr.relayPool.subscribe(
+    test(
+      'targetRelays keeps the pooled relay it names and skips the rest',
+      () async {
+        // #8377: the membership test compares a `handleAddrList`-normalized
+        // target (trailing slash ADDED) against a pool key from
+        // `normalizeRelayUrl` (trailing slash STRIPPED). Before the fix those
+        // never match, so `targetRelays` is a universal exclusion and NOTHING
+        // is subscribed. No tempRelays here — a temp entry would reach the
+        // pooled socket by the other path and mask the bug.
+        nostr.relayPool.subscribe(
+          filters,
+          (_) {},
+          id: 'target-only',
+          targetRelays: const [pooledPrimary],
+        );
+        await _waitForReq(primaryFactory, 'target-only');
+
+        expect(_reqIds(primaryFactory), contains('target-only'));
+        expect(_reqIds(fallbackFactory), isNot(contains('target-only')));
+        expect(tempRelaysGenerated, isEmpty);
+      },
+    );
+
+    test(
+      'targetRelays matches a pooled relay given with a trailing slash',
+      () async {
+        // The identity must hold from both directions: a caller that already
+        // supplies the slashed form names the same pooled relay.
+        nostr.relayPool.subscribe(
+          filters,
+          (_) {},
+          id: 'target-slashed',
+          targetRelays: const ['$pooledPrimary/'],
+        );
+        await _waitForReq(primaryFactory, 'target-slashed');
+
+        expect(_reqIds(primaryFactory), contains('target-slashed'));
+        expect(_reqIds(fallbackFactory), isNot(contains('target-slashed')));
+        expect(tempRelaysGenerated, isEmpty);
+      },
+    );
+
+    test('query targetRelays asks only the pooled relay it names', () async {
+      // The same membership test guards `query` (#8377). `sentTo` names the
+      // relays that took the REQ, so an empty result is the universal
+      // exclusion this fixes — not "every relay had nothing".
+      final result = await nostr.relayPool.query(
         filters,
         (_) {},
-        id: 'targeted',
-        tempRelays: const [pooledPrimary],
+        id: 'query-target',
         targetRelays: const [pooledPrimary],
       );
-      await _waitForReq(primaryFactory, 'targeted');
 
-      expect(_reqIds(primaryFactory), contains('targeted'));
-      expect(_reqIds(fallbackFactory), isNot(contains('targeted')));
-      expect(tempRelaysGenerated, isEmpty);
+      expect(result.sentTo, contains(pooledPrimary));
+      expect(result.sentTo, isNot(contains(pooledFallback)));
     });
+
+    test(
+      'targetRelays and tempRelays naming one pooled relay share its socket',
+      () async {
+        // `targetRelays` filters the pool down to the named relay, so the
+        // fallback is skipped. Naming that same relay through tempRelays as
+        // well must reuse the pooled socket rather than dialing a duplicate.
+        nostr.relayPool.subscribe(
+          filters,
+          (_) {},
+          id: 'targeted',
+          tempRelays: const [pooledPrimary],
+          targetRelays: const [pooledPrimary],
+        );
+        await _waitForReq(primaryFactory, 'targeted');
+
+        expect(_reqIds(primaryFactory), contains('targeted'));
+        expect(_reqIds(fallbackFactory), isNot(contains('targeted')));
+        expect(tempRelaysGenerated, isEmpty);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Description

`RelayPool.subscribe` and `RelayPool.query` narrow the pool with
`targetRelays.contains(relayAddr)`. That test could never be true for a pooled
relay, because the two sides are normalized in opposite directions:

- `targetRelays` goes through `handleAddrList` → `RelayAddrUtil.handle`, which
  rebuilds the URI with `path: "/"` when path/query/fragment are blank — it
  **adds** a trailing slash.
- Pool keys come from `normalizeRelayUrl`, which explicitly **strips** one.

So `['wss://relay.divine.video/'].contains('wss://relay.divine.video')` is
`false`, the loop `continue`s past every pooled relay, and `targetRelays`
behaves as a universal exclusion rather than a filter — nothing is subscribed
or queried at all.

The fix compares on `_relayIdentity`, the helper #8378 added for the temp-relay
lookups, so one identity rule now covers both paths. Wire addresses are
untouched; only the comparison is normalized.

**This PR also fixes a second, live defect.** `d3bc23a71` deduplicates the
subscribe/query fan-out by normalized relay identity. Without it, a
`tempRelays` entry naming a relay that is already pooled is subscribed twice —
once by the temp loop (which resolves it to the pooled socket via
`_pooledRelayForTempAddr`) and again by the pool loop, with no dedup between
them. That needs no `targetRelays` at all and is live on `main` today; see
#8424 for the mechanism, measurement, and production reach.

**Related Issue:** Part of #8377, Closes #8424

## Out of Scope

The two publish-path sites are deliberately left alone:

| line | method | `targetRelays` normalized? | compared against | today |
|---|---|---|---|---|
| 1910 | `subscribe` | yes — `handleAddrList` | `relayAddr` (pool key, slash **stripped**) | fixed here |
| 2153 | `query` | yes — `handleAddrList` | `relayAddr` | fixed here |
| 2279 | `_sendCollect` | no | `relay.url` raw | unchanged |
| 2509 | `_intendedPublishTargets` | no | `relay.url` raw | unchanged |

`_sendCollect` and `_intendedPublishTargets` compare raw against raw, so they
work correctly today. That symmetry is accidental rather than designed, but
publish routing is live on DM gift wraps, kind-5 deletions and reports —
changing it to fix an unreachable read-path bug trades real risk for tidiness.
The publish-path normalization decision remains tracked on #8377, which this PR leaves open.

The `_intendedPublishTargets` dartdoc was also examined: its statement that explicit targets are exempt from offline-denominator narrowing matches the implementation and is not stale.

**Reachability — the two halves differ, and this matters for release notes.**

*The `targetRelays` half is latent.* Of the 45 non-test sites passing
`targetRelays`, exactly two are read-path, and both are the internal forwards
inside `nostr.dart` (`Nostr.subscribe` → `_pool.subscribe`, `Nostr.query` →
`_pool.query`). No production caller passes a non-null `targetRelays` into a
subscribe or query. It is not dead, though: `NostrClient.subscribe` exposes the
parameter publicly and runs it through `_allowedRelays`, so the next caller to
use it would have silently received an empty result set.

*The duplicate-REQ half is live.* Measured on the real-socket harness with no
`targetRelays` passed at all:

```
subscribe(filters, cb, id: 'probe', tempRelays: ['wss://relay.divine.video'])
  origin/main (f76bf5c34f):  reqs=2   tempSocketsGenerated=[]
  d3bc23a713:                reqs=1
```

`DmRepository` passes the user's own kind-10050 relays as `tempRelays` on the
live gift-wrap subscription (`dm_repository.dart:995`) and on every history
drain page (`:1624`). Since #8378 every user advertises `_dmInboxRelayUrl`,
which is pooled — so the overlap is the normal case and each DM session and
drain page has been issuing a duplicate REQ. Tracked in #8424.

## Verification

- `flutter test packages/nostr_sdk/test` — **637 passed**
- `flutter test packages/nostr_client/test` — **352 passed**
- `flutter analyze` from within `packages/nostr_sdk` (the package's own lint
  set, not the app's) — no issues
- `dart format --set-exit-if-changed` on both changed files — clean

Takeover verification also pinned overlapping `tempRelays` + `targetRelays` on one pooled identity. The subscribe and query assertions both failed first with two REQs, then passed with exactly one after per-call identity deduplication. Query coverage now includes the caller-supplied trailing-slash form as well.

Both new tests were watched failing first, over the existing real-socket
harness rather than mocks:

- subscribe: `REQ target-only was not written` — the REQ never left, which is
  the universal-exclusion symptom.
- query: the fix touches `query` as well, so that line was reverted on its own
  to confirm the test could fail — `Expected: contains 'wss://relay.divine.video'`
  / `Actual: []`. An empty `sentTo` means nothing was asked, which is not the
  same as every relay having nothing.

The existing test named *"targetRelays narrows the pool away, even when it
names a pooled relay verbatim"* pinned the pre-fix exclusion semantics. It
still passes (its `tempRelays` reaches the pooled socket either way), but the
name described behavior that no longer exists, so it is renamed to
*"targetRelays and tempRelays naming one pooled relay share its socket"* and
now documents socket reuse rather than exclusion.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

