### PR TITLE
test(widgets): scope positional finders that feed a decoration cast

### DIFF
--- a/mobile/test/router/explore_tab_tap_navigation_test.dart
+++ b/mobile/test/router/explore_tab_tap_navigation_test.dart
@@ -43,7 +43,13 @@ void main() {
 
         // Simulate tapping explore tab (index 1)
         // This should navigate to /explore (grid mode), NOT /explore/0 (feed mode)
-        final appShell = tester.widget<Scaffold>(find.byType(Scaffold).first);
+        // Name the Scaffold that owns the bottom nav rather than taking the
+        // first one in the tree: the shell nests page Scaffolds inside its own.
+        final appShell = tester.widget<Scaffold>(
+          find.byWidgetPredicate(
+            (w) => w is Scaffold && w.bottomNavigationBar != null,
+          ),
+        );
         final bottomNav = appShell.bottomNavigationBar! as BottomNavigationBar;
         bottomNav.onTap!(1); // Tap explore tab
         await tester.pumpAndSettle();

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/timeline_trim_handles_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/timeline_trim_handles_test.dart
@@ -73,7 +73,12 @@ void main() {
         await tester.pumpWidget(buildWidget(handleColor: color));
 
         final decorated = tester.widget<DecoratedBox>(
-          find.byType(DecoratedBox).first,
+          find
+              .descendant(
+                of: find.byType(TimelineTrimHandles),
+                matching: find.byType(DecoratedBox),
+              )
+              .first,
         );
         final decoration = decorated.decoration as BoxDecoration;
         expect(decoration.border, isNotNull);
@@ -239,15 +244,10 @@ void main() {
     group('narrow widths', () {
       testWidgets(
         'extends left hit testing beyond the original outward range',
-        (
-          tester,
-        ) async {
+        (tester) async {
           const trimWidth = 20.0;
           await tester.pumpWidget(
-            buildWidget(
-              width: trimWidth,
-              trimWidth: trimWidth,
-            ),
+            buildWidget(width: trimWidth, trimWidth: trimWidth),
           );
 
           final box = tester.renderObject<RenderBox>(
@@ -267,15 +267,10 @@ void main() {
 
       testWidgets(
         'extends right hit testing beyond the original outward range',
-        (
-          tester,
-        ) async {
+        (tester) async {
           const trimWidth = 20.0;
           await tester.pumpWidget(
-            buildWidget(
-              width: trimWidth,
-              trimWidth: trimWidth,
-            ),
+            buildWidget(width: trimWidth, trimWidth: trimWidth),
           );
 
           final box = tester.renderObject<RenderBox>(
@@ -343,7 +338,12 @@ void main() {
         await tester.pumpWidget(buildWidget());
 
         final decorated = tester.widget<DecoratedBox>(
-          find.byType(DecoratedBox).first,
+          find
+              .descendant(
+                of: find.byType(TimelineTrimHandles),
+                matching: find.byType(DecoratedBox),
+              )
+              .first,
         );
         final decoration = decorated.decoration as BoxDecoration;
         expect(

--- a/mobile/test/widgets/video_metadata/video_metadata_limit_warning_banner_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_limit_warning_banner_test.dart
@@ -58,7 +58,12 @@ void main() {
     testWidgets('warning has correct background color', (tester) async {
       await tester.pumpWidget(buildWidget(metadataLimitReached: true));
 
-      final container = tester.widget<Container>(find.byType(Container).first);
+      final container = tester.widget<Container>(
+        find.descendant(
+          of: find.byType(VideoMetadataLimitWarningBanner),
+          matching: find.byType(Container),
+        ),
+      );
       final decoration = container.decoration! as BoxDecoration;
       expect(decoration.color, equals(VineTheme.contentWarningBackground));
     });
@@ -66,7 +71,12 @@ void main() {
     testWidgets('warning has rounded corners', (tester) async {
       await tester.pumpWidget(buildWidget(metadataLimitReached: true));
 
-      final container = tester.widget<Container>(find.byType(Container).first);
+      final container = tester.widget<Container>(
+        find.descendant(
+          of: find.byType(VideoMetadataLimitWarningBanner),
+          matching: find.byType(Container),
+        ),
+      );
       final decoration = container.decoration! as BoxDecoration;
       expect(decoration.borderRadius, equals(BorderRadius.circular(16)));
     });


### PR DESCRIPTION
## Description

`find.byType(X).first` followed by an unguarded cast reads a widget the test does not control. #8320 failed exactly this way: an ambient Cupertino page transition put a `_CupertinoEdgeShadowDecoration` ahead of the widget under test, and `.first` handed it to a `BoxDecoration` cast — in a test whose own tree pumps a plain `MaterialApp`.

Three sites are exposed, and each is fixed by naming what the assertion actually means:

- **`timeline_trim_handles_test.dart:76, 346`** — the same code as #8320, character for character. Scoped to `TimelineTrimHandles`.
- **`video_metadata_limit_warning_banner_test.dart:61, 69`** — `find.byType(Container).first` → `.decoration! as BoxDecoration`. Scoped to the banner; since that widget has exactly one `Container`, the positional index goes away entirely rather than being kept in a narrower scope.
- **`explore_tab_tap_navigation_test.dart:46`** — the assertion wanted the shell's `Scaffold`, but the shell nests page `Scaffold`s inside its own. It now selects by the property it means: `find.byWidgetPredicate((w) => w is Scaffold && w.bottomNavigationBar != null)`.

## Out of Scope

**Four other sites the same search returns are deliberately untouched.** In `featured_videos_tab_test.dart` (3 sites) and `comments_screen_test.dart` (1), the cast is on `verify().captured`, not on the finder, and `.first` is the *intent* — those tests go on to assert `initialIndex == 0` / `initialVideoId == 'first'`. Rewriting them would replace a meaningful `.first` with noise.

**No ratchet.** The hazard and its benign twin are textually identical — a positional finder plus a nearby `as`. A grep guard flags the same four false positives, which teaches people to work around it rather than fix anything; my own first-pass regex made exactly that mistake on 4 of 9. The durable prevention for #8320's specific cause already shipped in #8376, which initializes the merged-isolate themes at the Flutter test baseline.

**Related Issue:** Closes #8422, Refs #6880, #8330

## Verification

- **The fixes are load-bearing, not cosmetic.** Injecting an ambient decoration ancestor into each exposed file reproduces the #8320 class:

  | | with an ambient ancestor decoration |
  |---|---|
  | `timeline_trim_handles_test.dart`, old form | `type 'ShapeDecoration' is not a subtype of type 'BoxDecoration' in type cast` — 2 failures |
  | same file, scoped form | 15/15 pass |
  | `video_metadata_limit_warning_banner_test.dart`, old form | same cast error — 2 failures |
  | same file, scoped form | 0 cast failures |

  (The banner probe also trips that file's own `expect(find.byType(Container), findsNothing)`, which is the injected wrapper being counted — an artifact of the probe, not of the scoping.) The probes were reverted, not committed.
- All three files green unmodified: `+20 ~1`.
- `flutter analyze lib test integration_test` → No issues found. `dart format --set-exit-if-changed` → 0 changed.
- Ratchets green: `check_placeholder_tests`, `check_ungrouped_tests`, `check_test_unit_structure`, `check_skip_ceiling`, `check_process_global_mutations`, `check_shared_setup_stubs`, `check_l10n_delegates_ceiling`.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
