### PR TITLE
test(dm): cover transaction rollback and membership on the DM persist paths

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -609,11 +609,6 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
     return result.read(directMessages.id.count()) ?? 0;
   }
 
-  /// Run a callback inside a database transaction.
-  Future<T> runInTransaction<T>(Future<T> Function() action) {
-    return attachedDatabase.transaction(action);
-  }
-
   /// Deletes DMs for the departing account plus unattributed legacy rows.
   ///
   /// Ambiguous rows must never cross an account boundary and become visible to

--- a/mobile/packages/dm_repository/test/src/dm_persist_transaction_rollback_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_persist_transaction_rollback_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Regression coverage for #8408 — when a write inside the receive
-// ABOUTME: path's transaction throws, the message insert must roll back.
+// ABOUTME: Regression coverage for #8408 — the receive path's persist writes
+// ABOUTME: must run inside one transaction, and roll back when one throws.
 
 import 'dart:async';
 
@@ -15,16 +15,43 @@ import 'package:nostr_sdk/signer/local_nostr_signer.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 
-/// A real [ConversationsDao] that can be told to throw from
-/// `upsertConversation`, which the receive path calls *after* it has already
-/// inserted the message row and while the transaction is still open.
+/// A real [ConversationsDao] that records whether each write ran inside a
+/// transaction, and can be told to throw from `upsertConversation` — the call
+/// the receive path makes *after* it has already inserted the message row and
+/// while the transaction is still open.
 ///
-/// `runInTransaction` is deliberately inherited unchanged: the point is to
-/// exercise drift's real transaction, not a stub that runs the callback inline.
-class _FailingUpsertConversationsDao extends ConversationsDao {
-  _FailingUpsertConversationsDao(super.attachedDatabase);
+/// `runInTransaction` delegates to `super`, so drift's real transaction is what
+/// runs; the override only brackets it with a flag so membership is
+/// observable. Presence of a transaction and membership *in* it are different
+/// properties: a write can be moved out of a still-present transaction without
+/// changing any call count or call order (#8408).
+class _InstrumentedConversationsDao extends ConversationsDao {
+  _InstrumentedConversationsDao(super.attachedDatabase);
 
   bool failUpsert = false;
+
+  /// Write name -> whether a transaction was open when it ran.
+  final membership = <String, bool>{};
+
+  bool _open = false;
+
+  @override
+  Future<T> runInTransaction<T>(Future<T> Function() action) {
+    return super.runInTransaction(() async {
+      _open = true;
+      try {
+        return await action();
+      } finally {
+        _open = false;
+      }
+    });
+  }
+
+  @override
+  Future<bool> markAsRead(String id, {String? ownerPubkey}) {
+    membership['markAsRead'] = _open;
+    return super.markAsRead(id, ownerPubkey: ownerPubkey);
+  }
 
   @override
   Future<void> upsertConversation({
@@ -42,6 +69,7 @@ class _FailingUpsertConversationsDao extends ConversationsDao {
     String? dmProtocol,
     bool forceUpdateLastMessage = false,
   }) {
+    membership['upsertConversation'] = _open;
     if (failUpsert) {
       throw StateError('injected mid-transaction failure');
     }
@@ -81,9 +109,9 @@ void main() {
   // runInTransaction to run its callback inline, which is indistinguishable
   // from having no transaction at all, so a test written there cannot observe
   // a rollback (#8408).
-  group('a throw inside the receive path transaction', () {
+  group('the receive path persist transaction', () {
     late AppDatabase db;
-    late _FailingUpsertConversationsDao conversationsDao;
+    late _InstrumentedConversationsDao conversationsDao;
     late DirectMessagesDao messagesDao;
     late ProcessedGiftWrapsDao processedDao;
     late _MockNostrClient nostrClient;
@@ -96,7 +124,7 @@ void main() {
 
     setUp(() async {
       db = AppDatabase.test(NativeDatabase.memory());
-      conversationsDao = _FailingUpsertConversationsDao(db);
+      conversationsDao = _InstrumentedConversationsDao(db);
       messagesDao = DirectMessagesDao(db);
       processedDao = ProcessedGiftWrapsDao(db);
       nostrClient = _MockNostrClient();
@@ -205,55 +233,80 @@ void main() {
     const rumorId =
         'd1c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a2';
 
-    test('rolls the message insert back instead of orphaning it', () async {
-      conversationsDao.failUpsert = true;
+    group('membership', () {
+      test(
+        'runs the conversation upsert inside it, not merely after it',
+        () async {
+          await deliverNip17(
+            wrapId: wrapId,
+            rumorId: rumorId,
+            content: 'hello',
+          );
 
-      await deliverNip17(
-        wrapId: wrapId,
-        rumorId: rumorId,
-        content: 'hello',
-      );
-
-      // Without the transaction the insert commits and the upsert throws into
-      // the receive path's `on Object catch`, leaving a direct_messages row
-      // whose conversation never existed: invisible in the UI, and silently.
-      expect(await storedMessages(), isEmpty);
-      expect(
-        await conversationsDao.getConversation(
-          conversationId,
-          ownerPubkey: _owner,
-        ),
-        isNull,
+          // The rollback tests prove the transaction wraps *something*. This
+          // proves it wraps this particular write: moving the upsert out of a
+          // still-present transaction changes no call count and no call order,
+          // so nothing else in the package would notice. That is the shape of
+          // the unenforced `_upsertSentConversationAndMarkRead` contract.
+          expect(
+            conversationsDao.membership['upsertConversation'],
+            isTrue,
+            reason:
+                'upsertConversation ran outside the transaction that carries '
+                'the message insert, so the two are no longer atomic',
+          );
+        },
       );
     });
 
-    test(
-      'leaves the wrap replayable rather than permanently swallowed',
-      () async {
+    group('rollback', () {
+      test('rolls the message insert back instead of orphaning it', () async {
         conversationsDao.failUpsert = true;
-        await deliverNip17(
-          wrapId: wrapId,
-          rumorId: rumorId,
-          content: 'hello',
+
+        await deliverNip17(wrapId: wrapId, rumorId: rumorId, content: 'hello');
+
+        // Without the transaction the insert commits and the upsert throws
+        // into the receive path's `on Object catch`, leaving a
+        // direct_messages row whose conversation never existed: invisible in
+        // the UI, and silent.
+        expect(await storedMessages(), isEmpty);
+        expect(
+          await conversationsDao.getConversation(
+            conversationId,
+            ownerPubkey: _owner,
+          ),
+          isNull,
         );
+      });
 
-        // The rolled-back insert must take the gift-wrap marker with it. If
-        // the row survived, hasGiftWrap() would short-circuit the TOCTOU
-        // re-check on every replay and the message could never be recovered.
-        expect(await messagesDao.hasGiftWrap(wrapId), isFalse);
+      test(
+        'leaves the wrap replayable rather than permanently swallowed',
+        () async {
+          conversationsDao.failUpsert = true;
+          await deliverNip17(
+            wrapId: wrapId,
+            rumorId: rumorId,
+            content: 'hello',
+          );
 
-        conversationsDao.failUpsert = false;
-        await deliverNip17(
-          wrapId: wrapId,
-          rumorId: rumorId,
-          content: 'hello',
-        );
+          // The rolled-back insert must take the gift-wrap marker with it. If
+          // the row survived, hasGiftWrap() would short-circuit the TOCTOU
+          // re-check on every replay and the message could never be recovered.
+          expect(await messagesDao.hasGiftWrap(wrapId), isFalse);
 
-        final recovered = await storedMessages();
-        expect(recovered, hasLength(1));
-        expect(recovered.single.id, rumorId);
-        expect(recovered.single.content, 'hello');
-      },
-    );
+          conversationsDao.failUpsert = false;
+          await deliverNip17(
+            wrapId: wrapId,
+            rumorId: rumorId,
+            content: 'hello',
+          );
+
+          final recovered = await storedMessages();
+          expect(recovered, hasLength(1));
+          expect(recovered.single.id, rumorId);
+          expect(recovered.single.content, 'hello');
+        },
+      );
+    });
   });
 }

--- a/mobile/packages/dm_repository/test/src/dm_persist_transaction_rollback_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_persist_transaction_rollback_test.dart
@@ -48,12 +48,6 @@ class _InstrumentedConversationsDao extends ConversationsDao {
   }
 
   @override
-  Future<bool> markAsRead(String id, {String? ownerPubkey}) {
-    membership['markAsRead'] = _open;
-    return super.markAsRead(id, ownerPubkey: ownerPubkey);
-  }
-
-  @override
   Future<void> upsertConversation({
     required String id,
     required String participantPubkeys,
@@ -184,21 +178,18 @@ void main() {
     });
 
     Future<void> settle() async {
-      for (var i = 0; i < 8; i++) {
-        await Future<void>.delayed(Duration.zero);
-      }
+      await pumpEventQueue();
     }
 
     Future<void> deliverNip17({
       required String wrapId,
       required String rumorId,
       required String content,
-      int createdAt = _baseCreatedAt,
     }) async {
       rumors[wrapId] = Event.fromJson({
         'id': rumorId,
         'pubkey': _peer,
-        'created_at': createdAt,
+        'created_at': _baseCreatedAt,
         'kind': EventKind.privateDirectMessage,
         'tags': [
           ['p', _owner],
@@ -210,7 +201,7 @@ void main() {
         Event.fromJson({
           'id': wrapId,
           'pubkey': _peer,
-          'created_at': createdAt,
+          'created_at': _baseCreatedAt,
           'kind': EventKind.giftWrap,
           'tags': [
             ['p', _owner],
@@ -222,11 +213,8 @@ void main() {
       await settle();
     }
 
-    Future<List<DirectMessageRow>> storedMessages() =>
-        messagesDao.getMessagesForConversation(
-          conversationId,
-          ownerPubkey: _owner,
-        );
+    Future<List<DirectMessageRow>> storedMessages() => messagesDao
+        .getMessagesForConversation(conversationId, ownerPubkey: _owner);
 
     const wrapId =
         'c1c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a1';
@@ -265,18 +253,13 @@ void main() {
 
         await deliverNip17(wrapId: wrapId, rumorId: rumorId, content: 'hello');
 
+        expect(conversationsDao.membership['upsertConversation'], isTrue);
+
         // Without the transaction the insert commits and the upsert throws
         // into the receive path's `on Object catch`, leaving a
         // direct_messages row whose conversation never existed: invisible in
         // the UI, and silent.
         expect(await storedMessages(), isEmpty);
-        expect(
-          await conversationsDao.getConversation(
-            conversationId,
-            ownerPubkey: _owner,
-          ),
-          isNull,
-        );
       });
 
       test(
@@ -288,6 +271,8 @@ void main() {
             rumorId: rumorId,
             content: 'hello',
           );
+
+          expect(conversationsDao.membership['upsertConversation'], isTrue);
 
           // The rolled-back insert must take the gift-wrap marker with it. If
           // the row survived, hasGiftWrap() would short-circuit the TOCTOU

--- a/mobile/packages/dm_repository/test/src/dm_persist_transaction_rollback_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_persist_transaction_rollback_test.dart
@@ -1,0 +1,259 @@
+// ABOUTME: Regression coverage for #8408 — when a write inside the receive
+// ABOUTME: path's transaction throws, the message insert must roll back.
+
+import 'dart:async';
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+/// A real [ConversationsDao] that can be told to throw from
+/// `upsertConversation`, which the receive path calls *after* it has already
+/// inserted the message row and while the transaction is still open.
+///
+/// `runInTransaction` is deliberately inherited unchanged: the point is to
+/// exercise drift's real transaction, not a stub that runs the callback inline.
+class _FailingUpsertConversationsDao extends ConversationsDao {
+  _FailingUpsertConversationsDao(super.attachedDatabase);
+
+  bool failUpsert = false;
+
+  @override
+  Future<void> upsertConversation({
+    required String id,
+    required String participantPubkeys,
+    required bool isGroup,
+    required int createdAt,
+    String? lastMessageContent,
+    int? lastMessageTimestamp,
+    String? lastMessageSenderPubkey,
+    String? subject,
+    bool isRead = true,
+    bool currentUserHasSent = false,
+    String? ownerPubkey,
+    String? dmProtocol,
+    bool forceUpdateLastMessage = false,
+  }) {
+    if (failUpsert) {
+      throw StateError('injected mid-transaction failure');
+    }
+    return super.upsertConversation(
+      id: id,
+      participantPubkeys: participantPubkeys,
+      isGroup: isGroup,
+      createdAt: createdAt,
+      lastMessageContent: lastMessageContent,
+      lastMessageTimestamp: lastMessageTimestamp,
+      lastMessageSenderPubkey: lastMessageSenderPubkey,
+      subject: subject,
+      isRead: isRead,
+      currentUserHasSent: currentUserHasSent,
+      ownerPubkey: ownerPubkey,
+      dmProtocol: dmProtocol,
+      forceUpdateLastMessage: forceUpdateLastMessage,
+    );
+  }
+}
+
+const _owner =
+    'a4f5c1b2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8';
+const _peer =
+    'b1c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0';
+const _privateKey =
+    '5426e5b8b4b0e2a1f5e8d3c7a9b2f4e6d8c0a2b4f6e8d0c2a4b6f8e0d2c4a6b8';
+
+const _baseCreatedAt = 1700000000;
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(Duration.zero);
+  });
+
+  // Drives the real DAOs against a real database. The mock suite stubs
+  // runInTransaction to run its callback inline, which is indistinguishable
+  // from having no transaction at all, so a test written there cannot observe
+  // a rollback (#8408).
+  group('a throw inside the receive path transaction', () {
+    late AppDatabase db;
+    late _FailingUpsertConversationsDao conversationsDao;
+    late DirectMessagesDao messagesDao;
+    late ProcessedGiftWrapsDao processedDao;
+    late _MockNostrClient nostrClient;
+    late StreamController<Event> relay;
+    late DmRepository repository;
+    late Map<String, Event> rumors;
+
+    final participants = [_owner, _peer]..sort();
+    late String conversationId;
+
+    setUp(() async {
+      db = AppDatabase.test(NativeDatabase.memory());
+      conversationsDao = _FailingUpsertConversationsDao(db);
+      messagesDao = DirectMessagesDao(db);
+      processedDao = ProcessedGiftWrapsDao(db);
+      nostrClient = _MockNostrClient();
+      relay = StreamController<Event>();
+      rumors = <String, Event>{};
+      conversationId = DmRepository.computeConversationId(participants);
+
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(() => nostrClient.configuredRelayCount).thenReturn(1);
+      when(
+        () => nostrClient.queryEvents(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+        ),
+      ).thenAnswer((_) async => const <Event>[]);
+      when(
+        () => nostrClient.queryEventsDetailed(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+          tempRelays: any(named: 'tempRelays'),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async =>
+            (events: const <Event>[], timedOut: false, noRelays: false),
+      );
+      when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
+      when(
+        () => nostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((_) => relay.stream);
+
+      repository = DmRepository(
+        nostrClient: nostrClient,
+        directMessagesDao: messagesDao,
+        conversationsDao: conversationsDao,
+        processedGiftWrapsDao: processedDao,
+        userPubkey: _owner,
+        signer: LocalNostrSigner(_privateKey),
+        rumorDecryptor: (_, giftWrap) async => rumors[giftWrap.id],
+        nip04Decryptor: (_, ciphertext) async => ciphertext,
+      );
+      await repository.startListening();
+    });
+
+    tearDown(() async {
+      await repository.stopListening();
+      await relay.close();
+      await db.close();
+    });
+
+    Future<void> settle() async {
+      for (var i = 0; i < 8; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+    }
+
+    Future<void> deliverNip17({
+      required String wrapId,
+      required String rumorId,
+      required String content,
+      int createdAt = _baseCreatedAt,
+    }) async {
+      rumors[wrapId] = Event.fromJson({
+        'id': rumorId,
+        'pubkey': _peer,
+        'created_at': createdAt,
+        'kind': EventKind.privateDirectMessage,
+        'tags': [
+          ['p', _owner],
+        ],
+        'content': content,
+        'sig': '',
+      });
+      relay.add(
+        Event.fromJson({
+          'id': wrapId,
+          'pubkey': _peer,
+          'created_at': createdAt,
+          'kind': EventKind.giftWrap,
+          'tags': [
+            ['p', _owner],
+          ],
+          'content': 'wrapped',
+          'sig': '',
+        }),
+      );
+      await settle();
+    }
+
+    Future<List<DirectMessageRow>> storedMessages() =>
+        messagesDao.getMessagesForConversation(
+          conversationId,
+          ownerPubkey: _owner,
+        );
+
+    const wrapId =
+        'c1c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a1';
+    const rumorId =
+        'd1c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a2';
+
+    test('rolls the message insert back instead of orphaning it', () async {
+      conversationsDao.failUpsert = true;
+
+      await deliverNip17(
+        wrapId: wrapId,
+        rumorId: rumorId,
+        content: 'hello',
+      );
+
+      // Without the transaction the insert commits and the upsert throws into
+      // the receive path's `on Object catch`, leaving a direct_messages row
+      // whose conversation never existed: invisible in the UI, and silently.
+      expect(await storedMessages(), isEmpty);
+      expect(
+        await conversationsDao.getConversation(
+          conversationId,
+          ownerPubkey: _owner,
+        ),
+        isNull,
+      );
+    });
+
+    test(
+      'leaves the wrap replayable rather than permanently swallowed',
+      () async {
+        conversationsDao.failUpsert = true;
+        await deliverNip17(
+          wrapId: wrapId,
+          rumorId: rumorId,
+          content: 'hello',
+        );
+
+        // The rolled-back insert must take the gift-wrap marker with it. If
+        // the row survived, hasGiftWrap() would short-circuit the TOCTOU
+        // re-check on every replay and the message could never be recovered.
+        expect(await messagesDao.hasGiftWrap(wrapId), isFalse);
+
+        conversationsDao.failUpsert = false;
+        await deliverNip17(
+          wrapId: wrapId,
+          rumorId: rumorId,
+          content: 'hello',
+        );
+
+        final recovered = await storedMessages();
+        expect(recovered, hasLength(1));
+        expect(recovered.single.id, rumorId);
+        expect(recovered.single.content, 'hello');
+      },
+    );
+  });
+}


### PR DESCRIPTION
Refs #8408.

`ConversationsDao.runInTransaction` wraps 11 persist paths in `dm_repository.dart`, and nothing in the package could tell whether any of them was inside a transaction at all. `dm_repository_test.dart` stubs it to run the callback inline, which is indistinguishable from having no transaction — so every one of those paths could lose its transaction with the suite still green.

The production code is correct today. This is about the absence of anything that would notice if it stopped being.

## What landed

**Rollback coverage** — a new real-DB test that injects a throw from `upsertConversation`, the call the receive path makes *after* it has already inserted the message row and while the transaction is still open. `runInTransaction` is inherited unchanged, so this exercises drift's real transaction rather than a stub.

Two assertions, because the orphan row is worse than it first looks:

- the message insert rolls back, rather than leaving a `direct_messages` row whose `conversations` row never existed — invisible in the UI, and silent, since the throw lands in the receive path's `on Object catch`;
- the gift-wrap marker rolls back with it, so a replay can still recover the message. If the row survived, `hasGiftWrap()` would short-circuit the TOCTOU re-check on every replay and the message would be lost permanently.

**Membership coverage** — rollback proves the transaction wraps *something*; it does not prove it wraps a particular write. This test brackets `super.runInTransaction` with a flag and records whether the receive path’s `upsertConversation` ran while that transaction was open. The transaction stays drift’s real one; only the observation is added. The send-path contract and the other persist sites remain tracked by #8408.

**Dead API** — `DirectMessagesDao.runInTransaction` had zero callers and zero stubs anywhere. Both definitions delegated to the same `attachedDatabase.transaction`, so it was harmless, but a second equally valid-looking entry point invites a future caller to open a transaction on whichever DAO happens to be in scope.

## Mutation-verified against production

These tests pass today, so each was checked to be capable of failing — against the production code, not just the harness:

| Mutation | Result |
|---|---|
| `runInTransaction` overridden to run inline (what the mock suite's stub does) | rollback tests fail: `Expected: empty`, and `Expected: false, Actual: <true>` |
| Receive path's `upsertConversation` moved outside its transaction closure — same calls, same order, transaction still present | all three fail, membership with `Expected: true, Actual: <false>` |

## Verification

- `dm_repository`: 745 tests green, coverage 94.49% (gate 93)
- `db_client`: 1033 tests green
- `flutter analyze` clean in both packages
- Ratchets green: `shared_setup_stubs`, `ungrouped_tests`, `placeholder_tests`, `skip_ceiling`, `test_unit_structure`

## Scope note

This covers the receive path, which is where the harness already existed. The remaining transaction sites, including the send-path contract, remain tracked by #8408.