### PR TITLE
fix(dm): publish the sender's self-wrap to their own kind-10050 inbox relays

### DIFF
--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -63,7 +63,7 @@ jobs:
       #
       # The list is explicit rather than a glob over integration_test/e2e/,
       # because `service` and "runnable on a Linux CI runner" are different
-      # axes. Every suite in that directory is tagged `service`; these five
+      # axes. Every suite in that directory is tagged `service`; these six
       # are the ones this runner can actually execute. The remaining four are
       # excluded
       # for reasons no workflow change can fix:
@@ -76,7 +76,7 @@ jobs:
       #
       # local_stack cannot start on a GitHub runner at all:
       # divine-invite-darshan:e2e is a private GHCR package, compose resolves
-      # every image before starting any, so zero containers come up. The two
+      # every image before starting any, so zero containers come up. The
       # suites below need none of it — they stand up their own in-process relay
       # (integration_test/helpers/fake_relay.dart).
       - name: 🚀 Run service integration tests
@@ -84,6 +84,7 @@ jobs:
           for suite in \
             integration_test/e2e/relay_list_admission_test.dart \
             integration_test/e2e/dm_inbox_relay_admission_test.dart \
+            integration_test/e2e/dm_self_wrap_inbox_relays_test.dart \
             integration_test/e2e/reel_reply_retry_double_send_test.dart \
             integration_test/e2e/block_leaves_kind3_follow_test.dart \
             integration_test/e2e/dm_group_delete_for_everyone_test.dart; do

--- a/mobile/integration_test/e2e/dm_self_wrap_inbox_relays_test.dart
+++ b/mobile/integration_test/e2e/dm_self_wrap_inbox_relays_test.dart
@@ -1,0 +1,213 @@
+// ABOUTME: E2E for #7328 — the sender's own gift-wrap copy reaches the relays
+// ABOUTME: their own kind-10050 advertises, not just the connected pool.
+// ABOUTME: Drives a real DmRepository + NostrClient over real sockets.
+// ABOUTME: Requires: NO Docker stack — every dependency here is local.
+
+@Tags(['service'])
+library;
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay_base.dart';
+import 'package:nostr_sdk/relay/relay_status.dart';
+import 'package:nostr_sdk/relay/web_socket_connection_manager.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../helpers/fake_relay.dart';
+
+/// Redirects every advertised hostname onto the in-process relay and records
+/// the address it was asked for.
+///
+/// The recording is the assertion. `isRemoteSuppliedRelayUrlAllowed` refuses
+/// loopback hosts, so a `ws://127.0.0.1` entry could never *be* an admitted
+/// inbox target — it has to be reached through a public-looking name, and
+/// "this host was dialed" is then observed rather than inferred from a
+/// publish result.
+class _RecordingRedirectFactory implements WebSocketChannelFactory {
+  _RecordingRedirectFactory(this.port);
+
+  final int port;
+  final List<String> requested = [];
+
+  @override
+  WebSocketChannel create(Uri uri) {
+    requested.add(uri.toString());
+    return WebSocketChannel.connect(
+      Uri.parse('ws://127.0.0.1:$port${uri.path}'),
+    );
+  }
+}
+
+/// A DM inbox relay the SENDER advertises and the pool does not contain.
+///
+/// This models divine's own shape since #8378: every account's kind-10050
+/// names `nos.lol` and `relay.primal.net` on top of the divine relay, and
+/// neither joins the pool unless NIP-65 discovery came back empty.
+const _senderOnlyInbox = 'wss://sender-inbox.example';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const senderKey =
+      '3333333333333333333333333333333333333333333333333333333333333333';
+  const recipientKey =
+      '4444444444444444444444444444444444444444444444444444444444444444';
+  final senderPubkey = getPublicKey(senderKey);
+  final recipientPubkey = getPublicKey(recipientKey);
+
+  /// A kind-10050 signed by the SENDER.
+  ///
+  /// [FakeRelay] serves one reply for every `REQ` regardless of filter, and
+  /// that is exactly what makes this test able to attribute a dial. The
+  /// repository only accepts a relay list whose `event.pubkey` matches the
+  /// author it asked about, so this same event resolves `found` for the
+  /// sender's own lookup and is discarded as off-filter for the recipient's.
+  /// The recipient therefore has no advertised inbox, their wrap goes to the
+  /// plain pool, and any connection to [_senderOnlyInbox] can only have come
+  /// from the self-addressed wrap.
+  Map<String, dynamic> senderInbox() {
+    final event = Event(
+      senderPubkey,
+      10050,
+      [
+        ['relay', _senderOnlyInbox],
+      ],
+      '',
+      createdAt: 1700000000,
+    )..sign(senderKey);
+    return event.toJson();
+  }
+
+  /// Builds the real stack: Nostr → RelayPool → RelayManager → NostrClient →
+  /// NIP17MessageService → DmRepository, with every socket landing on [relay].
+  Future<
+    ({DmRepository repository, Nostr nostr, _RecordingRedirectFactory factory})
+  >
+  buildStack(FakeRelay relay) async {
+    final factory = _RecordingRedirectFactory(relay.port);
+    final signer = LocalNostrSigner(senderKey);
+
+    RelayBase gen(String url) =>
+        RelayBase(url, RelayStatus(url), channelFactory: factory);
+    final nostr = Nostr(signer, [], gen, channelFactory: factory);
+
+    final relayManager = RelayManager(
+      config: RelayManagerConfig(
+        defaultRelayUrl: relay.url,
+        storage: InMemoryRelayStorage(),
+        // A relay that drops at teardown would otherwise keep retrying and
+        // surface its failure against whichever test runs next.
+        autoReconnect: false,
+      ),
+      relayPool: nostr.relayPool,
+    );
+    final client = NostrClient.forTesting(
+      nostr: nostr,
+      relayManager: relayManager,
+    );
+
+    final db = AppDatabase.test(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final repository = DmRepository(
+      nostrClient: client,
+      directMessagesDao: db.directMessagesDao,
+      conversationsDao: db.conversationsDao,
+      outgoingDmsDao: db.outgoingDmsDao,
+      userPubkey: senderPubkey,
+      signer: signer,
+      messageService: NIP17MessageService(
+        signer: signer,
+        senderPublicKey: senderPubkey,
+        nostrService: client,
+      ),
+    );
+    addTearDown(repository.stopListening);
+    // `addTearDown` is LIFO and `relay.stop` was registered first, so this
+    // closes every socket ahead of it — otherwise in-flight connects fail
+    // after the test completes and get attributed to it.
+    addTearDown(nostr.relayPool.removeAll);
+
+    // Through the manager, not RelayPool.add: a publish with no explicit
+    // targets checks `connectedRelays`, which only the manager populates.
+    await client.initialize();
+
+    return (repository: repository, nostr: nostr, factory: factory);
+  }
+
+  group('#7328 self-wrap inbox relays', () {
+    testWidgets('dials the sender own advertised inbox on a send', (
+      tester,
+    ) async {
+      final relay = await FakeRelay.start(reply: senderInbox());
+      addTearDown(relay.stop);
+      final stack = await buildStack(relay);
+
+      // The discriminator, asserted rather than assumed: the recipient has no
+      // admitted inbox, so their wrap goes to the plain pool and cannot be
+      // what reaches _senderOnlyInbox.
+      expect(
+        await stack.repository.resolveDmInboxRelays(recipientPubkey),
+        isNull,
+        reason:
+            'the served kind-10050 is authored by the sender, so it must be '
+            'discarded as off-filter for the recipient',
+      );
+
+      final result = await stack.repository.sendMessage(
+        recipientPubkey: recipientPubkey,
+        content: 'self-wrap destination probe',
+      );
+
+      // Positive control. Without it every "was dialed" assertion below could
+      // pass on a harness that never sent anything.
+      expect(result.success, isTrue, reason: result.toString());
+      expect(result.selfWrapPublished, isTrue, reason: result.toString());
+
+      final host = Uri.parse(_senderOnlyInbox).host;
+      expect(
+        stack.factory.requested.where((u) => u.contains(host)),
+        isNotEmpty,
+        reason:
+            'the sender advertises $_senderOnlyInbox as a DM inbox, so their '
+            'own copy of an outgoing message has to reach it — publishing to '
+            'the connected pool alone leaves their replies missing from the '
+            'relay their own kind-10050 points every other client at',
+      );
+    });
+
+    testWidgets('still delivers when the sender advertises no inbox', (
+      tester,
+    ) async {
+      // The `absent` fallback. An account with no kind-10050 keeps the plain
+      // pool publish, and nothing outside the pool is contacted.
+      final relay = await FakeRelay.start();
+      addTearDown(relay.stop);
+      final stack = await buildStack(relay);
+
+      final result = await stack.repository.sendMessage(
+        recipientPubkey: recipientPubkey,
+        content: 'no-inbox fallback probe',
+      );
+
+      expect(result.success, isTrue, reason: result.toString());
+      expect(result.selfWrapPublished, isTrue, reason: result.toString());
+      expect(relay.publishedEventIds, isNotEmpty);
+
+      final host = Uri.parse(_senderOnlyInbox).host;
+      expect(
+        stack.factory.requested.where((u) => u.contains(host)),
+        isEmpty,
+        reason: 'nothing advertised this host, so nothing may dial it',
+      );
+    });
+  });
+}

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1090,6 +1090,32 @@ class DmRepository {
     return res.state == _OwnDmInboxState.found ? res.relays : null;
   }
 
+  /// Where the sender's own gift-wrap copy of an outgoing DM should land: the
+  /// configured pool UNION the user's advertised kind-10050 DM inbox.
+  ///
+  /// `null` when no inbox is advertised (`absent`/`failed`), which keeps the
+  /// historic plain-pool publish for those accounts.
+  ///
+  /// The union is the whole point. `NostrClient.publishEvent` forwards one set
+  /// as BOTH `targetRelays` and `tempRelays`, and `targetRelays` FILTERS the
+  /// pool (`RelayPool._sendCollect`) rather than adding to it — so passing the
+  /// inbox alone would have swapped the pool's write redundancy for inbox
+  /// reach instead of gaining both. Naming the pool's own URLs alongside the
+  /// inbox keeps every pool relay past that filter, while the unpooled inbox
+  /// relays get a temporary connection. #7328.
+  ///
+  /// Before this, the self-copy went to the pool only. Divine advertises
+  /// `nos.lol` and `relay.primal.net` in every account's kind-10050 (the app
+  /// layer's `IndexerRelayConfig.dmInboxTaggedRelays`, passed in as
+  /// [_dmInboxTaggedRelays]), and neither joins the pool unless NIP-65
+  /// discovery came back empty — so the sender's own replies were absent from
+  /// two of the three relays their own inbox list points at.
+  Future<List<String>?> _selfWrapTargetRelays() async {
+    final ownInbox = await _ownInboxRelays();
+    if (ownInbox == null || ownInbox.isEmpty) return null;
+    return <String>{..._nostrClient.configuredRelays, ...ownInbox}.toList();
+  }
+
   /// Fetches a single older page of DM events (gift wraps, NIP-04,
   /// deletions) addressed to [pubkey] from the relay older than [until]
   /// (inclusive), capped to [limit]. Each event flows through
@@ -3881,7 +3907,12 @@ class DmRepository {
     // default relay pool so reachability is preserved for recipients who
     // have not published a DM inbox. Resolved after the queue enqueue
     // above so the optimistic UI echo is never delayed by this lookup.
-    final inboxRelays = await resolveDmInboxRelays(recipientPubkey);
+    // Both lookups together: the sender's own inbox is memoized per session,
+    // so pairing it with the recipient's costs no extra round trip.
+    final (inboxRelays, selfWrapRelays) = await (
+      resolveDmInboxRelays(recipientPubkey),
+      _selfWrapTargetRelays(),
+    ).wait;
 
     // OK-confirm the recipient wrap: a WebSocket frame-accept is a false
     // positive on a flaky single relay (the relay may never store the event),
@@ -3893,6 +3924,7 @@ class DmRepository {
       rumor: rumor,
       recipientPubkey: recipientPubkey,
       targetRelays: inboxRelays,
+      selfWrapTargetRelays: selfWrapRelays,
       awaitRecipientOk: true,
     );
 
@@ -4344,7 +4376,24 @@ class DmRepository {
       return NIP17SendResult.failure('rumor JSON parse failed: $e');
     }
 
-    final result = await _messageService!.publishSelfWrap(rumorEvent: rumor);
+    // Session-identity token before the inbox lookup: `ownerPubkey` was checked
+    // against `_userPubkey` above, but an account switch during this await
+    // would otherwise resolve the NEW account's inbox and publish the previous
+    // account's rumor to it. Bail retryable instead — the row stays queued and
+    // the next sweep re-drives it under the right identity.
+    final gen = _resetGeneration;
+    final selfWrapRelays = await _selfWrapTargetRelays();
+    if (_disposed || _resetGeneration != gen) {
+      return const NIP17SendResult.failure(
+        'self-wrap recovery abandoned: account changed mid-flight',
+        retryablePending: true,
+      );
+    }
+
+    final result = await _messageService!.publishSelfWrap(
+      rumorEvent: rumor,
+      targetRelays: selfWrapRelays,
+    );
 
     if (result.success) {
       // Both wraps have landed. Mirror sendMessage's full-delivery
@@ -4569,12 +4618,16 @@ class DmRepository {
     // recipient's own inbox — a false "confirmed" for a recipient who only
     // reads their advertised inbox. Resolution never throws (it degrades to
     // null), so it cannot abort a sweep pass.
-    final inboxRelays = await resolveDmInboxRelays(row.recipientPubkey);
+    final (inboxRelays, selfWrapRelays) = await (
+      resolveDmInboxRelays(row.recipientPubkey),
+      _selfWrapTargetRelays(),
+    ).wait;
 
     final result = await _sendRumorWithTimeout(
       rumor: rumor,
       recipientPubkey: row.recipientPubkey,
       targetRelays: inboxRelays,
+      selfWrapTargetRelays: selfWrapRelays,
       awaitRecipientOk: true,
     );
 
@@ -5224,6 +5277,7 @@ class DmRepository {
     required Event rumor,
     required String recipientPubkey,
     List<String>? targetRelays,
+    List<String>? selfWrapTargetRelays,
     bool awaitRecipientOk = false,
   }) {
     return _messageService!
@@ -5231,6 +5285,7 @@ class DmRepository {
           rumorEvent: rumor,
           recipientPubkey: recipientPubkey,
           targetRelays: targetRelays,
+          selfWrapTargetRelays: selfWrapTargetRelays,
           awaitRecipientOk: awaitRecipientOk,
           // A soft-unconfirmed message send must NOT publish the self-wrap:
           // the durable queue replays the full send until the recipient wrap
@@ -5364,6 +5419,10 @@ class DmRepository {
       for (final pubkey in recipientPubkeys)
         resolveDmInboxRelays(pubkey).then((r) => inboxByRecipient[pubkey] = r),
     ]);
+
+    // One destination for every self-copy in the batch — it is addressed to
+    // the sender, not to a recipient, so it does not vary per wrap.
+    final selfWrapRelays = await _selfWrapTargetRelays();
 
     // Per-recipient durable handle for the queue row. The wire rumor is shared
     // across the batch, so the rumor id alone can no longer key a row: the
@@ -5562,6 +5621,7 @@ class DmRepository {
             rumor: groupRumor,
             recipientPubkey: pubkey,
             targetRelays: inboxByRecipient[pubkey],
+            selfWrapTargetRelays: selfWrapRelays,
             awaitRecipientOk: true,
           ),
         );

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -528,6 +528,15 @@ class NIP17MessageService {
   /// (PR #3910) will surface the self-wrap outcome separately so the
   /// repository can mark each wrap status independently.
   ///
+  /// [targetRelays] routes the RECIPIENT's wrap; [selfWrapTargetRelays] routes
+  /// the sender's own copy, and the two are deliberately separate because they
+  /// address different people. `null` on either keeps that wrap on the default
+  /// pool. The self-copy's destination is the sender's own kind-10050 DM inbox
+  /// unioned with the pool — a bare pool publish never reached the inbox relays
+  /// the sender advertises to everyone else, so their own replies were missing
+  /// from any client reading that inbox (#7328). `DmRepository` resolves the
+  /// union; see `DmRepository._selfWrapTargetRelays`.
+  ///
   /// [selfWrapOnSoftUnconfirmed] controls whether the self-addressed wrap is
   /// still published when the recipient publish ends soft-unconfirmed (frame
   /// written, no OK). Reactions keep the default `true` — a lost OK may mean
@@ -570,6 +579,7 @@ class NIP17MessageService {
     required Event rumorEvent,
     required String recipientPubkey,
     List<String>? targetRelays,
+    List<String>? selfWrapTargetRelays,
     bool awaitRecipientOk = false,
     bool selfWrapOnSoftUnconfirmed = true,
     Duration? recipientWrapBuildTimeout = DmBatchSendBudget.recipientWrapBuild,
@@ -749,6 +759,7 @@ class NIP17MessageService {
               rumorEvent: rumorEvent,
               wrapBuildTimeout: selfWrapBound,
               prebuiltSelfWrap: prebuiltSelfWrap,
+              targetRelays: selfWrapTargetRelays,
             );
 
         if (outcome.confirmed) {
@@ -828,6 +839,7 @@ class NIP17MessageService {
         rumorEvent: rumorEvent,
         wrapBuildTimeout: selfWrapBound,
         prebuiltSelfWrap: prebuiltSelfWrap,
+        targetRelays: selfWrapTargetRelays,
       );
 
       Log.info(
@@ -923,7 +935,10 @@ class NIP17MessageService {
   /// [NIP17SendResult.failure] when the self-wrap could not be built
   /// or did not reach a relay.
   @useResult
-  Future<NIP17SendResult> publishSelfWrap({required Event rumorEvent}) async {
+  Future<NIP17SendResult> publishSelfWrap({
+    required Event rumorEvent,
+    List<String>? targetRelays,
+  }) async {
     try {
       // Same fail-fast as sendRumor: a frame buffered to a stale-`connected`
       // socket while offline would count as PublishSuccess and mark the
@@ -950,6 +965,7 @@ class NIP17MessageService {
         nostr: nostr,
         rumorEvent: rumorEvent,
         wrapBuildTimeout: DmSendBudget.selfWrapUncappedBuild,
+        targetRelays: targetRelays,
       );
       if (!published) {
         return const NIP17SendResult.failure('Self-wrap publish failed');
@@ -988,6 +1004,7 @@ class NIP17MessageService {
     required Event rumorEvent,
     required Duration? wrapBuildTimeout,
     Event? prebuiltSelfWrap,
+    List<String>? targetRelays,
   }) async {
     try {
       // Bounded: letting these 2 remote round trips run unbounded is what
@@ -1035,22 +1052,44 @@ class NIP17MessageService {
       // cap and misclassify a recipient-confirmed send as retryable-pending.
       // try/on rather than onTimeout: the future's reified type can be a
       // PublishResult subtype, which an onTimeout closure cannot satisfy.
+      // Naming relays here is what carries the self-copy to the sender's own
+      // kind-10050 DM inbox; `null` keeps the historic plain-pool publish.
+      // #7328.
+      final destination = (targetRelays != null && targetRelays.isNotEmpty)
+          ? targetRelays
+          : null;
       PublishResult published;
       try {
-        published = await _nostrService
-            .publishEvent(selfWrapEvent)
-            .timeout(_selfWrapPublishTimeout);
+        published =
+            await (destination == null
+                    ? _nostrService.publishEvent(selfWrapEvent)
+                    : _nostrService.publishEvent(
+                        selfWrapEvent,
+                        targetRelays: destination,
+                      ))
+                .timeout(_selfWrapPublishTimeout);
       } on TimeoutException {
         published = const PublishFailed();
       }
+      // Name the destination on both outcomes. Reporting only a bare
+      // success/failure is what let a self-copy that never reached the
+      // sender's advertised inbox read as delivered (#7328), and support
+      // cannot tell those apart from the event id alone.
+      final destinationForLog = destination?.join(', ') ?? 'default pool';
       if (published is! PublishSuccess) {
         Log.warning(
           'Self-wrap publish failed — the sender will not see this '
-          'message on other devices or after a reinstall.',
+          'message on other devices or after a reinstall '
+          '(event=${selfWrapEvent.id}, relays=$destinationForLog)',
           category: LogCategory.system,
         );
         return false;
       }
+      Log.info(
+        'Self-wrap published (event=${selfWrapEvent.id}, '
+        'relays=$destinationForLog)',
+        category: LogCategory.system,
+      );
       return true;
     } on Object catch (e) {
       Log.error(
@@ -1113,6 +1152,7 @@ class NIP17MessageService {
     int eventKind = EventKind.privateDirectMessage,
     List<List<String>> additionalTags = const [],
     List<String>? targetRelays,
+    List<String>? selfWrapTargetRelays,
     bool awaitRecipientOk = false,
     bool selfWrapOnSoftUnconfirmed = true,
   }) async {
@@ -1126,6 +1166,7 @@ class NIP17MessageService {
       rumorEvent: rumor,
       recipientPubkey: recipientPubkey,
       targetRelays: targetRelays,
+      selfWrapTargetRelays: selfWrapTargetRelays,
       awaitRecipientOk: awaitRecipientOk,
       selfWrapOnSoftUnconfirmed: selfWrapOnSoftUnconfirmed,
       // No caller of this method owns an outgoing_dms row, so a bounded

--- a/mobile/packages/dm_repository/test/src/dm_repository_self_wrap_relays_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_self_wrap_relays_test.dart
@@ -1,0 +1,215 @@
+// ABOUTME: Regression guard for where DmRepository sends the sender's own
+// ABOUTME: gift-wrap copy of an outgoing DM (#7328). The self-copy must reach
+// ABOUTME: the configured pool UNION the user's advertised kind-10050 DM
+// ABOUTME: inbox, because targetRelays FILTERS the pool rather than adding.
+
+import 'dart:convert';
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' show NIP17SendResult;
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockNIP17MessageService extends Mock implements NIP17MessageService {}
+
+class _MockDirectMessagesDao extends Mock implements DirectMessagesDao {}
+
+class _MockConversationsDao extends Mock implements ConversationsDao {}
+
+class _MockOutgoingDmsDao extends Mock implements OutgoingDmsDao {}
+
+class _FakeEvent extends Fake implements Event {}
+
+const _ownerPubkey =
+    'a1b2c3d4e5f6789012345678901234567890abcdef1234567890123456789012';
+const _recipientPubkey =
+    'b2c3d4e5f6789012345678901234567890abcdef1234567890123456789012a1';
+const _privateKey =
+    'd4e5f6789012345678901234567890abcdef1234567890123456789012ab12c3';
+const _rumorId = 'rumor-id-for-self-wrap-recovery';
+
+/// The pool the app is actually connected to.
+const _poolRelays = ['wss://relay.divine.video', 'wss://relay.nos.social'];
+
+/// What divine advertises in every account's kind-10050 — its own relay plus
+/// the two tagged inbox relays. Two of these are NOT in [_poolRelays], which
+/// is the entire failure this file guards.
+const _advertisedInbox = [
+  'wss://relay.divine.video',
+  'wss://nos.lol',
+  'wss://relay.primal.net',
+];
+
+void main() {
+  group('$DmRepository self-wrap destination', () {
+    late _MockNostrClient nostrClient;
+    late _MockNIP17MessageService messageService;
+    late _MockOutgoingDmsDao outgoingDao;
+    late List<String?> capturedTargets;
+
+    setUpAll(() {
+      registerFallbackValue(_FakeEvent());
+      registerFallbackValue(Duration.zero);
+    });
+
+    /// A stored queue row whose self-wrap never landed — the shape
+    /// `recoverSelfWrap` exists to finish.
+    OutgoingDm pendingSelfWrapRow() {
+      final rumor = Event(
+        _ownerPubkey,
+        EventKind.privateDirectMessage,
+        [
+          ['p', _recipientPubkey],
+        ],
+        'recovered message',
+      );
+      return OutgoingDm(
+        id: _rumorId,
+        conversationId: 'conversation-id',
+        recipientPubkey: _recipientPubkey,
+        content: 'recovered message',
+        createdAt: 1788000000,
+        rumorEventJson: jsonEncode(rumor.toJson()),
+        recipientWrapStatus: OutgoingWrapStatus.sent,
+        selfWrapStatus: OutgoingWrapStatus.pending,
+        queuedAt: DateTime.fromMillisecondsSinceEpoch(1788000000000),
+        ownerPubkey: _ownerPubkey,
+      );
+    }
+
+    /// Answers the own-kind-10050 lookup with [relayTags], or with nothing at
+    /// all when it is null (the `absent` outcome).
+    void stubOwnDmInbox(List<String>? relayTags) {
+      final events = relayTags == null
+          ? <Event>[]
+          : <Event>[
+              Event(
+                _ownerPubkey,
+                EventKind.dmRelaysList,
+                [
+                  for (final relay in relayTags) ['relay', relay],
+                ],
+                '',
+              ),
+            ];
+      when(
+        () => nostrClient.queryEventsDetailed(
+          any(),
+          useCache: any(named: 'useCache'),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async => (events: events, timedOut: false, noRelays: false),
+      );
+    }
+
+    DmRepository buildRepository() {
+      return DmRepository(
+        nostrClient: nostrClient,
+        messageService: messageService,
+        directMessagesDao: _MockDirectMessagesDao(),
+        conversationsDao: _MockConversationsDao(),
+        outgoingDmsDao: outgoingDao,
+      )..setCredentials(
+        userPubkey: _ownerPubkey,
+        signer: LocalNostrSigner(_privateKey),
+        messageService: messageService,
+      );
+    }
+
+    setUp(() {
+      nostrClient = _MockNostrClient();
+      messageService = _MockNIP17MessageService();
+      outgoingDao = _MockOutgoingDmsDao();
+      capturedTargets = <String?>[];
+
+      when(() => nostrClient.connectedRelayCount).thenReturn(2);
+      when(() => nostrClient.configuredRelayCount).thenReturn(2);
+      when(() => nostrClient.configuredRelays).thenReturn(_poolRelays);
+
+      when(() => outgoingDao.getById(any())).thenAnswer(
+        (_) async => pendingSelfWrapRow(),
+      );
+      when(() => outgoingDao.deleteById(any())).thenAnswer((_) async => 1);
+
+      when(
+        () => messageService.publishSelfWrap(
+          rumorEvent: any(named: 'rumorEvent'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        final targets =
+            invocation.namedArguments[#targetRelays] as List<String>?;
+        capturedTargets.add(targets?.join(','));
+        return NIP17SendResult.success(
+          rumorEventId: _rumorId,
+          messageEventId: _rumorId,
+          recipientPubkey: _ownerPubkey,
+        );
+      });
+    });
+
+    test(
+      'unions the connected pool with the advertised kind-10050 inbox',
+      () async {
+        stubOwnDmInbox(_advertisedInbox);
+
+        final result = await buildRepository().recoverSelfWrap(
+          rumorId: _rumorId,
+        );
+
+        expect(result.success, isTrue);
+        expect(capturedTargets, hasLength(1));
+        final targets = capturedTargets.single!.split(',');
+        // Both halves, and no duplicate for the relay that is in both:
+        // `targetRelays` filters the pool, so dropping a pool relay here
+        // would silently narrow the self-copy instead of widening it.
+        expect(
+          targets,
+          containsAll(_poolRelays),
+          reason:
+              'omitting the pool would trade the write redundancy #8378 '
+              'deliberately preserved for inbox reach, rather than gaining '
+              'both',
+        );
+        expect(
+          targets,
+          containsAll(['wss://nos.lol', 'wss://relay.primal.net']),
+          reason:
+              'these are advertised in the account own kind-10050 but are not '
+              'in the pool — reaching them is the whole point of #7328',
+        );
+        expect(
+          targets.toSet(),
+          hasLength(targets.length),
+          reason: 'relay.divine.video is in both sets and must appear once',
+        );
+      },
+    );
+
+    test(
+      'falls back to the plain pool publish when no inbox is advertised',
+      () async {
+        // The `absent` outcome. An account with no kind-10050 keeps exactly
+        // its pre-#7328 behaviour rather than being pinned to the pool list
+        // as an explicit filter.
+        stubOwnDmInbox(null);
+
+        final result = await buildRepository().recoverSelfWrap(
+          rumorId: _rumorId,
+        );
+
+        expect(result.success, isTrue);
+        expect(capturedTargets, equals([null]));
+      },
+    );
+  });
+}

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -19520,6 +19520,12 @@ void main() {
         'resolves each recipient kind-10050 inbox and OK-confirms every '
         'per-recipient wrap against it',
         () async {
+          // The author-agnostic stub below also answers the SENDER's own
+          // kind-10050 lookup, so the self-wrap destination resolves too and
+          // reads the pool to union with it (#7328).
+          when(() => mockNostrClient.configuredRelays).thenReturn(const [
+            'wss://relay.divine.video',
+          ]);
           // Both recipients advertise a DM inbox (the stub returns it for any
           // author query); each wrap must route there with OK-confirm, not the
           // default pool.
@@ -19572,6 +19578,13 @@ void main() {
                 rumorEvent: any(named: 'rumorEvent'),
                 recipientPubkey: recipient,
                 targetRelays: ['wss://inbox.example'],
+                // The self-copy is addressed to the SENDER, so unlike
+                // targetRelays it does not vary per recipient — it is the pool
+                // unioned with the sender's own advertised inbox (#7328).
+                selfWrapTargetRelays: const [
+                  'wss://relay.divine.video',
+                  'wss://inbox.example',
+                ],
                 awaitRecipientOk: true,
                 selfWrapOnSoftUnconfirmed: any(
                   named: 'selfWrapOnSoftUnconfirmed',

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -524,12 +524,101 @@ void main() {
           );
 
           // The first publish is the recipient gift wrap; it must be routed
-          // to the recipient's NIP-17 DM inbox relays (the self-wrap, if any,
-          // follows with no targetRelays).
+          // to the recipient's NIP-17 DM inbox relays.
           expect(captured, isNotEmpty);
           expect(captured.first, const ['wss://inbox.example.com']);
         },
       );
+
+      group('self-wrap destination (#7328)', () {
+        late NIP17MessageService selfService;
+        late List<List<String>?> captured;
+
+        setUp(() {
+          // Real curve self key, or the self-addressed wrap never builds and
+          // never reaches publishEvent — the module-level placeholder key
+          // silently produces a one-publish send and the assertions below
+          // would pass against a self-wrap that does not exist.
+          selfService = NIP17MessageService(
+            signer: LocalNostrSigner(_testPrivateKey),
+            senderPublicKey: getPublicKey(_testPrivateKey),
+            nostrService: mockNostrClient,
+          );
+          captured = <List<String>?>[];
+          when(
+            () => mockNostrClient.publishEvent(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((invocation) async {
+            captured.add(
+              invocation.namedArguments[#targetRelays] as List<String>?,
+            );
+            return PublishSuccess(
+              event: invocation.positionalArguments[0] as Event,
+            );
+          });
+        });
+
+        Future<NIP17SendResult> send({List<String>? selfWrapTargetRelays}) {
+          final rumor = selfService.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'routed message',
+          );
+          return selfService.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _recipientPubkey,
+            targetRelays: const ['wss://inbox.example.com'],
+            selfWrapTargetRelays: selfWrapTargetRelays,
+          );
+        }
+
+        test('routes the self-wrap to its own relay set', () async {
+          final result = await send(
+            selfWrapTargetRelays: const [
+              'wss://relay.divine.video',
+              'wss://nos.lol',
+            ],
+          );
+
+          expect(result.selfWrapPublished, isTrue);
+          // Asserted as the whole ordered list, not `captured.first` plus a
+          // membership check: the defect is a per-wrap destination, so the
+          // only assertion that can catch the self-wrap inheriting the
+          // recipient's relays — or losing its own — names both entries.
+          expect(captured, hasLength(2));
+          expect(captured, [
+            const ['wss://inbox.example.com'],
+            const ['wss://relay.divine.video', 'wss://nos.lol'],
+          ]);
+        });
+
+        test(
+          'publishes the self-wrap bare when no relay set is supplied',
+          () async {
+            // The `absent`/`failed` own-inbox outcome. Preserving the bare
+            // publish is what keeps an account with no advertised kind-10050
+            // on exactly its pre-#7328 behaviour.
+            final result = await send();
+
+            expect(result.selfWrapPublished, isTrue);
+            expect(captured, hasLength(2));
+            expect(captured.last, isNull);
+          },
+        );
+
+        test('treats an empty relay set as no relay set', () async {
+          // A kind-10050 that parsed to zero usable relays must not narrow the
+          // publish to nothing — `_sendCollect` skips the filter only when the
+          // list is null OR empty, but relying on that coincidence across two
+          // packages is how a silent total-loss regression gets in.
+          final result = await send(selfWrapTargetRelays: const []);
+
+          expect(result.selfWrapPublished, isTrue);
+          expect(captured, hasLength(2));
+          expect(captured.last, isNull);
+        });
+      });
     });
 
     group('sendRumor awaitRecipientOk (reaction OK-confirm path)', () {

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -377,6 +377,16 @@ class RelayPool {
   /// keys from `normalizeRelayUrl` (which STRIPS one), so a raw `contains`
   /// matched no pooled relay and turned the filter into a universal
   /// exclusion. #8377.
+  ///
+  /// The publish path reaches the same trap by a different route. [_sendCollect]
+  /// does NOT run its `targetRelays` through [handleAddrList], so the strings it
+  /// compares are whatever the caller passed — for a DM those are `relay` tag
+  /// values lifted verbatim off a kind-10050 event, written by another client and
+  /// carrying a trailing slash or not at its author's whim. A raw `contains` there
+  /// silently drops the pooled socket for a relay the caller explicitly named, and
+  /// the event reaches it only if the temp-relay arm happens to redial it. Both the
+  /// fan-out and [_intendedPublishTargets] — which must agree, or the reachable
+  /// denominator diverges from what was actually written — compare through here.
   bool _namesRelay(List<String> addrs, String url) {
     final wanted = _relayIdentity(url);
     for (final addr in addrs) {
@@ -2290,7 +2300,7 @@ class RelayPool {
       }
 
       if (targetRelays != null && targetRelays.isNotEmpty) {
-        if (!targetRelays.contains(relay.url)) {
+        if (!_namesRelay(targetRelays, relay.url)) {
           // not contain this relay
           continue;
         }
@@ -2520,7 +2530,7 @@ class RelayPool {
     final hasFilter = targetRelays != null && targetRelays.isNotEmpty;
     for (final relay in _relaysSnapshot()) {
       if (isEvent && !relay.relayStatus.writeAccess) continue;
-      if (hasFilter && !targetRelays.contains(relay.url)) continue;
+      if (hasFilter && !_namesRelay(targetRelays, relay.url)) continue;
       expected.add(relay.url);
       if (isEvent &&
           !hasFilter &&

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_publish_targets_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_publish_targets_test.dart
@@ -467,4 +467,104 @@ void main() {
       },
     );
   });
+
+  group('RelayPool publish target identity', () {
+    // The pool stores its keys through `normalizeRelayUrl`, which STRIPS a
+    // trailing slash.
+    const pooledUrl = 'wss://relay.divine.video';
+    // A `relay` tag lifted verbatim off someone's kind-10050. Whether it
+    // carries a trailing slash is that author's choice, not ours — and the
+    // publish path, unlike subscribe/query, does not run its targets through
+    // `handleAddrList` first. #8377 / #7328.
+    const slashedTarget = 'wss://relay.divine.video/';
+    const eventId = 'slashed-publish-target-event-id';
+
+    late Nostr nostr;
+    late FakeWebSocketChannelFactory pooledFactory;
+
+    setUp(() async {
+      final signer = LocalNostrSigner(
+        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+      );
+      // Every temp socket refuses, so the only way an EVENT can reach the
+      // relay is over the POOLED connection. Without this the temp-relay arm
+      // would dial a second socket to the same host and mask the bug.
+      nostr = Nostr(
+        signer,
+        [],
+        (url) => RelayBase(
+          url,
+          RelayStatus(url),
+          channelFactory: FakeWebSocketChannelFactory(
+            readyError: StateError('temp socket refused'),
+          ),
+        ),
+      );
+      await nostr.refreshPublicKey();
+
+      pooledFactory = FakeWebSocketChannelFactory();
+      await nostr.relayPool.add(
+        RelayBase(
+          pooledUrl,
+          RelayStatus(pooledUrl),
+          channelFactory: pooledFactory,
+        ),
+      );
+    });
+
+    tearDown(() => nostr.relayPool.removeAll());
+
+    /// EVENT frames that actually went down a socket [pooledFactory] made.
+    List<dynamic> pooledEventFrames() => pooledFactory.createdChannels
+        .expand((channel) => channel.sentMessages)
+        .where(
+          (message) =>
+              (jsonDecode(message as String) as List<dynamic>).first == 'EVENT',
+        )
+        .toList();
+
+    test('a trailing-slash target still reaches the pooled socket', () async {
+      await nostr.relayPool.send(
+        [
+          'EVENT',
+          {'id': eventId, 'kind': 1059},
+        ],
+        targetRelays: const [slashedTarget],
+      );
+
+      // Counted, not `contains`-ed: the failure this guards is "the pooled
+      // socket was skipped and a second one dialed instead", and a
+      // membership matcher cannot tell one delivery from two.
+      expect(
+        pooledEventFrames(),
+        hasLength(1),
+        reason:
+            'the caller named this exact relay; comparing the target to the '
+            'pool key as a raw string drops the pooled socket over a '
+            'trailing slash and sends over a duplicate temp connection '
+            'instead',
+      );
+    });
+
+    test('a target naming a different relay still excludes the pool', () async {
+      await nostr.relayPool.send(
+        [
+          'EVENT',
+          {'id': eventId, 'kind': 1059},
+        ],
+        targetRelays: const ['wss://relay.elsewhere.example'],
+      );
+
+      // The companion assertion: identity-matching must not turn the filter
+      // into a no-op. A target that names nobody in the pool still narrows it
+      // to nothing.
+      expect(
+        pooledEventFrames(),
+        isEmpty,
+        reason:
+            'targetRelays is a filter — a relay the caller did not name must '
+            'not receive the event just because the comparison got looser',
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Description

NIP-17 has the client build two gift wraps per message — one to the recipient, one to the sender, so the sender's own copy is recoverable on another device. The recipient's wrap has routed to the recipient's advertised kind-10050 DM inbox since #570. The sender's wrap goes to whatever pool happens to be connected.

**That was deliberate, and I am reversing it on purpose.** #570 (`4161e95ff9`, 2026-06-08) — the commit that introduced relay targeting to this file at all — says so explicitly:

> Thread targetRelays through NIP17MessageService.sendRumor to the recipient gift-wrap publish (*the self-wrap stays on the default pool*). The no-targetRelays call shape is unchanged to preserve behavior.

It was the right call then and is the wrong one now, because the world changed underneath it rather than because the reasoning was bad. In June, `publishDmRelayList` was off in every build, so no Divine account advertised a kind-10050 at all — "the self-wrap stays on the default pool" cost nothing, since the pool was the only place the account's own reads would look. #8378 deleted that flag and started advertising `nos.lol` and `relay.primal.net` on every account. The moment an account advertises relays it does not connect to, "stays on the default pool" stops being a no-op and starts being the bug.

Since #8378 (merged ~17h before this branch) every Divine account advertises a kind-10050 naming `relay.divine.video`, `nos.lol` and `relay.primal.net` (`IndexerRelayConfig.dmInboxTaggedRelays`). The latter two join the pool only when NIP-65 discovery comes back empty — so for an account with a working relay list, the sender's own replies were absent from two of the three relays their own inbox list points every other client at.

### The destination is pool ∪ inbox, not the inbox alone

`NostrClient.publishEvent` takes one relay set and forwards it as **both** `targetRelays` and `tempRelays`. On the write path `targetRelays` **filters** the pool (`RelayPool._sendCollect`) rather than adding to it, so passing the inbox by itself would have traded the write redundancy #8378 deliberately preserved for inbox reach instead of gaining both. Naming the pool's own URLs alongside the inbox keeps every pool relay past that filter while the unpooled inbox relays get a temporary connection. An account with no advertised inbox resolves to `null` and keeps exactly its previous behaviour.

Worth flagging for review: #8378's commit message states *"`NostrClient.publishEvent` forwards targets as temp relays anyway. Nothing it feeds narrows a pool."* That is not accurate for the publish caller — the `targetRelays` half does narrow. #8378 reached the right outcome (pool redundancy preserved) via the wrong premise, and the union here is what actually delivers both properties.

### Commits

1. **`fix(nostr_sdk)`** — the publish half of #8377. `_sendCollect` compared `targetRelays` against `relay.url` with a raw `contains` while the pool keys through `normalizeRelayUrl`. A caller naming an already-pooled relay with a trailing slash failed the filter, the pooled socket was skipped, and `checkAndGenTempRelay` — which, unlike subscribe/query, never resolves back to a pooled relay — dialled a second socket. If that dial failed the event reached nothing while the relay sat connected and write-enabled. DM relay targets are `relay` tag values lifted verbatim off someone else's kind-10050, where the trailing slash is the tag author's choice, so the fix above depends on this.
2. **`fix(dm)`** — threads the destination through `sendRumor` / `publishSelfWrap` / `_publishSelfWrap` and supplies it from `DmRepository` at the 1:1 send, the retry sweep, the group fan-out and `recoverSelfWrap`. Also names the destination in the self-wrap's success and failure logs: the publish previously reported only a bare `selfWrapPublished=true`, so a self-copy that never reached the advertised inbox was indistinguishable from one that did.
3. **`test(dm)`** — end-to-end guard over real sockets.

### A note on the spec basis

The issue cites NIP-17 §Publishing (*"Clients MUST only publish events to the relays listed in the recipient's kind 10050 event"*) as requiring this. Read fresh at `nostr-protocol/nips` HEAD (`24b2ae9`), **the spec is silent on where the sender's own copy goes** — kind 10050 is defined in NIP-17, NIP-51 and the README only as "where to *receive* DMs", with no author-side write set. NIP-17 *did* carry the rule from Apr 2024 until it was deleted on 2025-10-30 (`3ec830c`) with no rationale and never replaced:

> Clients should also send a copy of their outgoing messages to their own `kind:10050` relay set.

So this is justified on the user having advertised those relays as their DM inbox, not on a current MUST. The deleted sentence is historical intent, not current spec.

**Related Issue:** Closes #7328. Refs #8377 (its publish half is fixed here), #7321.

## Out of Scope

- **Reaction self-wraps** still publish pool-only. `DmReactionsRepository` holds only DAOs and a message service — no relay client and no inbox resolver — so it cannot resolve either destination without the constructor plumbing #7321 exists to add. It does not route the *recipient* wrap today either, so #7321 should thread both destinations when it lands.
- The broader conformance question — gift wraps landing on pool relays outside the addressee's 10050, which both wraps already do — is unchanged here.

## Verification

Reproduced before fixing, on production, and verified after.

**End to end over real sockets** (`dm_self_wrap_inbox_relays_test.dart`) — real `DmRepository → NostrClient → RelayPool`, in-process relay, every dialed address recorded. Attribution is exact: `FakeRelay` serves one reply per REQ regardless of filter, and the repository accepts a relay list only when `event.pubkey` matches the author it asked about, so a kind-10050 signed by the *sender* resolves `found` for their own lookup and is discarded as off-filter for the recipient's — a dial to `sender-inbox.example` can only be the self-wrap.

| arm | result |
|---|---|
| destination not threaded (pre-fix) | `Expected: non-empty` / `Actual: []` — the advertised host is **never dialed** |
| fix in place | passes |

**On device, against production.** iPhone 17 Pro Max simulator, `env=production`, Divine OAuth (Keycast), real account. Sent a DM through the UI; the new log named the fan-out:

```
Self-wrap published (event=040b000656ce88fd4c59ab18221c9b0e68b012299ad29f203f5fd84fa5cf963a,
  relays=wss://relay.divine.video, wss://nos.lol, wss://relay.primal.net)
```

Confirmed on the relays themselves (`nak req -i <event id>`): present on **all three**, including the two that are not in the connected pool and could not have received it before. That account's advertised kind-10050 was read from production first (`nak req -k 10050`) and names exactly those three, while the device's own DM subscription reported a pool of `relay.divine.video` + `relay.nos.social` — which is not `nos.lol`.

**`_namesRelay` red/green** — pool `wss://relay.divine.video`, target `wss://relay.divine.video/`, temp sockets forced to refuse: pre-fix `Expected: length 1` / `Actual: []` (pooled socket skipped entirely); post-fix passes. Paired with a companion assertion that identity matching did not turn the filter into a no-op.

Every new test was mutation-checked at the production boundary and observed to fail for the right reason.

- `flutter analyze lib test integration_test` — clean
- `dm_repository` — 750 passed
- `nostr_sdk` unit — 514 passed
- `dm_self_wrap_inbox_relays_test.dart --tags service` — 2 passed
- Ratchets run locally: ungrouped-tests, placeholder-tests, shared-setup-stubs, skip-ceiling, test-unit-structure, nostr-id-log-truncation, pubkey-log-encoding, l10n-delegates, untested-services, layer-direction — all pass

Registered the new suite in `mobile_service_integration_tests.yaml`; that list is explicit rather than a glob, so a new file there runs nowhere until it is named. The workflow's path filter already covers `dm_repository`.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
