### PR TITLE
fix(dm): stop scoring a fallback-pool OK as delivery on an unreadable inbox

### DIFF
--- a/mobile/integration_test/e2e/reel_reply_retry_double_send_test.dart
+++ b/mobile/integration_test/e2e/reel_reply_retry_double_send_test.dart
@@ -34,7 +34,6 @@ import 'package:openvine/widgets/video_feed_item/reel_dm_reply_bar.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../helpers/fake_relay.dart';
-import '../helpers/navigation_helpers.dart';
 import '../helpers/test_setup.dart';
 
 class _MockDmReactionsRepository extends Mock
@@ -166,10 +165,9 @@ void main() {
     );
   }
 
-  group('#7316 reel reply Retry re-drives instead of re-sending', () {
+  group('#7316 reel reply soft-unconfirmed delivery', () {
     testWidgets(
-      'soft-unconfirmed send: Retry re-drives the parked outgoing_dms row '
-      'and never enqueues a second one',
+      'stays optimistic and parks exactly one outgoing_dms row',
       (tester) async {
         final originalOnError = suppressSetStateErrors();
         addTearDown(() => restoreErrorHandler(originalOnError));
@@ -192,12 +190,11 @@ void main() {
         await tester.tap(find.byType(IconButton));
         await tester.pump();
 
-        final failed = await waitForWidget(
-          tester,
-          find.text(l10n.dmSendFailedRetry),
-          maxSeconds: 45,
-        );
-        expect(failed, isTrue, reason: 'retry snackbar never appeared');
+        // Let the send run its full OK-confirm budget. A soft-unconfirmed
+        // result is durable and retryable in the background, so it must stay
+        // optimistic instead of presenting the manual hard-failure action.
+        await pumpUntilSettled(tester, maxSeconds: 20);
+        expect(find.text(l10n.dmSendFailedRetry), findsNothing);
 
         final afterFirst = await stack.db.outgoingDmsDao.getForConversation(
           conversationId: replyContext.conversationId,
@@ -212,69 +209,10 @@ void main() {
           hasLength(1),
           reason: 'the first send must park exactly one durable row',
         );
-        final firstRumorId = afterFirst.single.id;
-
-        // Pump the snackbar's entrance animation to completion before tapping.
-        // `waitForWidget` returns as soon as the label EXISTS, which is the
-        // first frame of the slide-in — the action is still translated away
-        // from where the finder reports it, and the tap misses.
-        //
-        // This doubles as the clock guard: `pump(duration)` advances real time
-        // under the integration binding, and the wall clock must cross a full
-        // second before the retry or the second rumor hashes to the same id
-        // (`created_at` is seconds) and `enqueue`'s insertOrIgnore silently
-        // coalesces the two rows. A human tapping a snackbar always clears
-        // that bar; making it explicit keeps the test measuring the retry
-        // rather than the clock.
-        await pumpUntilSettled(tester, maxSeconds: 3);
-
-        // ── Retry ──
-        logPhase('── Phase 2: tap Retry ──');
-        final wrapsBeforeRetry = relay.publishedEventIds.length;
-        await tester.tap(
-          find.widgetWithText(SnackBarAction, l10n.dmSendFailedRetry),
-        );
-        await tester.pump();
-
-        // Let the second send run its full OK-confirm budget.
-        await pumpUntilSettled(tester, maxSeconds: 20);
-
-        // Positive control. Without it a tap that silently missed (the
-        // snackbar hit-test trap above) would leave one row and read as
-        // "no bug" — the most dangerous possible false negative for this
-        // test. A retry that really ran publishes at least one more wrap.
-        logPhase(
-          'wraps published: $wrapsBeforeRetry before retry, '
-          '${relay.publishedEventIds.length} after',
-        );
         expect(
-          relay.publishedEventIds.length,
-          greaterThan(wrapsBeforeRetry),
-          reason: 'the Retry tap never dispatched a send — test is invalid',
-        );
-
-        final afterRetry = await stack.db.outgoingDmsDao.getForConversation(
-          conversationId: replyContext.conversationId,
-          ownerPubkey: senderPubkey,
-        );
-        logPhase('rows after retry: ${afterRetry.length}');
-        for (final row in afterRetry) {
-          logPhase('  row id=${row.id} content="${row.content}"');
-        }
-
-        // The contract. Retry replays the SAME rumor, so the queue still holds
-        // exactly one row under the original id. Before the #7316 fix this was
-        // two rows under two ids, which the receiver keys `direct_messages` on
-        // and therefore renders as two messages.
-        expect(
-          afterRetry.map((r) => r.id).toSet(),
-          {firstRumorId},
-          reason: 'Retry must re-drive the parked row, not mint a second rumor',
-        );
-        expect(
-          afterRetry.single.content,
+          afterFirst.single.content,
           'reel reply probe',
-          reason: 'the surviving row still carries the reply text',
+          reason: 'the parked row still carries the reply text',
         );
       },
       timeout: const Timeout(Duration(minutes: 3)),

--- a/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_cubit.dart
+++ b/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_cubit.dart
@@ -71,7 +71,9 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
                 content: trimmed,
                 replyToId: _replyContext.sharedReelMessageId,
               );
-        ok = results.any((r) => r.success);
+        ok =
+            results.any((r) => r.success) ||
+            (results.isNotEmpty && results.every((r) => r.retryablePending));
         parked = [for (final r in results) ?r.queuedRumorId];
       } else {
         final result = videoRef != null
@@ -90,7 +92,7 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
                 content: trimmed,
                 replyToId: _replyContext.sharedReelMessageId,
               );
-        ok = result.success;
+        ok = result.success || result.retryablePending;
         parked = [?result.queuedRumorId];
       }
       if (!isClosed) {

--- a/mobile/lib/services/collaborator_invite_service.dart
+++ b/mobile/lib/services/collaborator_invite_service.dart
@@ -10,16 +10,26 @@ import 'package:openvine/l10n/l10n.dart';
 class CollaboratorInviteResult extends Equatable {
   const CollaboratorInviteResult({
     required this.success,
+    this.retryablePending = false,
     this.messageEventId,
     this.error,
   });
 
   final bool success;
+
+  /// The invite has a durable queue row and will be retried in the background.
+  /// This is neither confirmed delivery nor a user-actionable hard failure.
+  final bool retryablePending;
   final String? messageEventId;
   final String? error;
 
   @override
-  List<Object?> get props => [success, messageEventId, error];
+  List<Object?> get props => [
+    success,
+    retryablePending,
+    messageEventId,
+    error,
+  ];
 }
 
 class CollaboratorInviteBatchResult extends Equatable {
@@ -27,7 +37,10 @@ class CollaboratorInviteBatchResult extends Equatable {
 
   final Map<String, CollaboratorInviteResult> results;
 
-  bool get hasFailures => results.values.any((result) => !result.success);
+  /// Whether any invite hard-failed. Retryable pending rows are still active.
+  bool get hasFailures => results.values.any(
+    (result) => !result.success && !result.retryablePending,
+  );
 
   @override
   List<Object?> get props => [results];
@@ -118,8 +131,9 @@ class CollaboratorInviteService {
 
     return CollaboratorInviteResult(
       success: result.success,
+      retryablePending: result.retryablePending,
       messageEventId: result.messageEventId,
-      error: result.error,
+      error: result.retryablePending ? null : result.error,
     );
   }
 

--- a/mobile/lib/services/video_metadata_update_service.dart
+++ b/mobile/lib/services/video_metadata_update_service.dart
@@ -569,6 +569,8 @@ class VideoMetadataUpdateService {
       previousCollaboratorPubkeys: initialCollaboratorPubkeys,
       updatedCollaboratorPubkeys: updatedCollaboratorPubkeys,
     );
-    return results.values.where((r) => !r.success).length;
+    return results.values
+        .where((result) => !result.success && !result.retryablePending)
+        .length;
   }
 }

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -639,7 +639,9 @@ class VideoPublishService {
       );
       if (result.hasFailures) {
         final failures = result.results.entries
-            .where((entry) => !entry.value.success)
+            .where(
+              (entry) => !entry.value.success && !entry.value.retryablePending,
+            )
             .map((entry) => '${entry.key}:${entry.value.error ?? "unknown"}')
             .join(', ');
         Log.error(
@@ -649,7 +651,9 @@ class VideoPublishService {
         );
       }
       return result.results.entries
-          .where((entry) => !entry.value.success)
+          .where(
+            (entry) => !entry.value.success && !entry.value.retryablePending,
+          )
           .map(
             (entry) => CollaboratorInviteWarning(
               collaboratorPubkey: entry.key,

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -243,7 +243,15 @@ class VideoSharingService {
       skipNip04Fallback: true,
     );
 
-    if (result.success) {
+    // Soft-unconfirmed sends stay in the durable queue and render like the
+    // ordinary DM optimistic bubble. Use that queue handle as the share result
+    // identity so the sheet reports success without minting a second rumor.
+    final optimisticMessageId = result.success
+        ? result.messageEventId
+        : result.retryablePending
+        ? result.queuedRumorId
+        : null;
+    if (optimisticMessageId != null) {
       _shareHistory[recipientPubkey] = DateTime.now();
       // Fire-and-forget: this only refreshes the in-memory recents list for
       // the next share-sheet open. Awaiting it kept the success toast waiting
@@ -261,7 +269,7 @@ class VideoSharingService {
       );
 
       return ShareResult.createSuccess(
-        result.messageEventId!,
+        optimisticMessageId,
         conversationId: conversationId,
       );
     }

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -232,6 +232,28 @@ enum _OwnDmInboxState {
   failed,
 }
 
+/// Why a recipient's NIP-17 DM inbox lookup returned what it did.
+///
+/// The relay list alone cannot answer this: [DmInboxResolution.absent] and
+/// [DmInboxResolution.unreadable] both yield `null` relays and both fall back
+/// to the default pool, but only the first is a fact about the recipient. The
+/// second is a fact about our own read, and scoring a fallback-pool `OK` as
+/// delivery on it tells the sender a message arrived when it was written where
+/// the recipient does not look (#7317).
+enum DmInboxResolution {
+  /// The recipient advertises a kind-10050 and we read it.
+  found,
+
+  /// The relays answered, and the recipient advertises no usable inbox.
+  /// NIP-17 calls this "not ready to receive messages"; we still fall back to
+  /// the default pool so reachability is preserved (#570).
+  absent,
+
+  /// We could not read the recipient's inbox: no relay took the REQ, or
+  /// nothing settled inside the budget. Says nothing about the recipient.
+  unreadable,
+}
+
 /// Who authored the kind-10050 a relay list is being read out of.
 ///
 /// The two are admitted on different terms. Our own list may name the local
@@ -3342,7 +3364,30 @@ class DmRepository {
   /// gets rather than waiting for full relay settlement (#8212). Reporting an
   /// unreadable recipient inbox as delivery is a separate defect, #7317.
   Future<List<String>?> resolveDmInboxRelays(String pubkey) async {
-    return (await _queryOwnDmInbox(pubkey, requireAuthoritative: false)).relays;
+    return (await resolveDmInboxRelaysDetailed(pubkey)).relays;
+  }
+
+  /// [resolveDmInboxRelays], plus why it returned what it did.
+  ///
+  /// Callers that route a gift wrap need the relays; callers that also report
+  /// delivery need the reason. A `null` list from [DmInboxResolution.absent]
+  /// and from [DmInboxResolution.unreadable] send to the same place, but only
+  /// the first means the default pool is where the recipient reads — so only
+  /// the first may be scored as delivered (#7317).
+  Future<({List<String>? relays, DmInboxResolution state})>
+  resolveDmInboxRelaysDetailed(String pubkey) async {
+    final resolved = await _queryOwnDmInbox(
+      pubkey,
+      requireAuthoritative: false,
+    );
+    return (
+      relays: resolved.relays,
+      state: switch (resolved.state) {
+        _OwnDmInboxState.found => DmInboxResolution.found,
+        _OwnDmInboxState.absent => DmInboxResolution.absent,
+        _OwnDmInboxState.failed => DmInboxResolution.unreadable,
+      },
+    );
   }
 
   /// Filters and bounds the relay URLs advertised in a kind-10050.
@@ -3454,7 +3499,14 @@ class DmRepository {
       // relay that settled before another relay timed out.
       final _OwnDmInboxState absentOrFailed;
       String? inconclusiveReason;
-      if (requireAuthoritative && (result.noRelays || result.timedOut)) {
+      // NOT gated on [requireAuthoritative]: `noRelays` and `timedOut` are
+      // computed identically in both read modes (`Nostr.queryEventsDetailed`),
+      // so the send path can tell an unreadable inbox from an absent one at no
+      // cost — no extra round trip, no settle wait, so #8220's decision to keep
+      // the strict read off the send path is untouched (#7317). What
+      // `requireAllRelaysSettled` still buys the authoritative caller is the
+      // CLOSED-refusal case, which completes early and remains `absent` here.
+      if (result.noRelays || result.timedOut) {
         absentOrFailed = _OwnDmInboxState.failed;
         // `noRelays` first: an offline device sets both flags, and reporting
         // that as a timeout misreads it.
@@ -3465,13 +3517,20 @@ class DmRepository {
         absentOrFailed = _OwnDmInboxState.absent;
       }
 
+      // Both callers reach this, and they act on it differently, so the line
+      // has to say which one is speaking: RC3 is about to replace the list it
+      // read, the send path is about to route a gift wrap by it.
       void logInconclusiveRead() {
         final reason = inconclusiveReason;
         if (reason == null) return;
         Log.warning(
-          'Own kind-10050 lookup for ${pubkeyForLogs(pubkey)} was '
-          'inconclusive ($reason) — not publishing over a list we could not '
-          'read; will retry',
+          requireAuthoritative
+              ? 'Own kind-10050 lookup for ${pubkeyForLogs(pubkey)} was '
+                    'inconclusive ($reason) — not publishing over a list we '
+                    'could not read; will retry'
+              : 'Recipient kind-10050 lookup for ${pubkeyForLogs(pubkey)} was '
+                    'inconclusive ($reason) — routing to the default pool, and '
+                    'NOT scoring the publish as delivered (#7317)',
           category: LogCategory.system,
         );
       }
@@ -3908,9 +3967,12 @@ class DmRepository {
     // have not published a DM inbox. Resolved after the queue enqueue
     // above so the optimistic UI echo is never delayed by this lookup.
     // Both lookups together: the sender's own inbox is memoized per session,
-    // so pairing it with the recipient's costs no extra round trip.
-    final (inboxRelays, selfWrapRelays) = await (
-      resolveDmInboxRelays(recipientPubkey),
+    // so pairing it with the recipient's costs no extra round trip (#7328).
+    // The recipient side resolves DETAILED: routing only needs the relays, but
+    // reporting delivery needs to know whether we could read them at all
+    // (#7317).
+    final (inbox, selfWrapRelays) = await (
+      resolveDmInboxRelaysDetailed(recipientPubkey),
       _selfWrapTargetRelays(),
     ).wait;
 
@@ -3920,13 +3982,37 @@ class DmRepository {
     // lost/late OK comes back soft (retryablePending) and keeps the durable
     // queue row pending for the sweep — never a false "delivered". See #5977
     // for the reaction precedent this mirrors.
-    final result = await _sendRumorWithTimeout(
+    final publishResult = await _sendRumorWithTimeout(
       rumor: rumor,
       recipientPubkey: recipientPubkey,
-      targetRelays: inboxRelays,
+      targetRelays: inbox.relays,
       selfWrapTargetRelays: selfWrapRelays,
       awaitRecipientOk: true,
     );
+
+    // An `OK` from the DEFAULT POOL is not delivery when we never read the
+    // recipient's inbox. Absent and unreadable both routed here, but only
+    // absent means the pool is where they read; on unreadable the wrap may sit
+    // on relays the recipient never queries, and deleting the queue row would
+    // destroy the only handle that could ever re-resolve and republish (#7317).
+    //
+    // Reuses the soft-unconfirmed contract verbatim: row stays `pending`,
+    // `incrementRetry` charges the budget, and `recoverFullSend` re-resolves on
+    // the next sweep. The bubble is unchanged — `pending` and `delivered`
+    // render identically — so this buys durability, not a new indicator.
+    //
+    // Only when the queue is wired: with no row to preserve there is nothing to
+    // gain, and downgrading would skip the local persist and drop the message
+    // from the conversation.
+    final result =
+        (publishResult.success &&
+            inbox.state == DmInboxResolution.unreadable &&
+            outgoingDao != null)
+        ? const NIP17SendResult.failure(
+            'Recipient DM inbox unreadable; published to the fallback pool',
+            retryablePending: true,
+          )
+        : publishResult;
 
     if (result.success) {
       // Persist our own sent message locally so it appears immediately

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3361,10 +3361,36 @@ class DmRepository {
   /// The read is deliberately non-authoritative: it runs on every send,
   /// degrades to the default pool whether the list is absent or unreadable,
   /// and overwrites nothing — so it keeps the cache and the first answer it
-  /// gets rather than waiting for full relay settlement (#8212). Reporting an
-  /// unreadable recipient inbox as delivery is a separate defect, #7317.
+  /// gets rather than waiting for full relay settlement (#8212).
+  ///
+  /// Routing only needs the relays, so this signature stays. A caller that
+  /// also REPORTS delivery must use [resolveDmInboxRelaysDetailed] instead:
+  /// scoring a fallback-pool `OK` as delivered on an unreadable inbox is
+  /// #7317. `sendGroupMessage` is the last caller here that still needs the
+  /// upgrade (#8434).
   Future<List<String>?> resolveDmInboxRelays(String pubkey) async {
     return (await resolveDmInboxRelaysDetailed(pubkey)).relays;
+  }
+
+  /// Re-classifies a publish that a relay confirmed but which was routed to
+  /// the default pool because the recipient's inbox could not be read.
+  ///
+  /// [DmInboxResolution.absent] is left alone: the recipient advertises no
+  /// inbox, so the pool is where they read and the `OK` is real delivery.
+  /// [DmInboxResolution.unreadable] is a fact about our own read — the wrap
+  /// may be sitting on relays the recipient never queries, so it is reported
+  /// soft-unconfirmed and the durable row is kept for the sweep to re-resolve
+  /// (#7317). Shared by the initial send and the retry so the sweep cannot
+  /// undo what the send path preserved.
+  NIP17SendResult _downgradeFallbackPoolDelivery(
+    NIP17SendResult result,
+    DmInboxResolution state,
+  ) {
+    if (!result.success || state != DmInboxResolution.unreadable) return result;
+    return const NIP17SendResult.failure(
+      'Recipient DM inbox unreadable; published to the fallback pool',
+      retryablePending: true,
+    );
   }
 
   /// [resolveDmInboxRelays], plus why it returned what it did.
@@ -3450,9 +3476,11 @@ class DmRepository {
   /// found / absent / failed outcome (#4974).
   ///
   /// Collapsing absent and failed to `null` (as the public
-  /// [resolveDmInboxRelays] does) is safe for the send path and the live
-  /// read (both fall back to the default pool either way), but RC3 must tell
-  /// them apart — see [ensureDmRelayListPublished].
+  /// [resolveDmInboxRelays] does) is safe for anything that only ROUTES —
+  /// both fall back to the default pool either way. Anything that reports
+  /// delivery, or replaces the list it read, must tell them apart: see
+  /// [resolveDmInboxRelaysDetailed] (#7317) and [ensureDmRelayListPublished]
+  /// (#8212) respectively.
   ///
   /// [requireAuthoritative] is what makes `absent` trustworthy enough to
   /// publish over. RC3 REPLACES whatever the user advertises, so it may only
@@ -4004,15 +4032,9 @@ class DmRepository {
     // Only when the queue is wired: with no row to preserve there is nothing to
     // gain, and downgrading would skip the local persist and drop the message
     // from the conversation.
-    final result =
-        (publishResult.success &&
-            inbox.state == DmInboxResolution.unreadable &&
-            outgoingDao != null)
-        ? const NIP17SendResult.failure(
-            'Recipient DM inbox unreadable; published to the fallback pool',
-            retryablePending: true,
-          )
-        : publishResult;
+    final result = outgoingDao == null
+        ? publishResult
+        : _downgradeFallbackPoolDelivery(publishResult, inbox.state);
 
     if (result.success) {
       // Persist our own sent message locally so it appears immediately
@@ -4704,18 +4726,28 @@ class DmRepository {
     // recipient's own inbox — a false "confirmed" for a recipient who only
     // reads their advertised inbox. Resolution never throws (it degrades to
     // null), so it cannot abort a sweep pass.
-    final (inboxRelays, selfWrapRelays) = await (
-      resolveDmInboxRelays(row.recipientPubkey),
+    final (inbox, selfWrapRelays) = await (
+      resolveDmInboxRelaysDetailed(row.recipientPubkey),
       _selfWrapTargetRelays(),
     ).wait;
 
-    final result = await _sendRumorWithTimeout(
+    final publishResult = await _sendRumorWithTimeout(
       rumor: rumor,
       recipientPubkey: row.recipientPubkey,
-      targetRelays: inboxRelays,
+      targetRelays: inbox.relays,
       selfWrapTargetRelays: selfWrapRelays,
       awaitRecipientOk: true,
     );
+
+    // Same rule as the initial send: a default-pool `OK` is not delivery when
+    // the recipient's inbox stayed unreadable. Without this the sweep undoes
+    // the send path's fix — it re-resolves to null, republishes to the pool,
+    // scores the OK as success and deletes the row, converging on the old
+    // false-`delivered` outcome one sweep later (#7317).
+    //
+    // `dao` is non-null here (guarded above), so unlike `sendMessage` there is
+    // always a row to preserve.
+    final result = _downgradeFallbackPoolDelivery(publishResult, inbox.state);
 
     if (result.success) {
       // Mirror sendMessage's happy-path transaction: persist

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -4790,6 +4790,68 @@ void main() {
         },
       );
 
+      test(
+        'an inconclusive own-inbox read is not memoized and the next consumer '
+        're-queries',
+        () async {
+          var resolveQueries = 0;
+          final capturedDrainTempRelays = <List<String>?>[];
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((inv) async {
+            final filter =
+                (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                    .single;
+            if (filter.kinds?.contains(EventKind.dmRelaysList) ?? false) {
+              resolveQueries++;
+              return resolveQueries == 1
+                  ? unansweredList(timedOut: true)
+                  : answeredList([
+                      ownInbox(['wss://own.example']),
+                    ]);
+            }
+            if (filter.p?.isNotEmpty ?? false) {
+              capturedDrainTempRelays.add(
+                inv.namedArguments[#tempRelays] as List<String>?,
+              );
+            }
+            return answeredPage(const <Event>[]);
+          });
+
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+          await repository.startListening();
+          await repository.backfillHistoryIfNeeded();
+
+          expect(resolveQueries, 2);
+          expect(
+            capturedDrainTempRelays,
+            contains(equals(['wss://own.example'])),
+          );
+
+          await repository.stopListening();
+          await controller.close();
+        },
+      );
+
       // NOTE: the analogous "stopListening() during the resolve" case shares
       // the identical session-token guard (stopListening bumps _resetGeneration
       // exactly as _resetState does), so the account-switch test below covers

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -21869,6 +21869,52 @@ void main() {
       });
 
       test(
+        'an unreadable recipient inbox on retry is NOT delivery: the sweep '
+        'must not consume the row a soft send preserved (#7317)',
+        () async {
+          // Persistently unreadable — the same state the original send saw.
+          // Without this fix the sweep re-resolves to null, publishes to the
+          // pool, scores the OK as success and deletes the row, converging on
+          // exactly the pre-fix outcome ~160s later.
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => unansweredList(noRelays: true));
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer((_) async => queuedRow());
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId2,
+              recipientPubkey: recipientPubkey,
+            ),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverFullSend(
+            rumorId: _rumorEventId,
+          );
+
+          expect(result.success, isFalse);
+          expect(result.retryablePending, isTrue);
+          verifyNever(() => mockOutgoingDmsDao.deleteById(any()));
+          verify(
+            () => mockOutgoingDmsDao.incrementRetry(_rumorEventId),
+          ).called(1);
+        },
+      );
+
+      test(
         'skips the local persist when the row is cancelled while the '
         'replay publish is in flight — the message must not resurrect',
         () async {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -4437,6 +4437,14 @@ void main() {
           ),
         ).thenThrow(Exception('relay down'));
         final repository = createRepository();
+        // The relay list is still null — the send falls back to the pool. But
+        // the CALLER must be able to tell this apart from genuine absence, or
+        // it scores a fallback-pool OK as delivery (#7317).
+        final resolved = await repository.resolveDmInboxRelaysDetailed(
+          _validPubkeyB,
+        );
+        expect(resolved.relays, isNull);
+        expect(resolved.state, DmInboxResolution.unreadable);
         expect(await repository.resolveDmInboxRelays(_validPubkeyB), isNull);
       });
 
@@ -4472,6 +4480,115 @@ void main() {
           ['wss://relay-tag.example', 'wss://r-tag.example'],
         );
       });
+    });
+
+    group('resolveDmInboxRelaysDetailed', () {
+      Event kind10050Event(List<String> relays) => Event(
+        _validPubkeyB,
+        EventKind.dmRelaysList,
+        [
+          for (final r in relays) ['relay', r],
+        ],
+        '',
+        createdAt: 1700000000,
+      );
+
+      void stubQueryDetailed(
+        ({List<Event> events, bool timedOut, bool noRelays}) answer,
+      ) {
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            useCache: any(named: 'useCache'),
+            tempRelays: any(named: 'tempRelays'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async => answer);
+      }
+
+      test('reports found when the recipient advertises an inbox', () async {
+        stubQueryDetailed(
+          answeredList([
+            kind10050Event(['wss://inbox.example']),
+          ]),
+        );
+        final repository = createRepository();
+        final resolved = await repository.resolveDmInboxRelaysDetailed(
+          _validPubkeyB,
+        );
+        expect(resolved.state, DmInboxResolution.found);
+        expect(resolved.relays, ['wss://inbox.example']);
+      });
+
+      test(
+        'reports absent when the relays answered and there is no inbox',
+        () async {
+          stubQueryDetailed(answeredList(const <Event>[]));
+          final repository = createRepository();
+          final resolved = await repository.resolveDmInboxRelaysDetailed(
+            _validPubkeyB,
+          );
+          expect(resolved.state, DmInboxResolution.absent);
+          expect(resolved.relays, isNull);
+        },
+      );
+
+      test('reports unreadable when no relay took the REQ', () async {
+        stubQueryDetailed(unansweredList(noRelays: true));
+        final repository = createRepository();
+        final resolved = await repository.resolveDmInboxRelaysDetailed(
+          _validPubkeyB,
+        );
+        expect(resolved.state, DmInboxResolution.unreadable);
+        expect(resolved.relays, isNull);
+      });
+
+      test('reports unreadable when nothing settled in the budget', () async {
+        stubQueryDetailed(unansweredList(timedOut: true));
+        final repository = createRepository();
+        final resolved = await repository.resolveDmInboxRelaysDetailed(
+          _validPubkeyB,
+        );
+        expect(resolved.state, DmInboxResolution.unreadable);
+        expect(resolved.relays, isNull);
+      });
+
+      test(
+        'a list returned alongside an unsettled relay is FOUND, not unreadable '
+        '- the local cache leg is merged in regardless of the relay leg, so '
+        'checking the flags before the events would discard a real answer',
+        () async {
+          stubQueryDetailed((
+            events: [
+              kind10050Event(['wss://inbox.example']),
+            ],
+            timedOut: true,
+            noRelays: false,
+          ));
+          final repository = createRepository();
+          final resolved = await repository.resolveDmInboxRelaysDetailed(
+            _validPubkeyB,
+          );
+          expect(resolved.state, DmInboxResolution.found);
+          expect(resolved.relays, ['wss://inbox.example']);
+        },
+      );
+
+      test(
+        'an inbox whose relay tags are all inadmissible is absent, not '
+        'unreadable - the relays answered and we read what they said',
+        () async {
+          stubQueryDetailed(answeredList([kind10050Event(const [])]));
+          final repository = createRepository();
+          final resolved = await repository.resolveDmInboxRelaysDetailed(
+            _validPubkeyB,
+          );
+          expect(resolved.state, DmInboxResolution.absent);
+          expect(resolved.relays, isNull);
+        },
+      );
     });
 
     group('own kind-10050 receive targeting (#4974 RC2)', () {
@@ -18088,6 +18205,94 @@ void main() {
               lastError: any(named: 'lastError'),
             ),
           );
+        },
+      );
+
+      test(
+        'an unreadable recipient inbox is NOT delivery: a fallback-pool OK '
+        'keeps the row pending instead of deleting it (#7317)',
+        () async {
+          // The recipient DOES advertise an inbox; our pool just could not
+          // read it. The publish still lands on the default pool and the
+          // relay still says OK - which is exactly the false positive.
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => unansweredList(noRelays: true));
+          stubSendRumor(
+            // selfWrapPublished defaults true, which is the arm that deletes
+            // the row — the exact behaviour under test.
+            (rumorEvent, recipientPubkey) async => NIP17SendResult.success(
+              rumorEventId: rumorEvent.id,
+              messageEventId: 'wrap-on-the-fallback-pool',
+              recipientPubkey: recipientPubkey,
+            ),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'routed to the fallback pool',
+          );
+
+          // Reported as retryable-pending, not delivered.
+          expect(result.success, isFalse);
+          expect(result.retryablePending, isTrue);
+
+          final enqueued =
+              verify(
+                    () => mockOutgoingDmsDao.enqueue(captureAny()),
+                  ).captured.single
+                  as OutgoingDm;
+          // The retry handle SURVIVES - this is the whole point. Without it
+          // no sweep can ever re-resolve the recipient's inbox.
+          verifyNever(() => mockOutgoingDmsDao.deleteById(any()));
+          verify(
+            () => mockOutgoingDmsDao.incrementRetry(enqueued.id),
+          ).called(1);
+        },
+      );
+
+      test(
+        'a recipient who genuinely advertises no inbox is still delivered - '
+        'the fallback lands where they read, so #7317 must not regress it',
+        () async {
+          // setUp stubs queryEventsDetailed -> answeredList([]): the relays
+          // answered and there is no kind-10050. Conclusive absence.
+          stubSendRumor(
+            (rumorEvent, recipientPubkey) async => NIP17SendResult.success(
+              rumorEventId: rumorEvent.id,
+              messageEventId: 'wrap',
+              recipientPubkey: recipientPubkey,
+            ),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'no inbox advertised',
+          );
+
+          expect(result.success, isTrue);
+          final enqueued =
+              verify(
+                    () => mockOutgoingDmsDao.enqueue(captureAny()),
+                  ).captured.single
+                  as OutgoingDm;
+          verify(() => mockOutgoingDmsDao.deleteById(enqueued.id)).called(1);
+          verifyNever(() => mockOutgoingDmsDao.incrementRetry(any()));
         },
       );
 

--- a/mobile/test/blocs/dm/inline_reel_reply/inline_reel_reply_cubit_test.dart
+++ b/mobile/test/blocs/dm/inline_reel_reply/inline_reel_reply_cubit_test.dart
@@ -283,6 +283,34 @@ void main() {
     );
 
     blocTest<InlineReelReplyCubit, InlineReelReplyState>(
+      'retryable-pending reply is optimistically sent, not failed',
+      build: () {
+        when(
+          () => repo.sendMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: any(named: 'content'),
+            replyToId: any(named: 'replyToId'),
+          ),
+        ).thenAnswer(
+          (_) async => const NIP17SendResult.failure(
+            'Recipient DM inbox unreadable; published to the fallback pool',
+            retryablePending: true,
+            queuedRumorId: 'queued-rumor-id',
+          ),
+        );
+        return InlineReelReplyCubit(
+          dmRepository: repo,
+          replyContext: oneToOne(),
+        );
+      },
+      act: (cubit) => cubit.submit('hi'),
+      expect: () => const [
+        InlineReelReplyState(status: InlineReelReplyStatus.sending),
+        InlineReelReplyState(status: InlineReelReplyStatus.success),
+      ],
+    );
+
+    blocTest<InlineReelReplyCubit, InlineReelReplyState>(
       'StateError from send is Reportable',
       build: () {
         when(
@@ -363,9 +391,7 @@ void main() {
         cubit.acknowledge();
       },
       skip: 2,
-      expect: () => const [
-        InlineReelReplyState(),
-      ],
+      expect: () => const [InlineReelReplyState()],
     );
 
     blocTest<InlineReelReplyCubit, InlineReelReplyState>(
@@ -558,8 +584,8 @@ void main() {
     // alongside the sweep's replay of the original row. Retry must re-drive
     // that row instead of sending again.
     group('retry', () {
-      /// Stubs a 1:1 send that parks [queuedRumorId]. `null` models a send
-      /// that left no row — a policy block, or an unwired queue DAO.
+      /// Stubs a hard-failed 1:1 send that parks [queuedRumorId]. `null` models
+      /// a failure that left no row, such as an unwired queue DAO.
       void stubSendParks(String? queuedRumorId) {
         when(
           () => repo.sendMessage(
@@ -570,7 +596,6 @@ void main() {
         ).thenAnswer(
           (_) async => NIP17SendResult.failure(
             'no relay responded',
-            retryablePending: true,
             queuedRumorId: queuedRumorId,
           ),
         );
@@ -683,10 +708,8 @@ void main() {
           await cubit.retry(queuedRumorIds: captured, content: 'hi');
 
           verify(
-            () => repo.recoverFullSend(
-              rumorId: 'row-1',
-              resetRetryBudget: true,
-            ),
+            () =>
+                repo.recoverFullSend(rumorId: 'row-1', resetRetryBudget: true),
           ).called(1);
           // Two submits, both deliberate. A third would be the duplicate.
           verifySendMessageCalled(2);

--- a/mobile/test/services/collaborator_invite_service_test.dart
+++ b/mobile/test/services/collaborator_invite_service_test.dart
@@ -113,6 +113,43 @@ void main() {
     });
 
     test(
+      'preserves retryable-pending without reporting a hard failure',
+      () async {
+        when(
+          () => dmRepository.sendMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: any(named: 'content'),
+            replyToId: any(named: 'replyToId'),
+            additionalTags: any(named: 'additionalTags'),
+            skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          ),
+        ).thenAnswer(
+          (_) async => const NIP17SendResult.failure(
+            'Recipient DM inbox unreadable; published to the fallback pool',
+            retryablePending: true,
+            queuedRumorId: 'queued-rumor-id',
+          ),
+        );
+
+        final result = await service.sendInvite(
+          collaboratorPubkey: collaboratorPubkey,
+          creatorPubkey: creatorPubkey,
+          videoAddress: videoAddress,
+        );
+
+        expect(result.success, isFalse);
+        expect(result.retryablePending, isTrue);
+        expect(result.error, isNull);
+        expect(
+          CollaboratorInviteBatchResult(
+            results: {collaboratorPubkey: result},
+          ).hasFailures,
+          isFalse,
+        );
+      },
+    );
+
+    test(
       'content endsWith invitePlaintextSuffix (contract for UI suppression)',
       () async {
         when(

--- a/mobile/test/services/video_metadata_update_service_test.dart
+++ b/mobile/test/services/video_metadata_update_service_test.dart
@@ -1397,6 +1397,36 @@ void main() {
       });
 
       test(
+        'returns inviteFailureCount = 0 when the invite remains queued',
+        () async {
+          when(
+            () => mockDmRepository.sendMessage(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+              additionalTags: any(named: 'additionalTags'),
+              skipNip04Fallback: any(named: 'skipNip04Fallback'),
+            ),
+          ).thenAnswer(
+            (_) async => const NIP17SendResult.failure(
+              'Delivery confirmation pending',
+              retryablePending: true,
+            ),
+          );
+
+          final result = await service.updateVideo(
+            originalVideo: _testVideo(),
+            editorState: VideoEditorProviderState(
+              collaboratorPubkeys: const {newCollaborator},
+            ),
+            initialCollaboratorPubkeys: const {},
+          );
+
+          expect(result, isA<VideoUpdateSuccess>());
+          expect((result as VideoUpdateSuccess).inviteFailureCount, equals(0));
+        },
+      );
+
+      test(
         'returns inviteFailureCount = 0 when no new collaborators were added',
         () async {
           final result = await service.updateVideo(

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -1469,6 +1469,48 @@ void main() {
         },
       );
 
+      test(
+        'successful publish does not warn for a queued collaborator invite',
+        () async {
+          const collaboratorPubkey =
+              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+          _setupSuccessfulPublish(
+            mockAuthService: mockAuthService,
+            mockUploadManager: mockUploadManager,
+            mockDraftService: mockDraftService,
+            mockVideoEventPublisher: mockVideoEventPublisher,
+          );
+          when(
+            () => mockCollaboratorInviteService.sendInvites(
+              collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
+              creatorPubkey: any(named: 'creatorPubkey'),
+              videoAddress: any(named: 'videoAddress'),
+              title: any(named: 'title'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              relayHint: any(named: 'relayHint'),
+            ),
+          ).thenAnswer(
+            (_) async => const CollaboratorInviteBatchResult(
+              results: {
+                collaboratorPubkey: CollaboratorInviteResult(
+                  success: false,
+                  retryablePending: true,
+                ),
+              },
+            ),
+          );
+
+          final result = await service.publishVideo(
+            draft: _createTestDraft(
+              collaboratorPubkeys: {collaboratorPubkey},
+            ),
+          );
+
+          expect(result, isA<PublishSuccess>());
+          expect((result as PublishSuccess).inviteWarnings, isEmpty);
+        },
+      );
+
       test('returns error when video event publishing fails', () async {
         // Arrange
         when(() => mockAuthService.isAuthenticated).thenReturn(true);

--- a/mobile/test/services/video_sharing_service_test.dart
+++ b/mobile/test/services/video_sharing_service_test.dart
@@ -534,6 +534,53 @@ void main() {
     });
 
     test(
+      'treats a retryable-pending NIP-17 share as optimistically sent',
+      () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
+        when(
+          () => mockDmRepository.sendSharedVideo(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            baseContent: any(named: 'baseContent'),
+            videoKind: any(named: 'videoKind'),
+            videoAuthorPubkey: any(named: 'videoAuthorPubkey'),
+            videoDTag: any(named: 'videoDTag'),
+            videoEventId: any(named: 'videoEventId'),
+            relayHint: any(named: 'relayHint'),
+            skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          ),
+        ).thenAnswer(
+          (_) async => const NIP17SendResult.failure(
+            'Recipient DM inbox unreadable; published to the fallback pool',
+            retryablePending: true,
+            queuedRumorId: 'queued-rumor-id',
+          ),
+        );
+        when(
+          () => mockProfileRepository.fetchFreshProfile(
+            pubkey: any(named: 'pubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        final now = DateTime.now();
+        final result = await nip17Service.shareVideoWithUser(
+          video: VideoEvent(
+            id: _testVideoId,
+            pubkey: _testPubkey,
+            createdAt: now.millisecondsSinceEpoch ~/ 1000,
+            timestamp: now,
+            content: 'Test',
+          ),
+          recipientPubkey: _recipientPubkey,
+        );
+
+        expect(result.success, isTrue);
+        expect(result.messageEventId, 'queued-rumor-id');
+        expect(result.conversationId, isNotNull);
+      },
+    );
+
+    test(
       'shareVideoWithMultipleUsers: one recipient failing does not abort the '
       'rest, and each outcome is reported',
       () async {

--- a/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
@@ -551,7 +551,6 @@ void main() {
       ).thenAnswer(
         (_) async => const NIP17SendResult.failure(
           'no relay responded',
-          retryablePending: true,
           queuedRumorId: 'parked-row',
         ),
       );
@@ -612,7 +611,6 @@ void main() {
       ).thenAnswer(
         (_) async => const NIP17SendResult.failure(
           'no relay responded',
-          retryablePending: true,
           queuedRumorId: 'parked-row',
         ),
       );
@@ -684,7 +682,6 @@ void main() {
         if (sends == 1) {
           return const NIP17SendResult.failure(
             'no relay responded',
-            retryablePending: true,
             queuedRumorId: 'parked-row',
           );
         }


### PR DESCRIPTION
Refs #7317

## What ships here, and what does not

**Ships:** the initial send (`sendMessage`) and the retry sweep (`recoverFullSend`) both stop scoring a default-pool `OK` as delivery when the recipient's DM inbox could not be read.

**Still open:** `sendGroupMessage` (`:5448`) is the last caller that still collapses the two states — #8434, assigned.

**Not attempted:** the routing itself. NIP-17 §Publishing and NIP-59 §"Broadcast Selectively" both require publishing only to the recipient's advertised relays. This PR does not honour that MUST; it stops misreporting the violation as delivery. Honouring it is a product decision, not a patch. `Refs #7317` rather than `Fixes`, so the issue stays open while that remains true.

## What was wrong

`resolveDmInboxRelays` returned `null` for two different facts: *"this recipient advertises no DM inbox"* and *"we could not read the inbox they do advertise."* Both fall back to Divine's default relay pool, a single `OK true` there is `PublishOutcome.confirmed`, and `_finalizeAfterRecipientSuccess` deletes the `outgoing_dms` row. So a gift wrap written to relays the recipient never reads was reported as delivered, and the handle that could have re-resolved it was destroyed.

## Reproduced, with a control

Same recipient, same app instance, two sends three minutes apart against **production** with a real Keycast OAuth identity. The only variable changed was whether our pool could read the recipient's kind-10050 — their advertised relays (`relay.0xchat.com`, `relay.damus.io`) were identical in both runs.

| run | pool can read the inbox | wrap on Divine's default pool | wrap on the recipient's advertised inbox |
|---|---|---|---|
| A | no | **1 — the wrap is here** | **0 — nothing** |
| B | yes | 0 | **1 — the wrap is here** |

Both logged `Successfully published NIP-17 message (selfWrapPublished=true)`, both deleted the queue row, and the conversation's accessibility tree after both sends contained no failure or resend label — the lost message and the delivered one rendered identically.

## The fix, and why it costs nothing

`_queryOwnDmInbox` **already computed** the signal that tells these apart. It gated the `noRelays` / `timedOut` mapping behind `requireAuthoritative`, which the send path passes `false`. Those flags are computed identically in both read modes (`Nostr.queryEventsDetailed`), so ungating them adds no round trip and no settle wait — **#8220's decision to keep the strict, fully-settled read off the send path is untouched**, and none of its measured 6004 ms worst case is incurred.

1. Surface the reason as `DmInboxResolution` (`found` / `absent` / `unreadable`) via `resolveDmInboxRelaysDetailed`. `resolveDmInboxRelays` stays as a thin delegate, so its remaining call sites are untouched.
2. Ungate the `noRelays || timedOut` mapping — applied **only** at the two exits where nothing matching came back. A relay-leg timeout with a local cache hit is a successful resolution, not an inconclusive one, and there is a test pinning exactly that.
3. `sendMessage` and `recoverFullSend` both route through `_downgradeFallbackPoolDelivery`, which reuses the **existing** soft-unconfirmed contract: row stays `pending`, `incrementRetry` charges the budget, the next sweep re-resolves.

### Why the retry half was not optional

Without it the sweep undoes the send path: it re-resolved through the collapsing helper, republished to the pool, scored the `OK` as success and deleted the row — the same false-`delivered` outcome, roughly 160s later (`_interruptedMinAge`). The row the send path preserved was consumed by the very sweep it was preserved for. Run A above is that case, so the PR would not have fixed what it reproduced.

## Deliberately unchanged

- **Conclusive `absent`.** The recipient advertises nothing, so the default pool is where they read; #570's reachability intent is preserved. Regression test pins this.
- **`CLOSED` refusals** still read as `absent` — they complete the query early, and telling them apart needs `requireAllRelaysSettled: true` and its 6 s worst case. Called out in the code rather than left implicit.

## No visible change

`DmDeliveryStatus.pending` and `.delivered` render **identically** — `message_bubble.dart:247` branches only on `failed`. There is no UI diff to look for. This buys durability: the row survives so the sweep can re-resolve. If every re-resolution stays inconclusive the row exhausts its 5 retries and terminalizes to the existing red "Failed to send", which is the honest end state for a send never confirmed to reach an inbox the recipient reads.

## Testing

- `resolveDmInboxRelaysDetailed` — `found`, `absent`, `unreadable` via `noRelays`, `unreadable` via `timedOut`, plus the two boundaries that matter: a list returned **alongside** an unsettled relay is `found` (the cache leg merges in regardless of the relay leg), and an inbox whose relay tags are all inadmissible is `absent`, not `unreadable`.
- Send classification — unreadable inbox + confirmed fallback-pool publish returns `retryablePending`, never calls `deleteById`, charges `incrementRetry` once.
- **Retry classification** — same assertions driven through `recoverFullSend`.
- Regression guard — a recipient who genuinely advertises no inbox is still delivered and still has its row deleted.
- The pre-existing test that asserted `null` and stopped there pinned the defect; it now also asserts the resolution state.

Mutation-tested at the production boundary: restoring the `requireAuthoritative` gate turns the resolver tests red, and neutering `_downgradeFallbackPoolDelivery` turns **both** the send and the retry test red, so each call site is genuinely covered.

```
flutter test  (packages/dm_repository)   759 passed
coverage                                 94.46%  (gate 93%)
flutter analyze lib test                 no issues
flutter analyze lib test integration_test (app)  no issues
```

Ratchets green: ungrouped tests, skip ceiling, placeholder tests, shared-setup stubs.

## Rebase note

Rebased onto `c9788ea569` (#8435). That PR changed the same two lines in `sendMessage` to resolve the recipient inbox and the sender's self-wrap targets in parallel; the conflict was resolved by keeping its `.wait` pairing and swapping the recipient side to the detailed resolver, so both behaviours are intact.

## Manual test plan

The A/B harness is the acceptance check and is re-runnable: mint a key, publish its kind-10050 only to a relay Divine does not dial, seed the thread with an inbound gift wrap, send, and read the wrap back by the ephemeral pubkey the app logs. After this change run A must keep the queue row and return `retryablePending` — **and still hold it after the sweep re-drives** — while run B stays unchanged.


## Takeover follow-up

The soft-unconfirmed result now stays optimistic at every app surface this PR reaches: video shares and inline reel replies report sent while the durable queue retries in the background, and collaborator invites carry an explicit pending state instead of exposing the repository error as a hard failure. Hard failures still retain the inline reply manual Retry affordance.

Ungating `noRelays || timedOut` also affects the signed-in user’s session memo: an inconclusive non-authoritative own-inbox read is no longer cached as absent. The memo clears, so the next subscription/history consumer re-queries and can recover the user’s advertised self-wrap targets. This does not add a round trip to the recipient lookup in the current send; it changes a later own-inbox consumer after an inconclusive read.

Additional regression coverage pins the three app adapters and the own-inbox memo re-query.
