### PR TITLE
fix(dm): route gift-wrapped DM reactions to the recipient's kind-10050 inbox

### DIFF
--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -741,10 +741,8 @@ DmRepository dmRepository(Ref ref) {
   // `dmReactionsRepositoryProvider` above, so reading it back from there would
   // close a Riverpod cycle.
   //
-  // Wired before the readiness gate: resolution only reads, and
-  // `AppShellBadgeScope` builds this provider eagerly at mount, so the resolver
-  // is in place before the reaction retry sweep — the one consumer that reaches
-  // the reactions repository without building this one — can fire.
+  // The reaction retry provider also watches this provider explicitly, making
+  // this wiring complete before its fire-immediately sweep can run.
   reactionsRepository.setDmInboxRelayResolver(repository.resolveDmInboxRelays);
 
   // Set credentials and open the gift-wrap subscription as soon as the

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -734,6 +734,19 @@ DmRepository dmRepository(Ref ref) {
 
   ref.onDispose(repository.stopListening);
 
+  // Hand the reactions repository this repository's kind-10050 resolver so a
+  // gift-wrapped reaction routes to the recipient's advertised DM inbox rather
+  // than the default pool (#7321). Injected downward because the dependency
+  // edge already runs this way — this provider watches
+  // `dmReactionsRepositoryProvider` above, so reading it back from there would
+  // close a Riverpod cycle.
+  //
+  // Wired before the readiness gate: resolution only reads, and
+  // `AppShellBadgeScope` builds this provider eagerly at mount, so the resolver
+  // is in place before the reaction retry sweep — the one consumer that reaches
+  // the reactions repository without building this one — can fire.
+  reactionsRepository.setDmInboxRelayResolver(repository.resolveDmInboxRelays);
+
   // Set credentials and open the gift-wrap subscription as soon as the
   // signer is ready. The subscription is auth-session-scoped (not inbox-
   // scoped) so DMs are ingested even when the user never visits /inbox.

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -1068,7 +1068,7 @@ final class DmRepositoryProvider
   }
 }
 
-String _$dmRepositoryHash() => r'639c33f88161f512cae32548e75f18303a690c9e';
+String _$dmRepositoryHash() => r'1c02998545a7ab7e291ac128f2a6024f2a17aa41';
 
 /// Provider for CommentsRepository instance
 ///

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -459,6 +459,10 @@ DmReactionRetryService? dmReactionRetryService(Ref ref) {
     return null;
   }
 
+  // The retry service can be constructed above the app composition tree.
+  // Watching DmRepository makes its downward resolver wiring deterministic
+  // before the fire-immediately sweep can settle a retry through the pool.
+  ref.watch(dmRepositoryProvider);
   final reactionsRepository = ref.watch(dmReactionsRepositoryProvider);
 
   // Bridge the synchronous AppForeground notifier into a Stream<bool> so the

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -249,7 +249,7 @@ final class DmReactionRetryServiceProvider
 }
 
 String _$dmReactionRetryServiceHash() =>
-    r'e6617b1b4b2af0e0f4c8ad7cc1196cfbddad4cd5';
+    r'281cbb241736d787dffdca43af2c6a402bc30488';
 
 /// Auto-sweep service for the durable `pending_view_events` queue.
 

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -101,6 +101,20 @@ class DmReactionRetryTarget {
   final int createdAt;
 }
 
+/// Resolves [pubkey]'s NIP-17 kind-10050 DM inbox relays.
+///
+/// A function port rather than a `DmRepository` reference: `dmRepository`'s
+/// provider already watches `dmReactionsRepositoryProvider`
+/// (`repository_providers.dart`), so reading it back from here would close a
+/// Riverpod dependency cycle — and `ref.read` trips that guard at call time,
+/// not only during build.
+///
+/// Contract: **must not throw**. Resolution failures degrade to `null`, and
+/// `null` means "publish to the default relay pool", which is the behaviour
+/// that shipped before #7321. `DmRepository.resolveDmInboxRelays` satisfies
+/// this — its whole body is wrapped in `on Object catch`.
+typedef DmInboxRelayResolver = Future<List<String>?> Function(String pubkey);
+
 /// Repository for DM emoji reactions.
 ///
 /// Public surface:
@@ -169,6 +183,27 @@ class DmReactionsRepository {
   void clearCredentials() {
     _userPubkey = '';
     _messageService = null;
+  }
+
+  /// Resolves a recipient's kind-10050 DM inbox so a reaction gift wrap is
+  /// published where they actually read (#7321). Null until wired, and a null
+  /// result routes to the default pool — both are the pre-#7321 behaviour.
+  DmInboxRelayResolver? _resolveDmInboxRelays;
+
+  /// Wire the kind-10050 resolver.
+  ///
+  /// Injected downward by `DmRepository`'s provider rather than read from a
+  /// provider here; see [DmInboxRelayResolver] for why. The only consumer that
+  /// reaches this repository without also building `DmRepository` is the
+  /// reaction retry sweep, and the app shell constructs `dmRepositoryProvider`
+  /// eagerly at mount, so the resolver is always wired before a sweep can fire.
+  /// Kept a method rather than a setter: a bare setter trips
+  /// `avoid_setters_without_getters`, and satisfying that would mean exposing a
+  /// getter no consumer wants purely to appease the pair. The `set*` shape also
+  /// matches [setCredentials] / [clearCredentials] on this class.
+  // ignore: use_setters_to_change_properties
+  void setDmInboxRelayResolver(DmInboxRelayResolver? resolver) {
+    _resolveDmInboxRelays = resolver;
   }
 
   /// Drop every reaction row this account holds for [conversationIds].
@@ -337,6 +372,15 @@ class DmReactionsRepository {
     // soft-deleted locally and the new emoji stays as a retryable failed
     // chip — whereas a wire rollback would desync the two sides. Recovery is
     // re-tapping (or the sweep re-driving) the new emoji.
+    // Resolve each recipient's kind-10050 inbox ONCE for the whole tap. An
+    // emoji swap drives two fan-outs milliseconds apart — the kind-5 supersede
+    // below and the kind-7 add after it — and they concern the same recipients
+    // at the same moment, so a second lookup would be redundant latency for an
+    // answer that cannot have changed. Resolved here rather than inside
+    // `_fanOutRumor` so both share it; the optimistic row is already written
+    // above, so this never delays the visible chip.
+    final inboxByRecipient = await _resolveInboxes(recipients);
+
     for (final priorId in superseded) {
       await _durablyDeleteReaction(
         rumorId: priorId,
@@ -344,6 +388,7 @@ class DmReactionsRepository {
         messageService: messageService,
         reportSite:
             DmReactionsRepositoryReportableSites.publishSupersedeDeletion,
+        inboxByRecipient: inboxByRecipient,
       );
     }
 
@@ -352,6 +397,7 @@ class DmReactionsRepository {
         messageService: messageService,
         rumor: rumor,
         recipients: recipients,
+        inboxByRecipient: inboxByRecipient,
         awaitRecipientOk: true,
       );
       switch (result) {
@@ -618,6 +664,7 @@ class DmReactionsRepository {
     required List<String> recipients,
     required NIP17MessageService messageService,
     required String reportSite,
+    Map<String, List<String>?>? inboxByRecipient,
   }) async {
     if (recipients.isEmpty) return;
     final deletion = messageService.buildRumor(
@@ -647,6 +694,7 @@ class DmReactionsRepository {
         deletion: deletion,
         recipients: recipients,
         messageService: messageService,
+        inboxByRecipient: inboxByRecipient,
       ),
     );
   }
@@ -773,12 +821,14 @@ class DmReactionsRepository {
     required Event deletion,
     required List<String> recipients,
     required NIP17MessageService messageService,
+    Map<String, List<String>?>? inboxByRecipient,
   }) async {
     try {
       final result = await _fanOutRumor(
         messageService: messageService,
         rumor: deletion,
         recipients: recipients,
+        inboxByRecipient: inboxByRecipient,
         awaitRecipientOk: true,
       );
       final terminal =
@@ -962,12 +1012,17 @@ class DmReactionsRepository {
     required NIP17MessageService messageService,
     required Event rumor,
     required String recipientPubkey,
+    List<String>? targetRelays,
     bool awaitRecipientOk = false,
   }) {
     return messageService
         .sendRumor(
           rumorEvent: rumor,
           recipientPubkey: recipientPubkey,
+          // Route the wrap to the recipient's advertised NIP-17 inbox when it
+          // resolved; null falls back to the default pool, preserving
+          // reachability for recipients who publish no kind-10050 (#7321).
+          targetRelays: targetRelays,
           awaitRecipientOk: awaitRecipientOk,
         )
         .timeout(
@@ -1038,6 +1093,45 @@ class DmReactionsRepository {
       ? const <String>[]
       : <String>[targetMessageAuthor];
 
+  /// Resolve every recipient's NIP-17 kind-10050 DM inbox concurrently.
+  ///
+  /// Hoisted out of the per-recipient send loop and run in parallel, exactly as
+  /// `DmRepository.sendGroupMessage` does: resolution is a live relay query
+  /// capped at 5 s and is not meaningfully cached, so resolving inside the loop
+  /// would cost N sequential waits before the last wrap is even attempted.
+  ///
+  /// Every lookup is isolated. [DmInboxRelayResolver]'s contract forbids
+  /// throwing and `DmRepository.resolveDmInboxRelays` honours it, but the
+  /// resolver is an injected port rather than a method this class owns — and an
+  /// unguarded `Future.wait` fails *whole* on a single rejection, which would
+  /// turn one bad lookup into a failed fan-out instead of one recipient falling
+  /// back to the default pool.
+  ///
+  /// Returns an empty map when no resolver is wired, so every recipient reads
+  /// back `null` and routing is byte-identical to the pre-#7321 behaviour.
+  Future<Map<String, List<String>?>> _resolveInboxes(
+    List<String> recipients,
+  ) async {
+    final resolve = _resolveDmInboxRelays;
+    if (resolve == null) return const <String, List<String>?>{};
+    final inboxes = <String, List<String>?>{};
+    // try/catch rather than `.catchError((_) => null)`: on a
+    // `Future<List<String>?>` that handler is only type-checked at runtime, and
+    // Dart rejects it with "The error handler of Future.catchError must return
+    // a value of the future's type" — turning the guard into the very crash it
+    // exists to prevent. Caught by the throwing-resolver test below.
+    Future<void> resolveOne(String recipient) async {
+      try {
+        inboxes[recipient] = await resolve(recipient);
+      } on Object {
+        inboxes[recipient] = null;
+      }
+    }
+
+    await Future.wait(recipients.map(resolveOne));
+    return inboxes;
+  }
+
   /// Wrap [rumor] to each of [recipients] (each send also self-wraps for
   /// cross-device recovery; self-wrap copies dedupe on the rumor id at the
   /// receiver). Terminal success ONLY when EVERY recipient wrap lands.
@@ -1068,11 +1162,13 @@ class DmReactionsRepository {
     required NIP17MessageService messageService,
     required Event rumor,
     required List<String> recipients,
+    Map<String, List<String>?>? inboxByRecipient,
     bool awaitRecipientOk = false,
   }) async {
     if (recipients.isEmpty) {
       return const NIP17SendResult.failure('No reaction wrap recipients');
     }
+    final inboxes = inboxByRecipient ?? await _resolveInboxes(recipients);
     NIP17SendSuccess? lastSuccess;
     final failures = <NIP17SendFailure>[];
     for (final recipient in recipients) {
@@ -1080,6 +1176,7 @@ class DmReactionsRepository {
         messageService: messageService,
         rumor: rumor,
         recipientPubkey: recipient,
+        targetRelays: inboxes[recipient],
         awaitRecipientOk: awaitRecipientOk,
       );
       switch (result) {

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -170,6 +170,10 @@ class DmReactionsRepository {
   /// Has the repository been wired with auth credentials?
   bool get isInitialized => _messageService != null && _userPubkey.isNotEmpty;
 
+  /// Whether recipient inbox routing has been wired by the app layer.
+  @visibleForTesting
+  bool get hasDmInboxRelayResolver => _resolveDmInboxRelays != null;
+
   /// Set the credentials needed for outgoing publishes.
   void setCredentials({
     required String userPubkey,
@@ -379,7 +383,7 @@ class DmReactionsRepository {
     // answer that cannot have changed. Resolved here rather than inside
     // `_fanOutRumor` so both share it; the optimistic row is already written
     // above, so this never delays the visible chip.
-    final inboxByRecipient = await _resolveInboxes(recipients);
+    final inboxes = _resolveInboxes(recipients);
 
     for (final priorId in superseded) {
       await _durablyDeleteReaction(
@@ -388,10 +392,11 @@ class DmReactionsRepository {
         messageService: messageService,
         reportSite:
             DmReactionsRepositoryReportableSites.publishSupersedeDeletion,
-        inboxByRecipient: inboxByRecipient,
+        inboxes: inboxes,
       );
     }
 
+    final inboxByRecipient = await inboxes;
     try {
       final result = await _fanOutRumor(
         messageService: messageService,
@@ -664,7 +669,7 @@ class DmReactionsRepository {
     required List<String> recipients,
     required NIP17MessageService messageService,
     required String reportSite,
-    Map<String, List<String>?>? inboxByRecipient,
+    Future<Map<String, List<String>?>>? inboxes,
   }) async {
     if (recipients.isEmpty) return;
     final deletion = messageService.buildRumor(
@@ -694,7 +699,7 @@ class DmReactionsRepository {
         deletion: deletion,
         recipients: recipients,
         messageService: messageService,
-        inboxByRecipient: inboxByRecipient,
+        inboxes: inboxes,
       ),
     );
   }
@@ -821,9 +826,10 @@ class DmReactionsRepository {
     required Event deletion,
     required List<String> recipients,
     required NIP17MessageService messageService,
-    Map<String, List<String>?>? inboxByRecipient,
+    Future<Map<String, List<String>?>>? inboxes,
   }) async {
     try {
+      final inboxByRecipient = await inboxes;
       final result = await _fanOutRumor(
         messageService: messageService,
         rumor: deletion,

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -6081,12 +6081,14 @@ class DmRepository {
     // reads their advertised inbox. Resolution never throws (it degrades to
     // null → default pool), so a failed lookup cannot abort the fan-out.
     final inboxByRecipient = <String, List<String>?>{};
+    final selfWrapRelays = _selfWrapTargetRelays();
     await Future.wait([
       for (final recipient in recipients)
         resolveDmInboxRelays(
           recipient,
         ).then((relays) => inboxByRecipient[recipient] = relays),
     ]);
+    final selfWrapTargets = await selfWrapRelays;
     NIP17SendSuccess? lastSuccess;
     final failures = <NIP17SendFailure>[];
     for (final recipient in recipients) {
@@ -6095,6 +6097,7 @@ class DmRepository {
             rumorEvent: deletion,
             recipientPubkey: recipient,
             targetRelays: inboxByRecipient[recipient],
+            selfWrapTargetRelays: selfWrapTargets,
             awaitRecipientOk: true,
           )
           .timeout(

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -6074,6 +6074,19 @@ class DmRepository {
     required Event deletion,
     required List<String> recipients,
   }) async {
+    // Resolve every recipient's kind-10050 inbox concurrently BEFORE the loop,
+    // exactly as `sendMessage` and `sendGroupMessage` do. Without it the
+    // OK-confirm below is satisfied by the default pool rather than the
+    // recipient's own inbox — a false "confirmed" for a recipient who only
+    // reads their advertised inbox. Resolution never throws (it degrades to
+    // null → default pool), so a failed lookup cannot abort the fan-out.
+    final inboxByRecipient = <String, List<String>?>{};
+    await Future.wait([
+      for (final recipient in recipients)
+        resolveDmInboxRelays(
+          recipient,
+        ).then((relays) => inboxByRecipient[recipient] = relays),
+    ]);
     NIP17SendSuccess? lastSuccess;
     final failures = <NIP17SendFailure>[];
     for (final recipient in recipients) {
@@ -6081,6 +6094,7 @@ class DmRepository {
           .sendRumor(
             rumorEvent: deletion,
             recipientPubkey: recipient,
+            targetRelays: inboxByRecipient[recipient],
             awaitRecipientOk: true,
           )
           .timeout(

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -735,7 +735,25 @@ class NIP17MessageService {
         // Kind-aware noun for logs and error strings: this path serves both
         // reaction (kind 7) and message (kind 14/15) sends, and a log that
         // says "reaction" for a text message misdirects field debugging.
-        final isReaction = rumorEvent.kind == EventKind.reaction;
+        // A wrapped kind-5 is a DELETION of something, and which noun it takes
+        // depends on what it deletes — a reaction removal and a message
+        // delete-for-everyone both arrive here as kind 5. NIP-09's `k` tag
+        // names the deleted kind, and both builders set it
+        // (`DmReactionsRepository._durablyDeleteReaction` writes 7,
+        // `DmRepository._driveDeleteForEveryone` writes the row's message
+        // kind), so read it rather than guessing. Without this a reaction
+        // removal logs as "message" and sends field debugging to the wrong
+        // send path.
+        final deletesReaction =
+            rumorEvent.kind == EventKind.eventDeletion &&
+            rumorEvent.tags.any(
+              (tag) =>
+                  tag.length >= 2 &&
+                  tag[0] == 'k' &&
+                  tag[1] == '${EventKind.reaction}',
+            );
+        final isReaction =
+            rumorEvent.kind == EventKind.reaction || deletesReaction;
         final rumorNoun = isReaction ? 'reaction' : 'message';
         final rumorNounCapitalized = isReaction ? 'Reaction' : 'Message';
 

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -2186,6 +2186,64 @@ void main() {
           expect(resolveCalls, 1);
         },
       );
+
+      test(
+        'an emoji swap persists its deletion before inbox resolution finishes',
+        () async {
+          final deletionRumor = reactionRumor(
+            id: _giftWrapId,
+            content: '',
+            kind: EventKind.eventDeletion,
+            tags: [
+              ['e', _reactionRumorId],
+              ['k', EventKind.reaction.toString()],
+            ],
+          );
+          stubPublishPath(superseded: const [_reactionRumorId]);
+          when(
+            () => mockMessageService.buildRumor(
+              recipientPubkey: _otherPubkey,
+              content: '',
+              eventKind: EventKind.eventDeletion,
+              additionalTags: any(named: 'additionalTags'),
+            ),
+          ).thenReturn(deletionRumor);
+          when(
+            () => mockDao.markOwnDeletionPending(
+              id: _reactionRumorId,
+              ownerPubkey: _ownerPubkey,
+              deletionRumorJson: any(named: 'deletionRumorJson'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockDao.markDeletionSent(
+              id: _reactionRumorId,
+              ownerPubkey: _ownerPubkey,
+            ),
+          ).thenAnswer((_) async {});
+
+          final inboxResolution = Completer<List<String>?>();
+          addTearDown(() {
+            if (!inboxResolution.isCompleted) inboxResolution.complete(inbox);
+          });
+          final repository = createRepository()
+            ..setDmInboxRelayResolver((_) => inboxResolution.future);
+
+          final publish = publishReaction(repository);
+          await Future<void>.delayed(Duration.zero);
+
+          verify(
+            () => mockDao.markOwnDeletionPending(
+              id: _reactionRumorId,
+              ownerPubkey: _ownerPubkey,
+              deletionRumorJson: any(named: 'deletionRumorJson'),
+            ),
+          ).called(1);
+
+          inboxResolution.complete(inbox);
+          await publish;
+        },
+      );
     });
   });
 }

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -1918,5 +1918,274 @@ void main() {
         },
       );
     });
+
+    // ------------------------------------------------------------------
+    // #7321 — kind-10050 inbox routing.
+    //
+    // Stubs live in this leaf group rather than a shared setUp: the shared-
+    // setup ratchet does not baseline this file, and a decision stub is only
+    // legible next to the tests it governs.
+    // ------------------------------------------------------------------
+    group('kind-10050 inbox routing (#7321)', () {
+      const inbox = ['wss://inbox.example'];
+
+      /// Stubs the optimistic insert + placeholder swap a `publish` needs, and
+      /// returns the rumor it will send.
+      Event stubPublishPath({List<String> superseded = const []}) {
+        final rumor = reactionRumor();
+        when(
+          () => mockMessageService.buildRumor(
+            recipientPubkey: _otherPubkey,
+            content: '🔥',
+            eventKind: EventKind.reaction,
+            additionalTags: any(named: 'additionalTags'),
+          ),
+        ).thenReturn(rumor);
+        when(
+          () => mockDao.insertOwnReactionSuperseding(
+            placeholderId: rumor.id,
+            conversationId: _conversationId,
+            targetMessageId: _targetMessageId,
+            targetMessageAuthor: _otherPubkey,
+            reactorPubkey: _ownerPubkey,
+            emoji: '🔥',
+            createdAt: rumor.createdAt,
+            ownerPubkey: _ownerPubkey,
+            rumorEventJson: jsonEncode(rumor.toJson()),
+          ),
+        ).thenAnswer((_) async => superseded);
+        when(
+          () => mockDao.swapPlaceholderId(
+            placeholderId: rumor.id,
+            realRumorId: rumor.id,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockMessageService.sendRumor(
+            rumorEvent: any(named: 'rumorEvent'),
+            recipientPubkey: any(named: 'recipientPubkey'),
+            targetRelays: any(named: 'targetRelays'),
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          ),
+        ).thenAnswer(
+          (_) async => NIP17SendResult.success(
+            rumorEventId: rumor.id,
+            messageEventId: _giftWrapId,
+            recipientPubkey: _otherPubkey,
+          ),
+        );
+        return rumor;
+      }
+
+      Future<DmReactionPublishResult> publishReaction(
+        DmReactionsRepository repository,
+      ) => repository.publish(
+        conversationId: _conversationId,
+        targetMessageId: _targetMessageId,
+        targetMessageAuthor: _otherPubkey,
+        emoji: '🔥',
+      );
+
+      test(
+        'routes the reaction wrap to the resolved kind-10050 inbox',
+        () async {
+          final rumor = stubPublishPath();
+          final repository = createRepository()
+            ..setDmInboxRelayResolver((_) async => inbox);
+
+          await publishReaction(repository);
+
+          // The exact resolved value, not any() — the whole defect was
+          // that this
+          // argument never arrived at all.
+          verify(
+            () => mockMessageService.sendRumor(
+              rumorEvent: rumor,
+              recipientPubkey: _otherPubkey,
+              targetRelays: inbox,
+              awaitRecipientOk: true,
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'falls back to the default pool when the recipient advertises no inbox',
+        () async {
+          final rumor = stubPublishPath();
+          final repository = createRepository()
+            ..setDmInboxRelayResolver((_) async => null);
+
+          await publishReaction(repository);
+
+          verify(
+            () => mockMessageService.sendRumor(
+              rumorEvent: rumor,
+              recipientPubkey: _otherPubkey,
+              // `any(that: isNull)` rather than a literal `null`: the literal
+              // matches sendRumor's default and trips
+              // avoid_redundant_argument_values, but asserting the fallback is
+              // the point of these three tests.
+              targetRelays: any(named: 'targetRelays', that: isNull),
+              awaitRecipientOk: true,
+            ),
+          ).called(1);
+        },
+      );
+
+      test('publishes untargeted when no resolver is wired', () async {
+        final rumor = stubPublishPath();
+        final repository = createRepository();
+
+        await publishReaction(repository);
+
+        verify(
+          () => mockMessageService.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _otherPubkey,
+            targetRelays: any(named: 'targetRelays', that: isNull),
+            awaitRecipientOk: true,
+          ),
+        ).called(1);
+      });
+
+      test(
+        'a throwing resolver degrades that recipient to the pool, '
+        'it does not fail the fan-out',
+        () async {
+          final rumor = stubPublishPath();
+          final repository = createRepository()
+            ..setDmInboxRelayResolver(
+              (_) async => throw StateError('resolver blew up'),
+            );
+
+          final result = await publishReaction(repository);
+
+          expect(result.success, isTrue);
+          verify(
+            () => mockMessageService.sendRumor(
+              rumorEvent: rumor,
+              recipientPubkey: _otherPubkey,
+              // `any(that: isNull)` rather than a literal `null`: the literal
+              // matches sendRumor's default and trips
+              // avoid_redundant_argument_values, but asserting the fallback is
+              // the point of these three tests.
+              targetRelays: any(named: 'targetRelays', that: isNull),
+              awaitRecipientOk: true,
+            ),
+          ).called(1);
+        },
+      );
+
+      test('routes the kind-5 reaction removal to the same inbox', () async {
+        final deletionRumor = reactionRumor(
+          id: _giftWrapId,
+          content: '',
+          kind: EventKind.eventDeletion,
+          tags: [
+            ['e', _reactionRumorId],
+            ['k', EventKind.reaction.toString()],
+          ],
+        );
+        when(
+          () => mockDao.markOwnDeletionPending(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+            deletionRumorJson: any(named: 'deletionRumorJson'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockMessageService.buildRumor(
+            recipientPubkey: _otherPubkey,
+            content: '',
+            eventKind: EventKind.eventDeletion,
+            additionalTags: any(named: 'additionalTags'),
+          ),
+        ).thenReturn(deletionRumor);
+        when(
+          () => mockMessageService.sendRumor(
+            rumorEvent: deletionRumor,
+            recipientPubkey: _otherPubkey,
+            targetRelays: any(named: 'targetRelays'),
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          ),
+        ).thenAnswer((_) async => const NIP17SendResult.failure('offline'));
+
+        final repository = createRepository()
+          ..setDmInboxRelayResolver((_) async => inbox);
+        await repository.removeOwn(
+          rumorId: _reactionRumorId,
+          targetMessageAuthor: _otherPubkey,
+        );
+        // _driveDeletion fires via unawaited; let it run.
+        await Future<void>.delayed(Duration.zero);
+
+        verify(
+          () => mockMessageService.sendRumor(
+            rumorEvent: deletionRumor,
+            recipientPubkey: _otherPubkey,
+            targetRelays: inbox,
+            awaitRecipientOk: true,
+          ),
+        ).called(1);
+      });
+
+      test(
+        'an emoji swap resolves the inbox once for both the kind-5 and kind-7',
+        () async {
+          final deletionRumor = reactionRumor(
+            id: _giftWrapId,
+            content: '',
+            kind: EventKind.eventDeletion,
+            tags: [
+              ['e', _reactionRumorId],
+              ['k', EventKind.reaction.toString()],
+            ],
+          );
+          stubPublishPath(superseded: const [_reactionRumorId]);
+          when(
+            () => mockDao.markOwnDeletionPending(
+              id: _reactionRumorId,
+              ownerPubkey: _ownerPubkey,
+              deletionRumorJson: any(named: 'deletionRumorJson'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockMessageService.buildRumor(
+              recipientPubkey: _otherPubkey,
+              content: '',
+              eventKind: EventKind.eventDeletion,
+              additionalTags: any(named: 'additionalTags'),
+            ),
+          ).thenReturn(deletionRumor);
+          // _driveDeletion writes this on a confirmed kind-5. Unstubbed it
+          // returns null, the await throws, and the drive logs "DM reaction
+          // deletion publish threw" — the test would still pass while
+          // exercising the error branch.
+          when(
+            () => mockDao.markDeletionSent(
+              id: _reactionRumorId,
+              ownerPubkey: _ownerPubkey,
+            ),
+          ).thenAnswer((_) async {});
+
+          var resolveCalls = 0;
+          final repository = createRepository()
+            ..setDmInboxRelayResolver((_) async {
+              resolveCalls++;
+              return inbox;
+            });
+
+          await publishReaction(repository);
+          await Future<void>.delayed(Duration.zero);
+
+          // One recipient, one tap — the supersede kind-5 and the new kind-7
+          // concern the same person at the same moment, so a second lookup
+          // would be latency for an answer that cannot have changed.
+          expect(resolveCalls, 1);
+        },
+      );
+    });
   });
 }

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -12405,6 +12405,138 @@ void main() {
         },
       );
 
+      test(
+        'routes the delete-for-everyone kind-5 to the recipient '
+        'kind-10050 inbox',
+        () async {
+          final repo = createRepository();
+
+          when(
+            () => mockDirectMessagesDao.getMessageById(
+              _rumorEventId,
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer(
+            (_) async => DirectMessageRow(
+              id: _rumorEventId,
+              conversationId: conversationId,
+              senderPubkey: _validPubkeyA, // current user
+              content: 'Hello',
+              createdAt: 1700000000,
+              giftWrapId: _giftWrapEventId,
+              messageKind: 14,
+              isDeleted: false,
+              twinCollapsed: false,
+            ),
+          );
+
+          when(
+            () => mockConversationsDao.getConversation(
+              conversationId,
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer(
+            (_) async => ConversationRow(
+              id: conversationId,
+              participantPubkeys: '["$_validPubkeyA","$_validPubkeyB"]',
+              isGroup: false,
+              createdAt: 1700000000,
+              isRead: true,
+              currentUserHasSent: true,
+            ),
+          );
+
+          stubSendRumor(
+            (rumorEvent, recipientPubkey) => NIP17SendResult.success(
+              rumorEventId: rumorEvent.id,
+              messageEventId: _giftWrapEventId,
+              recipientPubkey: recipientPubkey,
+            ),
+          );
+
+          when(
+            () => mockDirectMessagesDao.markMessageDeletionPending(
+              _rumorEventId,
+              deletionRumorJson: any(named: 'deletionRumorJson'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => true);
+          when(
+            () => mockDirectMessagesDao.markMessageDeletionSent(
+              _rumorEventId,
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => true);
+
+          when(
+            () => mockDirectMessagesDao.getMessagesForConversation(
+              conversationId,
+              limit: 1,
+              ownerPubkey: _validPubkeyA,
+            ),
+          ).thenAnswer((_) async => []);
+
+          when(
+            () => mockConversationsDao.upsertConversation(
+              id: any(named: 'id'),
+              participantPubkeys: any(named: 'participantPubkeys'),
+              isGroup: any(named: 'isGroup'),
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: any(named: 'lastMessageContent'),
+              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+              lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+              forceUpdateLastMessage: any(named: 'forceUpdateLastMessage'),
+            ),
+          ).thenAnswer((_) async {});
+
+          // Recipient advertises a DM inbox. Before #7321's sibling fix the
+          // delete-for-everyone fan-out omitted targetRelays entirely while
+          // still demanding an OK, so the OK came from the default pool — a
+          // false "confirmed" for an inbox-only reader.
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => answeredList([
+              Event(
+                _validPubkeyB,
+                EventKind.dmRelaysList,
+                [
+                  ['relay', 'wss://inbox.example'],
+                ],
+                '',
+                createdAt: 1700000000,
+              ),
+            ]),
+          );
+
+          await repo.deleteMessageForEveryone(_rumorEventId);
+          // The wire attempt is unawaited, so let it settle.
+          await Future<void>.delayed(Duration.zero);
+
+          verify(
+            () => mockMessageService.sendRumor(
+              rumorEvent: any(named: 'rumorEvent'),
+              recipientPubkey: _validPubkeyB,
+              targetRelays: ['wss://inbox.example'],
+              awaitRecipientOk: true,
+              selfWrapOnSoftUnconfirmed: any(
+                named: 'selfWrapOnSoftUnconfirmed',
+              ),
+            ),
+          ).called(1);
+        },
+      );
+
       // Regression for #7322: `getMessageById` has no `isDeleted`
       // predicate, so without the early return a repeat delete of the same
       // rumor passed both guards above and signed + published a SECOND

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -830,6 +830,7 @@ void main() {
           rumorEvent: any(named: 'rumorEvent'),
           recipientPubkey: any(named: 'recipientPubkey'),
           targetRelays: any(named: 'targetRelays'),
+          selfWrapTargetRelays: any(named: 'selfWrapTargetRelays'),
           awaitRecipientOk: any(named: 'awaitRecipientOk'),
           selfWrapOnSoftUnconfirmed: any(named: 'selfWrapOnSoftUnconfirmed'),
         ),
@@ -12411,6 +12412,10 @@ void main() {
         () async {
           final repo = createRepository();
 
+          when(() => mockNostrClient.configuredRelays).thenReturn(const [
+            'wss://relay.divine.video',
+          ]);
+
           when(
             () => mockDirectMessagesDao.getMessageById(
               _rumorEventId,
@@ -12506,17 +12511,23 @@ void main() {
               timeout: any(named: 'timeout'),
             ),
           ).thenAnswer(
-            (_) async => answeredList([
-              Event(
-                _validPubkeyB,
-                EventKind.dmRelaysList,
-                [
-                  ['relay', 'wss://inbox.example'],
-                ],
-                '',
-                createdAt: 1700000000,
-              ),
-            ]),
+            (invocation) async {
+              final filters =
+                  invocation.positionalArguments.first
+                      as List<nostr_filter.Filter>;
+              final author = filters.single.authors!.single;
+              return answeredList([
+                Event(
+                  author,
+                  EventKind.dmRelaysList,
+                  [
+                    ['relay', 'wss://inbox.example'],
+                  ],
+                  '',
+                  createdAt: 1700000000,
+                ),
+              ]);
+            },
           );
 
           await repo.deleteMessageForEveryone(_rumorEventId);
@@ -12528,6 +12539,10 @@ void main() {
               rumorEvent: any(named: 'rumorEvent'),
               recipientPubkey: _validPubkeyB,
               targetRelays: ['wss://inbox.example'],
+              selfWrapTargetRelays: const [
+                'wss://relay.divine.video',
+                'wss://inbox.example',
+              ],
               awaitRecipientOk: true,
               selfWrapOnSoftUnconfirmed: any(
                 named: 'selfWrapOnSoftUnconfirmed',

--- a/mobile/test/providers/dm_repository_provider_test.dart
+++ b/mobile/test/providers/dm_repository_provider_test.dart
@@ -50,6 +50,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(<nostr_filter.Filter>[_FakeFilter()]);
+    registerFallbackValue(Duration.zero);
   });
 
   group('dmRepositoryProvider (#2931)', () {
@@ -82,6 +83,22 @@ void main() {
         ),
       ).thenAnswer((_) => const Stream<Event>.empty());
       when(() => mockNostrClient.unsubscribe(any())).thenAnswer((_) async {});
+      when(
+        () => mockNostrClient.queryEventsDetailed(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+          tempRelays: any(named: 'tempRelays'),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async => (
+          events: const <Event>[],
+          noRelays: false,
+          timedOut: false,
+        ),
+      );
 
       // AuthService stubs for auth-state-driven providers.
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
@@ -140,6 +157,10 @@ void main() {
       ).called(1);
       expect(repository.isInitialized, isTrue);
       expect(repository.userPubkey, equals(testPubkey));
+      expect(
+        container.read(dmReactionsRepositoryProvider).hasDmInboxRelayResolver,
+        isTrue,
+      );
     });
 
     // #8391: the removal policy is what stops ANY caller destroying a Divine


### PR DESCRIPTION
## Summary

Gift-wrapped DM reactions (kind 7) and reaction removals (kind 5) were published to the device's connected relay pool instead of the recipient's advertised NIP-17 kind-10050 inbox. Because those paths still required an `OK true`, an acknowledgement from any pool relay could mark a reaction sent even when the recipient's inbox never received it.

This PR injects a DM-inbox resolver into `DmReactionsRepository`, resolves recipients concurrently, and passes the resolved relays through every reaction publish and retry path. Missing, empty, or failed resolution safely falls back to the existing untargeted behavior.

It also fixes the same recipient-routing omission on delete-for-everyone messages and routes that deletion's self-wrap to the sender's own inbox.

Fixes #7321

## Durability and startup ordering

- A reaction swap starts inbox discovery immediately but persists the superseded reaction's pending deletion before awaiting discovery. An app termination during a stalled relay query therefore cannot lose the durable retry record.
- The retry provider explicitly watches `dmRepositoryProvider` before constructing the reaction retry service. This guarantees the resolver is wired before the service's immediate foreground sweep; a provider-level assertion guards the production wiring.

## Changes outside #7321

- `DmRepository._fanOutDeletion` now routes both the recipient wrap and the sender self-wrap to their advertised inbox relays.
- Wrapped kind-5 reaction removals are logged as reactions by inspecting the NIP-09 `k` tag. This is log-only and does not change the event.

## Scope

- Reaction self-wrap routing remains tracked by #8446.
- Message-path false-delivery behavior when an inbox cannot be resolved remains tracked by #7317.

## Verification

- `flutter analyze` on all affected source and test paths: clean
- Focused provider, reaction-repository, and DM-repository suites: 470 passed
- Pre-push affected suites: 472 passed
- Regression tests cover recipient routing, fallback behavior, reaction removal and swap routing, the pre-resolution durability boundary, deletion self-wrap routing, and provider wiring

The branch is rebased onto current `origin/main`, including #8435's `selfWrapTargetRelays` support.
