### PR TITLE
docs(nostr_sdk): replace the settle window's latency basis with measured data

### DIFF
--- a/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
@@ -147,9 +147,10 @@ class PublishOutcome {
 ///    most [fanOutReportGrace], so a publish that times out mid-fan-out can
 ///    still tell an unreached target from a silent one.
 ///
-/// The settle window bounds the cost of one wedged relay: healthy relays
-/// answer in single-digit milliseconds, so waiting the full [timeout] for a
-/// silent sibling would stall every publish behind the slowest connection.
+/// The settle window bounds the cost of one wedged relay: waiting the full
+/// [timeout] for a silent sibling would stall every publish behind the
+/// slowest connection. See [PublishTracker.defaultSettleWindow] for the
+/// latency it is sized against.
 class PublishTracker {
   PublishTracker({
     required this.eventId,
@@ -166,10 +167,31 @@ class PublishTracker {
 
   /// Grace period granted to the remaining relays after the first answer.
   ///
-  /// Sized against measured relay behaviour: a healthy relay returns `OK`
-  /// within a few milliseconds, so this is orders of magnitude of headroom
-  /// while still capping a wedged relay far below the publish timeout. Revisit
-  /// once publish telemetry gives a real latency distribution.
+  /// #6583 sized this against "a few milliseconds" and asked to be revisited
+  /// once real publish telemetry existed. It now does. Measured against
+  /// production `relay.divine.video` on the shape that stresses this most --
+  /// kind-1059 gift wraps, which pay more pre-`OK` ClickHouse round trips than
+  /// any other kind on the relay's ingest path (#7442,
+  /// 2026-08-31, n=330 over three runs, one connection, sequential sends):
+  ///
+  ///     p50 245ms   p90 290ms   p95 310ms   p99 1044ms   max 15.9s
+  ///
+  /// A healthy answer is ~50x the figure this was sized against, so the
+  /// headroom is ~3x at p95 rather than orders of magnitude -- and the window
+  /// sits *below* the measured p99. A sibling answering in the tail is
+  /// therefore recorded in [PublishOutcome.noResponseFrom] even though it
+  /// accepted, which is a false negative this constant chooses to accept.
+  ///
+  /// Left at 1s deliberately: widening it slows every publish that has a
+  /// wedged relay in its fan-out, and the error is asymmetric -- a publish
+  /// still succeeds on [PublishOutcome.acceptedByAny], so a missed sibling
+  /// costs breadth reporting rather than delivery.
+  ///
+  /// Watch the tail rather than the median. Those runs saw ~0.6% of publishes
+  /// hit a relay-wide stall of 4-16s, long enough to miss even the 10s
+  /// `DmSendBudget.recipientOkConfirm`. No settle window of this order can
+  /// absorb that, and it is not specific to any kind: the auto-allowed
+  /// control kind was hit in the same windows.
   static const defaultSettleWindow = Duration(seconds: 1);
 
   /// How long [timeout] may overrun while waiting for the fan-out's report.


### PR DESCRIPTION
## Summary

`PublishTracker.defaultSettleWindow` is the grace period a publish gives the
remaining relays after the first one answers. #6583 sized it against "a few
milliseconds" of relay answer latency and its own doc asked to be revisited
"once publish telemetry gives a real latency distribution".

Measuring #7442 produced that distribution. The figure is wrong by ~50x.

This PR changes **no behaviour** — only the comment, so the constant stops
justifying itself with a number that is not true.

## The measurement

Production `wss://relay.divine.video`, n=330 kind-1059 gift wraps across three
runs, one WebSocket, strictly sequential sends (the shape the DM client
actually produces), alternated against a matched control kind so relay load
could not land on one arm:

| | p50 | p90 | p95 | p99 | max |
|---|---|---|---|---|---|
| kind 1059 (3 kind-gate lookups) | 245ms | 290ms | 310ms | 1044ms | 15.9s |
| kind 30078 (auto-allowed, 1 lookup) | 224ms | 267ms | 285ms | 363ms | 5.4s |

Full method, the A/B control design, and the raw percentiles are in the
measurement writeup on #7442:
https://github.com/divinevideo/divine-mobile/issues/7442#issuecomment-5479785031

## What the comment got wrong

1. **"a healthy relay returns `OK` within a few milliseconds"** — it is ~245ms.
2. **"orders of magnitude of headroom"** — it is ~3x at p95.
3. Not previously stated, and the sharper point: **the 1s window sits below the
   measured p99 of 1044ms.** A sibling relay answering in the tail is recorded
   in `PublishOutcome.noResponseFrom` even though it accepted. The comment now
   documents that false negative instead of implying it cannot happen.

## Why the value is unchanged

Widening the window slows every publish that has a wedged relay in its fan-out,
and the error is asymmetric: a publish still succeeds on
`PublishOutcome.acceptedByAny`, so a missed sibling costs breadth *reporting*,
not delivery. Changing it is a behaviour change that this measurement does not
by itself justify — flagged in the comment for whoever picks it up.

## Also

The same "single-digit milliseconds" claim appeared in the `PublishTracker`
class doc. That copy is removed and points at the constant, so the number lives
in one place.

## Testing

- `flutter test test/unit/publish_outcome_test.dart test/unit/relay_pool_auth_test.dart` — 42 passed
- `dart format` clean, `flutter analyze` clean

No test is added: the change is a doc comment. I considered pinning the
constant against the measured p99 in a test, and rejected it — encoding a
production measurement as a unit-test invariant would fail on relay changes
that are not regressions in this code.

## Risk

None to behaviour. The risk is that the numbers age; they are dated and
attributed in the comment so a future reader can tell.

Refs #7442
