### PR TITLE
fix(dm): make the forced recovery drain actually reach the window it was bumped for

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1551,15 +1551,7 @@ class DmRepository {
     // the relay still holds unrecovered history. A drain-version bump clears
     // the stale flag once so recovery runs again. No-op once at the current
     // version, so it does not loop on every inbox open. See #5202.
-    final wasComplete = syncState.historyDrainComplete(pubkey);
     await syncState.upgradeDrainVersionIfNeeded(pubkey);
-    // A pass the version bump un-latched, rather than an ordinary drain. The
-    // completion log below reports it separately: nothing else can size how
-    // much a forced recovery actually recovers, and #8362 shipped without
-    // being able to answer that. Derived from the flag transition rather than
-    // a return value so no API surface is added for a log line.
-    final forcedRecovery =
-        wasComplete && !syncState.historyDrainComplete(pubkey);
     if (syncState.historyDrainComplete(pubkey)) {
       Log.info(
         'DM history drain skipped for ${pubkeyForLogs(pubkey)}: already '
@@ -1773,8 +1765,6 @@ class DmRepository {
           await _restoreReadStateAfterDrain(pubkey, gen);
           Log.info(
             'DM history drain complete for ${pubkeyForLogs(pubkey)}: '
-            '${forcedRecovery ? 'forced recovery pass '
-                      '(v${DmSyncState.currentDrainVersion}), ' : ''}'
             'pages=$pagesRun, eventsFetched=$totalEvents',
             category: LogCategory.system,
           );

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1551,7 +1551,15 @@ class DmRepository {
     // the relay still holds unrecovered history. A drain-version bump clears
     // the stale flag once so recovery runs again. No-op once at the current
     // version, so it does not loop on every inbox open. See #5202.
+    final wasComplete = syncState.historyDrainComplete(pubkey);
     await syncState.upgradeDrainVersionIfNeeded(pubkey);
+    // A pass the version bump un-latched, rather than an ordinary drain. The
+    // completion log below reports it separately: nothing else can size how
+    // much a forced recovery actually recovers, and #8362 shipped without
+    // being able to answer that. Derived from the flag transition rather than
+    // a return value so no API surface is added for a log line.
+    final forcedRecovery =
+        wasComplete && !syncState.historyDrainComplete(pubkey);
     if (syncState.historyDrainComplete(pubkey)) {
       Log.info(
         'DM history drain skipped for ${pubkeyForLogs(pubkey)}: already '
@@ -1765,6 +1773,8 @@ class DmRepository {
           await _restoreReadStateAfterDrain(pubkey, gen);
           Log.info(
             'DM history drain complete for ${pubkeyForLogs(pubkey)}: '
+            '${forcedRecovery ? 'forced recovery pass '
+                      '(v${DmSyncState.currentDrainVersion}), ' : ''}'
             'pages=$pagesRun, eventsFetched=$totalEvents',
             category: LogCategory.system,
           );

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -220,8 +220,7 @@ class DmSyncState {
 
     if (!repaired) return;
 
-    await _prefs.remove('$_drainCompletePrefix$pubkey');
-    await _prefs.setInt('$_drainCursorPrefix$pubkey', nowSec);
+    await _armRedrainFromNow(pubkey, nowSec);
   }
 
   /// Whether the one-time full-history drain has completed for [pubkey].
@@ -281,35 +280,19 @@ class DmSyncState {
   /// that cannot contain it. Seeding at now covers both. See #8362.
   Future<void> upgradeDrainVersionIfNeeded(String pubkey) async {
     if (drainVersion(pubkey) >= currentDrainVersion) return;
-    if (_needsForcedRedrain(pubkey)) {
-      await _prefs.remove('$_drainCompletePrefix$pubkey');
-      await _prefs.setInt(
-        '$_drainCursorPrefix$pubkey',
+    if (historyDrainComplete(pubkey)) {
+      await _armRedrainFromNow(
+        pubkey,
         DateTime.now().millisecondsSinceEpoch ~/ 1000,
       );
     }
     await setDrainVersion(pubkey, currentDrainVersion);
   }
 
-  /// Whether a version bump has anything to recover for [pubkey].
-  ///
-  /// Two conditions, both necessary:
-  ///
-  /// * [historyDrainComplete] — only a *latched* install needs forcing. One
-  ///   that never completed a drain still owns a meaningful resume state, and
-  ///   overwriting its cursor here would widen an ordinary in-progress drain
-  ///   for no recovery benefit.
-  /// * [newestSyncedAt] is non-null — the install has processed at least one
-  ///   DM under some build. A latched install that never processed one drained
-  ///   an empty history and would drain an empty history again.
-  ///
-  /// Deliberately *not* "the rumor boundary leads the wire boundary". That
-  /// reads like stronger evidence and is weaker: an unwrapped NIP-04 kind 4
-  /// feeds its own `created_at` to both boundaries, so an install whose newest
-  /// DM is a legacy kind 4 has `newestSyncedAt == newestWireSyncedAt` and
-  /// would be skipped while still holding a stranded NIP-17 band. See #8362.
-  bool _needsForcedRedrain(String pubkey) =>
-      historyDrainComplete(pubkey) && newestSyncedAt(pubkey) != null;
+  Future<void> _armRedrainFromNow(String pubkey, int nowSec) async {
+    await _prefs.remove('$_drainCompletePrefix$pubkey');
+    await _prefs.setInt('$_drainCursorPrefix$pubkey', nowSec);
+  }
 
   /// The outer gift-wrap `created_at` (unix seconds) the history drain has
   /// paged down to for [pubkey], or `null` if no drain has persisted a

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -56,7 +56,20 @@ class DmSyncState {
   /// drain; the gift wraps are still there to recover (funnelcake retains kind
   /// 1059 indefinitely), and the drain is unawaited background work that
   /// resumes from its persisted cursor, so the cost is bounded and one-time.
-  static const int currentDrainVersion = 4;
+  ///
+  /// Bumped to 5 for #8362: #8217 and #8361 fixed #8209's two mechanisms
+  /// forward, but neither recovers a gift wrap an install already lost. The
+  /// `since:` fix only re-exposes a band as wide as the newest wrap's own
+  /// backdate, and that floor only rises, so anything missed longer ago stays
+  /// outside every future window. The history drain is the one path that
+  /// reaches below the live window, and an established install has already
+  /// latched [historyDrainComplete].
+  ///
+  /// This bump is only useful together with the cursor seeding fixed in
+  /// [upgradeDrainVersionIfNeeded]: on its own it re-reads history below
+  /// [oldestSyncedAt], recovers nothing, and re-latches completion off the
+  /// resulting empty page — spending the recovery pass it exists to provide.
+  static const int currentDrainVersion = 5;
 
   /// Maximum clock skew, in seconds, tolerated on a self-asserted DM
   /// `created_at` before callers should stop treating it as an honest send
@@ -243,19 +256,60 @@ class DmSyncState {
 
   /// Forces a one-time re-drain for [pubkey] when its persisted
   /// [drainVersion] is below [currentDrainVersion], by clearing the
-  /// completion flag and resume cursor, then stamping the current version.
+  /// completion flag and seeding the resume cursor at now, then stamping the
+  /// current version.
   ///
   /// This is the recovery path for installs stranded by an older drain that
   /// marked [historyDrainComplete] without fully recovering history (#5202).
   /// A no-op for fresh installs (nothing to clear) and for installs already
   /// at the current version. Idempotent: after the bump the version matches,
   /// so it does not loop on every inbox open.
+  ///
+  /// The cursor is **seeded at now, not removed** — for the same reason
+  /// [repairPoisonedBoundaries] seeds it. `DmRepository` resolves the drain's
+  /// `until:` as `historyDrainCursor ?? oldestSyncedAt ?? now` and pages
+  /// strictly downward from it, and [markHistoryDrainComplete] has already
+  /// removed the cursor on any install this method can help. Removing it
+  /// therefore seeds from [oldestSyncedAt] — the floor of the account's whole
+  /// history — so the pass re-reads only history the install already has.
+  ///
+  /// That was survivable for the earlier bumps because their missing history
+  /// sat *below* [oldestSyncedAt]: a prematurely latched drain has more
+  /// history underneath it. #8209's `since:` residue is the first class where
+  /// the loss sits *above* the seed, near the live window's own floor, so
+  /// removing the cursor would spend the one-shot recovery pass on a window
+  /// that cannot contain it. Seeding at now covers both. See #8362.
   Future<void> upgradeDrainVersionIfNeeded(String pubkey) async {
     if (drainVersion(pubkey) >= currentDrainVersion) return;
-    await _prefs.remove('$_drainCompletePrefix$pubkey');
-    await _prefs.remove('$_drainCursorPrefix$pubkey');
+    if (_needsForcedRedrain(pubkey)) {
+      await _prefs.remove('$_drainCompletePrefix$pubkey');
+      await _prefs.setInt(
+        '$_drainCursorPrefix$pubkey',
+        DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
+    }
     await setDrainVersion(pubkey, currentDrainVersion);
   }
+
+  /// Whether a version bump has anything to recover for [pubkey].
+  ///
+  /// Two conditions, both necessary:
+  ///
+  /// * [historyDrainComplete] — only a *latched* install needs forcing. One
+  ///   that never completed a drain still owns a meaningful resume state, and
+  ///   overwriting its cursor here would widen an ordinary in-progress drain
+  ///   for no recovery benefit.
+  /// * [newestSyncedAt] is non-null — the install has processed at least one
+  ///   DM under some build. A latched install that never processed one drained
+  ///   an empty history and would drain an empty history again.
+  ///
+  /// Deliberately *not* "the rumor boundary leads the wire boundary". That
+  /// reads like stronger evidence and is weaker: an unwrapped NIP-04 kind 4
+  /// feeds its own `created_at` to both boundaries, so an install whose newest
+  /// DM is a legacy kind 4 has `newestSyncedAt == newestWireSyncedAt` and
+  /// would be skipped while still holding a stranded NIP-17 band. See #8362.
+  bool _needsForcedRedrain(String pubkey) =>
+      historyDrainComplete(pubkey) && newestSyncedAt(pubkey) != null;
 
   /// The outer gift-wrap `created_at` (unix seconds) the history drain has
   /// paged down to for [pubkey], or `null` if no drain has persisted a

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -435,7 +435,7 @@ class _FakeDmSyncState implements DmSyncState {
   Future<void> upgradeDrainVersionIfNeeded(String pubkey) async {
     if (drainVersionOverride >= DmSyncState.currentDrainVersion) return;
     upgradedPubkeys.add(pubkey);
-    if (drainCompleteOverride && newestOverride != null) {
+    if (drainCompleteOverride) {
       drainCompleteOverride = false;
       drainCursorOverride = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     }
@@ -446,11 +446,28 @@ class _FakeDmSyncState implements DmSyncState {
   Future<void> repairPoisonedBoundaries(String pubkey) async {
     repairedPubkeys.add(pubkey);
     final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    var repaired = false;
     final newest = newestOverride;
-    if (newest != null && newest > nowSec + DmSyncState.maxFutureSkewSeconds) {
+    if (newest != null && newest > nowSec) {
       newestOverride = nowSec;
+      repaired = true;
+    }
+    final newestWire = newestWireOverride;
+    if (newestWire != null && newestWire > nowSec) {
+      newestWireOverride = nowSec;
+      repaired = true;
+    }
+    final oldest = oldestOverride;
+    if (oldest != null &&
+        (oldest < DmSyncState.minPlausibleCreatedAt || oldest > nowSec)) {
+      oldestOverride = oldest < DmSyncState.minPlausibleCreatedAt
+          ? DmSyncState.minPlausibleCreatedAt
+          : nowSec;
+      repaired = true;
+    }
+    if (repaired) {
       drainCompleteOverride = false;
-      drainCursorOverride = null;
+      drainCursorOverride = nowSec;
     }
   }
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -435,8 +435,10 @@ class _FakeDmSyncState implements DmSyncState {
   Future<void> upgradeDrainVersionIfNeeded(String pubkey) async {
     if (drainVersionOverride >= DmSyncState.currentDrainVersion) return;
     upgradedPubkeys.add(pubkey);
-    drainCompleteOverride = false;
-    drainCursorOverride = null;
+    if (drainCompleteOverride && newestOverride != null) {
+      drainCompleteOverride = false;
+      drainCursorOverride = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    }
     drainVersionOverride = DmSyncState.currentDrainVersion;
   }
 
@@ -6369,13 +6371,19 @@ void main() {
         're-runs once for an install stranded complete by an older drain '
         '(drainVersion below current) — #5202',
         () async {
+          final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          final oldestRumor = nowSec - 90 * 86400;
           final capturedUntil = <int?>[];
           stubFiniteHistory(const <Event>[], capturedUntil);
 
           // Pre-#5202 install: flagged complete at an older drain version
-          // while history still exists on the relay.
+          // while history still exists on the relay. oldestSyncedAt is set
+          // because a real install always has one - leaving it null let the
+          // seed fall through to `now` and made this assertion vacuous.
           final syncState = _FakeDmSyncState()
             ..drainCompleteOverride = true
+            ..newestOverride = nowSec - 3600
+            ..oldestOverride = oldestRumor
             ..drainVersionOverride = 0;
           final repository = createRepository(syncState: syncState);
 
@@ -6385,6 +6393,9 @@ void main() {
           // then re-completed cleanly (default 3 relays connected).
           expect(syncState.upgradedPubkeys, isNotEmpty);
           expect(capturedUntil, isNotEmpty);
+          // Not merely "a query happened": the forced pass must start ABOVE
+          // oldestSyncedAt, or it only re-reads history the install has.
+          expect(capturedUntil.first, greaterThan(oldestRumor));
           expect(syncState.drainCompleteOverride, isTrue);
           expect(
             syncState.drainVersionOverride,
@@ -6394,9 +6405,50 @@ void main() {
       );
 
       test(
+        'a forced re-drain requests the recent window the eroded since: '
+        'stranded, not just history below oldestSyncedAt — #8362',
+        () async {
+          final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          // Established install: the drain completed months ago, so
+          // markHistoryDrainComplete already removed the resume cursor and
+          // oldestSyncedAt is the floor of the whole account history.
+          final oldestRumor = nowSec - 90 * 86400;
+          // A gift wrap the pre-#8361 `since:` window dropped. Its OUTER
+          // stamp sits just under the two-day overlap - far ABOVE the
+          // account's oldest rumor, which is why seeding the forced pass at
+          // oldestSyncedAt never asks for it.
+          final strandedOuter = nowSec - 2 * 86400 - 3600;
+
+          final capturedUntil = <int?>[];
+          stubFiniteHistory(<Event>[deletion(strandedOuter)], capturedUntil);
+
+          final syncState = _FakeDmSyncState()
+            ..drainCompleteOverride = true
+            ..newestOverride = nowSec - 3600
+            ..oldestOverride = oldestRumor
+            ..drainVersionOverride = DmSyncState.currentDrainVersion - 1;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          expect(syncState.upgradedPubkeys, isNotEmpty);
+          expect(
+            capturedUntil.any((until) => (until ?? 0) >= strandedOuter),
+            isTrue,
+            reason:
+                'the forced pass must request a window that covers the '
+                'stranded wrap; seeding at oldestSyncedAt asks only for '
+                '${nowSec - oldestRumor}s-old history and recovers nothing',
+          );
+        },
+      );
+
+      test(
         're-arms an install the pre-#8209 drain latched complete while '
         'history was still on the relay',
         () async {
+          final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          final oldestRumor = nowSec - 90 * 86400;
           final capturedUntil = <int?>[];
           stubFiniteHistory(const <Event>[], capturedUntil);
 
@@ -6408,6 +6460,8 @@ void main() {
           // fails if #8209 ships without one.
           final syncState = _FakeDmSyncState()
             ..drainCompleteOverride = true
+            ..newestOverride = nowSec - 3600
+            ..oldestOverride = oldestRumor
             ..drainVersionOverride = 3;
           final repository = createRepository(syncState: syncState);
 
@@ -6415,6 +6469,7 @@ void main() {
 
           expect(syncState.upgradedPubkeys, isNotEmpty);
           expect(capturedUntil, isNotEmpty);
+          expect(capturedUntil.first, greaterThan(oldestRumor));
           expect(syncState.drainCompleteOverride, isTrue);
         },
       );

--- a/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
@@ -226,19 +226,55 @@ void main() {
       });
 
       test(
-        'upgradeDrainVersionIfNeeded clears a stale completion flag + cursor '
-        'and stamps the current version when below it',
+        'upgradeDrainVersionIfNeeded clears a stale completion flag, seeds the '
+        'cursor at now, and stamps the current version when below it',
         () async {
-          // Simulate an install stranded by an older, buggy drain.
+          final before = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          // Simulate an install stranded by an older, buggy drain. It has
+          // processed DMs, which is what distinguishes it from an install
+          // whose completed drain genuinely found nothing.
+          await state.recordSeen(pkA, createdAt: before - 3600);
           await state.markHistoryDrainComplete(pkA);
           await state.setHistoryDrainCursor(pkA, 1234);
           expect(state.historyDrainComplete(pkA), isTrue);
 
           await state.upgradeDrainVersionIfNeeded(pkA);
+          final after = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
           expect(state.historyDrainComplete(pkA), isFalse);
-          expect(state.historyDrainCursor(pkA), isNull);
+          // Seeded at now, NOT removed. Removing it would let the drain fall
+          // back to oldestSyncedAt and re-read only history the install
+          // already has, which is the whole defect in #8362.
+          expect(
+            state.historyDrainCursor(pkA),
+            inInclusiveRange(before, after),
+          );
           expect(state.drainVersion(pkA), DmSyncState.currentDrainVersion);
+        },
+      );
+
+      test(
+        'the seeded cursor is above a realistic oldestSyncedAt, so the forced '
+        'pass covers the recent window a bare clear would skip — #8362',
+        () async {
+          final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          // Established install: months of history, drain long since latched.
+          await state.recordSeen(pkA, createdAt: nowSec - 90 * 86400);
+          await state.recordSeen(pkA, createdAt: nowSec - 3600);
+          await state.markHistoryDrainComplete(pkA);
+          await state.setDrainVersion(pkA, DmSyncState.currentDrainVersion - 1);
+
+          await state.upgradeDrainVersionIfNeeded(pkA);
+
+          final cursor = state.historyDrainCursor(pkA);
+          expect(cursor, isNotNull);
+          expect(
+            cursor,
+            greaterThan(state.oldestSyncedAt(pkA)!),
+            reason: 'a cursor at oldestSyncedAt cannot reach the stranded band',
+          );
+          // The band #8361 re-exposes sits just under the two-day overlap.
+          expect(cursor, greaterThan(nowSec - 2 * 86400));
         },
       );
 
@@ -271,6 +307,10 @@ void main() {
             reason: 'drain version must advance past the pre-#5304 value (2)',
           );
 
+          await state.recordSeen(
+            pkA,
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 - 3600,
+          );
           await state.setDrainVersion(pkA, 2);
           await state.markHistoryDrainComplete(pkA);
 

--- a/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
@@ -230,9 +230,7 @@ void main() {
         'cursor at now, and stamps the current version when below it',
         () async {
           final before = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-          // Simulate an install stranded by an older, buggy drain. It has
-          // processed DMs, which is what distinguishes it from an install
-          // whose completed drain genuinely found nothing.
+          // Simulate an established install stranded by an older, buggy drain.
           await state.recordSeen(pkA, createdAt: before - 3600);
           await state.markHistoryDrainComplete(pkA);
           await state.setHistoryDrainCursor(pkA, 1234);
@@ -275,6 +273,42 @@ void main() {
           );
           // The band #8361 re-exposes sits just under the two-day overlap.
           expect(cursor, greaterThan(nowSec - 2 * 86400));
+        },
+      );
+
+      test(
+        're-arms a completed pre-guard drain with no recorded messages',
+        () async {
+          final before = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          await state.markHistoryDrainComplete(pkA);
+          await state.setDrainVersion(pkA, 0);
+
+          expect(state.newestSyncedAt(pkA), isNull);
+          expect(state.oldestSyncedAt(pkA), isNull);
+
+          await state.upgradeDrainVersionIfNeeded(pkA);
+
+          final after = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          expect(state.historyDrainComplete(pkA), isFalse);
+          expect(
+            state.historyDrainCursor(pkA),
+            inInclusiveRange(before, after),
+          );
+          expect(state.drainVersion(pkA), DmSyncState.currentDrainVersion);
+        },
+      );
+
+      test(
+        'preserves an in-progress drain cursor while stamping its version',
+        () async {
+          await state.setHistoryDrainCursor(pkA, 1234);
+          await state.setDrainVersion(pkA, 0);
+
+          await state.upgradeDrainVersionIfNeeded(pkA);
+
+          expect(state.historyDrainComplete(pkA), isFalse);
+          expect(state.historyDrainCursor(pkA), 1234);
+          expect(state.drainVersion(pkA), DmSyncState.currentDrainVersion);
         },
       );
 


### PR DESCRIPTION
Fixes #8362

## Problem

Earlier DM sync bugs could permanently strand gift wraps outside the live subscription window. Those bugs are fixed for new traffic, but installs that already marked their history drain complete never query the missing window again.

A drain-version bump is the existing one-time recovery mechanism. The old bump path cleared its cursor, however, so the next drain fell back to the account's oldest locally known message and paged downward. That re-read history the install already had instead of the newer gap the bump was meant to recover.

## Fix

- Bump `DmSyncState.currentDrainVersion` from 4 to 5.
- Re-arm completed older drains with a cursor seeded at the current time, so pagination covers the stranded window before moving into older history.
- Apply the recovery to every completed older drain, including pre-#8217 false-latch installs that recorded no messages and therefore have null sync boundaries.
- Preserve the cursor of an ordinary drain that is still in progress.
- Share the re-arm operation with poisoned-boundary repair so the two recovery paths cannot diverge again.
- Align the repository test double with production boundary repair behavior.

Already persisted wraps are rejected by the batch dedup probe before local or remote decryption, so the widened pass costs relay bandwidth and database reads rather than repeated signer RPCs.

## Deliberately unchanged

Late-delivered wraps can still fall below the live window after this recovery. That separate case remains tracked in #8439.

The PR does not label `eventsFetched` as recovered messages: that value is counted before deduplication and a multi-run forced pass would lose an in-memory label at the page cap.

## Verification

- `flutter test` in `mobile/packages/dm_repository`: 754 passed
- `flutter analyze lib test` in `mobile/packages/dm_repository`: clean
- Pre-push changed-file analysis and tests: clean
