### PR TITLE
fix(observability): report the real memory peak, pressure events, and stop crowding the log

### DIFF
--- a/mobile/lib/app/divine_app.dart
+++ b/mobile/lib/app/divine_app.dart
@@ -235,9 +235,24 @@ class _DivineAppState extends ConsumerState<DivineApp>
 
   static const int _bytesPerMb = 1024 * 1024;
 
-  static int _currentRssBytes() => kIsWeb ? 0 : io.ProcessInfo.currentRss;
+  static int _currentRssBytes() => _probe(() => io.ProcessInfo.currentRss);
 
-  static int _peakRssBytes() => kIsWeb ? 0 : io.ProcessInfo.maxRss;
+  static int _peakRssBytes() => _probe(() => io.ProcessInfo.maxRss);
+
+  /// Reads a `ProcessInfo` memory gauge, or 0 where it is unavailable.
+  ///
+  /// The probes throw on platforms that do not implement them. A throw here
+  /// would take out the memory-pressure handler's load shedding along with
+  /// the reading, which is the opposite of what the caller needs.
+  static int _probe(int Function() read) {
+    if (kIsWeb) return 0;
+    try {
+      final value = read();
+      return value < 0 ? 0 : value;
+    } on Object catch (_) {
+      return 0;
+    }
+  }
 
   static String _rssMb(int bytes) => (bytes / _bytesPerMb).toStringAsFixed(1);
 

--- a/mobile/lib/app/divine_app.dart
+++ b/mobile/lib/app/divine_app.dart
@@ -149,7 +149,8 @@ class _DivineAppState extends ConsumerState<DivineApp>
       },
     );
     _memoryTelemetry = MemoryTelemetryService(
-      readRssBytes: () => kIsWeb ? 0 : io.ProcessInfo.currentRss,
+      readRssBytes: _currentRssBytes,
+      readPeakRssBytes: _peakRssBytes,
       nativeControllerCount: () =>
           DivineVideoPlayerController.liveControllerCount,
       queueDepth: () =>
@@ -217,8 +218,28 @@ class _DivineAppState extends ConsumerState<DivineApp>
 
   @override
   void didHaveMemoryPressure() {
+    // Warning, not info: a bug report keeps the last 200 error/warning
+    // entries but only the last 50 of any level, so an info line is gone
+    // within a minute of ordinary use. This is the one signal that tells an
+    // OS memory kill apart from a native crash Crashlytics missed (#8300),
+    // so it has to survive a whole session.
+    Log.warning(
+      'OS memory pressure at rss ${_rssMb(_currentRssBytes())} MB '
+      '(peak ${_rssMb(_peakRssBytes())} MB) — shedding image cache '
+      'and low-priority ingestion',
+      name: 'MemoryTelemetry',
+      category: LogCategory.system,
+    );
     _memoryPressureHandler.onMemoryPressure();
   }
+
+  static const int _bytesPerMb = 1024 * 1024;
+
+  static int _currentRssBytes() => kIsWeb ? 0 : io.ProcessInfo.currentRss;
+
+  static int _peakRssBytes() => kIsWeb ? 0 : io.ProcessInfo.maxRss;
+
+  static String _rssMb(int bytes) => (bytes / _bytesPerMb).toStringAsFixed(1);
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
@@ -243,9 +264,8 @@ class _DivineAppState extends ConsumerState<DivineApp>
   /// Logs a memory snapshot at info and annotates Crashlytics custom keys so
   /// OOM crash reports carry the last-seen memory footprint and gauges.
   void _emitMemorySnapshot(MemorySnapshot snapshot) {
-    const bytesPerMb = 1024 * 1024;
-    final rssMb = (snapshot.rssBytes / bytesPerMb).toStringAsFixed(1);
-    final peakMb = (snapshot.peakRssBytes / bytesPerMb).toStringAsFixed(1);
+    final rssMb = _rssMb(snapshot.rssBytes);
+    final peakMb = _rssMb(snapshot.peakRssBytes);
     Log.info(
       'Memory: rss $rssMb MB (peak $peakMb MB), '
       'vc_native=${snapshot.nativeControllers}, '

--- a/mobile/lib/services/memory_telemetry_service.dart
+++ b/mobile/lib/services/memory_telemetry_service.dart
@@ -16,7 +16,11 @@ class MemorySnapshot {
   /// Resident set size at sample time, in bytes.
   final int rssBytes;
 
-  /// Highest [rssBytes] observed by the sampler so far, in bytes.
+  /// Highest resident set size this process has reached, in bytes.
+  ///
+  /// Sourced from the OS high-water mark, so it covers spikes that occur
+  /// between samples. Falls back to the highest sampled [rssBytes] where no
+  /// OS gauge is available (web).
   final int peakRssBytes;
 
   /// Live `divine_video_player` native controllers.
@@ -35,20 +39,30 @@ class MemorySnapshot {
 ///
 /// All inputs are injected as callbacks so the service stays Flutter-free and
 /// trivially testable. Production wiring supplies a `readRssBytes` backed by
-/// `ProcessInfo.currentRss` and an `emit` that logs and annotates Crashlytics.
+/// `ProcessInfo.currentRss`, a `readPeakRssBytes` backed by
+/// `ProcessInfo.maxRss`, and an `emit` that logs and annotates Crashlytics.
+///
+/// The peak must come from the OS rather than from this sampler's own
+/// readings. Sampling on an interval can only ever report a peak it happened
+/// to land on, and the allocation that gets an app jetsammed is over long
+/// before the next tick: a 1.0.20 report measured 229.3 MB of sampled peak in
+/// a process whose OS high-water mark was 2266.0 MB (#8300).
 class MemoryTelemetryService {
   MemoryTelemetryService({
     required int Function() readRssBytes,
+    required int Function() readPeakRssBytes,
     required int Function() nativeControllerCount,
     required int Function() queueDepth,
     required void Function(MemorySnapshot) emit,
     this.interval = const Duration(seconds: 30),
   }) : _readRssBytes = readRssBytes,
+       _readPeakRssBytes = readPeakRssBytes,
        _nativeControllerCount = nativeControllerCount,
        _queueDepth = queueDepth,
        _emit = emit;
 
   final int Function() _readRssBytes;
+  final int Function() _readPeakRssBytes;
   final int Function() _nativeControllerCount;
   final int Function() _queueDepth;
   final void Function(MemorySnapshot) _emit;
@@ -60,9 +74,15 @@ class MemoryTelemetryService {
   int _peakRssBytes = 0;
 
   /// Reads every gauge once, updates the running peak, and emits a snapshot.
+  ///
+  /// The peak is the OS high-water mark, floored by the highest sampled RSS
+  /// so a platform without an OS gauge still reports something monotonic.
   void sampleOnce() {
     final rss = _readRssBytes();
-    _peakRssBytes = math.max(_peakRssBytes, rss);
+    _peakRssBytes = math.max(
+      math.max(_peakRssBytes, rss),
+      _readPeakRssBytes(),
+    );
     _emit(
       MemorySnapshot(
         rssBytes: rss,

--- a/mobile/lib/utils/video_nostr_enrichment.dart
+++ b/mobile/lib/utils/video_nostr_enrichment.dart
@@ -151,15 +151,13 @@ Future<List<VideoEvent>> enrichVideosWithNostrTags(
 
     // Build a lookup map: event ID -> parsed VideoEvent for enrichment
     final nostrEventsMap = <String, VideoEvent>{};
+    var parsedCount = 0;
+    var withBlurhash = 0;
     for (final event in nostrEvents) {
       try {
         final parsed = VideoEvent.fromNostrEvent(event, permissive: true);
-        Log.info(
-          'enrichVideos: parsed Nostr event ${parsed.id} '
-          'blurhash=${parsed.blurhash} '
-          'rawTags.len=${parsed.rawTags.length}',
-          name: callerName,
-        );
+        parsedCount++;
+        if (parsed.blurhash != null) withBlurhash++;
         if (parsed.rawTags.isNotEmpty) {
           nostrEventsMap[parsed.id] = parsed;
         }
@@ -167,6 +165,15 @@ Future<List<VideoEvent>> enrichVideosWithNostrTags(
         // Skip events that fail to parse
       }
     }
+    // One line per batch, not per event. A bug report carries only the last
+    // 50 entries of any level, and a 50-video batch logging per event took
+    // ~40% of that window on #8300's report — crowding out the context the
+    // report was filed to capture.
+    Log.info(
+      'enrichVideos: parsed $parsedCount/${nostrEvents.length} Nostr events, '
+      '$withBlurhash with a blurhash, ${nostrEventsMap.length} with tags',
+      name: callerName,
+    );
 
     if (nostrEventsMap.isEmpty) {
       attemptTracker?.recordAttemptResults(

--- a/mobile/test/services/memory_telemetry_service_test.dart
+++ b/mobile/test/services/memory_telemetry_service_test.dart
@@ -15,12 +15,14 @@ void main() {
 
     MemoryTelemetryService build({
       required int Function() readRssBytes,
+      int Function() readPeakRssBytes = _zero,
       int Function() nativeControllerCount = _zero,
       int Function() queueDepth = _zero,
       Duration interval = const Duration(seconds: 30),
     }) {
       return MemoryTelemetryService(
         readRssBytes: readRssBytes,
+        readPeakRssBytes: readPeakRssBytes,
         nativeControllerCount: nativeControllerCount,
         queueDepth: queueDepth,
         emit: emitted.add,
@@ -40,6 +42,63 @@ void main() {
 
       expect(emitted.map((s) => s.rssBytes), equals([100, 300, 200]));
       expect(emitted.map((s) => s.peakRssBytes), equals([100, 300, 300]));
+    });
+
+    test('peakRssBytes reports a spike that landed between samples', () {
+      // The shape measured on the 1.0.20 report in #8300: every sampled RSS
+      // sat near 200 MB while the OS high-water mark was an order of
+      // magnitude higher, because the allocation that drives an iOS memory
+      // kill is over long before the next 30s tick.
+      const mb = 1024 * 1024;
+      final sampled = [201 * mb, 229 * mb, 188 * mb];
+      var index = 0;
+      final service = build(
+        readRssBytes: () => sampled[index++],
+        readPeakRssBytes: () => 2266 * mb,
+      );
+
+      service
+        ..sampleOnce()
+        ..sampleOnce()
+        ..sampleOnce();
+
+      expect(
+        emitted.map((s) => s.peakRssBytes),
+        everyElement(equals(2266 * mb)),
+      );
+    });
+
+    test('peakRssBytes stays monotonic when the OS gauge reads lower', () {
+      // Web has no OS gauge and reports 0; the sampled max still has to hold.
+      final readings = [100, 500, 200];
+      var index = 0;
+      final service = build(readRssBytes: () => readings[index++]);
+
+      service
+        ..sampleOnce()
+        ..sampleOnce()
+        ..sampleOnce();
+
+      expect(emitted.map((s) => s.peakRssBytes), equals([100, 500, 500]));
+    });
+
+    test('peakRssBytes tracks the OS gauge upward between samples', () {
+      // Consecutive log lines are what localize a spike to a 30s window, so
+      // a rising OS mark has to move the reported peak on the next sample.
+      final peaks = [100, 900, 900];
+      var index = 0;
+      final service = build(
+        readRssBytes: () => 100,
+        readPeakRssBytes: () => peaks[index++],
+      );
+
+      service
+        ..sampleOnce()
+        ..sampleOnce()
+        ..sampleOnce();
+
+      expect(emitted.map((s) => s.rssBytes), equals([100, 100, 100]));
+      expect(emitted.map((s) => s.peakRssBytes), equals([100, 900, 900]));
     });
 
     test('snapshot carries the injected controller and queue gauges', () {


### PR DESCRIPTION
## Why

Two TestFlight 1.0.20+848 reports two days apart — #8300 ("shows me the same 15 to 20 videos and then crash", iPhone 13 Pro) and a Discord report today ("lots of crashing when checking notifications and scrolling", iPhone 16 Pro) — and Crashlytics has no matching event for either. That is the signature of an iOS memory kill, which Crashlytics cannot capture. #8300 stalled there, because nothing in our own data could confirm it.

Our data could have confirmed it. It was wrong.

The Discord reporter's full log export carries two peak-memory numbers from two different code paths in the same process:

| Source | Peak reported |
|---|---|
| `MemoryTelemetryService` — the service whose file header says "for OOM instrumentation" | **229.3 MB** |
| `ProcessInfo.maxRss` in the bug-report header — the OS high-water mark | **2266.0 MB** |

Same process, same metric, same units, 10x apart. Verified on Darwin that `maxRss` is bytes and a genuine process-lifetime high-water mark that survives the spike (`cur=1690.6MB max=1690.6MB` at peak, `cur=154.7MB max=1690.7MB` after release), so the two are directly comparable and the gap is pure sampling blindness.

`MemoryTelemetryService` computed its peak as the max of *its own 30-second samples*. The allocation that gets an app jetsammed is over long before the next tick. That understated number is also what ships to Crashlytics as `mem_peak_mb` — so every OOM report the team has looked at understated the peak by an order of magnitude, on the one metric the investigation turns on.

Four commits, one per defect, all in the same family: instrumentation that prevented the diagnosis.

## What changed

**1. Report the OS high-water mark, not a sampled peak** — `MemoryTelemetryService` takes the peak from `ProcessInfo.maxRss`, floored by the sampled max so web (no OS gauge; the stub returns 0) stays monotonic. Consecutive log lines now also localize a spike to the 30-second window it happened in, which the old sampler could never do.

**2. Log OS memory-pressure events** — `didHaveMemoryPressure` fanned straight out to load shedding and logged nothing, so a report could not answer whether the OS was under memory pressure at all. That is precisely what separates a memory kill from a native crash Crashlytics missed. Logged at **warning** on purpose: a bug report keeps the last 200 error/warning entries but only the last 50 of any level, so an info line is gone within a minute of ordinary use and never reaches support.

**3. Summarize Nostr enrichment per batch, not per event** — `enrichVideos` logged one info line per parsed event, leftover diagnostics from #4155's blurhash fix four months ago. On #8300's own report a single 50-video batch took **19 of the 53** lines in the recent-context block, crowding out the context the report was filed to capture. Collapsed to one line per batch carrying the same signal (parsed / with blurhash / with tags).

**4. Keep a failed memory probe from taking out load shedding** — both `ProcessInfo` gauges are guarded and invalid readings fall back to zero. The pressure handler still sheds load and records the warning when a platform cannot provide a memory reading, while the injected peak probe keeps the production wiring testable.

## What this does not do

It does not fix the crash. It makes the next report conclusive: a real peak, a pressure signal, and room in the log to see them. The 2266 MB is a real measurement, but iOS jetsam evaluates `phys_footprint`, not RSS, so it bounds the problem rather than proving the kill — if we need that precision the follow-up is a `task_vm_info` channel, which is a much bigger change than this one and not worth doing before these changes land.

## Testing

- `flutter test test/services/memory_telemetry_service_test.dart` — 7/7, including a regression test built from the measured shape (sampled 201/229/188 MB against a 2266 MB OS mark).
- Mutation-checked at the production boundary: reverting the peak source turns the new tests red with `Actual: [210763776, 240123904, 240123904]` — the report's own numbers.
- `flutter test` across every enrichment-touching suite (`video_nostr_enrichment_*`, `profile_feed_cubit`, `video_feed_bloc`) — 155/155.
- `flutter analyze` clean on all four changed files; `check_ungrouped_tests`, `check_placeholder_tests`, `check_nostr_id_log_truncation` all green.

Refs #8300, #8293
