### PR TITLE
fix(avatar): decode avatars at their slot size instead of full resolution

### DIFF
--- a/mobile/lib/widgets/user_avatar.dart
+++ b/mobile/lib/widgets/user_avatar.dart
@@ -101,7 +101,7 @@ class UserAvatar extends StatelessWidget {
         child: Stack(
           fit: StackFit.expand,
           children: [
-            _buildContent(),
+            _buildContent(context),
             DecoratedBox(
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(_cornerRadius),
@@ -145,14 +145,29 @@ class UserAvatar extends StatelessWidget {
     name: name,
   );
 
-  Widget _buildContent() {
+  /// Decode width for this avatar's slot, in device pixels.
+  ///
+  /// An avatar URL is an arbitrary user-supplied kind-0 `picture` at an
+  /// arbitrary resolution, and the slot is usually 32-44pt. Without a hint
+  /// Flutter decodes at the source's full resolution, so a 4000x3000 photo
+  /// costs 48 MB of bitmap to fill 4 KB of pixels — and `SizedBox.square`
+  /// above bounds layout, not decode. Height is deliberately left to
+  /// [ResizeImage] so the aspect ratio survives.
+  int _decodeWidth(BuildContext context) =>
+      (size * MediaQuery.devicePixelRatioOf(context)).ceil();
+
+  Widget _buildContent(BuildContext context) {
     if (contentOverride case final override?) {
       return override;
     }
 
     if (imageProvider != null) {
       return Image(
-        image: imageProvider!,
+        image: ResizeImage.resizeIfNeeded(
+          _decodeWidth(context),
+          null,
+          imageProvider!,
+        ),
         fit: BoxFit.cover,
         errorBuilder: (context, error, stackTrace) => _buildPlaceholder(),
       );
@@ -177,6 +192,7 @@ class UserAvatar extends StatelessWidget {
 
       return VineCachedImage(
         imageUrl: imageUrl!,
+        memCacheWidth: _decodeWidth(context),
         placeholder: (context, url) => _buildPlaceholder(),
         errorWidget: (context, url, error) {
           final failureKind = AvatarFailureCache.instance.recordFailureForError(

--- a/mobile/lib/widgets/user_avatar.dart
+++ b/mobile/lib/widgets/user_avatar.dart
@@ -153,8 +153,16 @@ class UserAvatar extends StatelessWidget {
   /// costs 48 MB of bitmap to fill 4 KB of pixels — and `SizedBox.square`
   /// above bounds layout, not decode. Height is deliberately left to
   /// [ResizeImage] so the aspect ratio survives.
-  int _decodeWidth(BuildContext context) =>
-      (size * MediaQuery.devicePixelRatioOf(context)).ceil();
+  ///
+  /// Returns null for a non-finite or non-positive [size], leaving the
+  /// framework to decode at native resolution. A `double.infinity` slot
+  /// (an avatar told to fill its cell) would otherwise reach
+  /// `(size * dpr).ceil()`, which throws. Mirrors
+  /// `_VideoThumbnailWidgetState._decodeWidth`.
+  int? _decodeWidth(BuildContext context) {
+    if (!size.isFinite || size <= 0) return null;
+    return (size * MediaQuery.devicePixelRatioOf(context)).ceil();
+  }
 
   Widget _buildContent(BuildContext context) {
     if (contentOverride case final override?) {

--- a/mobile/test/widgets/comprehensive_user_avatar_test.dart
+++ b/mobile/test/widgets/comprehensive_user_avatar_test.dart
@@ -259,7 +259,7 @@ void main() {
         expect(_gradientFinder(), findsAtLeastNWidgets(1));
       });
 
-      testWidgets('renders provided imageProvider directly', (tester) async {
+      testWidgets('renders the provided imageProvider', (tester) async {
         final provider = MemoryImage(
           Uint8List.fromList(_transparentImageBytes),
         );
@@ -277,7 +277,10 @@ void main() {
         expect(find.byType(VineCachedImage), findsNothing);
         expect(find.byType(Image), findsOneWidget);
         final image = tester.widget<Image>(find.byType(Image));
-        expect(image.image, same(provider));
+        // Wrapped for a bounded decode, but still resolving the caller's
+        // provider — see the 'Decode size' group for the bound itself.
+        expect(image.image, isA<ResizeImage>());
+        expect((image.image as ResizeImage).imageProvider, same(provider));
       });
 
       testWidgets('uses explicit placeholder tone when provided', (
@@ -601,6 +604,87 @@ void main() {
 
         await tester.pumpAndSettle();
         expect(find.byType(UserAvatar), findsOneWidget);
+      });
+    });
+
+    group('Decode size', () {
+      testWidgets('bounds the network decode to the slot in device pixels', (
+        tester,
+      ) async {
+        tester.view.devicePixelRatio = 3.0;
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: UserAvatar(
+                imageUrl: 'https://example.com/avatar.jpg',
+                size: 32,
+              ),
+            ),
+          ),
+        );
+
+        final image = tester.widget<VineCachedImage>(
+          find.byType(VineCachedImage),
+        );
+        // 32pt slot at 3x. Without this hint Flutter decodes the source at
+        // full resolution, which is how a 32x32 avatar costs tens of MB.
+        expect(image.memCacheWidth, equals(96));
+        // Left null so ResizeImage preserves the source aspect ratio.
+        expect(image.memCacheHeight, isNull);
+      });
+
+      testWidgets('scales the decode hint with the slot size', (tester) async {
+        tester.view.devicePixelRatio = 2.0;
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: UserAvatar(
+                imageUrl: 'https://example.com/avatar.jpg',
+                size: 120,
+              ),
+            ),
+          ),
+        );
+
+        expect(
+          tester
+              .widget<VineCachedImage>(find.byType(VineCachedImage))
+              .memCacheWidth,
+          equals(240),
+        );
+      });
+
+      testWidgets('bounds a caller-supplied ImageProvider too', (tester) async {
+        tester.view.devicePixelRatio = 3.0;
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: UserAvatar(
+                imageProvider: MemoryImage(
+                  Uint8List.fromList(_transparentImageBytes),
+                ),
+                size: 40,
+              ),
+            ),
+          ),
+        );
+
+        final provider = tester.widget<Image>(find.byType(Image)).image;
+        expect(provider, isA<ResizeImage>());
+        expect((provider as ResizeImage).width, equals(120));
+        expect(provider.height, isNull);
       });
     });
 

--- a/mobile/test/widgets/comprehensive_user_avatar_test.dart
+++ b/mobile/test/widgets/comprehensive_user_avatar_test.dart
@@ -686,6 +686,40 @@ void main() {
         expect((provider as ResizeImage).width, equals(120));
         expect(provider.height, isNull);
       });
+
+      testWidgets('leaves the decode unbounded for a non-finite size', (
+        tester,
+      ) async {
+        tester.view.devicePixelRatio = 3.0;
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: SizedBox(
+                width: 40,
+                height: 40,
+                child: UserAvatar(
+                  imageProvider: MemoryImage(
+                    Uint8List.fromList(_transparentImageBytes),
+                  ),
+                  size: double.infinity,
+                ),
+              ),
+            ),
+          ),
+        );
+
+        // An infinite slot must not reach (size * dpr).ceil(), which throws.
+        // The provider is used unwrapped so the framework decodes natively.
+        expect(tester.takeException(), isNull);
+        expect(
+          tester.widget<Image>(find.byType(Image)).image,
+          isA<MemoryImage>(),
+        );
+      });
     });
 
     group('Multiple Avatars', () {


### PR DESCRIPTION
## Why

Every avatar in the app decodes at the source image's **full resolution**.

`UserAvatar` never passed a decode hint to `VineCachedImage`, and exposed no parameter for one, so its 33 call sites could not supply it either. `VineCachedImage` applies the hint through `ResizeImage.resizeIfNeeded(memCacheWidth, memCacheHeight, ...)` — with both null that returns the provider untouched, and `MediaCacheImageProvider` then calls `decode(await ui.ImmutableBuffer.fromFilePath(...))` with no `targetWidth`. The `SizedBox.square(dimension: size)` above bounds **layout, not decode**.

The URL is the raw Nostr kind-0 `picture` field — an arbitrary user-supplied image at an arbitrary resolution, with no resize proxy anywhere in the path. A 4000×3000 phone photo used as a profile picture decodes to **~48 MB of bitmap to fill a 32pt slot**, roughly 10,000× the pixels the slot needs.

Nothing downstream catches it:

- `app_bootstrap.dart` raises `imageCache.maximumSizeBytes` to 256 MB, on a comment that reads *"Per-thumbnail memory is bounded by decoding at display size."* That is true of the notification video thumbnail — `notification_video_thumbnail.dart` does pass `memCacheWidth: 224` — and false of avatars, which outnumber it on the screen.
- 256 MB is not a ceiling on RSS anyway. On-screen images live in `_liveImages`, outside that budget; an image larger than the max is decoded and never cached; and eviction is post-hoc, after the decode has already happened.
- There is no decode-concurrency cap. `media_cache`'s only related structure is `_inFlightRelativePaths`, a same-URL dedup set. A fling decodes many avatars at once.

Scrolling a follow-heavy notifications inbox means one distinct actor per row, so essentially every row is a cache miss — which is the reported shape in #8300 ("the same 15 to 20 videos and then crash") and in a same-build Discord report today ("crashing when checking notifications and scrolling"). Neither has a Crashlytics event, the signature of an iOS memory kill. #8445 established that the app reached a **2266 MB** OS high-water mark on one of those sessions.

## What changed

`UserAvatar` derives the decode width from the `size` it already knows, times the device pixel ratio, and applies it to **both** image branches — the network one via `memCacheWidth`, and the caller-supplied `imageProvider` via `ResizeImage.resizeIfNeeded`. Height stays null so `ResizeImage` preserves the aspect ratio, matching what `notification_video_thumbnail.dart` documents.

This bounds all 33 call sites at once. It matches the existing idiom in `video_thumbnail_widget.dart:645`, which computes its hint the same way.

No visual change: the hint is exactly the slot's physical pixel count, and `ResizeImage` does not upscale.

## Testing

- 3 new tests in a `Decode size` group pin the bound: 32pt @3x → 96, 120pt @2x → 240, and the `imageProvider` branch wrapped at 40pt @3x → 120, with `memCacheHeight` asserted null so the aspect ratio is not silently pinned. Every `devicePixelRatio` override is paired with `addTearDown(resetDevicePixelRatio)`.
- Mutation-checked at the production boundary: dropping `memCacheWidth` turns them red with `Expected: <96> Actual: <null>`.
- One existing test asserted `image.image` was `same(provider)` — it pinned the unbounded behaviour. Updated to assert the wrapper resolves the caller's provider, so the contract is still covered.
- **574 tests green** across all 24 suites that render a `UserAvatar`.
- `golden.sh verify`: the **notification-row goldens pass** — those are the ones that render avatars. The 3 failures are `design_system_gallery_golden_test.dart`, which imports only `divine_ui` and contains zero avatar references, failing at 2.79% / 2.67% / 3.65% — the documented macOS font-antialiasing range in AGENTS.md. CI's Ubuntu runner is authoritative.
- `flutter analyze` clean; `check_l10n_delegates_ceiling`, `check_ungrouped_tests`, `check_placeholder_tests`, `check_process_global_mutations`, `check_skip_ceiling`, `check_shared_setup_stubs` all green.

## Guard added in review (`0983f0a1e`, @mbradley)

`_decodeWidth` computed `(size * dpr).ceil()` unconditionally, which throws `UnsupportedError: Infinity or NaN toInt` on a non-finite size. It now returns null for a non-finite or non-positive `size`, mirroring `_VideoThumbnailWidgetState._decodeWidth`, with a test that fails without it.

Two call sites derive `size` from layout rather than a constant: `people_list_search_card.dart:168` passes `double.infinity` but supplies no image, so it never reaches the computation; `_AvatarHeroFlightShuttle` (`profile_header_media.dart:638`) passes `constraints.biggest.shortestSide` from a `LayoutBuilder` **and** an `imageUrl`, so it does. A flight shuttle normally gets tight constraints from the overlay's flight rect, so it should be finite in practice — but it is layout-derived, which is the shape that can go non-finite. Every other call site passes a constant.

## Honest limit

The code proves the decode is unbounded; it does not prove *these two reporters'* avatars were large. That is measurable, not proven — the confirmation is a `JetsamEvent` from either device, still outstanding on #8300. This is the one mechanism in either reported path that reaches GB scale, and the fix is correct regardless of whether it turns out to be the whole story.

Refs #8300

