### PR TITLE
feat(auth): add marketing opt-in to create-account flow

### DIFF
--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -132,6 +132,14 @@ class DivineAuthCubit extends Cubit<DivineAuthState>
     emit(current.copyWith(obscurePassword: !current.obscurePassword));
   }
 
+  /// Set whether the user opted in to marketing communications at sign-up.
+  void updateMarketingConsent(bool value) {
+    final current = state;
+    if (current is! DivineAuthFormState) return;
+
+    emit(current.copyWith(marketingConsent: value));
+  }
+
   /// Validate and submit the form
   Future<void> submit() async {
     final current = state;
@@ -187,7 +195,11 @@ class DivineAuthCubit extends Cubit<DivineAuthState>
       if (current.isSignIn) {
         await _handleSignIn(email, current.password);
       } else {
-        await _handleSignUp(email, current.password);
+        await _handleSignUp(
+          email,
+          current.password,
+          marketingConsent: current.marketingConsent,
+        );
       }
     } catch (e, stackTrace) {
       Log.error(
@@ -264,7 +276,11 @@ class DivineAuthCubit extends Cubit<DivineAuthState>
     }
   }
 
-  Future<void> _handleSignUp(String email, String password) async {
+  Future<void> _handleSignUp(
+    String email,
+    String password, {
+    required bool marketingConsent,
+  }) async {
     Log.info(
       'Attempting sign up using email and password',
       name: 'DivineAuthCubit',
@@ -275,6 +291,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState>
       email: email,
       password: password,
       scope: 'policy:full',
+      marketingConsent: marketingConsent,
     );
 
     if (!result.success) {

--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -35,6 +35,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState>
     String? inviteCode,
     String? inviteSourceSlug,
     bool requirePasswordConfirmation = false,
+    String? appVersion,
     AnalyticsEventSink analytics = const NoOpAnalyticsEventSink(),
   }) : _oauthClient = oauthClient,
        _authService = authService,
@@ -46,6 +47,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState>
        _inviteSourceSlug = inviteSourceSlug,
        _validationMessages = validationMessages,
        _requirePasswordConfirmation = requirePasswordConfirmation,
+       _appVersion = appVersion,
        _analytics = analytics,
        super(const DivineAuthInitial());
 
@@ -57,6 +59,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState>
   final String? _inviteSourceSlug;
   final AuthValidationMessages _validationMessages;
   final bool _requirePasswordConfirmation;
+  final String? _appVersion;
   final AnalyticsEventSink _analytics;
 
   /// Initialize form with default state (sign up mode)
@@ -292,6 +295,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState>
       password: password,
       scope: 'policy:full',
       marketingConsent: marketingConsent,
+      appVersion: _appVersion,
     );
 
     if (!result.success) {

--- a/mobile/lib/blocs/divine_auth/divine_auth_state.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_state.dart
@@ -59,6 +59,7 @@ class DivineAuthFormState extends DivineAuthState {
     this.obscurePassword = true,
     this.isSubmitting = false,
     this.isSkipping = false,
+    this.marketingConsent = false,
   });
 
   /// User's email address
@@ -115,6 +116,12 @@ class DivineAuthFormState extends DivineAuthState {
   /// Whether anonymous account creation is in progress
   final bool isSkipping;
 
+  /// Whether the user opted in to marketing communications at sign-up.
+  ///
+  /// Sign-up only and unchecked by default (explicit opt-in). Sent to keycast
+  /// with headless registration and recorded on the account.
+  final bool marketingConsent;
+
   /// Returns true if form has no validation errors and fields are filled
   bool get canSubmit =>
       email.isNotEmpty &&
@@ -144,6 +151,7 @@ class DivineAuthFormState extends DivineAuthState {
     bool? obscurePassword,
     bool? isSubmitting,
     bool? isSkipping,
+    bool? marketingConsent,
     bool clearEmailError = false,
     bool clearPasswordError = false,
     bool clearConfirmPasswordError = false,
@@ -185,6 +193,7 @@ class DivineAuthFormState extends DivineAuthState {
       obscurePassword: obscurePassword ?? this.obscurePassword,
       isSubmitting: isSubmitting ?? this.isSubmitting,
       isSkipping: isSkipping ?? this.isSkipping,
+      marketingConsent: marketingConsent ?? this.marketingConsent,
     );
   }
 
@@ -207,6 +216,7 @@ class DivineAuthFormState extends DivineAuthState {
     obscurePassword,
     isSubmitting,
     isSkipping,
+    marketingConsent,
   ];
 }
 

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2077,6 +2077,7 @@
     "description": "Tappable call-to-action span of the failed-sign-in hint. Opens the sheet listing all sign-in methods."
   },
   "authCreateAccountTitle": "Create account",
+  "authCreateAccountMarketingOptIn": "Send me Divine inspiration",
   "authBackToInviteCode": "Back to invite code",
   "authUseDivineNoBackup": "Use Divine with no backup",
   "authSkipConfirmTitle": "One last thing...",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2077,7 +2077,7 @@
     "description": "Tappable call-to-action span of the failed-sign-in hint. Opens the sheet listing all sign-in methods."
   },
   "authCreateAccountTitle": "Create account",
-  "authCreateAccountMarketingOptIn": "Send me Divine inspiration",
+  "authCreateAccountMarketingOptIn": "Sign-up for Divine app updates and news",
   "authBackToInviteCode": "Back to invite code",
   "authUseDivineNoBackup": "Use Divine with no backup",
   "authSkipConfirmTitle": "One last thing...",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2077,7 +2077,7 @@
     "description": "Tappable call-to-action span of the failed-sign-in hint. Opens the sheet listing all sign-in methods."
   },
   "authCreateAccountTitle": "Create account",
-  "authCreateAccountMarketingOptIn": "Sign-up for Divine app updates and news",
+  "authCreateAccountMarketingOptIn": "Get Divine app updates and news",
   "authBackToInviteCode": "Back to invite code",
   "authUseDivineNoBackup": "Use Divine with no backup",
   "authSkipConfirmTitle": "One last thing...",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -5473,6 +5473,12 @@ abstract class AppLocalizations {
   /// **'Create account'**
   String get authCreateAccountTitle;
 
+  /// No description provided for @authCreateAccountMarketingOptIn.
+  ///
+  /// In en, this message translates to:
+  /// **'Send me Divine inspiration'**
+  String get authCreateAccountMarketingOptIn;
+
   /// No description provided for @authBackToInviteCode.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -5476,7 +5476,7 @@ abstract class AppLocalizations {
   /// No description provided for @authCreateAccountMarketingOptIn.
   ///
   /// In en, this message translates to:
-  /// **'Sign-up for Divine app updates and news'**
+  /// **'Get Divine app updates and news'**
   String get authCreateAccountMarketingOptIn;
 
   /// No description provided for @authBackToInviteCode.

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -5476,7 +5476,7 @@ abstract class AppLocalizations {
   /// No description provided for @authCreateAccountMarketingOptIn.
   ///
   /// In en, this message translates to:
-  /// **'Send me Divine inspiration'**
+  /// **'Sign-up for Divine app updates and news'**
   String get authCreateAccountMarketingOptIn;
 
   /// No description provided for @authBackToInviteCode.

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3122,7 +3122,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'ወደ ግብዣ ኮድ ተመለስ';

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3121,6 +3121,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get authCreateAccountTitle => 'መለያ ይፍጠሩ';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'ወደ ግብዣ ኮድ ተመለስ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3121,7 +3121,8 @@ class AppLocalizationsAm extends AppLocalizations {
   String get authCreateAccountTitle => 'መለያ ይፍጠሩ';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'ወደ ግብዣ ኮድ ተመለስ';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3160,7 +3160,8 @@ class AppLocalizationsAr extends AppLocalizations {
   String get authCreateAccountTitle => 'إنشاء حساب';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'العودة إلى رمز الدعوة';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3160,6 +3160,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get authCreateAccountTitle => 'إنشاء حساب';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'العودة إلى رمز الدعوة';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3161,7 +3161,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'العودة إلى رمز الدعوة';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -3239,7 +3239,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Назад към кода на поканата';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -3238,6 +3238,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get authCreateAccountTitle => 'Създаване на акаунт';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'Назад към кода на поканата';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -3238,7 +3238,8 @@ class AppLocalizationsBg extends AppLocalizations {
   String get authCreateAccountTitle => 'Създаване на акаунт';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Назад към кода на поканата';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3229,6 +3229,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get authCreateAccountTitle => 'Konto erstellen';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'Zurück zum Einladungscode';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3229,7 +3229,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get authCreateAccountTitle => 'Konto erstellen';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Zurück zum Einladungscode';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3230,7 +3230,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Zurück zum Einladungscode';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3258,7 +3258,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authCreateAccountTitle => 'Create account';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Back to invite code';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3258,6 +3258,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authCreateAccountTitle => 'Create account';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'Back to invite code';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3259,7 +3259,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Back to invite code';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3227,7 +3227,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get authCreateAccountTitle => 'Crear cuenta';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Volver al código de invitación';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3228,7 +3228,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Volver al código de invitación';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3227,6 +3227,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get authCreateAccountTitle => 'Crear cuenta';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'Volver al código de invitación';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -3207,7 +3207,8 @@ class AppLocalizationsFil extends AppLocalizations {
   String get authCreateAccountTitle => 'Gumawa ng account';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Bumalik sa invite code';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -3207,6 +3207,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get authCreateAccountTitle => 'Gumawa ng account';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'Bumalik sa invite code';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -3208,7 +3208,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Bumalik sa invite code';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3239,6 +3239,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get authCreateAccountTitle => 'Créer un compte';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'Retour au code d\'invitation';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3239,7 +3239,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get authCreateAccountTitle => 'Créer un compte';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Retour au code d\'invitation';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3240,7 +3240,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Retour au code d\'invitation';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3120,6 +3120,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get authCreateAccountTitle => 'Buat akun';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'Kembali ke kode undangan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3121,7 +3121,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Kembali ke kode undangan';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3120,7 +3120,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get authCreateAccountTitle => 'Buat akun';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Kembali ke kode undangan';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3233,7 +3233,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Torna al codice invito';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3232,7 +3232,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get authCreateAccountTitle => 'Crea account';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Torna al codice invito';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3232,6 +3232,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get authCreateAccountTitle => 'Crea account';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'Torna al codice invito';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2989,7 +2989,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => '招待コードに戻る';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2988,7 +2988,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get authCreateAccountTitle => 'アカウントを作ろう';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => '招待コードに戻る';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2988,6 +2988,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get authCreateAccountTitle => 'アカウントを作ろう';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => '招待コードに戻る';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2997,7 +2997,8 @@ class AppLocalizationsKo extends AppLocalizations {
   String get authCreateAccountTitle => '계정 만들기';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => '초대 코드로 돌아가기';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2997,6 +2997,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get authCreateAccountTitle => '계정 만들기';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => '초대 코드로 돌아가기';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2998,7 +2998,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => '초대 코드로 돌아가기';

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -3180,6 +3180,9 @@ class AppLocalizationsMs extends AppLocalizations {
   String get authCreateAccountTitle => 'Cipta akaun';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'Kembali ke kod jemputan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -3181,7 +3181,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Kembali ke kod jemputan';

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -3180,7 +3180,8 @@ class AppLocalizationsMs extends AppLocalizations {
   String get authCreateAccountTitle => 'Cipta akaun';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Kembali ke kod jemputan';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3204,7 +3204,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get authCreateAccountTitle => 'Account aanmaken';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Terug naar invite-code';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3205,7 +3205,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Terug naar invite-code';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3204,6 +3204,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get authCreateAccountTitle => 'Account aanmaken';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'Terug naar invite-code';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3282,7 +3282,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Wróć do kodu zaproszenia';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3281,6 +3281,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get authCreateAccountTitle => 'Utwórz konto';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'Wróć do kodu zaproszenia';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3281,7 +3281,8 @@ class AppLocalizationsPl extends AppLocalizations {
   String get authCreateAccountTitle => 'Utwórz konto';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Wróć do kodu zaproszenia';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3215,6 +3215,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get authCreateAccountTitle => 'Criar conta';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'Voltar para o código de convite';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3215,7 +3215,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get authCreateAccountTitle => 'Criar conta';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Voltar para o código de convite';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3216,7 +3216,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Voltar para o código de convite';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3293,6 +3293,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get authCreateAccountTitle => 'Creează cont';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'Înapoi la codul de invitație';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3293,7 +3293,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get authCreateAccountTitle => 'Creează cont';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Înapoi la codul de invitație';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3294,7 +3294,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Înapoi la codul de invitație';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3188,7 +3188,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Tillbaka till inbjudningskod';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3187,7 +3187,8 @@ class AppLocalizationsSv extends AppLocalizations {
   String get authCreateAccountTitle => 'Skapa konto';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Tillbaka till inbjudningskod';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3187,6 +3187,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get authCreateAccountTitle => 'Skapa konto';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'Tillbaka till inbjudningskod';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -3325,6 +3325,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get authCreateAccountTitle => 'ఖాతాను సృష్టించండి';
 
   @override
+  String get authCreateAccountMarketingOptIn =>
+      'Get Divine app updates and news';
+
+  @override
   String get authBackToInviteCode => 'ఆహ్వాన కోడ్‌కి తిరిగి వెళ్లండి';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3130,6 +3130,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get authCreateAccountTitle => 'Hesap oluştur';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'Davet koduna geri dön';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3131,7 +3131,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Davet koduna geri dön';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3130,7 +3130,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get authCreateAccountTitle => 'Hesap oluştur';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Davet koduna geri dön';

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -3192,7 +3192,8 @@ class AppLocalizationsUr extends AppLocalizations {
   String get authCreateAccountTitle => 'اکاؤنٹ بنائیں';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'دعوتی کوڈ پر واپس';

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -3193,7 +3193,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'دعوتی کوڈ پر واپس';

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -3192,6 +3192,9 @@ class AppLocalizationsUr extends AppLocalizations {
   String get authCreateAccountTitle => 'اکاؤنٹ بنائیں';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'دعوتی کوڈ پر واپس';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -3163,6 +3163,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get authCreateAccountTitle => 'Tạo tài khoản';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => 'Quay lại mã mời';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -3163,7 +3163,8 @@ class AppLocalizationsVi extends AppLocalizations {
   String get authCreateAccountTitle => 'Tạo tài khoản';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Quay lại mã mời';

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -3164,7 +3164,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => 'Quay lại mã mời';

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -2995,7 +2995,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get authCreateAccountTitle => '创建账号';
 
   @override
-  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+  String get authCreateAccountMarketingOptIn =>
+      'Sign-up for Divine app updates and news';
 
   @override
   String get authBackToInviteCode => '返回邀请码';

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -2996,7 +2996,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get authCreateAccountMarketingOptIn =>
-      'Sign-up for Divine app updates and news';
+      'Get Divine app updates and news';
 
   @override
   String get authBackToInviteCode => '返回邀请码';

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -2995,6 +2995,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get authCreateAccountTitle => '创建账号';
 
   @override
+  String get authCreateAccountMarketingOptIn => 'Send me Divine inspiration';
+
+  @override
   String get authBackToInviteCode => '返回邀请码';
 
   @override

--- a/mobile/lib/screens/auth/create_account_screen.dart
+++ b/mobile/lib/screens/auth/create_account_screen.dart
@@ -260,6 +260,10 @@ class _CreateAccountBodyState extends State<_CreateAccountBody> {
           context.read<DivineAuthCubit>().updatePassword(value),
       onConfirmPasswordChanged: (value) =>
           context.read<DivineAuthCubit>().updateConfirmPassword(value),
+      belowFieldsWidget: _MarketingOptInCheckbox(
+        value: widget.state.marketingConsent,
+        enabled: !isDisabled,
+      ),
       errorWidget: widget.state.generalError != null
           ? Column(
               mainAxisSize: MainAxisSize.min,
@@ -289,6 +293,44 @@ class _CreateAccountBodyState extends State<_CreateAccountBody> {
         isSkipping: isSkipping,
         isDisabled: isDisabled,
         onPressed: _skip,
+      ),
+    );
+  }
+}
+
+/// Unchecked-by-default opt-in for marketing communications, shown on the
+/// email/password create-account form. Toggles [DivineAuthCubit]'s
+/// marketing-consent state; the value is sent with headless registration.
+class _MarketingOptInCheckbox extends StatelessWidget {
+  const _MarketingOptInCheckbox({required this.value, required this.enabled});
+
+  final bool value;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.vineColors;
+    return MergeSemantics(
+      child: Semantics(
+        checked: value,
+        enabled: enabled,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: enabled
+              ? () => context.read<DivineAuthCubit>().updateMarketingConsent(
+                  !value,
+                )
+              : null,
+          child: DivineCheckbox(
+            state: value
+                ? DivineCheckboxState.selected
+                : DivineCheckboxState.unselected,
+            label: Text(
+              context.l10n.authCreateAccountMarketingOptIn,
+              style: VineTheme.bodyLargeFont(color: palette.primaryText),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/mobile/lib/screens/auth/create_account_screen.dart
+++ b/mobile/lib/screens/auth/create_account_screen.dart
@@ -321,13 +321,16 @@ class _MarketingOptInCheckbox extends StatelessWidget {
                   !value,
                 )
               : null,
-          child: DivineCheckbox(
-            state: value
-                ? DivineCheckboxState.selected
-                : DivineCheckboxState.unselected,
-            label: Text(
-              context.l10n.authCreateAccountMarketingOptIn,
-              style: VineTheme.bodyLargeFont(color: palette.primaryText),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(minHeight: 48),
+            child: DivineCheckbox(
+              state: value
+                  ? DivineCheckboxState.selected
+                  : DivineCheckboxState.unselected,
+              label: Text(
+                context.l10n.authCreateAccountMarketingOptIn,
+                style: VineTheme.bodyLargeFont(color: palette.primaryText),
+              ),
             ),
           ),
         ),

--- a/mobile/lib/screens/auth/create_account_screen.dart
+++ b/mobile/lib/screens/auth/create_account_screen.dart
@@ -20,6 +20,7 @@ import 'package:openvine/generated/product_analytics.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/app_version_provider.dart';
 import 'package:openvine/screens/auth/email_verification_screen.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/utils/validators.dart';
@@ -82,6 +83,7 @@ class _CreateAccountScreenState extends ConsumerState<CreateAccountScreen> {
         inviteSourceSlug: inviteAccessGrant?.creatorSlug,
         validationMessages: AuthValidationMessages.fromL10n(l10n),
         requirePasswordConfirmation: true,
+        appVersion: ref.watch(appVersionProvider),
         analytics: ref.read(analyticsEventSinkProvider),
       )..initialize(),
       child: _CreateAccountView(inviteAccessGrant: inviteAccessGrant),

--- a/mobile/lib/widgets/auth/auth_form_scaffold.dart
+++ b/mobile/lib/widgets/auth/auth_form_scaffold.dart
@@ -43,6 +43,7 @@ class AuthFormScaffold extends StatelessWidget {
     this.onConfirmPasswordChanged,
     this.errorWidget,
     this.headerWidget,
+    this.belowFieldsWidget,
     this.secondaryButton,
     this.onBack,
     this.emailLabel = 'Email',
@@ -89,6 +90,10 @@ class AuthFormScaffold extends StatelessWidget {
 
   /// Optional content displayed between the title and form fields.
   final Widget? headerWidget;
+
+  /// Optional content displayed directly below the form fields (e.g. a
+  /// marketing opt-in checkbox on the create-account form).
+  final Widget? belowFieldsWidget;
 
   /// The primary action button (e.g. "Create account").
   final Widget primaryButton;
@@ -213,6 +218,11 @@ class AuthFormScaffold extends StatelessWidget {
                               ),
                             ),
                           ),
+
+                          if (belowFieldsWidget != null) ...[
+                            const SizedBox(height: 16),
+                            belowFieldsWidget!,
+                          ],
 
                           const SizedBox(height: 16),
 

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -347,12 +347,15 @@ class KeycastOAuth {
   /// [exchangeCode].
   ///
   /// [nsec] - Optional: import existing Nostr key instead of generating new one
+  /// [marketingConsent] - Whether the user opted in to marketing
+  /// communications at sign-up. Recorded on the account by keycast.
   Future<(HeadlessRegisterResult, String verifier)> headlessRegister({
     required String email,
     required String password,
     String scope = 'policy:social',
     String? nsec,
     String? state,
+    bool marketingConsent = false,
   }) async {
     String? byokPubkey;
     if (nsec != null) {
@@ -371,6 +374,7 @@ class KeycastOAuth {
         'scope': scope,
         'code_challenge': challenge,
         'code_challenge_method': 'S256',
+        'marketing_consent': marketingConsent,
       };
 
       if (byokPubkey != null) {

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -347,15 +347,17 @@ class KeycastOAuth {
   /// [exchangeCode].
   ///
   /// [nsec] - Optional: import existing Nostr key instead of generating new one
-  /// [marketingConsent] - Whether the user opted in to marketing
-  /// communications at sign-up. Recorded on the account by keycast.
+  /// [marketingConsent] - The answer from a marketing consent prompt. Omit
+  /// when the registration flow did not show one.
+  /// [appVersion] - The app version that displayed the consent wording.
   Future<(HeadlessRegisterResult, String verifier)> headlessRegister({
     required String email,
     required String password,
     String scope = 'policy:social',
     String? nsec,
     String? state,
-    bool marketingConsent = false,
+    bool? marketingConsent,
+    String? appVersion,
   }) async {
     String? byokPubkey;
     if (nsec != null) {
@@ -374,8 +376,15 @@ class KeycastOAuth {
         'scope': scope,
         'code_challenge': challenge,
         'code_challenge_method': 'S256',
-        'marketing_consent': marketingConsent,
       };
+
+      if (marketingConsent != null) {
+        body['marketing_consent'] = marketingConsent;
+      }
+
+      if (appVersion != null) {
+        body['app_version'] = appVersion;
+      }
 
       if (byokPubkey != null) {
         body['nsec'] = nsec;
@@ -988,10 +997,7 @@ class KeycastOAuth {
   }
 
   /// One `DELETE /api/user/account` attempt carrying [authorization].
-  Future<http.Response> _sendAccountDeletion(
-    String url,
-    String authorization,
-  ) {
+  Future<http.Response> _sendAccountDeletion(String url, String authorization) {
     return _client
         .delete(
           Uri.parse(url),
@@ -1335,19 +1341,16 @@ class KeycastOAuth {
 
       if (response.statusCode == 401) {
         final probe = await _probeAccount(token);
-        return ChangePasswordResult.failure(
-          switch (probe) {
-            // A probe that never answered proves nothing, so neither cause may
-            // be reported as a verdict.
-            null => ChangePasswordFailure.unknown,
-            // The token still authenticates, so what the 401 rejected was the
-            // submitted current password.
-            (authenticated: true, status: _) =>
-              ChangePasswordFailure.wrongPassword,
-            _ => ChangePasswordFailure.needsSignIn,
-          },
-          message: message,
-        );
+        return ChangePasswordResult.failure(switch (probe) {
+          // A probe that never answered proves nothing, so neither cause may
+          // be reported as a verdict.
+          null => ChangePasswordFailure.unknown,
+          // The token still authenticates, so what the 401 rejected was the
+          // submitted current password.
+          (authenticated: true, status: _) =>
+            ChangePasswordFailure.wrongPassword,
+          _ => ChangePasswordFailure.needsSignIn,
+        }, message: message);
       }
 
       // The server enforces its own minimum on the new password. The client
@@ -1422,15 +1425,11 @@ class KeycastOAuth {
 
       if (response.statusCode == 401) {
         final probe = await _probeAccount(token);
-        return ChangeEmailResult.failure(
-          switch (probe) {
-            null => ChangeEmailFailure.unknown,
-            (authenticated: true, status: _) =>
-              ChangeEmailFailure.wrongPassword,
-            _ => ChangeEmailFailure.needsSignIn,
-          },
-          message: message,
-        );
+        return ChangeEmailResult.failure(switch (probe) {
+          null => ChangeEmailFailure.unknown,
+          (authenticated: true, status: _) => ChangeEmailFailure.wrongPassword,
+          _ => ChangeEmailFailure.needsSignIn,
+        }, message: message);
       }
 
       if (response.statusCode == 400) {

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -439,6 +439,49 @@ void main() {
         );
       });
 
+      test('sends marketing_consent true in body when opted in', () async {
+        final mockClient = MockClient((request) async {
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          expect(body['marketing_consent'], isTrue);
+          return http.Response(
+            jsonEncode({
+              'success': true,
+              'pubkey': 'pubkey',
+              'verification_required': true,
+            }),
+            200,
+          );
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        await oauth.headlessRegister(
+          email: 'test@example.com',
+          password: 'password123',
+          marketingConsent: true,
+        );
+      });
+
+      test('sends marketing_consent false in body by default', () async {
+        final mockClient = MockClient((request) async {
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          expect(body['marketing_consent'], isFalse);
+          return http.Response(
+            jsonEncode({
+              'success': true,
+              'pubkey': 'pubkey',
+              'verification_required': true,
+            }),
+            200,
+          );
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        await oauth.headlessRegister(
+          email: 'test@example.com',
+          password: 'password123',
+        );
+      });
+
       test('returns error on 404 response', () async {
         final mockClient = MockClient((request) async {
           return http.Response('Not Found', 404);

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -439,10 +439,11 @@ void main() {
         );
       });
 
-      test('sends marketing_consent true in body when opted in', () async {
+      test('sends consent and app version when opted in', () async {
         final mockClient = MockClient((request) async {
           final body = jsonDecode(request.body) as Map<String, dynamic>;
           expect(body['marketing_consent'], isTrue);
+          expect(body['app_version'], '1.2.3');
           return http.Response(
             jsonEncode({
               'success': true,
@@ -458,13 +459,37 @@ void main() {
           email: 'test@example.com',
           password: 'password123',
           marketingConsent: true,
+          appVersion: '1.2.3',
         );
       });
 
-      test('sends marketing_consent false in body by default', () async {
+      test('sends marketing_consent false when declined', () async {
         final mockClient = MockClient((request) async {
           final body = jsonDecode(request.body) as Map<String, dynamic>;
           expect(body['marketing_consent'], isFalse);
+          return http.Response(
+            jsonEncode({
+              'success': true,
+              'pubkey': 'pubkey',
+              'verification_required': true,
+            }),
+            200,
+          );
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        await oauth.headlessRegister(
+          email: 'test@example.com',
+          password: 'password123',
+          marketingConsent: false,
+        );
+      });
+
+      test('omits consent provenance when the flow did not ask', () async {
+        final mockClient = MockClient((request) async {
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          expect(body, isNot(contains('marketing_consent')));
+          expect(body, isNot(contains('app_version')));
           return http.Response(
             jsonEncode({
               'success': true,

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -226,6 +226,23 @@ void main() {
       );
     });
 
+    group('updateMarketingConsent', () {
+      blocTest<DivineAuthCubit, DivineAuthState>(
+        'sets marketingConsent when the user opts in',
+        build: buildCubit,
+        seed: () => const DivineAuthFormState(),
+        act: (cubit) => cubit.updateMarketingConsent(true),
+        expect: () => [const DivineAuthFormState(marketingConsent: true)],
+      );
+
+      blocTest<DivineAuthCubit, DivineAuthState>(
+        'does nothing when state is not $DivineAuthFormState',
+        build: buildCubit,
+        act: (cubit) => cubit.updateMarketingConsent(true),
+        expect: () => <DivineAuthState>[],
+      );
+    });
+
     group('submit', () {
       group('validation', () {
         blocTest<DivineAuthCubit, DivineAuthState>(
@@ -1023,6 +1040,58 @@ void main() {
                 email: any(named: 'email'),
                 password: any(named: 'password'),
                 scope: any(named: 'scope'),
+              ),
+            ).called(1);
+
+            await cubit.close();
+          },
+        );
+
+        test(
+          'forwards marketingConsent to headlessRegister when opted in',
+          () async {
+            when(
+              () => mockOAuth.headlessRegister(
+                email: any(named: 'email'),
+                password: any(named: 'password'),
+                scope: any(named: 'scope'),
+                marketingConsent: any(named: 'marketingConsent'),
+              ),
+            ).thenAnswer(
+              (_) async => (
+                HeadlessRegisterResult(
+                  success: true,
+                  pubkey: 'test-pubkey',
+                  verificationRequired: true,
+                  deviceCode: testDeviceCode,
+                  email: testEmail,
+                ),
+                testVerifier,
+              ),
+            );
+            when(
+              () => mockPendingVerification.save(
+                deviceCode: any(named: 'deviceCode'),
+                verifier: any(named: 'verifier'),
+                email: any(named: 'email'),
+                inviteCode: any(named: 'inviteCode'),
+              ),
+            ).thenAnswer((_) async {});
+
+            final cubit = buildCubit()
+              ..initialize()
+              ..updateEmail(testEmail)
+              ..updatePassword(testPassword)
+              ..updateMarketingConsent(true);
+
+            await cubit.submit();
+
+            verify(
+              () => mockOAuth.headlessRegister(
+                email: any(named: 'email'),
+                password: any(named: 'password'),
+                scope: any(named: 'scope'),
+                marketingConsent: true,
               ),
             ).called(1);
 
@@ -2107,8 +2176,9 @@ void main() {
           inviteRecoverySourceSlug: 'lele-pons',
           obscurePassword: false,
           isSubmitting: true,
+          marketingConsent: true,
         );
-        expect(state.props, hasLength(17));
+        expect(state.props, hasLength(18));
       });
     });
 

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -115,13 +115,14 @@ void main() {
       );
     });
 
-    DivineAuthCubit buildCubit({String? inviteCode}) {
+    DivineAuthCubit buildCubit({String? inviteCode, String? appVersion}) {
       return DivineAuthCubit(
         oauthClient: mockOAuth,
         authService: mockAuthService,
         pendingVerificationService: mockPendingVerification,
         inviteApiClient: mockInviteApiClient,
         inviteCode: inviteCode,
+        appVersion: appVersion,
         validationMessages: AuthValidationMessages.englishDefaults,
         analytics: analytics,
       );
@@ -1003,6 +1004,7 @@ void main() {
                 email: any(named: 'email'),
                 password: any(named: 'password'),
                 scope: any(named: 'scope'),
+                marketingConsent: any(named: 'marketingConsent'),
               ),
             ).thenAnswer((_) => registered.future);
             when(
@@ -1040,6 +1042,7 @@ void main() {
                 email: any(named: 'email'),
                 password: any(named: 'password'),
                 scope: any(named: 'scope'),
+                marketingConsent: any(named: 'marketingConsent'),
               ),
             ).called(1);
 
@@ -1048,7 +1051,7 @@ void main() {
         );
 
         test(
-          'forwards marketingConsent to headlessRegister when opted in',
+          'forwards consent provenance to headlessRegister when opted in',
           () async {
             when(
               () => mockOAuth.headlessRegister(
@@ -1056,6 +1059,7 @@ void main() {
                 password: any(named: 'password'),
                 scope: any(named: 'scope'),
                 marketingConsent: any(named: 'marketingConsent'),
+                appVersion: any(named: 'appVersion'),
               ),
             ).thenAnswer(
               (_) async => (
@@ -1078,7 +1082,7 @@ void main() {
               ),
             ).thenAnswer((_) async {});
 
-            final cubit = buildCubit()
+            final cubit = buildCubit(appVersion: '1.2.3')
               ..initialize()
               ..updateEmail(testEmail)
               ..updatePassword(testPassword)
@@ -1092,6 +1096,7 @@ void main() {
                 password: any(named: 'password'),
                 scope: any(named: 'scope'),
                 marketingConsent: true,
+                appVersion: '1.2.3',
               ),
             ).called(1);
 
@@ -1107,6 +1112,7 @@ void main() {
                 email: any(named: 'email'),
                 password: any(named: 'password'),
                 scope: any(named: 'scope'),
+                marketingConsent: any(named: 'marketingConsent'),
               ),
             ).thenAnswer(
               (_) async => (
@@ -1167,6 +1173,7 @@ void main() {
                 email: any(named: 'email'),
                 password: any(named: 'password'),
                 scope: any(named: 'scope'),
+                marketingConsent: any(named: 'marketingConsent'),
               ),
             ).thenAnswer(
               (_) async => (
@@ -1201,6 +1208,7 @@ void main() {
                 email: testEmail,
                 password: testPassword,
                 scope: 'policy:full',
+                marketingConsent: false,
               ),
             ).called(1);
             verify(
@@ -1222,6 +1230,7 @@ void main() {
                 email: any(named: 'email'),
                 password: any(named: 'password'),
                 scope: any(named: 'scope'),
+                marketingConsent: any(named: 'marketingConsent'),
               ),
             ).thenAnswer(
               (_) async => (
@@ -1271,6 +1280,7 @@ void main() {
                 email: any(named: 'email'),
                 password: any(named: 'password'),
                 scope: any(named: 'scope'),
+                marketingConsent: any(named: 'marketingConsent'),
               ),
             ).thenAnswer(
               (_) async => (
@@ -1312,6 +1322,7 @@ void main() {
                   email: any(named: 'email'),
                   password: any(named: 'password'),
                   scope: any(named: 'scope'),
+                  marketingConsent: any(named: 'marketingConsent'),
                 ),
               ).thenAnswer(
                 (_) async => (
@@ -1354,6 +1365,7 @@ void main() {
                   email: any(named: 'email'),
                   password: any(named: 'password'),
                   scope: any(named: 'scope'),
+                  marketingConsent: any(named: 'marketingConsent'),
                 ),
               ).thenAnswer(
                 (_) async => (
@@ -1393,6 +1405,7 @@ void main() {
                   email: any(named: 'email'),
                   password: any(named: 'password'),
                   scope: any(named: 'scope'),
+                  marketingConsent: any(named: 'marketingConsent'),
                 ),
               ).thenAnswer(
                 (_) async => (
@@ -1429,6 +1442,7 @@ void main() {
                   email: any(named: 'email'),
                   password: any(named: 'password'),
                   scope: any(named: 'scope'),
+                  marketingConsent: any(named: 'marketingConsent'),
                 ),
               ).thenAnswer(
                 (_) async => (
@@ -1468,6 +1482,7 @@ void main() {
                   email: any(named: 'email'),
                   password: any(named: 'password'),
                   scope: any(named: 'scope'),
+                  marketingConsent: any(named: 'marketingConsent'),
                 ),
               ).thenAnswer(
                 (_) async => (
@@ -1507,6 +1522,7 @@ void main() {
                   email: any(named: 'email'),
                   password: any(named: 'password'),
                   scope: any(named: 'scope'),
+                  marketingConsent: any(named: 'marketingConsent'),
                 ),
               ).thenAnswer(
                 (_) async => (
@@ -1546,6 +1562,7 @@ void main() {
                   email: any(named: 'email'),
                   password: any(named: 'password'),
                   scope: any(named: 'scope'),
+                  marketingConsent: any(named: 'marketingConsent'),
                 ),
               ).thenAnswer(
                 (_) async => (
@@ -1585,6 +1602,7 @@ void main() {
                   email: any(named: 'email'),
                   password: any(named: 'password'),
                   scope: any(named: 'scope'),
+                  marketingConsent: any(named: 'marketingConsent'),
                 ),
               ).thenAnswer(
                 (_) async => (
@@ -1628,6 +1646,7 @@ void main() {
                   email: any(named: 'email'),
                   password: any(named: 'password'),
                   scope: any(named: 'scope'),
+                  marketingConsent: any(named: 'marketingConsent'),
                 ),
               ).thenAnswer(
                 (_) async => (
@@ -1668,6 +1687,7 @@ void main() {
                   email: any(named: 'email'),
                   password: any(named: 'password'),
                   scope: any(named: 'scope'),
+                  marketingConsent: any(named: 'marketingConsent'),
                 ),
               ).thenAnswer(
                 (_) async => (
@@ -1708,6 +1728,7 @@ void main() {
                 email: any(named: 'email'),
                 password: any(named: 'password'),
                 scope: any(named: 'scope'),
+                marketingConsent: any(named: 'marketingConsent'),
               ),
             ).thenThrow(Exception('network failure'));
           },
@@ -1745,6 +1766,7 @@ void main() {
                 email: any(named: 'email'),
                 password: any(named: 'password'),
                 scope: any(named: 'scope'),
+                marketingConsent: any(named: 'marketingConsent'),
               ),
             ).thenAnswer((_) => registered.future);
             when(

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -669,6 +669,9 @@ const _knownUntranslatedDebt = <String>{
   // profileBadgeOgVinerBody to _profileBadgeSheetKeys below, which already
   // guards the sheet against English fallback and covers neither today.
   'profileBadgeOgBetaTesterBody',
+  // Create-account marketing opt-in translation is deferred until the locale
+  // pass for this new consent copy.
+  'authCreateAccountMarketingOptIn',
   // The four social-proof keys and searchUserVideoCount left this list when
   // this branch translated them into every locale.
 };

--- a/mobile/test/screens/auth/create_account_screen_test.dart
+++ b/mobile/test/screens/auth/create_account_screen_test.dart
@@ -380,6 +380,8 @@ void main() {
               email: any(named: 'email'),
               password: any(named: 'password'),
               scope: any(named: 'scope'),
+              marketingConsent: any(named: 'marketingConsent'),
+              appVersion: any(named: 'appVersion'),
             ),
           ).thenAnswer(
             (_) async => (
@@ -487,6 +489,8 @@ void main() {
               email: any(named: 'email'),
               password: any(named: 'password'),
               scope: any(named: 'scope'),
+              marketingConsent: any(named: 'marketingConsent'),
+              appVersion: any(named: 'appVersion'),
             ),
           ).thenAnswer(
             (_) async => (
@@ -593,6 +597,8 @@ void main() {
             email: any(named: 'email'),
             password: any(named: 'password'),
             scope: any(named: 'scope'),
+            marketingConsent: any(named: 'marketingConsent'),
+            appVersion: any(named: 'appVersion'),
           ),
         ).thenAnswer(
           (_) async => (
@@ -643,6 +649,8 @@ void main() {
             email: any(named: 'email'),
             password: any(named: 'password'),
             scope: any(named: 'scope'),
+            marketingConsent: any(named: 'marketingConsent'),
+            appVersion: any(named: 'appVersion'),
           ),
         );
       });
@@ -685,6 +693,8 @@ void main() {
             email: any(named: 'email'),
             password: any(named: 'password'),
             scope: any(named: 'scope'),
+            marketingConsent: any(named: 'marketingConsent'),
+            appVersion: any(named: 'appVersion'),
           ),
         );
       });
@@ -696,6 +706,8 @@ void main() {
             email: any(named: 'email'),
             password: any(named: 'password'),
             scope: any(named: 'scope'),
+            marketingConsent: any(named: 'marketingConsent'),
+            appVersion: any(named: 'appVersion'),
           ),
         ).thenAnswer(
           (_) async => (
@@ -750,6 +762,8 @@ void main() {
             email: 'test@example.com',
             password: 'SecurePass123!',
             scope: 'policy:full',
+            marketingConsent: false,
+            appVersion: 'test',
           ),
         ).called(1);
       });
@@ -766,6 +780,8 @@ void main() {
             email: any(named: 'email'),
             password: any(named: 'password'),
             scope: any(named: 'scope'),
+            marketingConsent: any(named: 'marketingConsent'),
+            appVersion: any(named: 'appVersion'),
           ),
         ).thenAnswer((_) => registered.future);
 
@@ -817,6 +833,8 @@ void main() {
             email: 'test@example.com',
             password: 'SecurePass123!',
             scope: 'policy:full',
+            marketingConsent: false,
+            appVersion: 'test',
           ),
         ).called(1);
 

--- a/mobile/test/screens/auth/create_account_screen_test.dart
+++ b/mobile/test/screens/auth/create_account_screen_test.dart
@@ -823,5 +823,33 @@ void main() {
         await tester.pumpAndSettle();
       });
     });
+
+    group('marketing opt-in', () {
+      DivineCheckbox optInCheckbox(WidgetTester tester) =>
+          tester.widget<DivineCheckbox>(find.byType(DivineCheckbox));
+
+      testWidgets('renders unchecked by default', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.text(l10n.authCreateAccountMarketingOptIn),
+          findsOneWidget,
+        );
+        expect(optInCheckbox(tester).state, DivineCheckboxState.unselected);
+      });
+
+      testWidgets('checks when the user taps it', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.authCreateAccountMarketingOptIn));
+        await tester.pumpAndSettle();
+
+        expect(optInCheckbox(tester).state, DivineCheckboxState.selected);
+      });
+    });
   });
 }

--- a/mobile/test/screens/auth/create_account_screen_test.dart
+++ b/mobile/test/screens/auth/create_account_screen_test.dart
@@ -95,6 +95,7 @@ void main() {
   Widget createTestWidget({
     InviteAccessGrant? inviteAccessGrant,
     AnalyticsService? analyticsService,
+    TextScaler? textScaler,
   }) {
     return ProviderScope(
       overrides: [
@@ -125,6 +126,14 @@ void main() {
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             theme: VineTheme.theme,
+            builder: textScaler == null
+                ? null
+                : (context, child) => MediaQuery(
+                    data: MediaQuery.of(
+                      context,
+                    ).copyWith(textScaler: textScaler),
+                    child: child!,
+                  ),
             home: const CreateAccountScreen(),
           ),
         ),
@@ -849,6 +858,20 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(optInCheckbox(tester).state, DivineCheckboxState.selected);
+      });
+
+      testWidgets('renders without overflow at 2x text scale', (tester) async {
+        await tester.pumpWidget(
+          createTestWidget(textScaler: const TextScaler.linear(2)),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.text(l10n.authCreateAccountMarketingOptIn),
+          findsOneWidget,
+        );
+        expect(tester.takeException(), isNull);
       });
     });
   });


### PR DESCRIPTION
## What this does

Adds an unchecked opt-in to the email/password create-account screen, so someone making an account can choose to hear from us. The choice and app version are sent to keycast with registration and stored on the account, preserving which wording the person answered.

Companion backend PR: divinevideo/keycast#404.

**Do not merge this before keycast#404 is deployed to production.** Production keycast does not know `marketing_consent` or `app_version` yet, and `HeadlessRegisterRequest` ignores unknown fields rather than rejecting them. Merging this first leaves registration working normally while every opt-in is silently discarded: no error, no log, and nothing to notice until somebody asks why the mailing list has no consents in it. Deployed, not merged, is the condition.

## Why it sits here

The issue's constraint is that asking for an email must not read as a requirement, must not add friction, and must not imply the address is tied to account recovery. This screen already collects an email, so the opt-in adds no new ask, only a choice about an address the person is already giving us. The nsec path is untouched, and skipping is free: the box starts unchecked and nothing depends on it.

## What it does not do

It does not close divinevideo/divine-mobile#8279. That issue is `needs design` and its acceptance criteria are mostly decisions rather than code. This is the follow-on implementation it anticipates, so it links as related.

Getting an opt-in from keycast into the mailing list is separate, unbuilt work that will be tracked and linked.

## Copy

The checkbox now says "Get Divine app updates and news," so an unticked control describes what selecting it provides. It uses its own translation key rather than changing the retired waitlist wording. Non-English translations are deferred through the existing localization-debt mechanism.

## Accessibility

The tap target was under the 48dp minimum from the repo's own accessibility guidance and is now wrapped to meet it. There is a test that pumps the screen at 2x text scale and asserts the opt-in row renders without overflow, since larger text settings are called out explicitly in the sibling web issue.

Screen-reader behaviour is unchanged rather than newly tested: the wrapping widget is layout-only and cannot alter a semantics node, and the existing tap test already routes through the semantics tree, so it would fail if that path broke. Noting this rather than claiming a test that does not exist.

## Testing

Rebased onto current main. App and package analysis, format, generated localization, create-account, secure-account, authentication cubit, Keycast client, localization consistency, and the repository's `mise run test` suite pass locally.

Per the note on #8279, this should not block the current mobile release.

Relates to divinevideo/divine-mobile#8279. Does not close it.

