### PR TITLE
fix(reporting): refuse self-reports before they publish (#8352)

### DIFF
--- a/mobile/lib/blocs/comments/comment_reactions/comment_reactions_bloc.dart
+++ b/mobile/lib/blocs/comments/comment_reactions/comment_reactions_bloc.dart
@@ -362,9 +362,7 @@ class CommentReactionsBloc
       // A deliberately refused report (a self-report, #8352) is a silent
       // success like `reached` — it must not surface as a failure the user
       // could "retry", since it will always refuse identically.
-      if (!result.success ||
-          (result.delivery != ReportDelivery.reached &&
-              result.delivery != ReportDelivery.refused)) {
+      if (!result.isSilentSuccess) {
         Log.warning(
           'Comment report not delivered '
           '(success=${result.success}, delivery=${result.delivery}): '

--- a/mobile/lib/blocs/comments/comment_reactions/comment_reactions_bloc.dart
+++ b/mobile/lib/blocs/comments/comment_reactions/comment_reactions_bloc.dart
@@ -359,7 +359,12 @@ class CommentReactionsBloc
       // or an unbuildable event, and a `success` report can still have
       // reached no channel off this device (#6387). Neither throws, so
       // discarding the result showed the user a silent success (#6595).
-      if (!result.success || result.delivery != ReportDelivery.reached) {
+      // A deliberately refused report (a self-report, #8352) is a silent
+      // success like `reached` — it must not surface as a failure the user
+      // could "retry", since it will always refuse identically.
+      if (!result.success ||
+          (result.delivery != ReportDelivery.reached &&
+              result.delivery != ReportDelivery.refused)) {
         Log.warning(
           'Comment report not delivered '
           '(success=${result.success}, delivery=${result.delivery}): '

--- a/mobile/lib/blocs/dm/conversation_actions/conversation_actions_cubit.dart
+++ b/mobile/lib/blocs/dm/conversation_actions/conversation_actions_cubit.dart
@@ -88,7 +88,12 @@ class ConversationActionsCubit extends Cubit<ConversationActionsState> {
       // even when the relay publish and the Zendesk ticket both failed and
       // nothing left the device. The caller shows a "Reported {name}"
       // confirmation off this bool, so require actual delivery.
-      return result.success && result.delivery == ReportDelivery.reached;
+      // A deliberately refused report (a self-report, #8352) is a silent
+      // success: return true so the caller shows the normal confirmation
+      // rather than a failure, since nothing was (or ever will be) sent.
+      return result.success &&
+          (result.delivery == ReportDelivery.reached ||
+              result.delivery == ReportDelivery.refused);
     } catch (e, stackTrace) {
       // `ContentReportingService.reportUser` returns `ReportResult.failure`
       // for expected publish/auth problems. Any throw escaping here is

--- a/mobile/lib/blocs/dm/conversation_actions/conversation_actions_cubit.dart
+++ b/mobile/lib/blocs/dm/conversation_actions/conversation_actions_cubit.dart
@@ -91,9 +91,7 @@ class ConversationActionsCubit extends Cubit<ConversationActionsState> {
       // A deliberately refused report (a self-report, #8352) is a silent
       // success: return true so the caller shows the normal confirmation
       // rather than a failure, since nothing was (or ever will be) sent.
-      return result.success &&
-          (result.delivery == ReportDelivery.reached ||
-              result.delivery == ReportDelivery.refused);
+      return result.isSilentSuccess;
     } catch (e, stackTrace) {
       // `ContentReportingService.reportUser` returns `ReportResult.failure`
       // for expected publish/auth problems. Any throw escaping here is

--- a/mobile/lib/blocs/report/report_submission_cubit.dart
+++ b/mobile/lib/blocs/report/report_submission_cubit.dart
@@ -328,6 +328,18 @@ class ReportSubmissionCubit extends Cubit<ReportSubmissionState> {
             );
       if (isClosed) return;
 
+      if (result.success && result.delivery == ReportDelivery.refused) {
+        // A deliberate refusal — a self-report (#8352). Nothing was built,
+        // published, or recorded, and nothing should be sent: not the
+        // kind-1984 event, and NOT the moderation DM. Unlike `localOnly`
+        // below (a real report that couldn't reach a channel and is handed to
+        // the retrying DM), `refused` must never touch the DM path, or a
+        // self-naming report leaves the device privately. Silent success —
+        // show the normal confirmation.
+        _update(status: ReportSubmissionStatus.submitted);
+        return;
+      }
+
       if (result.success && result.delivery == ReportDelivery.localOnly) {
         // Nothing left the device — every channel refused, which usually
         // means no connectivity. The confirmation screen would be false in

--- a/mobile/lib/blocs/report/report_submission_cubit.dart
+++ b/mobile/lib/blocs/report/report_submission_cubit.dart
@@ -328,7 +328,7 @@ class ReportSubmissionCubit extends Cubit<ReportSubmissionState> {
             );
       if (isClosed) return;
 
-      if (result.success && result.delivery == ReportDelivery.refused) {
+      if (result.isSilentSuccess && result.delivery == ReportDelivery.refused) {
         // A deliberate refusal — a self-report (#8352). Nothing was built,
         // published, or recorded, and nothing should be sent: not the
         // kind-1984 event, and NOT the moderation DM. Unlike `localOnly`

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -209,6 +209,26 @@ class ContentReportingService {
       // Generate report ID
       final reportId = 'report_${DateTime.now().millisecondsSinceEpoch}';
 
+      // Self-report guard (#8352). A bare user report carries only a `p` tag,
+      // so when reporter and target are the same pubkey the published kind-1984
+      // event names the report's own author as the reported party — a permanent,
+      // public record with no signal to a moderator that they are the same
+      // person. Refuse it before anything is built or published. Silent, like
+      // the follow/unfollow/mute self-guards: a user who reaches this is not
+      // doing it deliberately, so we return success and simply publish nothing.
+      final reporterPubkey = _authService.currentPublicKeyHex;
+      if (reporterPubkey != null && reporterPubkey == authorPubkey) {
+        Log.info(
+          'Refused a self-report before publishing (target == reporter)',
+          name: 'ContentReportingService',
+          category: LogCategory.system,
+        );
+        return ReportResult.createSuccess(
+          reportId,
+          delivery: ReportDelivery.localOnly,
+        );
+      }
+
       // Redact once, here, so every projection of this report inherits it.
       // The kind-1984 event is published to relays in plaintext and the
       // Zendesk ticket can be mirrored publicly, so a credential pasted into

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -62,6 +62,15 @@ class ReportResult {
   /// the optimistic answer.
   final ReportDelivery delivery;
 
+  /// Whether callers should present this result as a successful submission.
+  ///
+  /// A refusal is intentionally silent, so it has the same user-facing
+  /// outcome as a delivered report even though nothing left the device.
+  bool get isSilentSuccess =>
+      success &&
+      (delivery == ReportDelivery.reached ||
+          delivery == ReportDelivery.refused);
+
   factory ReportResult.createSuccess(
     String reportId, {
     required ReportDelivery delivery,
@@ -220,10 +229,14 @@ class ContentReportingService {
       // so when reporter and target are the same pubkey the published kind-1984
       // event names the report's own author as the reported party — a permanent,
       // public record with no signal to a moderator that they are the same
-      // person. Refuse it before anything is built or published. Silent, like
+      // person. Refuse it before any report payload or event is built or
+      // published. Silent, like
       // the follow/unfollow/mute self-guards: a user who reaches this is not
       // doing it deliberately, so we return success and simply publish nothing.
       final reporterPubkey = _authService.currentPublicKeyHex;
+      // Authentication normally guarantees a current public key. If that
+      // invariant is temporarily broken, fail open here so unrelated reports
+      // are not all mistaken for self-reports and refused.
       if (reporterPubkey != null &&
           reporterPubkey.toLowerCase() == authorPubkey.toLowerCase()) {
         Log.info(

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -30,6 +30,13 @@ enum ReportDelivery {
   /// which nothing in the app ever replays — so it is a dead letter
   /// unless the user submits again.
   localOnly,
+
+  /// The report was deliberately refused before anything was built,
+  /// published, or recorded — e.g. a self-report (#8352). Distinct from
+  /// [localOnly]: there is no local record, and callers must treat it as a
+  /// silent no-op, never as a failed delivery to retry or hand to a fallback
+  /// channel such as the moderation DM.
+  refused,
 }
 
 /// Report submission result
@@ -217,7 +224,8 @@ class ContentReportingService {
       // the follow/unfollow/mute self-guards: a user who reaches this is not
       // doing it deliberately, so we return success and simply publish nothing.
       final reporterPubkey = _authService.currentPublicKeyHex;
-      if (reporterPubkey != null && reporterPubkey == authorPubkey) {
+      if (reporterPubkey != null &&
+          reporterPubkey.toLowerCase() == authorPubkey.toLowerCase()) {
         Log.info(
           'Refused a self-report before publishing (target == reporter)',
           name: 'ContentReportingService',
@@ -225,7 +233,7 @@ class ContentReportingService {
         );
         return ReportResult.createSuccess(
           reportId,
-          delivery: ReportDelivery.localOnly,
+          delivery: ReportDelivery.refused,
         );
       }
 

--- a/mobile/test/blocs/comments/comment_reactions/comment_reactions_bloc_test.dart
+++ b/mobile/test/blocs/comments/comment_reactions/comment_reactions_bloc_test.dart
@@ -152,16 +152,14 @@ void main() {
             validId('c1'): '34236:${validId('author1')}:reply-d',
           };
           verify(
-            () => mockLikesRepository.getVoteCounts(
-              [validId('c1')],
-              addressableIds: expected,
-            ),
+            () => mockLikesRepository.getVoteCounts([
+              validId('c1'),
+            ], addressableIds: expected),
           ).called(1);
           verify(
-            () => mockLikesRepository.getUserVoteStatuses(
-              [validId('c1')],
-              addressableIds: expected,
-            ),
+            () => mockLikesRepository.getUserVoteStatuses([
+              validId('c1'),
+            ], addressableIds: expected),
           ).called(1);
         },
       );
@@ -564,6 +562,34 @@ void main() {
             ),
           ).called(1);
         },
+      );
+
+      blocTest<CommentReactionsBloc, CommentReactionsState>(
+        'emits no error when the report is deliberately refused',
+        setUp: () {
+          when(
+            () => mockContentReportingService.reportContent(
+              eventId: any(named: 'eventId'),
+              authorPubkey: any(named: 'authorPubkey'),
+              reason: any(named: 'reason'),
+              details: any(named: 'details'),
+            ),
+          ).thenAnswer(
+            (_) async => ReportResult.createSuccess(
+              'rid',
+              delivery: ReportDelivery.refused,
+            ),
+          );
+        },
+        build: createBloc,
+        act: (b) => b.add(
+          CommentReportRequested(
+            commentId: validId('c1'),
+            authorPubkey: validId('a1'),
+            reason: ContentFilterReason.spam,
+          ),
+        ),
+        expect: () => isEmpty,
       );
 
       blocTest<CommentReactionsBloc, CommentReactionsState>(

--- a/mobile/test/blocs/dm/conversation_actions/conversation_actions_cubit_test.dart
+++ b/mobile/test/blocs/dm/conversation_actions/conversation_actions_cubit_test.dart
@@ -127,6 +127,35 @@ void main() {
       );
 
       blocTest<ConversationActionsCubit, ConversationActionsState>(
+        'returns true when a self-report is deliberately refused',
+        setUp: () {
+          when(
+            () => mockReportingService.reportUser(
+              userPubkey: pubkey,
+              reason: ContentFilterReason.other,
+              details: 'Reported from DM conversation',
+            ),
+          ).thenAnswer(
+            (_) async => ReportResult.createSuccess(
+              'report-id',
+              delivery: ReportDelivery.refused,
+            ),
+          );
+        },
+        build: createCubit,
+        act: (cubit) async {
+          final result = await cubit.reportUser(pubkey);
+          expect(result, isTrue);
+        },
+        expect: () => [
+          const ConversationActionsState(
+            status: ConversationActionsStatus.processing,
+          ),
+          const ConversationActionsState(),
+        ],
+      );
+
+      blocTest<ConversationActionsCubit, ConversationActionsState>(
         'returns false when the report reached no channel',
         // #6387: `success` is true even when the relay publish and the
         // Zendesk ticket both failed. The caller renders a

--- a/mobile/test/blocs/report/report_submission_cubit_test.dart
+++ b/mobile/test/blocs/report/report_submission_cubit_test.dart
@@ -161,6 +161,45 @@ void main() {
       },
     );
 
+    blocTest<ReportSubmissionCubit, ReportSubmissionState>(
+      'a refused self-report is silent — confirmation shown, nothing sent (#8352)',
+      build: () {
+        when(
+          () => reportingService.reportContent(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
+            reason: any(named: 'reason'),
+            details: any(named: 'details'),
+            sourceRelay: any(named: 'sourceRelay'),
+            additionalContext: any(named: 'additionalContext'),
+            hashtags: any(named: 'hashtags'),
+          ),
+        ).thenAnswer(
+          (_) async => ReportResult.createSuccess(
+            'id',
+            delivery: ReportDelivery.refused,
+          ),
+        );
+        return buildCubit();
+      },
+      act: submit,
+      verify: (cubit) {
+        // Silent success — unlike the `localOnly` offline path, a refusal must
+        // NOT hand off to the moderation DM, or a self-naming report would
+        // still leave the device privately (the exact bug #8352 fixes).
+        expect(cubit.state.status, ReportSubmissionStatus.submitted);
+        verifyNever(
+          () => dmRepository.sendMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: any(named: 'content'),
+            replyToId: any(named: 'replyToId'),
+            skipNip04Fallback: any(named: 'skipNip04Fallback'),
+            additionalTags: any(named: 'additionalTags'),
+          ),
+        );
+      },
+    );
+
     test('hands back the rejection detail for the inline error', () async {
       when(
         () => reportingService.reportContent(

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -372,7 +372,7 @@ void main() {
         // Silent success to the caller, nothing left the device, and neither
         // signing nor publishing was ever attempted.
         expect(result.success, isTrue);
-        expect(result.delivery, ReportDelivery.localOnly);
+        expect(result.delivery, ReportDelivery.refused);
         verifyNever(
           () => mockAuthService.createAndSignEvent(
             kind: any(named: 'kind'),

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -335,6 +335,60 @@ void main() {
       },
     );
 
+    test(
+      'reportContent() silently refuses a self-report (target == reporter) '
+      'without building or publishing any event (#8352)',
+      () async {
+        // Publishing WOULD succeed here — the point is that the guard refuses
+        // before we ever reach signing or the relay.
+        final wouldBeEvent = createTestEvent(
+          pubkey: testPublicKey,
+          kind: 1984,
+          tags: const <List<String>>[],
+          content: '',
+        );
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((_) async => wouldBeEvent);
+        when(
+          () => mockNostrService.publishEvent(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => PublishSuccess(event: wouldBeEvent));
+
+        // Act: target the reporter's own pubkey (== currentPublicKeyHex).
+        final result = await service.reportContent(
+          eventId: _validEventId('a'),
+          authorPubkey: testPublicKey,
+          reason: ContentFilterReason.other,
+          details: 'accidental self-report',
+        );
+
+        // Silent success to the caller, nothing left the device, and neither
+        // signing nor publishing was ever attempted.
+        expect(result.success, isTrue);
+        expect(result.delivery, ReportDelivery.localOnly);
+        verifyNever(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        );
+        verifyNever(
+          () => mockNostrService.publishEvent(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+      },
+    );
+
     test('reportContent() handles all ContentFilterReason types including '
         'aiGenerated', () async {
       // Arrange

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -389,6 +389,29 @@ void main() {
       },
     );
 
+    test(
+      'reportContent() self-report guard is case-insensitive (#8352)',
+      () async {
+        // authorPubkey can arrive uppercased (it is copied from Event.pubkey),
+        // while currentPublicKeyHex is lowercase. The guard must still catch it.
+        final result = await service.reportContent(
+          eventId: _validEventId('a'),
+          authorPubkey: testPublicKey.toUpperCase(),
+          reason: ContentFilterReason.other,
+          details: 'accidental self-report, upper-cased target',
+        );
+
+        expect(result.success, isTrue);
+        expect(result.delivery, ReportDelivery.refused);
+        verifyNever(
+          () => mockNostrService.publishEvent(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+      },
+    );
+
     test('reportContent() handles all ContentFilterReason types including '
         'aiGenerated', () async {
       // Arrange


### PR DESCRIPTION
Fixes #8352.

## What
`content_reporting_service.dart` never compared reporter to target, so a report whose target is the reporter published a permanent, public kind-1984 event naming the reporter as the reported party (a bare user report carries only a `p` tag). Two commits:

1. **Guard at the `reportContent` seam** (both `reportUser` and `quickReport` funnel through it): if the target equals `_authService.currentPublicKeyHex` (case-normalized), refuse before anything is built or published.
2. **Route the refusal away from every channel.** The refusal is signalled with a distinct `ReportDelivery.refused` (not `localOnly`), and `ReportSubmissionCubit` treats it as a silent `submitted` confirmation — **never** the moderation-DM fallback. (An adversarial review caught that returning `localOnly` first made the cubit hand a self-report to the moderation DM as an "offline retry", so it still left the device privately as a NIP-17 DM naming the reporter. Fixed.)

Silent throughout — matching the follow/unfollow/mute self-guards. Nothing published, nothing DM'd, no local record.

## Acceptance (#8352)
- [x] A report whose target equals the reporter is refused before any event is published — and does not reach the moderation DM either.
- [x] Covered by tests: a service test (refusal, verified RED without the guard) **and** consumer tests proving no moderation DM fires and every UI consumer treats refusal as silent success. The focused suites and analyzer are green.
- [x] Server-side guard decision recorded + tracked: divinevideo/divine-moderation-service#211 (client checks depend on every client; a pipeline guard also covers divine-web's unguarded Report path).

## Out of scope
- The sibling `Block` self-target behavior is a **harmless, cosmetic** UI nit (the blocklist repository already skips a self-block and logs it — nothing is published). Left out to keep this PR focused on the security fix.
