### PR TITLE
fix(dm): tell the user when a resend failed again

### DIFF
--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -505,8 +505,12 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
       emit(state.copyWith(sendStatus: SendStatus.sent));
     } else {
       // Some rows are still hard-failing. They remain `failed` in the queue
-      // (red bubbles) and are re-tappable to resend; just re-raise the status.
-      emit(state.copyWith(sendStatus: SendStatus.failed));
+      // (red bubbles) and are re-tappable to resend. Re-raising `failed` here
+      // would leave the UI byte-identical to before the tap — the bubble was
+      // already red — so the resend reads as a tap that did nothing (#8461).
+      // `resendFailed` carries that the attempt happened and lost, which is
+      // the part the red bubble cannot express a second time.
+      emit(state.copyWith(sendStatus: SendStatus.resendFailed));
     }
     // Reflect the recovery's queue-row transitions (a row re-marked `failed`,
     // or deleted on success) immediately — a watch tick fired mid-handler can

--- a/mobile/lib/blocs/dm/conversation/conversation_state.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_state.dart
@@ -18,12 +18,22 @@ enum ConversationStatus { initial, loading, loaded, error }
 /// [failed] leans on the red "Not delivered" bubble as its affordance, so it
 /// raises no toast. [blocked] and [noRecipient] never produce a queue row and
 /// therefore never produce a bubble, which is why both are toasted instead.
+///
+/// [resendFailed] is that same failure reached from an explicit resend, and it
+/// is separate precisely because the bubble affordance does NOT work twice: the
+/// row was already red before the tap, so re-emitting [failed] leaves the
+/// before and after states identical and the resend is indistinguishable from
+/// a tap that did nothing (#8461). It is toasted for that reason.
 enum SendStatus {
   idle,
   sending,
   sent,
   sentPartial,
   failed,
+
+  /// A user-initiated resend that failed again. See the enum doc: this is
+  /// [failed] with a working affordance, not a different repository outcome.
+  resendFailed,
   blocked,
 
   /// Dispatched with an empty recipient list (#7335). Refused before the

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2424,6 +2424,7 @@
     "dmRetiredThreadClosedBody": "Divine Moderation ወደ አዲስ መለያ አዛውረናል። ይህን መለያ የሚያነበው የለም።",
     "dmRetiredThreadOpenSupport": "Divine Moderation ላይ መልእክት ይላኩ",
     "dmSendFailedMessage": "መልዕክቱ መላክ አልተሳካም",
+    "dmResendFailedMessage": "አሁንም መላክ አልተሳካም",
     "dmSendFailedSubtitle": "አሁን እንደገና ላክ ወይም መሞከር አቁም።",
     "dmSendFailedRetry": "እንደገና ይሞክሩ",
     "dmSendPartialMessage": "ተልኳል፣ ግን ወደ ሌሎች መሣሪያዎች አልተመሳሰለም",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2152,6 +2152,7 @@
     "dmRetiredThreadClosedBody": "نقلنا Divine Moderation إلى حساب جديد. لم يعد أحد يقرأ هذا الحساب.",
     "dmRetiredThreadOpenSupport": "راسل Divine Moderation",
     "dmSendFailedMessage": "تعذّر إرسال الرسالة",
+    "dmResendFailedMessage": "ما زال الإرسال متعذّرًا",
     "dmSendFailedSubtitle": "أعد إرسالها الآن، أو أوقف المحاولة.",
     "dmSendFailedRetry": "إعادة المحاولة",
     "dmSendPartialMessage": "أُرسلت، لكنّها لم تُزامَن مع أجهزتك الأخرى",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2217,6 +2217,7 @@
     "dmRetiredThreadClosedBody": "Преместихме Divine Moderation в нов профил. Този вече не се чете от никого.",
     "dmRetiredThreadOpenSupport": "Пишете на Divine Moderation",
     "dmSendFailedMessage": "Съобщението не мина",
+    "dmResendFailedMessage": "Още не мина",
     "dmSendFailedSubtitle": "Изпрати го отново сега или спри опитите.",
     "dmSendFailedRetry": "Опитай пак",
     "dmSendPartialMessage": "Изпратено, но не се синхронизира с другите ти устройства",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2162,6 +2162,7 @@
     "dmRetiredThreadClosedBody": "Wir haben Divine Moderation auf ein neues Konto umgezogen. Dieses hier liest niemand mehr.",
     "dmRetiredThreadOpenSupport": "Divine Moderation schreiben",
     "dmSendFailedMessage": "Nachricht konnte nicht gesendet werden",
+    "dmResendFailedMessage": "Konnte weiterhin nicht gesendet werden",
     "dmSendFailedSubtitle": "Sende sie jetzt erneut oder versuche es nicht mehr.",
     "dmSendFailedRetry": "Erneut versuchen",
     "dmSendPartialMessage": "Gesendet, aber nicht mit deinen anderen Geräten synchronisiert",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3550,6 +3550,10 @@
   "@dmSendFailedMessage": {
     "description": "Accessibility announcement text, and the recovery bottom sheet's title, shown in a DM conversation when a send fails (relay error, signer error, network error). The bottom sheet pairs it with `dmSendFailedSubtitle` and the `dmMessageActionRetrySend` / `dmMessageActionCancelSend` actions."
   },
+  "dmResendFailedMessage": "Still couldn't send",
+  "@dmResendFailedMessage": {
+    "description": "SnackBar text shown in a DM conversation when the user taps Resend on a failed message and the retry fails again. Distinct from `dmSendFailedMessage`, which titles the recovery sheet and announces a FIRST send failure: on a resend the bubble is already red, so the red bubble cannot signal the new attempt and a toast is the only feedback the user gets."
+  },
   "dmSendFailedSubtitle": "Resend it now, or stop trying.",
   "@dmSendFailedSubtitle": {
     "description": "Subtitle in the recovery bottom sheet shown when a failed own DM bubble is tapped, below the `dmSendFailedMessage` title."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2170,6 +2170,7 @@
     "dmRetiredThreadClosedBody": "Movimos Divine Moderation a una cuenta nueva. Ya nadie lee esta.",
     "dmRetiredThreadOpenSupport": "Enviar mensaje a Divine Moderation",
     "dmSendFailedMessage": "No se pudo enviar el mensaje",
+    "dmResendFailedMessage": "Sigue sin poder enviarse",
     "dmSendFailedSubtitle": "Reenvíalo ahora o deja de intentarlo.",
     "dmSendFailedRetry": "Reintentar",
     "dmSendPartialMessage": "Enviado, pero no se sincronizó con tus otros dispositivos",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1434,6 +1434,7 @@
     "dmRetiredThreadClosedBody": "Inilipat namin ang Divine Moderation sa bagong account. Wala nang nagbabasa nito.",
     "dmRetiredThreadOpenSupport": "I-message ang Divine Moderation",
     "dmSendFailedMessage": "Hindi naipadala ang message",
+    "dmResendFailedMessage": "Hindi pa rin naipadala",
     "dmSendFailedSubtitle": "I-resend ito ngayon, o itigil ang pagsubok.",
     "dmSendFailedRetry": "Subukan ulit",
     "dmSendPartialMessage": "Naipadala, pero hindi nag-sync sa iba mong device",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2162,6 +2162,7 @@
     "dmRetiredThreadClosedBody": "Nous avons déplacé Divine Moderation vers un nouveau compte. Personne ne lit plus celui-ci.",
     "dmRetiredThreadOpenSupport": "Écrire à Divine Moderation",
     "dmSendFailedMessage": "Impossible d'envoyer le message",
+    "dmResendFailedMessage": "Toujours impossible d'envoyer",
     "dmSendFailedSubtitle": "Renvoie-le maintenant, ou arrête d'essayer.",
     "dmSendFailedRetry": "Réessayer",
     "dmSendPartialMessage": "Envoyé, mais pas synchronisé avec tes autres appareils",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2159,6 +2159,7 @@
     "dmRetiredThreadClosedBody": "Kami memindahkan Divine Moderation ke akun baru. Akun ini tidak dibaca lagi.",
     "dmRetiredThreadOpenSupport": "Kirim pesan ke Divine Moderation",
     "dmSendFailedMessage": "Pesan gagal dikirim",
+    "dmResendFailedMessage": "Masih gagal dikirim",
     "dmSendFailedSubtitle": "Kirim ulang sekarang, atau berhenti mencoba.",
     "dmSendFailedRetry": "Coba Lagi",
     "dmSendPartialMessage": "Terkirim, tapi tidak tersinkron ke perangkat lainmu",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2162,6 +2162,7 @@
     "dmRetiredThreadClosedBody": "Abbiamo spostato Divine Moderation su un nuovo account. Questo non lo legge più nessuno.",
     "dmRetiredThreadOpenSupport": "Scrivi a Divine Moderation",
     "dmSendFailedMessage": "Impossibile inviare il messaggio",
+    "dmResendFailedMessage": "Ancora impossibile inviare",
     "dmSendFailedSubtitle": "Invialo di nuovo ora, oppure smetti di provare.",
     "dmSendFailedRetry": "Riprova",
     "dmSendPartialMessage": "Inviato, ma non sincronizzato con gli altri tuoi dispositivi",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2152,6 +2152,7 @@
     "dmRetiredThreadClosedBody": "Divine Moderation は新しいアカウントに移りました。こちらはもう誰も読んでいません。",
     "dmRetiredThreadOpenSupport": "Divine Moderation にメッセージを送る",
     "dmSendFailedMessage": "メッセージを送信できなかった",
+    "dmResendFailedMessage": "まだ送信できなかった",
     "dmSendFailedSubtitle": "今すぐ再送するか、送信を中止してね。",
     "dmSendFailedRetry": "もう一回",
     "dmSendPartialMessage": "送信したけど、ほかのデバイスには同期できなかった",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1690,6 +1690,7 @@
     "dmRetiredThreadClosedBody": "Divine Moderation을 새 계정으로 옮겼습니다. 이 계정은 더 이상 아무도 읽지 않습니다.",
     "dmRetiredThreadOpenSupport": "Divine Moderation에 메시지 보내기",
     "dmSendFailedMessage": "메시지를 보내지 못했어요",
+    "dmResendFailedMessage": "여전히 보내지 못했어요",
     "dmSendFailedSubtitle": "지금 다시 보내거나 전송을 중단하세요.",
     "dmSendFailedRetry": "다시 시도",
     "dmSendPartialMessage": "보냈지만 다른 기기에 동기화되지 않았어요",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -2946,6 +2946,7 @@
   "@dmSendFailedMessage": {
     "description": "Accessibility announcement text, and the recovery bottom sheet's title, shown in a DM conversation when a send fails (relay error, signer error, network error). The bottom sheet pairs it with `dmSendFailedSubtitle` and the `dmMessageActionRetrySend` / `dmMessageActionCancelSend` actions."
   },
+  "dmResendFailedMessage": "Masih tidak dapat dihantar",
   "dmSendFailedSubtitle": "Hantar semula sekarang, atau berhenti mencuba.",
   "@dmSendFailedSubtitle": {
     "description": "Subtitle in the recovery bottom sheet shown when a failed own DM bubble is tapped, below the `dmSendFailedMessage` title."

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2162,6 +2162,7 @@
     "dmRetiredThreadClosedBody": "We hebben Divine Moderation naar een nieuw account verplaatst. Dit account leest niemand meer.",
     "dmRetiredThreadOpenSupport": "Bericht sturen naar Divine Moderation",
     "dmSendFailedMessage": "Bericht kon niet worden verzonden",
+    "dmResendFailedMessage": "Kon nog steeds niet worden verzonden",
     "dmSendFailedSubtitle": "Verstuur het nu opnieuw, of stop met proberen.",
     "dmSendFailedRetry": "Opnieuw",
     "dmSendPartialMessage": "Verzonden, maar niet gesynchroniseerd met je andere apparaten",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2162,6 +2162,7 @@
     "dmRetiredThreadClosedBody": "Przenieśliśmy Divine Moderation na nowe konto. Tego nikt już nie czyta.",
     "dmRetiredThreadOpenSupport": "Napisz do Divine Moderation",
     "dmSendFailedMessage": "Nie udało się wysłać wiadomości",
+    "dmResendFailedMessage": "Nadal nie udało się wysłać",
     "dmSendFailedSubtitle": "Wyślij ją ponownie teraz albo przestań próbować.",
     "dmSendFailedRetry": "Spróbuj ponownie",
     "dmSendPartialMessage": "Wysłano, ale nie zsynchronizowano z twoimi innymi urządzeniami",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2162,6 +2162,7 @@
     "dmRetiredThreadClosedBody": "Movemos a Divine Moderation para uma nova conta. Ninguém lê mais esta.",
     "dmRetiredThreadOpenSupport": "Enviar mensagem para a Divine Moderation",
     "dmSendFailedMessage": "Falha ao enviar a mensagem",
+    "dmResendFailedMessage": "Ainda não foi possível enviar",
     "dmSendFailedSubtitle": "Reenvie agora, ou pare de tentar.",
     "dmSendFailedRetry": "Tentar novamente",
     "dmSendPartialMessage": "Enviado, mas não sincronizou com seus outros dispositivos",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2162,6 +2162,7 @@
     "dmRetiredThreadClosedBody": "Am mutat Divine Moderation pe un cont nou. Acesta nu mai este citit de nimeni.",
     "dmRetiredThreadOpenSupport": "Scrie către Divine Moderation",
     "dmSendFailedMessage": "Mesajul nu a putut fi trimis",
+    "dmResendFailedMessage": "Tot nu a putut fi trimis",
     "dmSendFailedSubtitle": "Retrimite-l acum sau nu mai încerca.",
     "dmSendFailedRetry": "Reîncearcă",
     "dmSendPartialMessage": "Trimis, dar nu s-a sincronizat cu celelalte dispozitive",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2162,6 +2162,7 @@
     "dmRetiredThreadClosedBody": "Vi har flyttat Divine Moderation till ett nytt konto. Det här kontot läser ingen längre.",
     "dmRetiredThreadOpenSupport": "Skriv till Divine Moderation",
     "dmSendFailedMessage": "Meddelandet kunde inte skickas",
+    "dmResendFailedMessage": "Kunde fortfarande inte skickas",
     "dmSendFailedSubtitle": "Skicka det igen nu, eller sluta försöka.",
     "dmSendFailedRetry": "Försök igen",
     "dmSendPartialMessage": "Skickat, men inte synkat till dina andra enheter",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2159,6 +2159,7 @@
     "dmRetiredThreadClosedBody": "Divine Moderation'ı yeni bir hesaba taşıdık. Bu hesabı artık kimse okumuyor.",
     "dmRetiredThreadOpenSupport": "Divine Moderation'a mesaj gönder",
     "dmSendFailedMessage": "Mesaj gönderilemedi",
+    "dmResendFailedMessage": "Yine gönderilemedi",
     "dmSendFailedSubtitle": "Şimdi tekrar gönder ya da denemeyi durdur.",
     "dmSendFailedRetry": "Tekrar Dene",
     "dmSendPartialMessage": "Gönderildi, ama diğer cihazlarınla eşitlenmedi",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -2946,6 +2946,7 @@
   "@dmSendFailedMessage": {
     "description": "Accessibility announcement text, and the recovery bottom sheet's title, shown in a DM conversation when a send fails (relay error, signer error, network error). The bottom sheet pairs it with `dmSendFailedSubtitle` and the `dmMessageActionRetrySend` / `dmMessageActionCancelSend` actions."
   },
+  "dmResendFailedMessage": "اب بھی نہیں بھیجا جا سکا",
   "dmSendFailedSubtitle": "ابھی دوبارہ بھیجیں، یا کوشش بند کر دیں۔",
   "@dmSendFailedSubtitle": {
     "description": "Subtitle in the recovery bottom sheet shown when a failed own DM bubble is tapped, below the `dmSendFailedMessage` title."

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -2946,6 +2946,7 @@
   "@dmSendFailedMessage": {
     "description": "Accessibility announcement text, and the recovery bottom sheet's title, shown in a DM conversation when a send fails (relay error, signer error, network error). The bottom sheet pairs it with `dmSendFailedSubtitle` and the `dmMessageActionRetrySend` / `dmMessageActionCancelSend` actions."
   },
+  "dmResendFailedMessage": "Vẫn không gửi được",
   "dmSendFailedSubtitle": "Gửi lại ngay, hoặc ngừng thử.",
   "@dmSendFailedSubtitle": {
     "description": "Subtitle in the recovery bottom sheet shown when a failed own DM bubble is tapped, below the `dmSendFailedMessage` title."

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -2946,6 +2946,7 @@
   "@dmSendFailedMessage": {
     "description": "Accessibility announcement text, and the recovery bottom sheet's title, shown in a DM conversation when a send fails (relay error, signer error, network error). The bottom sheet pairs it with `dmSendFailedSubtitle` and the `dmMessageActionRetrySend` / `dmMessageActionCancelSend` actions."
   },
+  "dmResendFailedMessage": "仍然发送失败",
   "dmSendFailedSubtitle": "立即重发，或放弃发送。",
   "@dmSendFailedSubtitle": {
     "description": "Subtitle in the recovery bottom sheet shown when a failed own DM bubble is tapped, below the `dmSendFailedMessage` title."

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9875,6 +9875,12 @@ abstract class AppLocalizations {
   /// **'Message couldn\'t be sent'**
   String get dmSendFailedMessage;
 
+  /// SnackBar text shown in a DM conversation when the user taps Resend on a failed message and the retry fails again. Distinct from `dmSendFailedMessage`, which titles the recovery sheet and announces a FIRST send failure: on a resend the bubble is already red, so the red bubble cannot signal the new attempt and a toast is the only feedback the user gets.
+  ///
+  /// In en, this message translates to:
+  /// **'Still couldn\'t send'**
+  String get dmResendFailedMessage;
+
   /// Subtitle in the recovery bottom sheet shown when a failed own DM bubble is tapped, below the `dmSendFailedMessage` title.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5580,6 +5580,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get dmSendFailedMessage => 'መልዕክቱ መላክ አልተሳካም';
 
   @override
+  String get dmResendFailedMessage => 'አሁንም መላክ አልተሳካም';
+
+  @override
   String get dmSendFailedSubtitle => 'አሁን እንደገና ላክ ወይም መሞከር አቁም።';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5669,6 +5669,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dmSendFailedMessage => 'تعذّر إرسال الرسالة';
 
   @override
+  String get dmResendFailedMessage => 'ما زال الإرسال متعذّرًا';
+
+  @override
   String get dmSendFailedSubtitle => 'أعد إرسالها الآن، أو أوقف المحاولة.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5771,6 +5771,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get dmSendFailedMessage => 'Съобщението не мина';
 
   @override
+  String get dmResendFailedMessage => 'Още не мина';
+
+  @override
   String get dmSendFailedSubtitle => 'Изпрати го отново сега или спри опитите.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5792,6 +5792,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dmSendFailedMessage => 'Nachricht konnte nicht gesendet werden';
 
   @override
+  String get dmResendFailedMessage => 'Konnte weiterhin nicht gesendet werden';
+
+  @override
   String get dmSendFailedSubtitle =>
       'Sende sie jetzt erneut oder versuche es nicht mehr.';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5810,6 +5810,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dmSendFailedMessage => 'Message couldn\'t be sent';
 
   @override
+  String get dmResendFailedMessage => 'Still couldn\'t send';
+
+  @override
   String get dmSendFailedSubtitle => 'Resend it now, or stop trying.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5767,6 +5767,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dmSendFailedMessage => 'No se pudo enviar el mensaje';
 
   @override
+  String get dmResendFailedMessage => 'Sigue sin poder enviarse';
+
+  @override
   String get dmSendFailedSubtitle => 'Reenvíalo ahora o deja de intentarlo.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5753,6 +5753,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get dmSendFailedMessage => 'Hindi naipadala ang message';
 
   @override
+  String get dmResendFailedMessage => 'Hindi pa rin naipadala';
+
+  @override
   String get dmSendFailedSubtitle =>
       'I-resend ito ngayon, o itigil ang pagsubok.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5788,6 +5788,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dmSendFailedMessage => 'Impossible d\'envoyer le message';
 
   @override
+  String get dmResendFailedMessage => 'Toujours impossible d\'envoyer';
+
+  @override
   String get dmSendFailedSubtitle =>
       'Renvoie-le maintenant, ou arrête d\'essayer.';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5646,6 +5646,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get dmSendFailedMessage => 'Pesan gagal dikirim';
 
   @override
+  String get dmResendFailedMessage => 'Masih gagal dikirim';
+
+  @override
   String get dmSendFailedSubtitle =>
       'Kirim ulang sekarang, atau berhenti mencoba.';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5774,6 +5774,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dmSendFailedMessage => 'Impossibile inviare il messaggio';
 
   @override
+  String get dmResendFailedMessage => 'Ancora impossibile inviare';
+
+  @override
   String get dmSendFailedSubtitle =>
       'Invialo di nuovo ora, oppure smetti di provare.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5403,6 +5403,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get dmSendFailedMessage => 'メッセージを送信できなかった';
 
   @override
+  String get dmResendFailedMessage => 'まだ送信できなかった';
+
+  @override
   String get dmSendFailedSubtitle => '今すぐ再送するか、送信を中止してね。';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5421,6 +5421,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dmSendFailedMessage => '메시지를 보내지 못했어요';
 
   @override
+  String get dmResendFailedMessage => '여전히 보내지 못했어요';
+
+  @override
   String get dmSendFailedSubtitle => '지금 다시 보내거나 전송을 중단하세요.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -5722,6 +5722,9 @@ class AppLocalizationsMs extends AppLocalizations {
   String get dmSendFailedMessage => 'Mesej tidak dapat dihantar';
 
   @override
+  String get dmResendFailedMessage => 'Masih tidak dapat dihantar';
+
+  @override
   String get dmSendFailedSubtitle =>
       'Hantar semula sekarang, atau berhenti mencuba.';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5742,6 +5742,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dmSendFailedMessage => 'Bericht kon niet worden verzonden';
 
   @override
+  String get dmResendFailedMessage => 'Kon nog steeds niet worden verzonden';
+
+  @override
   String get dmSendFailedSubtitle =>
       'Verstuur het nu opnieuw, of stop met proberen.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5862,6 +5862,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dmSendFailedMessage => 'Nie udało się wysłać wiadomości';
 
   @override
+  String get dmResendFailedMessage => 'Nadal nie udało się wysłać';
+
+  @override
   String get dmSendFailedSubtitle =>
       'Wyślij ją ponownie teraz albo przestań próbować.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5755,6 +5755,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get dmSendFailedMessage => 'Falha ao enviar a mensagem';
 
   @override
+  String get dmResendFailedMessage => 'Ainda não foi possível enviar';
+
+  @override
   String get dmSendFailedSubtitle => 'Reenvie agora, ou pare de tentar.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5874,6 +5874,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dmSendFailedMessage => 'Mesajul nu a putut fi trimis';
 
   @override
+  String get dmResendFailedMessage => 'Tot nu a putut fi trimis';
+
+  @override
   String get dmSendFailedSubtitle => 'Retrimite-l acum sau nu mai încerca.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5710,6 +5710,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dmSendFailedMessage => 'Meddelandet kunde inte skickas';
 
   @override
+  String get dmResendFailedMessage => 'Kunde fortfarande inte skickas';
+
+  @override
   String get dmSendFailedSubtitle => 'Skicka det igen nu, eller sluta försöka.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5648,6 +5648,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dmSendFailedMessage => 'Mesaj gönderilemedi';
 
   @override
+  String get dmResendFailedMessage => 'Yine gönderilemedi';
+
+  @override
   String get dmSendFailedSubtitle =>
       'Şimdi tekrar gönder ya da denemeyi durdur.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -5720,6 +5720,9 @@ class AppLocalizationsUr extends AppLocalizations {
   String get dmSendFailedMessage => 'پیغام نہیں بھیجا جا سکا';
 
   @override
+  String get dmResendFailedMessage => 'اب بھی نہیں بھیجا جا سکا';
+
+  @override
   String get dmSendFailedSubtitle => 'ابھی دوبارہ بھیجیں، یا کوشش بند کر دیں۔';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -5683,6 +5683,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get dmSendFailedMessage => 'Tin nhắn không gửi được';
 
   @override
+  String get dmResendFailedMessage => 'Vẫn không gửi được';
+
+  @override
   String get dmSendFailedSubtitle => 'Gửi lại ngay, hoặc ngừng thử.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -5372,6 +5372,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get dmSendFailedMessage => '消息发送失败';
 
   @override
+  String get dmResendFailedMessage => '仍然发送失败';
+
+  @override
   String get dmSendFailedSubtitle => '立即重发，或放弃发送。';
 
   @override

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -335,6 +335,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                 (current.sendStatus == SendStatus.sentPartial ||
                     current.sendStatus == SendStatus.blocked ||
                     current.sendStatus == SendStatus.noRecipient ||
+                    current.sendStatus == SendStatus.resendFailed ||
                     current.sendStatus == SendStatus.failed),
             listener: _onSendOutcome,
             child: Column(
@@ -501,6 +502,24 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
     // participant list.
     if (state.sendStatus == SendStatus.noRecipient) {
       final message = l10n.dmSendNoRecipientMessage;
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(DivineSnackbarContainer.snackBar(message, error: true));
+      SemanticsService.sendAnnouncement(
+        View.of(context),
+        message,
+        Directionality.of(context),
+      );
+      return;
+    }
+
+    // A resend that failed again (#8461). The bubble was already red when the
+    // user tapped it, so — unlike the first-send case below — turning it red
+    // is not a state change and the tap would otherwise produce no visible
+    // result at all. Toast it so the attempt is legible; the bubble stays red
+    // and re-tappable, and `resetRetryBudget` has re-armed the sweep.
+    if (state.sendStatus == SendStatus.resendFailed) {
+      final message = l10n.dmResendFailedMessage;
       ScaffoldMessenger.of(context)
         ..hideCurrentSnackBar()
         ..showSnackBar(DivineSnackbarContainer.snackBar(message, error: true));

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -484,14 +484,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
       final message = isRetiredModerationAccount(_otherPubkey)
           ? l10n.dmSendBlockedRetiredMessage
           : l10n.dmSendBlockedMessage;
-      ScaffoldMessenger.of(context)
-        ..hideCurrentSnackBar()
-        ..showSnackBar(DivineSnackbarContainer.snackBar(message, error: true));
-      SemanticsService.sendAnnouncement(
-        View.of(context),
-        message,
-        Directionality.of(context),
-      );
+      _showErrorToastAndAnnounce(context, message);
       return;
     }
 
@@ -502,14 +495,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
     // participant list.
     if (state.sendStatus == SendStatus.noRecipient) {
       final message = l10n.dmSendNoRecipientMessage;
-      ScaffoldMessenger.of(context)
-        ..hideCurrentSnackBar()
-        ..showSnackBar(DivineSnackbarContainer.snackBar(message, error: true));
-      SemanticsService.sendAnnouncement(
-        View.of(context),
-        message,
-        Directionality.of(context),
-      );
+      _showErrorToastAndAnnounce(context, message);
       return;
     }
 
@@ -520,14 +506,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
     // and re-tappable, and `resetRetryBudget` has re-armed the sweep.
     if (state.sendStatus == SendStatus.resendFailed) {
       final message = l10n.dmResendFailedMessage;
-      ScaffoldMessenger.of(context)
-        ..hideCurrentSnackBar()
-        ..showSnackBar(DivineSnackbarContainer.snackBar(message, error: true));
-      SemanticsService.sendAnnouncement(
-        View.of(context),
-        message,
-        Directionality.of(context),
-      );
+      _showErrorToastAndAnnounce(context, message);
       return;
     }
 
@@ -578,6 +557,17 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
     // Per `accessibility.md`, async visible state changes must announce
     // explicitly — Material's default SnackBar semantics are weaker than the
     // written rule and not guaranteed across platforms.
+    SemanticsService.sendAnnouncement(
+      View.of(context),
+      message,
+      Directionality.of(context),
+    );
+  }
+
+  void _showErrorToastAndAnnounce(BuildContext context, String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(DivineSnackbarContainer.snackBar(message, error: true));
     SemanticsService.sendAnnouncement(
       View.of(context),
       message,

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -1914,13 +1914,15 @@ void main() {
           isA<ConversationState>().having(
             (s) => s.sendStatus,
             'sendStatus',
-            SendStatus.failed,
+            SendStatus.resendFailed,
           ),
         ],
       );
 
       blocTest<ConversationBloc, ConversationState>(
-        're-raises failed when a hard-failed row still cannot be recovered',
+        'raises resendFailed, not failed, when a hard-failed row still '
+        'cannot be recovered — the bubble was already red, so re-raising '
+        'failed would leave the resend with no visible outcome (#8461)',
         setUp: () {
           when(
             () => mockDmRepository.recoverFullSend(
@@ -1948,7 +1950,42 @@ void main() {
           isA<ConversationState>().having(
             (s) => s.sendStatus,
             'sendStatus',
-            SendStatus.failed,
+            SendStatus.resendFailed,
+          ),
+        ],
+      );
+
+      blocTest<ConversationBloc, ConversationState>(
+        'keeps resendFailed distinct from the first-send failure status so '
+        'the view can toast one and stay silent for the other (#8461)',
+        setUp: () {
+          when(
+            () => mockDmRepository.recoverFullSend(
+              rumorId: rumorId1,
+              resetRetryBudget: true,
+            ),
+          ).thenAnswer(
+            (_) async => const NIP17SendResult.failure('relay still down'),
+          );
+        },
+        seed: () => const ConversationState(
+          status: ConversationStatus.loaded,
+          sendStatus: SendStatus.failed,
+        ),
+        build: buildBloc,
+        act: (bloc) => bloc.add(
+          const ConversationFullSendRecoveryRequested(rumorIds: [rumorId1]),
+        ),
+        expect: () => [
+          isA<ConversationState>().having(
+            (s) => s.sendStatus,
+            'sendStatus',
+            SendStatus.sending,
+          ),
+          isA<ConversationState>().having(
+            (s) => s.sendStatus,
+            'sendStatus',
+            isNot(SendStatus.failed),
           ),
         ],
       );

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -1954,41 +1954,6 @@ void main() {
           ),
         ],
       );
-
-      blocTest<ConversationBloc, ConversationState>(
-        'keeps resendFailed distinct from the first-send failure status so '
-        'the view can toast one and stay silent for the other (#8461)',
-        setUp: () {
-          when(
-            () => mockDmRepository.recoverFullSend(
-              rumorId: rumorId1,
-              resetRetryBudget: true,
-            ),
-          ).thenAnswer(
-            (_) async => const NIP17SendResult.failure('relay still down'),
-          );
-        },
-        seed: () => const ConversationState(
-          status: ConversationStatus.loaded,
-          sendStatus: SendStatus.failed,
-        ),
-        build: buildBloc,
-        act: (bloc) => bloc.add(
-          const ConversationFullSendRecoveryRequested(rumorIds: [rumorId1]),
-        ),
-        expect: () => [
-          isA<ConversationState>().having(
-            (s) => s.sendStatus,
-            'sendStatus',
-            SendStatus.sending,
-          ),
-          isA<ConversationState>().having(
-            (s) => s.sendStatus,
-            'sendStatus',
-            isNot(SendStatus.failed),
-          ),
-        ],
-      );
     });
 
     group(ConversationOutgoingSendCancelled, () {

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -1646,6 +1646,51 @@ void main() {
         expect(find.text(l10n.dmSendNoRecipientMessage), findsOneWidget);
       });
 
+      // #8461. A resend that fails again is the one failure the red bubble
+      // cannot express: the bubble was ALREADY red when the user tapped it,
+      // so re-raising `failed` leaves the before and after states identical
+      // and the resend is indistinguishable from a tap that did nothing.
+      testWidgets('shows a toast when a resend fails again', (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            previousState: const ConversationState(
+              status: ConversationStatus.loaded,
+              sendStatus: SendStatus.sending,
+            ),
+            state: const ConversationState(
+              status: ConversationStatus.loaded,
+              sendStatus: SendStatus.resendFailed,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text(l10n.dmResendFailedMessage), findsOneWidget);
+      });
+
+      // Guards the split itself: the resend toast must not be the first-send
+      // copy, or collapsing the two statuses back together would still pass.
+      testWidgets(
+        'the resend toast is distinct from the first-send failure copy',
+        (tester) async {
+          await tester.pumpWidget(
+            buildSubject(
+              previousState: const ConversationState(
+                status: ConversationStatus.loaded,
+                sendStatus: SendStatus.sending,
+              ),
+              state: const ConversationState(
+                status: ConversationStatus.loaded,
+                sendStatus: SendStatus.resendFailed,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          expect(find.text(l10n.dmSendFailedMessage), findsNothing);
+        },
+      );
+
       testWidgets(
         'does not show a SnackBar when sendStatus stays non-failed '
         '(e.g. sending → sent)',


### PR DESCRIPTION
Fixes #8461

## What was wrong

Tapping **Resend** on a failed DM fired a real recovery attempt. When that
attempt failed, the screen was byte-identical to before the tap: same bubble,
same red "Failed to send", no toast, no spinner, no state change. The resend
was indistinguishable from a tap that did nothing.

`_onFullSendRecoveryRequested` re-emitted `SendStatus.failed`, and the view
deliberately raises no toast for it — `conversation_view.dart` says why:

> `// Hard failure: the red "Not delivered" row on the bubble is the visual affordance, so no toast`

That is right for a **first** send, where the bubble turning red is the change.
It does not hold for a **resend**: the bubble was already red before the tap, so
the affordance fires into a state the user is already looking at. The only
feedback left was a `SemanticsService` announcement, inaudible unless VoiceOver
is on.

## The fix

Split the two apart with `SendStatus.resendFailed` — the same repository
outcome, a different affordance. The view toasts it and keeps announcing it;
the bubble stays red and re-tappable, and `resetRetryBudget: true` has already
re-armed the sweep.

Three production files, ~30 lines. No repository or queue changes: this is
purely how an existing outcome is surfaced.

## Reproduced and verified on device

iPhone 17 Pro Max simulator, debug, production environment, real Keycast OAuth
identity. The pool was reduced to a single local relay that answers no `REQ`
and rejects every `EVENT`, so a send and its resend both fail deterministically.

**Before** (on `main`): tapped Resend, and the only trace was

```
Bloc error: ConversationBloc: Exception: Message not sent: no relay reached
```

The bubble did not change.

**After** (this branch):

```
[02:35:09] NIP-17 message recipient publish unconfirmed (rumor=5fdba947…,
           rejected by ws://127.0.0.1:7447: blocked: harness reject)
```

and the conversation showed **"Still couldn't send"**, with the bubble back to
red and still tappable.

One detail worth recording for anyone re-running this: taking the relay pool
away entirely does **not** reproduce it. The app notices it has no relay list,
connects to a "safe DM-friendly fallback relay set", and the resend then
succeeds. The failure has to come from a relay that is reachable and refuses,
which is why the harness rejects with `OK false` rather than going offline.

## Copy

New key `dmResendFailedMessage` — "Still couldn't send". Deliberately minimal:
it asserts only what is provably true at that moment. It does not promise a
background retry, because `OutgoingDmRetryService` is foreground- and
connectivity-triggered rather than periodic, so "we'll keep trying" would be
overstating it.

Translated into all 21 non-English locales rather than added to
`_knownUntranslatedDebt` — that list is for safety-critical and diagnostic copy
where machine translation is dangerous, which this is not. Each translation
carries the "still / again" sense that marks it as a retry, parallel in register
to that locale's existing `dmSendFailedMessage`.

## Testing

The two existing recovery tests asserted the old `failed` emit — they pinned the
defect, and both now assert `resendFailed`. Added a bloc test for the split
itself and two view tests (the toast appears; it is **not** the first-send
copy, so collapsing the statuses back together fails).

Mutation-tested at the production boundary:

- restoring the `failed` emit in the bloc turns **3** bloc tests red
- disabling the view's `resendFailed` branch turns the toast test red

```
flutter analyze lib test integration_test          No issues found
conversation_bloc_test + conversation_view_test
  + arb_consistency_test                           154 passed
conversation_page_repo_swap_test                   5 passed
```

Ratchets green: orphaned ARB keys, Maestro copy drift, ungrouped tests, skip
ceiling, placeholder tests, l10n delegates, shared-setup stubs.

## Scope note

Whether the recovery sheet should be dismissible at all is a separate question
and is **not** touched here — #6092 asked it to stop auto-dismissing on a timer,
and the fix also removed deliberate dismissal. The dead drag handle that sheet
still paints is filed as #8462.

## Found via

Patrolling #8443 on a device. The reporter's words were "why the message doesn't
get Resend when I tap on it, nothing changes."
