### PR TITLE
fix(audio): restore classic Vine reuse while honoring creator opt-outs

### DIFF
--- a/mobile/lib/providers/sounds_providers.dart
+++ b/mobile/lib/providers/sounds_providers.dart
@@ -180,6 +180,7 @@ bool? audioReuseTermsFromEvent(AudioEvent sound) {
   if (sound.externalSource case final external?) {
     return external.license.allowsDerivatives;
   }
+  if (sound.requiresCurrentReuseVerification) return null;
   if (sound.allowsReuse) return true;
   if (sound.hasExplicitReuseConsent) return false;
   return null;
@@ -197,15 +198,13 @@ Future<bool> audioReuseTerms(Ref ref, AudioEvent sound) {
 
 /// Fail-closed reuse consent for explicit and legacy audio events.
 ///
-/// A creator may reuse their own sound when no explicit terms exist. Explicit
-/// declines remain authoritative. The shared permission provider owns that
-/// rule so call sites agree; UI may still short-circuit synchronously knowable
-/// cases to avoid one-frame action flicker.
+/// A creator may always reuse their own sound. The shared permission provider
+/// owns that rule so call sites agree; UI may still short-circuit synchronously
+/// knowable cases to avoid one-frame action flicker.
 @riverpod
 Future<bool> audioReuseConsent(Ref ref, AudioEvent sound) {
   final knownTerms = audioReuseTermsFromEvent(sound);
   if (knownTerms == true) return Future.value(true);
-  if (knownTerms == false) return Future.value(false);
   // Re-read on auth transitions so an account switch cannot leave the previous
   // identity's ownership answer cached against this sound.
   ref.watch(currentAuthStateProvider);
@@ -213,6 +212,7 @@ Future<bool> audioReuseConsent(Ref ref, AudioEvent sound) {
   if (viewer != null && viewer.isNotEmpty && viewer == sound.pubkey) {
     return Future.value(true);
   }
+  if (knownTerms == false) return Future.value(false);
   return AudioReuseConsentResolver(
     videosRepository: ref.watch(videosRepositoryProvider),
   ).verify(sound);

--- a/mobile/lib/providers/sounds_providers.dart
+++ b/mobile/lib/providers/sounds_providers.dart
@@ -190,7 +190,7 @@ bool? audioReuseTermsFromEvent(AudioEvent sound) {
 @riverpod
 Future<bool> audioReuseTerms(Ref ref, AudioEvent sound) {
   final knownTerms = audioReuseTermsFromEvent(sound);
-  if (knownTerms != null) return Future.value(knownTerms);
+  if (knownTerms == false) return Future.value(false);
   return AudioReuseConsentResolver(
     videosRepository: ref.watch(videosRepositoryProvider),
   ).verify(sound);
@@ -204,7 +204,6 @@ Future<bool> audioReuseTerms(Ref ref, AudioEvent sound) {
 @riverpod
 Future<bool> audioReuseConsent(Ref ref, AudioEvent sound) {
   final knownTerms = audioReuseTermsFromEvent(sound);
-  if (knownTerms == true) return Future.value(true);
   // Re-read on auth transitions so an account switch cannot leave the previous
   // identity's ownership answer cached against this sound.
   ref.watch(currentAuthStateProvider);
@@ -213,9 +212,7 @@ Future<bool> audioReuseConsent(Ref ref, AudioEvent sound) {
     return Future.value(true);
   }
   if (knownTerms == false) return Future.value(false);
-  return AudioReuseConsentResolver(
-    videosRepository: ref.watch(videosRepositoryProvider),
-  ).verify(sound);
+  return ref.watch(audioReuseTermsProvider(sound).future);
 }
 
 /// State provider for the currently selected sound.

--- a/mobile/lib/providers/sounds_providers.dart
+++ b/mobile/lib/providers/sounds_providers.dart
@@ -197,13 +197,15 @@ Future<bool> audioReuseTerms(Ref ref, AudioEvent sound) {
 
 /// Fail-closed reuse consent for explicit and legacy audio events.
 ///
-/// A creator always has consent for their own sound. The shared permission
-/// provider owns that rule so call sites agree; UI may still short-circuit
-/// synchronously knowable cases to avoid one-frame action flicker.
+/// A creator may reuse their own sound when no explicit terms exist. Explicit
+/// declines remain authoritative. The shared permission provider owns that
+/// rule so call sites agree; UI may still short-circuit synchronously knowable
+/// cases to avoid one-frame action flicker.
 @riverpod
 Future<bool> audioReuseConsent(Ref ref, AudioEvent sound) {
   final knownTerms = audioReuseTermsFromEvent(sound);
   if (knownTerms == true) return Future.value(true);
+  if (knownTerms == false) return Future.value(false);
   // Re-read on auth transitions so an account switch cannot leave the previous
   // identity's ownership answer cached against this sound.
   ref.watch(currentAuthStateProvider);
@@ -211,7 +213,6 @@ Future<bool> audioReuseConsent(Ref ref, AudioEvent sound) {
   if (viewer != null && viewer.isNotEmpty && viewer == sound.pubkey) {
     return Future.value(true);
   }
-  if (knownTerms == false) return Future.value(false);
   return AudioReuseConsentResolver(
     videosRepository: ref.watch(videosRepositoryProvider),
   ).verify(sound);

--- a/mobile/lib/providers/sounds_providers.g.dart
+++ b/mobile/lib/providers/sounds_providers.g.dart
@@ -747,7 +747,7 @@ final class AudioReuseTermsProvider
   }
 }
 
-String _$audioReuseTermsHash() => r'29a3be9aebb039c124e6afc99f33c2492a55bc6a';
+String _$audioReuseTermsHash() => r'6c5b36e30d803320d075b60393eb586e6e2fc72d';
 
 /// Viewer-independent reuse terms for explicit and legacy audio events.
 
@@ -837,7 +837,7 @@ final class AudioReuseConsentProvider
   }
 }
 
-String _$audioReuseConsentHash() => r'd1e80a3056b98eaab653f8708aeac735cd21d4e8';
+String _$audioReuseConsentHash() => r'7949ee74ffd86f788f2ff4c77050697c37a182a0';
 
 /// Fail-closed reuse consent for explicit and legacy audio events.
 ///

--- a/mobile/lib/providers/sounds_providers.g.dart
+++ b/mobile/lib/providers/sounds_providers.g.dart
@@ -773,30 +773,27 @@ final class AudioReuseTermsFamily extends $Family
 
 /// Fail-closed reuse consent for explicit and legacy audio events.
 ///
-/// A creator may reuse their own sound when no explicit terms exist. Explicit
-/// declines remain authoritative. The shared permission provider owns that
-/// rule so call sites agree; UI may still short-circuit synchronously knowable
-/// cases to avoid one-frame action flicker.
+/// A creator may always reuse their own sound. The shared permission provider
+/// owns that rule so call sites agree; UI may still short-circuit synchronously
+/// knowable cases to avoid one-frame action flicker.
 
 @ProviderFor(audioReuseConsent)
 final audioReuseConsentProvider = AudioReuseConsentFamily._();
 
 /// Fail-closed reuse consent for explicit and legacy audio events.
 ///
-/// A creator may reuse their own sound when no explicit terms exist. Explicit
-/// declines remain authoritative. The shared permission provider owns that
-/// rule so call sites agree; UI may still short-circuit synchronously knowable
-/// cases to avoid one-frame action flicker.
+/// A creator may always reuse their own sound. The shared permission provider
+/// owns that rule so call sites agree; UI may still short-circuit synchronously
+/// knowable cases to avoid one-frame action flicker.
 
 final class AudioReuseConsentProvider
     extends $FunctionalProvider<AsyncValue<bool>, bool, FutureOr<bool>>
     with $FutureModifier<bool>, $FutureProvider<bool> {
   /// Fail-closed reuse consent for explicit and legacy audio events.
   ///
-  /// A creator may reuse their own sound when no explicit terms exist. Explicit
-  /// declines remain authoritative. The shared permission provider owns that
-  /// rule so call sites agree; UI may still short-circuit synchronously knowable
-  /// cases to avoid one-frame action flicker.
+  /// A creator may always reuse their own sound. The shared permission provider
+  /// owns that rule so call sites agree; UI may still short-circuit synchronously
+  /// knowable cases to avoid one-frame action flicker.
   AudioReuseConsentProvider._({
     required AudioReuseConsentFamily super.from,
     required AudioEvent super.argument,
@@ -840,14 +837,13 @@ final class AudioReuseConsentProvider
   }
 }
 
-String _$audioReuseConsentHash() => r'3fa40f347bd17c972b234eb3c565141c028cc9d7';
+String _$audioReuseConsentHash() => r'd1e80a3056b98eaab653f8708aeac735cd21d4e8';
 
 /// Fail-closed reuse consent for explicit and legacy audio events.
 ///
-/// A creator may reuse their own sound when no explicit terms exist. Explicit
-/// declines remain authoritative. The shared permission provider owns that
-/// rule so call sites agree; UI may still short-circuit synchronously knowable
-/// cases to avoid one-frame action flicker.
+/// A creator may always reuse their own sound. The shared permission provider
+/// owns that rule so call sites agree; UI may still short-circuit synchronously
+/// knowable cases to avoid one-frame action flicker.
 
 final class AudioReuseConsentFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<bool>, AudioEvent> {
@@ -862,10 +858,9 @@ final class AudioReuseConsentFamily extends $Family
 
   /// Fail-closed reuse consent for explicit and legacy audio events.
   ///
-  /// A creator may reuse their own sound when no explicit terms exist. Explicit
-  /// declines remain authoritative. The shared permission provider owns that
-  /// rule so call sites agree; UI may still short-circuit synchronously knowable
-  /// cases to avoid one-frame action flicker.
+  /// A creator may always reuse their own sound. The shared permission provider
+  /// owns that rule so call sites agree; UI may still short-circuit synchronously
+  /// knowable cases to avoid one-frame action flicker.
 
   AudioReuseConsentProvider call(AudioEvent sound) =>
       AudioReuseConsentProvider._(argument: sound, from: this);

--- a/mobile/lib/providers/sounds_providers.g.dart
+++ b/mobile/lib/providers/sounds_providers.g.dart
@@ -773,27 +773,30 @@ final class AudioReuseTermsFamily extends $Family
 
 /// Fail-closed reuse consent for explicit and legacy audio events.
 ///
-/// A creator always has consent for their own sound. The shared permission
-/// provider owns that rule so call sites agree; UI may still short-circuit
-/// synchronously knowable cases to avoid one-frame action flicker.
+/// A creator may reuse their own sound when no explicit terms exist. Explicit
+/// declines remain authoritative. The shared permission provider owns that
+/// rule so call sites agree; UI may still short-circuit synchronously knowable
+/// cases to avoid one-frame action flicker.
 
 @ProviderFor(audioReuseConsent)
 final audioReuseConsentProvider = AudioReuseConsentFamily._();
 
 /// Fail-closed reuse consent for explicit and legacy audio events.
 ///
-/// A creator always has consent for their own sound. The shared permission
-/// provider owns that rule so call sites agree; UI may still short-circuit
-/// synchronously knowable cases to avoid one-frame action flicker.
+/// A creator may reuse their own sound when no explicit terms exist. Explicit
+/// declines remain authoritative. The shared permission provider owns that
+/// rule so call sites agree; UI may still short-circuit synchronously knowable
+/// cases to avoid one-frame action flicker.
 
 final class AudioReuseConsentProvider
     extends $FunctionalProvider<AsyncValue<bool>, bool, FutureOr<bool>>
     with $FutureModifier<bool>, $FutureProvider<bool> {
   /// Fail-closed reuse consent for explicit and legacy audio events.
   ///
-  /// A creator always has consent for their own sound. The shared permission
-  /// provider owns that rule so call sites agree; UI may still short-circuit
-  /// synchronously knowable cases to avoid one-frame action flicker.
+  /// A creator may reuse their own sound when no explicit terms exist. Explicit
+  /// declines remain authoritative. The shared permission provider owns that
+  /// rule so call sites agree; UI may still short-circuit synchronously knowable
+  /// cases to avoid one-frame action flicker.
   AudioReuseConsentProvider._({
     required AudioReuseConsentFamily super.from,
     required AudioEvent super.argument,
@@ -837,13 +840,14 @@ final class AudioReuseConsentProvider
   }
 }
 
-String _$audioReuseConsentHash() => r'd1e80a3056b98eaab653f8708aeac735cd21d4e8';
+String _$audioReuseConsentHash() => r'3fa40f347bd17c972b234eb3c565141c028cc9d7';
 
 /// Fail-closed reuse consent for explicit and legacy audio events.
 ///
-/// A creator always has consent for their own sound. The shared permission
-/// provider owns that rule so call sites agree; UI may still short-circuit
-/// synchronously knowable cases to avoid one-frame action flicker.
+/// A creator may reuse their own sound when no explicit terms exist. Explicit
+/// declines remain authoritative. The shared permission provider owns that
+/// rule so call sites agree; UI may still short-circuit synchronously knowable
+/// cases to avoid one-frame action flicker.
 
 final class AudioReuseConsentFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<bool>, AudioEvent> {
@@ -858,9 +862,10 @@ final class AudioReuseConsentFamily extends $Family
 
   /// Fail-closed reuse consent for explicit and legacy audio events.
   ///
-  /// A creator always has consent for their own sound. The shared permission
-  /// provider owns that rule so call sites agree; UI may still short-circuit
-  /// synchronously knowable cases to avoid one-frame action flicker.
+  /// A creator may reuse their own sound when no explicit terms exist. Explicit
+  /// declines remain authoritative. The shared permission provider owns that
+  /// rule so call sites agree; UI may still short-circuit synchronously knowable
+  /// cases to avoid one-frame action flicker.
 
   AudioReuseConsentProvider call(AudioEvent sound) =>
       AudioReuseConsentProvider._(argument: sound, from: this);

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -285,6 +285,7 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
     final sound = widget.sound;
     final knownTerms = audioReuseTermsFromEvent(sound);
     if (knownTerms == true) return true;
+    if (knownTerms == false) return false;
     // Keep the synchronously knowable owner gate local so the button does not
     // disappear for a frame on the creator's own sound.
     ref.watch(currentAuthStateProvider);
@@ -292,7 +293,6 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
     if (viewer != null && viewer.isNotEmpty && viewer == sound.pubkey) {
       return true;
     }
-    if (knownTerms == false) return false;
     return ref.watch(audioReuseConsentProvider(sound)).value ?? false;
   }
 

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -285,7 +285,6 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
     final sound = widget.sound;
     final knownTerms = audioReuseTermsFromEvent(sound);
     if (knownTerms == true) return true;
-    if (knownTerms == false) return false;
     // Keep the synchronously knowable owner gate local so the button does not
     // disappear for a frame on the creator's own sound.
     ref.watch(currentAuthStateProvider);
@@ -293,6 +292,7 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
     if (viewer != null && viewer.isNotEmpty && viewer == sound.pubkey) {
       return true;
     }
+    if (knownTerms == false) return false;
     return ref.watch(audioReuseConsentProvider(sound)).value ?? false;
   }
 

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -284,7 +284,6 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
   bool _canReuseSound() {
     final sound = widget.sound;
     final knownTerms = audioReuseTermsFromEvent(sound);
-    if (knownTerms == true) return true;
     // Keep the synchronously knowable owner gate local so the button does not
     // disappear for a frame on the creator's own sound.
     ref.watch(currentAuthStateProvider);
@@ -300,8 +299,8 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
   /// consent is still being verified.
   bool? _reuseTerms() {
     final sound = widget.sound;
-    return audioReuseTermsFromEvent(sound) ??
-        ref.watch(audioReuseTermsProvider(sound)).value;
+    if (audioReuseTermsFromEvent(sound) == false) return false;
+    return ref.watch(audioReuseTermsProvider(sound)).value;
   }
 
   void _navigateToVideo(String videoId, int index, List<VideoEvent> videos) {

--- a/mobile/lib/services/audio_reuse_consent_resolver.dart
+++ b/mobile/lib/services/audio_reuse_consent_resolver.dart
@@ -41,7 +41,7 @@ class AudioReuseConsentResolver {
       // source is never older than its own sound.
       final source = matching.first;
       if (source.createdAt < sound.createdAt) return false;
-      return source.allowAudioReuse;
+      return originalSoundReuseTerms(source) ?? false;
     } catch (error) {
       // Fail closed, but leave a trace — otherwise "why is reuse blocked?" is
       // unanswerable from a bug report.

--- a/mobile/lib/services/audio_reuse_consent_resolver.dart
+++ b/mobile/lib/services/audio_reuse_consent_resolver.dart
@@ -12,12 +12,16 @@ class AudioReuseConsentResolver {
   final VideosRepository _videosRepository;
 
   Future<bool> verify(AudioEvent sound) async {
-    if (sound.allowsReuse) return true;
-    if (sound.hasExplicitReuseConsent) return false;
+    if (sound.isBundled || sound.isLocalImport) return true;
+    if (sound.externalSource case final external?) {
+      return external.license.allowsDerivatives;
+    }
+    if (sound.hasExplicitReuseConsent && !sound.allowsReuse) return false;
 
     final sourceAddress = sound.sourceVideoReference;
     if (sourceAddress == null || sourceAddress.isEmpty) return false;
 
+    String? sha256;
     try {
       // Read the source video straight off the address the sound already
       // carries. Resolving it the other way round — asking which videos
@@ -32,21 +36,34 @@ class AudioReuseConsentResolver {
           .where((video) => video.addressableId == sourceAddress)
           .toList();
       if (matching.isEmpty) return false;
-      // `allow_audio_reuse` is rebuilt on every edit — dropping the tag is how
-      // a creator revokes consent — and an addressable read resolves to the
-      // current revision, so this is the live answer. A revision predating the
+      // `allow_audio_reuse` is rebuilt on every edit and an addressable read
+      // resolves to the current revision, so this is the live answer. A
+      // revision predating the
       // sound cannot speak for it. This does not lock out the legacy population:
       // `VideoEventPublisher` publishes the Kind 1063 before the video event
       // because the video needs the audio id for its `e` tag, so an unedited
       // source is never older than its own sound.
       final source = matching.first;
       if (source.createdAt < sound.createdAt) return false;
-      return originalSoundReuseTerms(source) ?? false;
+      if (originalSoundReuseTerms(source) != true) return false;
+      sha256 = source.sha256;
     } catch (error) {
-      // Fail closed, but leave a trace — otherwise "why is reuse blocked?" is
-      // unanswerable from a bug report.
       Log.warning(
         'Reuse consent lookup failed for source $sourceAddress: $error',
+        name: 'AudioReuseConsentResolver',
+        category: LogCategory.video,
+      );
+      return false;
+    }
+
+    if (sha256 == null || sha256.isEmpty) return false;
+
+    try {
+      final policy = await _videosRepository.getAudioReusePolicy(sha256);
+      return policy.allowAudioReuse && !policy.audioReuseSuppressed;
+    } catch (error) {
+      Log.warning(
+        'Audio reuse policy lookup failed; blocking reuse: $error',
         name: 'AudioReuseConsentResolver',
         category: LogCategory.video,
       );

--- a/mobile/lib/services/audio_reuse_consent_resolver.dart
+++ b/mobile/lib/services/audio_reuse_consent_resolver.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Verifies reuse consent for legacy audio events without consent tags.
-// ABOUTME: Fails closed unless the sound's source video grants reuse.
+// ABOUTME: Verifies audio reuse terms and fresh creator takedown decisions.
+// ABOUTME: Allows verified classic Vine audio unless explicitly suppressed.
 
 import 'package:models/models.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -16,12 +16,10 @@ class AudioReuseConsentResolver {
     if (sound.externalSource case final external?) {
       return external.license.allowsDerivatives;
     }
-    if (sound.hasExplicitReuseConsent && !sound.allowsReuse) return false;
-
     final sourceAddress = sound.sourceVideoReference;
     if (sourceAddress == null || sourceAddress.isEmpty) return false;
 
-    String? sha256;
+    VideoEvent? source;
     try {
       // Read the source video straight off the address the sound already
       // carries. Resolving it the other way round — asking which videos
@@ -43,10 +41,9 @@ class AudioReuseConsentResolver {
       // `VideoEventPublisher` publishes the Kind 1063 before the video event
       // because the video needs the audio id for its `e` tag, so an unedited
       // source is never older than its own sound.
-      final source = matching.first;
+      source = matching.first;
       if (source.createdAt < sound.createdAt) return false;
       if (originalSoundReuseTerms(source) != true) return false;
-      sha256 = source.sha256;
     } catch (error) {
       Log.warning(
         'Reuse consent lookup failed for source $sourceAddress: $error',
@@ -56,11 +53,9 @@ class AudioReuseConsentResolver {
       return false;
     }
 
-    if (sha256 == null || sha256.isEmpty) return false;
-
     try {
-      final policy = await _videosRepository.getAudioReusePolicy(sha256);
-      return policy.allowAudioReuse && !policy.audioReuseSuppressed;
+      final policy = await _videosRepository.refreshAudioReusePolicy(source);
+      return !policy.audioReuseSuppressed;
     } catch (error) {
       Log.warning(
         'Audio reuse policy lookup failed; blocking reuse: $error',

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -206,10 +206,11 @@ class VideoEventPublisher {
   /// Verifies that a selected sound is permitted to be reused.
   ///
   /// Bundled and local sounds do not represent another creator's Nostr
-  /// event. A creator may also reuse their own sound. Every other sound must
+  /// event. A creator may also reuse their own sound when no explicit terms
+  /// exist; an explicit decline remains authoritative. Every other sound must
   /// have explicit consent or pass the legacy source-video resolver; anything
-  /// short of a granted answer blocks the publish so a private sound cannot be
-  /// remixed by accident.
+  /// short of a granted answer blocks the publish so a private sound cannot
+  /// be remixed by accident.
   ///
   /// This answer is fail-closed, not a verdict: it is `false` for a refusal,
   /// for missing evidence, and for a lookup that never completed. Only
@@ -222,6 +223,8 @@ class VideoEventPublisher {
         sound.allowsReuse) {
       return true;
     }
+
+    if (sound.hasExplicitReuseConsent) return false;
 
     final currentPubkey = _authService?.currentPublicKeyHex;
     if (currentPubkey != null && currentPubkey == sound.pubkey) {

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -206,8 +206,7 @@ class VideoEventPublisher {
   /// Verifies that a selected sound is permitted to be reused.
   ///
   /// Bundled and local sounds do not represent another creator's Nostr
-  /// event. A creator may also reuse their own sound when no explicit terms
-  /// exist; an explicit decline remains authoritative. Every other sound must
+  /// event. A creator may also reuse their own sound. Every other sound must
   /// have explicit consent or pass the legacy source-video resolver; anything
   /// short of a granted answer blocks the publish so a private sound cannot
   /// be remixed by accident.
@@ -220,16 +219,16 @@ class VideoEventPublisher {
     if (sound.isBundled ||
         sound.isLocalImport ||
         sound.isExternalProviderSound ||
-        sound.allowsReuse) {
+        (sound.allowsReuse && !sound.requiresCurrentReuseVerification)) {
       return true;
     }
-
-    if (sound.hasExplicitReuseConsent) return false;
 
     final currentPubkey = _authService?.currentPublicKeyHex;
     if (currentPubkey != null && currentPubkey == sound.pubkey) {
       return true;
     }
+
+    if (sound.hasExplicitReuseConsent) return false;
 
     final checker = _audioReuseConsentChecker;
     if (checker == null) return false;
@@ -1587,6 +1586,9 @@ class VideoEventPublisher {
       // and the caller is told so it can say so rather than reporting a
       // clean success.
       var audioReuseDegraded = false;
+      if (!allowAudioReuse) {
+        tags.add(['allow_audio_reuse', 'false']);
+      }
       if (allowAudioReuse &&
           reusableSelectedAudioEventId == null &&
           selectedAudio?.isExternalProviderSound != true &&

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -205,16 +205,10 @@ class VideoEventPublisher {
 
   /// Verifies that a selected sound is permitted to be reused.
   ///
-  /// Bundled and local sounds do not represent another creator's Nostr
-  /// event. A creator may also reuse their own sound. Every other sound must
-  /// have explicit consent or pass the legacy source-video resolver; anything
-  /// short of a granted answer blocks the publish so a private sound cannot
-  /// be remixed by accident.
+  /// Bundled, local, and provider sounds carry their own terms. Creators may
+  /// reuse their own sound; every other sound needs current verified consent.
   ///
-  /// This answer is fail-closed, not a verdict: it is `false` for a refusal,
-  /// for missing evidence, and for a lookup that never completed. Only
-  /// [AudioEvent.hasExplicitReuseConsent] separates a real refusal out, and
-  /// the publish path handles that case before reaching here.
+  /// Refusal, missing evidence, and failed lookup all fail closed.
   Future<bool> _canReuseSelectedAudio(AudioEvent sound) async {
     if (sound.isBundled ||
         sound.isLocalImport ||
@@ -1586,9 +1580,7 @@ class VideoEventPublisher {
       // and the caller is told so it can say so rather than reporting a
       // clean success.
       var audioReuseDegraded = false;
-      if (!allowAudioReuse) {
-        tags.add(['allow_audio_reuse', 'false']);
-      }
+      if (!allowAudioReuse) tags.add(['allow_audio_reuse', 'false']);
       if (allowAudioReuse &&
           reusableSelectedAudioEventId == null &&
           selectedAudio?.isExternalProviderSound != true &&

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -221,8 +221,6 @@ class VideoEventPublisher {
       return true;
     }
 
-    if (sound.hasExplicitReuseConsent && !sound.allowsReuse) return false;
-
     final checker = _audioReuseConsentChecker;
     if (checker == null) return false;
 

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -212,8 +212,7 @@ class VideoEventPublisher {
   Future<bool> _canReuseSelectedAudio(AudioEvent sound) async {
     if (sound.isBundled ||
         sound.isLocalImport ||
-        sound.isExternalProviderSound ||
-        (sound.allowsReuse && !sound.requiresCurrentReuseVerification)) {
+        sound.isExternalProviderSound) {
       return true;
     }
 
@@ -222,7 +221,7 @@ class VideoEventPublisher {
       return true;
     }
 
-    if (sound.hasExplicitReuseConsent) return false;
+    if (sound.hasExplicitReuseConsent && !sound.allowsReuse) return false;
 
     final checker = _audioReuseConsentChecker;
     if (checker == null) return false;

--- a/mobile/lib/services/video_metadata_update_service.dart
+++ b/mobile/lib/services/video_metadata_update_service.dart
@@ -413,9 +413,7 @@ class VideoMetadataUpdateService {
         ]);
       }
 
-      if (editorState.allowAudioReuse) {
-        tags.add(['allow_audio_reuse', 'true']);
-      }
+      tags.add(['allow_audio_reuse', editorState.allowAudioReuse.toString()]);
 
       tags.addAll(preservedTags);
       tags.addAll(

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -130,11 +130,13 @@ class _OriginalSoundSection extends ConsumerWidget {
   /// can't be confirmed offline, so fail closed — attribution still shows but
   /// the sound isn't offered for reuse (an owner-saved private sound must not
   /// leak this way). Otherwise this is the video's own original sound, reusable
-  /// only when its creator enabled audio reuse (the `allow_audio_reuse`
-  /// marker) or when the viewer is that creator.
+  /// when its creator enabled audio reuse, when an unmarked classic Vine uses
+  /// the compatibility policy, or when consent is absent and the viewer is
+  /// that creator. An explicit decline overrides the owner exception.
   bool _canReuseSound(WidgetRef ref) {
     if (video.hasAudioReference) return false;
-    if (video.allowAudioReuse) return true;
+    final knownTerms = originalSoundReuseTerms(video);
+    if (knownTerms != null) return knownTerms;
     // Re-evaluate on auth restore/logout/account-switch so the owner exception
     // can't go stale (authServiceProvider alone is a stable instance).
     ref.watch(currentAuthStateProvider);

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -131,7 +131,8 @@ class _OriginalSoundSection extends ConsumerWidget {
   /// the sound isn't offered for reuse (an owner-saved private sound must not
   /// leak this way). Otherwise this is the video's own original sound, reusable
   /// when its creator enabled audio reuse, when an exact verified archive
-  /// record uses the compatibility policy, or when the viewer is that creator.
+  /// record receives Divine's legacy reuse presumption, or when the viewer is
+  /// that creator. The archive presumption is not affirmative creator consent.
   bool _canReuseSound(WidgetRef ref) {
     if (video.hasAudioReference) return false;
     final knownTerms = originalSoundReuseTerms(video);

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -136,13 +136,14 @@ class _OriginalSoundSection extends ConsumerWidget {
   bool _canReuseSound(WidgetRef ref) {
     if (video.hasAudioReference) return false;
     final knownTerms = originalSoundReuseTerms(video);
-    if (knownTerms == true) return true;
     // Re-evaluate on auth restore/logout/account-switch so the owner exception
     // can't go stale (authServiceProvider alone is a stable instance).
     ref.watch(currentAuthStateProvider);
     final viewerPubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
     if (viewerPubkey != null && viewerPubkey == video.pubkey) return true;
-    return knownTerms ?? false;
+    if (knownTerms != true) return false;
+    final sound = AudioEvent.fromVideoOriginalSound(video);
+    return ref.watch(audioReuseConsentProvider(sound)).value ?? false;
   }
 
   void _navigateToSoundDetail(BuildContext context, String creatorName) {
@@ -277,18 +278,28 @@ class _SoundListItem extends ConsumerWidget {
     // Null while legacy terms are still being verified. The badge states the
     // sound's public terms, not the current viewer's permission to reuse it.
     final knownReuseTerms = audioReuseTermsFromEvent(audio);
-    final reuseAllowed =
-        knownReuseTerms ?? ref.watch(audioReuseTermsProvider(audio)).value;
+    final reuseAllowed = knownReuseTerms == false
+        ? false
+        : ref.watch(audioReuseTermsProvider(audio)).value;
+    ref.watch(currentAuthStateProvider);
+    final viewerPubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
+    final isOwner = viewerPubkey != null && viewerPubkey == audio.pubkey;
+    final canReuse =
+        isOwner ||
+        audio.isBundled ||
+        audio.isLocalImport ||
+        (audio.externalSource?.license.allowsDerivatives ?? false) ||
+        (ref.watch(audioReuseConsentProvider(audio)).value ?? false);
 
     return Semantics(
-      button: true,
+      button: canReuse,
       label: context.l10n.metadataSoundsSharedSoundSemantics(
         soundName,
         creditText,
       ),
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: () => _navigateToSoundDetail(context),
+        onTap: canReuse ? () => _navigateToSoundDetail(context) : null,
         child: Row(
           spacing: 16,
           children: [
@@ -357,11 +368,12 @@ class _SoundListItem extends ConsumerWidget {
                 ],
               ),
             ),
-            DivineIcon(
-              icon: DivineIconName.caretRight,
-              color: context.vineColors.onSurfaceVariant,
-              size: 20,
-            ),
+            if (canReuse)
+              DivineIcon(
+                icon: DivineIconName.caretRight,
+                color: context.vineColors.onSurfaceVariant,
+                size: 20,
+              ),
           ],
         ),
       ),

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -130,18 +130,18 @@ class _OriginalSoundSection extends ConsumerWidget {
   /// can't be confirmed offline, so fail closed — attribution still shows but
   /// the sound isn't offered for reuse (an owner-saved private sound must not
   /// leak this way). Otherwise this is the video's own original sound, reusable
-  /// when its creator enabled audio reuse, when an unmarked classic Vine uses
-  /// the compatibility policy, or when consent is absent and the viewer is
-  /// that creator. An explicit decline overrides the owner exception.
+  /// when its creator enabled audio reuse, when an exact verified archive
+  /// record uses the compatibility policy, or when the viewer is that creator.
   bool _canReuseSound(WidgetRef ref) {
     if (video.hasAudioReference) return false;
     final knownTerms = originalSoundReuseTerms(video);
-    if (knownTerms != null) return knownTerms;
+    if (knownTerms == true) return true;
     // Re-evaluate on auth restore/logout/account-switch so the owner exception
     // can't go stale (authServiceProvider alone is a stable instance).
     ref.watch(currentAuthStateProvider);
     final viewerPubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
-    return viewerPubkey != null && viewerPubkey == video.pubkey;
+    if (viewerPubkey != null && viewerPubkey == video.pubkey) return true;
+    return knownTerms ?? false;
   }
 
   void _navigateToSoundDetail(BuildContext context, String creatorName) {

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -130,9 +130,9 @@ class _OriginalSoundSection extends ConsumerWidget {
   /// can't be confirmed offline, so fail closed — attribution still shows but
   /// the sound isn't offered for reuse (an owner-saved private sound must not
   /// leak this way). Otherwise this is the video's own original sound, reusable
-  /// when its creator enabled audio reuse, when an exact verified archive
-  /// record receives Divine's legacy reuse presumption, or when the viewer is
-  /// that creator. The archive presumption is not affirmative creator consent.
+  /// when its creator enabled audio reuse, when an exact verified classic Vine
+  /// is reusable under Divine's classic-audio policy, or when the viewer is
+  /// that creator. A fresh server check enforces any creator takedown.
   bool _canReuseSound(WidgetRef ref) {
     if (video.hasAudioReference) return false;
     final knownTerms = originalSoundReuseTerms(video);

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -1794,6 +1794,37 @@ class FunnelcakeApiClient {
     }
   }
 
+  /// Fetches the current server-side audio reuse decision for [sha256].
+  Future<AudioReusePolicy> getAudioReusePolicy(String sha256) async {
+    if (!isAvailable) throw const FunnelcakeNotConfiguredException();
+    if (!RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(sha256)) {
+      throw const FunnelcakeException('SHA-256 must be 64 hexadecimal digits');
+    }
+
+    final normalizedHash = sha256.toLowerCase();
+    final uri = Uri.parse(
+      '$_baseUrl/api/videos/by-sha256/$normalizedHash/audio-reuse',
+    );
+    try {
+      final response = await _get(uri);
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        return AudioReusePolicy.fromJson(data);
+      }
+      throw FunnelcakeApiException(
+        message: 'Failed to fetch audio reuse policy',
+        statusCode: response.statusCode,
+        url: uri.toString(),
+      );
+    } on TimeoutException {
+      throw FunnelcakeTimeoutException(uri.toString());
+    } on FunnelcakeException {
+      rethrow;
+    } catch (error) {
+      throw FunnelcakeException('Failed to fetch audio reuse policy: $error');
+    }
+  }
+
   /// Fetches the pubkeys that have liked a video, most recent first.
   ///
   /// [eventId] is the Nostr event ID (or d-tag) for the video.

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -1794,25 +1794,37 @@ class FunnelcakeApiClient {
     }
   }
 
-  /// Fetches the current server-side audio reuse decision for [sha256].
-  Future<AudioReusePolicy> getAudioReusePolicy(String sha256) async {
+  /// Refreshes the action-time takedown decision for one selected video.
+  Future<AudioReusePolicy> refreshAudioReusePolicy({
+    required int kind,
+    required String pubkey,
+    required String dTag,
+  }) async {
     if (!isAvailable) throw const FunnelcakeNotConfiguredException();
-    if (!RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(sha256)) {
-      throw const FunnelcakeException('SHA-256 must be 64 hexadecimal digits');
+    if (kind != 34235 && kind != 34236) {
+      throw const FunnelcakeException('Unsupported video kind');
+    }
+    if (!RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(pubkey) || dTag.isEmpty) {
+      throw const FunnelcakeException('Invalid video coordinate');
     }
 
-    final normalizedHash = sha256.toLowerCase();
-    final uri = Uri.parse(
-      '$_baseUrl/api/videos/by-sha256/$normalizedHash/audio-reuse',
-    );
+    final uri = Uri.parse('$_baseUrl/api/videos/audio-reuse/bulk');
+    final elapsed = Stopwatch()..start();
     try {
-      final response = await _get(uri);
+      final response = await _post(
+        uri,
+        body: {
+          'videos': [
+            {'kind': kind, 'pubkey': pubkey.toLowerCase(), 'd_tag': dTag},
+          ],
+        },
+      );
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
-        return AudioReusePolicy.fromJson(data);
+        return AudioReusePolicy.fromRefreshJson(data, elapsed: elapsed.elapsed);
       }
       throw FunnelcakeApiException(
-        message: 'Failed to fetch audio reuse policy',
+        message: 'Failed to refresh audio reuse policy',
         statusCode: response.statusCode,
         url: uri.toString(),
       );
@@ -1821,7 +1833,7 @@ class FunnelcakeApiClient {
     } on FunnelcakeException {
       rethrow;
     } catch (error) {
-      throw FunnelcakeException('Failed to fetch audio reuse policy: $error');
+      throw FunnelcakeException('Failed to refresh audio reuse policy: $error');
     }
   }
 

--- a/mobile/packages/funnelcake_api_client/lib/src/models/audio_reuse_policy.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/audio_reuse_policy.dart
@@ -1,33 +1,49 @@
-// ABOUTME: Server-side audio reuse suppression decision for a video blob.
-// ABOUTME: Keeps creator opt-outs separate from event-level reuse metadata.
+// ABOUTME: Action-time server decision for a selected video's audio reuse.
+// ABOUTME: Models the creator takedown signal and its short validity lease.
 
 import 'package:meta/meta.dart';
 
 @immutable
-/// The server's current decision for reuse of one content-addressed video.
+/// The server's fresh suppression decision for one selected video.
 class AudioReusePolicy {
   /// Creates an audio reuse policy response.
   const AudioReusePolicy({
-    required this.allowAudioReuse,
     required this.audioReuseSuppressed,
+    required this.validFor,
   });
 
   /// Parses the Funnelcake response, rejecting missing or non-boolean fields.
-  factory AudioReusePolicy.fromJson(Map<String, dynamic> json) {
-    final allowAudioReuse = json['allow_audio_reuse'];
-    final audioReuseSuppressed = json['audio_reuse_suppressed'];
-    if (allowAudioReuse is! bool || audioReuseSuppressed is! bool) {
+  factory AudioReusePolicy.fromRefreshJson(
+    Map<String, dynamic> json, {
+    required Duration elapsed,
+  }) {
+    final policies = json['policies'];
+    final evaluatedAt = DateTime.tryParse(
+      json['evaluated_at']?.toString() ?? '',
+    );
+    final validUntil = DateTime.tryParse(json['valid_until']?.toString() ?? '');
+    if (policies is! List ||
+        policies.length != 1 ||
+        policies.single is! Map<String, dynamic> ||
+        evaluatedAt == null ||
+        validUntil == null) {
       throw const FormatException('Invalid audio reuse policy response');
     }
+    final audioReuseSuppressed =
+        (policies.single as Map<String, dynamic>)['audio_reuse_suppressed'];
+    final validFor = validUntil.difference(evaluatedAt) - elapsed;
+    if (audioReuseSuppressed is! bool || validFor <= Duration.zero) {
+      throw const FormatException('Expired audio reuse policy response');
+    }
     return AudioReusePolicy(
-      allowAudioReuse: allowAudioReuse,
       audioReuseSuppressed: audioReuseSuppressed,
+      validFor: validFor,
     );
   }
 
-  /// Whether the source's event terms allow audio reuse.
-  final bool allowAudioReuse;
-
-  /// Whether a creator opt-out overrides otherwise permissive event terms.
+  /// Whether an explicit creator takedown blocks new reuse.
   final bool audioReuseSuppressed;
+
+  /// Remaining server-issued lease after request time is subtracted.
+  final Duration validFor;
 }

--- a/mobile/packages/funnelcake_api_client/lib/src/models/audio_reuse_policy.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/audio_reuse_policy.dart
@@ -1,0 +1,33 @@
+// ABOUTME: Server-side audio reuse suppression decision for a video blob.
+// ABOUTME: Keeps creator opt-outs separate from event-level reuse metadata.
+
+import 'package:meta/meta.dart';
+
+@immutable
+/// The server's current decision for reuse of one content-addressed video.
+class AudioReusePolicy {
+  /// Creates an audio reuse policy response.
+  const AudioReusePolicy({
+    required this.allowAudioReuse,
+    required this.audioReuseSuppressed,
+  });
+
+  /// Parses the Funnelcake response, rejecting missing or non-boolean fields.
+  factory AudioReusePolicy.fromJson(Map<String, dynamic> json) {
+    final allowAudioReuse = json['allow_audio_reuse'];
+    final audioReuseSuppressed = json['audio_reuse_suppressed'];
+    if (allowAudioReuse is! bool || audioReuseSuppressed is! bool) {
+      throw const FormatException('Invalid audio reuse policy response');
+    }
+    return AudioReusePolicy(
+      allowAudioReuse: allowAudioReuse,
+      audioReuseSuppressed: audioReuseSuppressed,
+    );
+  }
+
+  /// Whether the source's event terms allow audio reuse.
+  final bool allowAudioReuse;
+
+  /// Whether a creator opt-out overrides otherwise permissive event terms.
+  final bool audioReuseSuppressed;
+}

--- a/mobile/packages/funnelcake_api_client/lib/src/models/models.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/models.dart
@@ -1,3 +1,4 @@
+export 'audio_reuse_policy.dart';
 export 'featured_tab_config.dart';
 export 'featured_tab_videos_response.dart';
 export 'notification_response.dart';

--- a/mobile/packages/funnelcake_api_client/test/src/audio_reuse_policy_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/audio_reuse_policy_test.dart
@@ -1,0 +1,77 @@
+// ABOUTME: Tests the content-addressed audio reuse policy endpoint contract.
+// ABOUTME: Ensures suppression fields are strict and hashes are normalized.
+
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class _MockHttpClient extends Mock implements http.Client {}
+
+class _FakeUri extends Fake implements Uri {}
+
+void main() {
+  setUpAll(() => registerFallbackValue(_FakeUri()));
+
+  late _MockHttpClient httpClient;
+  late FunnelcakeApiClient client;
+  final hash = 'A' * 64;
+
+  setUp(() {
+    httpClient = _MockHttpClient();
+    client = FunnelcakeApiClient(
+      baseUrl: 'https://api.example.com',
+      httpClient: httpClient,
+      retryBaseDelay: Duration.zero,
+    );
+  });
+
+  tearDown(() => client.dispose());
+
+  test('parses the authoritative policy and normalizes the hash', () async {
+    when(
+      () => httpClient.get(any(), headers: any(named: 'headers')),
+    ).thenAnswer(
+      (_) async => http.Response(
+        '{"allow_audio_reuse":false,"audio_reuse_suppressed":true}',
+        200,
+      ),
+    );
+
+    final policy = await client.getAudioReusePolicy(hash);
+
+    expect(policy.allowAudioReuse, isFalse);
+    expect(policy.audioReuseSuppressed, isTrue);
+    final uri =
+        verify(
+              () =>
+                  httpClient.get(captureAny(), headers: any(named: 'headers')),
+            ).captured.single
+            as Uri;
+    expect(
+      uri.path,
+      '/api/videos/by-sha256/${hash.toLowerCase()}/audio-reuse',
+    );
+  });
+
+  test('rejects malformed policy responses', () async {
+    when(
+      () => httpClient.get(any(), headers: any(named: 'headers')),
+    ).thenAnswer(
+      (_) async => http.Response('{"allow_audio_reuse":true}', 200),
+    );
+
+    await expectLater(
+      client.getAudioReusePolicy(hash),
+      throwsA(isA<FunnelcakeException>()),
+    );
+  });
+
+  test('rejects a malformed hash before making a request', () async {
+    await expectLater(
+      client.getAudioReusePolicy('not-a-hash'),
+      throwsA(isA<FunnelcakeException>()),
+    );
+    verifyNever(() => httpClient.get(any(), headers: any(named: 'headers')));
+  });
+}

--- a/mobile/packages/funnelcake_api_client/test/src/audio_reuse_policy_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/audio_reuse_policy_test.dart
@@ -1,5 +1,7 @@
-// ABOUTME: Tests the content-addressed audio reuse policy endpoint contract.
-// ABOUTME: Ensures suppression fields are strict and hashes are normalized.
+// ABOUTME: Tests the selected-video audio reuse refresh contract.
+// ABOUTME: Ensures suppression and lease fields fail closed.
+
+import 'dart:convert';
 
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:http/http.dart' as http;
@@ -15,7 +17,7 @@ void main() {
 
   late _MockHttpClient httpClient;
   late FunnelcakeApiClient client;
-  final hash = 'A' * 64;
+  final pubkey = 'A' * 64;
 
   setUp(() {
     httpClient = _MockHttpClient();
@@ -28,54 +30,95 @@ void main() {
 
   tearDown(() => client.dispose());
 
-  group('getAudioReusePolicy', () {
-    test('parses the authoritative policy and normalizes the hash', () async {
+  group('refreshAudioReusePolicy', () {
+    test(
+      'posts the selected coordinate and parses a fresh suppression',
+      () async {
+        when(
+          () => httpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(
+            '{"policies":[{"audio_reuse_suppressed":true}],'
+            '"evaluated_at":"2026-09-10T00:00:00Z",'
+            '"valid_until":"2026-09-10T00:01:00Z"}',
+            200,
+          ),
+        );
+
+        final policy = await client.refreshAudioReusePolicy(
+          kind: 34236,
+          pubkey: pubkey,
+          dTag: 'Classic-ID',
+        );
+
+        expect(policy.audioReuseSuppressed, isTrue);
+        expect(policy.validFor, greaterThan(Duration.zero));
+        final captured = verify(
+          () => httpClient.post(
+            captureAny(),
+            headers: any(named: 'headers'),
+            body: captureAny(named: 'body'),
+          ),
+        ).captured;
+        expect((captured[0] as Uri).path, '/api/videos/audio-reuse/bulk');
+        expect(jsonDecode(captured[1] as String), {
+          'videos': [
+            {
+              'kind': 34236,
+              'pubkey': pubkey.toLowerCase(),
+              'd_tag': 'Classic-ID',
+            },
+          ],
+        });
+      },
+    );
+
+    test('rejects an expired policy response', () async {
       when(
-        () => httpClient.get(any(), headers: any(named: 'headers')),
+        () => httpClient.post(
+          any(),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+        ),
       ).thenAnswer(
         (_) async => http.Response(
-          '{"allow_audio_reuse":false,"audio_reuse_suppressed":true}',
+          '{"policies":[{"audio_reuse_suppressed":false}],'
+          '"evaluated_at":"2026-09-10T00:01:00Z",'
+          '"valid_until":"2026-09-10T00:00:00Z"}',
           200,
         ),
       );
 
-      final policy = await client.getAudioReusePolicy(hash);
-
-      expect(policy.allowAudioReuse, isFalse);
-      expect(policy.audioReuseSuppressed, isTrue);
-      final uri =
-          verify(
-                () => httpClient.get(
-                  captureAny(),
-                  headers: any(named: 'headers'),
-                ),
-              ).captured.single
-              as Uri;
-      expect(
-        uri.path,
-        '/api/videos/by-sha256/${hash.toLowerCase()}/audio-reuse',
-      );
-    });
-
-    test('rejects malformed policy responses', () async {
-      when(
-        () => httpClient.get(any(), headers: any(named: 'headers')),
-      ).thenAnswer(
-        (_) async => http.Response('{"allow_audio_reuse":true}', 200),
-      );
-
       await expectLater(
-        client.getAudioReusePolicy(hash),
+        client.refreshAudioReusePolicy(
+          kind: 34236,
+          pubkey: pubkey,
+          dTag: 'classic-id',
+        ),
         throwsA(isA<FunnelcakeException>()),
       );
     });
 
-    test('rejects a malformed hash before making a request', () async {
+    test('rejects malformed coordinates before making a request', () async {
       await expectLater(
-        client.getAudioReusePolicy('not-a-hash'),
+        client.refreshAudioReusePolicy(
+          kind: 22,
+          pubkey: pubkey,
+          dTag: 'classic-id',
+        ),
         throwsA(isA<FunnelcakeException>()),
       );
-      verifyNever(() => httpClient.get(any(), headers: any(named: 'headers')));
+      verifyNever(
+        () => httpClient.post(
+          any(),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+        ),
+      );
     });
   });
 }

--- a/mobile/packages/funnelcake_api_client/test/src/audio_reuse_policy_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/audio_reuse_policy_test.dart
@@ -28,50 +28,54 @@ void main() {
 
   tearDown(() => client.dispose());
 
-  test('parses the authoritative policy and normalizes the hash', () async {
-    when(
-      () => httpClient.get(any(), headers: any(named: 'headers')),
-    ).thenAnswer(
-      (_) async => http.Response(
-        '{"allow_audio_reuse":false,"audio_reuse_suppressed":true}',
-        200,
-      ),
-    );
+  group('getAudioReusePolicy', () {
+    test('parses the authoritative policy and normalizes the hash', () async {
+      when(
+        () => httpClient.get(any(), headers: any(named: 'headers')),
+      ).thenAnswer(
+        (_) async => http.Response(
+          '{"allow_audio_reuse":false,"audio_reuse_suppressed":true}',
+          200,
+        ),
+      );
 
-    final policy = await client.getAudioReusePolicy(hash);
+      final policy = await client.getAudioReusePolicy(hash);
 
-    expect(policy.allowAudioReuse, isFalse);
-    expect(policy.audioReuseSuppressed, isTrue);
-    final uri =
-        verify(
-              () =>
-                  httpClient.get(captureAny(), headers: any(named: 'headers')),
-            ).captured.single
-            as Uri;
-    expect(
-      uri.path,
-      '/api/videos/by-sha256/${hash.toLowerCase()}/audio-reuse',
-    );
-  });
+      expect(policy.allowAudioReuse, isFalse);
+      expect(policy.audioReuseSuppressed, isTrue);
+      final uri =
+          verify(
+                () => httpClient.get(
+                  captureAny(),
+                  headers: any(named: 'headers'),
+                ),
+              ).captured.single
+              as Uri;
+      expect(
+        uri.path,
+        '/api/videos/by-sha256/${hash.toLowerCase()}/audio-reuse',
+      );
+    });
 
-  test('rejects malformed policy responses', () async {
-    when(
-      () => httpClient.get(any(), headers: any(named: 'headers')),
-    ).thenAnswer(
-      (_) async => http.Response('{"allow_audio_reuse":true}', 200),
-    );
+    test('rejects malformed policy responses', () async {
+      when(
+        () => httpClient.get(any(), headers: any(named: 'headers')),
+      ).thenAnswer(
+        (_) async => http.Response('{"allow_audio_reuse":true}', 200),
+      );
 
-    await expectLater(
-      client.getAudioReusePolicy(hash),
-      throwsA(isA<FunnelcakeException>()),
-    );
-  });
+      await expectLater(
+        client.getAudioReusePolicy(hash),
+        throwsA(isA<FunnelcakeException>()),
+      );
+    });
 
-  test('rejects a malformed hash before making a request', () async {
-    await expectLater(
-      client.getAudioReusePolicy('not-a-hash'),
-      throwsA(isA<FunnelcakeException>()),
-    );
-    verifyNever(() => httpClient.get(any(), headers: any(named: 'headers')));
+    test('rejects a malformed hash before making a request', () async {
+      await expectLater(
+        client.getAudioReusePolicy('not-a-hash'),
+        throwsA(isA<FunnelcakeException>()),
+      );
+      verifyNever(() => httpClient.get(any(), headers: any(named: 'headers')));
+    });
   });
 }

--- a/mobile/packages/models/lib/models.dart
+++ b/mobile/packages/models/lib/models.dart
@@ -7,6 +7,7 @@ export 'package:logging_types/logging_types.dart'
 export 'src/actor_info.dart';
 export 'src/aspect_ratio.dart';
 export 'src/audio_event.dart';
+export 'src/audio_reuse_policy.dart';
 export 'src/bug_report_data.dart';
 export 'src/bulk_profiles_response.dart';
 export 'src/bulk_video_stats_entry.dart';

--- a/mobile/packages/models/lib/src/audio_event.dart
+++ b/mobile/packages/models/lib/src/audio_event.dart
@@ -3,6 +3,7 @@
 // ABOUTME: parsing audio shared for use in other videos
 
 import 'package:meta/meta.dart';
+import 'package:models/src/audio_reuse_policy.dart';
 import 'package:models/src/nostr_hex_utils.dart';
 import 'package:models/src/video_event.dart';
 import 'package:models/src/vine_sound.dart';
@@ -251,6 +252,7 @@ class AudioEvent {
     VideoEvent video, {
     String? creatorName,
   }) {
+    final reuseTerms = originalSoundReuseTerms(video);
     return AudioEvent(
       id: 'video_${video.id}',
       pubkey: video.pubkey,
@@ -260,7 +262,8 @@ class AudioEvent {
       title: creatorName == null ? null : 'Original sound - $creatorName',
       source: 'Original Sound',
       sourceVideoReference: video.addressableId,
-      allowsReuse: video.allowAudioReuse,
+      allowsReuse: reuseTerms ?? false,
+      hasExplicitReuseConsent: reuseTerms != null,
     );
   }
 
@@ -577,10 +580,12 @@ class AudioEvent {
   /// `true` default for bundled and existing in-memory app sounds.
   final bool allowsReuse;
 
-  /// Whether a parsed Kind 1063 explicitly carried an audio-reuse decision.
+  /// Whether this event carries definitive audio-reuse terms.
   ///
-  /// This distinguishes legacy events with no consent tag from an explicit
-  /// `false`, which must remain credit-only.
+  /// Parsed Kind 1063 events set this only for an explicit consent tag.
+  /// Synthetic original sounds also set it when their source video policy is
+  /// definitive, including the classic Vine compatibility verdict. This
+  /// distinguishes those results from legacy events that still need lookup.
   final bool hasExplicitReuseConsent;
 
   /// Whether this audio is currently anchored to a source video clip.

--- a/mobile/packages/models/lib/src/audio_event.dart
+++ b/mobile/packages/models/lib/src/audio_event.dart
@@ -329,9 +329,10 @@ class AudioEvent {
           ? Duration(milliseconds: json['endTimeMs'] as int)
           : null,
       anchorClipId: json['anchorClipId'] as String?,
-      // Persisted events without a consent field predate the reuse policy.
+      // Persisted events without a terms field predate the reuse policy.
       // Treat them as unknown and let the source-video resolver decide;
-      // defaulting to true would silently grant remix permission.
+      // archive compatibility is a provisional Divine policy grant, not an
+      // affirmative creator-consent record, and must be verified again.
       allowsReuse: json['allowsReuse'] as bool? ?? false,
       hasExplicitReuseConsent:
           json['hasExplicitReuseConsent'] as bool? ?? false,

--- a/mobile/packages/models/lib/src/audio_event.dart
+++ b/mobile/packages/models/lib/src/audio_event.dart
@@ -84,6 +84,7 @@ class AudioEvent {
     this.anchorClipId,
     this.allowsReuse = true,
     this.hasExplicitReuseConsent = false,
+    this.requiresCurrentReuseVerification = false,
   }) : title = sanitizeUtf16OrNull(title),
        source = sanitizeUtf16OrNull(source),
        creatorName = sanitizeUtf16OrNull(creatorName),
@@ -263,7 +264,12 @@ class AudioEvent {
       source: 'Original Sound',
       sourceVideoReference: video.addressableId,
       allowsReuse: reuseTerms ?? false,
-      hasExplicitReuseConsent: reuseTerms != null,
+      hasExplicitReuseConsent:
+          video.audioReuseConsent == AudioReuseConsent.granted ||
+          video.audioReuseConsent == AudioReuseConsent.declined,
+      requiresCurrentReuseVerification:
+          reuseTerms == true &&
+          video.audioReuseConsent == AudioReuseConsent.unspecified,
     );
   }
 
@@ -329,6 +335,8 @@ class AudioEvent {
       allowsReuse: json['allowsReuse'] as bool? ?? false,
       hasExplicitReuseConsent:
           json['hasExplicitReuseConsent'] as bool? ?? false,
+      requiresCurrentReuseVerification:
+          json['requiresCurrentReuseVerification'] as bool? ?? false,
     );
   }
 
@@ -583,10 +591,14 @@ class AudioEvent {
   /// Whether this event carries definitive audio-reuse terms.
   ///
   /// Parsed Kind 1063 events set this only for an explicit consent tag.
-  /// Synthetic original sounds also set it when their source video policy is
-  /// definitive, including the classic Vine compatibility verdict. This
-  /// distinguishes those results from legacy events that still need lookup.
+  /// Synthetic original sounds set it only for an explicit source marker.
   final bool hasExplicitReuseConsent;
+
+  /// Whether reuse must be checked against the current source video.
+  ///
+  /// Archive compatibility is controlled by server state and cannot become a
+  /// durable grant when this sound is saved or carried through the editor.
+  final bool requiresCurrentReuseVerification;
 
   /// Whether this audio is currently anchored to a source video clip.
   bool get isAnchored => anchorClipId != null;
@@ -736,6 +748,7 @@ class AudioEvent {
     bool clearAnchorClipId = false,
     bool? allowsReuse,
     bool? hasExplicitReuseConsent,
+    bool? requiresCurrentReuseVerification,
   }) {
     return AudioEvent(
       id: id ?? this.id,
@@ -769,6 +782,9 @@ class AudioEvent {
       allowsReuse: allowsReuse ?? this.allowsReuse,
       hasExplicitReuseConsent:
           hasExplicitReuseConsent ?? this.hasExplicitReuseConsent,
+      requiresCurrentReuseVerification:
+          requiresCurrentReuseVerification ??
+          this.requiresCurrentReuseVerification,
     );
   }
 
@@ -820,6 +836,7 @@ class AudioEvent {
     'proxyProtocol': ?proxyProtocol,
     'allowsReuse': allowsReuse,
     'hasExplicitReuseConsent': hasExplicitReuseConsent,
+    'requiresCurrentReuseVerification': requiresCurrentReuseVerification,
     // Always serialize volume so history and draft snapshots preserve
     // explicit user edits instead of relying on an implicit default.
     'volume': volume,

--- a/mobile/packages/models/lib/src/audio_event.dart
+++ b/mobile/packages/models/lib/src/audio_event.dart
@@ -259,6 +259,7 @@ class AudioEvent {
       pubkey: video.pubkey,
       createdAt: video.createdAt,
       url: video.videoUrl,
+      sha256: video.sha256,
       duration: video.duration?.toDouble(),
       title: creatorName == null ? null : 'Original sound - $creatorName',
       source: 'Original Sound',

--- a/mobile/packages/models/lib/src/audio_reuse_policy.dart
+++ b/mobile/packages/models/lib/src/audio_reuse_policy.dart
@@ -1,0 +1,18 @@
+// ABOUTME: Defines viewer-independent reuse terms for original video audio.
+// ABOUTME: Preserves classic Vine compatibility while honoring creator terms.
+
+import 'package:models/src/video_event.dart';
+
+/// Viewer-independent reuse terms for a video's own original sound.
+///
+/// A `null` result means the marker is genuinely absent and a viewer-aware
+/// policy may still grant the video's creator access to their own sound.
+bool? originalSoundReuseTerms(VideoEvent video) {
+  return switch (video.audioReuseConsent) {
+    AudioReuseConsent.granted => true,
+    AudioReuseConsent.declined || AudioReuseConsent.invalid => false,
+    // TODO(NotThatKindOfDrLiz): Replace this compatibility signal with
+    // verified archive provenance after #8466 ships.
+    AudioReuseConsent.unspecified => video.isOriginalVine ? true : null,
+  };
+}

--- a/mobile/packages/models/lib/src/audio_reuse_policy.dart
+++ b/mobile/packages/models/lib/src/audio_reuse_policy.dart
@@ -1,5 +1,6 @@
 // ABOUTME: Defines viewer-independent reuse terms for original video audio.
-// ABOUTME: Preserves classic Vine compatibility while honoring creator terms.
+// ABOUTME: Applies Divine's classic Vine reuse policy.
+// ABOUTME: Preserves explicit creator terms and the owner exception.
 
 import 'package:models/src/video_event.dart';
 
@@ -7,6 +8,9 @@ import 'package:models/src/video_event.dart';
 ///
 /// A `null` result means the marker is genuinely absent and a viewer-aware
 /// policy may still grant the video's creator access to their own sound.
+/// For an authoritatively verified classic Vine, the server may instead apply
+/// Divine's legacy compatibility presumption. That is a product-policy grant,
+/// not affirmative creator consent.
 bool? originalSoundReuseTerms(VideoEvent video) {
   return switch (video.audioReuseConsent) {
     AudioReuseConsent.granted => true,

--- a/mobile/packages/models/lib/src/audio_reuse_policy.dart
+++ b/mobile/packages/models/lib/src/audio_reuse_policy.dart
@@ -11,8 +11,7 @@ bool? originalSoundReuseTerms(VideoEvent video) {
   return switch (video.audioReuseConsent) {
     AudioReuseConsent.granted => true,
     AudioReuseConsent.declined || AudioReuseConsent.invalid => false,
-    // TODO(NotThatKindOfDrLiz): Replace this compatibility signal with
-    // verified archive provenance after #8466 ships.
-    AudioReuseConsent.unspecified => video.isOriginalVine ? true : null,
+    AudioReuseConsent.unspecified =>
+      video.isVerifiedArchive && video.archiveAudioReuseEnabled ? true : null,
   };
 }

--- a/mobile/packages/models/lib/src/audio_reuse_policy.dart
+++ b/mobile/packages/models/lib/src/audio_reuse_policy.dart
@@ -8,14 +8,16 @@ import 'package:models/src/video_event.dart';
 ///
 /// A `null` result means the marker is genuinely absent and a viewer-aware
 /// policy may still grant the video's creator access to their own sound.
-/// For an authoritatively verified classic Vine, the server may instead apply
-/// Divine's legacy compatibility presumption. That is a product-policy grant,
-/// not affirmative creator consent.
+/// Verified classic Vine audio is reusable by default while rollout is enabled.
+/// Its imported event marker is not a creator takedown; takedowns are enforced
+/// separately through the action-time server policy.
 bool? originalSoundReuseTerms(VideoEvent video) {
+  if (video.isVerifiedArchive) {
+    return video.archiveAudioReuseEnabled ? true : null;
+  }
   return switch (video.audioReuseConsent) {
     AudioReuseConsent.granted => true,
     AudioReuseConsent.declined || AudioReuseConsent.invalid => false,
-    AudioReuseConsent.unspecified =>
-      video.isVerifiedArchive && video.archiveAudioReuseEnabled ? true : null,
+    AudioReuseConsent.unspecified => null,
   };
 }

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -1027,11 +1027,10 @@ class VideoEvent {
   /// itself express creator consent.
   final bool isVerifiedArchive;
 
-  /// Whether Funnelcake currently enables Divine's legacy archive audio policy.
+  /// Whether Funnelcake enables audio reuse for this verified classic Vine.
   ///
-  /// Combined with [isVerifiedArchive], this permits presumed reuse when no
-  /// creator preference is recorded. Explicit opt-outs remain authoritative.
-  /// The server controls this kill switch; absent values fail closed.
+  /// Combined with [isVerifiedArchive], this grants reuse by default. Creator
+  /// takedowns are separate server decisions refreshed at action time.
   final bool archiveAudioReuseEnabled;
 
   /// Generic `p` tags that mark users mentioned by this video.

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -20,6 +20,9 @@ String? _usableThumbnailUrl(Object? value) {
   return url;
 }
 
+/// The creator's `allow_audio_reuse` marker on a video event.
+enum AudioReuseConsent { granted, declined, unspecified, invalid }
+
 /// Compact backend-computed ProofMode verification result for feed/list rows.
 @immutable
 class ProofVerificationSummary {
@@ -1035,15 +1038,24 @@ class VideoEvent {
     return pubkeys;
   }
 
-  /// Whether the creator marked this video's audio as reusable.
+  /// The creator's audio-reuse marker without collapsing absent and false.
   ///
   /// Reads the editor-owned `allow_audio_reuse` marker. Prefers
   /// [nostrEventTags] but falls back to [rawTags], so the flag survives a
   /// JSON-cache round-trip — [nostrEventTags] is intentionally not persisted
   /// through `toJson`/`fromJson`, but [rawTags] is, which keeps the edit form
   /// from seeding the toggle `false` on a cache-rehydrated video.
-  bool get allowAudioReuse =>
-      _firstNostrTagValue('allow_audio_reuse') == 'true';
+  AudioReuseConsent get audioReuseConsent {
+    return switch (_firstNostrTagValue('allow_audio_reuse')) {
+      'true' => AudioReuseConsent.granted,
+      'false' => AudioReuseConsent.declined,
+      null => AudioReuseConsent.unspecified,
+      _ => AudioReuseConsent.invalid,
+    };
+  }
+
+  /// Whether the creator explicitly marked this video's audio as reusable.
+  bool get allowAudioReuse => audioReuseConsent == AudioReuseConsent.granted;
 
   /// Whether this video has any content warnings.
   bool get hasContentWarning => contentWarningLabels.isNotEmpty;
@@ -1436,11 +1448,11 @@ class VideoEvent {
     return proofSummary?.shouldShowBasicProofTier == true;
   }
 
-  /// Original Vine: Check if this is a recovered original vine from the
-  /// Internet Archive.  Uses the server-controlled `platform` field from
-  /// Funnelcake (set to "vine" for genuine archive imports).  This cannot
-  /// be spoofed by publishing a crafted Nostr event because `platform` is
-  /// relay metadata, not a user-settable tag.
+  /// Original Vine: Check if this appears to be a recovered original Vine.
+  ///
+  /// The meaning of `platform` differs by ingestion path, so this is a
+  /// compatibility signal rather than authoritative archive provenance.
+  /// #8466 tracks replacing it.
   bool get isOriginalVine {
     return rawTags['platform'] == 'vine';
   }

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -1023,11 +1023,14 @@ class VideoEvent {
 
   /// Whether Funnelcake matched this exact event to its verified archive.
   ///
-  /// This server-derived state is never read from Nostr tags.
+  /// This server-derived state is never read from Nostr tags and does not by
+  /// itself express creator consent.
   final bool isVerifiedArchive;
 
-  /// Whether Funnelcake currently enables archive audio compatibility.
+  /// Whether Funnelcake currently enables Divine's legacy archive audio policy.
   ///
+  /// Combined with [isVerifiedArchive], this permits presumed reuse when no
+  /// creator preference is recorded. Explicit opt-outs remain authoritative.
   /// The server controls this kill switch; absent values fail closed.
   final bool archiveAudioReuseEnabled;
 

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -243,6 +243,8 @@ class VideoEvent {
     this.moderationLabels = const [],
     this.warnLabels = const [],
     this.proofSummary,
+    this.isVerifiedArchive = false,
+    this.archiveAudioReuseEnabled = false,
     this.eventKind,
     this.sourceRelay,
   }) : content = sanitizeUtf16(content),
@@ -363,6 +365,9 @@ class VideoEvent {
           : ProofVerificationSummary.fromJson(
               json['proofSummary'] as Map<String, dynamic>,
             ),
+      isVerifiedArchive: json['isVerifiedArchive'] as bool? ?? false,
+      archiveAudioReuseEnabled:
+          json['archiveAudioReuseEnabled'] as bool? ?? false,
     );
   }
 
@@ -1015,6 +1020,16 @@ class VideoEvent {
 
   /// Compact proof verification summary returned by Funnelcake REST feeds.
   final ProofVerificationSummary? proofSummary;
+
+  /// Whether Funnelcake matched this exact event to its verified archive.
+  ///
+  /// This server-derived state is never read from Nostr tags.
+  final bool isVerifiedArchive;
+
+  /// Whether Funnelcake currently enables archive audio compatibility.
+  ///
+  /// The server controls this kill switch; absent values fail closed.
+  final bool archiveAudioReuseEnabled;
 
   /// Generic `p` tags that mark users mentioned by this video.
   ///
@@ -1758,6 +1773,8 @@ class VideoEvent {
     List<String>? moderationLabels,
     List<String>? warnLabels,
     ProofVerificationSummary? proofSummary,
+    bool? isVerifiedArchive,
+    bool? archiveAudioReuseEnabled,
     int? eventKind,
     String? sourceRelay,
   }) => VideoEvent(
@@ -1826,6 +1843,9 @@ class VideoEvent {
     moderationLabels: moderationLabels ?? this.moderationLabels,
     warnLabels: warnLabels ?? this.warnLabels,
     proofSummary: proofSummary ?? this.proofSummary,
+    isVerifiedArchive: isVerifiedArchive ?? this.isVerifiedArchive,
+    archiveAudioReuseEnabled:
+        archiveAudioReuseEnabled ?? this.archiveAudioReuseEnabled,
     eventKind: eventKind ?? this.eventKind,
     sourceRelay: sourceRelay ?? this.sourceRelay,
   );
@@ -1912,6 +1932,8 @@ class VideoEvent {
     'contentWarningLabels': contentWarningLabels,
     'moderationLabels': moderationLabels,
     'proofSummary': proofSummary?.toJson(),
+    'isVerifiedArchive': isVerifiedArchive,
+    'archiveAudioReuseEnabled': archiveAudioReuseEnabled,
     'eventKind': eventKind,
     'sourceRelay': sourceRelay,
   };

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -51,6 +51,8 @@ class VideoStats {
     this.categories = const [],
     this.collaboratorPubkeys = const [],
     this.proofSummary,
+    this.isVerifiedArchive = false,
+    this.archiveAudioReuseEnabled = false,
     List<String> moderationLabels = const [],
     @Deprecated('Use moderationLabels') List<String>? contentLabels,
   }) : moderationLabels = contentLabels ?? moderationLabels;
@@ -364,7 +366,8 @@ class VideoStats {
       statsData['embedded_reposts'] ?? json['embedded_reposts'],
     );
 
-    // Parse platform from Funnelcake (server-controlled, not user-settable).
+    // Preserve the compatibility label when present. This is descriptive
+    // metadata only: Nostr events can supply it, so it is not provenance.
     // "vine" indicates a genuine Vine archive import.
     final platform =
         json['platform']?.toString() ?? eventData['platform']?.toString();
@@ -438,6 +441,8 @@ class VideoStats {
       textTrackContent: textTrackContent,
       moderationLabels: moderationLabels,
       proofSummary: proofSummary,
+      isVerifiedArchive: json['verified_archive'] == true,
+      archiveAudioReuseEnabled: json['archive_audio_reuse_enabled'] == true,
     );
   }
 
@@ -563,6 +568,12 @@ class VideoStats {
   /// Compact backend-computed proof verification result for list/feed cards.
   final ProofVerificationSummary? proofSummary;
 
+  /// Whether Funnelcake matched this exact event to its verified archive.
+  final bool isVerifiedArchive;
+
+  /// Whether Funnelcake currently enables archive audio compatibility.
+  final bool archiveAudioReuseEnabled;
+
   /// Deprecated alias for [moderationLabels].
   @Deprecated('Use moderationLabels')
   List<String> get contentLabels => moderationLabels;
@@ -643,6 +654,8 @@ class VideoStats {
       collaboratorPubkeys: collaboratorPubkeys,
       moderationLabels: moderationLabels,
       proofSummary: proofSummary,
+      isVerifiedArchive: isVerifiedArchive,
+      archiveAudioReuseEnabled: archiveAudioReuseEnabled,
       nostrEventTags: eventTags,
       rawTags: {
         ...rawTags,

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -569,9 +569,14 @@ class VideoStats {
   final ProofVerificationSummary? proofSummary;
 
   /// Whether Funnelcake matched this exact event to its verified archive.
+  ///
+  /// This server-derived classification does not express creator consent.
   final bool isVerifiedArchive;
 
-  /// Whether Funnelcake currently enables archive audio compatibility.
+  /// Whether Funnelcake currently enables Divine's legacy archive audio policy.
+  ///
+  /// Combined with [isVerifiedArchive], this permits presumed reuse when no
+  /// creator preference is recorded. Explicit opt-outs remain authoritative.
   final bool archiveAudioReuseEnabled;
 
   /// Deprecated alias for [moderationLabels].

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -573,10 +573,10 @@ class VideoStats {
   /// This server-derived classification does not express creator consent.
   final bool isVerifiedArchive;
 
-  /// Whether Funnelcake currently enables Divine's legacy archive audio policy.
+  /// Whether Funnelcake enables audio reuse for this verified classic Vine.
   ///
-  /// Combined with [isVerifiedArchive], this permits presumed reuse when no
-  /// creator preference is recorded. Explicit opt-outs remain authoritative.
+  /// Combined with [isVerifiedArchive], this grants reuse by default. Creator
+  /// takedowns are separate server decisions refreshed at action time.
   final bool archiveAudioReuseEnabled;
 
   /// Deprecated alias for [moderationLabels].

--- a/mobile/packages/models/test/src/audio_event_test.dart
+++ b/mobile/packages/models/test/src/audio_event_test.dart
@@ -484,32 +484,47 @@ void main() {
         },
       );
 
-      test('carries allowsReuse from the source video', () {
-        VideoEvent video({required bool allowReuse}) => VideoEvent(
-          id: testHexId,
-          pubkey: testPubkey,
-          createdAt: 1700000000,
-          content: 'classic vine',
-          timestamp: DateTime(2026),
-          videoUrl: 'https://example.com/video.mp4',
-          duration: 6,
-          vineId: 'vine-123',
-          addressableDTag: 'vine-123',
-          rawTags: allowReuse ? const {'allow_audio_reuse': 'true'} : const {},
-        );
+      test('carries definitive reuse terms from the source video', () {
+        VideoEvent video({String? marker, bool isClassicVine = false}) {
+          final rawTags = <String, String>{
+            if (isClassicVine) 'platform': 'vine',
+          };
+          if (marker case final value?) {
+            rawTags['allow_audio_reuse'] = value;
+          }
+          return VideoEvent(
+            id: testHexId,
+            pubkey: testPubkey,
+            createdAt: 1700000000,
+            content: 'classic vine',
+            timestamp: DateTime(2026),
+            videoUrl: 'https://example.com/video.mp4',
+            duration: 6,
+            vineId: 'vine-123',
+            addressableDTag: 'vine-123',
+            rawTags: rawTags,
+          );
+        }
 
-        expect(
-          AudioEvent.fromVideoOriginalSound(
-            video(allowReuse: true),
-          ).allowsReuse,
-          isTrue,
+        final granted = AudioEvent.fromVideoOriginalSound(
+          video(marker: 'true'),
         );
-        expect(
-          AudioEvent.fromVideoOriginalSound(
-            video(allowReuse: false),
-          ).allowsReuse,
-          isFalse,
+        final declined = AudioEvent.fromVideoOriginalSound(
+          video(marker: 'false', isClassicVine: true),
         );
+        final classicCompatibility = AudioEvent.fromVideoOriginalSound(
+          video(isClassicVine: true),
+        );
+        final unspecified = AudioEvent.fromVideoOriginalSound(video());
+
+        expect(granted.allowsReuse, isTrue);
+        expect(granted.hasExplicitReuseConsent, isTrue);
+        expect(declined.allowsReuse, isFalse);
+        expect(declined.hasExplicitReuseConsent, isTrue);
+        expect(classicCompatibility.allowsReuse, isTrue);
+        expect(classicCompatibility.hasExplicitReuseConsent, isTrue);
+        expect(unspecified.allowsReuse, isFalse);
+        expect(unspecified.hasExplicitReuseConsent, isFalse);
       });
 
       test('defaults allowsReuse to true for a plain AudioEvent', () {

--- a/mobile/packages/models/test/src/audio_event_test.dart
+++ b/mobile/packages/models/test/src/audio_event_test.dart
@@ -485,10 +485,8 @@ void main() {
       );
 
       test('carries definitive reuse terms from the source video', () {
-        VideoEvent video({String? marker, bool isClassicVine = false}) {
-          final rawTags = <String, String>{
-            if (isClassicVine) 'platform': 'vine',
-          };
+        VideoEvent video({String? marker, bool isVerifiedArchive = false}) {
+          final rawTags = <String, String>{};
           if (marker case final value?) {
             rawTags['allow_audio_reuse'] = value;
           }
@@ -503,6 +501,8 @@ void main() {
             vineId: 'vine-123',
             addressableDTag: 'vine-123',
             rawTags: rawTags,
+            isVerifiedArchive: isVerifiedArchive,
+            archiveAudioReuseEnabled: isVerifiedArchive,
           );
         }
 
@@ -510,10 +510,10 @@ void main() {
           video(marker: 'true'),
         );
         final declined = AudioEvent.fromVideoOriginalSound(
-          video(marker: 'false', isClassicVine: true),
+          video(marker: 'false', isVerifiedArchive: true),
         );
         final classicCompatibility = AudioEvent.fromVideoOriginalSound(
-          video(isClassicVine: true),
+          video(isVerifiedArchive: true),
         );
         final unspecified = AudioEvent.fromVideoOriginalSound(video());
 
@@ -522,7 +522,8 @@ void main() {
         expect(declined.allowsReuse, isFalse);
         expect(declined.hasExplicitReuseConsent, isTrue);
         expect(classicCompatibility.allowsReuse, isTrue);
-        expect(classicCompatibility.hasExplicitReuseConsent, isTrue);
+        expect(classicCompatibility.hasExplicitReuseConsent, isFalse);
+        expect(classicCompatibility.requiresCurrentReuseVerification, isTrue);
         expect(unspecified.allowsReuse, isFalse);
         expect(unspecified.hasExplicitReuseConsent, isFalse);
       });

--- a/mobile/packages/models/test/src/audio_event_test.dart
+++ b/mobile/packages/models/test/src/audio_event_test.dart
@@ -511,7 +511,7 @@ void main() {
         final granted = AudioEvent.fromVideoOriginalSound(
           video(marker: 'true'),
         );
-        final declined = AudioEvent.fromVideoOriginalSound(
+        final classicWithImportedFalse = AudioEvent.fromVideoOriginalSound(
           video(marker: 'false', isVerifiedArchive: true),
         );
         final classicCompatibility = AudioEvent.fromVideoOriginalSound(
@@ -521,8 +521,8 @@ void main() {
 
         expect(granted.allowsReuse, isTrue);
         expect(granted.hasExplicitReuseConsent, isTrue);
-        expect(declined.allowsReuse, isFalse);
-        expect(declined.hasExplicitReuseConsent, isTrue);
+        expect(classicWithImportedFalse.allowsReuse, isTrue);
+        expect(classicWithImportedFalse.hasExplicitReuseConsent, isTrue);
         expect(classicCompatibility.allowsReuse, isTrue);
         expect(classicCompatibility.hasExplicitReuseConsent, isFalse);
         expect(classicCompatibility.requiresCurrentReuseVerification, isTrue);

--- a/mobile/packages/models/test/src/audio_event_test.dart
+++ b/mobile/packages/models/test/src/audio_event_test.dart
@@ -427,6 +427,7 @@ void main() {
           content: 'classic vine',
           timestamp: now,
           videoUrl: 'https://example.com/video.mp4',
+          sha256: testSha256,
           duration: 6,
           vineId: 'vine-123',
           addressableDTag: 'vine-123',
@@ -438,6 +439,7 @@ void main() {
         );
 
         expect(audioEvent.duration, equals(6.0));
+        expect(audioEvent.sha256, equals(testSha256));
         expect(audioEvent.title, equals('Original sound - Kenya'));
         expect(
           audioEvent.sourceVideoReference,

--- a/mobile/packages/models/test/src/audio_reuse_policy_test.dart
+++ b/mobile/packages/models/test/src/audio_reuse_policy_test.dart
@@ -1,0 +1,65 @@
+// ABOUTME: Verifies viewer-independent original-sound reuse policy.
+// ABOUTME: Preserves classic Vine compatibility without overriding declines.
+
+import 'package:models/models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('originalSoundReuseTerms', () {
+    VideoEvent video({required bool isClassicVine, String? marker}) {
+      final rawTags = <String, String>{
+        if (isClassicVine) 'platform': 'vine',
+      };
+      if (marker case final value?) {
+        rawTags['allow_audio_reuse'] = value;
+      }
+      return VideoEvent(
+        id: 'a' * 64,
+        pubkey: 'b' * 64,
+        createdAt: 1700000000,
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
+        rawTags: rawTags,
+      );
+    }
+
+    for (final isClassicVine in [false, true]) {
+      final source = isClassicVine ? 'classic Vine' : 'ordinary video';
+
+      test('grants explicit consent for $source', () {
+        expect(
+          originalSoundReuseTerms(
+            video(marker: 'true', isClassicVine: isClassicVine),
+          ),
+          isTrue,
+        );
+      });
+
+      test('honors explicit decline for $source', () {
+        expect(
+          originalSoundReuseTerms(
+            video(marker: 'false', isClassicVine: isClassicVine),
+          ),
+          isFalse,
+        );
+      });
+
+      test('fails closed for a malformed marker on $source', () {
+        expect(
+          originalSoundReuseTerms(
+            video(marker: 'invalid', isClassicVine: isClassicVine),
+          ),
+          isFalse,
+        );
+      });
+    }
+
+    test('grants compatibility reuse for an unmarked classic Vine', () {
+      expect(originalSoundReuseTerms(video(isClassicVine: true)), isTrue);
+    });
+
+    test('defers an unmarked ordinary video to viewer-aware policy', () {
+      expect(originalSoundReuseTerms(video(isClassicVine: false)), isNull);
+    });
+  });
+}

--- a/mobile/packages/models/test/src/audio_reuse_policy_test.dart
+++ b/mobile/packages/models/test/src/audio_reuse_policy_test.dart
@@ -6,10 +6,12 @@ import 'package:test/test.dart';
 
 void main() {
   group('originalSoundReuseTerms', () {
-    VideoEvent video({required bool isClassicVine, String? marker}) {
-      final rawTags = <String, String>{
-        if (isClassicVine) 'platform': 'vine',
-      };
+    VideoEvent video({
+      required bool isVerifiedArchive,
+      String? marker,
+      bool archiveAudioReuseEnabled = true,
+    }) {
+      final rawTags = <String, String>{};
       if (marker case final value?) {
         rawTags['allow_audio_reuse'] = value;
       }
@@ -20,16 +22,18 @@ void main() {
         content: '',
         timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
         rawTags: rawTags,
+        isVerifiedArchive: isVerifiedArchive,
+        archiveAudioReuseEnabled: archiveAudioReuseEnabled,
       );
     }
 
-    for (final isClassicVine in [false, true]) {
-      final source = isClassicVine ? 'classic Vine' : 'ordinary video';
+    for (final isVerifiedArchive in [false, true]) {
+      final source = isVerifiedArchive ? 'verified archive' : 'ordinary video';
 
       test('grants explicit consent for $source', () {
         expect(
           originalSoundReuseTerms(
-            video(marker: 'true', isClassicVine: isClassicVine),
+            video(marker: 'true', isVerifiedArchive: isVerifiedArchive),
           ),
           isTrue,
         );
@@ -38,7 +42,7 @@ void main() {
       test('honors explicit decline for $source', () {
         expect(
           originalSoundReuseTerms(
-            video(marker: 'false', isClassicVine: isClassicVine),
+            video(marker: 'false', isVerifiedArchive: isVerifiedArchive),
           ),
           isFalse,
         );
@@ -47,19 +51,36 @@ void main() {
       test('fails closed for a malformed marker on $source', () {
         expect(
           originalSoundReuseTerms(
-            video(marker: 'invalid', isClassicVine: isClassicVine),
+            video(marker: 'invalid', isVerifiedArchive: isVerifiedArchive),
           ),
           isFalse,
         );
       });
     }
 
-    test('grants compatibility reuse for an unmarked classic Vine', () {
-      expect(originalSoundReuseTerms(video(isClassicVine: true)), isTrue);
+    test('grants enabled compatibility for an unmarked verified archive', () {
+      expect(originalSoundReuseTerms(video(isVerifiedArchive: true)), isTrue);
     });
 
     test('defers an unmarked ordinary video to viewer-aware policy', () {
-      expect(originalSoundReuseTerms(video(isClassicVine: false)), isNull);
+      expect(originalSoundReuseTerms(video(isVerifiedArchive: false)), isNull);
+    });
+
+    test('fails closed when archive audio compatibility is disabled', () {
+      expect(
+        originalSoundReuseTerms(
+          video(isVerifiedArchive: true, archiveAudioReuseEnabled: false),
+        ),
+        isNull,
+      );
+    });
+
+    test('ignores a self-authored classic Vine platform tag', () {
+      final spoofed = video(
+        isVerifiedArchive: false,
+      ).copyWith(rawTags: const {'platform': 'vine'});
+
+      expect(originalSoundReuseTerms(spoofed), isNull);
     });
   });
 }

--- a/mobile/packages/models/test/src/audio_reuse_policy_test.dart
+++ b/mobile/packages/models/test/src/audio_reuse_policy_test.dart
@@ -58,7 +58,7 @@ void main() {
       });
     }
 
-    test('grants enabled compatibility for an unmarked verified archive', () {
+    test('applies enabled legacy policy to an unmarked verified archive', () {
       expect(originalSoundReuseTerms(video(isVerifiedArchive: true)), isTrue);
     });
 

--- a/mobile/packages/models/test/src/audio_reuse_policy_test.dart
+++ b/mobile/packages/models/test/src/audio_reuse_policy_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Verifies viewer-independent original-sound reuse policy.
-// ABOUTME: Preserves classic Vine compatibility without overriding declines.
+// ABOUTME: Makes classic Vine audio reusable unless a server takedown applies.
 
 import 'package:models/models.dart';
 import 'package:test/test.dart';
@@ -39,21 +39,21 @@ void main() {
         );
       });
 
-      test('honors explicit decline for $source', () {
+      test('interprets an explicit decline correctly for $source', () {
         expect(
           originalSoundReuseTerms(
             video(marker: 'false', isVerifiedArchive: isVerifiedArchive),
           ),
-          isFalse,
+          isVerifiedArchive ? isTrue : isFalse,
         );
       });
 
-      test('fails closed for a malformed marker on $source', () {
+      test('interprets a malformed marker correctly for $source', () {
         expect(
           originalSoundReuseTerms(
             video(marker: 'invalid', isVerifiedArchive: isVerifiedArchive),
           ),
-          isFalse,
+          isVerifiedArchive ? isTrue : isFalse,
         );
       });
     }

--- a/mobile/packages/models/test/src/video_event_allow_audio_reuse_test.dart
+++ b/mobile/packages/models/test/src/video_event_allow_audio_reuse_test.dart
@@ -7,14 +7,14 @@ import 'package:test/test.dart';
 
 void main() {
   group('VideoEvent.allowAudioReuse', () {
-    Event buildEvent({required bool withMarker}) {
+    Event buildEvent({String? marker}) {
       return Event(
         'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
         34236,
         [
           const ['d', 'audio-reuse-d-tag'],
           const ['url', 'https://media.divine.video/reuse.mp4'],
-          if (withMarker) const ['allow_audio_reuse', 'true'],
+          if (marker != null) ['allow_audio_reuse', marker],
         ],
         'Audio reuse video',
         createdAt: 1778120201,
@@ -22,15 +22,31 @@ void main() {
     }
 
     test('is true when the live event carries the marker', () {
-      final video = VideoEvent.fromNostrEvent(buildEvent(withMarker: true));
+      final video = VideoEvent.fromNostrEvent(buildEvent(marker: 'true'));
 
       expect(video.allowAudioReuse, isTrue);
+      expect(video.audioReuseConsent, AudioReuseConsent.granted);
     });
 
     test('is false when the live event omits the marker', () {
-      final video = VideoEvent.fromNostrEvent(buildEvent(withMarker: false));
+      final video = VideoEvent.fromNostrEvent(buildEvent());
 
       expect(video.allowAudioReuse, isFalse);
+      expect(video.audioReuseConsent, AudioReuseConsent.unspecified);
+    });
+
+    test('distinguishes an explicit decline from an omitted marker', () {
+      final video = VideoEvent.fromNostrEvent(buildEvent(marker: 'false'));
+
+      expect(video.allowAudioReuse, isFalse);
+      expect(video.audioReuseConsent, AudioReuseConsent.declined);
+    });
+
+    test('treats a malformed marker as invalid rather than absent', () {
+      final video = VideoEvent.fromNostrEvent(buildEvent(marker: 'TRUE'));
+
+      expect(video.allowAudioReuse, isFalse);
+      expect(video.audioReuseConsent, AudioReuseConsent.invalid);
     });
 
     test('prefers the live marker over a divergent rawTags value', () {
@@ -55,7 +71,7 @@ void main() {
     });
 
     test('survives a JSON-cache round-trip that drops nostrEventTags', () {
-      final original = VideoEvent.fromNostrEvent(buildEvent(withMarker: true));
+      final original = VideoEvent.fromNostrEvent(buildEvent(marker: 'true'));
 
       final restored = VideoEvent.fromJson(original.toJson());
 

--- a/mobile/packages/models/test/src/video_event_to_json_test.dart
+++ b/mobile/packages/models/test/src/video_event_to_json_test.dart
@@ -109,6 +109,8 @@ VideoEvent _fullVideo() => VideoEvent(
     version: 1,
     checks: const {'proofmode_present': true},
   ),
+  isVerifiedArchive: true,
+  archiveAudioReuseEnabled: true,
   eventKind: 34236,
   sourceRelay: 'wss://relay.divine.video',
 );
@@ -167,6 +169,8 @@ const _expectedKeys = <String>{
   'contentWarningLabels',
   'moderationLabels',
   'proofSummary',
+  'isVerifiedArchive',
+  'archiveAudioReuseEnabled',
   'eventKind',
   'sourceRelay',
 };
@@ -397,6 +401,8 @@ void main() {
         equals(original.contentWarningLabels),
       );
       expect(restored.proofSummary, equals(original.proofSummary));
+      expect(restored.isVerifiedArchive, isTrue);
+      expect(restored.archiveAudioReuseEnabled, isTrue);
     });
 
     test('hydrates addressableDTag from rawTags for older cache entries', () {

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -187,11 +187,7 @@ void main() {
             'content': 'Description',
             'tags': [
               ['d', 'video-1'],
-              [
-                'imeta',
-                'url https://example.com/video.mp4',
-                'size 480000',
-              ],
+              ['imeta', 'url https://example.com/video.mp4', 'size 480000'],
               ['size', '640000'],
             ],
           },
@@ -2187,6 +2183,59 @@ void main() {
         );
 
         expect(stats1, isNot(equals(stats2)));
+      });
+    });
+
+    group('archive audio reuse authority', () {
+      Map<String, dynamic> response({
+        Object? verifiedArchive,
+        Object? rolloutEnabled,
+      }) => {
+        'id': 'a' * 64,
+        'pubkey': 'b' * 64,
+        'created_at': 1700000000,
+        'kind': 34236,
+        'd_tag': 'archive-video',
+        'title': 'Archive video',
+        'video_url': 'https://example.com/video.mp4',
+        'verified_archive': verifiedArchive,
+        'archive_audio_reuse_enabled': rolloutEnabled,
+      };
+
+      test('parses typed Funnelcake authority fields', () {
+        final video = VideoStats.fromJson(
+          response(verifiedArchive: true, rolloutEnabled: true),
+        ).toVideoEvent();
+
+        expect(video.isVerifiedArchive, isTrue);
+        expect(video.archiveAudioReuseEnabled, isTrue);
+      });
+
+      test('fails closed for absent or malformed authority fields', () {
+        final absent = VideoStats.fromJson(response()).toVideoEvent();
+        final malformed = VideoStats.fromJson(
+          response(verifiedArchive: 'true', rolloutEnabled: 1),
+        ).toVideoEvent();
+
+        expect(absent.isVerifiedArchive, isFalse);
+        expect(absent.archiveAudioReuseEnabled, isFalse);
+        expect(malformed.isVerifiedArchive, isFalse);
+        expect(malformed.archiveAudioReuseEnabled, isFalse);
+      });
+
+      test('ignores Nostr tags that spoof the authority fields', () {
+        final json = response();
+        json['event'] = {
+          ...json,
+          'tags': [
+            ['verified_archive', 'true'],
+            ['archive_audio_reuse_enabled', 'true'],
+          ],
+        };
+        final video = VideoStats.fromJson(json).toVideoEvent();
+
+        expect(video.isVerifiedArchive, isFalse);
+        expect(video.archiveAudioReuseEnabled, isFalse);
       });
     });
 

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -237,6 +237,15 @@ class VideosRepository {
   bool isVideoKnownDeleted(VideoEvent video) =>
       _deletedFilter?.call(video) ?? false;
 
+  /// Returns the authoritative server-side audio reuse policy for [sha256].
+  Future<AudioReusePolicy> getAudioReusePolicy(String sha256) {
+    final client = _funnelcakeApiClient;
+    if (client == null || !client.isAvailable) {
+      throw const FunnelcakeNotConfiguredException();
+    }
+    return client.getAudioReusePolicy(sha256);
+  }
+
   /// Clears the in-memory feed cache.
   ///
   /// When [key] is provided, only that feed mode's cache is removed

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -237,13 +237,24 @@ class VideosRepository {
   bool isVideoKnownDeleted(VideoEvent video) =>
       _deletedFilter?.call(video) ?? false;
 
-  /// Returns the authoritative server-side audio reuse policy for [sha256].
-  Future<AudioReusePolicy> getAudioReusePolicy(String sha256) {
+  /// Refreshes the authoritative takedown decision for [video].
+  Future<AudioReusePolicy> refreshAudioReusePolicy(VideoEvent video) {
     final client = _funnelcakeApiClient;
     if (client == null || !client.isAvailable) {
       throw const FunnelcakeNotConfiguredException();
     }
-    return client.getAudioReusePolicy(sha256);
+    final dTag = video.addressableDTag;
+    if (dTag == null || dTag.isEmpty) {
+      throw const FunnelcakeException('Video is not addressable');
+    }
+    return client.refreshAudioReusePolicy(
+      // This method already requires an addressable d-tag. REST/cache models
+      // can omit eventKind, so use the current addressable short-video kind
+      // rather than letting shareKind fall back to non-addressable kind 22.
+      kind: video.eventKind ?? EventKind.videoVertical,
+      pubkey: video.pubkey,
+      dTag: dTag,
+    );
   }
 
   /// Clears the in-memory feed cache.

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -156,6 +156,53 @@ void main() {
       expect(repository, isNotNull);
     });
 
+    group('getAudioReusePolicy', () {
+      const sha256 =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const policy = AudioReusePolicy(
+        allowAudioReuse: true,
+        audioReuseSuppressed: false,
+      );
+
+      test('delegates to an available Funnelcake client', () async {
+        final client = MockFunnelcakeApiClient();
+        when(() => client.isAvailable).thenReturn(true);
+        when(() => client.getAudioReusePolicy(sha256)).thenAnswer(
+          (_) async => policy,
+        );
+        final repositoryWithClient = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: client,
+        );
+
+        await expectLater(
+          repositoryWithClient.getAudioReusePolicy(sha256),
+          completion(same(policy)),
+        );
+        verify(() => client.getAudioReusePolicy(sha256)).called(1);
+      });
+
+      test('fails closed without an available Funnelcake client', () {
+        expect(
+          () => repository.getAudioReusePolicy(sha256),
+          throwsA(isA<FunnelcakeNotConfiguredException>()),
+        );
+
+        final client = MockFunnelcakeApiClient();
+        when(() => client.isAvailable).thenReturn(false);
+        final repositoryWithUnavailableClient = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: client,
+        );
+
+        expect(
+          () => repositoryWithUnavailableClient.getAudioReusePolicy(sha256),
+          throwsA(isA<FunnelcakeNotConfiguredException>()),
+        );
+        verifyNever(() => client.getAudioReusePolicy(any()));
+      });
+    });
+
     test('isVideoKnownDeleted delegates to the injected deletion filter', () {
       final visibleVideo = VideoEvent(
         id: 'visible-video',

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -156,35 +156,51 @@ void main() {
       expect(repository, isNotNull);
     });
 
-    group('getAudioReusePolicy', () {
-      const sha256 =
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    group('refreshAudioReusePolicy', () {
+      final video = VideoEvent(
+        id: 'video-id',
+        pubkey: 'a' * 64,
+        createdAt: 1704067200,
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1704067200 * 1000),
+        addressableDTag: 'classic-id',
+      );
       const policy = AudioReusePolicy(
-        allowAudioReuse: true,
         audioReuseSuppressed: false,
+        validFor: Duration(seconds: 60),
       );
 
       test('delegates to an available Funnelcake client', () async {
         final client = MockFunnelcakeApiClient();
         when(() => client.isAvailable).thenReturn(true);
-        when(() => client.getAudioReusePolicy(sha256)).thenAnswer(
-          (_) async => policy,
-        );
+        when(
+          () => client.refreshAudioReusePolicy(
+            kind: 34236,
+            pubkey: video.pubkey,
+            dTag: 'classic-id',
+          ),
+        ).thenAnswer((_) async => policy);
         final repositoryWithClient = VideosRepository(
           nostrClient: mockNostrClient,
           funnelcakeApiClient: client,
         );
 
         await expectLater(
-          repositoryWithClient.getAudioReusePolicy(sha256),
+          repositoryWithClient.refreshAudioReusePolicy(video),
           completion(same(policy)),
         );
-        verify(() => client.getAudioReusePolicy(sha256)).called(1);
+        verify(
+          () => client.refreshAudioReusePolicy(
+            kind: 34236,
+            pubkey: video.pubkey,
+            dTag: 'classic-id',
+          ),
+        ).called(1);
       });
 
       test('fails closed without an available Funnelcake client', () {
         expect(
-          () => repository.getAudioReusePolicy(sha256),
+          () => repository.refreshAudioReusePolicy(video),
           throwsA(isA<FunnelcakeNotConfiguredException>()),
         );
 
@@ -196,10 +212,16 @@ void main() {
         );
 
         expect(
-          () => repositoryWithUnavailableClient.getAudioReusePolicy(sha256),
+          () => repositoryWithUnavailableClient.refreshAudioReusePolicy(video),
           throwsA(isA<FunnelcakeNotConfiguredException>()),
         );
-        verifyNever(() => client.getAudioReusePolicy(any()));
+        verifyNever(
+          () => client.refreshAudioReusePolicy(
+            kind: any(named: 'kind'),
+            pubkey: any(named: 'pubkey'),
+            dTag: any(named: 'dTag'),
+          ),
+        );
       });
     });
 
@@ -1299,19 +1321,16 @@ void main() {
             ),
           ).thenAnswer((invocation) async {
             final limit = invocation.namedArguments[#limit] as int;
-            return _recentPage(
-              [
-                for (var i = 0; i < limit; i++)
-                  _createVideoStats(
-                    id: 'v$i',
-                    pubkey: 'p$i',
-                    dTag: 'd$i',
-                    videoUrl: 'https://example.com/v$i.mp4',
-                    createdAt: 1704060000 - i,
-                  ),
-              ],
-              hasMore: false,
-            );
+            return _recentPage([
+              for (var i = 0; i < limit; i++)
+                _createVideoStats(
+                  id: 'v$i',
+                  pubkey: 'p$i',
+                  dTag: 'd$i',
+                  videoUrl: 'https://example.com/v$i.mp4',
+                  createdAt: 1704060000 - i,
+                ),
+            ], hasMore: false);
           });
 
           final page = await repoWithCache.getNewVideos(limit: 3);
@@ -10584,58 +10603,54 @@ void main() {
         expect(result!.id, equals(fallbackEventId));
       });
 
-      test(
-        'still tries fallback route IDs when the primary lookup was '
-        'unreachable',
-        () async {
-          // The unreachable-lookup rethrow must not pre-empt the fallbacks.
-          // A DM-shared video passes the bare stable ID as the primary route
-          // and the author-scoped addressable as a fallback, which is a
-          // relay-only query that resolves fine while Funnelcake is down.
-          const fallbackEventId =
-              'e46ff7d0d71d6c8114b58728afa43f08'
-              'd6286fd9a704683af799fd8f855586c2';
-          const author =
-              '076c979382b90f5d3a2b21f95e1ee86b'
-              '6033f14c92e79b7fad3fe1f1073f4886';
-          const missingAddressableId = '34236:$author:missing-stable-id';
-          final fallbackEvent = _createVideoEvent(
-            id: fallbackEventId,
-            pubkey: author,
-            videoUrl: 'https://example.com/fallback.mp4',
-            createdAt: 1777868006,
-          );
+      test('still tries fallback route IDs when the primary lookup was '
+          'unreachable', () async {
+        // The unreachable-lookup rethrow must not pre-empt the fallbacks.
+        // A DM-shared video passes the bare stable ID as the primary route
+        // and the author-scoped addressable as a fallback, which is a
+        // relay-only query that resolves fine while Funnelcake is down.
+        const fallbackEventId =
+            'e46ff7d0d71d6c8114b58728afa43f08'
+            'd6286fd9a704683af799fd8f855586c2';
+        const author =
+            '076c979382b90f5d3a2b21f95e1ee86b'
+            '6033f14c92e79b7fad3fe1f1073f4886';
+        const missingAddressableId = '34236:$author:missing-stable-id';
+        final fallbackEvent = _createVideoEvent(
+          id: fallbackEventId,
+          pubkey: author,
+          videoUrl: 'https://example.com/fallback.mp4',
+          createdAt: 1777868006,
+        );
 
-          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
-          when(
-            () => mockFunnelcakeClient.getVideoEvent(any()),
-          ).thenThrow(const FunnelcakeTimeoutException('https://example.com'));
-          when(() => mockNostrClient.queryEvents(any())).thenAnswer((
-            invocation,
-          ) async {
-            final filters =
-                invocation.positionalArguments.single as List<Filter>;
-            final filter = filters.single;
-            if (filter.ids?.contains(fallbackEventId) ?? false) {
-              return [fallbackEvent];
-            }
-            return <Event>[];
-          });
+        when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+        when(
+          () => mockFunnelcakeClient.getVideoEvent(any()),
+        ).thenThrow(const FunnelcakeTimeoutException('https://example.com'));
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer((
+          invocation,
+        ) async {
+          final filters = invocation.positionalArguments.single as List<Filter>;
+          final filter = filters.single;
+          if (filter.ids?.contains(fallbackEventId) ?? false) {
+            return [fallbackEvent];
+          }
+          return <Event>[];
+        });
 
-          final repo = VideosRepository(
-            nostrClient: mockNostrClient,
-            funnelcakeApiClient: mockFunnelcakeClient,
-          );
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+        );
 
-          final result = await repo.fetchVideoWithStatsForRouteId(
-            missingAddressableId,
-            fallbackRouteIds: const [fallbackEventId],
-          );
+        final result = await repo.fetchVideoWithStatsForRouteId(
+          missingAddressableId,
+          fallbackRouteIds: const [fallbackEventId],
+        );
 
-          expect(result, isNotNull);
-          expect(result!.id, equals(fallbackEventId));
-        },
-      );
+        expect(result, isNotNull);
+        expect(result!.id, equals(fallbackEventId));
+      });
 
       test(
         'rethrows once every fallback route ID has also come up empty',

--- a/mobile/test/providers/sounds_providers_test.dart
+++ b/mobile/test/providers/sounds_providers_test.dart
@@ -677,6 +677,18 @@ void _ownerExceptionTests() {
       );
     });
 
+    test('an explicit decline overrides the owner exception', () async {
+      final sound = createTestAudioEvent(
+        id: 'own',
+        pubkey: ownerPubkey,
+      ).copyWith(allowsReuse: false, hasExplicitReuseConsent: true);
+      final container = buildContainer(ownerPubkey);
+      await expectLater(
+        container.read(audioReuseConsentProvider(sound).future),
+        completion(isFalse),
+      );
+    });
+
     test("another creator's sound does not get the owner exception", () async {
       final sound = createTestAudioEvent(
         id: 'theirs',

--- a/mobile/test/providers/sounds_providers_test.dart
+++ b/mobile/test/providers/sounds_providers_test.dart
@@ -677,7 +677,7 @@ void _ownerExceptionTests() {
       );
     });
 
-    test('an explicit decline overrides the owner exception', () async {
+    test('an explicit decline still permits the sound owner', () async {
       final sound = createTestAudioEvent(
         id: 'own',
         pubkey: ownerPubkey,
@@ -685,8 +685,30 @@ void _ownerExceptionTests() {
       final container = buildContainer(ownerPubkey);
       await expectLater(
         container.read(audioReuseConsentProvider(sound).future),
-        completion(isFalse),
+        completion(isTrue),
       );
+    });
+
+    test('a malformed marker still permits the sound owner', () async {
+      final sound = createTestAudioEvent(
+        id: 'own',
+        pubkey: ownerPubkey,
+      ).copyWith(allowsReuse: false, hasExplicitReuseConsent: false);
+      final container = buildContainer(ownerPubkey);
+
+      await expectLater(
+        container.read(audioReuseConsentProvider(sound).future),
+        completion(isTrue),
+      );
+    });
+
+    test('a provisional grant still requires current verification', () async {
+      final sound = createTestAudioEvent(
+        id: 'theirs',
+        pubkey: ownerPubkey,
+      ).copyWith(allowsReuse: true, requiresCurrentReuseVerification: true);
+
+      expect(audioReuseTermsFromEvent(sound), isNull);
     });
 
     test("another creator's sound does not get the owner exception", () async {

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -960,21 +960,29 @@ void main() {
       const creatorPubkey =
           'test_pubkey_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
-      VideoEvent sourceVideo({required bool allowReuse}) => VideoEvent(
-        id: sourceVideoId,
-        pubkey: creatorPubkey,
-        createdAt: 1700000000,
-        content: '',
-        timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
-        videoUrl: 'https://example.com/video/$sourceVideoId.mp4',
-        rawTags: allowReuse ? const {'allow_audio_reuse': 'true'} : const {},
-      );
+      VideoEvent sourceVideo({String? marker, bool isClassicVine = false}) {
+        final rawTags = <String, String>{
+          if (isClassicVine) 'platform': 'vine',
+        };
+        if (marker case final value?) {
+          rawTags['allow_audio_reuse'] = value;
+        }
+        return VideoEvent(
+          id: sourceVideoId,
+          pubkey: creatorPubkey,
+          createdAt: 1700000000,
+          content: '',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
+          videoUrl: 'https://example.com/video/$sourceVideoId.mp4',
+          rawTags: rawTags,
+        );
+      }
 
       // The synthesized original sound carries allowsReuse from the video, so
       // the gate works regardless of whether sourceVideo is threaded through.
-      AudioEvent originalSound({required bool allowReuse}) =>
+      AudioEvent originalSound({String? marker, bool isClassicVine = false}) =>
           AudioEvent.fromVideoOriginalSound(
-            sourceVideo(allowReuse: allowReuse),
+            sourceVideo(marker: marker, isClassicVine: isClassicVine),
           );
 
       List<Override> gridOverrides() => [
@@ -987,12 +995,12 @@ void main() {
         audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
       ];
 
-      testWidgets('hides Use Sound when the creator disabled audio reuse', (
+      testWidgets('hides Use Sound when audio reuse is unspecified', (
         tester,
       ) async {
         await tester.pumpWidget(
           createTestWidget(
-            child: SoundDetailScreen(sound: originalSound(allowReuse: false)),
+            child: SoundDetailScreen(sound: originalSound()),
             overrides: gridOverrides(),
           ),
         );
@@ -1013,7 +1021,7 @@ void main() {
           // enabled it.
           await tester.pumpWidget(
             createTestWidget(
-              child: SoundDetailScreen(sound: originalSound(allowReuse: true)),
+              child: SoundDetailScreen(sound: originalSound(marker: 'true')),
               overrides: gridOverrides(),
             ),
           );
@@ -1030,7 +1038,7 @@ void main() {
       ) async {
         final termsCompleter = Completer<bool>();
         final consentCompleter = Completer<bool>();
-        final sound = originalSound(allowReuse: false);
+        final sound = originalSound();
 
         await tester.pumpWidget(
           createTestWidget(
@@ -1066,13 +1074,46 @@ void main() {
         await tester.pumpWidget(
           createTestWidget(
             viewerPubkey: creatorPubkey,
-            child: SoundDetailScreen(sound: originalSound(allowReuse: false)),
+            child: SoundDetailScreen(sound: originalSound()),
             overrides: gridOverrides(),
           ),
         );
         await tester.pump();
 
         expect(find.text('Use Sound'), findsOneWidget);
+      });
+
+      testWidgets('shows Use Sound for an unmarked classic Vine sound', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(
+              sound: originalSound(isClassicVine: true),
+            ),
+            overrides: gridOverrides(),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Use Sound'), findsOneWidget);
+      });
+
+      testWidgets('an explicit decline overrides the sound owner', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          createTestWidget(
+            viewerPubkey: creatorPubkey,
+            child: SoundDetailScreen(
+              sound: originalSound(marker: 'false', isClassicVine: true),
+            ),
+            overrides: gridOverrides(),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Use Sound'), findsNothing);
       });
     });
 

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -137,7 +137,11 @@ Widget createTestWidget({
   final mockAuth = createMockAuthService();
   when(() => mockAuth.currentPublicKeyHex).thenReturn(viewerPubkey);
   return ProviderScope(
-    overrides: [authServiceProvider.overrideWithValue(mockAuth), ...?overrides],
+    overrides: [
+      authServiceProvider.overrideWithValue(mockAuth),
+      ..._testAudioReuseOverrides(),
+      ...?overrides,
+    ],
     child: MaterialApp(
       localizationsDelegates: appLocalizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
@@ -153,6 +157,17 @@ Widget createTestWidget({
 
 Finder _divineIcon(DivineIconName name) =>
     find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+
+List<dynamic> _testAudioReuseOverrides() {
+  return [
+    audioReuseConsentProvider.overrideWith(
+      (ref, sound) async => sound.allowsReuse,
+    ),
+    audioReuseTermsProvider.overrideWith(
+      (ref, sound) async => sound.allowsReuse,
+    ),
+  ];
+}
 
 void main() {
   group('SoundDetailScreen', () {
@@ -1334,6 +1349,8 @@ void main() {
           final sharedPreferences = await SharedPreferences.getInstance();
           final container = ProviderContainer(
             overrides: [
+              ..._testAudioReuseOverrides(),
+              authServiceProvider.overrideWithValue(createMockAuthService()),
               sharedPreferencesProvider.overrideWithValue(sharedPreferences),
               soundUsageCountProvider(
                 testSound.id,
@@ -1393,6 +1410,8 @@ void main() {
             mediaProbe: _NoopSavedSoundMediaProbe(),
             child: ProviderScope(
               overrides: [
+                ..._testAudioReuseOverrides(),
+                authServiceProvider.overrideWithValue(createMockAuthService()),
                 sharedPreferencesProvider.overrideWithValue(sharedPreferences),
                 soundUsageCountProvider(
                   testSound.id,
@@ -1851,6 +1870,8 @@ void main() {
           await tester.pumpWidget(
             ProviderScope(
               overrides: [
+                ..._testAudioReuseOverrides(),
+                authServiceProvider.overrideWithValue(createMockAuthService()),
                 soundUsageCountProvider(
                   testSound.id,
                 ).overrideWith((ref) => Future.value(0)),
@@ -1909,6 +1930,8 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              ..._testAudioReuseOverrides(),
+              authServiceProvider.overrideWithValue(createMockAuthService()),
               userProfileReactiveProvider(creatorPubkey).overrideWith((
                 ref,
               ) async* {
@@ -1958,6 +1981,8 @@ void main() {
             mediaProbe: _NoopSavedSoundMediaProbe(),
             child: ProviderScope(
               overrides: [
+                ..._testAudioReuseOverrides(),
+                authServiceProvider.overrideWithValue(createMockAuthService()),
                 sharedPreferencesProvider.overrideWithValue(sharedPreferences),
                 soundUsageCountProvider(
                   testSound.id,
@@ -1996,6 +2021,8 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              ..._testAudioReuseOverrides(),
+              authServiceProvider.overrideWithValue(createMockAuthService()),
               soundUsageCountProvider(
                 testSound.id,
               ).overrideWith((ref) => Future.value(0)),

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -960,10 +960,8 @@ void main() {
       const creatorPubkey =
           'test_pubkey_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
-      VideoEvent sourceVideo({String? marker, bool isClassicVine = false}) {
-        final rawTags = <String, String>{
-          if (isClassicVine) 'platform': 'vine',
-        };
+      VideoEvent sourceVideo({String? marker, bool isVerifiedArchive = false}) {
+        final rawTags = <String, String>{};
         if (marker case final value?) {
           rawTags['allow_audio_reuse'] = value;
         }
@@ -975,15 +973,19 @@ void main() {
           timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
           videoUrl: 'https://example.com/video/$sourceVideoId.mp4',
           rawTags: rawTags,
+          isVerifiedArchive: isVerifiedArchive,
+          archiveAudioReuseEnabled: isVerifiedArchive,
         );
       }
 
       // The synthesized original sound carries allowsReuse from the video, so
       // the gate works regardless of whether sourceVideo is threaded through.
-      AudioEvent originalSound({String? marker, bool isClassicVine = false}) =>
-          AudioEvent.fromVideoOriginalSound(
-            sourceVideo(marker: marker, isClassicVine: isClassicVine),
-          );
+      AudioEvent originalSound({
+        String? marker,
+        bool isVerifiedArchive = false,
+      }) => AudioEvent.fromVideoOriginalSound(
+        sourceVideo(marker: marker, isVerifiedArchive: isVerifiedArchive),
+      );
 
       List<Override> gridOverrides() => [
         soundUsageCountProvider(
@@ -1083,13 +1085,35 @@ void main() {
         expect(find.text('Use Sound'), findsOneWidget);
       });
 
-      testWidgets('shows Use Sound for an unmarked classic Vine sound', (
+      testWidgets('shows Use Sound for an enabled verified archive sound', (
         tester,
       ) async {
         await tester.pumpWidget(
           createTestWidget(
             child: SoundDetailScreen(
-              sound: originalSound(isClassicVine: true),
+              sound: originalSound(isVerifiedArchive: true),
+            ),
+            overrides: [
+              ...gridOverrides(),
+              audioReuseConsentProvider(
+                originalSound(isVerifiedArchive: true),
+              ).overrideWith((ref) => Future.value(true)),
+            ],
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Use Sound'), findsOneWidget);
+      });
+
+      testWidgets('an explicit decline still permits the sound owner', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          createTestWidget(
+            viewerPubkey: creatorPubkey,
+            child: SoundDetailScreen(
+              sound: originalSound(marker: 'false', isVerifiedArchive: true),
             ),
             overrides: gridOverrides(),
           ),
@@ -1099,21 +1123,19 @@ void main() {
         expect(find.text('Use Sound'), findsOneWidget);
       });
 
-      testWidgets('an explicit decline overrides the sound owner', (
+      testWidgets('a malformed marker still permits the sound owner', (
         tester,
       ) async {
         await tester.pumpWidget(
           createTestWidget(
             viewerPubkey: creatorPubkey,
-            child: SoundDetailScreen(
-              sound: originalSound(marker: 'false', isClassicVine: true),
-            ),
+            child: SoundDetailScreen(sound: originalSound(marker: 'TRUE')),
             overrides: gridOverrides(),
           ),
         );
         await tester.pump();
 
-        expect(find.text('Use Sound'), findsNothing);
+        expect(find.text('Use Sound'), findsOneWidget);
       });
     });
 

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -158,7 +158,7 @@ Widget createTestWidget({
 Finder _divineIcon(DivineIconName name) =>
     find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
-List<dynamic> _testAudioReuseOverrides() {
+List<Override> _testAudioReuseOverrides() {
   return [
     audioReuseConsentProvider.overrideWith(
       (ref, sound) async => sound.allowsReuse,

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -1085,7 +1085,7 @@ void main() {
         expect(find.text('Use Sound'), findsOneWidget);
       });
 
-      testWidgets('shows Use Sound for an enabled verified archive sound', (
+      testWidgets('shows Use Sound for a legacy-policy verified archive', (
         tester,
       ) async {
         await tester.pumpWidget(

--- a/mobile/test/services/audio_reuse_consent_resolver_test.dart
+++ b/mobile/test/services/audio_reuse_consent_resolver_test.dart
@@ -33,8 +33,15 @@ VideoEvent _video({
   String id = 'video-event',
   String vineId = 'source-video',
   int createdAt = 101,
-  bool allowsReuse = true,
+  String? reuseMarker = 'true',
+  bool isClassicVine = false,
 }) {
+  final rawTags = <String, String>{
+    if (isClassicVine) 'platform': 'vine',
+  };
+  if (reuseMarker case final value?) {
+    rawTags['allow_audio_reuse'] = value;
+  }
   return VideoEvent(
     id: id,
     pubkey: _pubkey,
@@ -46,9 +53,7 @@ VideoEvent _video({
     ),
     vineId: vineId,
     addressableDTag: vineId,
-    rawTags: allowsReuse
-        ? const {'allow_audio_reuse': 'true'}
-        : const {'allow_audio_reuse': 'false'},
+    rawTags: rawTags,
   );
 }
 
@@ -92,7 +97,25 @@ void main() {
     });
 
     test('honours a revocation on the current revision', () async {
-      stubSource([_video(createdAt: 120, allowsReuse: false)]);
+      stubSource([_video(createdAt: 120, reuseMarker: 'false')]);
+
+      expect(await resolver.verify(_sound()), isFalse);
+    });
+
+    test('grants reuse for an unmarked classic Vine source', () async {
+      stubSource([_video(reuseMarker: null, isClassicVine: true)]);
+
+      expect(await resolver.verify(_sound()), isTrue);
+    });
+
+    test('fails closed for an unmarked ordinary source', () async {
+      stubSource([_video(reuseMarker: null)]);
+
+      expect(await resolver.verify(_sound()), isFalse);
+    });
+
+    test('honors an explicit decline on a classic Vine source', () async {
+      stubSource([_video(reuseMarker: 'false', isClassicVine: true)]);
 
       expect(await resolver.verify(_sound()), isFalse);
     });

--- a/mobile/test/services/audio_reuse_consent_resolver_test.dart
+++ b/mobile/test/services/audio_reuse_consent_resolver_test.dart
@@ -34,11 +34,9 @@ VideoEvent _video({
   String vineId = 'source-video',
   int createdAt = 101,
   String? reuseMarker = 'true',
-  bool isClassicVine = false,
+  bool isVerifiedArchive = false,
 }) {
-  final rawTags = <String, String>{
-    if (isClassicVine) 'platform': 'vine',
-  };
+  final rawTags = <String, String>{};
   if (reuseMarker case final value?) {
     rawTags['allow_audio_reuse'] = value;
   }
@@ -54,6 +52,8 @@ VideoEvent _video({
     vineId: vineId,
     addressableDTag: vineId,
     rawTags: rawTags,
+    isVerifiedArchive: isVerifiedArchive,
+    archiveAudioReuseEnabled: isVerifiedArchive,
   );
 }
 
@@ -102,8 +102,8 @@ void main() {
       expect(await resolver.verify(_sound()), isFalse);
     });
 
-    test('grants reuse for an unmarked classic Vine source', () async {
-      stubSource([_video(reuseMarker: null, isClassicVine: true)]);
+    test('grants reuse for an enabled verified archive source', () async {
+      stubSource([_video(reuseMarker: null, isVerifiedArchive: true)]);
 
       expect(await resolver.verify(_sound()), isTrue);
     });
@@ -115,7 +115,7 @@ void main() {
     });
 
     test('honors an explicit decline on a classic Vine source', () async {
-      stubSource([_video(reuseMarker: 'false', isClassicVine: true)]);
+      stubSource([_video(reuseMarker: 'false', isVerifiedArchive: true)]);
 
       expect(await resolver.verify(_sound()), isFalse);
     });

--- a/mobile/test/services/audio_reuse_consent_resolver_test.dart
+++ b/mobile/test/services/audio_reuse_consent_resolver_test.dart
@@ -102,11 +102,14 @@ void main() {
       expect(await resolver.verify(_sound()), isFalse);
     });
 
-    test('grants reuse for an enabled verified archive source', () async {
-      stubSource([_video(reuseMarker: null, isVerifiedArchive: true)]);
+    test(
+      'applies legacy reuse policy to an enabled verified archive',
+      () async {
+        stubSource([_video(reuseMarker: null, isVerifiedArchive: true)]);
 
-      expect(await resolver.verify(_sound()), isTrue);
-    });
+        expect(await resolver.verify(_sound()), isTrue);
+      },
+    );
 
     test('fails closed for an unmarked ordinary source', () async {
       stubSource([_video(reuseMarker: null)]);

--- a/mobile/test/services/audio_reuse_consent_resolver_test.dart
+++ b/mobile/test/services/audio_reuse_consent_resolver_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Ensures only the sound's own source video can grant reuse.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/services/audio_reuse_consent_resolver.dart';
@@ -13,17 +14,21 @@ const _pubkey =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
 const _sourceAddress = '34236:$_pubkey:source-video';
+final String _sha256 = 'b' * 64;
+final String _audioSha256 = 'c' * 64;
 
 AudioEvent _sound({
   bool allowsReuse = false,
   bool hasExplicitReuseConsent = false,
   String? sourceVideoReference = _sourceAddress,
+  String? sha256,
 }) {
   return AudioEvent(
     id: 'audio-event',
     pubkey: _pubkey,
     createdAt: 100,
     sourceVideoReference: sourceVideoReference,
+    sha256: sha256,
     allowsReuse: allowsReuse,
     hasExplicitReuseConsent: hasExplicitReuseConsent,
   );
@@ -54,6 +59,7 @@ VideoEvent _video({
     rawTags: rawTags,
     isVerifiedArchive: isVerifiedArchive,
     archiveAudioReuseEnabled: isVerifiedArchive,
+    sha256: _sha256,
   );
 }
 
@@ -64,6 +70,14 @@ void main() {
   setUp(() {
     videosRepository = _MockVideosRepository();
     resolver = AudioReuseConsentResolver(videosRepository: videosRepository);
+    when(
+      () => videosRepository.getAudioReusePolicy(any()),
+    ).thenAnswer(
+      (_) async => const AudioReusePolicy(
+        allowAudioReuse: true,
+        audioReuseSuppressed: false,
+      ),
+    );
   });
 
   void stubSource(List<VideoEvent> videos) {
@@ -73,9 +87,40 @@ void main() {
   }
 
   group('verify', () {
-    test('accepts explicit true without a legacy lookup', () async {
-      expect(await resolver.verify(_sound(allowsReuse: true)), isTrue);
-      verifyNever(() => videosRepository.getVideosByAddressableIds(any()));
+    test(
+      'accepts explicit true after current-source and suppression checks',
+      () async {
+        stubSource([_video()]);
+        expect(
+          await resolver.verify(
+            _sound(allowsReuse: true, sha256: _audioSha256),
+          ),
+          isTrue,
+        );
+        verify(
+          () => videosRepository.getVideosByAddressableIds([_sourceAddress]),
+        ).called(1);
+        verify(() => videosRepository.getAudioReusePolicy(_sha256)).called(1);
+      },
+    );
+
+    test('suppression overrides explicit true', () async {
+      stubSource([_video()]);
+      when(
+        () => videosRepository.getAudioReusePolicy(_sha256),
+      ).thenAnswer(
+        (_) async => const AudioReusePolicy(
+          allowAudioReuse: false,
+          audioReuseSuppressed: true,
+        ),
+      );
+
+      expect(
+        await resolver.verify(
+          _sound(allowsReuse: true, sha256: _audioSha256),
+        ),
+        isFalse,
+      );
     });
 
     test('honors explicit false without a legacy lookup', () async {
@@ -84,6 +129,7 @@ void main() {
         isFalse,
       );
       verifyNever(() => videosRepository.getVideosByAddressableIds(any()));
+      verifyNever(() => videosRepository.getAudioReusePolicy(any()));
     });
 
     test('grants reuse from the source video the sound points at', () async {
@@ -153,6 +199,15 @@ void main() {
       when(
         () => videosRepository.getVideosByAddressableIds([_sourceAddress]),
       ).thenThrow(StateError('relay unavailable'));
+
+      expect(await resolver.verify(_sound()), isFalse);
+    });
+
+    test('fails closed when the suppression lookup throws', () async {
+      when(
+        () => videosRepository.getAudioReusePolicy(_sha256),
+      ).thenThrow(StateError('policy unavailable'));
+      stubSource([_video()]);
 
       expect(await resolver.verify(_sound()), isFalse);
     });

--- a/mobile/test/services/audio_reuse_consent_resolver_test.dart
+++ b/mobile/test/services/audio_reuse_consent_resolver_test.dart
@@ -10,6 +10,8 @@ import 'package:videos_repository/videos_repository.dart';
 
 class _MockVideosRepository extends Mock implements VideosRepository {}
 
+class _FakeVideoEvent extends Fake implements VideoEvent {}
+
 const _pubkey =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
@@ -64,18 +66,18 @@ VideoEvent _video({
 }
 
 void main() {
+  setUpAll(() => registerFallbackValue(_FakeVideoEvent()));
+
   late _MockVideosRepository videosRepository;
   late AudioReuseConsentResolver resolver;
 
   setUp(() {
     videosRepository = _MockVideosRepository();
     resolver = AudioReuseConsentResolver(videosRepository: videosRepository);
-    when(
-      () => videosRepository.getAudioReusePolicy(any()),
-    ).thenAnswer(
+    when(() => videosRepository.refreshAudioReusePolicy(any())).thenAnswer(
       (_) async => const AudioReusePolicy(
-        allowAudioReuse: true,
         audioReuseSuppressed: false,
+        validFor: Duration(seconds: 60),
       ),
     );
   });
@@ -100,36 +102,32 @@ void main() {
         verify(
           () => videosRepository.getVideosByAddressableIds([_sourceAddress]),
         ).called(1);
-        verify(() => videosRepository.getAudioReusePolicy(_sha256)).called(1);
+        verify(() => videosRepository.refreshAudioReusePolicy(any())).called(1);
       },
     );
 
     test('suppression overrides explicit true', () async {
       stubSource([_video()]);
-      when(
-        () => videosRepository.getAudioReusePolicy(_sha256),
-      ).thenAnswer(
+      when(() => videosRepository.refreshAudioReusePolicy(any())).thenAnswer(
         (_) async => const AudioReusePolicy(
-          allowAudioReuse: false,
           audioReuseSuppressed: true,
+          validFor: Duration(seconds: 60),
         ),
       );
 
       expect(
-        await resolver.verify(
-          _sound(allowsReuse: true, sha256: _audioSha256),
-        ),
+        await resolver.verify(_sound(allowsReuse: true, sha256: _audioSha256)),
         isFalse,
       );
     });
 
-    test('honors explicit false without a legacy lookup', () async {
+    test('honors explicit false on the current ordinary source', () async {
+      stubSource([_video(reuseMarker: 'false')]);
       expect(
         await resolver.verify(_sound(hasExplicitReuseConsent: true)),
         isFalse,
       );
-      verifyNever(() => videosRepository.getVideosByAddressableIds(any()));
-      verifyNever(() => videosRepository.getAudioReusePolicy(any()));
+      verifyNever(() => videosRepository.refreshAudioReusePolicy(any()));
     });
 
     test('grants reuse from the source video the sound points at', () async {
@@ -149,7 +147,7 @@ void main() {
     });
 
     test(
-      'applies legacy reuse policy to an enabled verified archive',
+      'allows an enabled verified classic without an event grant',
       () async {
         stubSource([_video(reuseMarker: null, isVerifiedArchive: true)]);
 
@@ -163,10 +161,10 @@ void main() {
       expect(await resolver.verify(_sound()), isFalse);
     });
 
-    test('honors an explicit decline on a classic Vine source', () async {
+    test('does not treat an imported classic marker as a takedown', () async {
       stubSource([_video(reuseMarker: 'false', isVerifiedArchive: true)]);
 
-      expect(await resolver.verify(_sound()), isFalse);
+      expect(await resolver.verify(_sound()), isTrue);
     });
 
     test('ignores a video at a different address', () async {
@@ -205,7 +203,7 @@ void main() {
 
     test('fails closed when the suppression lookup throws', () async {
       when(
-        () => videosRepository.getAudioReusePolicy(_sha256),
+        () => videosRepository.refreshAudioReusePolicy(any()),
       ).thenThrow(StateError('policy unavailable'));
       stubSource([_video()]);
 

--- a/mobile/test/services/saved_sounds_service_test.dart
+++ b/mobile/test/services/saved_sounds_service_test.dart
@@ -22,8 +22,7 @@ AudioEvent _sound({
 }) {
   return AudioEvent(
     id: id,
-    pubkey:
-        'test_pubkey_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    pubkey: 'test_pubkey_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
     createdAt: createdAt,
     title: title ?? 'Test Sound $id',
     duration: 6,
@@ -191,9 +190,9 @@ void main() {
 
         await service.saveSavedSound(record);
 
-        final raw =
-            jsonDecode(sharedPreferences.getString(service.storageKey)!)
-                as Map<String, dynamic>;
+        final raw = jsonDecode(
+          sharedPreferences.getString(service.storageKey)!,
+        ) as Map<String, dynamic>;
         expect(
           raw['schemaVersion'],
           SavedSoundLibraryPayload.currentSchemaVersion,
@@ -808,11 +807,9 @@ void main() {
             filePath: '/documents/draft_audio_imports/d1/good.m4a',
           ),
         );
-        final stored =
-            jsonDecode(
-                  sharedPreferences.getString('saved_reusable_sounds_anon')!,
-                )
-                as Map<String, dynamic>;
+        final stored = jsonDecode(
+          sharedPreferences.getString('saved_reusable_sounds_anon')!,
+        ) as Map<String, dynamic>;
         (stored['sounds'] as List<dynamic>).add({'audio': 'not a map'});
         await sharedPreferences.setString(
           'saved_reusable_sounds_anon',

--- a/mobile/test/services/saved_sounds_service_test.dart
+++ b/mobile/test/services/saved_sounds_service_test.dart
@@ -22,7 +22,8 @@ AudioEvent _sound({
 }) {
   return AudioEvent(
     id: id,
-    pubkey: 'test_pubkey_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    pubkey:
+        'test_pubkey_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
     createdAt: createdAt,
     title: title ?? 'Test Sound $id',
     duration: 6,
@@ -35,16 +36,14 @@ AudioEvent _sound({
   );
 }
 
-AudioEvent _importedSound({
-  required String id,
-  required String filePath,
-}) => AudioEvent.fromLocalImport(
-  id: id,
-  filePath: filePath,
-  createdAt: 1700000000,
-  title: 'Imported sound',
-  mimeType: 'audio/mp4',
-);
+AudioEvent _importedSound({required String id, required String filePath}) =>
+    AudioEvent.fromLocalImport(
+      id: id,
+      filePath: filePath,
+      createdAt: 1700000000,
+      title: 'Imported sound',
+      mimeType: 'audio/mp4',
+    );
 
 void main() {
   group(SavedSoundsService, () {
@@ -66,6 +65,24 @@ void main() {
 
       expect(result, SavedSoundSaveResult.saved);
       expect(service.loadSounds(), [sound]);
+    });
+
+    test('keeps archive compatibility provisional after a reload', () async {
+      final service = SavedSoundsService(sharedPreferences);
+      final sound = _sound(id: 'archive').copyWith(
+        allowsReuse: true,
+        hasExplicitReuseConsent: false,
+        requiresCurrentReuseVerification: true,
+      );
+
+      await service.saveSound(sound);
+      final reloaded = SavedSoundsService(
+        sharedPreferences,
+      ).loadSounds().single;
+
+      expect(reloaded.allowsReuse, isTrue);
+      expect(reloaded.hasExplicitReuseConsent, isFalse);
+      expect(reloaded.requiresCurrentReuseVerification, isTrue);
     });
 
     test('clears local editor anchors before persisting sounds', () async {
@@ -174,9 +191,9 @@ void main() {
 
         await service.saveSavedSound(record);
 
-        final raw = jsonDecode(
-          sharedPreferences.getString(service.storageKey)!,
-        ) as Map<String, dynamic>;
+        final raw =
+            jsonDecode(sharedPreferences.getString(service.storageKey)!)
+                as Map<String, dynamic>;
         expect(
           raw['schemaVersion'],
           SavedSoundLibraryPayload.currentSchemaVersion,
@@ -264,9 +281,7 @@ void main() {
         ).thenAnswer((_) async => false);
 
         await expectLater(
-          service.saveSavedSound(
-            SavedSound.fromLegacy(_sound(id: 'sound1')),
-          ),
+          service.saveSavedSound(SavedSound.fromLegacy(_sound(id: 'sound1'))),
           throwsA(isA<StateError>()),
         );
       });
@@ -711,9 +726,9 @@ void main() {
       });
 
       test('ignores published sounds and unrelated keys', () async {
-        await SavedSoundsService(sharedPreferences).saveSound(
-          _sound(id: 'published'),
-        );
+        await SavedSoundsService(
+          sharedPreferences,
+        ).saveSound(_sound(id: 'published'));
         await sharedPreferences.setString('vine_drafts', 'not a sound bucket');
 
         expect(
@@ -793,9 +808,11 @@ void main() {
             filePath: '/documents/draft_audio_imports/d1/good.m4a',
           ),
         );
-        final stored = jsonDecode(
-          sharedPreferences.getString('saved_reusable_sounds_anon')!,
-        ) as Map<String, dynamic>;
+        final stored =
+            jsonDecode(
+                  sharedPreferences.getString('saved_reusable_sounds_anon')!,
+                )
+                as Map<String, dynamic>;
         (stored['sounds'] as List<dynamic>).add({'audio': 'not a map'});
         await sharedPreferences.setString(
           'saved_reusable_sounds_anon',
@@ -818,13 +835,12 @@ void main() {
     group('removeSound', () {
       const filePath = '/documents/library_audio_imports/imported.m4a';
 
-      SavedSoundsService createService({
-        LocalAudioReclaimer? audioReclaimer,
-      }) => SavedSoundsService(
-        sharedPreferences,
-        documentsPath: '/documents',
-        audioReclaimer: audioReclaimer,
-      );
+      SavedSoundsService createService({LocalAudioReclaimer? audioReclaimer}) =>
+          SavedSoundsService(
+            sharedPreferences,
+            documentsPath: '/documents',
+            audioReclaimer: audioReclaimer,
+          );
 
       test("hands the removed entry's audio file to the reclaimer", () async {
         final reclaimed = <String>[];
@@ -898,9 +914,7 @@ void main() {
         final failing = _MockSharedPreferences();
         when(failing.getKeys).thenReturn({'saved_reusable_sounds_anon'});
         when(() => failing.containsKey(any())).thenReturn(true);
-        when(
-          () => failing.getString('saved_reusable_sounds_anon'),
-        ).thenReturn(
+        when(() => failing.getString('saved_reusable_sounds_anon')).thenReturn(
           jsonEncode({
             'schemaVersion': 1,
             'sounds': [

--- a/mobile/test/services/video_event_publisher_test.dart
+++ b/mobile/test/services/video_event_publisher_test.dart
@@ -591,8 +591,10 @@ void main() {
 
       final result = await publisher.publishVideoEvent(
         upload: createUpload().copyWith(
-          streamingMp4Url: 'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/play_360p.mp4',
-          streamingHlsUrl: 'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/playlist.m3u8',
+          streamingMp4Url:
+              'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/play_360p.mp4',
+          streamingHlsUrl:
+              'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/playlist.m3u8',
           fallbackUrl: 'https://media.divine.video/fa4a90a3.mp4',
           cdnUrl: 'https://stream.divine.video/legacy/playlist.m3u8',
         ),
@@ -603,6 +605,16 @@ void main() {
       final imetaText = imeta.join(' ');
       expect(imetaText, contains('https://media.divine.video/fa4a90a3.mp4'));
       expect(imetaText, isNot(contains('stream.divine.video')));
+    });
+
+    test('publishVideoEvent writes an explicit false reuse marker', () async {
+      stubSignAndPublish();
+
+      expect(await publisher.publishVideoEvent(upload: createUpload()), isTrue);
+      expect(
+        _containsTag(capturedTags, const ['allow_audio_reuse', 'false']),
+        isTrue,
+      );
     });
 
     test(
@@ -708,7 +720,7 @@ void main() {
         hasExplicitReuseConsent: true,
       );
 
-      test('publishes with an unmarked classic Vine original sound', () async {
+      test('publishes with an enabled verified archive sound', () async {
         stubSignAndPublish();
         final classicVideo = VideoEvent(
           id: sourceVideoId,
@@ -718,20 +730,56 @@ void main() {
           timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
           videoUrl: 'https://example.com/classic.mp4',
           addressableDTag: 'classic-vine',
-          rawTags: const {'platform': 'vine'},
+          isVerifiedArchive: true,
+          archiveAudioReuseEnabled: true,
         );
         final classicSound = AudioEvent.fromVideoOriginalSound(classicVideo);
 
-        final result = await publisher.publishVideoEvent(
-          upload: createUpload(),
-          selectedAudio: classicSound,
-          selectedAudioEventId: classicSound.id,
-        );
+        final result = await publisherWithConsent(consent: true)
+            .publishVideoEvent(
+              upload: createUpload(),
+              selectedAudio: classicSound,
+              selectedAudioEventId: classicSound.id,
+            );
 
         expect(result, isTrue);
         expect(classicSound.allowsReuse, isTrue);
-        expect(classicSound.hasExplicitReuseConsent, isTrue);
+        expect(classicSound.hasExplicitReuseConsent, isFalse);
+        expect(classicSound.requiresCurrentReuseVerification, isTrue);
       });
+
+      test(
+        'revalidates an archive grant after the saved-sound handoff',
+        () async {
+          stubSignAndPublish();
+          final persistedSound = AudioEvent.fromJson(
+            AudioEvent.fromVideoOriginalSound(
+              VideoEvent(
+                id: sourceVideoId,
+                pubkey: sourceCreator,
+                createdAt: 1700000000,
+                content: '',
+                timestamp: DateTime.fromMillisecondsSinceEpoch(
+                  1700000000 * 1000,
+                ),
+                videoUrl: 'https://example.com/classic.mp4',
+                isVerifiedArchive: true,
+                archiveAudioReuseEnabled: true,
+              ),
+            ).toJson(),
+          );
+
+          expect(persistedSound.requiresCurrentReuseVerification, isTrue);
+          expect(
+            await publisherWithConsent(consent: true).publishVideoEvent(
+              upload: createUpload(),
+              selectedAudio: persistedSound,
+              selectedAudioEventId: persistedSound.id,
+            ),
+            isTrue,
+          );
+        },
+      );
 
       test(
         'blocks selected audio when the source explicitly forbids reuse',
@@ -764,17 +812,58 @@ void main() {
         },
       );
 
-      test('an explicit decline blocks the sound owner', () async {
+      test('an explicit decline still permits the sound owner', () async {
         stubSignAndPublish();
         final ownDeclinedSound = withheldSound.copyWith(pubkey: testPubkey);
 
-        await expectLater(
-          publisher.publishVideoEvent(
-            upload: createUpload(),
-            selectedAudio: ownDeclinedSound,
-            selectedAudioEventId: ownDeclinedSound.id,
+        final result = await publisher.publishVideoEvent(
+          upload: createUpload(),
+          selectedAudio: ownDeclinedSound,
+          selectedAudioEventId: ownDeclinedSound.id,
+        );
+
+        expect(result, isTrue);
+      });
+
+      test('an unmarked legacy sound still permits the sound owner', () async {
+        stubSignAndPublish();
+        final ownLegacySound = AudioEvent(
+          id: 'e' * 64,
+          pubkey: testPubkey,
+          createdAt: 1700000000,
+          allowsReuse: false,
+        );
+
+        final result = await publisher.publishVideoEvent(
+          upload: createUpload(),
+          selectedAudio: ownLegacySound,
+          selectedAudioEventId: ownLegacySound.id,
+        );
+
+        expect(result, isTrue);
+      });
+
+      test('a malformed reuse marker still permits the sound owner', () async {
+        stubSignAndPublish();
+        final ownedSound = AudioEvent.fromVideoOriginalSound(
+          VideoEvent(
+            id: sourceVideoId,
+            pubkey: testPubkey,
+            createdAt: 1700000000,
+            content: '',
+            timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
+            videoUrl: 'https://example.com/owned.mp4',
+            rawTags: const {'allow_audio_reuse': 'TRUE'},
           ),
-          throwsA(isA<AudioReuseNotPermittedException>()),
+        );
+
+        expect(
+          await publisher.publishVideoEvent(
+            upload: createUpload(),
+            selectedAudio: ownedSound,
+            selectedAudioEventId: ownedSound.id,
+          ),
+          isTrue,
         );
       });
 
@@ -917,7 +1006,8 @@ void main() {
             audioFilePath: audioPath,
             duration: 6,
             fileSize: 12345,
-            sha256Hash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            sha256Hash:
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
             mimeType: 'audio/m4a',
           ),
         );
@@ -934,7 +1024,8 @@ void main() {
             success: true,
             url: 'https://cdn.example.com/audio.m4a',
             fallbackUrl: 'https://cdn.example.com/audio.m4a',
-            videoId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            videoId:
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           ),
         );
         when(
@@ -1025,42 +1116,36 @@ void main() {
       // audioExtractionService, so the audio step returns at its first guard —
       // nothing is extracted or uploaded here. The real extraction-failure
       // path is covered in video_event_publisher_audio_degrade_test.dart.
-      test(
-        'an unavailable audio pipeline still publishes the video, without '
-        'claiming reuse',
-        () async {
-          stubSignAndPublish();
+      test('an unavailable audio pipeline still publishes the video, without '
+          'claiming reuse', () async {
+        stubSignAndPublish();
 
-          final result = await publisher.publishVideoEvent(
-            upload: createUpload(localVideoPath: '/tmp/video-with-audio.mp4'),
-            allowAudioReuse: true,
-          );
+        final result = await publisher.publishVideoEvent(
+          upload: createUpload(localVideoPath: '/tmp/video-with-audio.mp4'),
+          allowAudioReuse: true,
+        );
 
-          // A video-only publish beats discarding an already-uploaded video.
-          expect(result, isTrue);
+        // A video-only publish beats discarding an already-uploaded video.
+        expect(result, isTrue);
 
-          final tags =
-              verify(
-                    () => authService.createAndSignEvent(
-                      kind: NIP71VideoKinds.getPreferredAddressableKind(),
-                      content: any(named: 'content'),
-                      tags: captureAny(named: 'tags'),
-                    ),
-                  ).captured.single
-                  as List<List<String>>;
+        final tags =
+            verify(
+                  () => authService.createAndSignEvent(
+                    kind: NIP71VideoKinds.getPreferredAddressableKind(),
+                    content: any(named: 'content'),
+                    tags: captureAny(named: 'tags'),
+                  ),
+                ).captured.single
+                as List<List<String>>;
 
-          // The event must never advertise reusable audio that was never
-          // published — no allow_audio_reuse, and no audio `e` reference.
-          expect(
-            tags.where((tag) => tag.first == 'allow_audio_reuse'),
-            isEmpty,
-          );
-          expect(
-            tags.where((tag) => tag.first == 'e' && tag.last == 'audio'),
-            isEmpty,
-          );
-        },
-      );
+        // The event must never advertise reusable audio that was never
+        // published — no allow_audio_reuse, and no audio `e` reference.
+        expect(tags.where((tag) => tag.first == 'allow_audio_reuse'), isEmpty);
+        expect(
+          tags.where((tag) => tag.first == 'e' && tag.last == 'audio'),
+          isEmpty,
+        );
+      });
 
       test(
         'publishes durable provider credit without claiming ownership',
@@ -1429,7 +1514,8 @@ void main() {
               success: true,
               url: 'https://cdn.example/audiohash',
               fallbackUrl: 'https://cdn.example/audiohash',
-              videoId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              videoId:
+                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
             ),
           );
 
@@ -1512,69 +1598,65 @@ void main() {
         },
       );
 
-      test(
-        'a sync failure does not fail the video publish',
-        () async {
-          when(
-            () => syncRepository.publishLocalChange(any()),
-          ).thenThrow(SyncIndexException('relay down'));
+      test('a sync failure does not fail the video publish', () async {
+        when(
+          () => syncRepository.publishLocalChange(any()),
+        ).thenThrow(SyncIndexException('relay down'));
 
-          final audioFile = File(
-            '${Directory.systemTemp.path}/imported_audio_sync_failure.mp3',
-          );
-          await audioFile.writeAsBytes([1, 2, 3]);
-          addTearDown(() {
-            if (audioFile.existsSync()) audioFile.deleteSync();
-          });
+        final audioFile = File(
+          '${Directory.systemTemp.path}/imported_audio_sync_failure.mp3',
+        );
+        await audioFile.writeAsBytes([1, 2, 3]);
+        addTearDown(() {
+          if (audioFile.existsSync()) audioFile.deleteSync();
+        });
 
-          when(
-            () => blossomUploadService.uploadAudio(
-              audioFile: any(named: 'audioFile'),
-              mimeType: 'audio/mpeg',
-              onProgress: any(named: 'onProgress'),
-            ),
-          ).thenAnswer(
-            (_) async => const BlossomUploadResult(
-              success: true,
-              url: 'https://cdn.example/audiohash',
-              fallbackUrl: 'https://cdn.example/audiohash',
-              videoId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            ),
-          );
+        when(
+          () => blossomUploadService.uploadAudio(
+            audioFile: any(named: 'audioFile'),
+            mimeType: 'audio/mpeg',
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenAnswer(
+          (_) async => const BlossomUploadResult(
+            success: true,
+            url: 'https://cdn.example/audiohash',
+            fallbackUrl: 'https://cdn.example/audiohash',
+            videoId:
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          ),
+        );
 
-          final result = await publisher.publishVideoEvent(
-            upload: createUpload(),
-            allowAudioReuse: true,
-            selectedAudio: AudioEvent.fromLocalImport(
-              id: 'local_import_1700000000001',
-              filePath: audioFile.path,
-              createdAt: 1700000000,
-              title: 'imported_audio_sync_failure',
-              mimeType: 'audio/mpeg',
-              duration: 3,
-            ),
-            audioShareAttribution: const AudioShareAttribution(
-              title: 'Rain on a roof',
-              creatorName: 'Field Recordist',
-              creatorUrl: 'https://creator.example/profile',
-              sourceUrl: 'https://creator.example/rain',
-              licenseName: 'CC BY 4.0',
-              licenseUrl: 'https://creativecommons.org/licenses/by/4.0/',
-              publicTags: ['rain', 'field-recording'],
-              confirmedOwnWork: false,
-            ),
-          );
+        final result = await publisher.publishVideoEvent(
+          upload: createUpload(),
+          allowAudioReuse: true,
+          selectedAudio: AudioEvent.fromLocalImport(
+            id: 'local_import_1700000000001',
+            filePath: audioFile.path,
+            createdAt: 1700000000,
+            title: 'imported_audio_sync_failure',
+            mimeType: 'audio/mpeg',
+            duration: 3,
+          ),
+          audioShareAttribution: const AudioShareAttribution(
+            title: 'Rain on a roof',
+            creatorName: 'Field Recordist',
+            creatorUrl: 'https://creator.example/profile',
+            sourceUrl: 'https://creator.example/rain',
+            licenseName: 'CC BY 4.0',
+            licenseUrl: 'https://creativecommons.org/licenses/by/4.0/',
+            publicTags: ['rain', 'field-recording'],
+            confirmedOwnWork: false,
+          ),
+        );
 
-          expect(result, isTrue);
-          verify(() => savedSoundsService.saveSound(any())).called(1);
-          // The mirror sits inside an enclosing catch-and-log, so without
-          // this the test would pass unchanged even if _mirrorSavedSound's
-          // own try/catch — or the mirror call entirely — were deleted.
-          verify(
-            () => syncRepository.publishLocalChange(any()),
-          ).called(1);
-        },
-      );
+        expect(result, isTrue);
+        verify(() => savedSoundsService.saveSound(any())).called(1);
+        // The mirror sits inside an enclosing catch-and-log, so without
+        // this the test would pass unchanged even if _mirrorSavedSound's
+        // own try/catch — or the mirror call entirely — were deleted.
+        verify(() => syncRepository.publishLocalChange(any())).called(1);
+      });
 
       test(
         'publishes video privately without uploading a local import',

--- a/mobile/test/services/video_event_publisher_test.dart
+++ b/mobile/test/services/video_event_publisher_test.dart
@@ -494,6 +494,7 @@ void main() {
         nostrService: nostrClient,
         authService: authService,
         videoEventService: videoEventService,
+        audioReuseConsentChecker: (_) async => true,
       );
 
       when(() => nostrClient.isInitialized).thenReturn(true);
@@ -748,6 +749,27 @@ void main() {
         expect(classicSound.requiresCurrentReuseVerification, isTrue);
       });
 
+      test('server suppression overrides an explicit reuse grant', () async {
+        stubSignAndPublish();
+        final explicitlyGranted = AudioEvent(
+          id: 'c' * 64,
+          pubkey: sourceCreator,
+          createdAt: 1700000000,
+          sha256: 'd' * 64,
+          sourceVideoReference: '34236:$sourceCreator:vine-xyz',
+          hasExplicitReuseConsent: true,
+        );
+
+        final result = await publisherWithConsent().publishVideoEvent(
+          upload: createUpload(),
+          selectedAudio: explicitlyGranted,
+          selectedAudioEventId: explicitlyGranted.id,
+        );
+
+        expect(result, isFalse);
+        expect(capturedTags, isEmpty);
+      });
+
       test(
         'revalidates an archive grant after the saved-sound handoff',
         () async {
@@ -898,6 +920,12 @@ void main() {
       // missing check. `publisher` here is the bare one from setUp.
       test('blocks reuse when no consent checker is wired', () async {
         stubSignAndPublish();
+        final publisherWithoutChecker = VideoEventPublisher(
+          uploadManager: uploadManager,
+          nostrService: nostrClient,
+          authService: authService,
+          videoEventService: videoEventService,
+        );
 
         final legacySound = AudioEvent(
           id: 'f' * 64,
@@ -907,7 +935,7 @@ void main() {
           sourceVideoReference: '34236:$sourceCreator:vine-xyz',
         );
 
-        final result = await publisher.publishVideoEvent(
+        final result = await publisherWithoutChecker.publishVideoEvent(
           upload: createUpload(),
           selectedAudio: legacySound,
           selectedAudioEventId: legacySound.id,

--- a/mobile/test/services/video_event_publisher_test.dart
+++ b/mobile/test/services/video_event_publisher_test.dart
@@ -17,6 +17,7 @@ import 'package:models/models.dart'
         AudioExternalSource,
         AudioLicenseMetadata,
         UserProfile,
+        VideoEvent,
         VideoUrlResolver,
         audioEventKind;
 import 'package:nostr_client/nostr_client.dart';
@@ -707,6 +708,31 @@ void main() {
         hasExplicitReuseConsent: true,
       );
 
+      test('publishes with an unmarked classic Vine original sound', () async {
+        stubSignAndPublish();
+        final classicVideo = VideoEvent(
+          id: sourceVideoId,
+          pubkey: sourceCreator,
+          createdAt: 1700000000,
+          content: '',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
+          videoUrl: 'https://example.com/classic.mp4',
+          addressableDTag: 'classic-vine',
+          rawTags: const {'platform': 'vine'},
+        );
+        final classicSound = AudioEvent.fromVideoOriginalSound(classicVideo);
+
+        final result = await publisher.publishVideoEvent(
+          upload: createUpload(),
+          selectedAudio: classicSound,
+          selectedAudioEventId: classicSound.id,
+        );
+
+        expect(result, isTrue);
+        expect(classicSound.allowsReuse, isTrue);
+        expect(classicSound.hasExplicitReuseConsent, isTrue);
+      });
+
       test(
         'blocks selected audio when the source explicitly forbids reuse',
         () async {
@@ -737,6 +763,20 @@ void main() {
           );
         },
       );
+
+      test('an explicit decline blocks the sound owner', () async {
+        stubSignAndPublish();
+        final ownDeclinedSound = withheldSound.copyWith(pubkey: testPubkey);
+
+        await expectLater(
+          publisher.publishVideoEvent(
+            upload: createUpload(),
+            selectedAudio: ownDeclinedSound,
+            selectedAudioEventId: ownDeclinedSound.id,
+          ),
+          throwsA(isA<AudioReuseNotPermittedException>()),
+        );
+      });
 
       // The legacy resolver's `false` cannot tell a refusal from an
       // unreachable relay, a source video outside the query window, or one the

--- a/mobile/test/services/video_event_publisher_test.dart
+++ b/mobile/test/services/video_event_publisher_test.dart
@@ -720,7 +720,7 @@ void main() {
         hasExplicitReuseConsent: true,
       );
 
-      test('publishes with an enabled verified archive sound', () async {
+      test('publishes with a legacy-policy verified archive sound', () async {
         stubSignAndPublish();
         final classicVideo = VideoEvent(
           id: sourceVideoId,

--- a/mobile/test/services/video_event_publisher_test.dart
+++ b/mobile/test/services/video_event_publisher_test.dart
@@ -592,10 +592,8 @@ void main() {
 
       final result = await publisher.publishVideoEvent(
         upload: createUpload().copyWith(
-          streamingMp4Url:
-              'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/play_360p.mp4',
-          streamingHlsUrl:
-              'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/playlist.m3u8',
+          streamingMp4Url: 'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/play_360p.mp4',
+          streamingHlsUrl: 'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/playlist.m3u8',
           fallbackUrl: 'https://media.divine.video/fa4a90a3.mp4',
           cdnUrl: 'https://stream.divine.video/legacy/playlist.m3u8',
         ),
@@ -748,6 +746,39 @@ void main() {
         expect(classicSound.hasExplicitReuseConsent, isFalse);
         expect(classicSound.requiresCurrentReuseVerification, isTrue);
       });
+
+      test(
+        'does not treat an imported classic false marker as a takedown',
+        () async {
+          stubSignAndPublish();
+          final classicSound = AudioEvent.fromVideoOriginalSound(
+            VideoEvent(
+              id: sourceVideoId,
+              pubkey: sourceCreator,
+              createdAt: 1700000000,
+              content: '',
+              timestamp: DateTime.fromMillisecondsSinceEpoch(
+                1700000000 * 1000,
+              ),
+              videoUrl: 'https://example.com/classic.mp4',
+              addressableDTag: 'classic-vine',
+              rawTags: const {'allow_audio_reuse': 'false'},
+              isVerifiedArchive: true,
+              archiveAudioReuseEnabled: true,
+            ),
+          );
+
+          expect(classicSound.hasExplicitReuseConsent, isTrue);
+          expect(
+            await publisherWithConsent(consent: true).publishVideoEvent(
+              upload: createUpload(),
+              selectedAudio: classicSound,
+              selectedAudioEventId: classicSound.id,
+            ),
+            isTrue,
+          );
+        },
+      );
 
       test('server suppression overrides an explicit reuse grant', () async {
         stubSignAndPublish();
@@ -1034,8 +1065,7 @@ void main() {
             audioFilePath: audioPath,
             duration: 6,
             fileSize: 12345,
-            sha256Hash:
-                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            sha256Hash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
             mimeType: 'audio/m4a',
           ),
         );
@@ -1052,8 +1082,7 @@ void main() {
             success: true,
             url: 'https://cdn.example.com/audio.m4a',
             fallbackUrl: 'https://cdn.example.com/audio.m4a',
-            videoId:
-                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            videoId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           ),
         );
         when(
@@ -1542,8 +1571,7 @@ void main() {
               success: true,
               url: 'https://cdn.example/audiohash',
               fallbackUrl: 'https://cdn.example/audiohash',
-              videoId:
-                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              videoId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
             ),
           );
 
@@ -1650,8 +1678,7 @@ void main() {
             success: true,
             url: 'https://cdn.example/audiohash',
             fallbackUrl: 'https://cdn.example/audiohash',
-            videoId:
-                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            videoId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           ),
         );
 

--- a/mobile/test/services/video_metadata_update_service_test.dart
+++ b/mobile/test/services/video_metadata_update_service_test.dart
@@ -138,6 +138,20 @@ void main() {
   });
 
   group(VideoMetadataUpdateService, () {
+    test('writes an explicit false audio-reuse marker', () async {
+      final result = await service.updateVideo(
+        originalVideo: _testVideo(),
+        editorState: VideoEditorProviderState(),
+        initialCollaboratorPubkeys: const {},
+      );
+
+      expect(result, isA<VideoUpdateSuccess>());
+      expect(
+        capturedTags,
+        contains(equals(['allow_audio_reuse', 'false'])),
+      );
+    });
+
     group('auth guard', () {
       test('returns VideoUpdateFailure when not authenticated', () async {
         when(() => mockAuthService.isAuthenticated).thenReturn(false);

--- a/mobile/test/utils/video_nostr_enrichment_views_test.dart
+++ b/mobile/test/utils/video_nostr_enrichment_views_test.dart
@@ -14,6 +14,8 @@ class _MockNostrClient extends Mock implements NostrClient {}
 VideoEvent _restVideo({
   required String id,
   int? originalLoops,
+  bool isVerifiedArchive = false,
+  bool archiveAudioReuseEnabled = false,
   Map<String, String> extraTags = const {},
 }) {
   return VideoEvent(
@@ -27,6 +29,8 @@ VideoEvent _restVideo({
     ),
     videoUrl: 'https://example.com/$id.mp4',
     originalLoops: originalLoops,
+    isVerifiedArchive: isVerifiedArchive,
+    archiveAudioReuseEnabled: archiveAudioReuseEnabled,
     // Base REST rawTags are intentionally sparse (1 entry) so the enrichment
     // trigger in enrichVideosWithNostrTags — `rawTags.length < 4` — fires on
     // every test. Each test adds `views`, `title`, etc. via [extraTags].
@@ -190,6 +194,42 @@ void main() {
 
       expect(enriched.single.rawTags['title'], equals('Nostr Title Wins'));
       expect(enriched.single.rawTags['views'], equals('7'));
+    });
+
+    test('Nostr tags cannot overwrite server archive verification', () async {
+      const pubkey =
+          'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+      final nostrEvent = Event(
+        pubkey,
+        34236,
+        const [
+          ['d', 'verified-archive-video'],
+          ['url', 'https://example.com/verified-archive-video.mp4'],
+          ['verified_archive', 'false'],
+          ['archive_audio_reuse_enabled', 'false'],
+          ['platform', 'vine'],
+        ],
+        'Nostr content',
+        createdAt: 1704067200,
+      );
+      final restVideo = _restVideo(
+        id: nostrEvent.id,
+        isVerifiedArchive: true,
+        archiveAudioReuseEnabled: true,
+      );
+
+      when(
+        () => mockNostrClient.queryEvents(any()),
+      ).thenAnswer((_) async => [nostrEvent]);
+
+      final enriched = await enrichVideosWithNostrTags(
+        [restVideo],
+        nostrService: mockNostrClient,
+      );
+
+      expect(enriched.single.isVerifiedArchive, isTrue);
+      expect(enriched.single.archiveAudioReuseEnabled, isTrue);
+      expect(enriched.single.rawTags['verified_archive'], equals('false'));
     });
 
     test(

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -454,7 +454,7 @@ void main() {
         expect(_divineIcon(DivineIconName.caretRight), findsNothing);
       });
 
-      testWidgets('honors an explicit decline on a classic Vine', (
+      testWidgets('ignores imported reuse markers on a classic Vine', (
         tester,
       ) async {
         final video = createVideoWithoutAudio(
@@ -463,7 +463,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildTestWidget(video: video, viewerPubkey: testPubkey),
+          buildTestWidget(video: video),
         );
         await tester.pumpAndSettle();
 

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -97,6 +97,7 @@ void main() {
       String? viewerPubkey,
       Object? audioError,
       ValueNotifier<int>? rebuilds,
+      bool currentPolicyAllowsReuse = true,
     }) {
       return ProviderScope(
         overrides: [
@@ -106,6 +107,12 @@ void main() {
           }),
           authServiceProvider.overrideWithValue(
             _mockAuth(viewerPubkey: viewerPubkey),
+          ),
+          audioReuseConsentProvider.overrideWith(
+            (ref, sound) async => currentPolicyAllowsReuse,
+          ),
+          audioReuseTermsProvider.overrideWith(
+            (ref, sound) async => currentPolicyAllowsReuse,
           ),
         ],
         child: MaterialApp(
@@ -434,6 +441,19 @@ void main() {
         expect(_divineIcon(DivineIconName.caretRight), findsOneWidget);
       });
 
+      testWidgets('suppression removes the classic reuse entry point', (
+        tester,
+      ) async {
+        final video = createVideoWithoutAudio(isVerifiedArchive: true);
+
+        await tester.pumpWidget(
+          buildTestWidget(video: video, currentPolicyAllowsReuse: false),
+        );
+        await tester.pumpAndSettle();
+
+        expect(_divineIcon(DivineIconName.caretRight), findsNothing);
+      });
+
       testWidgets('honors an explicit decline on a classic Vine', (
         tester,
       ) async {
@@ -617,6 +637,13 @@ void main() {
                 soundByIdProvider(
                   testAudioEventId,
                 ).overrideWith((ref) async => reusedSynth),
+                authServiceProvider.overrideWithValue(_mockAuth()),
+                audioReuseConsentProvider.overrideWith(
+                  (ref, sound) async => true,
+                ),
+                audioReuseTermsProvider.overrideWith(
+                  (ref, sound) async => true,
+                ),
               ],
               child: MaterialApp.router(
                 localizationsDelegates: appLocalizationsDelegates,

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -67,7 +67,8 @@ void main() {
 
     VideoEvent createVideoWithoutAudio({
       String? authorName,
-      bool allowAudioReuse = false,
+      bool? allowAudioReuse,
+      bool isClassicVine = false,
       InspiredByInfo? inspiredBy,
     }) {
       final now = DateTime.now();
@@ -81,9 +82,11 @@ void main() {
         title: 'Test Video',
         authorName: authorName,
         inspiredByVideo: inspiredBy,
-        rawTags: allowAudioReuse
-            ? const {'allow_audio_reuse': 'true'}
-            : const {},
+        rawTags: {
+          if (allowAudioReuse case final allowed?)
+            'allow_audio_reuse': allowed.toString(),
+          if (isClassicVine) 'platform': 'vine',
+        },
       );
     }
 
@@ -419,8 +422,33 @@ void main() {
         expect(_divineIcon(DivineIconName.caretRight), findsOneWidget);
       });
 
+      testWidgets('shows chevron for an unmarked classic Vine', (tester) async {
+        final video = createVideoWithoutAudio(isClassicVine: true);
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        expect(_divineIcon(DivineIconName.caretRight), findsOneWidget);
+      });
+
+      testWidgets('honors an explicit decline on a classic Vine', (
+        tester,
+      ) async {
+        final video = createVideoWithoutAudio(
+          allowAudioReuse: false,
+          isClassicVine: true,
+        );
+
+        await tester.pumpWidget(
+          buildTestWidget(video: video, viewerPubkey: testPubkey),
+        );
+        await tester.pumpAndSettle();
+
+        expect(_divineIcon(DivineIconName.caretRight), findsNothing);
+      });
+
       testWidgets(
-        'shows chevron for the creator viewing their own video with reuse off',
+        'shows chevron for the creator viewing their own unmarked video',
         (tester) async {
           final video = createVideoWithoutAudio();
 

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -423,7 +423,7 @@ void main() {
         expect(_divineIcon(DivineIconName.caretRight), findsOneWidget);
       });
 
-      testWidgets('shows chevron for an enabled verified archive', (
+      testWidgets('shows chevron for a legacy-policy verified archive', (
         tester,
       ) async {
         final video = createVideoWithoutAudio(isVerifiedArchive: true);

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -68,7 +68,7 @@ void main() {
     VideoEvent createVideoWithoutAudio({
       String? authorName,
       bool? allowAudioReuse,
-      bool isClassicVine = false,
+      bool isVerifiedArchive = false,
       InspiredByInfo? inspiredBy,
     }) {
       final now = DateTime.now();
@@ -85,8 +85,9 @@ void main() {
         rawTags: {
           if (allowAudioReuse case final allowed?)
             'allow_audio_reuse': allowed.toString(),
-          if (isClassicVine) 'platform': 'vine',
         },
+        isVerifiedArchive: isVerifiedArchive,
+        archiveAudioReuseEnabled: isVerifiedArchive,
       );
     }
 
@@ -359,7 +360,7 @@ void main() {
 
     group('Original sound reuse gating', () {
       testWidgets(
-        'is display-only (no chevron) when the creator disabled audio reuse',
+        'is display-only (no chevron) when audio reuse is unspecified',
         (tester) async {
           final video = createVideoWithoutAudio();
 
@@ -422,8 +423,10 @@ void main() {
         expect(_divineIcon(DivineIconName.caretRight), findsOneWidget);
       });
 
-      testWidgets('shows chevron for an unmarked classic Vine', (tester) async {
-        final video = createVideoWithoutAudio(isClassicVine: true);
+      testWidgets('shows chevron for an enabled verified archive', (
+        tester,
+      ) async {
+        final video = createVideoWithoutAudio(isVerifiedArchive: true);
 
         await tester.pumpWidget(buildTestWidget(video: video));
         await tester.pumpAndSettle();
@@ -436,7 +439,7 @@ void main() {
       ) async {
         final video = createVideoWithoutAudio(
           allowAudioReuse: false,
-          isClassicVine: true,
+          isVerifiedArchive: true,
         );
 
         await tester.pumpWidget(
@@ -444,7 +447,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(_divineIcon(DivineIconName.caretRight), findsNothing);
+        expect(_divineIcon(DivineIconName.caretRight), findsOneWidget);
       });
 
       testWidgets(
@@ -460,6 +463,21 @@ void main() {
           expect(_divineIcon(DivineIconName.caretRight), findsOneWidget);
         },
       );
+
+      testWidgets('shows chevron for the creator despite a malformed marker', (
+        tester,
+      ) async {
+        final video = createVideoWithoutAudio().copyWith(
+          rawTags: const {'allow_audio_reuse': 'TRUE'},
+        );
+
+        await tester.pumpWidget(
+          buildTestWidget(video: video, viewerPubkey: testPubkey),
+        );
+        await tester.pumpAndSettle();
+
+        expect(_divineIcon(DivineIconName.caretRight), findsOneWidget);
+      });
     });
 
     group('Reused sound fallback', () {
@@ -517,36 +535,35 @@ void main() {
         },
       );
 
-      testWidgets(
-        'is display-only when the reused source cannot be resolved',
-        (tester) async {
-          // hasAudioReference + unresolved source: the referenced creator's
-          // reuse consent is unconfirmable, so the row credits them but offers
-          // no reuse affordance (fail closed).
-          await tester.pumpWidget(
-            ProviderScope(
-              overrides: [
-                soundByIdProvider(
-                  testAudioEventId,
-                ).overrideWith((ref) async => null),
-              ],
-              child: MaterialApp(
-                localizationsDelegates: appLocalizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                theme: VineTheme.theme,
-                home: Scaffold(
-                  backgroundColor: Colors.black,
-                  body: MetadataSoundsSection(video: reusedVideo()),
-                ),
+      testWidgets('is display-only when the reused source cannot be resolved', (
+        tester,
+      ) async {
+        // hasAudioReference + unresolved source: the referenced creator's
+        // reuse consent is unconfirmable, so the row credits them but offers
+        // no reuse affordance (fail closed).
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              soundByIdProvider(
+                testAudioEventId,
+              ).overrideWith((ref) async => null),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: appLocalizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              theme: VineTheme.theme,
+              home: Scaffold(
+                backgroundColor: Colors.black,
+                body: MetadataSoundsSection(video: reusedVideo()),
               ),
             ),
-          );
-          await tester.pumpAndSettle();
+          ),
+        );
+        await tester.pumpAndSettle();
 
-          expect(find.text('Original sound'), findsOneWidget);
-          expect(_divineIcon(DivineIconName.caretRight), findsNothing);
-        },
-      );
+        expect(find.text('Original sound'), findsOneWidget);
+        expect(_divineIcon(DivineIconName.caretRight), findsNothing);
+      });
 
       testWidgets(
         'tapping a resolved reused sound opens the detail (no dead-end)',

--- a/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
@@ -353,7 +353,7 @@ void main() {
         expect(find.byType(AudioEditorSelectionOverlay), findsNothing);
       });
 
-      testWidgets('selects an enabled verified archive original sound', (
+      testWidgets('selects a legacy-policy verified archive original sound', (
         tester,
       ) async {
         final classicVideo = VideoEvent(

--- a/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
@@ -347,6 +347,37 @@ void main() {
         expect(find.byType(AudioEditorSelectionOverlay), findsNothing);
       });
 
+      testWidgets('selects an unmarked classic Vine original sound', (
+        tester,
+      ) async {
+        final classicVideo = VideoEvent(
+          id: 'a' * 64,
+          pubkey: 'b' * 64,
+          createdAt: 1704067200,
+          content: '',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(1704067200 * 1000),
+          videoUrl: 'https://example.com/classic.mp4',
+          rawTags: const {'platform': 'vine'},
+        );
+        final classicSound = AudioEvent.fromVideoOriginalSound(
+          classicVideo,
+          creatorName: 'Classic Creator',
+        );
+
+        await tester.pumpWidget(
+          buildWidget(trendingSoundsAsync: AsyncValue.data([classicSound])),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.videoEditorAudioCategoryCommunity));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Original sound - Classic Creator'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(AudioEditorSelectionOverlay), findsOneWidget);
+      });
+
       testWidgets('collapses repeated reuse-blocked toasts into one', (
         tester,
       ) async {

--- a/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
@@ -57,23 +57,23 @@ class _MockAudioPlaybackService extends Mock implements AudioPlaybackService {}
 /// so a test can assert on selection rather than on playback plumbing.
 _MockAudioPlaybackService _stubbedAudioService() {
   final service = _MockAudioPlaybackService();
-  when(() => service.positionStream).thenAnswer(
-    (_) => const Stream<Duration>.empty(),
-  );
-  when(() => service.durationStream).thenAnswer(
-    (_) => const Stream<Duration?>.empty(),
-  );
-  when(() => service.headphonesConnectedStream).thenAnswer(
-    (_) => const Stream<bool>.empty(),
-  );
+  when(
+    () => service.positionStream,
+  ).thenAnswer((_) => const Stream<Duration>.empty());
+  when(
+    () => service.durationStream,
+  ).thenAnswer((_) => const Stream<Duration?>.empty());
+  when(
+    () => service.headphonesConnectedStream,
+  ).thenAnswer((_) => const Stream<bool>.empty());
   when(() => service.duration).thenReturn(null);
   when(() => service.isPlaying).thenReturn(false);
-  when(() => service.playingStream).thenAnswer(
-    (_) => const Stream<bool>.empty(),
-  );
-  when(() => service.loadAudio(any())).thenAnswer(
-    (_) async => const Duration(seconds: 5),
-  );
+  when(
+    () => service.playingStream,
+  ).thenAnswer((_) => const Stream<bool>.empty());
+  when(
+    () => service.loadAudio(any()),
+  ).thenAnswer((_) async => const Duration(seconds: 5));
   when(() => service.seek(Duration.zero)).thenAnswer((_) async {});
   when(service.play).thenAnswer((_) async {});
   when(service.pause).thenAnswer((_) async {});
@@ -104,6 +104,8 @@ void main() {
       AudioPlaybackService? audioService,
       String? viewerPubkey,
       Map<String, int>? usageCounts,
+      AudioEvent? consentSound,
+      bool? consentResult,
     }) {
       final savedSoundsBloc = _MockSavedSoundsBloc();
       when(() => savedSoundsBloc.state).thenReturn(
@@ -134,6 +136,10 @@ void main() {
             soundLibraryServiceProvider.overrideWith(
               (_) async => _FakeSoundLibraryService(bundledSounds),
             ),
+            if (consentSound != null && consentResult != null)
+              audioReuseConsentProvider(
+                consentSound,
+              ).overrideWith((ref) => Future.value(consentResult)),
             if (trendingSoundsAsync != null)
               trendingSoundsProvider.overrideWith(
                 () => _FakeTrendingSounds(trendingSoundsAsync),
@@ -347,7 +353,7 @@ void main() {
         expect(find.byType(AudioEditorSelectionOverlay), findsNothing);
       });
 
-      testWidgets('selects an unmarked classic Vine original sound', (
+      testWidgets('selects an enabled verified archive original sound', (
         tester,
       ) async {
         final classicVideo = VideoEvent(
@@ -357,7 +363,8 @@ void main() {
           content: '',
           timestamp: DateTime.fromMillisecondsSinceEpoch(1704067200 * 1000),
           videoUrl: 'https://example.com/classic.mp4',
-          rawTags: const {'platform': 'vine'},
+          isVerifiedArchive: true,
+          archiveAudioReuseEnabled: true,
         );
         final classicSound = AudioEvent.fromVideoOriginalSound(
           classicVideo,
@@ -365,7 +372,11 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildWidget(trendingSoundsAsync: AsyncValue.data([classicSound])),
+          buildWidget(
+            trendingSoundsAsync: AsyncValue.data([classicSound]),
+            consentSound: classicSound,
+            consentResult: true,
+          ),
         );
         await tester.pumpAndSettle();
 

--- a/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
@@ -133,13 +133,17 @@ void main() {
             authServiceProvider.overrideWithValue(
               _StubAuthService(viewerPubkey),
             ),
+            audioReuseConsentProvider.overrideWith(
+              (ref, sound) async {
+                if (sound.hasExplicitReuseConsent && !sound.allowsReuse) {
+                  return false;
+                }
+                return sound.id != consentSound?.id || (consentResult ?? true);
+              },
+            ),
             soundLibraryServiceProvider.overrideWith(
               (_) async => _FakeSoundLibraryService(bundledSounds),
             ),
-            if (consentSound != null && consentResult != null)
-              audioReuseConsentProvider(
-                consentSound,
-              ).overrideWith((ref) => Future.value(consentResult)),
             if (trendingSoundsAsync != null)
               trendingSoundsProvider.overrideWith(
                 () => _FakeTrendingSounds(trendingSoundsAsync),


### PR DESCRIPTION
Classic Vine audio is available for lip-syncing, remixing, and similar reuse by default. The only creator-specific exception is an explicit takedown through Divine's existing process. A takedown blocks new reuse from that moment forward; it does not retroactively remove remixes created before the notice.

The app limits that policy to authoritatively verified archive records. A classic is eligible only when Funnelcake supplies both `verified_archive=true` and the rollout signal `archive_audio_reuse_enabled=true`; a self-authored `platform=vine` tag cannot claim classic status. Imported or historical `allow_audio_reuse` tags do not represent an original Viner's takedown and therefore do not override the classic policy.

Before a non-owner selects or publishes reused audio, the app refreshes the selected video's current takedown status through the no-store `POST /api/videos/audio-reuse/bulk` contract from divinevideo/divine-funnelcake#1217. The request uses the logical video coordinate, so the decision follows edits and replacement media. A current suppression blocks new reuse. Missing, malformed, expired, or unavailable policy also blocks the action so a takedown cannot be bypassed during an outage. The creator-owner exception remains intact.

Ordinary Divine videos continue to use their creator-controlled `allow_audio_reuse` setting. New publishes and metadata replacements write `allow_audio_reuse=false` when that toggle is off.

## Draft blockers — do not merge

- [x] divinevideo/divine-funnelcake#1182 is deployed with authoritative `verified_archive` and default-off `archive_audio_reuse_enabled` fields
- [ ] divinevideo/divine-funnelcake#1217 is approved, merged, and deployed so creator suppression is authoritative
- [ ] #8774 has an accessible creator opt-out and takedown path
- [x] External counsel review was completed on 2026-09-09 and the legal policy decision is recorded in #8464
- [x] Product approval by Liz Sweigart is recorded in #8464

Issue #221 is deliberately not changed by this PR.

## Verification

- Pre-push changed-file suite: 882 tests passed
- Targeted Flutter analysis: no issues
- Generated Riverpod output verified
- `git diff --check`: clean
- No merge conflicts with `main`

Refs #8464
Closes #8769
Related to #8774
Depends on divinevideo/divine-funnelcake#1217

