### PR TITLE
fix(release): keep Zapstore icon aligned with iOS

### DIFF
--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -14,6 +14,7 @@ tags:
     - decentralized
 license: MPL-2.0
 website: https://divine.video
+icon: ./mobile/assets/icon/app_icon.png
 match: ".*arm64.*\\.apk$"
 supported_nips:
     - "01"


### PR DESCRIPTION
## Problem

Zapstore can display a different app icon from the one people see on iOS because the listing currently inherits its artwork from Google Play. The Play listing is using another valid brand variant, so the two storefronts have drifted apart.

## Why this fix

The Zapstore configuration now names the same canonical 1024×1024 source used to generate the iOS app icon. Explicit YAML metadata takes priority over Play Store enrichment, which keeps the app artwork stable while preserving Play Store enrichment for descriptions and other listing metadata.

## Scope

This does not change the app binary, Google Play listing, feature graphic, screenshots, or the Zapstore publisher's Nostr profile. Those credentialed updates remain tracked in #8468.

## Verification

- `git diff --check origin/main...HEAD`
- `go run github.com/zapstore/zsp@latest publish --check zapstore.yaml`
  - resolved package: `co.openvine.app`
- Confirmed `mobile/assets/icon/app_icon.png` exists and is byte-identical to `mobile/assets/icon/Divine-1024.png`

Refs #8468
