### PR TITLE
fix(privacy): redact filesystem paths from bug report diagnostics

### DIFF
--- a/mobile/lib/config/bug_report_config.dart
+++ b/mobile/lib/config/bug_report_config.dart
@@ -67,7 +67,7 @@ const _credentialValue =
 ///
 /// Quote-specific rules run first and, when the path sits inside quotes (the
 /// dominant exception form,
-/// `path = '/Users/name/My Song.m4a'`), consumes to the closing quote so a
+/// `path = '/Users/name/My Song.m4a'`), consume to the closing quote so a
 /// basename containing spaces or brackets is redacted whole. Redacting only the
 /// account name and leaving the filename beside a `[REDACTED]` marker would be
 /// the partial leak this file elsewhere calls worse than none.

--- a/mobile/lib/config/bug_report_config.dart
+++ b/mobile/lib/config/bug_report_config.dart
@@ -65,8 +65,8 @@ const _credentialValue =
 /// `local_audio_import_service` preserves verbatim into the stored path and so
 /// into any `FileSystemException` about it.
 ///
-/// Two tails cover the two renders. [_filesystemPathQuotedTail] runs first and,
-/// when the path sits inside quotes (the dominant exception form,
+/// Quote-specific rules run first and, when the path sits inside quotes (the
+/// dominant exception form,
 /// `path = '/Users/name/My Song.m4a'`), consumes to the closing quote so a
 /// basename containing spaces or brackets is redacted whole. Redacting only the
 /// account name and leaving the filename beside a `[REDACTED]` marker would be
@@ -97,10 +97,10 @@ const _credentialValue =
 /// with a `{1,255}` or `{0,4000}` cap and no nested quantifier, so matching
 /// cannot backtrack superlinearly and one match cannot run past the bound on
 /// the UI thread. Known residuals, accepted like the credential rule's own: a
-/// basename containing whitespace (when unquoted) or an unescaped quote leaks
-/// the fragment after it, a path tail beyond 4000 characters keeps its end, and
-/// purely internal roots (`/data/media`, `/mnt`, `/var/mobile/Media`) are not
-/// matched. The deanonymizing account name is redacted in every case.
+/// basename containing whitespace (when unquoted), a path tail beyond 4000
+/// characters keeps its end, and purely internal roots (`/data/media`, `/mnt`,
+/// `/var/mobile/Media`) are not matched. The deanonymizing account name is
+/// redacted in every case.
 const _filesystemPathRoot =
     r'''(?:[/\\]Users[/\\]'''
     r'''|[/\\]home[/\\][^\s'",;)\]}/\\]{1,255}[/\\]'''
@@ -110,10 +110,6 @@ const _filesystemPathRoot =
 /// Tail for an unquoted path: stops at the first whitespace or delimiter so it
 /// does not consume the surrounding log line.
 const _filesystemPathTail = r'''[^\s'",;)\]}]{0,4000}''';
-
-/// Tail for a quoted path: consumes to the closing quote or newline, so a
-/// basename with spaces or brackets is redacted whole.
-const _filesystemPathQuotedTail = r'''[^'"\n]{0,4000}''';
 
 /// Configuration for bug report system
 class BugReportConfig {
@@ -233,10 +229,19 @@ class BugReportConfig {
       caseSensitive: false,
     ),
     // Filesystem paths rooted at a user or app-sandbox directory. See
-    // [_filesystemPathRoot]. The quoted rule runs first so a quoted path with a
-    // spaced basename is redacted whole before the unquoted rule can stop at
-    // the space and strand the filename beside the marker.
-    RegExp('''(?<=['"])$_filesystemPathRoot$_filesystemPathQuotedTail'''),
+    // [_filesystemPathRoot]. Quote-specific rules run first so a quoted path
+    // with a spaced basename is redacted whole before the unquoted rule can
+    // stop at the space and strand the filename beside the marker. Requiring
+    // the matching closing quote keeps malformed input from consuming the rest
+    // of its diagnostic line.
+    RegExp(
+      "(?<=')$_filesystemPathRoot"
+      r"[^'\n]{0,4000}(?=')",
+    ),
+    RegExp(
+      '(?<=")$_filesystemPathRoot'
+      r'[^"\n]{0,4000}(?=")',
+    ),
     RegExp('$_filesystemPathRoot$_filesystemPathTail'),
   ];
 

--- a/mobile/lib/config/bug_report_config.dart
+++ b/mobile/lib/config/bug_report_config.dart
@@ -55,6 +55,66 @@ const _credentialValue =
     r"""|'(?:''|\\.|[^'\\\n])*'"""
     r'''|["']?(?:(?:bearer|basic|token)\s+)?[^\s"',;}]+)''';
 
+/// A filesystem path rooted at a user or app-sandbox directory.
+///
+/// The whole path is redacted, not one segment: the report already carries the
+/// platform in its device info, so the root marker (`/Users`, an iOS
+/// container, an Android data dir) adds no triage value worth a partial leak.
+/// The tail that gets consumed is where the PII lives, a desktop account name
+/// (`/Users/<name>`) and the user-chosen basename of an imported file, which
+/// `local_audio_import_service` preserves verbatim into the stored path and so
+/// into any `FileSystemException` about it.
+///
+/// Two tails cover the two renders. [_filesystemPathQuotedTail] runs first and,
+/// when the path sits inside quotes (the dominant exception form,
+/// `path = '/Users/name/My Song.m4a'`), consumes to the closing quote so a
+/// basename containing spaces or brackets is redacted whole. Redacting only the
+/// account name and leaving the filename beside a `[REDACTED]` marker would be
+/// the partial leak this file elsewhere calls worse than none.
+/// [_filesystemPathTail] then handles an unquoted path, stopping at the next
+/// whitespace or delimiter so it does not swallow the surrounding log line.
+///
+/// The lowercase `/home/` branch requires the account name to be followed by a
+/// further separator, so a real path (`/home/<name>/<file>`) matches while the
+/// terminal `/home/<index>` video-feed route (`RoutePaths.videoFeedForIndex`)
+/// does not; that separator is a correctness device, not a performance one.
+/// `/Users` (macOS/Windows) and `/Volumes` (external drives) collide with no
+/// route, so they need no such guard and also redact a bare `/Users/<name>`;
+/// the app-sandbox roots collide with no route either.
+///
+/// URLs, GoRouter routes, and `package:` / `dart:` references carry no account
+/// name and are triage-critical, so they are left intact - with one safe
+/// exception: the root is unanchored, so a URL whose *path* contains a covered
+/// segment (a capital `/Users/`, `/home/<seg>/`, `/Volumes/`, or a sandbox
+/// root) is over-redacted from that segment on. That is over-redaction, never a
+/// leak, and it does not touch Divine's own triage URLs - content-addressed
+/// media, host-only relay, and the terminal `/home/<index>` route all survive,
+/// and the match is case-sensitive so lowercase web routes like `/users/` are
+/// untouched. URL secrets (userinfo, `?token=`) are handled by the credential
+/// rules above and by `redactUriStringForLogs` at the structured log sites.
+///
+/// Linearity comes from the bounds: every segment is a single character class
+/// with a `{1,255}` or `{0,4000}` cap and no nested quantifier, so matching
+/// cannot backtrack superlinearly and one match cannot run past the bound on
+/// the UI thread. Known residuals, accepted like the credential rule's own: a
+/// basename containing whitespace (when unquoted) or an unescaped quote leaks
+/// the fragment after it, a path tail beyond 4000 characters keeps its end, and
+/// purely internal roots (`/data/media`, `/mnt`, `/var/mobile/Media`) are not
+/// matched. The deanonymizing account name is redacted in every case.
+const _filesystemPathRoot =
+    r'''(?:[/\\]Users[/\\]'''
+    r'''|[/\\]home[/\\][^\s'",;)\]}/\\]{1,255}[/\\]'''
+    r'''|(?:/private)?/var/mobile/Containers/|/data/user/\d{1,4}/|/data/data/'''
+    r'''|/storage/emulated/\d{1,4}/|/Volumes/)''';
+
+/// Tail for an unquoted path: stops at the first whitespace or delimiter so it
+/// does not consume the surrounding log line.
+const _filesystemPathTail = r'''[^\s'",;)\]}]{0,4000}''';
+
+/// Tail for a quoted path: consumes to the closing quote or newline, so a
+/// basename with spaces or brackets is redacted whole.
+const _filesystemPathQuotedTail = r'''[^'"\n]{0,4000}''';
+
 /// Configuration for bug report system
 class BugReportConfig {
   /// Maximum log entries to include in bug report
@@ -172,6 +232,12 @@ class BugReportConfig {
       r'\b[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\.[A-Z]{2,24}\b',
       caseSensitive: false,
     ),
+    // Filesystem paths rooted at a user or app-sandbox directory. See
+    // [_filesystemPathRoot]. The quoted rule runs first so a quoted path with a
+    // spaced basename is redacted whole before the unquoted rule can stop at
+    // the space and strand the filename beside the marker.
+    RegExp('''(?<=['"])$_filesystemPathRoot$_filesystemPathQuotedTail'''),
+    RegExp('$_filesystemPathRoot$_filesystemPathTail'),
   ];
 
   /// Log levels to include in bug reports (all by default)

--- a/mobile/test/config/bug_report_config_test.dart
+++ b/mobile/test/config/bug_report_config_test.dart
@@ -157,6 +157,91 @@ void main() {
       }
     });
 
+    group('redacts filesystem paths that carry PII', () {
+      // Each case pairs a path shape that reaches the log buffer through an
+      // exception toString() with the PII fragment that must not survive: a
+      // desktop account name, an install UUID, or a user-chosen imported-file
+      // basename. The whole path is redacted rather than one segment: the
+      // platform is already in the report's device info, so the FS root marker
+      // adds no triage value worth the risk of a partial leak.
+      const cases = <String, ({String input, String forbidden})>{
+        'macos home account name': (
+          input:
+              "PathNotFoundException: path = '/Users/mjbradley/Library/Preferences/app.plist'",
+          forbidden: 'mjbradley',
+        ),
+        'macos home directory terminal': (
+          input: "FileSystemException: directory '/Users/mjbradley' is gone",
+          forbidden: 'mjbradley',
+        ),
+        // A quoted path (the dominant exception render) whose basename holds a
+        // space must redact whole. Stopping at the space would leave the
+        // filename fragment beside the marker, a partial leak.
+        'macos home spaced filename quoted': (
+          input:
+              "FileSystemException: path = '/Users/mjbradley/Music/My Song.m4a'",
+          forbidden: 'Song',
+        ),
+        'ios container spaced filename quoted': (
+          input:
+              "FileSystemException: path = '/var/mobile/Containers/Data/Application/1A2B3C4D-5E6F-7A8B-9C0D-1E2F3A4B5C6D/tmp/My Song.m4a'",
+          forbidden: 'Song',
+        ),
+        'macos external volume spaced filename quoted': (
+          input:
+              "FileSystemException: path = '/Volumes/Backup Drive/Music/My Song.m4a'",
+          forbidden: 'My Song',
+        ),
+        'linux home account name': (
+          input:
+              "FileSystemException: Cannot open, path = '/home/mbradley/notes.txt'",
+          forbidden: 'mbradley',
+        ),
+        'windows home account name': (
+          input: r'PathNotFoundException: C:\Users\mbradley\AppData\Local\Temp',
+          forbidden: 'mbradley',
+        ),
+        'ios container user filename': (
+          input:
+              "FileSystemException: path = '/var/mobile/Containers/Data/Application/1A2B3C4D-5E6F-7A8B-9C0D-1E2F3A4B5C6D/Documents/draft_audio_imports/d1/1699999999000_My_Song.m4a'",
+          forbidden: 'My_Song',
+        ),
+        'ios container install uuid': (
+          input:
+              "FileSystemException: path = '/var/mobile/Containers/Data/Application/1A2B3C4D-5E6F-7A8B-9C0D-1E2F3A4B5C6D/Documents/x.m4a'",
+          forbidden: '1A2B3C4D',
+        ),
+        'android app-data user filename': (
+          input:
+              '/data/user/0/video.divine.app/cache/1699999999000_My_Song.m4a (No such file)',
+          forbidden: 'My_Song',
+        ),
+        'android shared-storage user filename': (
+          input: '/storage/emulated/0/Download/1699999999000_My_Song.m4a',
+          forbidden: 'My_Song',
+        ),
+        'macos container user filename via home root': (
+          input:
+              "path = '/Users/mjbradley/Library/Containers/video.divine.app/Data/Documents/draft_audio_imports/d1/1699999999000_My_Song.m4a'",
+          forbidden: 'My_Song',
+        ),
+      };
+
+      for (final entry in cases.entries) {
+        test(entry.key, () {
+          final sanitized = sanitizeDiagnosticText(entry.value.input);
+
+          expect(sanitized, contains('[REDACTED]'));
+          expect(
+            sanitized,
+            isNot(contains(entry.value.forbidden)),
+            reason:
+                'leaked "${entry.value.forbidden}" from ${entry.value.input}',
+          );
+        });
+      }
+    });
+
     test('an unbalanced quote costs one word, not the rest of the report', () {
       // A quoted branch that tolerated a missing closing quote would run to
       // the end of the payload, so a user typing `password: "test1` into
@@ -355,6 +440,34 @@ void main() {
         'the login token expired instantly and I got logged out',
         'Secret DMs are not decrypting',
         'Token refresh scheduled',
+        // Triage-critical URLs and routes must survive. The team keeps hosts
+        // and routes by design (see redactUriStringForLogs), and a media or
+        // relay URL is often the whole point of a report.
+        'https://media.divine.video/abcdef0123456789.mp4',
+        'wss://relay.divine.video',
+        'GoRouterState: /video/abcdef0123',
+        '/invite',
+        // `/home/<index>` is the video-feed route (RoutePaths.videoFeedForIndex),
+        // not a Unix home directory. A home-dir path always has content below
+        // the account name; the route is terminal, so it must survive.
+        'navigated to /home/3',
+        'GoRouterState: /home/12',
+        // The quoted-path rule must not fire on a quoted value that is not a
+        // path rooted at a covered directory.
+        "error detail: 'connection reset by peer'",
+        "resource url: 'https://media.divine.video/abcdef0123456789.mp4'",
+        // The root is case-sensitive, so a lowercase `/users/` web-route
+        // segment in a URL is not mistaken for a macOS home directory. This
+        // guards against a regression that made the pattern case-insensitive.
+        'https://example.com/users/profile/123',
+        // Package and SDK references in stack frames are not PII.
+        'package:openvine/services/local_audio_import_service.dart:54:11',
+        'dart:async/zone.dart 1234:5',
+        // Absolute system paths carry no account name or user file.
+        '/usr/local/bin/dart',
+        '/System/Library/Frameworks/Foundation.framework',
+        // A relative asset path is not user data.
+        'assets/images/logo.png',
       ];
 
       for (final input in cases) {

--- a/mobile/test/config/bug_report_config_test.dart
+++ b/mobile/test/config/bug_report_config_test.dart
@@ -240,6 +240,48 @@ void main() {
           );
         });
       }
+
+      test('quoted path preserves surrounding diagnostic context', () {
+        const input =
+            "FileSystemException: path = '/Users/mjbradley/Music/My Song.m4a' "
+            '(OS Error: No such file, errno = 2)';
+
+        expect(
+          sanitizeDiagnosticText(input),
+          equals(
+            "FileSystemException: path = '[REDACTED]' "
+            '(OS Error: No such file, errno = 2)',
+          ),
+        );
+      });
+
+      test('unbalanced path quote preserves later diagnostic context', () {
+        const input =
+            "path = '/Users/mjbradley/song.m4a then relay "
+            'wss://relay.divine.video and event abc123';
+
+        expect(
+          sanitizeDiagnosticText(input),
+          equals(
+            "path = '[REDACTED] then relay "
+            'wss://relay.divine.video and event abc123',
+          ),
+        );
+      });
+
+      test('apostrophe in a double-quoted path is redacted whole', () {
+        const input =
+            'path = "/Users/mjbradley/Music/it\'s here.m4a" next '
+            'https://media.divine.video/a.mp4';
+
+        expect(
+          sanitizeDiagnosticText(input),
+          equals(
+            'path = "[REDACTED]" next '
+            'https://media.divine.video/a.mp4',
+          ),
+        );
+      });
     });
 
     test('an unbalanced quote costs one word, not the rest of the report', () {


### PR DESCRIPTION
## Description

`sanitizeDiagnosticText` is the boundary every bug report field and log line passes through before it reaches Zendesk. Its `sensitivePatterns` set redacts `nsec`/`ncryptsec` keys, credential key/value pairs, and email, but nothing for filesystem paths. Issue #8308 traced the consequence: exception `toString()` text (surfaced through the Bloc observer's log line and the many `Log.error('...: $e')` sites) carries paths that reveal a desktop account name (`/Users/<name>`) and, most concretely, the user-chosen basename of an imported audio file, which `local_audio_import_service` preserves verbatim into the stored path and therefore into any `FileSystemException` about it. Zendesk reports are one-way, so whatever the log carries is what a human reads.

This adds a filesystem-path rule to `sensitivePatterns`. It redacts paths rooted at a home or app-sandbox directory: home dirs (`/Users/…`, `/home/<name>/…`, `\Users\…`), macOS external volumes (`/Volumes/…`), iOS containers (`/var/mobile/Containers/…`), and Android app/shared storage (`/data/user/N/…`, `/data/data/…`, `/storage/emulated/N/…`). Two tails cover the two renders: a **quoted** rule runs first and consumes to the closing quote (the dominant `FileSystemException` form, `path = '…'`), so a basename containing spaces is redacted whole instead of stranding the filename beside the `[REDACTED]` marker; an **unquoted** rule then stops at the next whitespace or delimiter so it does not swallow the surrounding log line.

URLs, GoRouter routes, and `package:`/`dart:` references are deliberately left intact — they are triage-critical and carry no account name, URL secrets are already handled by the existing credential/email rules and `redactUriStringForLogs`, and the `/home/` branch requires a deeper path so the terminal `/home/<index>` feed route (`RoutePaths.videoFeedForIndex`) survives. Matching is a bounded single character class throughout, so it stays linear on the UI thread. Known residuals (an unquoted or unescaped-quote basename fragment, a >4000-char tail, purely internal roots) are documented in the code; the deanonymizing account name is redacted in every case.

**Related Issue:** Closes #8308

## Out of Scope

Two sibling hardenings the issue mentioned are not pursued to keep this focused on the boundary that governs every producer:

- Normalizing the Bloc observer to log `runtimeType` plus curated fields instead of the raw error. The observer is one of many producers; the report-boundary redaction here closes the leak for all of them, and stripping its raw error costs on-device debugging signal.
- Redacting a bare 64-hex private key in `sanitizeForCrashReport` (the Crashlytics path). Different function and threat surface, and it would reintroduce the 64-hex-vs-triage tradeoff the credential rules deliberately resolved in favor of keeping public pubkeys and event ids. The issue files it under "not this issue."

## Verification

- `flutter test test/config/bug_report_config_test.dart` (151 passing): PII-path redaction cases (home account names, iOS/Android/macOS sandbox paths, quoted spaced filenames, `/Volumes/`), triage-preservation cases (media/relay URLs, `/video` and `/home/<index>` routes, `package:`/`dart:` refs, system/asset paths, case-sensitivity of `/users/`), and still-redacts-`nsec`.
- Downstream sanitizer consumers green: `bug_report_service`, `zendesk_support_service`, `content_reporting_service`, `bug_report_log_summary`, `report_submission_cubit`.
- `flutter analyze lib test` and `dart format` clean.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

