### PR TITLE
fix(observability): redact ncryptsec in sanitizeForCrashReport

### DIFF
--- a/mobile/lib/observability/reportable_error.dart
+++ b/mobile/lib/observability/reportable_error.dart
@@ -58,6 +58,7 @@ final class Reportable<T extends Object> implements ReportableError {
 
 final RegExp _npubPattern = RegExp('npub1[a-z0-9]+');
 final RegExp _nsecPattern = RegExp('nsec1[a-z0-9]+');
+final RegExp _ncryptsecPattern = RegExp('ncryptsec1[a-z0-9]+');
 // Conservative email matcher: local-part of common chars then `@`, host with
 // at least one `.`. Intentionally narrower than RFC 5322 — false negatives on
 // exotic addresses are preferable to false positives on non-email strings.
@@ -65,22 +66,30 @@ final RegExp _emailPattern = RegExp(
   r'[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}',
 );
 
-/// Strips Nostr `npub1…` / `nsec1…` identifiers and email addresses from
-/// [input] before it is forwarded to a third-party crash reporter.
+/// Strips Nostr `npub1…` / `nsec1…` / `ncryptsec1…` identifiers and email
+/// addresses from [input] before it is forwarded to a third-party crash
+/// reporter.
 ///
 /// Scope is intentionally narrow:
-/// - Nostr: only `npub` (public-key bech32) and `nsec` (private-key bech32).
-///   Other Nostr-format references (`note1`, `nevent1`, `nprofile1`) encode
-///   event/profile pointers, not secrets, and removing them removes triage
-///   value. Call sites that need to redact those should do so explicitly
-///   before constructing the error message.
+/// - Nostr: `npub` (public-key bech32), plus the two private-key encodings
+///   `nsec` (raw bech32) and `ncryptsec` (NIP-49 encrypted). `ncryptsec` is
+///   the same class of private-key material as `nsec` and must not reach a
+///   third-party processor. Other Nostr-format references (`note1`, `nevent1`,
+///   `nprofile1`) encode event/profile pointers, not secrets, and removing
+///   them removes triage value. Call sites that need to redact those should do
+///   so explicitly before constructing the error message.
 /// - Email: any RFC-5321-ish local@host.tld pattern. Replacement delegates to
 ///   [redactEmailForLogs] so log redaction and crash-report redaction stay in
 ///   lockstep.
+///
+/// Credential key/value pairs and filesystem paths are covered by the Zendesk
+/// path (`BugReportConfig.sensitivePatterns`) but not yet here; see #8475 for
+/// the shared-source alignment that closes that divergence.
 String sanitizeForCrashReport(String input) {
   return input
       .replaceAll(_npubPattern, 'npub1<redacted>')
       .replaceAll(_nsecPattern, 'nsec1<redacted>')
+      .replaceAll(_ncryptsecPattern, 'ncryptsec1<redacted>')
       .replaceAllMapped(
         _emailPattern,
         // Reuse the log helper here so both redaction surfaces stay aligned.

--- a/mobile/test/observability/reportable_error_test.dart
+++ b/mobile/test/observability/reportable_error_test.dart
@@ -69,6 +69,17 @@ void main() {
       expect(wrapped.toString(), contains('nsec1<redacted>'));
       expect(wrapped.toString(), isNot(contains(nsec)));
     });
+
+    test('toString sanitizes ncryptsec identifiers in the inner message', () {
+      const ncryptsec =
+          'ncryptsec1qgtt2vq2vezy5xkdz6h2r3n3zqk3z0lqjx2vy7c8y9rfa2q6l3sh0';
+      final wrapped = Reportable(
+        StateError('Signer leaked $ncryptsec to logs'),
+      );
+
+      expect(wrapped.toString(), contains('ncryptsec1<redacted>'));
+      expect(wrapped.toString(), isNot(contains(ncryptsec)));
+    });
   });
 
   group('sanitizeForCrashReport', () {
@@ -86,6 +97,20 @@ void main() {
       const input = 'leaked nsec1qwertyuiopasdfghjklzxcvbnm0123456789abcdef';
 
       expect(sanitizeForCrashReport(input), 'leaked nsec1<redacted>');
+    });
+
+    test('replaces a single ncryptsec with the redaction marker', () {
+      // ncryptsec (NIP-49 encrypted private key) is the same class of
+      // private-key material as nsec and must not reach the third-party
+      // crash reporter. It is not a substring of nsec, so the two rules do
+      // not overlap.
+      const input =
+          'failed to decrypt ncryptsec1qgtt2vq2vezy5xkdz6h2r3n3zqk3z0lqjx';
+
+      expect(
+        sanitizeForCrashReport(input),
+        'failed to decrypt ncryptsec1<redacted>',
+      );
     });
 
     test('replaces multiple identifiers in the same string', () {


### PR DESCRIPTION
## Description

`sanitizeForCrashReport` (`mobile/lib/observability/reportable_error.dart`) is the single chokepoint for text forwarded to the third-party crash reporter — reached via `Reportable.toString()`, `DivineBlocObserver`'s custom keys, and `invite_error_utils`. It redacted `npub`, `nsec`, and email, but **not `ncryptsec`**. A NIP-49 encrypted private key is the same class of private-key material as `nsec` — AGENTS.md lists the two together as secrets that must never reach a log — so an `ncryptsec` in a forwarded bloc error was reaching Crashlytics in the clear.

This adds the `ncryptsec1…` bech32 prefix to the redaction chain, redacting it to `ncryptsec1<redacted>` exactly as `nsec` is handled. The two rules do not overlap (`ncryptsec1…` contains no `nsec1` substring, and the `nsec` pass runs on the original text before the `ncryptsec` marker exists). The deliberate differences with the Zendesk sanitizer are untouched: this path still redacts `npub` (which Zendesk keeps for triage) and still masks email to `u***@domain` (preserving the domain for correlation).

**Related Issue:** Refs #8475

## Out of Scope

This is the cleanly-shippable slice of #8475. Two things are intentionally deferred there, with reasoning:

- **Credential and filesystem-path alignment on the Crashlytics path.** Those are the ReDoS-bounded patterns in `bug_report_config.dart` — the file #8470 is editing. The correct fix is a shared secret-pattern source consumed by both sanitizers (so they cannot drift again); copying the patterns here now would recreate that drift, and editing `bug_report_config.dart` now would collide with #8470. Sequenced after #8470 merges.
- **Bloc-observer `$error` normalization** (deferred Item A from #8308) and **literal bare-64-hex redaction** (deferred Item B, literal form) are documented in #8475 as not-doing, with reasoning (superseded by boundary redaction; and indistinguishable from public identifiers that triage keeps, respectively).

## Verification

- `flutter test test/observability/reportable_error_test.dart` (20 passing): new `ncryptsec` cases on both the `Reportable.toString()` wrapper path and `sanitizeForCrashReport` directly; existing `npub` / `nsec` / email / note1 cases still green (no regression, domain-preserving email mask intact).
- `flutter analyze lib/observability test/observability` and `dart format` clean.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
