### PR TITLE
test(enforcement): restore the guard against rendering a moderation reason

### DIFF
--- a/docs/superpowers/specs/2026-09-01-enforcement-reason-durability-design.md
+++ b/docs/superpowers/specs/2026-09-01-enforcement-reason-durability-design.md
@@ -1,0 +1,144 @@
+# A durable home for the enforcement reason
+
+Design for [#8304](https://github.com/divinevideo/divine-mobile/issues/8304).
+Product half: `support-trust-safety#200`. Status: **design only — no implementation.**
+
+Written 2026-09-01 against `origin/main` `5d4d5a46fa`.
+
+## Summary
+
+#8304 asks for the moderation enforcement reason to be given a durable home
+outside the one-shot NIP-17 DM. Investigation found that the issue treats one
+problem where there are two, and that they have opposite shapes:
+
+| | Account-level (suspend / ban) | Content-level (per video) |
+|---|---|---|
+| Does a reason exist? | **No** | **Yes** — a reviewed six-category taxonomy |
+| Where does it live? | nowhere user-presentable | **only** in the DM |
+| Recommended action | confirm the omission; restore the guard | give the category a durable home |
+
+The account-level half needs a decision and no code. The content-level half is
+the real gap, and it is not the one the issue's proposal addresses.
+
+## Finding that drives the split
+
+The account-level enforcement DM carries no reason. Its templates take no
+parameters, and the template selector deliberately discards the reason argument
+for account-level actions. So the proposal in #8304 — *"`AccountStatusResponse`
+gains an optional human-readable reason … the moderation service already has
+the exact string"* — has no string to gain.
+
+What a user actually loses when that DM is destroyed is not the reason; it is
+the **appeal instruction**. The Account Status screen already replaces that with
+a Contact Support button, reachable without a failed post.
+
+The content-level templates are different: six categories, each with reviewed
+English copy and a policy URL, selected from the moderation categories on the
+action. That reason is specific, is real, and lives in exactly one destructible
+place.
+
+## Why no existing stored field can be surfaced
+
+Three independent stores hold something called a "reason". None is fit to send.
+
+1. **Keycast `users.suspended_reason`** — its admin API accepts arbitrary
+   caller-supplied text (sanitised for control characters and truncated, but
+   validated against no set), while Divine's only production writer constrains
+   it to four internal tags. Untrusted by contract; an untranslated token in
+   practice.
+2. **Funnelcake's enforcement tables** — free text supplied by whoever performed
+   the action, with a default that carries operator context when none is given.
+   Tracked separately as a disclosure risk; not usable as user-facing copy.
+3. **The moderation service's sent-message log** — holds the rendered DM body,
+   so for account actions it holds the same generic sentence, and for content
+   actions it holds the category copy. This is the one store whose contents are
+   already reviewed, because they are what was sent.
+
+The common failure is the same in all three: an operator-facing note and a
+user-facing explanation are being treated as the same field. They are not, and
+no amount of plumbing makes one into the other.
+
+## Recommendation
+
+### Part 1 — account level: confirm, do not build
+
+Recommend T&S confirm that account-level enforcement carries no per-account
+reason, because none exists to carry. This is the exit #8304's author offered
+("If the answer is 'the reason stays private', say so and this closes"), and the
+evidence supports it more strongly than the issue assumed.
+
+Two consequences, both already true and worth stating:
+
+- The generic copy the Account Status screen shows is not a placeholder for a
+  specific reason that exists elsewhere. It is the whole message.
+- Because the DM is the only carrier of the appeal instruction, the guards that
+  keep it from being destroyed remain load-bearing rather than defensive.
+
+If T&S instead wants account actions to carry a category, that is **new product
+work**: assigning a category at enforcement time, which nothing does today. It
+is not exposure of an existing field.
+
+### Part 2 — content level: give the category a durable home
+
+Surface the per-content moderation **category** — a closed enum drawn from the
+existing six — on a self-authenticated, owner-scoped surface, next to the
+content it describes.
+
+The natural anchor already exists: funnelcake's owner-export path is
+self-authenticated, carries a per-event moderation annotation today, and is
+deliberately available to suspended and banned accounts. Extending that
+annotation from a status to a status-plus-category is a smaller change than a
+new endpoint, and it inherits the auth binding that is already in place.
+
+Client side: render the category on the owner's own view of the affected video
+(My Library / video detail), mapping enum to copy through `context.l10n`,
+exactly as `AccountEnforcementKind` is mapped today.
+
+## Invariants any implementation must hold
+
+1. **No free text crosses the boundary.** The wire carries a closed enum only.
+   Copy is chosen client-side. This is what makes the surface safe, and it is
+   the same shape the account status surface already uses.
+2. **The operator note and the user-facing category are different fields.**
+   Never the same column, never derived from one another.
+3. **Owner-scoped, self-authenticated**, with the same caller-equals-subject
+   binding the account status endpoint enforces.
+4. **Localised** across all supported locales before shipping — six categories,
+   not free text, is what makes that possible at all.
+5. **The self-harm category's crisis-line text is part of its copy** and must
+   survive the move; it is currently spliced in at render time and is
+   deliberately excluded from account-level notices.
+
+## Risks and open decisions
+
+- **OQ-1 (T&S, blocking Part 2).** Publishing the category tells a user which
+  classification tripped. That is the substance of s-t-s#200's "how much reason
+  do we give", and it is a policy call, not an engineering one.
+- **OQ-2 (owner needed).** Part 2 is a funnelcake schema and API change; it
+  needs an owner in that repo.
+- **A ban purges content.** The per-event annotation may have nothing left to
+  attach to after a ban, since a ban deletes the author's events. The owner
+  export snapshot is the surviving artifact and is therefore the correct anchor
+  — designing against the live event tables would produce a surface that is
+  empty exactly for the users who most need it.
+- **Web and mobile currently disagree on the source of truth** for account
+  status. That divergence should be settled before either client renders a
+  reason, or the two will disagree about more than plumbing.
+
+## Non-goals
+
+- No appeals workflow. None exists in any repo; this design does not add one.
+- No change to any enforcement decision, threshold, or process.
+- No exposure of reviewer identity, rule identifiers, thresholds, or scores.
+- No email or push notification.
+
+## What was shipped alongside this design
+
+Two commits, neither of which requires the decision above:
+
+- Restored the client-side guard that a moderation reason cannot influence
+  enforcement state — a rationale and test that existed, then were removed as
+  collateral of a source change rather than by re-decision.
+- Documented why Keycast's `suspendedReason` is parsed and deliberately never
+  read, so it is neither deleted as dead code nor wired up as "the reason we
+  already have".

--- a/docs/superpowers/specs/2026-09-01-enforcement-reason-durability-design.md
+++ b/docs/superpowers/specs/2026-09-01-enforcement-reason-durability-design.md
@@ -1,7 +1,9 @@
 # A durable home for the enforcement reason
 
-Design for [#8304](https://github.com/divinevideo/divine-mobile/issues/8304).
-Product half: `support-trust-safety#200`. Status: **design only — no implementation.**
+Decision record for [#8304](https://github.com/divinevideo/divine-mobile/issues/8304).
+Product basis: `support-trust-safety#200`. Content-category follow-up:
+`support-trust-safety#214`. Status: **account-level policy decided; content-level
+policy remains open.**
 
 Written 2026-09-01 against `origin/main` `5d4d5a46fa`.
 
@@ -15,10 +17,12 @@ problem where there are two, and that they have opposite shapes:
 |---|---|---|
 | Does a reason exist? | **No** | **Yes** — a reviewed six-category taxonomy |
 | Where does it live? | nowhere user-presentable | **only** in the DM |
-| Recommended action | confirm the omission; restore the guard | give the category a durable home |
+| Recommended action | disclose state and effects, never a stored reason | decide whether to give the category a durable home |
 
-The account-level half needs a decision and no code. The content-level half is
-the real gap, and it is not the one the issue's proposal addresses.
+The account-level decision is to tell users the enforcement state and its
+effects, provide appeal and portability paths, and never expose a stored
+moderation reason. The content-level half is a separate policy question and is
+not the one the issue's proposal addresses.
 
 ## Finding that drives the split
 
@@ -39,16 +43,13 @@ place.
 
 ## Why no existing stored field can be surfaced
 
-Three independent stores hold something called a "reason". None is fit to send.
+Three independent stores hold something called a "reason". None is approved
+user-facing copy.
 
-1. **Keycast `users.suspended_reason`** — its admin API accepts arbitrary
-   caller-supplied text (sanitised for control characters and truncated, but
-   validated against no set), while Divine's only production writer constrains
-   it to four internal tags. Untrusted by contract; an untranslated token in
-   practice.
-2. **Funnelcake's enforcement tables** — free text supplied by whoever performed
-   the action, with a default that carries operator context when none is given.
-   Tracked separately as a disclosure risk; not usable as user-facing copy.
+1. **Keycast's account-status reason** — internal operational metadata, not
+   reviewed or localised user copy.
+2. **Funnelcake's enforcement reason** — internal operational metadata, not a
+   user-facing explanation.
 3. **The moderation service's sent-message log** — holds the rendered DM body,
    so for account actions it holds the same generic sentence, and for content
    actions it holds the category copy. This is the one store whose contents are
@@ -60,12 +61,11 @@ no amount of plumbing makes one into the other.
 
 ## Recommendation
 
-### Part 1 — account level: confirm, do not build
+### Part 1 — account level: disclose the state, not a stored reason
 
-Recommend T&S confirm that account-level enforcement carries no per-account
-reason, because none exists to carry. This is the exit #8304's author offered
-("If the answer is 'the reason stays private', say so and this closes"), and the
-evidence supports it more strongly than the issue assumed.
+The policy decision is that account-level enforcement carries no per-account
+reason. The notice identifies the enforcement state and its effects, provides
+appeal and portability paths, and exposes no stored moderation reason.
 
 Two consequences, both already true and worth stating:
 
@@ -74,15 +74,15 @@ Two consequences, both already true and worth stating:
 - Because the DM is the only carrier of the appeal instruction, the guards that
   keep it from being destroyed remain load-bearing rather than defensive.
 
-If T&S instead wants account actions to carry a category, that is **new product
-work**: assigning a category at enforcement time, which nothing does today. It
-is not exposure of an existing field.
+Introducing an account-level category would be **new product work**: assigning
+a reviewed category at enforcement time, which nothing does today. It would not
+be exposure of an existing field and is outside this decision.
 
-### Part 2 — content level: give the category a durable home
+### Part 2 — content level: decide whether to give the category a durable home
 
-Surface the per-content moderation **category** — a closed enum drawn from the
-existing six — on a self-authenticated, owner-scoped surface, next to the
-content it describes.
+`support-trust-safety#214` tracks the policy decision on whether to surface a
+per-content moderation **category** on a self-authenticated, owner-scoped
+surface next to the content it describes.
 
 The natural anchor already exists: funnelcake's owner-export path is
 self-authenticated, carries a per-event moderation annotation today, and is
@@ -111,9 +111,9 @@ exactly as `AccountEnforcementKind` is mapped today.
 
 ## Risks and open decisions
 
-- **OQ-1 (T&S, blocking Part 2).** Publishing the category tells a user which
-  classification tripped. That is the substance of s-t-s#200's "how much reason
-  do we give", and it is a policy call, not an engineering one.
+- **OQ-1 (T&S, tracked in `support-trust-safety#214`).** Publishing a category
+  tells a user which classification applied. That remains a policy call, not an
+  engineering one.
 - **OQ-2 (owner needed).** Part 2 is a funnelcake schema and API change; it
   needs an owner in that repo.
 - **A ban purges content.** The per-event annotation may have nothing left to
@@ -136,9 +136,9 @@ exactly as `AccountEnforcementKind` is mapped today.
 
 Two commits, neither of which requires the decision above:
 
-- Restored the client-side guard that a moderation reason cannot influence
-  enforcement state — a rationale and test that existed, then were removed as
-  collateral of a source change rather than by re-decision.
+- Restored the client-side guard that a stored moderation reason cannot
+  influence enforcement state — a rationale and test that existed, then were
+  removed as collateral of a source change rather than by re-decision.
 - Documented why Keycast's `suspendedReason` is parsed and deliberately never
   read, so it is neither deleted as dead code nor wired up as "the reason we
   already have".

--- a/mobile/lib/models/account_enforcement_status.dart
+++ b/mobile/lib/models/account_enforcement_status.dart
@@ -31,8 +31,19 @@ enum AccountEnforcementKind {
 /// Enforcement state for the authenticated account, as reported by
 /// Funnelcake's self-authenticated status endpoint.
 ///
-/// Deliberately carries no reason or moderation metadata. The self-status API
-/// returns only the public enforcement state, and copy is chosen from [kind].
+/// Deliberately carries no reason or moderation metadata, for two reasons that
+/// are worth keeping apart because only the first survives a change of backend:
+///
+/// 1. A stored moderation reason is free text written by whatever called an
+///    admin API, so rendering it would leak moderation internals to the user
+///    (support-trust-safety#200 R-7). This is why the omission is deliberate.
+/// 2. Funnelcake's self-status API happens not to return one today, and asserts
+///    that in its own suite. This is why the omission is currently free.
+///
+/// Reason (2) arrived with the move from Keycast to Funnelcake and reads like
+/// the whole story; it is not. Copy is chosen from [kind] alone. See #8304 for
+/// the open question of whether a *user-facing* reason should exist at all, and
+/// `account_status_api_client_test.dart` for the client-side guard.
 class AccountEnforcementStatus {
   const AccountEnforcementStatus({required this.kind});
 

--- a/mobile/lib/models/account_enforcement_status.dart
+++ b/mobile/lib/models/account_enforcement_status.dart
@@ -34,16 +34,17 @@ enum AccountEnforcementKind {
 /// Deliberately carries no reason or moderation metadata, for two reasons that
 /// are worth keeping apart because only the first survives a change of backend:
 ///
-/// 1. A stored moderation reason is free text written by whatever called an
-///    admin API, so rendering it would leak moderation internals to the user
-///    (support-trust-safety#200 R-7). This is why the omission is deliberate.
+/// 1. Stored moderation reasons are internal operational metadata, not
+///    reviewed or localised user copy. Account-level notices describe the
+///    state and its effects without rendering that metadata
+///    (support-trust-safety#200 R-7).
 /// 2. Funnelcake's self-status API happens not to return one today, and asserts
 ///    that in its own suite. This is why the omission is currently free.
 ///
 /// Reason (2) arrived with the move from Keycast to Funnelcake and reads like
 /// the whole story; it is not. Copy is chosen from [kind] alone. See #8304 for
-/// the open question of whether a *user-facing* reason should exist at all, and
-/// `account_status_api_client_test.dart` for the client-side guard.
+/// the account-level policy decision and `account_status_api_client_test.dart`
+/// for the client-side guard.
 class AccountEnforcementStatus {
   const AccountEnforcementStatus({required this.kind});
 

--- a/mobile/packages/keycast_flutter/lib/src/oauth/account_status.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/account_status.dart
@@ -38,22 +38,20 @@ class KeycastAccountStatus {
   /// Present only when the account is not active (suspended/banned/etc.).
   final String? accountStatus;
 
-  /// Keycast's stored reason for a non-active status. **Deliberately not
+  /// Keycast's internal reason for a non-active status. **Deliberately not
   /// consumed anywhere, and not safe to render to the user.**
   ///
-  /// It is neither a sentence nor reviewed copy. Keycast's admin API accepts
-  /// arbitrary caller-supplied text (sanitised for control characters and
-  /// truncated, but not validated against any set), while Divine's only
-  /// production writer constrains it to four internal tags — `moderation`,
-  /// `age_review`, `age_review_denied`, `age_review_expired`. So the field is
-  /// untrusted by contract and, in practice, an untranslated snake_case token.
+  /// This is operational metadata, not reviewed or localised user copy. The
+  /// account-level policy deliberately derives copy from the enforcement state
+  /// and its effects rather than from any stored reason field.
   ///
   /// It is also not the enforcement authority: divine-mobile reads account
   /// status from Funnelcake, not from here. Parsed only so this model matches
   /// the whole `GET /api/user/account` payload.
   ///
-  /// Whether a user-facing reason should exist at all is open in #8304; if it
-  /// lands, it will be a new field with reviewed copy, not this one.
+  /// #8304 records that account-level notices do not expose a stored reason.
+  /// Any separately approved content-level explanation will use a closed
+  /// category with reviewed copy, not this field.
   final String? suspendedReason;
 
   /// Durable approved-minor (13-15) flag. Independent of [accountStatus] —

--- a/mobile/packages/keycast_flutter/lib/src/oauth/account_status.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/account_status.dart
@@ -37,6 +37,23 @@ class KeycastAccountStatus {
 
   /// Present only when the account is not active (suspended/banned/etc.).
   final String? accountStatus;
+
+  /// Keycast's stored reason for a non-active status. **Deliberately not
+  /// consumed anywhere, and not safe to render to the user.**
+  ///
+  /// It is neither a sentence nor reviewed copy. Keycast's admin API accepts
+  /// arbitrary caller-supplied text (sanitised for control characters and
+  /// truncated, but not validated against any set), while Divine's only
+  /// production writer constrains it to four internal tags — `moderation`,
+  /// `age_review`, `age_review_denied`, `age_review_expired`. So the field is
+  /// untrusted by contract and, in practice, an untranslated snake_case token.
+  ///
+  /// It is also not the enforcement authority: divine-mobile reads account
+  /// status from Funnelcake, not from here. Parsed only so this model matches
+  /// the whole `GET /api/user/account` payload.
+  ///
+  /// Whether a user-facing reason should exist at all is open in #8304; if it
+  /// lands, it will be a new field with reviewed copy, not this one.
   final String? suspendedReason;
 
   /// Durable approved-minor (13-15) flag. Independent of [accountStatus] —

--- a/mobile/test/services/account_status_api_client_test.dart
+++ b/mobile/test/services/account_status_api_client_test.dart
@@ -66,10 +66,8 @@ void main() {
 
     test('keeps an unknown future status indeterminate', () async {
       final client = _client(
-        handler: (_) async => http.Response(
-          '{"pubkey":"$_pubkey","status":"future"}',
-          200,
-        ),
+        handler: (_) async =>
+            http.Response('{"pubkey":"$_pubkey","status":"future"}', 200),
       );
       await expectLater(
         client.fetchStatus(expectedPubkey: _pubkey),
@@ -139,11 +137,12 @@ void main() {
     // Guards the trust boundary PR #7839 established and PR #8161 removed as
     // collateral of moving the source of truth from Keycast to Funnelcake. The
     // rationale outlived that move and is not specific to either backend: a
-    // moderation reason is free text written by whatever called an admin API,
-    // so it must never reach state that copy or logging could render
-    // (support-trust-safety#200 R-7). Funnelcake omits it today and asserts
-    // that omission in its own suite; this pins the client side, so a server
-    // that starts sending one cannot silently become renderable here.
+    // stored moderation reasons are internal operational metadata, not reviewed
+    // or localised user copy, so they must never reach state that copy or
+    // logging could render (support-trust-safety#200 R-7). Funnelcake omits a
+    // reason today and asserts that omission in its own suite; this pins the
+    // client side, so a server that starts sending one cannot silently make it
+    // renderable here.
     test('ignores moderation metadata a 200 response might carry', () async {
       Future<FunnelcakeAccountStatus> statusFor(String body) {
         return _client(

--- a/mobile/test/services/account_status_api_client_test.dart
+++ b/mobile/test/services/account_status_api_client_test.dart
@@ -136,6 +136,35 @@ void main() {
       }
     });
 
+    // Guards the trust boundary PR #7839 established and PR #8161 removed as
+    // collateral of moving the source of truth from Keycast to Funnelcake. The
+    // rationale outlived that move and is not specific to either backend: a
+    // moderation reason is free text written by whatever called an admin API,
+    // so it must never reach state that copy or logging could render
+    // (support-trust-safety#200 R-7). Funnelcake omits it today and asserts
+    // that omission in its own suite; this pins the client side, so a server
+    // that starts sending one cannot silently become renderable here.
+    test('ignores moderation metadata a 200 response might carry', () async {
+      Future<FunnelcakeAccountStatus> statusFor(String body) {
+        return _client(
+          handler: (_) async => http.Response(body, 200),
+        ).fetchStatus(expectedPubkey: _pubkey);
+      }
+
+      const plain = '{"pubkey":"$_pubkey","status":"suspended"}';
+      const withReason =
+          '{"pubkey":"$_pubkey","status":"suspended",'
+          '"reason":"moderation","suspended_at":"2026-08-24T00:00:00Z",'
+          '"suspended_by":"a-moderator"}';
+      const withOtherReason =
+          '{"pubkey":"$_pubkey","status":"suspended",'
+          '"reason":"policy_violation"}';
+
+      expect(await statusFor(withReason), await statusFor(plain));
+      expect(await statusFor(withOtherReason), await statusFor(plain));
+      expect(await statusFor(withReason), FunnelcakeAccountStatus.suspended);
+    });
+
     test('reports missing signer, transport failure, and timeout', () async {
       final unsigned = _client(
         auth: ({required url, required method}) async => null,

--- a/mobile/test/services/account_status_api_client_test.dart
+++ b/mobile/test/services/account_status_api_client_test.dart
@@ -136,7 +136,7 @@ void main() {
 
     // Guards the trust boundary PR #7839 established and PR #8161 removed as
     // collateral of moving the source of truth from Keycast to Funnelcake. The
-    // rationale outlived that move and is not specific to either backend: a
+    // rationale outlived that move and is not specific to either backend:
     // stored moderation reasons are internal operational metadata, not reviewed
     // or localised user copy, so they must never reach state that copy or
     // logging could render (support-trust-safety#200 R-7). Funnelcake omits a


### PR DESCRIPTION
Closes #8304

## Problem

Account enforcement must be visible and contestable, but the stored moderation
reasons available to clients are internal operational metadata rather than
reviewed, localized user copy. A previous client-side guard against rendering
that metadata was lost when account status moved between backends.

## Decision

Account-level notices identify the enforcement state and its effects and provide
appeal and portability paths. They do not expose a stored moderation reason.
No operator-authored string may be returned to or rendered for the account it
describes.

Whether affected users should receive a durable content-level policy category
is a separate Trust & Safety decision, tracked in
`support-trust-safety#214`. If approved, that surface must carry a closed
category with localized client copy, never free text.

## Changes

- Restores a regression test proving unexpected moderation metadata cannot
  affect the parsed account status.
- Records the account-level policy on `AccountEnforcementStatus`.
- Documents why Keycast's internal reason remains parsed for payload
  compatibility but deliberately unread.
- Preserves the investigation as a public-safe decision record while moving
  sensitive implementation detail and the content-category decision to the
  Trust & Safety tracker.

No production behavior changes.

## Verification

- `flutter test test/services/account_status_api_client_test.dart test/models/account_enforcement_status_test.dart` — 11/11
- `cd packages/keycast_flutter && flutter test` — 307/307
- `flutter analyze lib test` — clean
- `cd packages/keycast_flutter && flutter analyze` — clean
- Full repository CI — green, including all four test shards and Generated Files

## Risk

Low. One regression test and documentation only.
