### PR TITLE
fix(observability): stop reporting image decode allocation failures as fatal

### DIFF
--- a/mobile/lib/utils/recoverable_flutter_error.dart
+++ b/mobile/lib/utils/recoverable_flutter_error.dart
@@ -8,6 +8,8 @@ import 'package:openvine/utils/expected_network_error.dart';
 
 const _recoverableMediaLoadReason = 'Recoverable media load failure';
 const _recoverableHeroFlightReason = 'Recoverable hero flight layout failure';
+const _imageDecodeAllocationReason =
+    'Recoverable image decode allocation failure';
 const _expectedNetworkFailureReason = 'Expected network failure';
 const _recoverableMediaHosts = <String>{
   'media.divine.video',
@@ -131,6 +133,37 @@ RecoverableFlutterError? classifyRecoverableFlutterError(
       isMissingHttpHost ||
       isInvalidImageData) {
     return (reason: _recoverableMediaLoadReason, report: true);
+  }
+
+  // The image pipeline could not allocate memory for a decoded frame, so the
+  // decode failed on a device that was out of room. Flutter catches this in
+  // MultiFrameImageStreamCompleter._decodeNextFrameAndSchedule, reports it
+  // with `silent: true` — its own marker for "expected in release builds" —
+  // and returns; the frame never arrives and the widget keeps its placeholder,
+  // so nothing crashes. It only reaches a handler at all when no
+  // ImageStreamListener was still attached, which is the scrolled-away case:
+  // VineCachedImage and VideoThumbnailWidget both register onError, and
+  // ImageStreamCompleter.reportError escalates to FlutterError only in its
+  // `if (!handled)` branch.
+  //
+  // Kept reportable, unlike a 404 or a dropped connection. An allocation
+  // failure is not a dead URL — it is evidence of device memory pressure, and
+  // that signal is the whole point of still seeing it.
+  //
+  // The message comes from the engine verbatim (dart:ui's Codec.getNextFrame
+  // rethrows the decoder's string as `Exception(decodeError)`), so match the
+  // allocation-failure family rather than the one wording observed in the
+  // field ('Could not allocate scaled bitmap for image decompression.').
+  final isImageDecodeAllocationFailure =
+      (library == 'image resource service' ||
+          context.contains('image codec') ||
+          context.contains('image frame')) &&
+      (error.contains('Could not allocate') ||
+          error.contains('Failed to allocate') ||
+          error.contains('Unable to allocate'));
+
+  if (isImageDecodeAllocationFailure) {
+    return (reason: _imageDecodeAllocationReason, report: true);
   }
 
   // A hero flight measures its destination hero in a post-frame callback, and

--- a/mobile/test/utils/recoverable_flutter_error_test.dart
+++ b/mobile/test/utils/recoverable_flutter_error_test.dart
@@ -404,5 +404,72 @@ void main() {
         expect(classifyRecoverableFlutterError(details), isNull);
       },
     );
+
+    // Crashlytics issue 198b20e4 (1.0.20+727, Android) filed this as a FATAL
+    // even though nothing crashed: Flutter catches the decode failure in
+    // MultiFrameImageStreamCompleter._decodeNextFrameAndSchedule, reports it
+    // with silent: true, and returns.
+    test('classifies image decode allocation failures as recoverable', () {
+      final details = FlutterErrorDetails(
+        exception: Exception(
+          'Could not allocate scaled bitmap for image decompression.',
+        ),
+        context: ErrorDescription('resolving an image frame'),
+        library: 'image resource service',
+      );
+
+      expect(classifyRecoverableFlutterError(details), (
+        reason: 'Recoverable image decode allocation failure',
+        report: true,
+      ));
+    });
+
+    // The engine hands dart:ui the decoder's own string, which
+    // Codec.getNextFrame rethrows verbatim as Exception(decodeError). Matching
+    // the allocation-failure family rather than the single observed wording is
+    // deliberate, so a differently-worded engine message does not land back on
+    // the fatal path.
+    for (final message in const [
+      'Could not allocate scaled bitmap for image decompression.',
+      'Failed to allocate memory for the decoded frame.',
+      'Unable to allocate bitmap pixels.',
+    ]) {
+      test('treats "$message" as a recoverable allocation failure', () {
+        final details = FlutterErrorDetails(
+          exception: Exception(message),
+          context: ErrorDescription('resolving an image codec'),
+          library: 'image resource service',
+        );
+
+        expect(classifyRecoverableFlutterError(details), (
+          reason: 'Recoverable image decode allocation failure',
+          report: true,
+        ));
+      });
+    }
+
+    test('keeps allocation failures outside the image pipeline fatal', () {
+      // Same wording, different subsystem. An allocation failure is only
+      // recoverable because the image pipeline degrades to a placeholder;
+      // nothing here promises that for anyone else.
+      final details = FlutterErrorDetails(
+        exception: Exception('Could not allocate a buffer.'),
+        library: 'services library',
+      );
+
+      expect(classifyRecoverableFlutterError(details), isNull);
+    });
+
+    test('keeps non-allocation image resource failures fatal', () {
+      // The branch must gate on the allocation wording, not on the library
+      // alone, or it would swallow every unclassified image-pipeline error.
+      final details = FlutterErrorDetails(
+        exception: Exception('Something else went wrong entirely.'),
+        context: ErrorDescription('resolving an image frame'),
+        library: 'image resource service',
+      );
+
+      expect(classifyRecoverableFlutterError(details), isNull);
+    });
   });
 }


### PR DESCRIPTION
## Description

Crashlytics filed `Exception: Could not allocate scaled bitmap for image decompression.` as a **Fatal Exception** on 1.0.20+727 (Android). Nothing crashed.

That string is the engine's. `dart:ui`'s `Codec.getNextFrame` rethrows the decoder's own message verbatim as `Exception(decodeError)` when a native bitmap allocation fails. Flutter catches it in `MultiFrameImageStreamCompleter._decodeNextFrameAndSchedule`, reports it with `silent: true` — its own marker for *"expected in release builds"* — and returns. The frame never arrives, the widget keeps its placeholder, the app carries on. The thread dump on the report shows ExoPlayer and Firebase threads parked and idle, not a dying process.

It reaches a handler at all only when no `ImageStreamListener` is still attached, which is the scrolled-away case: `VineCachedImage` and `VideoThumbnailWidget` both register `onError`, and `ImageStreamCompleter.reportError` escalates to `FlutterError` only in its `if (!handled)` branch.

From there the delivery chain is:

```
MultiFrameImageStreamCompleter._decodeNextFrameAndSchedule  (image_stream.dart:1080)
  -> ImageStreamCompleter.reportError                       (image_stream.dart:827)
    -> FlutterError.reportError                             (assertions.dart:1193)
      -> app_bootstrap.dart:415  (main.dart:1220 as shipped in 1.0.20)
        -> crash_reporting_service.dart:50
          -> recordFlutterFatalError
```

`classifyRecoverableFlutterError` had no branch matching an allocation failure, so it returned `null` — "must stay fatal" — and crash-free-users got charged for a recovery. This adds that branch, continuing the lineage of #6181, #6229, #6615, #7290 and #7298 in the same file.

Two deliberate choices:

- **Match the allocation-failure family, not the one observed wording.** The message crosses from the engine as an opaque string, so pinning the exact sentence would send a differently-worded engine message straight back to the fatal path. The branch is still gated on the image pipeline, so an allocation failure in another subsystem stays fatal.
- **Keep it reportable (`report: true`).** Unlike a 404 or a dropped connection, an allocation failure is not a dead URL — it is evidence of device memory pressure. Downgrading it to non-fatal stops the crash-rate pollution while keeping the signal, which is what the memory follow-up needs.

**Related Issue:** Relates to #8484. Crashlytics issue `198b20e41b65c26f4d7dcbd83993a011`.

## Out of Scope

The underlying memory pressure — filed as #8484 with the profiling it needs. `AppConstants.imageCacheMaxBytes` is 256 MB against Flutter's 100 MB default, and `.claude/rules/performance.md` requires that budget be tuned with measurements rather than guessed at. This PR changes how the failure is *reported*, not how often it happens — and keeping it reportable is what leaves #8484 a signal to work from.

Also out of scope, and being sent as its own PR: the three chained `safe_cache_info_repository.dart:66` frames visible in the same stack, which are evidence that `SafeCacheInfoRepository.open()` can leave a stale handler installed in the process-global `FlutterError.onError`.

## Verification

- `flutter analyze lib/utils/recoverable_flutter_error.dart test/utils/recoverable_flutter_error_test.dart` — no issues
- `flutter test test/utils/recoverable_flutter_error_test.dart` — 31 passing
- Mutation check: with the `lib/` change stashed, the 4 new positive tests fail and the 2 new negative tests still pass, which is the intended shape — the negatives guard the branch against being too broad, so they hold in both directions.
- `dart format` clean

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
