### PR TITLE
fix(media-cache): stop SafeCacheInfoRepository mutating FlutterError.onError

### DIFF
--- a/mobile/packages/media_cache/lib/src/safe_cache_info_repository.dart
+++ b/mobile/packages/media_cache/lib/src/safe_cache_info_repository.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -12,14 +13,28 @@ typedef DirectoryProvider = Future<Directory> Function();
 /// A safe wrapper around [CacheInfoRepository] that handles corrupted
 /// JSON files.
 ///
-/// The upstream [JsonCacheInfoRepository._readFile] catches all exceptions
-/// internally (`on Object`) and reports them via [FlutterError.reportError]
-/// instead of rethrowing. This means a standard try/catch around [open] never
-/// sees the error. Instead, the error flows to [FlutterError.onError], which
-/// Crashlytics records as a fatal crash.
+/// Upstream's `JsonCacheInfoRepository._readFile` catches every exception
+/// internally (`on Object`) and reports it through [FlutterError.reportError]
+/// rather than rethrowing, so a plain try/catch around [open] never sees a
+/// corrupt index — the error goes straight to [FlutterError.onError], where
+/// Crashlytics files it as a crash and the cache silently comes up empty.
 ///
-/// This wrapper temporarily intercepts [FlutterError.onError] during [open] to
-/// detect corruption, deletes the bad file, and retries cleanly.
+/// So this wrapper reads the index itself before delegating, parsing it
+/// exactly the way upstream will, and deletes the file when that parse fails.
+/// Corruption is then resolved before upstream ever sees it. The direct-throw
+/// paths are still caught, for repositories that raise instead of reporting.
+///
+/// It deliberately does **not** intercept [FlutterError.onError]. That handler
+/// is a process-global, and the details upstream reports carry no file or
+/// database identity — only `library: 'flutter cache manager'` — so a handler
+/// installed by one repository cannot tell its own corruption from another's.
+/// Two managers exist in the app and `CacheStore`'s constructor fires
+/// `repo.open()` eagerly and unawaited, so those windows overlap: swapping the
+/// global and restoring it by assignment dropped one handler whenever they
+/// finished out of order and left the other permanently installed, and the
+/// captured error could be attributed to the wrong cache and delete a healthy
+/// index. Reading the file directly removes the global from the design instead
+/// of trying to sequence it.
 ///
 /// Uses composition to wrap a [CacheInfoRepository] (defaults to
 /// [JsonCacheInfoRepository]), making it fully testable via dependency
@@ -52,47 +67,58 @@ class SafeCacheInfoRepository implements CacheInfoRepository {
 
   @override
   Future<bool> open() async {
-    // The upstream JsonCacheInfoRepository._readFile catches all exceptions
-    // internally (`on Object`) and reports via FlutterError.reportError instead
-    // of rethrowing. We must intercept FlutterError.onError to detect this.
-    // We also keep a try/catch for repositories that throw directly.
-    Object? caughtException;
-    final previousHandler = FlutterError.onError;
-    FlutterError.onError = (details) {
-      if (details.library == 'flutter cache manager') {
-        caughtException = details.exception;
-        return;
-      }
-      previousHandler?.call(details);
-    };
+    await _deleteCacheFileIfUnreadable();
 
+    // Kept for repositories that raise instead of reporting. The upstream
+    // JSON repository is handled above, before it can swallow the error.
     try {
-      final result = await _repository.open();
-
-      if (caughtException == null) {
-        return result;
-      }
+      return await _repository.open();
     } on FormatException {
       await deleteCacheFile();
-      FlutterError.onError = previousHandler;
       return _repository.open();
     } on Exception catch (e) {
       if (e.toString().contains('Unexpected end of input') ||
           e.toString().contains("type 'Null'")) {
         await deleteCacheFile();
-        FlutterError.onError = previousHandler;
         return _repository.open();
       }
       rethrow;
-    } finally {
-      FlutterError.onError = previousHandler;
+    }
+  }
+
+  /// Deletes the cache index when it cannot be parsed.
+  ///
+  /// Mirrors `JsonCacheInfoRepository._readFile` deliberately: same path
+  /// (`<applicationSupport>/<databaseName>.json`, matching upstream's
+  /// `_getFile`), same `jsonDecode` to a `List`, same [CacheObject.fromMap]
+  /// over each map element, and the same `on Object` reach — so anything that
+  /// would leave upstream with an unusable index is caught here first.
+  ///
+  /// A file that survives this and still fails upstream is no worse off than
+  /// before: the app's own handler downgrades `flutter cache manager` reports
+  /// to non-fatal and the cache comes up empty, which is what already happened
+  /// for every corruption shape the old interception missed.
+  Future<void> _deleteCacheFileIfUnreadable() async {
+    final File file;
+    try {
+      final directory = await _directoryProvider();
+      file = File(path.join(directory.path, '$_databaseName.json'));
+      if (!file.existsSync()) return;
+    } on Object {
+      // No support directory yet, or it cannot be resolved. There is nothing
+      // to validate and nothing to delete; let the repository open normally.
+      return;
     }
 
-    // Corruption reported through FlutterError rather than thrown. The retry
-    // runs outside the try so a second failure reaches the caller instead of
-    // re-entering the handlers above and deleting-and-reopening again.
-    await deleteCacheFile();
-    return _repository.open();
+    try {
+      final decoded = jsonDecode(await file.readAsString()) as List<dynamic>;
+      for (final element in decoded) {
+        if (element is! Map<String, dynamic>) continue;
+        CacheObject.fromMap(element);
+      }
+    } on Object {
+      await deleteCacheFile();
+    }
   }
 
   /// Deletes the cache JSON file.

--- a/mobile/packages/media_cache/test/src/safe_cache_info_repository_test.dart
+++ b/mobile/packages/media_cache/test/src/safe_cache_info_repository_test.dart
@@ -242,9 +242,7 @@ void main() {
           final secondOpen = Completer<bool>();
           final secondRepository = MockCacheInfoRepository();
           when(() => mockRepository.open()).thenAnswer((_) => firstOpen.future);
-          when(
-            () => secondRepository.open(),
-          ).thenAnswer((_) => secondOpen.future);
+          when(secondRepository.open).thenAnswer((_) => secondOpen.future);
 
           final previousHandler = FlutterError.onError;
           void sentinel(FlutterErrorDetails details) {}

--- a/mobile/packages/media_cache/test/src/safe_cache_info_repository_test.dart
+++ b/mobile/packages/media_cache/test/src/safe_cache_info_repository_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -148,100 +150,168 @@ void main() {
         expect(cacheFile.existsSync(), false);
       });
 
+      test('deletes a corrupt index before the repository opens it', () async {
+        // The real-world shape: upstream swallows the parse failure and
+        // reports it, so the wrapper has to resolve the corruption before
+        // delegating rather than react to it afterwards.
+        var openCallCount = 0;
+        when(() => mockRepository.open()).thenAnswer((_) async {
+          openCallCount++;
+          return true;
+        });
+
+        final cacheFile = File('$testSupportPath/test_corrupt_index.json');
+        await cacheFile.writeAsString('{"truncated":');
+
+        final repo = SafeCacheInfoRepository(
+          databaseName: 'test_corrupt_index',
+          repository: mockRepository,
+          directoryProvider: () async => testDirectory,
+        );
+
+        expect(await repo.open(), isTrue);
+        expect(cacheFile.existsSync(), isFalse);
+        // Once, not twice: the repository never sees the corrupt file, so
+        // there is nothing to recover from and no retry to make.
+        expect(openCallCount, equals(1));
+      });
+
+      test('deletes an index whose entries cannot be mapped', () async {
+        // Well-formed JSON that CacheObject.fromMap still rejects. Upstream
+        // treats this exactly like a syntax error, so this must too.
+        when(() => mockRepository.open()).thenAnswer((_) async => true);
+
+        final cacheFile = File('$testSupportPath/test_bad_entries.json');
+        await cacheFile.writeAsString(
+          jsonEncode([
+            {'url': 'https://example.com/a.jpg'},
+          ]),
+        );
+
+        final repo = SafeCacheInfoRepository(
+          databaseName: 'test_bad_entries',
+          repository: mockRepository,
+          directoryProvider: () async => testDirectory,
+        );
+
+        await repo.open();
+
+        expect(cacheFile.existsSync(), isFalse);
+      });
+
+      test('keeps a readable index', () async {
+        when(() => mockRepository.open()).thenAnswer((_) async => true);
+
+        final cacheFile = File('$testSupportPath/test_valid_index.json');
+        await cacheFile.writeAsString(
+          jsonEncode([
+            CacheObject(
+              'https://example.com/a.jpg',
+              relativePath: 'a.jpg',
+              validTill: DateTime.now().add(const Duration(days: 1)),
+              id: 1,
+            ).toMap(),
+          ]),
+        );
+
+        final repo = SafeCacheInfoRepository(
+          databaseName: 'test_valid_index',
+          repository: mockRepository,
+          directoryProvider: () async => testDirectory,
+        );
+
+        await repo.open();
+
+        expect(cacheFile.existsSync(), isTrue);
+      });
+
       test(
-        'recovers when upstream reports via FlutterError instead of throwing',
+        'leaves FlutterError.onError untouched across concurrent opens',
         () async {
-          // This tests the real-world scenario: JsonCacheInfoRepository
-          // catches exceptions internally and reports via
-          // FlutterError.reportError instead of rethrowing.
-          var openCallCount = 0;
-          when(() => mockRepository.open()).thenAnswer((_) async {
-            openCallCount++;
-            if (openCallCount == 1) {
-              // Simulate upstream behavior: report via FlutterError, not throw
-              FlutterError.reportError(
-                FlutterErrorDetails(
-                  exception: const FormatException('Unexpected end of input'),
-                  library: 'flutter cache manager',
-                  context: ErrorDescription('Reading cache info file'),
-                ),
-              );
-              return true; // Upstream returns normally after reporting
-            }
-            return true;
-          });
+          // The regression this guards: open() used to swap the process-global
+          // FlutterError.onError and restore it by assignment. CacheStore's
+          // constructor fires repo.open() eagerly and unawaited, and the app
+          // builds two managers, so those windows overlap.
+          //
+          // Restore-by-assignment is only correct when the opens finish LIFO.
+          // The completers below force the other order — the repository that
+          // installed first also finishes first — which dropped the second
+          // handler and then permanently reinstalled the first, stale one. A
+          // production stack showed three of these chained together.
+          final firstOpen = Completer<bool>();
+          final secondOpen = Completer<bool>();
+          final secondRepository = MockCacheInfoRepository();
+          when(() => mockRepository.open()).thenAnswer((_) => firstOpen.future);
+          when(
+            () => secondRepository.open(),
+          ).thenAnswer((_) => secondOpen.future);
 
-          final cacheFile = File('$testSupportPath/test_flutter_error.json');
-          await cacheFile.writeAsString('{"truncated":');
-
-          FlutterErrorDetails? capturedError;
           final previousHandler = FlutterError.onError;
-          FlutterError.onError = (details) {
-            capturedError = details;
-          };
+          void sentinel(FlutterErrorDetails details) {}
+          FlutterError.onError = sentinel;
+          addTearDown(() => FlutterError.onError = previousHandler);
 
-          try {
-            final repo = SafeCacheInfoRepository(
-              databaseName: 'test_flutter_error',
-              repository: mockRepository,
-              directoryProvider: () async => testDirectory,
-            );
+          final first = SafeCacheInfoRepository(
+            databaseName: 'test_concurrent_a',
+            repository: mockRepository,
+            directoryProvider: () async => testDirectory,
+          );
+          final second = SafeCacheInfoRepository(
+            databaseName: 'test_concurrent_b',
+            repository: secondRepository,
+            directoryProvider: () async => testDirectory,
+          );
 
-            await repo.open();
+          final firstFuture = first.open();
+          final secondFuture = second.open();
 
-            // File should be deleted
-            expect(cacheFile.existsSync(), isFalse);
-            // FlutterError should NOT have leaked to outer handler
-            expect(capturedError, isNull);
-            // open called twice: first detects corruption, second is retry
-            expect(openCallCount, equals(2));
-          } finally {
-            FlutterError.onError = previousHandler;
-          }
+          firstOpen.complete(true);
+          await firstFuture;
+          secondOpen.complete(true);
+          await secondFuture;
+
+          expect(FlutterError.onError, same(sentinel));
         },
       );
 
-      test(
-        'forwards non-cache FlutterErrors to previous handler during open',
-        () async {
-          when(() => mockRepository.open()).thenAnswer((_) async {
-            // Simulate a non-cache FlutterError during open
-            FlutterError.reportError(
-              FlutterErrorDetails(
-                exception: Exception('some rendering error'),
-                library: 'rendering library',
-                context: ErrorDescription('during layout'),
-              ),
-            );
-            return true;
-          });
+      test('a corrupt index for one database leaves another intact', () async {
+        // The old interception keyed only on library: 'flutter cache manager',
+        // which carries no file identity, so an overlapping open could
+        // attribute one cache's corruption to the other and delete a
+        // healthy index.
+        when(() => mockRepository.open()).thenAnswer((_) async => true);
 
-          FlutterErrorDetails? forwardedError;
-          final previousHandler = FlutterError.onError;
-          FlutterError.onError = (details) {
-            forwardedError = details;
-          };
+        final corrupt = File('$testSupportPath/test_isolation_corrupt.json');
+        await corrupt.writeAsString('not json at all');
+        final healthy = File('$testSupportPath/test_isolation_healthy.json');
+        await healthy.writeAsString(
+          jsonEncode([
+            CacheObject(
+              'https://example.com/b.jpg',
+              relativePath: 'b.jpg',
+              validTill: DateTime.now().add(const Duration(days: 1)),
+              id: 1,
+            ).toMap(),
+          ]),
+        );
 
-          try {
-            final repo = SafeCacheInfoRepository(
-              databaseName: 'test_forward',
-              repository: mockRepository,
-              directoryProvider: () async => testDirectory,
-            );
+        final corruptRepo = SafeCacheInfoRepository(
+          databaseName: 'test_isolation_corrupt',
+          repository: mockRepository,
+          directoryProvider: () async => testDirectory,
+        );
+        final healthyRepo = SafeCacheInfoRepository(
+          databaseName: 'test_isolation_healthy',
+          repository: MockCacheInfoRepository(),
+          directoryProvider: () async => testDirectory,
+        );
+        when(() => healthyRepo.repository.open()).thenAnswer((_) async => true);
 
-            await repo.open();
+        await Future.wait([corruptRepo.open(), healthyRepo.open()]);
 
-            // Non-cache error should have been forwarded to previous handler
-            expect(forwardedError, isNotNull);
-            expect(
-              forwardedError!.library,
-              equals('rendering library'),
-            );
-          } finally {
-            FlutterError.onError = previousHandler;
-          }
-        },
-      );
+        expect(corrupt.existsSync(), isFalse);
+        expect(healthy.existsSync(), isTrue);
+      });
 
       test(
         'propagates a retry failure instead of deleting and reopening again',
@@ -249,25 +319,8 @@ void main() {
           var openCallCount = 0;
           when(() => mockRepository.open()).thenAnswer((_) async {
             openCallCount++;
-            if (openCallCount == 1) {
-              FlutterError.reportError(
-                FlutterErrorDetails(
-                  exception: const FormatException('Unexpected end of input'),
-                  library: 'flutter cache manager',
-                  context: ErrorDescription('Reading cache info file'),
-                ),
-              );
-              return true;
-            }
             throw const FormatException('still unreadable');
           });
-
-          final cacheFile = File('$testSupportPath/test_retry_failure.json');
-          await cacheFile.writeAsString('{"truncated":');
-
-          final previousHandler = FlutterError.onError;
-          FlutterError.onError = (_) {};
-          addTearDown(() => FlutterError.onError = previousHandler);
 
           final repo = SafeCacheInfoRepository(
             databaseName: 'test_retry_failure',
@@ -277,10 +330,9 @@ void main() {
 
           await expectLater(repo.open(), throwsA(isA<FormatException>()));
 
-          // The corrupted file is already gone, so the retry is the last
-          // attempt — it must not re-enter the delete-and-retry handlers.
+          // One delete-and-retry, then the failure is the caller's. It must
+          // not re-enter the recovery path a second time.
           expect(openCallCount, equals(2));
-          expect(cacheFile.existsSync(), isFalse);
         },
       );
 


### PR DESCRIPTION
Closes #8483

## Description

`SafeCacheInfoRepository.open()` swapped the **process-global** `FlutterError.onError` to watch for the corruption upstream swallows, then restored it in a `finally` by plain assignment:

```dart
final previousHandler = FlutterError.onError;
FlutterError.onError = (details) { ... previousHandler?.call(details); };
try { ... } finally { FlutterError.onError = previousHandler; }
```

Restore-by-assignment is only correct when overlapping opens finish **LIFO**, and nothing makes them. `CacheStore`'s constructor fires `repo.open()` eagerly and unawaited, and the app builds two managers (`openvine_image_cache` and the video cache), so the windows overlap by construction. Finishing in the other order drops one handler — that repository's corruption detection silently stops working — and then **permanently reinstalls the other, stale one**, which from then on swallows every `flutter cache manager` report the class exists to catch.

This surfaced in the Crashlytics stack for an unrelated image-decode failure on 1.0.20+727, which shows three of these chained together:

```
at FlutterError.reportError (assertions.dart:1193)
at SafeCacheInfoRepository.open.<fn> (safe_cache_info_repository.dart:66)
at SafeCacheInfoRepository.open.<fn> (safe_cache_info_repository.dart:66)
at SafeCacheInfoRepository.open.<fn> (safe_cache_info_repository.dart:66)
```

Line 66 was `previousHandler?.call(details)`.

### Why it wasn't patched in place

The interception could not have been made correct where it stood. Upstream's report carries **no file or database identity** — `json_cache_info_repository.dart` reports only `library: 'flutter cache manager'` with a generic context — so a handler cannot distinguish its own corruption from the other cache's. An overlapping open could attribute one manager's failure to the other and delete a healthy index. Serializing the opens would have fixed the ordering but not the misattribution.

### What this does instead

Reads the index before delegating, parsing it the way `JsonCacheInfoRepository._readFile` will: same path (`<applicationSupport>/<databaseName>.json`, matching upstream's `_getFile`), same `jsonDecode` to a `List`, same `CacheObject.fromMap` over each map element, same `on Object` reach. Corruption is resolved before upstream can swallow it, and the global is gone from the design rather than sequenced around it. The direct-throw paths stay for repositories that raise instead of reporting.

Anything that still slips past is no worse off than before: `app_bootstrap` already downgrades `flutter cache manager` reports to non-fatal and the cache comes up empty — which is what happened for every corruption shape the old interception missed.

**Related Issue:** Relates to Crashlytics issue `198b20e41b65c26f4d7dcbd83993a011`, whose stack exposed this. The image-decode misreport in that same stack is #8480; the two are independent and this PR does not depend on it.

## Out of Scope

The image-decode allocation failure that produced the stack (#8480), and the underlying memory pressure (#8484).

## Verification

- `flutter analyze lib test` in `packages/media_cache` — no issues
- `flutter test` in `packages/media_cache` — 248 passing
- `flutter test --coverage` — **98.43%** against the package's `min_coverage: 98`; `safe_cache_info_repository.dart` is 54/54 lines
- Mutation check: with the `lib/` change reverted, 4 of the new tests fail, including `leaves FlutterError.onError untouched across concurrent opens`. That test uses `Completer`s to force the non-LIFO order deliberately — an earlier draft let the opens finish LIFO and passed against the buggy code, which is the safe ordering and proves nothing.
- Two tests that asserted the interception *mechanism* are replaced by tests of the behaviour it existed for.

## Note on CI

Two shard failures on the way to green, both outside this diff and both order-dependent. The shards randomize their ordering seed per run, each failure passed on a rerun with a new seed under no code change, #8480 passed the same shards from the same base commit, and `main` is green there. Filed rather than patched into this PR: #8485 (`badge_editor_screen_test.dart`, root cause confirmed — a text-measuring assertion over asynchronously-resolved `GoogleFonts`) and #8486 (`conversation_list_bloc_test.dart`, root cause not yet identified).

The `build / build` failure on that run *was* mine: `unnecessary_lambdas` is fatal under the package's bare `very_good_analysis` config, which the root `mobile/analysis_options.yaml` downgrades, so a `flutter analyze` against the root config could not see it. Fixed in the follow-up commit.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
