### PR TITLE
fix(dm): close the three retired-thread writes the composer notice missed

### DIFF
--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -399,7 +399,11 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                                   reactionsEnabled:
                                       !isRetiredModerationThread &&
                                       !isBlockedByUs,
-                                  sendRecoveryEnabled: !isBlockedByUs,
+                                  retractionsEnabled:
+                                      !isRetiredModerationThread,
+                                  sendRecoveryEnabled:
+                                      !isRetiredModerationThread &&
+                                      !isBlockedByUs,
                                   imageUrl: isDeleted ? null : profile?.picture,
                                   nip05: isDeleted
                                       ? null
@@ -739,6 +743,7 @@ class _ConversationContent extends StatelessWidget {
     required this.displayName,
     required this.isResolving,
     required this.reactionsEnabled,
+    required this.retractionsEnabled,
     required this.sendRecoveryEnabled,
     this.imageUrl,
     this.nip05,
@@ -754,6 +759,9 @@ class _ConversationContent extends StatelessWidget {
   final String displayName;
   final bool isResolving;
   final bool reactionsEnabled;
+
+  /// Whether the viewer may retract something already delivered here.
+  final bool retractionsEnabled;
 
   /// Whether tapping a failed own bubble may offer to resend it.
   final bool sendRecoveryEnabled;
@@ -807,6 +815,7 @@ class _ConversationContent extends StatelessWidget {
                     blockedPubkeys: blockedPubkeys,
                     senderDisplayName: displayName,
                     reactionsEnabled: reactionsEnabled,
+                    retractionsEnabled: retractionsEnabled,
                     sendRecoveryEnabled: sendRecoveryEnabled,
                   ),
         };
@@ -853,6 +862,7 @@ class _MessageList extends StatelessWidget {
     required this.blockedPubkeys,
     required this.senderDisplayName,
     required this.reactionsEnabled,
+    required this.retractionsEnabled,
     required this.sendRecoveryEnabled,
   });
 
@@ -864,6 +874,24 @@ class _MessageList extends StatelessWidget {
   final Set<String> blockedPubkeys;
   final String senderDisplayName;
   final bool reactionsEnabled;
+
+  /// Whether the viewer may retract something this thread already delivered:
+  /// "Delete for everyone" on an own bubble, and "Remove" on an own reaction
+  /// in the reactions detail sheet.
+  ///
+  /// False on a retired moderation thread. Both retractions publish a NIP-09
+  /// kind-5 through the same send path the composer uses, so `DmSendPolicy`
+  /// refuses them for a retired recipient — but each one has *already* dropped
+  /// the local row by then, so the message or reaction disappears for the
+  /// viewer while the copy the recipient received before the rotation stays
+  /// exactly where it was. A button reading "Delete for everyone" that deletes
+  /// for one person is the same false success `[_ClosedThreadNotice]` removes
+  /// the composer to avoid.
+  ///
+  /// Only the write goes. The bubble, the pill, and the detail sheet all stay
+  /// readable — a closed thread is an archive, and the viewer keeps their own
+  /// copy of an enforcement notice either way.
+  final bool retractionsEnabled;
 
   /// Whether tapping a failed own bubble may offer to resend it (#7025).
   ///
@@ -904,6 +932,7 @@ class _MessageList extends StatelessWidget {
       isSent: isSent,
       isVideoShare: videoTarget != null,
       showPicker: showPicker,
+      showDelete: retractionsEnabled,
     );
     if (result == null) return;
     if (!context.mounted) return;
@@ -1158,6 +1187,7 @@ class _MessageList extends StatelessWidget {
                 ownerPubkey: currentPubkey,
                 isSentByMe: isSent,
                 blockedPubkeys: blockedPubkeys,
+                removalEnabled: retractionsEnabled,
               ),
             ],
           );

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -901,11 +901,16 @@ class _MessageList extends StatelessWidget {
   /// as a red bubble, and its tap opens a recovery sheet whose primary action
   /// republishes the rumor. On a blocked thread that delivers a DM to the
   /// account the viewer blocked, from the one screen built to make that
-  /// impossible. On a retired thread the send policy refuses the kind-14 and
-  /// the failed row is dropped, so the bubble vanishes as if it had sent.
-  /// The bubble stays rendered; only the affordance goes, so the evidence is
-  /// intact and nothing is force-deleted. Unblocking (or the current
-  /// moderation key) restores the sheet along with the composer.
+  /// impossible. On a retired thread the send policy refuses the kind-14, so
+  /// the resend is a dead affordance either way.
+  ///
+  /// This flag removes the affordance only — the bubble itself stays rendered,
+  /// so the evidence is intact and nothing is force-deleted here. On a blocked
+  /// thread that holds end to end, and unblocking restores the sheet along with
+  /// the composer. On a retired thread it does not: the first retry sweep after
+  /// the rotation deletes the queue row outright, so the bubble disappears on
+  /// its own. That is a separate defect in the terminal-blocked queue
+  /// transition, tracked in #8492, not something this flag can reach.
   ///
   /// This closes the user-initiated path only. TODO(#7047): Decide whether a
   /// block cancels queued outgoing sends; the reconnect sweep still re-drives

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -895,14 +895,17 @@ class _MessageList extends StatelessWidget {
 
   /// Whether tapping a failed own bubble may offer to resend it (#7025).
   ///
-  /// False in a thread with an account the viewer blocked. Removing the
-  /// composer is not enough on its own: a message that hard-failed before the
-  /// block is still on screen as a red bubble, and its tap opens a recovery
-  /// sheet whose primary action republishes the rumor — delivering a DM to the
+  /// False in a thread with an account the viewer blocked, and on a retired
+  /// moderation thread. Removing the composer is not enough on its own: a
+  /// message that hard-failed before the block or rotation is still on screen
+  /// as a red bubble, and its tap opens a recovery sheet whose primary action
+  /// republishes the rumor. On a blocked thread that delivers a DM to the
   /// account the viewer blocked, from the one screen built to make that
-  /// impossible. The bubble stays rendered; only the affordance goes, so the
-  /// evidence is intact and nothing is force-deleted. Unblocking restores the
-  /// sheet along with the composer.
+  /// impossible. On a retired thread the send policy refuses the kind-14 and
+  /// the failed row is dropped, so the bubble vanishes as if it had sent.
+  /// The bubble stays rendered; only the affordance goes, so the evidence is
+  /// intact and nothing is force-deleted. Unblocking (or the current
+  /// moderation key) restores the sheet along with the composer.
   ///
   /// This closes the user-initiated path only. TODO(#7047): Decide whether a
   /// block cancels queued outgoing sends; the reconnect sweep still re-drives

--- a/mobile/lib/screens/inbox/conversation/widgets/reaction_picker_overlay.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reaction_picker_overlay.dart
@@ -54,6 +54,7 @@ class ReactionPickerOverlay {
     required BuildContext context,
     required bool isSent,
     bool showPicker = true,
+    bool showDelete = true,
     bool isVideoShare = false,
     List<String> emojis = kDefaultDmReactionEmojis,
   }) async {
@@ -91,6 +92,7 @@ class ReactionPickerOverlay {
                 if (showPicker) const SizedBox(height: 8),
                 _ActionList(
                   isSent: isSent,
+                  showDelete: showDelete,
                   isVideoShare: isVideoShare,
                   onSelected: (action) => sheetContext.popModalIfMounted(
                     ReactionPickerResult(action: action),
@@ -219,11 +221,17 @@ class _MoreButton extends StatelessWidget {
 class _ActionList extends StatelessWidget {
   const _ActionList({
     required this.isSent,
+    required this.showDelete,
     required this.isVideoShare,
     required this.onSelected,
   });
 
   final bool isSent;
+
+  /// Whether "Delete for everyone" is offered on an own message. False on a
+  /// closed thread, where the kind-5 cannot be published and the tile would
+  /// only drop the local copy.
+  final bool showDelete;
   final bool isVideoShare;
   final ValueChanged<MessageAction> onSelected;
 
@@ -248,7 +256,7 @@ class _ActionList extends StatelessWidget {
           label: l10n.shareSheetSaveVideo,
           onTap: () => onSelected(MessageAction.saveVideo),
         ),
-      if (isSent)
+      if (isSent && showDelete)
         _ActionTile(
           icon: DivineIconName.trash,
           label: l10n.dmMessageActionDeleteForEveryone,

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
@@ -33,6 +33,7 @@ abstract class ReactionsDetailSheet {
     required String messageAuthorPubkey,
     required String ownerPubkey,
     Set<String> blockedPubkeys = const <String>{},
+    bool removalEnabled = true,
   }) {
     return VineBottomSheet.show<void>(
       context: context,
@@ -54,6 +55,7 @@ abstract class ReactionsDetailSheet {
         messageAuthorPubkey: messageAuthorPubkey,
         ownerPubkey: ownerPubkey,
         blockedPubkeys: blockedPubkeys,
+        removalEnabled: removalEnabled,
       ),
     );
   }
@@ -67,6 +69,7 @@ class _ReactionsDetailBody extends StatelessWidget {
     required this.messageAuthorPubkey,
     required this.ownerPubkey,
     required this.blockedPubkeys,
+    required this.removalEnabled,
   });
 
   final ScrollController scrollController;
@@ -75,6 +78,10 @@ class _ReactionsDetailBody extends StatelessWidget {
   final String messageAuthorPubkey;
   final String ownerPubkey;
   final Set<String> blockedPubkeys;
+
+  /// Whether an own reaction may be retracted from here. See
+  /// [ReactionsRow.removalEnabled].
+  final bool removalEnabled;
 
   @override
   Widget build(BuildContext context) {
@@ -114,6 +121,7 @@ class _ReactionsDetailBody extends StatelessWidget {
               isOwn: reaction.reactorPubkey == ownerPubkey,
               conversationId: conversationId,
               messageAuthorPubkey: messageAuthorPubkey,
+              removalEnabled: removalEnabled,
             );
           },
         );
@@ -128,10 +136,15 @@ class _ReactorRow extends ConsumerWidget {
     required this.isOwn,
     required this.conversationId,
     required this.messageAuthorPubkey,
+    required this.removalEnabled,
   });
 
   final DmReaction reaction;
   final bool isOwn;
+
+  /// Whether this row's own-reaction retraction is offered. See
+  /// [ReactionsRow.removalEnabled].
+  final bool removalEnabled;
   final String conversationId;
   final String messageAuthorPubkey;
 
@@ -184,8 +197,9 @@ class _ReactorRow extends ConsumerWidget {
             reaction.emoji,
           );
 
+    final canRetract = isOwn && removalEnabled;
     return Semantics(
-      button: isOwn && !isPending,
+      button: canRetract && !isPending,
       label: label,
       child: Material(
         type: MaterialType.transparency,
@@ -223,11 +237,11 @@ class _ReactorRow extends ConsumerWidget {
           ),
           trailing: _Trailing(
             emoji: reaction.emoji,
-            isOwn: isOwn,
+            showAction: canRetract,
             isFailed: isFailed,
             isPending: isPending,
           ),
-          onTap: (isOwn && !isPending)
+          onTap: (canRetract && !isPending)
               ? () => _onOwnTap(context, isFailed: isFailed)
               : null,
         ),
@@ -268,13 +282,16 @@ class _ReactorRow extends ConsumerWidget {
 class _Trailing extends StatelessWidget {
   const _Trailing({
     required this.emoji,
-    required this.isOwn,
+    required this.showAction,
     required this.isFailed,
     required this.isPending,
   });
 
   final String emoji;
-  final bool isOwn;
+
+  /// Whether to render the trailing Remove/Retry affordance. False for another
+  /// reactor's row, and for the viewer's own on a closed thread.
+  final bool showAction;
   final bool isFailed;
   final bool isPending;
 
@@ -286,7 +303,7 @@ class _Trailing extends StatelessWidget {
       emoji,
       style: const TextStyle(fontSize: 18),
     );
-    if (!isOwn) return emojiText;
+    if (!showAction) return emojiText;
 
     final Widget action;
     if (isPending) {

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
@@ -184,20 +184,29 @@ class _ReactorRow extends ConsumerWidget {
     final isFailed = reaction.publishStatus == DmReactionPublishStatus.failed;
     final isPending = reaction.publishStatus == DmReactionPublishStatus.pending;
 
-    final label = isOwn
-        ? switch (reaction.publishStatus) {
-            DmReactionPublishStatus.pending =>
-              context.l10n.dmReactionChipPendingA11yLabel(reaction.emoji),
-            DmReactionPublishStatus.failed =>
-              context.l10n.dmReactionChipFailedA11yLabel,
-            _ => context.l10n.dmReactionChipOwnA11yLabel(reaction.emoji),
-          }
-        : context.l10n.dmReactionChipOtherA11yLabel(
-            isIdentityResolving ? context.l10n.commonLoading : name,
-            reaction.emoji,
-          );
-
     final canRetract = isOwn && removalEnabled;
+
+    // The pending/failed labels announce a spinner or "double tap to retry"
+    // that only render while the row is retractable. On a closed thread the
+    // trailing collapses to a bare emoji, so an own reaction keeps the plain
+    // descriptive label rather than promising an action wired to nothing.
+    final String label;
+    if (!isOwn) {
+      label = context.l10n.dmReactionChipOtherA11yLabel(
+        isIdentityResolving ? context.l10n.commonLoading : name,
+        reaction.emoji,
+      );
+    } else if (!canRetract) {
+      label = context.l10n.dmReactionChipOwnA11yLabel(reaction.emoji);
+    } else {
+      label = switch (reaction.publishStatus) {
+        DmReactionPublishStatus.pending =>
+          context.l10n.dmReactionChipPendingA11yLabel(reaction.emoji),
+        DmReactionPublishStatus.failed =>
+          context.l10n.dmReactionChipFailedA11yLabel,
+        _ => context.l10n.dmReactionChipOwnA11yLabel(reaction.emoji),
+      };
+    }
     return Semantics(
       button: canRetract && !isPending,
       label: label,

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
@@ -28,6 +28,7 @@ class ReactionsRow extends StatefulWidget {
     required this.ownerPubkey,
     required this.isSentByMe,
     this.blockedPubkeys = const <String>{},
+    this.removalEnabled = true,
     super.key,
   });
 
@@ -48,6 +49,13 @@ class ReactionsRow extends StatefulWidget {
 
   /// Pubkeys whose reactions should be hidden.
   final Set<String> blockedPubkeys;
+
+  /// Whether the own-reaction row in the detail sheet may retract the
+  /// reaction. False on a closed thread: the kind-5 is refused by
+  /// `DmSendPolicy`, so tapping it would only drop the local copy of a
+  /// reaction the recipient still holds. The sheet still opens — reading who
+  /// reacted is not a write.
+  final bool removalEnabled;
 
   @override
   State<ReactionsRow> createState() => _ReactionsRowState();
@@ -127,6 +135,7 @@ class _ReactionsRowState extends State<ReactionsRow> {
                   messageAuthorPubkey: widget.messageAuthorPubkey,
                   ownerPubkey: widget.ownerPubkey,
                   blockedPubkeys: widget.blockedPubkeys,
+                  removalEnabled: widget.removalEnabled,
                 ),
               ),
             ),

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -864,8 +864,10 @@ void main() {
           reason: 'the retraction is refused by the send policy',
         );
 
-        // And the row is inert rather than merely unlabelled.
-        await tester.tap(find.text(l10n.dmReactionsSheetTitle));
+        // The sheet header is not the row. Tap the reactor ListTile so
+        // this fails if onTap is still wired.
+        expect(find.byType(ListTile), findsOneWidget);
+        await tester.tap(find.byType(ListTile));
         await tester.pump();
         verifyNever(() => mockReactionsCubit.add(any()));
       });

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -743,6 +743,176 @@ void main() {
         expect(find.text(l10n.dmSendBlockedRetiredMessage), findsOneWidget);
         expect(find.text(l10n.dmSendBlockedMessage), findsNothing);
       });
+
+      // Closing the composer is not the whole of "closed". Every retraction
+      // below publishes a kind-5 through the same send path, so `DmSendPolicy`
+      // refuses it for a retired recipient — but each one drops the local row
+      // first. The viewer sees the thing disappear; the copy the recipient
+      // received before the rotation stays exactly where it was.
+      const ownMessageId =
+          '1212121212121212121212121212121212121212121212121212121212121212';
+      const ownConversationId =
+          '3434343434343434343434343434343434343434343434343434343434343434';
+
+      DmMessage ownMessage() => DmMessage(
+        id: ownMessageId,
+        conversationId: ownConversationId,
+        senderPubkey: currentPubkey,
+        content: 'something I sent before the rotation',
+        createdAt: now.millisecondsSinceEpoch ~/ 1000,
+        giftWrapId:
+            'aaaaaaaabbbbbbbbccccccccddddddddaaaaaaaabbbbbbbbccccccccdddddddd',
+      );
+
+      testWidgets('an own bubble offers no delete-for-everyone', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildSubject(
+            counterparty: retired,
+            state: ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [ownMessage()],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.longPress(find.text(ownMessage().content));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text(l10n.dmMessageActionDeleteForEveryone),
+          findsNothing,
+          reason:
+              'the kind-5 is refused by the send policy, so the tile would '
+              'only drop the local copy of a message the recipient still has',
+        );
+        // The read affordances stay: a closed thread is an archive.
+        expect(find.text(l10n.dmMessageActionCopyText), findsOneWidget);
+      });
+
+      testWidgets('a live thread still offers delete-for-everyone', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [ownMessage()],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.longPress(find.text(ownMessage().content));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text(l10n.dmMessageActionDeleteForEveryone),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('an own reaction cannot be retracted from the '
+          'who-reacted sheet', (tester) async {
+        const ownReaction = DmReaction(
+          id: 'r-own-retired',
+          conversationId: ownConversationId,
+          targetMessageId: ownMessageId,
+          targetMessageAuthor: currentPubkey,
+          reactorPubkey: currentPubkey,
+          emoji: '\u{2764}\u{FE0F}',
+          createdAt: 1700000000,
+          ownerPubkey: currentPubkey,
+          publishStatus: DmReactionPublishStatus.received,
+        );
+        const reactionsState = ConversationReactionsState(
+          status: ConversationReactionsStatus.loaded,
+          reactionsByMessageId: {
+            ownMessageId: [ownReaction],
+          },
+        );
+        whenListen(
+          mockReactionsCubit,
+          Stream<ConversationReactionsState>.value(reactionsState),
+          initialState: reactionsState,
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            counterparty: retired,
+            state: ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [ownMessage()],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.text('\u{2764}\u{FE0F}'));
+        // Avoid pumpAndSettle: the view's async profile providers can schedule
+        // continuous micro-tasks. Pump the bottom-sheet enter animation.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        // The sheet still opens — reading who reacted is not a write.
+        expect(find.text(l10n.dmReactionsSheetTitle), findsOneWidget);
+        expect(
+          find.text(l10n.dmReactionRemoveAction),
+          findsNothing,
+          reason: 'the retraction is refused by the send policy',
+        );
+
+        // And the row is inert rather than merely unlabelled.
+        await tester.tap(find.text(l10n.dmReactionsSheetTitle));
+        await tester.pump();
+        verifyNever(() => mockReactionsCubit.add(any()));
+      });
+
+      testWidgets('a failed own bubble cannot be resent', (tester) async {
+        const content = 'a message that never got through';
+        final failedRow = OutgoingDm(
+          id: 'rumor-failed-retired',
+          conversationId: ownConversationId,
+          recipientPubkey: retired,
+          content: content,
+          createdAt: DateTime(2026).millisecondsSinceEpoch ~/ 1000,
+          rumorEventJson: '{}',
+          recipientWrapStatus: OutgoingWrapStatus.failed,
+          selfWrapStatus: OutgoingWrapStatus.failed,
+          queuedAt: DateTime(2026),
+          ownerPubkey: currentPubkey,
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            counterparty: retired,
+            state: ConversationState(
+              status: ConversationStatus.loaded,
+              pendingOutgoing: [failedRow],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // The bubble stays: it is the viewer's own record of the exchange.
+        expect(find.text(content), findsOneWidget);
+
+        await tester.tap(find.text(content));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text(l10n.dmMessageActionRetrySend),
+          findsNothing,
+          reason: 'the recovery sheet must not open in a closed thread',
+        );
+        verifyNever(
+          () => mockBloc.add(
+            any(that: isA<ConversationFullSendRecoveryRequested>()),
+          ),
+        );
+      });
     });
 
     group('renders', () {

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -931,6 +931,51 @@ void main() {
         handle.dispose();
       });
 
+      testWidgets('a live thread still offers to remove an own reaction', (
+        tester,
+      ) async {
+        const emoji = '\u{2764}\u{FE0F}';
+        const ownReaction = DmReaction(
+          id: 'r-own-live',
+          conversationId: ownConversationId,
+          targetMessageId: ownMessageId,
+          targetMessageAuthor: currentPubkey,
+          reactorPubkey: currentPubkey,
+          emoji: emoji,
+          createdAt: 1700000000,
+          ownerPubkey: currentPubkey,
+          publishStatus: DmReactionPublishStatus.received,
+        );
+        const reactionsState = ConversationReactionsState(
+          status: ConversationReactionsStatus.loaded,
+          reactionsByMessageId: {
+            ownMessageId: [ownReaction],
+          },
+        );
+        whenListen(
+          mockReactionsCubit,
+          Stream<ConversationReactionsState>.value(reactionsState),
+          initialState: reactionsState,
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [ownMessage()],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.text(emoji));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.text(l10n.dmReactionsSheetTitle), findsOneWidget);
+        expect(find.text(l10n.dmReactionRemoveAction), findsOneWidget);
+      });
+
       testWidgets('a failed own bubble cannot be resent', (tester) async {
         const content = 'a message that never got through';
         final failedRow = OutgoingDm(

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -870,6 +870,67 @@ void main() {
         verifyNever(() => mockReactionsCubit.add(any()));
       });
 
+      testWidgets('a failed own reaction announces no retry action on a '
+          'closed thread', (tester) async {
+        const emoji = '\u{2764}\u{FE0F}';
+        const ownReaction = DmReaction(
+          id: 'r-own-retired-failed',
+          conversationId: ownConversationId,
+          targetMessageId: ownMessageId,
+          targetMessageAuthor: currentPubkey,
+          reactorPubkey: currentPubkey,
+          emoji: emoji,
+          createdAt: 1700000000,
+          ownerPubkey: currentPubkey,
+          publishStatus: DmReactionPublishStatus.failed,
+        );
+        const reactionsState = ConversationReactionsState(
+          status: ConversationReactionsStatus.loaded,
+          reactionsByMessageId: {
+            ownMessageId: [ownReaction],
+          },
+        );
+        whenListen(
+          mockReactionsCubit,
+          Stream<ConversationReactionsState>.value(reactionsState),
+          initialState: reactionsState,
+        );
+
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(
+          buildSubject(
+            counterparty: retired,
+            state: ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [ownMessage()],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.text(emoji));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        // The sheet rendered the own reaction row (so the retry-label check
+        // below is not trivially satisfied by an absent row)...
+        expect(find.text(l10n.dmReactionsSheetTitle), findsOneWidget);
+        // ...but the trailing collapses to a bare emoji, so the row must not
+        // tell a screen reader to "double tap to retry" a retraction it cannot
+        // make. The label falls back to the plain descriptive own-reaction one.
+        expect(
+          find.bySemanticsLabel(
+            RegExp(RegExp.escape(l10n.dmReactionChipFailedA11yLabel)),
+          ),
+          findsNothing,
+        );
+        expect(
+          find.bySemanticsLabel(RegExp(RegExp.escape('Your reaction'))),
+          findsWidgets,
+        );
+        handle.dispose();
+      });
+
       testWidgets('a failed own bubble cannot be resent', (tester) async {
         const content = 'a message that never got through';
         final failedRow = OutgoingDm(


### PR DESCRIPTION
## What

`#6963` replaced the composer on a retired moderation thread because a reply published there is accepted by the relay, reported as sent, and read by nobody. Three other write affordances on the same screen never received the retired flag:

| Affordance | Was gated on | Now |
|---|---|---|
| "Delete for everyone" (long-press) | `isSent` only | `isSent && !isRetiredModerationThread` |
| "Remove" on an own reaction (who-reacted sheet) | nothing | `!isRetiredModerationThread` |
| Resend sheet on a failed own bubble | `!isBlockedByUs` | `!isRetiredModerationThread && !isBlockedByUs` |

All three publish a NIP-09 kind-5 through `sendRumor`, so `DmSendPolicy` **correctly refuses** them — the send predicate is not the bug. The bug is that each one drops the local row *first*. The message or reaction disappears for the viewer while the copy the recipient received before the rotation stays exactly where it was.

A button labelled "Delete for everyone" that deletes for one person is the same false success the closed composer exists to prevent, inverted.

The `sendRecoveryEnabled` doc comment already made this exact argument — for the *blocked* case only. This applies it to the closed case too.

## Reproduced on device

iOS simulator (iPhone 17 Pro, iOS 26.5) against `relay.divine.video`, with a controllable stand-in key patched into `kLegacyModerationPubkeys` so a thread with genuine two-way history became retired mid-session:

- Tapping **Remove** on an own reaction → `NIP-17 send blocked by policy for recipient`. The pill vanished from the thread; a relay query for gift wraps addressed to the recipient showed no kind-5. The reaction the recipient already holds is now unretractable.
- Tapping **Delete for everyone** → `NIP-17 send blocked by policy for recipient` + `Deletion of <rumor id> refused by send policy; not retrying`. The bubble vanished locally; nothing published.

Controls confirmed the same build sends and reacts normally while the key is the current pin, and that the long-press emoji picker is already correctly hidden once it is retired.

## Tests

Four new cases in `ConversationView > retired moderation thread`, plus a live-thread control so the guards cannot pass by disabling the affordances everywhere.

Each guard was mutated **separately** and produces exactly one failure — its own:

| Mutation | Result |
|---|---|
| `showDelete: true` | delete-for-everyone test fails, others pass |
| `removalEnabled: true` | reaction-retraction test fails, others pass |
| `sendRecoveryEnabled: !isBlockedByUs` | failed-bubble test fails, others pass |

`flutter analyze` clean; 245/245 in `test/screens/inbox/conversation/`.

## Scope

Reads are untouched — the bubble, the pill and the detail sheet all still open. A closed thread is an archive, and the viewer's own copy of an enforcement notice is often the only record they have.

Behaviour on **blocked** threads is deliberately unchanged: a kind-5 to a blocked account is not refused by the send policy, so removing that affordance would be a separate behaviour change.

Refs #7851, #8228