### PR TITLE
feat(support): add a Clear Logs action to Support Center

### DIFF
--- a/mobile/lib/blocs/clear_logs/clear_logs_cubit.dart
+++ b/mobile/lib/blocs/clear_logs/clear_logs_cubit.dart
@@ -19,8 +19,10 @@ class ClearLogsCubit extends Cubit<ClearLogsState>
   /// Empties the in-memory log capture buffer.
   ///
   /// Emits [ClearLogsStatus.clearing] then [ClearLogsStatus.cleared] so a
-  /// repeat clear still produces a transition the UI can react to.
+  /// repeat clear still produces a transition the UI can react to. A second
+  /// call while one is in flight is ignored, mirroring the export cubit.
   Future<void> clear() async {
+    if (state.status == ClearLogsStatus.clearing) return;
     emitIfOpen(const ClearLogsState(status: ClearLogsStatus.clearing));
     await _bugReportService.clearCapturedLogs();
     emitIfOpen(const ClearLogsState(status: ClearLogsStatus.cleared));

--- a/mobile/lib/blocs/clear_logs/clear_logs_cubit.dart
+++ b/mobile/lib/blocs/clear_logs/clear_logs_cubit.dart
@@ -1,0 +1,28 @@
+// ABOUTME: Drives the Support Center "Clear Logs" action
+// ABOUTME: Keeps BugReportService out of the widget layer (UI -> Cubit -> Service)
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/clear_logs/clear_logs_state.dart';
+import 'package:openvine/blocs/close_guard.dart';
+import 'package:openvine/services/bug_report_service.dart';
+
+export 'package:openvine/blocs/clear_logs/clear_logs_state.dart';
+
+class ClearLogsCubit extends Cubit<ClearLogsState>
+    with CloseGuardedEmit<ClearLogsState> {
+  ClearLogsCubit({required BugReportService bugReportService})
+    : _bugReportService = bugReportService,
+      super(const ClearLogsState());
+
+  final BugReportService _bugReportService;
+
+  /// Empties the in-memory log capture buffer.
+  ///
+  /// Emits [ClearLogsStatus.clearing] then [ClearLogsStatus.cleared] so a
+  /// repeat clear still produces a transition the UI can react to.
+  Future<void> clear() async {
+    emitIfOpen(const ClearLogsState(status: ClearLogsStatus.clearing));
+    await _bugReportService.clearCapturedLogs();
+    emitIfOpen(const ClearLogsState(status: ClearLogsStatus.cleared));
+  }
+}

--- a/mobile/lib/blocs/clear_logs/clear_logs_state.dart
+++ b/mobile/lib/blocs/clear_logs/clear_logs_state.dart
@@ -1,0 +1,25 @@
+// ABOUTME: State for the Support Center clear-logs action
+// ABOUTME: Transient clearing state lets a repeat clear re-notify the UI
+
+import 'package:equatable/equatable.dart';
+
+/// Outcome of clearing the in-memory log capture buffer.
+enum ClearLogsStatus {
+  idle,
+
+  /// The clear is in flight. Emitted before [cleared] so a repeat clear still
+  /// produces a state change the UI can react to.
+  clearing,
+
+  /// The buffer was emptied.
+  cleared,
+}
+
+class ClearLogsState extends Equatable {
+  const ClearLogsState({this.status = ClearLogsStatus.idle});
+
+  final ClearLogsStatus status;
+
+  @override
+  List<Object?> get props => [status];
+}

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2821,6 +2821,20 @@
   "supportRequestFeatureSubtitle": "Suggest an improvement or new feature",
   "supportSaveLogs": "Save Logs",
   "supportSaveLogsSubtitle": "Export logs to file for manual sending",
+  "supportClearLogs": "Clear Logs",
+  "supportClearLogsSubtitle": "Wipe captured logs and start fresh",
+  "supportClearLogsConfirmTitle": "Clear captured logs?",
+  "@supportClearLogsConfirmTitle": {
+    "description": "Title of the confirmation sheet shown before clearing the in-memory log buffer."
+  },
+  "supportClearLogsConfirmButton": "Clear",
+  "@supportClearLogsConfirmButton": {
+    "description": "Confirm button on the clear-logs confirmation sheet, under the title 'Clear captured logs?'."
+  },
+  "supportLogsCleared": "Logs cleared",
+  "@supportLogsCleared": {
+    "description": "Snackbar shown after the in-memory log buffer is cleared."
+  },
   "supportFaq": "FAQ",
   "supportFaqSubtitle": "Common questions & answers",
   "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7771,6 +7771,36 @@ abstract class AppLocalizations {
   /// **'Export logs to file for manual sending'**
   String get supportSaveLogsSubtitle;
 
+  /// No description provided for @supportClearLogs.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear Logs'**
+  String get supportClearLogs;
+
+  /// No description provided for @supportClearLogsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Wipe captured logs and start fresh'**
+  String get supportClearLogsSubtitle;
+
+  /// Title of the confirmation sheet shown before clearing the in-memory log buffer.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear captured logs?'**
+  String get supportClearLogsConfirmTitle;
+
+  /// Confirm button on the clear-logs confirmation sheet, under the title 'Clear captured logs?'.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear'**
+  String get supportClearLogsConfirmButton;
+
+  /// Snackbar shown after the in-memory log buffer is cleared.
+  ///
+  /// In en, this message translates to:
+  /// **'Logs cleared'**
+  String get supportLogsCleared;
+
   /// No description provided for @supportFaq.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4430,6 +4430,21 @@ class AppLocalizationsAm extends AppLocalizations {
   String get supportSaveLogsSubtitle => 'በእጅ ለመላክ የምዝግብ ማስታወሻዎችን ወደ ፋይል ይላኩ።';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'የሚጠየቁ ጥያቄዎች';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4498,6 +4498,21 @@ class AppLocalizationsAr extends AppLocalizations {
   String get supportSaveLogsSubtitle => 'تصدير السجلات إلى ملف للإرسال يدويًا';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'الأسئلة الشائعة';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4585,6 +4585,21 @@ class AppLocalizationsBg extends AppLocalizations {
       'Експортирай логовете във файл за ръчно изпращане';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'ЧЗВ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4594,6 +4594,21 @@ class AppLocalizationsDe extends AppLocalizations {
       'Logs als Datei exportieren, um sie manuell zu senden';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'FAQ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4624,6 +4624,21 @@ class AppLocalizationsEn extends AppLocalizations {
       'Export logs to file for manual sending';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'FAQ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4583,6 +4583,21 @@ class AppLocalizationsEs extends AppLocalizations {
       'Exportá los logs a un archivo para enviarlos manualmente';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'Preguntas frecuentes';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4566,6 +4566,21 @@ class AppLocalizationsFil extends AppLocalizations {
       'I-export ang logs sa file para manual na maipadala';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'FAQ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4601,6 +4601,21 @@ class AppLocalizationsFr extends AppLocalizations {
       'Exporter les logs vers un fichier pour envoi manuel';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'FAQ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4468,6 +4468,21 @@ class AppLocalizationsId extends AppLocalizations {
       'Ekspor log ke file untuk pengiriman manual';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'FAQ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4588,6 +4588,21 @@ class AppLocalizationsIt extends AppLocalizations {
       'Esporta i log in un file per l\'invio manuale';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'FAQ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4265,6 +4265,21 @@ class AppLocalizationsJa extends AppLocalizations {
   String get supportSaveLogsSubtitle => '手動送信用にログをファイルにエクスポート';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'よくある質問';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4279,6 +4279,21 @@ class AppLocalizationsKo extends AppLocalizations {
   String get supportSaveLogsSubtitle => '수동 전송을 위해 로그를 파일로 내보내요';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => '자주 묻는 질문';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -4535,6 +4535,21 @@ class AppLocalizationsMs extends AppLocalizations {
       'Eksport log ke fail untuk penghantaran manual';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'Soalan Lazim';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4554,6 +4554,21 @@ class AppLocalizationsNl extends AppLocalizations {
       'Exporteer logs naar bestand om handmatig te versturen';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'Veelgestelde vragen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4656,6 +4656,21 @@ class AppLocalizationsPl extends AppLocalizations {
       'Eksportuj logi do pliku do ręcznego wysłania';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'FAQ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4566,6 +4566,21 @@ class AppLocalizationsPt extends AppLocalizations {
       'Exportar logs para um arquivo para envio manual';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'FAQ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4672,6 +4672,21 @@ class AppLocalizationsRo extends AppLocalizations {
       'Exportă jurnalele într-un fișier pentru trimitere manuală';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'Întrebări frecvente';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4534,6 +4534,21 @@ class AppLocalizationsSv extends AppLocalizations {
       'Exportera loggar till fil för manuell sändning';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'FAQ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -4705,6 +4705,21 @@ class AppLocalizationsTe extends AppLocalizations {
       'మాన్యువల్ పంపడం కోసం ఫైల్‌కి లాగ్‌లను ఎగుమతి చేయండి';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'తరచుగా అడిగే ప్రశ్నలు';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4476,6 +4476,21 @@ class AppLocalizationsTr extends AppLocalizations {
       'Manuel göndermek için günlükleri dosyaya aktar';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'SSS';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -4545,6 +4545,21 @@ class AppLocalizationsUr extends AppLocalizations {
       'دستی بھیجنے کے لیے لاگز فائل میں ایکسپورٹ کریں';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'عمومی سوالات';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -4503,6 +4503,21 @@ class AppLocalizationsVi extends AppLocalizations {
   String get supportSaveLogsSubtitle => 'Xuất nhật ký ra tệp để gửi thủ công';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => 'Câu hỏi thường gặp';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -4244,6 +4244,21 @@ class AppLocalizationsZh extends AppLocalizations {
   String get supportSaveLogsSubtitle => '导出日志到文件，手动发送';
 
   @override
+  String get supportClearLogs => 'Clear Logs';
+
+  @override
+  String get supportClearLogsSubtitle => 'Wipe captured logs and start fresh';
+
+  @override
+  String get supportClearLogsConfirmTitle => 'Clear captured logs?';
+
+  @override
+  String get supportClearLogsConfirmButton => 'Clear';
+
+  @override
+  String get supportLogsCleared => 'Logs cleared';
+
+  @override
   String get supportFaq => '常见问题';
 
   @override

--- a/mobile/lib/screens/settings/support_center_screen.dart
+++ b/mobile/lib/screens/settings/support_center_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/clear_logs/clear_logs_cubit.dart';
 import 'package:openvine/blocs/export_logs/export_logs_cubit.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/extensions/safe_pop_extension.dart';
@@ -18,6 +19,7 @@ import 'package:openvine/services/support_email_composer.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
 import 'package:openvine/utils/share_position_origin.dart';
 import 'package:openvine/widgets/bug_report_dialog.dart';
+import 'package:openvine/widgets/clear_logs_confirmation_sheet.dart';
 import 'package:openvine/widgets/delete_account_action.dart';
 import 'package:openvine/widgets/feature_request_dialog.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -78,6 +80,7 @@ class SupportCenterScreen extends ConsumerWidget {
                   onTap: () => _showFeatureRequest(context),
                 ),
               const _ExportLogsTile(),
+              const _ClearLogsTile(),
               // #6335 was filed from here by someone who could not find
               // deletion, so it has to be reachable from here too. It sits
               // above the outbound links rather than last so it stays on
@@ -398,5 +401,55 @@ class _ExportLogsTileView extends StatelessWidget {
         },
       ),
     );
+  }
+}
+
+/// Clears the in-memory log capture buffer, behind a confirmation.
+///
+/// Goes through [ClearLogsCubit] rather than calling `BugReportService`
+/// from here, so the widget layer never sees the service type.
+class _ClearLogsTile extends ConsumerWidget {
+  const _ClearLogsTile();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final bugReportService = ref.watch(bugReportServiceProvider);
+    return BlocProvider<ClearLogsCubit>(
+      key: ValueKey(bugReportService),
+      create: (_) => ClearLogsCubit(bugReportService: bugReportService),
+      child: const _ClearLogsTileView(),
+    );
+  }
+}
+
+class _ClearLogsTileView extends StatelessWidget {
+  const _ClearLogsTileView();
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return BlocListener<ClearLogsCubit, ClearLogsState>(
+      listenWhen: (previous, current) => previous.status != current.status,
+      listener: (context, state) {
+        if (state.status != ClearLogsStatus.cleared) return;
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            DivineSnackbarContainer.snackBar(context.l10n.supportLogsCleared),
+          );
+      },
+      child: _SupportTile(
+        icon: DivineIconName.trashSimple,
+        title: l10n.supportClearLogs,
+        subtitle: l10n.supportClearLogsSubtitle,
+        onTap: () => _confirmAndClear(context),
+      ),
+    );
+  }
+
+  Future<void> _confirmAndClear(BuildContext context) async {
+    final confirmed = await showClearLogsConfirmation(context);
+    if (confirmed != true || !context.mounted) return;
+    context.read<ClearLogsCubit>().clear();
   }
 }

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -335,6 +335,13 @@ class BugReportService {
     }
   }
 
+  /// Clears the in-memory log capture buffer.
+  ///
+  /// The buffer is memory-only, so it also empties on the next launch; this
+  /// lets the user reset it without restarting — for a clean reproduction
+  /// before exporting.
+  Future<void> clearCapturedLogs() => LogCaptureService().clearAllLogs();
+
   /// Environment diagnostics for the export header: network connectivity,
   /// text scale, active accessibility features, app uptime, device memory
   /// tier, and cache usage.

--- a/mobile/lib/widgets/clear_logs_confirmation_sheet.dart
+++ b/mobile/lib/widgets/clear_logs_confirmation_sheet.dart
@@ -19,6 +19,7 @@ Future<bool?> showClearLogsConfirmation(BuildContext context) {
       Padding(
         padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
         child: Row(
+          spacing: 16,
           children: [
             Expanded(
               child: DivineButton(
@@ -27,7 +28,6 @@ Future<bool?> showClearLogsConfirmation(BuildContext context) {
                 onPressed: () => Navigator.of(context).pop(false),
               ),
             ),
-            const SizedBox(width: 16),
             Expanded(
               child: DivineButton(
                 label: l10n.supportClearLogsConfirmButton,

--- a/mobile/lib/widgets/clear_logs_confirmation_sheet.dart
+++ b/mobile/lib/widgets/clear_logs_confirmation_sheet.dart
@@ -1,0 +1,43 @@
+// ABOUTME: Confirmation bottom sheet shown before clearing the captured logs
+// ABOUTME: Returns true if the user confirms, false/null if they back out
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+/// Shows a confirmation bottom sheet before clearing the in-memory log buffer.
+///
+/// Returns `true` if the user confirmed, `false` or `null` if they cancelled
+/// (including tapping outside the sheet).
+Future<bool?> showClearLogsConfirmation(BuildContext context) {
+  final l10n = context.l10n;
+  return VineBottomSheet.show<bool>(
+    context: context,
+    scrollable: false,
+    contentTitle: l10n.supportClearLogsConfirmTitle,
+    children: [
+      Padding(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+        child: Row(
+          children: [
+            Expanded(
+              child: DivineButton(
+                label: l10n.commonCancel,
+                type: DivineButtonType.secondary,
+                onPressed: () => Navigator.of(context).pop(false),
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: DivineButton(
+                label: l10n.supportClearLogsConfirmButton,
+                type: DivineButtonType.error,
+                onPressed: () => Navigator.of(context).pop(true),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ],
+  );
+}

--- a/mobile/test/blocs/clear_logs/clear_logs_cubit_test.dart
+++ b/mobile/test/blocs/clear_logs/clear_logs_cubit_test.dart
@@ -1,0 +1,79 @@
+// ABOUTME: Tests the clear-logs cubit's transient-then-cleared transitions
+// ABOUTME: The transient clearing state lets a repeat clear re-fire the UI
+
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/clear_logs/clear_logs_cubit.dart';
+import 'package:openvine/services/bug_report_service.dart';
+
+class _MockBugReportService extends Mock implements BugReportService {}
+
+void main() {
+  group(ClearLogsCubit, () {
+    late _MockBugReportService bugReportService;
+
+    setUp(() {
+      bugReportService = _MockBugReportService();
+    });
+
+    ClearLogsCubit build() =>
+        ClearLogsCubit(bugReportService: bugReportService);
+
+    group('clear', () {
+      blocTest<ClearLogsCubit, ClearLogsState>(
+        'clears the buffer and reports cleared',
+        setUp: () => when(
+          () => bugReportService.clearCapturedLogs(),
+        ).thenAnswer((_) async {}),
+        build: build,
+        act: (cubit) => cubit.clear(),
+        expect: () => const [
+          ClearLogsState(status: ClearLogsStatus.clearing),
+          ClearLogsState(status: ClearLogsStatus.cleared),
+        ],
+        verify: (_) {
+          verify(() => bugReportService.clearCapturedLogs()).called(1);
+        },
+      );
+
+      // A repeat clear must transition again so the UI re-fires its snackbar;
+      // the transient clearing state is what makes the state actually change.
+      blocTest<ClearLogsCubit, ClearLogsState>(
+        'transitions again on a repeat clear',
+        setUp: () => when(
+          () => bugReportService.clearCapturedLogs(),
+        ).thenAnswer((_) async {}),
+        build: build,
+        act: (cubit) async {
+          await cubit.clear();
+          await cubit.clear();
+        },
+        expect: () => const [
+          ClearLogsState(status: ClearLogsStatus.clearing),
+          ClearLogsState(status: ClearLogsStatus.cleared),
+          ClearLogsState(status: ClearLogsStatus.clearing),
+          ClearLogsState(status: ClearLogsStatus.cleared),
+        ],
+      );
+
+      // close() does not cancel an in-flight clear; the resumed emit would
+      // throw without the guard (#7370).
+      test('drops the outcome when closed mid-clear', () async {
+        final gate = Completer<void>();
+        when(
+          () => bugReportService.clearCapturedLogs(),
+        ).thenAnswer((_) => gate.future);
+
+        final cubit = build();
+        final pending = cubit.clear();
+        await cubit.close();
+        gate.complete();
+
+        await expectLater(pending, completes);
+      });
+    });
+  });
+}

--- a/mobile/test/blocs/clear_logs/clear_logs_cubit_test.dart
+++ b/mobile/test/blocs/clear_logs/clear_logs_cubit_test.dart
@@ -59,6 +59,24 @@ void main() {
         ],
       );
 
+      blocTest<ClearLogsCubit, ClearLogsState>(
+        'ignores a second clear while one is in flight',
+        setUp: () => when(
+          () => bugReportService.clearCapturedLogs(),
+        ).thenAnswer((_) => Completer<void>().future),
+        build: build,
+        act: (cubit) {
+          unawaited(cubit.clear());
+          unawaited(cubit.clear());
+        },
+        expect: () => const [
+          ClearLogsState(status: ClearLogsStatus.clearing),
+        ],
+        verify: (_) {
+          verify(() => bugReportService.clearCapturedLogs()).called(1);
+        },
+      );
+
       // close() does not cancel an in-flight clear; the resumed emit would
       // throw without the guard (#7370).
       test('drops the outcome when closed mid-clear', () async {

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -449,6 +449,13 @@ const _knownUntranslatedDebt = <String>{
   // has to follow exactly is how it stops meaning what it says.
   'supportNoLogsToExport',
   'supportExportLogsUnconfirmed',
+  // Clear-logs copy (#8114). New UI strings left in English until the same
+  // human translation pass rather than machine-translated into 21 locales.
+  'supportClearLogs',
+  'supportClearLogsSubtitle',
+  'supportClearLogsConfirmTitle',
+  'supportClearLogsConfirmButton',
+  'supportLogsCleared',
   // Account-enforcement translation remains tracked in #7765. The policy copy
   // is deliberately left in English until its human translation pass.
   'accountStatusTitle',

--- a/mobile/test/screens/settings/support_center_screen_test.dart
+++ b/mobile/test/screens/settings/support_center_screen_test.dart
@@ -225,6 +225,51 @@ void main() {
       });
     });
 
+    group('clear logs', () {
+      setUp(() {
+        when(
+          () => bugReportService.clearCapturedLogs(),
+        ).thenAnswer((_) async {});
+      });
+
+      testWidgets('reads its title and subtitle from l10n', (tester) async {
+        await pump(tester);
+
+        expect(find.text(en.supportClearLogs), findsOneWidget);
+        expect(find.text(en.supportClearLogsSubtitle), findsOneWidget);
+      });
+
+      testWidgets('confirms first, then clears and reports', (tester) async {
+        await pump(tester);
+        await tester.tap(find.text(en.supportClearLogs));
+        await tester.pumpAndSettle();
+
+        // A confirmation gate, not an immediate clear.
+        expect(find.text(en.supportClearLogsConfirmTitle), findsOneWidget);
+        verifyNever(() => bugReportService.clearCapturedLogs());
+
+        await tester.tap(find.text(en.supportClearLogsConfirmButton));
+        await tester.pumpAndSettle();
+
+        verify(() => bugReportService.clearCapturedLogs()).called(1);
+        expect(find.text(en.supportLogsCleared), findsOneWidget);
+      });
+
+      testWidgets('does nothing when the confirmation is cancelled', (
+        tester,
+      ) async {
+        await pump(tester);
+        await tester.tap(find.text(en.supportClearLogs));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text(en.commonCancel));
+        await tester.pumpAndSettle();
+
+        verifyNever(() => bugReportService.clearCapturedLogs());
+        expect(find.text(en.supportLogsCleared), findsNothing);
+      });
+    });
+
     // #6335 was filed from this screen by a user who could not find how to
     // delete their account. Deletion has to be reachable from here.
     testWidgets('shows the delete-account entry when authenticated', (

--- a/mobile/test/services/bug_report_service_test.dart
+++ b/mobile/test/services/bug_report_service_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' show BugReportData, LogEntry, LogLevel;
 import 'package:openvine/services/bug_report_service.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 const _rawNsec =
     'nsec1qqqsyrhq4p4d8hf40q7tlujzw87hqhz9axhfnm35s2a3u3rrnwsq9sp5p6';
@@ -450,5 +451,24 @@ void main() {
           ? 'Only runs on iOS/Android'
           : null,
     );
+
+    group('clearCapturedLogs', () {
+      test('empties the in-memory capture buffer', () async {
+        final capture = LogCaptureService();
+        await capture.clearAllLogs();
+        capture.captureLog(
+          LogEntry(
+            timestamp: DateTime.now(),
+            level: LogLevel.info,
+            message: 'before clear',
+          ),
+        );
+        expect(capture.isEmpty, isFalse);
+
+        await service.clearCapturedLogs();
+
+        expect(capture.isEmpty, isTrue);
+      });
+    });
   });
 }


### PR DESCRIPTION
## What problem this solves

The captured-log buffer had no user-facing way to clear it. `clearAllLogs()` was reachable only from tests, so a person diagnosing a problem could not reset the buffer before reproducing the issue for a clean export. In-app logs are memory-only, so the only way to "start fresh" was to force-quit and relaunch — which itself throws away the logs.

## Why this fix

Add a **Clear Logs** tile to Settings → Support, behind an "Are you sure?" confirmation, with a "Logs cleared" confirmation snackbar. It follows the same `UI → Cubit → Service` shape as the neighbouring Save Logs tile (`ClearLogsCubit → BugReportService.clearCapturedLogs()`), so the widget layer never reaches into the log service directly.

The primary #8114 fix—telling an empty buffer apart from a real export failure—shipped in #8115. This PR completes the remaining clear-buffer UI item while keeping two independent concerns focused in their own follow-ups:

- #8500 caps the exported payload before the platform share flow copies it.
- #8501 decides whether logs should persist across crashes and restarts, including the privacy and lifecycle boundaries that decision requires.

New user-facing copy is English-only and registered in the human translation pass tracked by #7632, matching how #8115 handled the sibling log-export strings.

Refs #8114.

## How it was verified

- New unit + widget tests: the service clear empties the buffer; the cubit transitions `clearing → cleared` (and re-transitions on a repeat clear), and ignores a second clear while one is in flight; the tile confirms first, then clears and reports; cancelling the confirmation does nothing.
- `flutter analyze lib test` clean; `dart format` clean.
- The existing 375×667 regression test (delete-account entry must stay on screen) still passes with the new tile added above it.
