### PR TITLE
fix(settings): guide profile-less users from NIP-05

### DIFF
--- a/mobile/lib/blocs/my_profile/my_profile_bloc.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_bloc.dart
@@ -97,7 +97,11 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
         );
         add(const VerifiedClaimsRequested());
       } else {
-        emit(const MyProfileError(errorType: MyProfileErrorType.notFound));
+        emit(
+          MyProfileError(
+            errorType: _missingProfileErrorType(),
+          ),
+        );
       }
     } on Exception {
       if (isClosed) return;
@@ -216,7 +220,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
         );
         add(const VerifiedClaimsRequested());
       } else {
-        emit(const MyProfileError(errorType: MyProfileErrorType.notFound));
+        emit(MyProfileError(errorType: _missingProfileErrorType()));
       }
     } on Exception catch (e, stackTrace) {
       addError(e, stackTrace);
@@ -368,6 +372,11 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
 
   String _identityKeyOf(IdentityClaim claim) =>
       '${claim.platform.toLowerCase()}:${claim.identity.toLowerCase()}';
+
+  MyProfileErrorType _missingProfileErrorType() =>
+      _profileRepository.isConfirmedMissing(pubkey)
+      ? MyProfileErrorType.notFound
+      : MyProfileErrorType.networkError;
 
   UserProfile? _profileFromState(MyProfileState state) {
     final profile = switch (state) {

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -396,6 +396,7 @@
     },
     "profileLinkCopied": "የመገለጫ አገናኝ ተቀድቷል።",
     "profileSetupEditProfileTitle": "መገለጫ አርትዕ",
+    "nostrSettingsNip05ProfileRequired": "የNIP-05 አድራሻ ከማከልዎ በፊት መገለጫዎን ያዘጋጁ።",
     "profileSetupBackLabel": "ተመለስ",
     "profileSetupAboutNostr": "ስለ Nostr",
     "profileSetupProfilePublished": "መገለጫ በተሳካ ሁኔታ ታትሟል!",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -333,6 +333,7 @@
     "profileSignInButton": "تسجيل الدخول",
     "profileLinkCopied": "تم نسخ رابط الملف الشخصي",
     "profileSetupEditProfileTitle": "تعديل الملف الشخصي",
+    "nostrSettingsNip05ProfileRequired": "أعِدّ ملفك الشخصي قبل إضافة عنوان NIP-05.",
     "profileSetupBackLabel": "رجوع",
     "profileSetupAboutNostr": "عن Nostr",
     "profileSetupProfilePublished": "تم نشر الملف الشخصي بنجاح!",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -371,6 +371,7 @@
     },
     "profileLinkCopied": "Връзката към профила е копирана",
     "profileSetupEditProfileTitle": "Редактиране на профил",
+    "nostrSettingsNip05ProfileRequired": "Настрой профила си, преди да добавиш NIP-05 адрес.",
     "profileSetupBackLabel": "Назад",
     "profileSetupAboutNostr": "Относно Nostr",
     "profileSetupProfilePublished": "Профилът е публикуван успешно!",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -333,6 +333,7 @@
     "profileSignInButton": "Anmelden",
     "profileLinkCopied": "Profil-Link kopiert",
     "profileSetupEditProfileTitle": "Profil bearbeiten",
+    "nostrSettingsNip05ProfileRequired": "Richte dein Profil ein, bevor du eine NIP-05-Adresse hinzufügst.",
     "profileSetupBackLabel": "Zurück",
     "profileSetupAboutNostr": "Über Nostr",
     "profileSetupProfilePublished": "Profil erfolgreich veröffentlicht!",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -578,6 +578,10 @@
   },
   "profileLinkCopied": "Profile link copied",
   "profileSetupEditProfileTitle": "Edit Profile",
+  "nostrSettingsNip05ProfileRequired": "Set up your profile before adding a NIP-05 address.",
+  "@nostrSettingsNip05ProfileRequired": {
+    "description": "Empty-state message on NIP-05 settings when the account has not published a profile yet."
+  },
   "profileSetupBackLabel": "Back",
   "profileSetupAboutNostr": "About Nostr",
   "profileSetupProfilePublished": "Profile published successfully!",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -333,6 +333,7 @@
     "profileSignInButton": "Iniciar sesión",
     "profileLinkCopied": "Link del perfil copiado",
     "profileSetupEditProfileTitle": "Editar perfil",
+    "nostrSettingsNip05ProfileRequired": "Configura tu perfil antes de añadir una dirección NIP-05.",
     "profileSetupBackLabel": "Atrás",
     "profileSetupAboutNostr": "Sobre Nostr",
     "profileSetupProfilePublished": "¡Perfil publicado con éxito!",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -201,6 +201,7 @@
     "profileSignInButton": "Mag-sign in",
     "profileLinkCopied": "Nakopya na ang profile link",
     "profileSetupEditProfileTitle": "I-edit ang Profile",
+    "nostrSettingsNip05ProfileRequired": "I-set up ang profile mo bago magdagdag ng NIP-05 address.",
     "profileSetupBackLabel": "Bumalik",
     "profileSetupAboutNostr": "Tungkol sa Nostr",
     "profileSetupProfilePublished": "Matagumpay na na-publish ang profile!",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -333,6 +333,7 @@
     "profileSignInButton": "Se connecter",
     "profileLinkCopied": "Lien du profil copié",
     "profileSetupEditProfileTitle": "Modifier le profil",
+    "nostrSettingsNip05ProfileRequired": "Configure ton profil avant d’ajouter une adresse NIP-05.",
     "profileSetupBackLabel": "Retour",
     "profileSetupAboutNostr": "À propos de Nostr",
     "profileSetupProfilePublished": "Profil publié avec succès !",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -333,6 +333,7 @@
     "profileSignInButton": "Masuk",
     "profileLinkCopied": "Tautan profil disalin",
     "profileSetupEditProfileTitle": "Ubah Profil",
+    "nostrSettingsNip05ProfileRequired": "Siapkan profilmu sebelum menambahkan alamat NIP-05.",
     "profileSetupBackLabel": "Kembali",
     "profileSetupAboutNostr": "Tentang Nostr",
     "profileSetupProfilePublished": "Profil berhasil dipublikasikan!",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -333,6 +333,7 @@
     "profileSignInButton": "Accedi",
     "profileLinkCopied": "Link del profilo copiato",
     "profileSetupEditProfileTitle": "Modifica profilo",
+    "nostrSettingsNip05ProfileRequired": "Configura il tuo profilo prima di aggiungere un indirizzo NIP-05.",
     "profileSetupBackLabel": "Indietro",
     "profileSetupAboutNostr": "Info su Nostr",
     "profileSetupProfilePublished": "Profilo pubblicato con successo!",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -333,6 +333,7 @@
     "profileSignInButton": "サインイン",
     "profileLinkCopied": "プロフィールのリンクをコピーしたよ",
     "profileSetupEditProfileTitle": "プロフィールを編集",
+    "nostrSettingsNip05ProfileRequired": "NIP-05アドレスを追加する前にプロフィールを設定してください。",
     "profileSetupBackLabel": "戻る",
     "profileSetupAboutNostr": "Nostr について",
     "profileSetupProfilePublished": "プロフィールを公開したよ！",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -201,6 +201,7 @@
     "profileSignInButton": "로그인",
     "profileLinkCopied": "프로필 링크를 복사했어요",
     "profileSetupEditProfileTitle": "프로필 편집",
+    "nostrSettingsNip05ProfileRequired": "NIP-05 주소를 추가하기 전에 프로필을 설정하세요.",
     "profileSetupBackLabel": "뒤로",
     "profileSetupAboutNostr": "Nostr란?",
     "profileSetupProfilePublished": "프로필을 게시했어요!",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -426,6 +426,7 @@
   },
   "profileLinkCopied": "Pautan profil disalin",
   "profileSetupEditProfileTitle": "Sunting Profil",
+  "nostrSettingsNip05ProfileRequired": "Sediakan profil anda sebelum menambah alamat NIP-05.",
   "profileSetupBackLabel": "Kembali",
   "profileSetupAboutNostr": "Perihal Nostr",
   "profileSetupProfilePublished": "Profil berjaya diterbitkan!",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -333,6 +333,7 @@
     "profileSignInButton": "Inloggen",
     "profileLinkCopied": "Profiellink gekopieerd",
     "profileSetupEditProfileTitle": "Profiel bewerken",
+    "nostrSettingsNip05ProfileRequired": "Stel je profiel in voordat je een NIP-05-adres toevoegt.",
     "profileSetupBackLabel": "Terug",
     "profileSetupAboutNostr": "Over Nostr",
     "profileSetupProfilePublished": "Profiel succesvol gepubliceerd!",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -333,6 +333,7 @@
     "profileSignInButton": "Zaloguj się",
     "profileLinkCopied": "Link do profilu skopiowany",
     "profileSetupEditProfileTitle": "Edytuj profil",
+    "nostrSettingsNip05ProfileRequired": "Skonfiguruj profil, zanim dodasz adres NIP-05.",
     "profileSetupBackLabel": "Wstecz",
     "profileSetupAboutNostr": "O Nostr",
     "profileSetupProfilePublished": "Profil opublikowany pomyślnie!",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -333,6 +333,7 @@
     "profileSignInButton": "Entrar",
     "profileLinkCopied": "Link do perfil copiado",
     "profileSetupEditProfileTitle": "Editar perfil",
+    "nostrSettingsNip05ProfileRequired": "Configura o teu perfil antes de adicionares um endereço NIP-05.",
     "profileSetupBackLabel": "Voltar",
     "profileSetupAboutNostr": "Sobre o Nostr",
     "profileSetupProfilePublished": "Perfil publicado com sucesso!",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -333,6 +333,7 @@
     "profileSignInButton": "Autentificare",
     "profileLinkCopied": "Linkul profilului a fost copiat",
     "profileSetupEditProfileTitle": "Editează profilul",
+    "nostrSettingsNip05ProfileRequired": "Configurează-ți profilul înainte de a adăuga o adresă NIP-05.",
     "profileSetupBackLabel": "Înapoi",
     "profileSetupAboutNostr": "Despre Nostr",
     "profileSetupProfilePublished": "Profil publicat cu succes!",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -333,6 +333,7 @@
     "profileSignInButton": "Logga in",
     "profileLinkCopied": "Profillänk kopierad",
     "profileSetupEditProfileTitle": "Redigera profil",
+    "nostrSettingsNip05ProfileRequired": "Konfigurera din profil innan du lägger till en NIP-05-adress.",
     "profileSetupBackLabel": "Tillbaka",
     "profileSetupAboutNostr": "Om Nostr",
     "profileSetupProfilePublished": "Profilen publicerades!",

--- a/mobile/lib/l10n/app_te.arb
+++ b/mobile/lib/l10n/app_te.arb
@@ -578,6 +578,7 @@
   },
   "profileLinkCopied": "ప్రొఫైల్ లింక్ కాపీ చేయబడింది",
   "profileSetupEditProfileTitle": "ప్రొఫైల్‌ను సవరించండి",
+  "nostrSettingsNip05ProfileRequired": "NIP-05 చిరునామాను జోడించే ముందు మీ ప్రొఫైల్‌ను సెటప్ చేయండి.",
   "profileSetupBackLabel": "వెనుకకు",
   "profileSetupAboutNostr": "Nostr గురించి",
   "profileSetupProfilePublished": "ప్రొఫైల్ విజయవంతంగా ప్రచురించబడింది!",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -333,6 +333,7 @@
     "profileSignInButton": "Giriş yap",
     "profileLinkCopied": "Profil bağlantısı kopyalandı",
     "profileSetupEditProfileTitle": "Profili Düzenle",
+    "nostrSettingsNip05ProfileRequired": "NIP-05 adresi eklemeden önce profilini oluştur.",
     "profileSetupBackLabel": "Geri",
     "profileSetupAboutNostr": "Nostr Hakkında",
     "profileSetupProfilePublished": "Profil başarıyla yayınlandı!",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -426,6 +426,7 @@
   },
   "profileLinkCopied": "پروفائل لنک کاپی ہو گیا",
   "profileSetupEditProfileTitle": "پروفائل میں ترمیم کریں",
+  "nostrSettingsNip05ProfileRequired": "NIP-05 پتہ شامل کرنے سے پہلے اپنا پروفائل ترتیب دیں۔",
   "profileSetupBackLabel": "واپس",
   "profileSetupAboutNostr": "Nostr کے بارے میں",
   "profileSetupProfilePublished": "پروفائل کامیابی سے شائع ہو گیا!",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -426,6 +426,7 @@
   },
   "profileLinkCopied": "Đã sao chép liên kết hồ sơ",
   "profileSetupEditProfileTitle": "Chỉnh sửa hồ sơ",
+  "nostrSettingsNip05ProfileRequired": "Hãy thiết lập hồ sơ trước khi thêm địa chỉ NIP-05.",
   "profileSetupBackLabel": "Quay lại",
   "profileSetupAboutNostr": "Về Nostr",
   "profileSetupProfilePublished": "Đã đăng hồ sơ thành công!",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -426,6 +426,7 @@
   },
   "profileLinkCopied": "主页链接已复制",
   "profileSetupEditProfileTitle": "编辑资料",
+  "nostrSettingsNip05ProfileRequired": "添加 NIP-05 地址前，请先设置个人资料。",
   "profileSetupBackLabel": "返回",
   "profileSetupAboutNostr": "关于 Nostr",
   "profileSetupProfilePublished": "资料发布成功！",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -1478,6 +1478,12 @@ abstract class AppLocalizations {
   /// **'Edit Profile'**
   String get profileSetupEditProfileTitle;
 
+  /// Empty-state message on NIP-05 settings when the account has not published a profile yet.
+  ///
+  /// In en, this message translates to:
+  /// **'Set up your profile before adding a NIP-05 address.'**
+  String get nostrSettingsNip05ProfileRequired;
+
   /// No description provided for @profileSetupBackLabel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -846,6 +846,10 @@ class AppLocalizationsAm extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'መገለጫ አርትዕ';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'የNIP-05 አድራሻ ከማከልዎ በፊት መገለጫዎን ያዘጋጁ።';
+
+  @override
   String get profileSetupBackLabel => 'ተመለስ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -847,6 +847,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'تعديل الملف الشخصي';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'أعِدّ ملفك الشخصي قبل إضافة عنوان NIP-05.';
+
+  @override
   String get profileSetupBackLabel => 'رجوع';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -874,6 +874,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'Редактиране на профил';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'Настрой профила си, преди да добавиш NIP-05 адрес.';
+
+  @override
   String get profileSetupBackLabel => 'Назад';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -873,6 +873,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'Profil bearbeiten';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'Richte dein Profil ein, bevor du eine NIP-05-Adresse hinzufügst.';
+
+  @override
   String get profileSetupBackLabel => 'Zurück';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -875,6 +875,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'Edit Profile';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'Set up your profile before adding a NIP-05 address.';
+
+  @override
   String get profileSetupBackLabel => 'Back';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -873,6 +873,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'Editar perfil';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'Configura tu perfil antes de añadir una dirección NIP-05.';
+
+  @override
   String get profileSetupBackLabel => 'Atrás';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -844,6 +844,10 @@ class AppLocalizationsFil extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'I-edit ang Profile';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'I-set up ang profile mo bago magdagdag ng NIP-05 address.';
+
+  @override
   String get profileSetupBackLabel => 'Bumalik';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -882,6 +882,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'Modifier le profil';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'Configure ton profil avant d’ajouter une adresse NIP-05.';
+
+  @override
   String get profileSetupBackLabel => 'Retour';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -807,6 +807,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'Ubah Profil';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'Siapkan profilmu sebelum menambahkan alamat NIP-05.';
+
+  @override
   String get profileSetupBackLabel => 'Kembali';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -878,6 +878,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'Modifica profilo';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'Configura il tuo profilo prima di aggiungere un indirizzo NIP-05.';
+
+  @override
   String get profileSetupBackLabel => 'Indietro';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -766,6 +766,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'プロフィールを編集';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'NIP-05アドレスを追加する前にプロフィールを設定してください。';
+
+  @override
   String get profileSetupBackLabel => '戻る';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -768,6 +768,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get profileSetupEditProfileTitle => '프로필 편집';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'NIP-05 주소를 추가하기 전에 프로필을 설정하세요.';
+
+  @override
   String get profileSetupBackLabel => '뒤로';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -836,6 +836,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'Sunting Profil';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'Sediakan profil anda sebelum menambah alamat NIP-05.';
+
+  @override
   String get profileSetupBackLabel => 'Kembali';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -868,6 +868,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'Profiel bewerken';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'Stel je profiel in voordat je een NIP-05-adres toevoegt.';
+
+  @override
   String get profileSetupBackLabel => 'Terug';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -889,6 +889,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'Edytuj profil';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'Skonfiguruj profil, zanim dodasz adres NIP-05.';
+
+  @override
   String get profileSetupBackLabel => 'Wstecz';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -874,6 +874,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'Editar perfil';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'Configura o teu perfil antes de adicionares um endereço NIP-05.';
+
+  @override
   String get profileSetupBackLabel => 'Voltar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -903,6 +903,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'Editează profilul';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'Configurează-ți profilul înainte de a adăuga o adresă NIP-05.';
+
+  @override
   String get profileSetupBackLabel => 'Înapoi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -849,6 +849,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'Redigera profil';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'Konfigurera din profil innan du lägger till en NIP-05-adress.';
+
+  @override
   String get profileSetupBackLabel => 'Tillbaka';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -886,6 +886,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'ప్రొఫైల్‌ను సవరించండి';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'NIP-05 చిరునామాను జోడించే ముందు మీ ప్రొఫైల్‌ను సెటప్ చేయండి.';
+
+  @override
   String get profileSetupBackLabel => 'వెనుకకు';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -803,6 +803,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'Profili Düzenle';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'NIP-05 adresi eklemeden önce profilini oluştur.';
+
+  @override
   String get profileSetupBackLabel => 'Geri';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -867,6 +867,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'پروفائل میں ترمیم کریں';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'NIP-05 پتہ شامل کرنے سے پہلے اپنا پروفائل ترتیب دیں۔';
+
+  @override
   String get profileSetupBackLabel => 'واپس';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -836,6 +836,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get profileSetupEditProfileTitle => 'Chỉnh sửa hồ sơ';
 
   @override
+  String get nostrSettingsNip05ProfileRequired =>
+      'Hãy thiết lập hồ sơ trước khi thêm địa chỉ NIP-05.';
+
+  @override
   String get profileSetupBackLabel => 'Quay lại';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -789,6 +789,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get profileSetupEditProfileTitle => '编辑资料';
 
   @override
+  String get nostrSettingsNip05ProfileRequired => '添加 NIP-05 地址前，请先设置个人资料。';
+
+  @override
   String get profileSetupBackLabel => '返回';
 
   @override

--- a/mobile/lib/screens/settings/nip05_settings_screen.dart
+++ b/mobile/lib/screens/settings/nip05_settings_screen.dart
@@ -14,6 +14,7 @@ import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/route_paths.dart';
+import 'package:openvine/screens/profile_setup/profile_setup.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/profile_editor/username_status_indicator.dart';
 
@@ -72,9 +73,7 @@ class _Nip05SettingsLoadingScreen extends StatelessWidget {
         onBackPressed: context.pop,
       ),
       backgroundColor: context.vineColors.background,
-      body: const Center(
-        child: BrandedLoadingIndicator(size: 60),
-      ),
+      body: const Center(child: BrandedLoadingIndicator(size: 60)),
     );
   }
 }
@@ -149,8 +148,13 @@ class _Nip05SettingsViewState extends State<Nip05SettingsView> {
             final currentProfile = _profileFromState(myProfileState);
             return BlocBuilder<ProfileEditorBloc, ProfileEditorState>(
               builder: (context, editorState) {
-                if (myProfileState is MyProfileError) {
-                  return const _Nip05SettingsLoadError();
+                if (myProfileState case MyProfileError(:final errorType)) {
+                  return switch (errorType) {
+                    MyProfileErrorType.notFound =>
+                      const _Nip05SettingsMissingProfile(),
+                    MyProfileErrorType.networkError =>
+                      const _Nip05SettingsLoadError(),
+                  };
                 }
 
                 return Align(
@@ -348,10 +352,7 @@ class _Nip05SettingsViewState extends State<Nip05SettingsView> {
     _didSeedInitialValues = true;
   }
 
-  void _onSaveStatusChanged(
-    BuildContext context,
-    ProfileEditorState state,
-  ) {
+  void _onSaveStatusChanged(BuildContext context, ProfileEditorState state) {
     if (state.status == ProfileEditorStatus.success) {
       ScaffoldMessenger.of(context).showSnackBar(
         DivineSnackbarContainer.snackBar(context.l10n.nostrSettingsNip05Saved),
@@ -439,10 +440,7 @@ class _Nip05SettingsViewState extends State<Nip05SettingsView> {
     return result ?? false;
   }
 
-  void _onSavePressed(
-    BuildContext context,
-    UserProfile currentProfile,
-  ) {
+  void _onSavePressed(BuildContext context, UserProfile currentProfile) {
     context.read<ProfileEditorBloc>().add(
       ProfileNip05Saved(currentProfile: currentProfile),
     );
@@ -463,6 +461,42 @@ class _Nip05SettingsViewState extends State<Nip05SettingsView> {
         normalizedExternal != initialExternal ||
             editorState.initialUsername != null,
     };
+  }
+}
+
+class _Nip05SettingsMissingProfile extends StatelessWidget {
+  const _Nip05SettingsMissingProfile();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          spacing: 16,
+          children: [
+            DivineIcon(
+              icon: DivineIconName.userCircle,
+              color: context.vineColors.secondaryText,
+              size: 48,
+            ),
+            Text(
+              context.l10n.nostrSettingsNip05ProfileRequired,
+              textAlign: TextAlign.center,
+              style: VineTheme.titleSmallFont(
+                color: context.vineColors.primaryText,
+              ),
+            ),
+            DivineButton(
+              size: DivineButtonSize.small,
+              label: context.l10n.profileSetupEditProfileTitle,
+              onPressed: () => context.go(ProfileSetupScreen.editPath),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/mobile/lib/screens/settings/nip05_settings_screen.dart
+++ b/mobile/lib/screens/settings/nip05_settings_screen.dart
@@ -491,7 +491,13 @@ class _Nip05SettingsMissingProfile extends StatelessWidget {
             DivineButton(
               size: DivineButtonSize.small,
               label: context.l10n.profileSetupEditProfileTitle,
-              onPressed: () => context.go(ProfileSetupScreen.editPath),
+              onPressed: () async {
+                await context.push(ProfileSetupScreen.editPath);
+                if (!context.mounted) return;
+                context.read<MyProfileBloc>().add(
+                  const MyProfileLoadRequested(),
+                );
+              },
             ),
           ],
         ),

--- a/mobile/packages/profile_repository/lib/src/profile_reader.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_reader.dart
@@ -61,12 +61,21 @@ abstract interface class ProfileReader {
   /// Fetches the freshest profile for [pubkey] and caches it locally.
   ///
   /// Reads only — the relay query and the funnelcake REST fallback are both
-  /// unauthenticated. Returns `null` when no profile exists anywhere.
+  /// unauthenticated. A `null` result can mean either authoritative absence
+  /// or an indeterminate relay/API result; use [isConfirmedMissing] to
+  /// distinguish them.
   Future<UserProfile?> fetchFreshProfile({
     required String pubkey,
     bool requireRawKind0,
     List<Duration> rawKind0RetryDelays,
   });
+
+  /// Whether the latest fetch positively established that [pubkey] has no
+  /// published profile.
+  ///
+  /// Empty or failed relay queries are not authoritative absence. This is
+  /// true only for sources that explicitly report a missing Kind 0 profile.
+  bool isConfirmedMissing(String pubkey);
 
   /// Resolves many profiles at once, preferring the Drift cache.
   ///

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -200,8 +200,7 @@ class ProfileRepository implements ProfileReader {
   /// same pubkey share the same future instead of firing duplicate requests.
   final _inFlightFetches = <String, Future<UserProfile?>>{};
 
-  /// Pubkeys confirmed to have no Kind 0 profile (FunnelCake returned
-  /// the `_noProfile` sentinel or relay + indexer returned nothing).
+  /// Pubkeys confirmed to have no Kind 0 profile by an authoritative source.
   /// Session-scoped — cleared on app restart.
   final _confirmedMissing = <String>{};
 
@@ -277,8 +276,9 @@ class ProfileRepository implements ProfileReader {
 
   /// Whether the given pubkey is known to have no Kind 0 profile.
   ///
-  /// Returns `true` if FunnelCake or relay fetches previously confirmed
-  /// this pubkey has no profile. Session-scoped.
+  /// Empty relay results are indeterminate because timeout and participation
+  /// details are not preserved by the current relay query API.
+  @override
   bool isConfirmedMissing(String pubkey) => _confirmedMissing.contains(pubkey);
 
   /// Synchronous check for whether a profile is cached.
@@ -989,11 +989,11 @@ class ProfileRepository implements ProfileReader {
     final fallback = await _userProfilesDao.getProfile(pubkey);
     if (fallback != null) return fallback;
 
-    // All sources exhausted — mark as confirmed missing.
-    _confirmedMissing.add(pubkey);
+    // Empty relay/indexer results are indeterminate: queryEvents discards
+    // timeout and participation details, so only an explicit server sentinel
+    // can establish that no Kind 0 has been published.
     Log.debug(
-      'No profile found for ${pubkeyForLogs(pubkey)} across all sources, '
-      'marked missing',
+      'No profile resolved for ${pubkeyForLogs(pubkey)} across all sources',
       name: 'ProfileRepository.fetchFreshProfile',
       category: LogCategory.relay,
     );

--- a/mobile/packages/profile_repository/test/src/profile_reader_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_reader_test.dart
@@ -53,6 +53,10 @@ class _ExhaustiveReader implements ProfileReader {
     List<Duration> rawKind0RetryDelays = const [],
   }) async => null;
 
+  // Widened consciously: this reads session-local fetch classification only.
+  @override
+  bool isConfirmedMissing(String pubkey) => false;
+
   @override
   Future<Map<String, UserProfile>> fetchBatchProfiles({
     required List<String> pubkeys,

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -247,8 +247,7 @@ void main() {
         expect(profileRepository.hasProfile(testPubkey), isTrue);
       });
 
-      test('clears pubkey from confirmed missing set', () async {
-        // First make the pubkey confirmed missing
+      test('does not infer confirmed missing from relay absence', () async {
         when(
           () => mockNostrClient.fetchProfile(testPubkey),
         ).thenAnswer((_) async => null);
@@ -260,12 +259,6 @@ void main() {
           ),
         ).thenAnswer((_) async => <Event>[]);
         await profileRepository.fetchFreshProfile(pubkey: testPubkey);
-        expect(profileRepository.isConfirmedMissing(testPubkey), isTrue);
-
-        // Now cache a profile for it
-        final profile = UserProfile.fromNostrEvent(mockProfileEvent);
-        await profileRepository.cacheProfile(profile);
-
         expect(profileRepository.isConfirmedMissing(testPubkey), isFalse);
       });
     });
@@ -597,25 +590,28 @@ void main() {
         verifyNever(() => mockUserProfilesDao.upsertProfile(any()));
       });
 
-      test('marks pubkey as confirmed missing when all sources miss', () async {
-        stubAllSourcesMiss();
-
-        await profileRepository.fetchFreshProfile(pubkey: testPubkey);
-
-        expect(profileRepository.isConfirmedMissing(testPubkey), isTrue);
-      });
-
       test(
-        'rechecks sources on explicit fetch after confirmed missing',
+        'leaves missing indeterminate when all relay sources miss',
         () async {
           stubAllSourcesMiss();
 
-          // First call — hits all sources, marks missing
+          await profileRepository.fetchFreshProfile(pubkey: testPubkey);
+
+          expect(profileRepository.isConfirmedMissing(testPubkey), isFalse);
+        },
+      );
+
+      test(
+        'rechecks sources after an indeterminate miss',
+        () async {
+          stubAllSourcesMiss();
+
+          // First call hits all sources without treating absence as proof.
           final firstResult = await profileRepository.fetchFreshProfile(
             pubkey: testPubkey,
           );
           expect(firstResult, isNull);
-          expect(profileRepository.isConfirmedMissing(testPubkey), isTrue);
+          expect(profileRepository.isConfirmedMissing(testPubkey), isFalse);
 
           // Second call — explicit fetch should clear the stale marker
           // and try the sources again.
@@ -1785,7 +1781,7 @@ void main() {
           verify(() => mockUserProfilesDao.upsertProfile(any())).called(1);
         });
 
-        test('marks missing when indexer also returns nothing', () async {
+        test('does not confirm missing from empty relay results', () async {
           when(
             () => mockNostrClient.fetchProfile(testPubkey),
           ).thenAnswer((_) async => null);
@@ -1802,7 +1798,7 @@ void main() {
           );
 
           expect(result, isNull);
-          expect(profileRepository.isConfirmedMissing(testPubkey), isTrue);
+          expect(profileRepository.isConfirmedMissing(testPubkey), isFalse);
         });
 
         test('handles indexer relay timeout gracefully', () async {
@@ -1822,7 +1818,7 @@ void main() {
           );
 
           expect(result, isNull);
-          expect(profileRepository.isConfirmedMissing(testPubkey), isTrue);
+          expect(profileRepository.isConfirmedMissing(testPubkey), isFalse);
         });
 
         test(

--- a/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
+++ b/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
@@ -387,7 +387,7 @@ void main() {
 
         blocTest<MyProfileBloc, MyProfileState>(
           'emits [loading null, error notFound] '
-          'when fresh fetch returns null',
+          'when fresh fetch is authoritatively missing',
           setUp: () {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
@@ -395,6 +395,9 @@ void main() {
             when(
               () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
+            when(
+              () => mockProfileRepository.isConfirmedMissing(testPubkey),
+            ).thenReturn(true);
           },
           build: createBloc,
           act: (bloc) => bloc.add(const MyProfileLoadRequested()),
@@ -404,6 +407,32 @@ void main() {
               (s) => s.errorType,
               'errorType',
               MyProfileErrorType.notFound,
+            ),
+          ],
+        );
+
+        blocTest<MyProfileBloc, MyProfileState>(
+          'emits [loading null, error networkError] '
+          'when fresh fetch is indeterminate',
+          setUp: () {
+            when(
+              () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+            ).thenAnswer((_) async => null);
+            when(
+              () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+            ).thenAnswer((_) async => null);
+            when(
+              () => mockProfileRepository.isConfirmedMissing(testPubkey),
+            ).thenReturn(false);
+          },
+          build: createBloc,
+          act: (bloc) => bloc.add(const MyProfileLoadRequested()),
+          expect: () => [
+            isA<MyProfileLoading>().having((s) => s.profile, 'profile', isNull),
+            isA<MyProfileError>().having(
+              (s) => s.errorType,
+              'errorType',
+              MyProfileErrorType.networkError,
             ),
           ],
         );
@@ -1018,6 +1047,9 @@ void main() {
           when(
             () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
           ).thenAnswer((_) async => null);
+          when(
+            () => mockProfileRepository.isConfirmedMissing(testPubkey),
+          ).thenReturn(true);
         },
         build: createBloc,
         act: (bloc) async {
@@ -1193,6 +1225,9 @@ void main() {
           when(
             () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
           ).thenAnswer((_) async => null);
+          when(
+            () => mockProfileRepository.isConfirmedMissing(testPubkey),
+          ).thenReturn(false);
         },
         build: createBloc,
         act: (bloc) async {
@@ -1205,7 +1240,7 @@ void main() {
           isA<MyProfileError>().having(
             (s) => s.errorType,
             'errorType',
-            MyProfileErrorType.notFound,
+            MyProfileErrorType.networkError,
           ),
         ],
       );

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -280,6 +280,7 @@ MockProfileRepository createMockProfileRepository() {
   when(
     () => mockRepo.fetchFreshProfile(pubkey: any(named: 'pubkey')),
   ).thenAnswer((_) async => null);
+  when(() => mockRepo.isConfirmedMissing(any())).thenReturn(false);
   when(
     () => mockRepo.watchProfile(pubkey: any(named: 'pubkey')),
   ).thenAnswer((_) => Stream.value(null));

--- a/mobile/test/screens/settings/nip05_settings_screen_test.dart
+++ b/mobile/test/screens/settings/nip05_settings_screen_test.dart
@@ -332,6 +332,9 @@ void main() {
         when(
           () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
         ).thenAnswer((_) async => null);
+        when(
+          () => mockProfileRepository.isConfirmedMissing(testPubkey),
+        ).thenReturn(true);
 
         final router = GoRouter(
           initialLocation: '/nip05',
@@ -360,7 +363,10 @@ void main() {
             ),
             GoRoute(
               path: ProfileSetupScreen.editPath,
-              builder: (context, state) => const Text('edit-profile-route'),
+              builder: (context, state) => TextButton(
+                onPressed: context.pop,
+                child: const Text('edit-profile-route'),
+              ),
             ),
           ],
         );
@@ -386,6 +392,17 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('edit-profile-route'), findsOneWidget);
+
+        await tester.tap(find.text('edit-profile-route'));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text(l10n.nostrSettingsNip05ProfileRequired),
+          findsOneWidget,
+        );
+        verify(
+          () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+        ).called(2);
       },
     );
 
@@ -397,7 +414,10 @@ void main() {
         ).thenAnswer((_) async => null);
         when(
           () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
-        ).thenThrow(Exception('network failed'));
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockProfileRepository.isConfirmedMissing(testPubkey),
+        ).thenReturn(false);
 
         await tester.pumpWidget(
           MaterialApp(

--- a/mobile/test/screens/settings/nip05_settings_screen_test.dart
+++ b/mobile/test/screens/settings/nip05_settings_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/screens/profile_setup/profile_setup.dart';
 import 'package:openvine/screens/settings/nip05_settings_screen.dart';
 import 'package:profile_repository/profile_repository.dart';
 
@@ -319,6 +320,72 @@ void main() {
         ).captured;
         final payload = captured[0] as PendingProfileSave;
         expect(payload.nip05, 'bob@example.com');
+      },
+    );
+
+    testWidgets(
+      'sends a profile-less user to Edit Profile instead of showing Retry',
+      (tester) async {
+        when(
+          () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+        ).thenAnswer((_) async => null);
+
+        final router = GoRouter(
+          initialLocation: '/nip05',
+          routes: [
+            GoRoute(
+              path: '/nip05',
+              builder: (context, state) => MultiBlocProvider(
+                providers: [
+                  BlocProvider(
+                    create: (_) => ProfileEditorBloc(
+                      profileRepository: mockProfileRepository,
+                      blossomUploadService: mockBlossomUploadService,
+                      hasExistingProfile: false,
+                      currentUserPubkey: testPubkey,
+                    ),
+                  ),
+                  BlocProvider(
+                    create: (_) => MyProfileBloc(
+                      profileRepository: mockProfileRepository,
+                      pubkey: testPubkey,
+                    )..add(const MyProfileLoadRequested()),
+                  ),
+                ],
+                child: const Nip05SettingsView(),
+              ),
+            ),
+            GoRoute(
+              path: ProfileSetupScreen.editPath,
+              builder: (context, state) => const Text('edit-profile-route'),
+            ),
+          ],
+        );
+        addTearDown(router.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            theme: VineTheme.theme,
+            routerConfig: router,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text(l10n.nostrSettingsNip05ProfileRequired),
+          findsOneWidget,
+        );
+        expect(find.text(l10n.profileRetryButton), findsNothing);
+
+        await tester.tap(find.text(l10n.profileSetupEditProfileTitle));
+        await tester.pumpAndSettle();
+
+        expect(find.text('edit-profile-route'), findsOneWidget);
       },
     );
 


### PR DESCRIPTION
## Problem

Accounts that have not published a profile receive a permanent profile-not-found result when opening NIP-05 settings. The screen presented that state as a transient failure with a Retry button, so every retry returned to the same dead end.

## Fix

- distinguish a missing profile from a network failure
- show localized guidance and an Edit Profile action when no profile exists
- preserve Retry for transient network failures
- cover the missing-profile route and existing retry behavior with widget tests

## Product decision intentionally left open

This PR does not make NIP-05 settings create a first profile. Supporting that flow requires deciding what display name should be published for a Divine username claim and for an external NIP-05 address when the user has not supplied one. Until that policy is defined, profile creation remains in Edit Profile.

## Verification

- flutter test test/screens/settings/nip05_settings_screen_test.dart
- flutter test test/l10n/arb_consistency_test.dart
- flutter analyze
- localization hardcoded-copy scan
- orphaned ARB and design-system ceiling checks

Closes #8487