### PR TITLE
fix(dm): clear the nip04 latch when the peer proves they speak NIP-17

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
@@ -279,6 +279,31 @@ END
     return rows > 0;
   }
 
+  /// Clears a `'nip04'` protocol latch on [id], marking the thread NIP-17.
+  ///
+  /// Narrow by design: it touches `dm_protocol` and nothing else, so a caller
+  /// that has only learned "the peer speaks NIP-17" cannot accidentally
+  /// rewrite the preview, timestamps or read state through a full upsert.
+  ///
+  /// Only ever upgrades. The `WHERE dm_protocol = 'nip04'` clause means a
+  /// thread that is already `'nip17'`, or one whose protocol was never set,
+  /// is left exactly as it is — so this can be called unconditionally on the
+  /// evidence without having to read the row first.
+  ///
+  /// Returns `true` when a latch was actually cleared, which is what makes the
+  /// call loggable exactly once per thread rather than on every message.
+  Future<bool> clearNip04ProtocolLatch(String id, {String? ownerPubkey}) async {
+    final rows = await customUpdate(
+      "UPDATE conversations SET dm_protocol = 'nip17' "
+      "WHERE id = ? AND dm_protocol = 'nip04'"
+      '${_ownerSqlClause(ownerPubkey)}',
+      variables: [Variable(id), ..._ownerSqlVariables(ownerPubkey)],
+      updates: {attachedDatabase.conversations},
+      updateKind: UpdateKind.update,
+    );
+    return rows > 0;
+  }
+
   /// Advances the read cursor for [id] to `max(existing, timestamp)` and, when
   /// the cursor then covers the latest message, marks the conversation read.
   ///

--- a/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
@@ -36,6 +36,71 @@ void main() {
   });
 
   group(ConversationsDao, () {
+    group('clearNip04ProtocolLatch', () {
+      Future<void> seed({
+        required String id,
+        String? protocol,
+        String? owner,
+      }) => dao.upsertConversation(
+        id: id,
+        participantPubkeys: '["pubkey_a","pubkey_b"]',
+        isGroup: false,
+        createdAt: 1700000000,
+        lastMessageContent: 'Hello!',
+        lastMessageTimestamp: 1700000100,
+        lastMessageSenderPubkey: 'pubkey_a',
+        ownerPubkey: owner,
+        dmProtocol: protocol,
+      );
+
+      test('clears a nip04 latch and reports that it did', () async {
+        await seed(id: 'conv_1', protocol: 'nip04');
+
+        expect(await dao.clearNip04ProtocolLatch('conv_1'), isTrue);
+        expect((await dao.getConversation('conv_1'))!.dmProtocol, 'nip17');
+      });
+
+      test('is a no-op on a thread already nip17', () async {
+        await seed(id: 'conv_1', protocol: 'nip17');
+
+        // Reports false so the caller can log the transition exactly once
+        // per thread rather than on every message.
+        expect(await dao.clearNip04ProtocolLatch('conv_1'), isFalse);
+        expect((await dao.getConversation('conv_1'))!.dmProtocol, 'nip17');
+      });
+
+      test('never sets a protocol on a thread that has none', () async {
+        await seed(id: 'conv_1');
+
+        // Only ever an upgrade: a null protocol is "not yet decided", and
+        // stamping it here would invent a decision from a duplicate.
+        expect(await dao.clearNip04ProtocolLatch('conv_1'), isFalse);
+        expect((await dao.getConversation('conv_1'))!.dmProtocol, isNull);
+      });
+
+      test("does not touch another account's row", () async {
+        await seed(id: 'conv_1', protocol: 'nip04', owner: 'owner_a');
+
+        expect(
+          await dao.clearNip04ProtocolLatch('conv_1', ownerPubkey: 'owner_b'),
+          isFalse,
+        );
+        expect((await dao.getConversation('conv_1'))!.dmProtocol, 'nip04');
+      });
+
+      test('leaves the rest of the row alone', () async {
+        await seed(id: 'conv_1', protocol: 'nip04');
+        await dao.clearNip04ProtocolLatch('conv_1');
+
+        // Narrow by design — the caller has learned one fact and must not be
+        // able to rewrite the preview or timestamps through it.
+        final row = (await dao.getConversation('conv_1'))!;
+        expect(row.lastMessageContent, 'Hello!');
+        expect(row.lastMessageTimestamp, 1700000100);
+        expect(row.lastMessageSenderPubkey, 'pubkey_a');
+      });
+    });
+
     group('upsertConversation', () {
       test('inserts new conversation', () async {
         await dao.upsertConversation(

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2543,7 +2543,52 @@ class DmRepository {
         );
       }
       if (isDuplicate) {
+        // A twin from the PEER is proof they speak NIP-17, and it is the only
+        // place that proof ever appears: the rumor is about to be dropped as a
+        // duplicate, so without this the evidence is discarded and the thread
+        // stays latched to 'nip04' forever. That latch is what makes the
+        // legacy dual-send the steady state rather than an edge case — every
+        // later pair hits this same early return, so the decision the first
+        // arrival race made is never revisited (#8499).
+        //
+        // `!isSentByMe` is load-bearing, not defensive. This `else` branch is
+        // reached by a peer's rumor AND by a self-authored 1:1 rumor with no
+        // send batch token, so clearing unconditionally would sometimes clear
+        // on our OWN self-wrap — inverting the rule into "clear when *I*
+        // speak NIP-17" and cutting a genuine legacy peer off from the only
+        // copy they can read.
+        // Ledger first, unlatch second, and the unlatch can never throw out of
+        // here. It is an opportunistic upgrade on evidence we happen to be
+        // holding; the dedup bookkeeping below it is what stops this wrap
+        // being decrypted again on every redelivery. Ordering them the other
+        // way round made a failed unlatch abort `_recordProcessedWrap`, so a
+        // transient DB error would have cost a signer round trip per replay,
+        // forever. A dropped unlatch costs nothing — the next message from the
+        // peer presents the same evidence again.
         await _recordProcessedWrap(giftWrapEvent.id, ownerPubkey: ownerPubkey);
+        if (!isSentByMe) {
+          try {
+            final cleared = await _conversationsDao.clearNip04ProtocolLatch(
+              conversationId,
+              ownerPubkey: ownerPubkey,
+            );
+            if (cleared) {
+              Log.info(
+                'Cleared the nip04 protocol latch on conversation '
+                '$conversationId: ${pubkeyForLogs(rumor.pubkey)} sent NIP-17, '
+                'so the legacy kind-4 copy is no longer published to them',
+                category: LogCategory.system,
+              );
+            }
+          } on Object catch (e) {
+            Log.warning(
+              'Could not clear the nip04 protocol latch on conversation '
+              '$conversationId: $e — the thread keeps dual-sending until the '
+              'next NIP-17 message from the peer',
+              category: LogCategory.system,
+            );
+          }
+        }
         Log.debug(
           'Skipping duplicate NIP-17 DM ${rumor.id} in conversation '
           '$conversationId from ${pubkeyForLogs(rumor.pubkey)}: matching '

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2551,12 +2551,12 @@ class DmRepository {
         // later pair hits this same early return, so the decision the first
         // arrival race made is never revisited (#8499).
         //
-        // `!isSentByMe` is load-bearing, not defensive. This `else` branch is
-        // reached by a peer's rumor AND by a self-authored 1:1 rumor with no
-        // send batch token, so clearing unconditionally would sometimes clear
-        // on our OWN self-wrap — inverting the rule into "clear when *I*
-        // speak NIP-17" and cutting a genuine legacy peer off from the only
-        // copy they can read.
+        // `!isSentByMe` is load-bearing on this duplicate branch. The `else`
+        // above is reached by a peer's rumor AND by a self-authored 1:1 rumor
+        // with no send batch token; clearing here on our own self-wrap would
+        // invert *this* path into "clear when *I* speak NIP-17". It does not
+        // cover a unique self-authored NIP-17, which is not a twin and still
+        // hits the persist upsert's `dmProtocol: 'nip17'` below.
         // Ledger first, unlatch second, and the unlatch can never throw out of
         // here. It is an opportunistic upgrade on evidence we happen to be
         // holding; the dedup bookkeeping below it is what stops this wrap

--- a/mobile/packages/dm_repository/test/src/dm_protocol_latch_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_protocol_latch_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Proves what decides a conversation's dm_protocol latch, and why a
-// ABOUTME: dual-sent thread cannot escape it — the blast radius behind #8262.
+// ABOUTME: Proves what decides a conversation's dm_protocol latch. Twin
+// ABOUTME: clearing lives in dm_protocol_unlatch_test.dart (#8499).
 
 import 'dart:async';
 

--- a/mobile/packages/dm_repository/test/src/dm_protocol_latch_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_protocol_latch_test.dart
@@ -216,16 +216,15 @@ void main() {
     );
 
     test(
-      'a latched thread is cleared only by a NIP-17 message with no kind-4 '
+      'a latched thread is also cleared by a NIP-17 message with no kind-4 '
       'twin',
       () async {
         await deliverNip04(id: '1' * 64, content: 'hello');
         expect(await storedProtocol(), 'nip04');
 
         // A genuinely new message from the peer — different text, so it is not
-        // the twin of anything stored. This is the escape hatch, and it only
-        // exists once the PEER stops dual-sending, i.e. once their own side is
-        // unlatched.
+        // the twin of anything stored. The persist path still writes nip17.
+        // Twin clearing lives in dm_protocol_unlatch_test.dart.
         await deliverNip17(
           wrapId: '2' * 64,
           rumorId: '3' * 64,

--- a/mobile/packages/dm_repository/test/src/dm_protocol_latch_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_protocol_latch_test.dart
@@ -174,29 +174,22 @@ void main() {
         ))?.dmProtocol;
 
     test(
-      'kind-4 first latches the thread, and the NIP-17 twin cannot clear it',
+      'kind-4 first latches the thread',
       () async {
-        // The ordering that creates the dual-send steady state. Both copies
-        // are the SAME message, dual-sent by a peer on a pre-#7664 build.
+        // The ordering that creates the dual-send steady state: an inbound
+        // legacy copy decides the thread before any NIP-17 message lands.
         await deliverNip04(id: 'a' * 64, content: 'hello');
         expect(await storedProtocol(), 'nip04');
-
-        await deliverNip17(
-          wrapId: 'b' * 64,
-          rumorId: 'c' * 64,
-          content: 'hello',
-        );
-
-        // The twin is collapsed onto the stored kind-4 and the handler returns
-        // BEFORE its unconditional `dmProtocol: 'nip17'` upsert. So the peer
-        // speaking NIP-17 perfectly well does not undo the latch.
-        expect(
-          await storedProtocol(),
-          'nip04',
-          reason: 'a collapsed twin must not reach the clearing upsert',
-        );
       },
     );
+
+    // What CLEARS that latch is asserted in `dm_protocol_unlatch_test.dart`.
+    // Until #8499 the answer was "almost nothing": the peer's NIP-17 twin was
+    // collapsed onto the stored kind-4 and the handler returned before its
+    // `dmProtocol: 'nip17'` upsert, so a peer speaking NIP-17 perfectly well
+    // could not undo the latch and two dual-sending sides deadlocked. That
+    // case used to be asserted here and now lives, inverted and split by
+    // sender, alongside the change that fixed it.
 
     test(
       'NIP-17 first leaves the thread nip17, and the kind-4 twin cannot '

--- a/mobile/packages/dm_repository/test/src/dm_protocol_unlatch_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_protocol_unlatch_test.dart
@@ -1,0 +1,259 @@
+// ABOUTME: #8499 — a peer's NIP-17 twin clears the nip04 protocol latch;
+// ABOUTME: a self-authored twin must not, as only the peer's capability counts.
+
+import 'dart:async';
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+const _owner =
+    'a4f5c1b2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8';
+const _peer =
+    'b1c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0';
+const _privateKey =
+    '5426e5b8b4b0e2a1f5e8d3c7a9b2f4e6d8c0a2b4f6e8d0c2a4b6f8e0d2c4a6b8';
+
+const _baseCreatedAt = 1700000000;
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(Duration.zero);
+  });
+
+  // Real DAOs on a real database. The claim, the early return and the upsert
+  // all have to run for the unlatch to be observable at all, and the mock
+  // suite stubs the dedup predicates in a shared setUp (#8170).
+  group('clearing the nip04 latch on a peer NIP-17 twin (#8499)', () {
+    late AppDatabase db;
+    late ConversationsDao conversationsDao;
+    late DirectMessagesDao messagesDao;
+    late ProcessedGiftWrapsDao processedDao;
+    late _MockNostrClient nostrClient;
+    late StreamController<Event> relay;
+    late DmRepository repository;
+    late Map<String, Event> rumors;
+
+    final participants = [_owner, _peer]..sort();
+    late String conversationId;
+
+    setUp(() async {
+      db = AppDatabase.test(NativeDatabase.memory());
+      conversationsDao = ConversationsDao(db);
+      messagesDao = DirectMessagesDao(db);
+      processedDao = ProcessedGiftWrapsDao(db);
+      nostrClient = _MockNostrClient();
+      relay = StreamController<Event>();
+      rumors = <String, Event>{};
+      conversationId = DmRepository.computeConversationId(participants);
+
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(() => nostrClient.configuredRelayCount).thenReturn(1);
+      when(
+        () => nostrClient.queryEvents(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+        ),
+      ).thenAnswer((_) async => const <Event>[]);
+      when(
+        () => nostrClient.queryEventsDetailed(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+          tempRelays: any(named: 'tempRelays'),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async =>
+            (events: const <Event>[], timedOut: false, noRelays: false),
+      );
+      when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
+      when(
+        () => nostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((_) => relay.stream);
+
+      repository = DmRepository(
+        nostrClient: nostrClient,
+        directMessagesDao: messagesDao,
+        conversationsDao: conversationsDao,
+        processedGiftWrapsDao: processedDao,
+        userPubkey: _owner,
+        signer: LocalNostrSigner(_privateKey),
+        rumorDecryptor: (_, giftWrap) async => rumors[giftWrap.id],
+        nip04Decryptor: (_, ciphertext) async => ciphertext,
+      );
+      await repository.startListening();
+    });
+
+    tearDown(() async {
+      await repository.stopListening();
+      await relay.close();
+      await db.close();
+    });
+
+    Future<void> settle() async {
+      for (var i = 0; i < 8; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+    }
+
+    /// Seeds a latched thread holding one kind-4-shaped row from [sender].
+    /// The NIP-04 receive path writes the wire id into BOTH columns, and that
+    /// is what marks a row as the twin a NIP-17 rumor may collapse onto.
+    Future<void> seedLatchedThreadWithKind4({
+      required String id,
+      required String sender,
+      required String content,
+    }) async {
+      await conversationsDao.upsertConversation(
+        id: conversationId,
+        participantPubkeys: participants.join(','),
+        isGroup: false,
+        createdAt: _baseCreatedAt,
+        lastMessageTimestamp: _baseCreatedAt,
+        ownerPubkey: _owner,
+        dmProtocol: 'nip04',
+      );
+      await messagesDao.insertMessage(
+        id: id,
+        conversationId: conversationId,
+        senderPubkey: sender,
+        content: content,
+        createdAt: _baseCreatedAt,
+        giftWrapId: id,
+        ownerPubkey: _owner,
+      );
+    }
+
+    Future<void> deliverGiftWrap({
+      required String wrapId,
+      required String rumorId,
+      required String author,
+      required String content,
+    }) async {
+      final recipient = author == _owner ? _peer : _owner;
+      rumors[wrapId] = Event.fromJson({
+        'id': rumorId,
+        'pubkey': author,
+        'created_at': _baseCreatedAt,
+        'kind': EventKind.privateDirectMessage,
+        'tags': [
+          ['p', recipient],
+        ],
+        'content': content,
+        'sig': '',
+      });
+      relay.add(
+        Event.fromJson({
+          'id': wrapId,
+          'pubkey': author,
+          'created_at': _baseCreatedAt,
+          'kind': EventKind.giftWrap,
+          'tags': [
+            ['p', _owner],
+          ],
+          'content': 'wrapped',
+          'sig': '',
+        }),
+      );
+      await settle();
+    }
+
+    Future<String?> storedProtocol() async =>
+        (await conversationsDao.getConversation(
+          conversationId,
+          ownerPubkey: _owner,
+        ))?.dmProtocol;
+
+    test(
+      "a peer's twin clears the latch, even though the rumor itself is "
+      'dropped as a duplicate',
+      () async {
+        await seedLatchedThreadWithKind4(
+          id: 'a' * 64,
+          sender: _peer,
+          content: 'hello',
+        );
+        expect(await storedProtocol(), 'nip04');
+
+        await deliverGiftWrap(
+          wrapId: 'b' * 64,
+          rumorId: 'c' * 64,
+          author: _peer,
+          content: 'hello',
+        );
+
+        // The twin is the ONLY place this evidence appears — the rumor is
+        // discarded, so before #8499 the proof went with it.
+        expect(await storedProtocol(), 'nip17');
+      },
+    );
+
+    test(
+      'a self-authored twin does NOT clear the latch — only the peer '
+      'speaking NIP-17 is evidence about the peer',
+      () async {
+        // The branch that claims the twin is an `else`: it catches a peer's
+        // rumor AND a self-authored 1:1 rumor with no send batch token. Without
+        // the `!isSentByMe` gate this case would clear the latch on our own
+        // capability and cut a genuine legacy peer off from their only copy.
+        await seedLatchedThreadWithKind4(
+          id: 'd' * 64,
+          sender: _owner,
+          content: 'my own message',
+        );
+        expect(await storedProtocol(), 'nip04');
+
+        await deliverGiftWrap(
+          wrapId: 'e' * 64,
+          rumorId: 'f' * 64,
+          author: _owner,
+          content: 'my own message',
+        );
+
+        expect(await storedProtocol(), 'nip04');
+      },
+    );
+
+    test(
+      'the unlatch is idempotent: a second peer twin leaves the thread nip17',
+      () async {
+        await seedLatchedThreadWithKind4(
+          id: '1' * 64,
+          sender: _peer,
+          content: 'hello',
+        );
+        await deliverGiftWrap(
+          wrapId: '2' * 64,
+          rumorId: '3' * 64,
+          author: _peer,
+          content: 'hello',
+        );
+        expect(await storedProtocol(), 'nip17');
+
+        await deliverGiftWrap(
+          wrapId: '4' * 64,
+          rumorId: '5' * 64,
+          author: _peer,
+          content: 'hello',
+        );
+        expect(await storedProtocol(), 'nip17');
+      },
+    );
+  });
+}

--- a/mobile/packages/dm_repository/test/src/dm_protocol_unlatch_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_protocol_unlatch_test.dart
@@ -210,8 +210,7 @@ void main() {
       () async {
         // The branch that claims the twin is an `else`: it catches a peer's
         // rumor AND a self-authored 1:1 rumor with no send batch token. Without
-        // the `!isSentByMe` gate this case would clear the latch on our own
-        // capability and cut a genuine legacy peer off from their only copy.
+        // the `!isSentByMe` gate this path would clear on our own self-wrap.
         await seedLatchedThreadWithKind4(
           id: 'd' * 64,
           sender: _owner,

--- a/mobile/packages/dm_repository/test/src/dm_protocol_unlatch_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_protocol_unlatch_test.dart
@@ -231,8 +231,11 @@ void main() {
     );
 
     test(
-      'the unlatch is idempotent: a second peer twin leaves the thread nip17',
+      'a later peer NIP-17 after the unlatch leaves the thread nip17',
       () async {
+        // The first wrap claims the kind-4 twin and clears. The second wrap
+        // is not a twin (`claimCrossProtocolTwin` already consumed it) so it
+        // persists; this pins that later path must not downgrade the thread.
         await seedLatchedThreadWithKind4(
           id: '1' * 64,
           sender: _peer,


### PR DESCRIPTION
## Description

A conversation stamped `dm_protocol = 'nip04'` publishes a cleartext-protocol kind-4 copy of **every** message alongside the gift wrap. NIP-04 says kind 4 must be used "only with relays that use `AUTH` to restrict who can fetch your `kind:4` events" (`04.md:51`), and Divine publishes it to the non-AUTH default pool — so on a latched thread NIP-17's headline benefit, "No Metadata Leak … Senders and receivers cannot be linked with public information alone" (`17.md:97`), does not hold for any message in it.

This clears the latch when the peer proves they can read NIP-17.

**The latch was unescapable for exactly the population that needed out of it.** It is decided by the arrival race of the first dual-sent pair, then frozen: every later pair is collapsed as a cross-protocol twin and returns *before* the upsert that would change it. Two dual-sending sides therefore deadlock and never heal, and upgrading does not fix it — #7664 only stopped the kind-4 on message #1 of a *new* thread, and never unlatches an existing one.

The evidence to escape was present the whole time and was being discarded: **a twin from the peer is proof the peer speaks NIP-17**, and the twin is exactly what gets dropped. Clearing at that point stops the thread dual-sending to someone who never needed the legacy copy — and because one clean message propagates, a single side unlatching drains the other.

A genuine legacy peer never sends NIP-17, so this can never fire for them; they keep receiving the kind-4.

**Related Issue:** Relates to #8499, #8262, #7664/#7342, #8211

### Two implementation details worth review attention

**`!isSentByMe` is load-bearing, not defensive.** The branch that claims the twin is an `else`, reached by a peer's rumor **and** by a self-authored 1:1 rumor with no send batch token. Clearing unconditionally there would sometimes clear on our *own* self-wrap — inverting the rule into "clear the latch when **I** speak NIP-17" and cutting a genuine legacy peer off from the only copy they can read. There is a test for the self-authored case specifically.

**Ordering.** `_recordProcessedWrap` runs first, and the unlatch cannot throw out of the handler. The first cut had them reversed, and an unstubbed DAO call aborted the ledger write — which in production means a transient DB error costs a signer round trip on every redelivery, forever. A dropped unlatch costs nothing: the next message from the peer presents the same evidence again.

## Out of Scope

- **No retry or durable row for the NIP-04 leg** (#8262 direction 3). This shrinks the population that leg serves; whether the remainder deserves a retry is a separate call, and the argument for "no" gets stronger after this.
- **The missing `e` tag** — NIP-04 allows an `e` tag for the replied-to message (`04.md:17`) and Divine's kind-4 carries only `p`, so legacy recipients lose reply threading. Deliberately not bundled: it adds tag data to a cleartext event, so it belongs *after* this narrowing, when it only touches genuine legacy threads.
- **AUTH-only relay targeting** (issue option 4). Best satisfies `04.md:51` literally, but does not reduce the number of cleartext events and depends on relay-side work outside this repo.
- **No repair pass for one-way latched threads.** If the peer never sends NIP-17, the latch stays. That includes a thread where we keep sending and they never reply — every outbound message still dual-sends a kind-4. Unlatching without the peer speaking NIP-17 would drop the only copy a genuine silent legacy peer can read. Dormant threads with no traffic in either direction are harmless; one-way outbound threads are not, and they remain after this change. Tracked as **#8519**, which also names a signal this PR does not use: the peer's kind-10050 already proves NIP-17 capability, and the send path fetches it anyway.

## Verification

- `flutter analyze lib packages/dm_repository packages/db_client` — **No issues found**
- `dm_repository`: **819 passing** · `db_client`: **1046 passing** (with `--coverage`)
- Ratchets green: `placeholder_tests`, `ungrouped_tests`, `shared_setup_stubs`, `skip_ceiling`, `test_unit_structure`
- `dart format` clean

**Mutation-verified.** The three repository tests run against real `ConversationsDao`/`DirectMessagesDao` on a real in-memory database, because the claim, the early return and the upsert all have to execute for the unlatch to be observable — the mock suite stubs the dedup predicates in a shared setUp and cannot see it (#8170).

| Mutation | Result |
|---|---|
| Drop the `!isSentByMe` gate | the self-authored test fails ✓ |
| Remove the unlatch entirely | both peer tests fail ✓ |

Five DAO tests cover the method itself: clears a latch, no-ops on `'nip17'`, never stamps a null protocol, respects owner scoping, and leaves the rest of the row alone.

## Coordination

Targets `main` and does not stack. **#8502 landed first** and brought `dm_protocol_latch_test.dart`. This branch rebased onto that and retired the inverted first case (kind-4 twin cannot clear the latch), leaving twin-clearing assertions in `dm_protocol_unlatch_test.dart`.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)


