### PR TITLE
fix(dm): carry the reply tag on the NIP-04 twin, when it resolves

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3156,13 +3156,14 @@ class DmRepository {
         );
       }
 
-      // Extract recipient from p tag
+      // Extract the recipient and optional reply target from their NIP-04
+      // wire tags. Preserve only the first value for each tag type.
       String? recipientPubkey;
+      String? replyToId;
       for (final tag in nip04Event.tags) {
-        if (tag.length >= 2 && tag[0] == 'p') {
-          recipientPubkey = tag[1];
-          break;
-        }
+        if (tag.length < 2) continue;
+        if (tag[0] == 'p') recipientPubkey ??= tag[1];
+        if (tag[0] == 'e') replyToId ??= tag[1];
       }
       // A missing recipient is rejected before decryption, so recording it in
       // the processed ledger would not avoid cryptographic work on replay.
@@ -3282,6 +3283,7 @@ class DmRepository {
           createdAt: persistedCreatedAt,
           giftWrapId: nip04Event.id,
           messageKind: EventKind.directMessage,
+          replyToId: replyToId,
           ownerPubkey: ownerPubkey,
         );
         if (!inserted) return;
@@ -3358,7 +3360,10 @@ class DmRepository {
       // decrypt and transaction return: this handler has no generation guard
       // to abandon on, and a switch inside that window would import this
       // stamp into the next account's maximum, narrowing its `since:`.
-      await _syncState?.recordSeen(ownerPubkey, createdAt: persistedCreatedAt);
+      await _syncState?.recordSeen(
+        ownerPubkey,
+        createdAt: persistedCreatedAt,
+      );
       await _syncState?.recordWireSeen(
         ownerPubkey,
         createdAt: nip04Event.createdAt,
@@ -6518,10 +6523,10 @@ class DmRepository {
   /// The event id to put in a kind-4 `e` tag for a reply, or `null` when the
   /// reply target is not one the legacy recipient can resolve.
   ///
-  /// Returns the id only when the replied-to message arrived over NIP-04, so
-  /// the reference names an event that is already public and that the
-  /// recipient has actually seen. See the call site for why a NIP-17 rumor id
-  /// must not be published here.
+  /// Returns the id only for a peer-authored row with the NIP-04 arrival shape,
+  /// so the reference names a public event the recipient has seen. Own NIP-17
+  /// sends before #2654 also have `id == giftWrapId` (#8211/#8216), so sender
+  /// identity is required to keep those private wrap ids out of public tags.
   Future<String?> _resolveNip04ReplyTag(String? replyToId) async {
     if (replyToId == null) return null;
     try {
@@ -6530,7 +6535,9 @@ class DmRepository {
         ownerPubkey: _userPubkey,
       );
       if (row == null) return null;
-      return row.id == row.giftWrapId ? row.id : null;
+      final arrivedFromPeerOverNip04 =
+          row.senderPubkey != _userPubkey && row.id == row.giftWrapId;
+      return arrivedFromPeerOverNip04 ? row.id : null;
     } on Object catch (e) {
       // Best-effort threading must never cost the message. A lookup failure
       // sends the copy untagged rather than not at all.
@@ -6583,26 +6590,8 @@ class DmRepository {
       return const NIP17SendResult.failure('NIP-04 encrypt returned null');
     }
 
-    // NIP-04 allows an `e` tag naming the message being replied to, "such that
-    // contextual, more organized conversations may happen" (04.md:17). Without
-    // it a legacy recipient — whose only readable copy is this kind 4 — gets
-    // every reply unthreaded.
-    //
-    // It is only added when the replied-to message ITSELF arrived over NIP-04,
-    // for two independent reasons:
-    //
-    //   * Resolvable. A row that arrived over NIP-17 is stored under its RUMOR
-    //     id, which the recipient never saw — the reference would dangle.
-    //   * Private. A rumor id is not published anywhere in NIP-17: the wrap and
-    //     the seal each carry their own id and the rumor's is not derivable
-    //     from them. Putting one in a cleartext tag would publish a stable
-    //     identifier for a private message next to the sender, the recipient
-    //     and the true timestamp.
-    //
-    // `id == giftWrapId` is the arrival-shape derivation from #8169. Our own
-    // sends are excluded by it too, and correctly so: they are stored under a
-    // rumor id, and the kind-4 twin we published had a different event id that
-    // is never persisted, so no resolvable reference to it exists.
+    // NIP-04 reply tags are public. Resolve through the stored row so only a
+    // kind-4 id already visible to the peer can leave this private store.
     final replyTag = await _resolveNip04ReplyTag(replyToId);
     final event = Event(_userPubkey, EventKind.directMessage, [
       ['p', recipientPubkey],
@@ -7600,8 +7589,12 @@ class DmRepository {
     );
     if (removedAt != null) return false;
 
-    final newest = bucket.reduce((a, b) => b.createdAt >= a.createdAt ? b : a);
-    final oldest = bucket.reduce((a, b) => b.createdAt < a.createdAt ? b : a);
+    final newest = bucket.reduce(
+      (a, b) => b.createdAt >= a.createdAt ? b : a,
+    );
+    final oldest = bucket.reduce(
+      (a, b) => b.createdAt < a.createdAt ? b : a,
+    );
     final messageIds = [for (final m in bucket) m.id];
 
     await _conversationsDao.runInTransaction(() async {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3358,10 +3358,7 @@ class DmRepository {
       // decrypt and transaction return: this handler has no generation guard
       // to abandon on, and a switch inside that window would import this
       // stamp into the next account's maximum, narrowing its `since:`.
-      await _syncState?.recordSeen(
-        ownerPubkey,
-        createdAt: persistedCreatedAt,
-      );
+      await _syncState?.recordSeen(ownerPubkey, createdAt: persistedCreatedAt);
       await _syncState?.recordWireSeen(
         ownerPubkey,
         createdAt: nip04Event.createdAt,
@@ -4200,6 +4197,7 @@ class DmRepository {
             _sendNip04Message(
               recipientPubkey: recipientPubkey,
               content: content,
+              replyToId: replyToId,
             ).catchError((Object e) {
               // Thrown failures only — a signer that reports by THROWING
               // (Keycast's RPC layer raises RpcException on 401/403/504, and a
@@ -6517,6 +6515,34 @@ class DmRepository {
   // Send - NIP-04 fallback (Kind 4)
   // -------------------------------------------------------------------------
 
+  /// The event id to put in a kind-4 `e` tag for a reply, or `null` when the
+  /// reply target is not one the legacy recipient can resolve.
+  ///
+  /// Returns the id only when the replied-to message arrived over NIP-04, so
+  /// the reference names an event that is already public and that the
+  /// recipient has actually seen. See the call site for why a NIP-17 rumor id
+  /// must not be published here.
+  Future<String?> _resolveNip04ReplyTag(String? replyToId) async {
+    if (replyToId == null) return null;
+    try {
+      final row = await _directMessagesDao.getMessageById(
+        replyToId,
+        ownerPubkey: _userPubkey,
+      );
+      if (row == null) return null;
+      return row.id == row.giftWrapId ? row.id : null;
+    } on Object catch (e) {
+      // Best-effort threading must never cost the message. A lookup failure
+      // sends the copy untagged rather than not at all.
+      Log.warning(
+        'Could not resolve a NIP-04 reply tag for $replyToId: $e — sending '
+        'the legacy kind-4 copy unthreaded',
+        category: LogCategory.system,
+      );
+      return null;
+    }
+  }
+
   /// Sends a NIP-04 encrypted direct message (kind 4) for legacy client
   /// interoperability.
   ///
@@ -6525,6 +6551,7 @@ class DmRepository {
   Future<NIP17SendResult> _sendNip04Message({
     required String recipientPubkey,
     required String content,
+    String? replyToId,
   }) async {
     // Reuses NIP17SendResult for simplicity — this is an internal helper.
     //
@@ -6556,8 +6583,30 @@ class DmRepository {
       return const NIP17SendResult.failure('NIP-04 encrypt returned null');
     }
 
+    // NIP-04 allows an `e` tag naming the message being replied to, "such that
+    // contextual, more organized conversations may happen" (04.md:17). Without
+    // it a legacy recipient — whose only readable copy is this kind 4 — gets
+    // every reply unthreaded.
+    //
+    // It is only added when the replied-to message ITSELF arrived over NIP-04,
+    // for two independent reasons:
+    //
+    //   * Resolvable. A row that arrived over NIP-17 is stored under its RUMOR
+    //     id, which the recipient never saw — the reference would dangle.
+    //   * Private. A rumor id is not published anywhere in NIP-17: the wrap and
+    //     the seal each carry their own id and the rumor's is not derivable
+    //     from them. Putting one in a cleartext tag would publish a stable
+    //     identifier for a private message next to the sender, the recipient
+    //     and the true timestamp.
+    //
+    // `id == giftWrapId` is the arrival-shape derivation from #8169. Our own
+    // sends are excluded by it too, and correctly so: they are stored under a
+    // rumor id, and the kind-4 twin we published had a different event id that
+    // is never persisted, so no resolvable reference to it exists.
+    final replyTag = await _resolveNip04ReplyTag(replyToId);
     final event = Event(_userPubkey, EventKind.directMessage, [
       ['p', recipientPubkey],
+      if (replyTag != null) ['e', replyTag],
     ], ciphertext);
 
     final signed = await signer.signEvent(event);
@@ -7551,12 +7600,8 @@ class DmRepository {
     );
     if (removedAt != null) return false;
 
-    final newest = bucket.reduce(
-      (a, b) => b.createdAt >= a.createdAt ? b : a,
-    );
-    final oldest = bucket.reduce(
-      (a, b) => b.createdAt < a.createdAt ? b : a,
-    );
+    final newest = bucket.reduce((a, b) => b.createdAt >= a.createdAt ? b : a);
+    final oldest = bucket.reduce((a, b) => b.createdAt < a.createdAt ? b : a);
     final messageIds = [for (final m in bucket) m.id];
 
     await _conversationsDao.runInTransaction(() async {

--- a/mobile/packages/dm_repository/test/src/dm_nip04_reply_tag_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_nip04_reply_tag_test.dart
@@ -10,6 +10,7 @@ import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
@@ -77,9 +78,24 @@ void main() {
         (_) async =>
             (events: const <Event>[], timedOut: false, noRelays: false),
       );
+      // The leg OK-confirms its kind 4 (#8262), so it calls
+      // `publishEventAwaitOk`. Stubbing `publishEvent` here would leave the
+      // real call unstubbed and the capture below empty.
       when(
-        () => nostrClient.publishEvent(any()),
-      ).thenAnswer((_) async => const PublishFailed());
+        () => nostrClient.publishEventAwaitOk(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+          timeout: any(named: 'timeout'),
+          diagnosticTag: any(named: 'diagnosticTag'),
+        ),
+      ).thenAnswer(
+        (_) async => const PublishOutcome(
+          eventId: 'nip04-reply-tag-probe',
+          acceptedBy: ['wss://relay.divine.video'],
+          rejectedBy: <String, String>{},
+          noResponseFrom: <String>[],
+        ),
+      );
       when(
         () => messageService.canSendTo(any()),
       ).thenAnswer((_) async => true);
@@ -166,7 +182,12 @@ void main() {
 
     Future<List<List<String>>?> publishedKind4Tags() async {
       final calls = verify(
-        () => nostrClient.publishEvent(captureAny()),
+        () => nostrClient.publishEventAwaitOk(
+          captureAny(),
+          targetRelays: any(named: 'targetRelays'),
+          timeout: any(named: 'timeout'),
+          diagnosticTag: any(named: 'diagnosticTag'),
+        ),
       ).captured;
       if (calls.isEmpty) return null;
       return (calls.last as Event).tags.map((t) => t.cast<String>()).toList();

--- a/mobile/packages/dm_repository/test/src/dm_nip04_reply_tag_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_nip04_reply_tag_test.dart
@@ -153,10 +153,11 @@ void main() {
     Future<void> storeMessage({
       required String id,
       required String giftWrapId,
+      String senderPubkey = _peer,
     }) => messagesDao.insertMessage(
       id: id,
       conversationId: conversationId,
-      senderPubkey: _peer,
+      senderPubkey: senderPubkey,
       content: 'earlier message',
       createdAt: _baseCreatedAt,
       giftWrapId: giftWrapId,
@@ -210,6 +211,26 @@ void main() {
         await storeMessage(id: _rumorId, giftWrapId: _wrapId);
 
         await send(replyToId: _rumorId);
+
+        expect(await publishedKind4Tags(), [
+          ['p', _peer],
+        ]);
+      },
+    );
+
+    test(
+      'does NOT expose a legacy-shaped self-authored NIP-17 wrap id',
+      () async {
+        await seedLatchedThread();
+        // Before #2654, own NIP-17 sends stored the gift-wrap id in both
+        // columns. The shape alone therefore cannot prove this was kind 4.
+        await storeMessage(
+          id: _wrapId,
+          giftWrapId: _wrapId,
+          senderPubkey: _owner,
+        );
+
+        await send(replyToId: _wrapId);
 
         expect(await publishedKind4Tags(), [
           ['p', _peer],

--- a/mobile/packages/dm_repository/test/src/dm_nip04_reply_tag_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_nip04_reply_tag_test.dart
@@ -1,0 +1,241 @@
+// ABOUTME: #8507 — the kind-4 twin carries an `e` tag only when the replied-to
+// ABOUTME: message arrived over NIP-04, so it is resolvable and already public.
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockMessageService extends Mock implements NIP17MessageService {}
+
+class _FakeEvent extends Fake implements Event {}
+
+const _owner =
+    'a4f5c1b2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8';
+const _peer =
+    'b1c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0';
+const _privateKey =
+    '5426e5b8b4b0e2a1f5e8d3c7a9b2f4e6d8c0a2b4f6e8d0c2a4b6f8e0d2c4a6b8';
+
+const _baseCreatedAt = 1700000000;
+const _kind4Id =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+const _rumorId =
+    '2222222222222222222222222222222222222222222222222222222222222222';
+const _wrapId =
+    '3333333333333333333333333333333333333333333333333333333333333333';
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+    registerFallbackValue(Duration.zero);
+  });
+
+  // Real DAOs: the rule turns on a stored row's arrival SHAPE
+  // (`id == giftWrapId`), so a stubbed lookup would be asserting the stub.
+  group('the kind-4 reply tag (#8507)', () {
+    late AppDatabase db;
+    late ConversationsDao conversationsDao;
+    late DirectMessagesDao messagesDao;
+    late ProcessedGiftWrapsDao processedDao;
+    late _MockNostrClient nostrClient;
+    late _MockMessageService messageService;
+    late DmRepository repository;
+
+    final participants = [_owner, _peer]..sort();
+    late String conversationId;
+
+    setUp(() async {
+      db = AppDatabase.test(NativeDatabase.memory());
+      conversationsDao = ConversationsDao(db);
+      messagesDao = DirectMessagesDao(db);
+      processedDao = ProcessedGiftWrapsDao(db);
+      nostrClient = _MockNostrClient();
+      messageService = _MockMessageService();
+      conversationId = DmRepository.computeConversationId(participants);
+
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(() => nostrClient.configuredRelayCount).thenReturn(1);
+      when(
+        () => nostrClient.queryEventsDetailed(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+          tempRelays: any(named: 'tempRelays'),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async =>
+            (events: const <Event>[], timedOut: false, noRelays: false),
+      );
+      when(
+        () => nostrClient.publishEvent(any()),
+      ).thenAnswer((_) async => const PublishFailed());
+      when(
+        () => messageService.canSendTo(any()),
+      ).thenAnswer((_) async => true);
+      // Real rumor construction: the NIP-17 leg's tags are not what this file
+      // asserts, but a null rumor stops `sendMessage` before the kind-4 twin.
+      when(
+        () => messageService.buildRumor(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          eventKind: any(named: 'eventKind'),
+          additionalTags: any(named: 'additionalTags'),
+          createdAt: any(named: 'createdAt'),
+        ),
+      ).thenAnswer(
+        (inv) => Event(
+          _owner,
+          EventKind.privateDirectMessage,
+          [
+            ['p', _peer],
+          ],
+          inv.namedArguments[#content] as String,
+        ),
+      );
+      when(
+        () => messageService.sendRumor(
+          rumorEvent: any(named: 'rumorEvent'),
+          recipientPubkey: any(named: 'recipientPubkey'),
+          targetRelays: any(named: 'targetRelays'),
+          selfWrapTargetRelays: any(named: 'selfWrapTargetRelays'),
+          awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          selfWrapOnSoftUnconfirmed: any(named: 'selfWrapOnSoftUnconfirmed'),
+          recipientWrapBuildTimeout: any(named: 'recipientWrapBuildTimeout'),
+          selfWrapBuildTimeout: any(named: 'selfWrapBuildTimeout'),
+        ),
+      ).thenAnswer(
+        (_) async => NIP17SendResult.success(
+          rumorEventId: _rumorId,
+          messageEventId: _wrapId,
+          recipientPubkey: _peer,
+        ),
+      );
+
+      repository = DmRepository(
+        nostrClient: nostrClient,
+        messageService: messageService,
+        directMessagesDao: messagesDao,
+        conversationsDao: conversationsDao,
+        processedGiftWrapsDao: processedDao,
+        userPubkey: _owner,
+        signer: LocalNostrSigner(_privateKey),
+      );
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    /// A thread latched to 'nip04' so the fallback gate is open.
+    Future<void> seedLatchedThread() => conversationsDao.upsertConversation(
+      id: conversationId,
+      participantPubkeys: participants.join(','),
+      isGroup: false,
+      createdAt: _baseCreatedAt,
+      lastMessageTimestamp: _baseCreatedAt,
+      ownerPubkey: _owner,
+      dmProtocol: 'nip04',
+    );
+
+    /// [giftWrapId] == [id] is the shape the NIP-04 receive path writes, and is
+    /// what marks a row as having arrived over kind 4 (#8169).
+    Future<void> storeMessage({
+      required String id,
+      required String giftWrapId,
+    }) => messagesDao.insertMessage(
+      id: id,
+      conversationId: conversationId,
+      senderPubkey: _peer,
+      content: 'earlier message',
+      createdAt: _baseCreatedAt,
+      giftWrapId: giftWrapId,
+      ownerPubkey: _owner,
+    );
+
+    Future<List<List<String>>?> publishedKind4Tags() async {
+      final calls = verify(
+        () => nostrClient.publishEvent(captureAny()),
+      ).captured;
+      if (calls.isEmpty) return null;
+      return (calls.last as Event).tags.map((t) => t.cast<String>()).toList();
+    }
+
+    Future<void> send({String? replyToId}) async {
+      final _ = await repository.sendMessage(
+        recipientPubkey: _peer,
+        content: 'my reply',
+        replyToId: replyToId,
+      );
+      await pumpEventQueue();
+    }
+
+    test(
+      'tags a reply to a message that arrived over NIP-04, so the legacy '
+      'recipient can resolve it',
+      () async {
+        await seedLatchedThread();
+        // id == giftWrapId: arrived over kind 4, so this id is a real event
+        // id already on relays.
+        await storeMessage(id: _kind4Id, giftWrapId: _kind4Id);
+
+        await send(replyToId: _kind4Id);
+
+        expect(await publishedKind4Tags(), [
+          ['p', _peer],
+          ['e', _kind4Id],
+        ]);
+      },
+    );
+
+    test(
+      'does NOT tag a reply to a message that arrived over NIP-17 — that id '
+      'is a rumor id the recipient never saw and that is not public',
+      () async {
+        await seedLatchedThread();
+        // id != giftWrapId: arrived wrapped, so `id` is the rumor id. It exists
+        // only inside the seal; publishing it in a cleartext tag would leak a
+        // stable identifier for a private message, and the recipient could not
+        // resolve it anyway.
+        await storeMessage(id: _rumorId, giftWrapId: _wrapId);
+
+        await send(replyToId: _rumorId);
+
+        expect(await publishedKind4Tags(), [
+          ['p', _peer],
+        ]);
+      },
+    );
+
+    test('omits the tag when the reply target is unknown locally', () async {
+      await seedLatchedThread();
+
+      await send(replyToId: _kind4Id);
+
+      expect(await publishedKind4Tags(), [
+        ['p', _peer],
+      ]);
+    });
+
+    test('omits the tag for a plain, non-reply message', () async {
+      await seedLatchedThread();
+      await storeMessage(id: _kind4Id, giftWrapId: _kind4Id);
+
+      await send();
+
+      expect(await publishedKind4Tags(), [
+        ['p', _peer],
+      ]);
+    });
+  });
+}

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -11640,6 +11640,55 @@ void main() {
         await repository.stopListening();
       });
 
+      test('persists the reply target from a NIP-04 e tag', () async {
+        final nip04Event = createNip04Event(
+          tags: [
+            ['p', _validPubkeyA],
+            ['e', _giftWrapEventId],
+          ],
+        );
+
+        when(
+          () => mockDirectMessagesDao.hasGiftWrap(_rumorEventId),
+        ).thenAnswer((_) async => false);
+        stubDaoInserts();
+
+        final controller = StreamController<Event>();
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).thenAnswer((_) => controller.stream);
+
+        final repository = createRepository(
+          nip04Decryptor: (_, _) async => 'Decrypted NIP-04 reply',
+        );
+
+        await repository.startListening();
+        controller.add(nip04Event);
+        await Future<void>.delayed(Duration.zero);
+
+        verify(
+          () => mockDirectMessagesDao.insertMessage(
+            id: _rumorEventId,
+            conversationId: any(named: 'conversationId'),
+            senderPubkey: _validPubkeyB,
+            content: 'Decrypted NIP-04 reply',
+            createdAt: 1700000000,
+            giftWrapId: _rumorEventId,
+            messageKind: EventKind.directMessage,
+            replyToId: _giftWrapEventId,
+            ownerPubkey: any(named: 'ownerPubkey'),
+            tagsJson: any(named: 'tagsJson'),
+            sendBatchId: any(named: 'sendBatchId'),
+          ),
+        ).called(1);
+
+        await controller.close();
+        await repository.stopListening();
+      });
+
       test(
         'skips conversation and sync updates when a NIP-04 insert is ignored',
         () async {


### PR DESCRIPTION
## Description

Legacy recipients could not see which message a Divine reply referred to because the NIP-04 copy dropped the reply tag already carried by the NIP-17 copy. This adds the standard `e` tag when the referenced event is safe and resolvable, and reads the same tag back into local reply threading.

The safety gate requires a peer-authored row with the NIP-04 arrival shape. NIP-17 rumor ids are private and unresolvable to a legacy recipient, while self-authored NIP-17 rows written before #2654 can look like NIP-04 rows because they stored the gift-wrap id in both id columns (#8211/#8216). Checking both sender and shape prevents either private identifier from entering a public kind-4 tag.

If the local lookup fails or the target does not satisfy that gate, the message still sends without an `e` tag.

**Related Issue:** Closes #8507 · Relates to #8262, #8499/#8505

## Out of Scope

- No `subject` tag; NIP-04 does not specify one.
- No change to which messages receive a kind-4 copy (#8499/#8505).
- No retry behavior change (#8506).

## Verification

- `flutter analyze packages/dm_repository/lib packages/dm_repository/test/src/dm_nip04_reply_tag_test.dart packages/dm_repository/test/src/dm_repository_test.dart`
- `flutter test packages/dm_repository` — 822 passing
- Pre-push focused analysis and changed-file tests — 439 passing
- CI: all checks green, including Generated Files, four test shards, and Integration Tests (services)

Five real-DAO send-path cases cover NIP-04, modern NIP-17, legacy-shaped self-authored NIP-17, unknown, and non-reply targets. Receive-path coverage verifies that an incoming NIP-04 `e` tag is persisted as `replyToId`.

## Coordination

Targets `main` and does not stack. The change remains independent of #8505 and may land in either order.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
