### PR TITLE
fix(reporting): surface dropped image insertions in the content report field

### DIFF
--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2899,6 +2899,10 @@
   "@reportDetailsTextOnly": {
     "description": "Shown above the content report details field to warn that photos, screenshots, and GIFs cannot be attached."
   },
+  "reportDetailsImageNotAttached": "That wasn’t attached. Reports are text only, so describe it in words.",
+  "@reportDetailsImageNotAttached": {
+    "description": "Shown in the content report details field the moment the user tries to insert a photo or GIF from the keyboard. Reports carry no attachments, so the image is intentionally dropped; this confirms it was not attached and redirects the reporter to describing the issue in words."
+  },
   "reportReasonSpam": "Spam or Unwanted Content",
   "reportReasonSpamSubtitle": "Unwanted or repetitive content",
   "reportReasonHarassment": "Harassment, Bullying, or Threats",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7951,6 +7951,12 @@ abstract class AppLocalizations {
   /// **'Text only — photos and GIFs can’t be attached here.'**
   String get reportDetailsTextOnly;
 
+  /// Shown in the content report details field the moment the user tries to insert a photo or GIF from the keyboard. Reports carry no attachments, so the image is intentionally dropped; this confirms it was not attached and redirects the reporter to describing the issue in words.
+  ///
+  /// In en, this message translates to:
+  /// **'That wasn’t attached. Reports are text only, so describe it in words.'**
+  String get reportDetailsImageNotAttached;
+
   /// No description provided for @reportReasonSpam.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4529,6 +4529,10 @@ class AppLocalizationsAm extends AppLocalizations {
       'ጽሑፍ ብቻ — ፎቶዎችን እና GIF-ዎችን እዚህ ማያያዝ አይቻልም።';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'አይፈለጌ መልእክት ወይም የማይፈለግ ይዘት';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4597,6 +4597,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'نص فقط — لا يمكن إرفاق الصور أو ملفات GIF هنا.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'محتوى غير مرغوب فيه أو مزعج';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4688,6 +4688,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Само текст — тук не могат да се прикачват снимки или GIF файлове.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'Спам или нежелано съдържание';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4698,6 +4698,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Nur Text – Fotos und GIFs können hier nicht angehängt werden.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'Spam oder unerwünschte Inhalte';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4726,6 +4726,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Text only — photos and GIFs can’t be attached here.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'Spam or Unwanted Content';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4687,6 +4687,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Solo texto: aquí no se pueden adjuntar fotos ni GIF.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'Spam o contenido no deseado';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4671,6 +4671,10 @@ class AppLocalizationsFil extends AppLocalizations {
       'Text lang — hindi puwedeng mag-attach ng mga litrato o GIF dito.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'Spam o Hindi Gustong Content';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4705,6 +4705,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Texte uniquement — impossible de joindre des photos ou des GIF ici.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'Spam ou contenu indésirable';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4570,6 +4570,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Hanya teks — foto dan GIF tidak dapat dilampirkan di sini.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'Spam atau Konten Tidak Diinginkan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4692,6 +4692,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Solo testo: qui non puoi allegare foto o GIF.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'Spam o contenuto indesiderato';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4362,6 +4362,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get reportDetailsTextOnly => 'テキストのみです。ここには写真やGIFを添付できません。';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'スパムや迷惑なコンテンツ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4377,6 +4377,10 @@ class AppLocalizationsKo extends AppLocalizations {
       '텍스트만 입력할 수 있습니다. 여기에는 사진이나 GIF를 첨부할 수 없습니다.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => '스팸 또는 원치 않는 콘텐츠';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -4639,6 +4639,10 @@ class AppLocalizationsMs extends AppLocalizations {
       'Teks sahaja — foto dan GIF tidak boleh dilampirkan di sini.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'Spam atau Kandungan Tidak Diingini';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4657,6 +4657,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Alleen tekst — je kunt hier geen foto\'s of GIF\'s toevoegen.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'Spam of ongewenste inhoud';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4759,6 +4759,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Tylko tekst — nie można tu dołączać zdjęć ani plików GIF.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'Spam lub niechciana treść';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4670,6 +4670,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Apenas texto — não é possível anexar fotos ou GIFs aqui.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'Spam ou conteúdo indesejado';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4777,6 +4777,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Doar text — fotografiile și GIF-urile nu pot fi atașate aici.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'Spam sau conținut nedorit';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4636,6 +4636,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Endast text – foton och GIF-bilder kan inte bifogas här.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'Skräppost eller ovälkommet innehåll';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -4809,6 +4809,10 @@ class AppLocalizationsTe extends AppLocalizations {
       'వచనం మాత్రమే — ఫోటోలు మరియు GIFలు ఇక్కడ జోడించబడవు.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'స్పామ్ లేదా అవాంఛిత కంటెంట్';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4578,6 +4578,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Yalnızca metin — buraya fotoğraf veya GIF eklenemez.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'Spam veya İstenmeyen İçerik';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -4647,6 +4647,10 @@ class AppLocalizationsUr extends AppLocalizations {
       'صرف متن — یہاں تصاویر یا GIF منسلک نہیں کیے جا سکتے۔';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'اسپیم یا ناپسندیدہ مواد';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -4605,6 +4605,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Chỉ văn bản — không thể đính kèm ảnh hoặc GIF ở đây.';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => 'Spam hoặc nội dung không mong muốn';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -4341,6 +4341,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get reportDetailsTextOnly => '仅限文字——无法在此附加照片或 GIF。';
 
   @override
+  String get reportDetailsImageNotAttached =>
+      'That wasn’t attached. Reports are text only, so describe it in words.';
+
+  @override
   String get reportReasonSpam => '垃圾或不受欢迎的内容';
 
   @override

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -735,6 +735,7 @@ class _CappedDetailsField extends StatefulWidget {
 
 class _CappedDetailsFieldState extends State<_CappedDetailsField> {
   bool _truncated = false;
+  bool _imageInsertionRejected = false;
 
   void _onTruncated() {
     if (_truncated || !mounted) return;
@@ -746,11 +747,32 @@ class _CappedDetailsFieldState extends State<_CappedDetailsField> {
     );
   }
 
+  void _onContentInserted(KeyboardInsertedContent content) {
+    // Reports are text only; there is no attachment path, so a keyboard-
+    // inserted image is intentionally dropped and never touches the field or
+    // any report state. Without this handler the framework drops it silently
+    // (#8210). Surface the drop instead so the reporter knows to use words.
+    if (!mounted) return;
+    if (!_imageInsertionRejected) {
+      setState(() => _imageInsertionRejected = true);
+    }
+    // Announce on every attempt, not once: each commit is a discrete,
+    // deliberate action worth confirming to a screen reader.
+    SemanticsService.sendAnnouncement(
+      View.of(context),
+      context.l10n.reportDetailsImageNotAttached,
+      Directionality.of(context),
+    );
+  }
+
   void _onChanged(String value) {
     widget.onChanged();
     if (_truncated &&
         value.characters.length < BugReportConfig.maxFreeTextFieldLength) {
       setState(() => _truncated = false);
+    }
+    if (_imageInsertionRejected) {
+      setState(() => _imageInsertionRejected = false);
     }
   }
 
@@ -769,6 +791,12 @@ class _CappedDetailsFieldState extends State<_CappedDetailsField> {
           textInputAction: TextInputAction.newline,
           textCapitalization: TextCapitalization.sentences,
           onChanged: _onChanged,
+          // The default config advertises the standard image types, so the
+          // keyboard still offers insertion (#8223 keeps the affordance
+          // visible); the handler rejects them honestly, not silently.
+          contentInsertionConfiguration: ContentInsertionConfiguration(
+            onContentInserted: _onContentInserted,
+          ),
           style: VineTheme.bodyLargeFont(color: context.vineColors.primaryText),
           minLines: 3,
           maxLines: 5,
@@ -788,6 +816,13 @@ class _CappedDetailsFieldState extends State<_CappedDetailsField> {
             context.l10n.supportFieldLimitReached,
             style: VineTheme.labelSmallFont(
               color: context.vineColors.onSurfaceVariant,
+            ),
+          ),
+        if (_imageInsertionRejected)
+          Text(
+            context.l10n.reportDetailsImageNotAttached,
+            style: VineTheme.labelSmallFont(
+              color: VineTheme.onSurfaceVariant,
             ),
           ),
       ],

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -249,10 +249,10 @@ class _ReportContentViewState extends State<_ReportContentView> {
   String? _errorMessage;
 
   /// Whether the reporter just tried to insert an image the report cannot
-  /// carry. Held here, above the details field, because that field's [State]
-  /// can be rebuilt from scratch mid-interaction (a reason reselection, or the
-  /// Android rebuild in #8511's review), which would otherwise drop this
-  /// one-shot notice while the announcement had already fired.
+  /// carry. Held here, not in the details field, because reselecting the
+  /// reason unmounts and rebuilds that field from scratch, which would drop
+  /// this one-shot notice if it lived there. The notice renders above the
+  /// field (see [_ReportFormBody]) so the keyboard cannot cover it.
   bool _imageInsertionRejected = false;
 
   bool _scrollWhenKeyboardOpens = false;
@@ -321,8 +321,10 @@ class _ReportContentViewState extends State<_ReportContentView> {
     if (!_imageInsertionRejected) {
       setState(() => _imageInsertionRejected = true);
     }
-    // Announce on every attempt, not once: each commit is a discrete,
-    // deliberate action worth confirming to a screen reader.
+    // Announce on every attempt, not via liveRegion (which fires once per
+    // appearance): each commit is a discrete action, and the spoken notice is
+    // the channel that still lands when the visual one is briefly behind the
+    // keyboard.
     SemanticsService.sendAnnouncement(
       View.of(context),
       context.l10n.reportDetailsImageNotAttached,
@@ -519,7 +521,8 @@ class _ReportFormBody extends StatelessWidget {
   /// soon as the user edits the details.
   final VoidCallback onDetailsChanged;
 
-  /// Whether the reporter tried to insert an image; drives the field's notice.
+  /// Whether the reporter tried to insert an image; drives the not-attached
+  /// notice shown above the field.
   final bool imageInsertionRejected;
 
   /// Forwarded to the details field's content-insertion handler.
@@ -583,12 +586,12 @@ class _ReportFormBody extends StatelessWidget {
                       color: context.vineColors.onSurfaceVariant,
                     ),
                   ),
+                  if (imageInsertionRejected) const _ImageNotAttachedNotice(),
                   _CappedDetailsField(
                     fieldKey: detailsFieldKey,
                     controller: detailsController,
                     focusNode: detailsFocusNode,
                     onChanged: onDetailsChanged,
-                    imageInsertionRejected: imageInsertionRejected,
                     onImageInserted: onImageInserted,
                   ),
                 ],
@@ -763,7 +766,6 @@ class _CappedDetailsField extends StatefulWidget {
     required this.controller,
     required this.focusNode,
     required this.onChanged,
-    required this.imageInsertionRejected,
     required this.onImageInserted,
   });
 
@@ -771,11 +773,6 @@ class _CappedDetailsField extends StatefulWidget {
   final TextEditingController controller;
   final FocusNode focusNode;
   final VoidCallback onChanged;
-
-  /// Whether the reporter tried to insert an image, which reports cannot carry.
-  /// Lives in the durable parent so a rebuild of this field's [State] cannot
-  /// drop the one-shot notice mid-interaction (#8511 review).
-  final bool imageInsertionRejected;
 
   /// Called when the keyboard commits image content, so the durable parent
   /// records the rejection and announces it.
@@ -851,14 +848,24 @@ class _CappedDetailsFieldState extends State<_CappedDetailsField> {
               color: context.vineColors.onSurfaceVariant,
             ),
           ),
-        if (widget.imageInsertionRejected)
-          Text(
-            context.l10n.reportDetailsImageNotAttached,
-            style: VineTheme.labelSmallFont(
-              color: context.vineColors.onSurfaceVariant,
-            ),
-          ),
       ],
+    );
+  }
+}
+
+/// The one-shot notice shown when the keyboard tries to insert an image the
+/// report cannot carry. Rendered above the field (in [_ReportFormBody]) so it
+/// is not occluded by the keyboard's media panel at the moment it fires
+/// (measured on device in #8511's review).
+class _ImageNotAttachedNotice extends StatelessWidget {
+  const _ImageNotAttachedNotice();
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.vineColors;
+    return Text(
+      context.l10n.reportDetailsImageNotAttached,
+      style: VineTheme.labelSmallFont(color: palette.onSurfaceVariant),
     );
   }
 }

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -248,6 +248,13 @@ class _ReportContentViewState extends State<_ReportContentView> {
   /// display text, which is exactly what must not live in cubit state.
   String? _errorMessage;
 
+  /// Whether the reporter just tried to insert an image the report cannot
+  /// carry. Held here, above the details field, because that field's [State]
+  /// can be rebuilt from scratch mid-interaction (a reason reselection, or the
+  /// Android rebuild in #8511's review), which would otherwise drop this
+  /// one-shot notice while the announcement had already fired.
+  bool _imageInsertionRejected = false;
+
   bool _scrollWhenKeyboardOpens = false;
   double _previousViewInsetsBottom = 0;
 
@@ -305,6 +312,24 @@ class _ReportContentViewState extends State<_ReportContentView> {
     }
   }
 
+  void _onImageInsertionRejected() {
+    // Reports are text only; there is no attachment path, so a keyboard-
+    // inserted image is intentionally dropped and never touches the field or
+    // any report state (#8210). Android-only: the engine implements
+    // commitContent nowhere else. Surface the drop so the reporter uses words.
+    if (!mounted) return;
+    if (!_imageInsertionRejected) {
+      setState(() => _imageInsertionRejected = true);
+    }
+    // Announce on every attempt, not once: each commit is a discrete,
+    // deliberate action worth confirming to a screen reader.
+    SemanticsService.sendAnnouncement(
+      View.of(context),
+      context.l10n.reportDetailsImageNotAttached,
+      Directionality.of(context),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final status = context.select(
@@ -331,7 +356,9 @@ class _ReportContentViewState extends State<_ReportContentView> {
                     detailsFocusNode: _detailsFocusNode,
                     detailsFieldKey: _detailsFieldKey,
                     otherCardKey: _otherCardKey,
-                    onDetailsChanged: _clearErrorMessage,
+                    onDetailsChanged: _onDetailsChanged,
+                    imageInsertionRejected: _imageInsertionRejected,
+                    onImageInserted: _onImageInsertionRejected,
                   ),
           ),
         ),
@@ -370,9 +397,12 @@ class _ReportContentViewState extends State<_ReportContentView> {
     );
   }
 
-  void _clearErrorMessage() {
-    if (_errorMessage == null) return;
-    setState(() => _errorMessage = null);
+  void _onDetailsChanged() {
+    if (_errorMessage == null && !_imageInsertionRejected) return;
+    setState(() {
+      _errorMessage = null;
+      _imageInsertionRejected = false;
+    });
   }
 
   void _handleSubmitReport() {
@@ -471,6 +501,8 @@ class _ReportFormBody extends StatelessWidget {
     required this.detailsFieldKey,
     required this.otherCardKey,
     required this.onDetailsChanged,
+    required this.imageInsertionRejected,
+    required this.onImageInserted,
   });
 
   final ContentFilterReason? selectedReason;
@@ -483,8 +515,15 @@ class _ReportFormBody extends StatelessWidget {
   /// keyboard pushes the details field up.
   final GlobalKey otherCardKey;
 
-  /// Clears a pending validation error as soon as the user edits the details.
+  /// Clears a pending validation error (and the image-rejection notice) as
+  /// soon as the user edits the details.
   final VoidCallback onDetailsChanged;
+
+  /// Whether the reporter tried to insert an image; drives the field's notice.
+  final bool imageInsertionRejected;
+
+  /// Forwarded to the details field's content-insertion handler.
+  final VoidCallback onImageInserted;
 
   @override
   Widget build(BuildContext context) {
@@ -549,6 +588,8 @@ class _ReportFormBody extends StatelessWidget {
                     controller: detailsController,
                     focusNode: detailsFocusNode,
                     onChanged: onDetailsChanged,
+                    imageInsertionRejected: imageInsertionRejected,
+                    onImageInserted: onImageInserted,
                   ),
                 ],
               ),
@@ -722,6 +763,8 @@ class _CappedDetailsField extends StatefulWidget {
     required this.controller,
     required this.focusNode,
     required this.onChanged,
+    required this.imageInsertionRejected,
+    required this.onImageInserted,
   });
 
   final GlobalKey fieldKey;
@@ -729,13 +772,21 @@ class _CappedDetailsField extends StatefulWidget {
   final FocusNode focusNode;
   final VoidCallback onChanged;
 
+  /// Whether the reporter tried to insert an image, which reports cannot carry.
+  /// Lives in the durable parent so a rebuild of this field's [State] cannot
+  /// drop the one-shot notice mid-interaction (#8511 review).
+  final bool imageInsertionRejected;
+
+  /// Called when the keyboard commits image content, so the durable parent
+  /// records the rejection and announces it.
+  final VoidCallback onImageInserted;
+
   @override
   State<_CappedDetailsField> createState() => _CappedDetailsFieldState();
 }
 
 class _CappedDetailsFieldState extends State<_CappedDetailsField> {
   bool _truncated = false;
-  bool _imageInsertionRejected = false;
 
   void _onTruncated() {
     if (_truncated || !mounted) return;
@@ -747,32 +798,11 @@ class _CappedDetailsFieldState extends State<_CappedDetailsField> {
     );
   }
 
-  void _onContentInserted(KeyboardInsertedContent content) {
-    // Reports are text only; there is no attachment path, so a keyboard-
-    // inserted image is intentionally dropped and never touches the field or
-    // any report state (#8210). Android-only: the engine implements
-    // commitContent nowhere else. Surface the drop so the reporter uses words.
-    if (!mounted) return;
-    if (!_imageInsertionRejected) {
-      setState(() => _imageInsertionRejected = true);
-    }
-    // Announce on every attempt, not once: each commit is a discrete,
-    // deliberate action worth confirming to a screen reader.
-    SemanticsService.sendAnnouncement(
-      View.of(context),
-      context.l10n.reportDetailsImageNotAttached,
-      Directionality.of(context),
-    );
-  }
-
   void _onChanged(String value) {
     widget.onChanged();
     if (_truncated &&
         value.characters.length < BugReportConfig.maxFreeTextFieldLength) {
       setState(() => _truncated = false);
-    }
-    if (_imageInsertionRejected) {
-      setState(() => _imageInsertionRejected = false);
     }
   }
 
@@ -798,7 +828,7 @@ class _CappedDetailsFieldState extends State<_CappedDetailsField> {
           // handler can answer it in our own words. #8223 chose not to hide
           // the keyboard's image button, so it stays live.
           contentInsertionConfiguration: ContentInsertionConfiguration(
-            onContentInserted: _onContentInserted,
+            onContentInserted: (_) => widget.onImageInserted(),
           ),
           style: VineTheme.bodyLargeFont(color: context.vineColors.primaryText),
           minLines: 3,
@@ -821,7 +851,7 @@ class _CappedDetailsFieldState extends State<_CappedDetailsField> {
               color: context.vineColors.onSurfaceVariant,
             ),
           ),
-        if (_imageInsertionRejected)
+        if (widget.imageInsertionRejected)
           Text(
             context.l10n.reportDetailsImageNotAttached,
             style: VineTheme.labelSmallFont(

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -822,7 +822,7 @@ class _CappedDetailsFieldState extends State<_CappedDetailsField> {
           Text(
             context.l10n.reportDetailsImageNotAttached,
             style: VineTheme.labelSmallFont(
-              color: VineTheme.onSurfaceVariant,
+              color: context.vineColors.onSurfaceVariant,
             ),
           ),
       ],

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -750,8 +750,8 @@ class _CappedDetailsFieldState extends State<_CappedDetailsField> {
   void _onContentInserted(KeyboardInsertedContent content) {
     // Reports are text only; there is no attachment path, so a keyboard-
     // inserted image is intentionally dropped and never touches the field or
-    // any report state. Without this handler the framework drops it silently
-    // (#8210). Surface the drop instead so the reporter knows to use words.
+    // any report state (#8210). Android-only: the engine implements
+    // commitContent nowhere else. Surface the drop so the reporter uses words.
     if (!mounted) return;
     if (!_imageInsertionRejected) {
       setState(() => _imageInsertionRejected = true);
@@ -791,9 +791,12 @@ class _CappedDetailsFieldState extends State<_CappedDetailsField> {
           textInputAction: TextInputAction.newline,
           textCapitalization: TextCapitalization.sentences,
           onChanged: _onChanged,
-          // The default config advertises the standard image types, so the
-          // keyboard still offers insertion (#8223 keeps the affordance
-          // visible); the handler rejects them honestly, not silently.
+          // Without a configuration Flutter advertises an empty mime-type
+          // list, so Android refuses the insert itself and shows a system
+          // toast that vanishes and never mentions the report. Declaring the
+          // default image types moves that moment into the app, where the
+          // handler can answer it in our own words. #8223 chose not to hide
+          // the keyboard's image button, so it stays live.
           contentInsertionConfiguration: ContentInsertionConfiguration(
             onContentInserted: _onContentInserted,
           ),

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -434,6 +434,12 @@ const _knownUntranslatedDebt = <String>{
   // per-locale verb for "delete for everyone", and this label has to match
   // whichever one that locale picked.
   'dmDeletePendingLabel',
+  // Content-report image-rejection notice (#8210). The translated sibling
+  // reportDetailsTextOnly already ships per locale; this reactive notice is
+  // left in English until the same human translation pass picks it up, rather
+  // than machine-translating moderation copy that has to say exactly what it
+  // means.
+  'reportDetailsImageNotAttached',
   // Deletion prep-failure copy (feature #6126). Deferred to the l10n
   // translation-debt pass (#7632) rather than machine-translating a
   // safety-critical "nothing was deleted" message. Mirror the translated

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -2797,5 +2797,34 @@ void main() {
         );
       },
     );
+
+    testWidgets(
+      'keeps the not-attached notice when the details field gets a fresh '
+      'State (reason reselection), because the flag lives in the durable '
+      'parent',
+      (tester) async {
+        await openDetailsField(tester);
+        await commitKeyboardImage(tester);
+        await tester.pumpAndSettle();
+        expect(find.text(l10n.reportDetailsImageNotAttached), findsOneWidget);
+
+        // Leaving "Other" unmounts the details field; returning builds a fresh
+        // _CappedDetailsField State. That is the same class of rebuild that
+        // dropped the notice on Android (#8511 review) — a State-local flag
+        // would be lost here.
+        await tester.tap(find.text(l10n.reportReasonSpam));
+        await tester.pumpAndSettle();
+        expect(find.byType(TextField), findsNothing);
+
+        await tester.tap(find.text(l10n.reportReasonOther));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text(l10n.reportDetailsImageNotAttached),
+          findsOneWidget,
+          reason: 'the notice must survive a fresh details-field State',
+        );
+      },
+    );
   });
 }

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -8,6 +8,7 @@ import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -2620,6 +2621,153 @@ void main() {
         ).hasMatch(ModerationLabelService.fallbackModerationPubkeyHex),
         isTrue,
       );
+    });
+  });
+
+  group('$ReportContentDialog image insertion (#8210)', () {
+    Widget buildSubject() => ProviderScope(
+      overrides: [
+        contentReportingServiceProvider.overrideWith(
+          (ref) async => mockReportingService,
+        ),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: ReportContentDialog(video: testVideo)),
+      ),
+    );
+
+    // Simulates a keyboard committing rich content (a GIF/image) into the
+    // focused field, exactly as Gboard does. Mirrors the framework's own
+    // content-insertion test in editable_text_test.dart: a
+    // `TextInputClient.performAction` / `TextInputAction.commitContent`
+    // platform message. Client id -1 is the debug-mode magic id that bypasses
+    // the connection-id check.
+    Future<void> commitKeyboardImage(
+      WidgetTester tester, {
+      String mimeType = 'image/gif',
+    }) {
+      const uri =
+          'content://com.google.android.inputmethod.latin.fileprovider/report.gif';
+      final message = const JSONMessageCodec().encodeMessage(<String, dynamic>{
+        'method': 'TextInputClient.performAction',
+        'args': <dynamic>[
+          -1,
+          'TextInputAction.commitContent',
+          <String, dynamic>{
+            'mimeType': mimeType,
+            'data': <int>[0, 1, 0, 1, 0, 1],
+            'uri': uri,
+          },
+        ],
+      });
+      return tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+        SystemChannels.textInput.name,
+        message,
+        (ByteData? _) {},
+      );
+    }
+
+    Future<void> openDetailsField(WidgetTester tester) async {
+      await setLargeSurface(tester);
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.reportReasonOther));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets(
+      'drops a keyboard-inserted image and shows an honest notice '
+      'instead of silently discarding it',
+      (tester) async {
+        await openDetailsField(tester);
+
+        const reporterWords = 'see the clip I am reporting';
+        await tester.enterText(find.byType(TextField), reporterWords);
+        await tester.pumpAndSettle();
+
+        await commitKeyboardImage(tester);
+        await tester.pumpAndSettle();
+
+        // The image never enters the field: the typed words are untouched and
+        // nothing from the inserted content leaks into the report.
+        expect(
+          tester.widget<TextField>(find.byType(TextField)).controller!.text,
+          reporterWords,
+        );
+        // And the reporter is told, on-surface, that it was not attached.
+        expect(find.text(l10n.reportDetailsImageNotAttached), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'does not show the not-attached notice until an image is inserted',
+      (tester) async {
+        await openDetailsField(tester);
+
+        expect(find.text(l10n.reportDetailsImageNotAttached), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'announces to screen readers that the inserted image was not attached',
+      (tester) async {
+        final announcements = <Map<Object?, Object?>>[];
+        tester.binding.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(
+              SystemChannels.accessibility,
+              (Object? message) async {
+                if (message is Map) announcements.add(message);
+                return null;
+              },
+            );
+        addTearDown(
+          () => tester.binding.defaultBinaryMessenger
+              .setMockDecodedMessageHandler<Object?>(
+                SystemChannels.accessibility,
+                null,
+              ),
+        );
+
+        await openDetailsField(tester);
+        await tester.enterText(find.byType(TextField), 'x');
+        await tester.pumpAndSettle();
+
+        await commitKeyboardImage(tester);
+        await tester.pumpAndSettle();
+
+        final announced = announcements
+            .where((m) => m['type'] == 'announce')
+            .map((m) => (m['data'] as Map?)?['message']);
+        expect(
+          announced,
+          contains(l10n.reportDetailsImageNotAttached),
+          reason:
+              'a dropped image must be announced to screen readers, not only '
+              'shown on screen',
+        );
+      },
+    );
+
+    testWidgets('clears the not-attached notice once the reporter types', (
+      tester,
+    ) async {
+      await openDetailsField(tester);
+
+      await tester.enterText(find.byType(TextField), 'x');
+      await tester.pumpAndSettle();
+      await commitKeyboardImage(tester);
+      await tester.pumpAndSettle();
+      expect(find.text(l10n.reportDetailsImageNotAttached), findsOneWidget);
+
+      await tester.enterText(
+        find.byType(TextField),
+        'the reported clip shows harassment',
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.reportDetailsImageNotAttached), findsNothing);
     });
   });
 }

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -2625,13 +2625,14 @@ void main() {
   });
 
   group('$ReportContentDialog image insertion (#8210)', () {
-    Widget buildSubject() => ProviderScope(
+    Widget buildSubject({ThemeData? theme}) => ProviderScope(
       overrides: [
         contentReportingServiceProvider.overrideWith(
           (ref) async => mockReportingService,
         ),
       ],
       child: MaterialApp(
+        theme: theme,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(body: ReportContentDialog(video: testVideo)),
@@ -2669,9 +2670,12 @@ void main() {
       );
     }
 
-    Future<void> openDetailsField(WidgetTester tester) async {
+    Future<void> openDetailsField(
+      WidgetTester tester, {
+      ThemeData? theme,
+    }) async {
       await setLargeSurface(tester);
-      await tester.pumpWidget(buildSubject());
+      await tester.pumpWidget(buildSubject(theme: theme));
       await tester.pumpAndSettle();
       await tester.tap(find.text(l10n.reportReasonOther));
       await tester.pumpAndSettle();
@@ -2769,5 +2773,29 @@ void main() {
 
       expect(find.text(l10n.reportDetailsImageNotAttached), findsNothing);
     });
+
+    testWidgets(
+      'paints the not-attached notice in the light palette so a light-mode '
+      'reporter can actually read it',
+      (tester) async {
+        await openDetailsField(tester, theme: VineTheme.lightTheme);
+
+        await commitKeyboardImage(tester);
+        await tester.pumpAndSettle();
+
+        final notice = tester.widget<Text>(
+          find.text(l10n.reportDetailsImageNotAttached),
+        );
+        expect(
+          notice.style?.color,
+          VineTheme.lightColors.onSurfaceVariant,
+          reason:
+              'The notice is the whole point of the fix. Painted with the '
+              'static dark constant it composites to white-on-white on the '
+              'light sheet, so a light-mode reporter sees the same silent '
+              'drop #8210 set out to end.',
+        );
+      },
+    );
   });
 }

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -2808,10 +2808,9 @@ void main() {
         await tester.pumpAndSettle();
         expect(find.text(l10n.reportDetailsImageNotAttached), findsOneWidget);
 
-        // Leaving "Other" unmounts the details field; returning builds a fresh
-        // _CappedDetailsField State. That is the same class of rebuild that
-        // dropped the notice on Android (#8511 review) — a State-local flag
-        // would be lost here.
+        // Leaving "Other" unmounts the details block and returning rebuilds it
+        // from scratch. A notice flag stored in the field's State would be
+        // lost across that; the parent-owned flag survives it.
         await tester.tap(find.text(l10n.reportReasonSpam));
         await tester.pumpAndSettle();
         expect(find.byType(TextField), findsNothing);
@@ -2823,6 +2822,28 @@ void main() {
           find.text(l10n.reportDetailsImageNotAttached),
           findsOneWidget,
           reason: 'the notice must survive a fresh details-field State',
+        );
+      },
+    );
+
+    testWidgets(
+      'renders the not-attached notice above the field, not below, so the '
+      'keyboard cannot cover it the moment it fires',
+      (tester) async {
+        await openDetailsField(tester);
+        await commitKeyboardImage(tester);
+        await tester.pumpAndSettle();
+
+        final noticeBottom = tester
+            .getRect(find.text(l10n.reportDetailsImageNotAttached))
+            .bottom;
+        final fieldTop = tester.getRect(find.byType(TextField)).top;
+        expect(
+          noticeBottom,
+          lessThanOrEqualTo(fieldTop),
+          reason:
+              'below the field the notice lands behind the keyboard media '
+              'panel at the instant it fires (#8511 review)',
         );
       },
     );


### PR DESCRIPTION
## Description

The content-report details field looked like it accepted image or GIF evidence because Android keyboards can offer media insertion, but the field could not accept that content. Android briefly showed a system rejection toast, then returned the reporter to an unchanged form. A reporter could miss that transient warning and type "see attached" even though no evidence was captured.

Root cause: without a `contentInsertionConfiguration`, Flutter advertises an empty accepted-MIME-type list. Android therefore rejects the keyboard's media commit before it reaches Dart. The operating-system toast is short-lived and says only that Divine does not support image insertion there; the report form itself provides no durable confirmation that the evidence was not attached.

This makes the text-only behavior explicit without adding attachments. The field now advertises Flutter's standard image MIME types so the app can receive the insertion attempt, intentionally discard the unsupported content before it touches the field or report state, and show an on-surface notice plus a screen-reader announcement telling the reporter it was not attached and to describe it in words. The notice clears when they start typing.

**Behavior change:** The field's `contentInsertionConfiguration` now advertises `image/png, image/jpeg, image/gif, image/webp` (was empty list). The platform commits image insertion attempts to Dart instead of rejecting them at the OS level. The app intercepts and rejects them with explicit in-app notice + accessibility announcement, replacing the transient system toast.

This deliberately replaces Android's transient system rejection toast with report-specific visual and spoken feedback. Flutter does not provide a supported way to hide a keyboard-owned GIF or image button, and #8223 rejected changing ordinary text suggestions merely to influence one keyboard's current UI. Although #8210 proposed suppressing the affordance, this closes the issue because it resolves the underlying trust failure: reporters now receive clear confirmation that an attempted attachment was not captured.

The new string `reportDetailsImageNotAttached` is English-only for now, tracked in `_knownUntranslatedDebt`, so non-English locales fall back to English until the human translation pass picks it up alongside its already-translated sibling. This matches how the repo handles moderation-critical copy rather than machine-translating it.

**Related Issue:** Closes #8210. Relates to #8222 (the text-only decision) and #8223 (the disclosure this complements).

## Out of Scope

- Accepting image or media attachments on reports (decided no in #8222).
- Substantiating DM abuse without exposing private content (spun out as #8508).
- Hiding or suppressing keyboard-owned image affordances, for which Flutter exposes no supported API.
- Applying the same report-specific feedback to bug-report and feature-request fields.

## Verification

- TDD: three widget tests written first, simulating a real keyboard `commitContent` platform message; watched them fail (notice absent), then pass after the fix. A fourth test, asserting the screen-reader announcement is actually delivered, was added during review.
- Mutation checks (single-variable): removing only the `contentInsertionConfiguration` reddens the notice tests; removing only the `SemanticsService.sendAnnouncement` reddens only the announcement test.
- `flutter test test/widgets/report_content_dialog_test.dart` — 67/67 pass.
- `flutter test test/l10n/arb_consistency_test.dart` — green with the new key in the untranslated-debt set.
- `flutter analyze lib test integration_test` — no issues.
- On-device: verified twice with Gboard on a Pixel emulator, including notice persistence, light-mode contrast, accessibility announcement, and above-field placement.
- CI: all checks green before the final rebase; CI will rerun on the rebased head.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)