### PR TITLE
fix(profile): keep failed batch lookups indeterminate

### DIFF
--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -2526,9 +2526,10 @@ class ProfileRepository implements ProfileReader {
               await _applyVanish(pubkey);
               remaining.remove(pubkey);
             case UserProfileNotPublished():
-              // User exists in Funnelcake but has no Kind 0. Skip relay
-              // fallback — the profile genuinely does not exist yet.
+              // Funnelcake explicitly established that the user has no Kind 0.
+              // Record that evidence and skip the unnecessary relay fallback.
               await _clearVanish(pubkey);
+              _confirmedMissing.add(pubkey);
               remaining.remove(pubkey);
             case UserProfileFound():
               await _clearVanish(pubkey);
@@ -2644,11 +2645,9 @@ class ProfileRepository implements ProfileReader {
       await _userProfilesDao.upsertProfiles(toCache);
     }
 
-    // Mark any still-remaining pubkeys as confirmed missing so future
-    // single-profile fetches skip the relay/indexer cascade.
-    if (remaining.isNotEmpty) {
-      _confirmedMissing.addAll(remaining);
-    }
+    // Still-remaining pubkeys are indeterminate: an empty result cannot
+    // distinguish absence from a failed, timed-out, or incomplete source.
+    // Only an explicit server sentinel establishes confirmed absence.
 
     filteredResults();
 

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -2636,12 +2636,17 @@ class ProfileRepository implements ProfileReader {
 
     // Step 4: Batch-write all freshly fetched to Drift.
     //
-    // Writes to the DAO directly rather than through cacheProfile, so the
-    // vanish guard has to be applied here too — otherwise a relay copy of an
-    // erased account slips back into the cache via the batch path.
+    // Writes to the DAO directly rather than through cacheProfile, so both of
+    // that method's in-memory guards have to be applied here too. The vanish
+    // check, or a relay copy of an erased account slips back into the cache
+    // via the batch path. The confirmed-missing clear, or a pubkey an earlier
+    // batch recorded as having no Kind 0 keeps that verdict after this batch
+    // resolved a profile for it.
     toCache.removeWhere((profile) => _vanished.contains(profile.pubkey));
     if (toCache.isNotEmpty) {
-      _knownCached.addAll(toCache.map((p) => p.pubkey));
+      final resolved = toCache.map((profile) => profile.pubkey).toList();
+      _knownCached.addAll(resolved);
+      _confirmedMissing.removeAll(resolved);
       await _userProfilesDao.upsertProfiles(toCache);
     }
 

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -7354,6 +7354,62 @@ void main() {
         },
       );
 
+      test(
+        'clears a stale confirmed-missing mark once a batch resolves the '
+        'profile',
+        () async {
+          when(
+            () => mockUserProfilesDao.getProfilesByPubkeys(any()),
+          ).thenAnswer((_) async => []);
+          when(
+            () => mockUserProfilesDao.upsertProfiles(any()),
+          ).thenAnswer((_) async {});
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+
+          var bulkCall = 0;
+          when(() => mockFunnelcakeClient.getBulkProfiles(any())).thenAnswer((
+            _,
+          ) async {
+            bulkCall++;
+            if (bulkCall == 1) {
+              return const BulkProfilesResponse(
+                profiles: {
+                  testPubkey: UserProfileNotPublished(pubkey: testPubkey),
+                },
+              );
+            }
+            return BulkProfilesResponse(
+              profiles: {
+                testPubkey: UserProfileFound(
+                  profile: UserProfileData.fromJson(testPubkey, const {
+                    'display_name': 'Now Published',
+                  }),
+                ),
+              },
+            );
+          });
+
+          final repoWithFunnelcake = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: mockUserProfilesDao,
+            httpClient: mockHttpClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          await repoWithFunnelcake.fetchBatchProfiles(pubkeys: [testPubkey]);
+          expect(repoWithFunnelcake.isConfirmedMissing(testPubkey), isTrue);
+
+          final second = await repoWithFunnelcake.fetchBatchProfiles(
+            pubkeys: [testPubkey],
+          );
+
+          // The batch just resolved and cached a profile for this pubkey, so
+          // the earlier absence verdict no longer describes the latest fetch.
+          expect(second[testPubkey]?.displayName, equals('Now Published'));
+          expect(repoWithFunnelcake.isConfirmedMissing(testPubkey), isFalse);
+        },
+      );
+
       test('evicts a vanished entry and skips relay fallback', () async {
         // The batch path is a second way into the cache, so it has to evict
         // on its own, and has to drop the pubkey from `remaining` or the

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -7125,6 +7125,7 @@ void main() {
         );
 
         expect(result, isEmpty);
+        expect(profileRepository.isConfirmedMissing(testPubkey), isFalse);
       });
 
       test(
@@ -7227,6 +7228,7 @@ void main() {
         );
 
         expect(result, isEmpty);
+        expect(profileRepository.isConfirmedMissing(testPubkey), isFalse);
       });
 
       test(
@@ -7256,6 +7258,7 @@ void main() {
           );
 
           expect(result, isEmpty);
+          expect(repoWithFunnelcake.isConfirmedMissing(testPubkey), isTrue);
           verifyNever(() => mockNostrClient.fetchProfile(any()));
           verifyNever(
             () => mockNostrClient.queryEvents(
@@ -7265,6 +7268,48 @@ void main() {
             ),
           );
           verifyNever(() => mockUserProfilesDao.upsertProfiles(any()));
+        },
+      );
+
+      test(
+        'distinguishes confirmed absence from an omitted bulk result',
+        () async {
+          when(
+            () => mockUserProfilesDao.getProfilesByPubkeys(any()),
+          ).thenAnswer((_) async => []);
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(() => mockFunnelcakeClient.getBulkProfiles(any())).thenAnswer(
+            (_) async => const BulkProfilesResponse(
+              profiles: {
+                testPubkey: UserProfileNotPublished(pubkey: testPubkey),
+              },
+            ),
+          );
+          when(
+            () => mockNostrClient.fetchProfile(testPubkey2),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              tempRelays: any(named: 'tempRelays'),
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenAnswer((_) async => <Event>[]);
+
+          final repoWithFunnelcake = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: mockUserProfilesDao,
+            httpClient: mockHttpClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repoWithFunnelcake.fetchBatchProfiles(
+            pubkeys: [testPubkey, testPubkey2],
+          );
+
+          expect(result, isEmpty);
+          expect(repoWithFunnelcake.isConfirmedMissing(testPubkey), isTrue);
+          expect(repoWithFunnelcake.isConfirmedMissing(testPubkey2), isFalse);
         },
       );
 
@@ -7344,6 +7389,7 @@ void main() {
 
         expect(result, isEmpty);
         expect(repoWithFunnelcake.isVanished(testPubkey), isTrue);
+        expect(repoWithFunnelcake.isConfirmedMissing(testPubkey), isTrue);
         verify(() => mockVanishedDao.markVanished(testPubkey)).called(1);
         verify(() => mockUserProfilesDao.deleteProfile(testPubkey)).called(1);
         verifyNever(() => mockNostrClient.fetchProfile(any()));


### PR DESCRIPTION
## Problem

Batch profile loading treated every unresolved account as confirmed to have no published profile. A timeout, unavailable relay, or incomplete server response could therefore be exposed through the profile repository as authoritative absence even though no source had established that result.

## Why this fix

The repository now records confirmed absence only when Funnelcake explicitly returns its “profile not published” result. Pubkeys left unresolved after failed, timed-out, empty, or incomplete sources remain indeterminate, matching the single-profile fetch contract. When a later batch resolves a real profile, it also clears any earlier confirmed-absence verdict so the state continues to describe the latest fetch.

This deliberately leaves cache selection, relay fallback, vanished-account handling, and bulk profile stats unchanged.

## Verification

- `cd mobile/packages/profile_repository && flutter test --coverage` — 451 tests, 1193/1193 lines covered
- `cd mobile && flutter analyze lib test integration_test`
- `cd mobile && flutter test test/blocs/my_profile/`
- iOS simulator against the local Docker stack: feed, own profile, Nostr settings, and NIP-05 settings
- All required checks green on the current head

Closes #8512