### PR TITLE
fix(logging): export log timestamps in UTC

### DIFF
--- a/local_stack/merge_logs.py
+++ b/local_stack/merge_logs.py
@@ -16,10 +16,9 @@ DOCKER_RE = re.compile(
     r'(.*)'                     # content
 )
 
-# App log with full timestamp: "[2026-03-04T15:30:00.100Z] ..."
-# The Z is optional: builds before the UTC export fix emit none.
+# App log with full timestamp: "[2026-03-04T15:30:00.100] ..."
 APP_TS_FULL_RE = re.compile(
-    r'^\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?)\]\s*(.*)'
+    r'^\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?)\]\s*(.*)'
 )
 
 # App log with time-only: "[11:06:55.268] ..."

--- a/local_stack/merge_logs.py
+++ b/local_stack/merge_logs.py
@@ -16,9 +16,10 @@ DOCKER_RE = re.compile(
     r'(.*)'                     # content
 )
 
-# App log with full timestamp: "[2026-03-04T15:30:00.100] ..."
+# App log with full timestamp: "[2026-03-04T15:30:00.100Z] ..."
+# The Z is optional: builds before the UTC export fix emit none.
 APP_TS_FULL_RE = re.compile(
-    r'^\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?)\]\s*(.*)'
+    r'^\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?)\]\s*(.*)'
 )
 
 # App log with time-only: "[11:06:55.268] ..."

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -40,6 +40,15 @@ class BugReportService {
 
   static const _uuid = Uuid();
 
+  @visibleForTesting
+  static String formatLogExportTimestamp(DateTime timestamp) =>
+      timestamp.toUtc().toIso8601String();
+
+  @visibleForTesting
+  static String buildLogExportFileName(DateTime timestamp) =>
+      'openvine_full_logs_'
+      '${formatLogExportTimestamp(timestamp).replaceAll(':', '-')}.txt';
+
   final ErrorAnalyticsTracker _errorTracker;
   final StorageManagementService? _storageManagementService;
   final Future<PackageInfo> Function() _packageInfoLoader;
@@ -292,11 +301,13 @@ class BugReportService {
         return const LogExportResult.noLogs();
       }
 
+      final exportTime = DateTime.now().toUtc();
       final buffer = StringBuffer()
         ..write(
           await _buildLogHeader(
             stats: stats,
             lineCount: allLogLines.length,
+            exportTime: exportTime,
             currentScreen: currentScreen,
             userPubkey: userPubkey,
           ),
@@ -309,8 +320,7 @@ class BugReportService {
       }
 
       final content = buffer.toString();
-      final timestamp = DateTime.now().toIso8601String().replaceAll(':', '-');
-      final fileName = 'openvine_full_logs_$timestamp.txt';
+      final fileName = buildLogExportFileName(exportTime);
 
       if (kIsWeb) {
         return _exportLogsWeb(content, fileName, allLogLines.length);
@@ -628,6 +638,7 @@ class BugReportService {
   Future<String> _buildLogHeader({
     required Map<String, dynamic> stats,
     required int lineCount,
+    required DateTime exportTime,
     String? currentScreen,
     String? userPubkey,
   }) async {
@@ -635,7 +646,7 @@ class BugReportService {
     final buffer = StringBuffer()
       ..writeln('OpenVine Comprehensive Log Export')
       ..writeln('═' * 80)
-      ..writeln('Export Time: ${DateTime.now().toIso8601String()}')
+      ..writeln('Export Time: ${formatLogExportTimestamp(exportTime)}')
       ..writeln(
         'App Version: ${packageInfo.version}+${packageInfo.buildNumber}',
       )

--- a/mobile/packages/unified_logger/lib/src/unified_logger.dart
+++ b/mobile/packages/unified_logger/lib/src/unified_logger.dart
@@ -176,7 +176,9 @@ class UnifiedLogger {
     // Memory capture must be comprehensive for debugging remote user issues
     try {
       final logEntry = LogEntry(
-        timestamp: DateTime.now(),
+        // UTC so exported logs correlate with relay, funnelcake and
+        // ClickHouse rows without guessing the reporter's timezone.
+        timestamp: DateTime.now().toUtc(),
         level: level,
         message: message,
         category: category,

--- a/mobile/packages/unified_logger/test/src/unified_logger_test.dart
+++ b/mobile/packages/unified_logger/test/src/unified_logger_test.dart
@@ -272,18 +272,25 @@ void main() {
 
   group('UnifiedLogger timestamp encoding', () {
     late LogCaptureService logService;
+    late Set<LogCategory> enabledCategories;
+    late LogLevel logLevel;
 
     setUp(() async {
       logService = LogCaptureService();
       await logService.clearAllLogs();
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+      enabledCategories = UnifiedLogger.enabledCategories;
+      logLevel = UnifiedLogger.currentLevel;
       UnifiedLogger.enableCategories({LogCategory.system});
       UnifiedLogger.setLogLevel(LogLevel.info);
     });
 
-    test('captures the entry timestamp in UTC', () async {
+    tearDown(() {
+      UnifiedLogger.enableCategories(enabledCategories);
+      UnifiedLogger.setLogLevel(logLevel);
+    });
+
+    test('captures the entry timestamp in UTC', () {
       Log.info('utc probe', category: LogCategory.system);
-      await Future<void>.delayed(const Duration(milliseconds: 50));
 
       final entry = logService.getRecentLogs().lastWhere(
         (log) => log.message == 'utc probe',
@@ -300,7 +307,6 @@ void main() {
 
     test('exports a Z-suffixed timestamp', () async {
       Log.info('export probe', category: LogCategory.system);
-      await Future<void>.delayed(const Duration(milliseconds: 50));
 
       final line = (await logService.getAllLogsAsText()).firstWhere(
         (text) => text.contains('export probe'),

--- a/mobile/packages/unified_logger/test/src/unified_logger_test.dart
+++ b/mobile/packages/unified_logger/test/src/unified_logger_test.dart
@@ -269,4 +269,49 @@ void main() {
       },
     );
   });
+
+  group('UnifiedLogger timestamp encoding', () {
+    late LogCaptureService logService;
+
+    setUp(() async {
+      logService = LogCaptureService();
+      await logService.clearAllLogs();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      UnifiedLogger.enableCategories({LogCategory.system});
+      UnifiedLogger.setLogLevel(LogLevel.info);
+    });
+
+    test('captures the entry timestamp in UTC', () async {
+      Log.info('utc probe', category: LogCategory.system);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final entry = logService.getRecentLogs().lastWhere(
+        (log) => log.message == 'utc probe',
+      );
+
+      expect(
+        entry.timestamp.isUtc,
+        isTrue,
+        reason:
+            'A local timestamp exports without an offset, so support '
+            'cannot align it with relay or funnelcake rows.',
+      );
+    });
+
+    test('exports a Z-suffixed timestamp', () async {
+      Log.info('export probe', category: LogCategory.system);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final line = (await logService.getAllLogsAsText()).firstWhere(
+        (text) => text.contains('export probe'),
+      );
+
+      expect(
+        line,
+        matches(
+          RegExp(r'^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\] '),
+        ),
+      );
+    });
+  });
 }

--- a/mobile/test/services/bug_report_log_export_test.dart
+++ b/mobile/test/services/bug_report_log_export_test.dart
@@ -73,6 +73,26 @@ void main() {
     });
   });
 
+  group('log export timestamp', () {
+    test('formats the export time as UTC', () {
+      final localTime = DateTime.parse('2026-09-02T13:00:00.000+05:00');
+
+      expect(
+        BugReportService.formatLogExportTimestamp(localTime),
+        '2026-09-02T08:00:00.000Z',
+      );
+    });
+
+    test('uses the same UTC timestamp in the export filename', () {
+      final localTime = DateTime.parse('2026-09-02T13:00:00.000+05:00');
+
+      expect(
+        BugReportService.buildLogExportFileName(localTime),
+        'openvine_full_logs_2026-09-02T08-00-00.000Z.txt',
+      );
+    });
+  });
+
   group('buildDeviceDescription', () {
     const channel = MethodChannel('dev.fluttercommunity.plus/device_info');
     final messenger =


### PR DESCRIPTION
Closes #8531

## Problem

Bug-report log lines used local wall-clock timestamps without an offset. Support could not reliably align those lines with UTC relay, API, or database records when the reporter's timezone was unknown.

The export header and filename used separate local timestamps as well, so changing only the captured log entries would have left one exported artifact mixing local and UTC values.

## Fix

- Capture each `LogEntry` timestamp in UTC, making serialized and formatted timestamps carry the `Z` suffix.
- Capture one UTC export instant and reuse it for both the `Export Time` header and the export filename.
- Keep the live developer-console timestamp local; it remains a time-only developer affordance and is not part of the exported bug report.
- Leave `local_stack/merge_logs.py` unchanged. That pipeline currently treats app timestamps as local and applies an inferred UTC offset, so accepting already-UTC entries there would require preserving timezone provenance through parsing.

## Verification

- `flutter test packages/unified_logger/test/src/unified_logger_test.dart`
- `flutter test test/services/bug_report_log_export_test.dart test/services/bug_report_service_test.dart`
- `flutter analyze`
- Pre-push affected-file analysis and tests

Regression coverage verifies that captured entries are UTC, formatted log lines end in `Z`, offset timestamps normalize to UTC, and export filenames carry the same UTC timestamp convention.
