### PR TITLE
chore(tooling): add lnav log formats for app exports and CI logs

### DIFF
--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -79,6 +79,10 @@ run = "docker compose -f ../e2e/docker-compose.yml logs keycast --tail=200"
 description = "Generate localization files from ARB"
 run = "flutter gen-l10n"
 
+[tasks.lnav_setup]
+description = "Install Divine lnav log formats (requires: brew install lnav)"
+run = "lnav -i ../scripts/lnav/*.json"
+
 [tasks.setup_hooks]
 description = "Install git hooks (pre-commit + pre-push) for local CI checks"
 run = "bash ../scripts/install-hooks.sh"

--- a/scripts/lnav/README.md
+++ b/scripts/lnav/README.md
@@ -4,7 +4,7 @@
 that carry enough structure to be worth parsing. `brew install lnav`, then:
 
 ```bash
-cd mobile && mise run lnav_setup     # or: lnav -i scripts/lnav/*.json
+cd mobile && mise run lnav_setup     # or, from the repo root: lnav -i scripts/lnav/*.json
 ```
 
 lnav's value here is not prettier output — it is merging several sources into
@@ -38,9 +38,11 @@ which is the same property that makes them greppable against relay and
 funnelcake rows.
 
 The timestamp accepts a trailing `Z` **and** its absence, so exports from
-builds shipped before the UTC fix still parse. Without the `Z` lnav reads the
-line as local time, so a merge against UTC server logs will be offset — check
-the app version before trusting a cross-source timeline on an old export.
+builds shipped before the UTC fix still parse. A `Z`-less line says nothing
+about its zone, and lnav's interpretation varies by platform — local time
+where the timezone database is available, UTC where it is not — so a merge
+against UTC server logs will be offset either way. Check the app version
+before trusting a cross-source timeline on an old export.
 
 ## `gha_log` — GitHub Actions job logs
 

--- a/scripts/lnav/README.md
+++ b/scripts/lnav/README.md
@@ -38,11 +38,10 @@ which is the same property that makes them greppable against relay and
 funnelcake rows.
 
 The timestamp accepts a trailing `Z` **and** its absence, so exports from
-builds shipped before the UTC fix still parse. A `Z`-less line says nothing
-about its zone, and lnav's interpretation varies by platform — local time
-where the timezone database is available, UTC where it is not — so a merge
-against UTC server logs will be offset either way. Check the app version
-before trusting a cross-source timeline on an old export.
+builds shipped before the UTC fix still parse. A `Z`-less line carries no
+zone, and lnav reads it as UTC, so a pre-UTC-fix export (device local time)
+lands shifted by the device's UTC offset against UTC server logs. Check the
+app version before trusting a cross-source timeline on an old export.
 
 ## `gha_log` — GitHub Actions job logs
 

--- a/scripts/lnav/README.md
+++ b/scripts/lnav/README.md
@@ -32,9 +32,11 @@ lnav openvine_full_logs_*.txt
  WHERE log_level >= 'warning' GROUP BY category ORDER BY 2 DESC;
 ```
 
-Full npubs, `nsec`/`ncryptsec`, and 64-char hex ids are highlighted. That works
-precisely *because* we never truncate them — a shortened id would not match,
-which is the same property that makes them greppable against relay and
+Full npubs and 64-char hex ids are highlighted; the `nsec`/`ncryptsec` pattern
+is a tripwire rather than a routine sight, because exports redact secrets
+before write (`_sanitizeString` in `bug_report_service.dart`). Highlighting
+works precisely *because* we never truncate ids — a shortened id would not
+match, which is the same property that makes them greppable against relay and
 funnelcake rows.
 
 The timestamp accepts a trailing `Z` **and** its absence, so exports from

--- a/scripts/lnav/README.md
+++ b/scripts/lnav/README.md
@@ -1,0 +1,94 @@
+# lnav log formats
+
+[lnav](https://lnav.org) format definitions for the two Divine log streams
+that carry enough structure to be worth parsing. `brew install lnav`, then:
+
+```bash
+cd mobile && mise run lnav_setup     # or: lnav -i scripts/lnav/*.json
+```
+
+lnav's value here is not prettier output — it is merging several sources into
+one time-ordered view and letting you query them with SQL. Everything below is
+a recipe that works once the formats are installed.
+
+## `divine_export_log` — bug-report log exports
+
+Parses `openvine_full_logs_*.txt`, the attachment produced by
+`LogCaptureService.getAllLogsAsText()`:
+
+```
+[2026-09-02T08:29:26.100000Z] [ERROR] [DmRepository] relay: publish failed | Error: TimeoutException
+```
+
+`logger` (the `name:` argument) and `category` (the `LogCategory` enum name,
+lowercase, or `GENERAL`) become queryable columns:
+
+```bash
+lnav openvine_full_logs_*.txt
+```
+
+```sql
+;SELECT category, count(*) FROM divine_export_log
+ WHERE log_level >= 'warning' GROUP BY category ORDER BY 2 DESC;
+```
+
+Full npubs, `nsec`/`ncryptsec`, and 64-char hex ids are highlighted. That works
+precisely *because* we never truncate them — a shortened id would not match,
+which is the same property that makes them greppable against relay and
+funnelcake rows.
+
+The timestamp accepts a trailing `Z` **and** its absence, so exports from
+builds shipped before the UTC fix still parse. Without the `Z` lnav reads the
+line as local time, so a merge against UTC server logs will be offset — check
+the app version before trusting a cross-source timeline on an old export.
+
+## `gha_log` — GitHub Actions job logs
+
+Parses `gh run view <id> --log` and `--log-failed`. The `job` column is what
+makes this worth doing: every `Tests (shard N/8)` log merges into one
+time-ordered view instead of eight files read in sequence.
+
+```bash
+gh run view <run-id> --log > /tmp/ci.log && lnav /tmp/ci.log
+```
+
+Press `e` / `Shift+E` to jump between errors — the runner's own `##[error]`
+and `##[warning]` markers are mapped to lnav levels. Step timings:
+
+```sql
+;SELECT step, count(*) AS lines,
+        cast((julianday(max(log_time)) - julianday(min(log_time))) * 86400 AS int) AS secs
+   FROM gha_log GROUP BY step ORDER BY secs DESC LIMIT 10;
+```
+
+Note the ratchet scripts in the `Generated Files` job emit free-form text with
+no `::error` annotations, so their failures stay at `info`. Adding annotations
+there would improve the GitHub UI and this view together.
+
+## Merging local_stack against the app
+
+lnav auto-detects Postgres, Redis, nginx and Rust tracing formats, so dumping
+each service to its own file gets you a merged timeline for free — the same job
+`local_stack/merge_logs.py` does for E2E runs, without the JSONL step:
+
+```bash
+cd local_stack
+for s in keycast funnelcake-relay funnelcake-api blossom; do
+  docker compose logs --no-log-prefix "$s" > "/tmp/$s.log"
+done
+lnav /tmp/*.log /path/to/openvine_full_logs_*.txt
+```
+
+## Known gaps
+
+- **`adb logcat`**: lnav ships a logcat format, but it only matches the default
+  `threadtime` output. `local_stack/profile.sh` passes `-v UTC -v year`, which
+  falls back to `generic_log` and loses the `tag` / `pid` / `tid` columns. Drop
+  those flags if you want the structured view.
+- **`LogEntry.toFormattedString()`** — the inline summary posted to Zendesk —
+  uses a different shape from the export (`[CATEGORY]` bracketed, `(name)` in
+  parentheses). Not covered here; the `.txt` attachment is the larger artifact.
+- **The console format** `[HH:MM:SS.mmm] [CAT] msg` carries no date and no
+  level, so there is little for lnav to extract. Read it live instead.
+- **Test output**: we use VGV's human-readable reporter, not
+  `--reporter json`, so there is no structure to parse.

--- a/scripts/lnav/README.md
+++ b/scripts/lnav/README.md
@@ -40,10 +40,21 @@ match, which is the same property that makes them greppable against relay and
 funnelcake rows.
 
 The timestamp accepts a trailing `Z` **and** its absence, so exports from
-builds shipped before the UTC fix still parse. A `Z`-less line carries no
-zone, and lnav reads it as UTC, so a pre-UTC-fix export (device local time)
-lands shifted by the device's UTC offset against UTC server logs. Check the
-app version before trusting a cross-source timeline on an old export.
+builds shipped before #8520 still parse. The two are not equivalent:
+
+- **With `Z`** the suffix is parsed as a zone (`%z`), so the line is read as
+  UTC and converted to your display zone. That conversion is what makes a
+  merge against relay or Postgres output line up.
+- **Without `Z`** the line carries no zone and is read as a bare wall clock,
+  displayed exactly as written. That was the device's local time, so it sits
+  off a UTC-aware source by the difference between the reporter's offset and
+  yours.
+
+Check the app version before trusting a cross-source timeline on an old
+export. One caveat: lnav locks a timestamp format per file, so in a file that
+mixed both shapes the non-matching lines fold into the preceding message's
+timestamp instead of parsing their own. A real export comes from one build
+and does not mix; both shapes were verified to parse correctly on their own.
 
 ## `gha_log` — GitHub Actions job logs
 

--- a/scripts/lnav/divine_export_log.json
+++ b/scripts/lnav/divine_export_log.json
@@ -9,8 +9,8 @@
             }
         },
         "timestamp-format": [
-            "%Y-%m-%dT%H:%M:%S.%fZ",
-            "%Y-%m-%dT%H:%M:%SZ",
+            "%Y-%m-%dT%H:%M:%S.%f%z",
+            "%Y-%m-%dT%H:%M:%S%z",
             "%Y-%m-%dT%H:%M:%S.%f",
             "%Y-%m-%dT%H:%M:%S"
         ],

--- a/scripts/lnav/divine_export_log.json
+++ b/scripts/lnav/divine_export_log.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "https://lnav.org/schemas/format-v1.schema.json",
+    "divine_export_log": {
+        "title": "Divine app log export",
+        "description": "LogCaptureService._formatLogEntry output: the openvine_full_logs_*.txt attached to bug reports.",
+        "regex": {
+            "std": {
+                "pattern": "^\\[(?<timestamp>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z?)\\] \\[(?<level>VERBOSE|DEBUG|INFO|WARNING|ERROR)\\] (?:\\[(?<logger>[^\\]]*)\\] )?(?<category>\\w+): (?<body>.*)$"
+            }
+        },
+        "timestamp-format": [
+            "%Y-%m-%dT%H:%M:%S.%fZ",
+            "%Y-%m-%dT%H:%M:%SZ",
+            "%Y-%m-%dT%H:%M:%S.%f",
+            "%Y-%m-%dT%H:%M:%S"
+        ],
+        "level-field": "level",
+        "level": {
+            "trace": "VERBOSE",
+            "debug": "DEBUG",
+            "info": "INFO",
+            "warning": "WARNING",
+            "error": "ERROR"
+        },
+        "body-field": "body",
+        "value": {
+            "logger": {
+                "kind": "string",
+                "identifier": true,
+                "description": "The `name:` argument at the call site, e.g. DmRepository."
+            },
+            "category": {
+                "kind": "string",
+                "identifier": true,
+                "description": "LogCategory enum name (lowercase), or GENERAL when the call site passed none."
+            },
+            "body": {
+                "kind": "string"
+            }
+        },
+        "highlights": {
+            "npub": {
+                "pattern": "npub1[023456789acdefghjklmnpqrstuvwxyz]{58}",
+                "color": "#5fd7af"
+            },
+            "nsec": {
+                "pattern": "(nsec1|ncryptsec1)[023456789acdefghjklmnpqrstuvwxyz]+",
+                "color": "#ff005f"
+            },
+            "hexid": {
+                "pattern": "\\b[0-9a-f]{64}\\b",
+                "color": "#87afff"
+            }
+        },
+        "sample": [
+            {
+                "line": "[2026-09-02T08:29:25.929639Z] [INFO] system: Completed phase: hive_storage in 19ms",
+                "level": "info"
+            },
+            {
+                "line": "[2026-09-02T08:29:26.100000Z] [ERROR] [DmRepository] relay: publish failed | Error: TimeoutException",
+                "level": "error"
+            },
+            {
+                "line": "[2026-03-04T15:30:00.100] [WARNING] GENERAL: pre-UTC build, no offset",
+                "level": "warning"
+            }
+        ]
+    }
+}

--- a/scripts/lnav/gha_log.json
+++ b/scripts/lnav/gha_log.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "https://lnav.org/schemas/format-v1.schema.json",
+    "gha_log": {
+        "title": "GitHub Actions job log",
+        "description": "Output of `gh run view <id> --log` / `--log-failed`: job TAB step TAB RFC3339 timestamp SPACE message.",
+        "url": "https://docs.github.com/en/actions",
+        "regex": {
+            "std": {
+                "pattern": "^(?<job>[^\\t]*)\\t(?<step>[^\\t]*)\\t\\x{feff}?(?<timestamp>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+Z) ?(?:##\\[(?<level>error|warning|notice|debug)\\])?(?<body>.*)$"
+            }
+        },
+        "timestamp-format": [
+            "%Y-%m-%dT%H:%M:%S.%fZ"
+        ],
+        "level-field": "level",
+        "level": {
+            "error": "error",
+            "warning": "warning",
+            "notice": "notice",
+            "debug": "debug"
+        },
+        "body-field": "body",
+        "value": {
+            "job": {
+                "kind": "string",
+                "identifier": true,
+                "description": "Workflow job, e.g. 'Tests (shard 3/8)'"
+            },
+            "step": {
+                "kind": "string",
+                "identifier": true,
+                "description": "Step name within the job"
+            },
+            "body": {
+                "kind": "string"
+            }
+        },
+        "sample": [
+            {
+                "line": "build / build\tUNKNOWN STEP\t2026-09-02T02:54:29.1670551Z ##[group]Runner Image Provisioner"
+            },
+            {
+                "line": "build / build\tUNKNOWN STEP\t2026-09-02T02:54:30.3725492Z   repository: divinevideo/divine-mobile"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Closes #8522

## What

Two [lnav](https://lnav.org) format definitions under `scripts/lnav/`, a
README of working recipes, and a `mise run lnav_setup` task that installs
them. No product code changes.

## Why

lnav's useful property is not prettier output — it merges several sources
into one time-ordered view and exposes them to SQL. That is the shape most
triage here already takes:

- a bug-report export read against relay / funnelcake / Postgres output
- eight `Tests (shard N/8)` logs read as one CI timeline instead of eight
  files in sequence

`local_stack/merge_logs.py` already hand-rolls the first half of this for
E2E runs. This does not replace it — it makes the same merge available
ad hoc, without the JSONL step.

## The formats

**`divine_export_log`** — `openvine_full_logs_*.txt` from
`LogCaptureService.getAllLogsAsText()`. Exposes the call-site `name:` and
the `LogCategory` as queryable columns:

```sql
;SELECT category, count(*) FROM divine_export_log
 WHERE log_level >= 'warning' GROUP BY category ORDER BY 2 DESC;
```

Full npubs, `nsec`/`ncryptsec` and 64-char hex ids are highlighted — which
works *because* we never truncate them, the same property that makes them
greppable against relay rows.

The trailing `Z` is optional, so exports from builds predating #8520 still
parse.

**`gha_log`** — `gh run view <id> --log`. Maps the runner's `##[error]` /
`##[warning]` onto lnav levels so `e` / `Shift+E` jump between failures,
and exposes `job`, which is what lets the shard logs merge.

## Verification

Both validated with `lnav -C` (clean) and queried headless against real
output — a real `gh run view --log` from this repo, and the verbatim export
line shape observed from a live `unified_logger` test run:

```
log_level    logger    category            body
info      <NULL>       system   Completed phase: hive_storage in 19ms
warning   DmRepository relay    no kind-10050 for npub1gekhlq0qs6xz5rxvz7yh8
error     DmRepository relay    publish failed | Error: TimeoutException
debug     <NULL>       GENERAL  no category at this call site
```

Covers both timestamp variants, both category cases, and present/absent
logger. `mise run lnav_setup` verified end to end.

## Gaps recorded in the README rather than papered over

- lnav's built-in logcat format matches only default `threadtime`.
  `profile.sh:128` passes `-v UTC -v year`, which falls back to
  `generic_log` and loses `tag` / `pid` / `tid`. Not changed here — that
  flag choice is load-bearing for `merge_logs.py`.
- `LogEntry.toFormattedString()` (the inline Zendesk summary) uses a
  different shape from the export and is not covered.
- Ratchet scripts in `Generated Files` emit no `::error` annotations, so
  their failures stay at `info`. Adding annotations would improve the
  GitHub UI and this view together.
- Test output uses VGV's human reporter, not `--reporter json`, so there
  is no structure to parse.

## Cost

Per-developer `brew install lnav`. Nothing in CI depends on this, and
nothing breaks if it is not installed.

Independent of #8520 — neither blocks the other; the format already
handles both timestamp shapes.