### PR TITLE
fix(dm): unlatch a one-way thread from the peer's advertised inbox

### DIFF
--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -89,7 +89,8 @@ jobs:
             integration_test/e2e/block_leaves_kind3_follow_test.dart \
             integration_test/e2e/dm_group_delete_for_everyone_test.dart \
             integration_test/e2e/dm_reaction_unreadable_inbox_test.dart \
-            integration_test/e2e/dm_deletion_unreadable_inbox_test.dart; do
+            integration_test/e2e/dm_deletion_unreadable_inbox_test.dart \
+            integration_test/e2e/dm_oneway_latch_unlatch_test.dart; do
             echo "── $suite"
             xvfb-run -a flutter test "$suite" --tags service -d linux
           done

--- a/mobile/integration_test/e2e/dm_oneway_latch_unlatch_test.dart
+++ b/mobile/integration_test/e2e/dm_oneway_latch_unlatch_test.dart
@@ -1,0 +1,300 @@
+// ABOUTME: E2E regression for #8519 — a thread latched to 'nip04' published a
+// ABOUTME: cleartext kind 4 on every outbound message forever, even though the
+// ABOUTME: send path had already resolved the peer's kind-10050 to `found`.
+// ABOUTME: Asserts on the wire: what the relay was actually handed, not on a
+// ABOUTME: mock. The two arms differ ONLY in the resolution state.
+// ABOUTME: Requires: NO Docker stack — every dependency here is local.
+
+@Tags(['service'])
+library;
+
+import 'dart:convert';
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay_base.dart';
+import 'package:nostr_sdk/relay/relay_status.dart';
+import 'package:nostr_sdk/relay/web_socket_connection_manager.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../helpers/fake_relay.dart';
+
+/// Redirects the public hostname the recipient's kind-10050 advertises onto
+/// the in-process relay. A `ws://127.0.0.1` host can never *be* an admitted
+/// target — `isRemoteSuppliedRelayUrlAllowed` refuses loopback by design, and
+/// an inbox whose every relay is refused resolves `absent`, not `found` — so
+/// reaching a `found` state at all requires a redirect like this one.
+class _RedirectFactory implements WebSocketChannelFactory {
+  _RedirectFactory(this.port);
+
+  final int port;
+
+  @override
+  WebSocketChannel create(Uri uri) =>
+      WebSocketChannel.connect(Uri.parse('ws://127.0.0.1:$port${uri.path}'));
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const senderKey =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+  const recipientKey =
+      '2222222222222222222222222222222222222222222222222222222222222222';
+  final senderPubkey = getPublicKey(senderKey);
+  final recipientPubkey = getPublicKey(recipientKey);
+
+  final conversationId = DmRepository.computeConversationId([
+    senderPubkey,
+    recipientPubkey,
+  ]);
+
+  /// A kind-10050 the recipient signs, advertising one admissible public host.
+  Map<String, dynamic> recipientInbox() {
+    final event = Event(
+      recipientPubkey,
+      EventKind.dmRelaysList,
+      [
+        ['relay', 'wss://inbox-1.example'],
+      ],
+      '',
+      createdAt: 1700000000,
+    )..sign(recipientKey);
+    return event.toJson();
+  }
+
+  /// The real stack, wired as `repository_providers.dart` wires it, over real
+  /// sockets — and seeded with a thread already latched to `'nip04'`, which is
+  /// the state an inbound kind 4 leaves behind (`_handleNip04Event`'s
+  /// `existing?.dmProtocol ?? 'nip04'`).
+  Future<({DmRepository repository, AppDatabase db})> buildLatchedStack(
+    FakeRelay relay,
+  ) async {
+    final factory = _RedirectFactory(relay.port);
+    final signer = LocalNostrSigner(senderKey);
+
+    RelayBase gen(String url) =>
+        RelayBase(url, RelayStatus(url), channelFactory: factory);
+    final nostr = Nostr(signer, [], gen, channelFactory: factory);
+
+    final relayManager = RelayManager(
+      config: RelayManagerConfig(
+        defaultRelayUrl: relay.url,
+        storage: InMemoryRelayStorage(),
+        autoReconnect: false,
+      ),
+      relayPool: nostr.relayPool,
+    );
+    final client = NostrClient.forTesting(
+      nostr: nostr,
+      relayManager: relayManager,
+    );
+
+    final db = AppDatabase.test(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final repository = DmRepository(
+      nostrClient: client,
+      directMessagesDao: db.directMessagesDao,
+      conversationsDao: db.conversationsDao,
+      outgoingDmsDao: db.outgoingDmsDao,
+      userPubkey: senderPubkey,
+      signer: signer,
+      messageService: NIP17MessageService(
+        signer: signer,
+        senderPublicKey: senderPubkey,
+        nostrService: client,
+      ),
+    );
+    addTearDown(repository.stopListening);
+    addTearDown(nostr.relayPool.removeAll);
+    await client.initialize();
+
+    await db.conversationsDao.upsertConversation(
+      id: conversationId,
+      participantPubkeys: jsonEncode([senderPubkey, recipientPubkey]),
+      isGroup: false,
+      createdAt: 1700000000,
+      ownerPubkey: senderPubkey,
+      dmProtocol: 'nip04',
+    );
+
+    return (repository: repository, db: db);
+  }
+
+  /// Kinds the relay was actually handed. The whole point of this file: the
+  /// leak is a real event on a real socket, so the assertion is on the wire.
+  List<int> publishedKinds(FakeRelay relay) => [
+    for (final frame in relay.receivedFrames)
+      if (frame.isNotEmpty &&
+          frame[0] == 'EVENT' &&
+          frame.length >= 2 &&
+          frame[1] is Map)
+        (frame[1] as Map)['kind'] as int,
+  ];
+
+  /// Whether [kind] reaches the relay inside [timeout].
+  ///
+  /// The NIP-04 leg is fired `unawaited` at its call site, so `sendMessage`
+  /// returning proves nothing about it in either direction — asserting on the
+  /// relay the moment the send resolves reports "no kind 4" even when the leg
+  /// is about to publish one. ARM B pins the positive case, and that is what
+  /// makes ARM A's negative one an assertion rather than a race it wins.
+  Future<bool> reachesRelay(
+    FakeRelay relay,
+    int kind, {
+    Duration timeout = const Duration(seconds: 3),
+  }) async {
+    final deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      if (publishedKinds(relay).contains(kind)) return true;
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+    }
+    return false;
+  }
+
+  Future<String?> storedProtocol(AppDatabase db) async =>
+      (await db.conversationsDao.getConversation(
+        conversationId,
+        ownerPubkey: senderPubkey,
+      ))?.dmProtocol;
+
+  setUp(() {
+    DmRepository.inboxResolutionBudget = DmSendBudget.inboxResolution;
+  });
+  tearDown(() {
+    DmRepository.inboxResolutionBudget = DmSendBudget.inboxResolution;
+  });
+
+  group('#8519 one-way latched thread', () {
+    testWidgets(
+      'ARM A: an advertised kind-10050 unlatches the thread, and THIS send '
+      'already publishes no cleartext kind 4',
+      (tester) async {
+        final relay = await FakeRelay.start(reply: recipientInbox());
+        addTearDown(relay.stop);
+        final stack = await buildLatchedStack(relay);
+
+        final detailed = await stack.repository.resolveDmInboxRelaysDetailed(
+          recipientPubkey,
+        );
+        expect(
+          detailed.state,
+          DmInboxResolution.found,
+          reason: 'precondition: the peer must advertise a readable inbox',
+        );
+
+        final _ = await stack.repository.sendMessage(
+          recipientPubkey: recipientPubkey,
+          content: 'outbound on a latched thread',
+        );
+
+        expect(await storedProtocol(stack.db), 'nip17');
+        expect(
+          publishedKinds(relay),
+          contains(EventKind.giftWrap),
+          reason: 'the NIP-17 leg must still have gone out',
+        );
+        // The leak is the assertion. Before #8519 a kind 4 whose `p` tag names
+        // the recipient in the clear reached this relay — on a socket with no
+        // NIP-42, which is what `04.md:51` says must not happen, and what
+        // voids NIP-17's "No Metadata Leak" (17.md:97).
+        expect(
+          await reachesRelay(relay, EventKind.directMessage),
+          isFalse,
+          reason:
+              'the peer can read a gift wrap; the cleartext twin buys them '
+              'nothing and leaks who is talking to whom',
+        );
+      },
+    );
+
+    testWidgets(
+      'ARM B (control): a peer who advertises NO inbox stays latched and still '
+      'gets the cleartext kind 4',
+      (tester) async {
+        // The one variable is the resolution state. This relay answers the
+        // kind-10050 REQ with EOSE and nothing else, which is a conclusive
+        // "they advertise none" — the state that still means the pool is where
+        // this peer reads, so the legacy copy is genuinely their only readable
+        // one and must keep going out.
+        final relay = await FakeRelay.start();
+        addTearDown(relay.stop);
+        final stack = await buildLatchedStack(relay);
+
+        final detailed = await stack.repository.resolveDmInboxRelaysDetailed(
+          recipientPubkey,
+        );
+        expect(
+          detailed.state,
+          DmInboxResolution.absent,
+          reason: 'precondition: the peer must advertise no inbox',
+        );
+
+        final _ = await stack.repository.sendMessage(
+          recipientPubkey: recipientPubkey,
+          content: 'outbound on a latched thread',
+        );
+
+        expect(await storedProtocol(stack.db), 'nip04');
+        expect(
+          await reachesRelay(relay, EventKind.directMessage),
+          isTrue,
+          reason: 'no advertised inbox is not evidence the peer reads NIP-17',
+        );
+      },
+    );
+
+    testWidgets(
+      'ARM C: an unreadable lookup is not evidence and leaves the thread '
+      'latched (#7317)',
+      (tester) async {
+        // Stalling the kind-10050 REQ is the only shape that makes the read
+        // inconclusive rather than empty; racing a short budget against an
+        // in-process loopback relay is a coin flip and resolved `found`.
+        //
+        // This arm deliberately asserts nothing about the kind 4. With the
+        // outgoing queue wired — as production wires it — `unreadable` makes
+        // `downgradeFallbackPoolDelivery` hold the send soft-unconfirmed, and
+        // the whole persist block (the kind-4 gate included) is skipped. So a
+        // kind 4 is absent here for a #7317 reason, not a #8519 one, and
+        // claiming it either way would pin the wrong mechanism.
+        final relay = await FakeRelay.start(
+          reply: recipientInbox(),
+          stallReqForKinds: const {EventKind.dmRelaysList},
+        );
+        addTearDown(relay.stop);
+        final stack = await buildLatchedStack(relay);
+        DmRepository.inboxResolutionBudget = const Duration(milliseconds: 800);
+
+        final detailed = await stack.repository.resolveDmInboxRelaysDetailed(
+          recipientPubkey,
+        );
+        expect(
+          detailed.state,
+          DmInboxResolution.unreadable,
+          reason: 'precondition: the lookup must be inconclusive',
+        );
+
+        final _ = await stack.repository.sendMessage(
+          recipientPubkey: recipientPubkey,
+          content: 'outbound on a latched thread',
+        );
+
+        // Collapsing a failed read onto `found` is the mistake #7317 exists to
+        // prevent: it would permanently cut a genuine legacy peer off from
+        // their only readable copy on the strength of a lookup that failed.
+        expect(await storedProtocol(stack.db), 'nip04');
+      },
+    );
+  });
+}

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -4898,6 +4898,14 @@ class DmRepository {
       _selfWrapTargetRelays(),
     ).wait;
 
+    // The sweep resolves the same inbox the send path does, so it holds the
+    // same evidence and must reach the same conclusion. A thread whose only
+    // traffic is a queued message the sweep drives would otherwise stay
+    // latched no matter how many times we re-read the peer's kind-10050, and
+    // the next foreground send would publish the twin this pass already knew
+    // was unnecessary (#8519).
+    await _clearLatchOnAdvertisedInbox(row.conversationId, inbox.state);
+
     final publishResult = await _sendRumorWithTimeout(
       rumor: rumor,
       recipientPubkey: row.recipientPubkey,

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3411,10 +3411,7 @@ class DmRepository {
       // decrypt and transaction return: this handler has no generation guard
       // to abandon on, and a switch inside that window would import this
       // stamp into the next account's maximum, narrowing its `since:`.
-      await _syncState?.recordSeen(
-        ownerPubkey,
-        createdAt: persistedCreatedAt,
-      );
+      await _syncState?.recordSeen(ownerPubkey, createdAt: persistedCreatedAt);
       await _syncState?.recordWireSeen(
         ownerPubkey,
         createdAt: nip04Event.createdAt,
@@ -4146,6 +4143,22 @@ class DmRepository {
       resolveDmInboxRelaysDetailed(recipientPubkey),
       _selfWrapTargetRelays(),
     ).wait;
+
+    // A recipient who advertises a kind-10050 implements NIP-17 — the kind is
+    // defined by it (17.md:63) and NIP-51 scopes it to NIP-17 DMs explicitly
+    // (51.md:42) — so they can read the gift wrap and do not need a cleartext
+    // twin. #8505 already unlatches on a NIP-17 event FROM the peer, but that
+    // needs them to send something. A one-way thread never gets that evidence,
+    // so it dual-sent a kind 4 on every message forever (#8519).
+    //
+    // This runs BEFORE the persist transaction on purpose: the gate below
+    // reads `dmProtocol` from the row that transaction loads, so clearing here
+    // means THIS send already skips the kind 4 rather than only later ones.
+    //
+    // `found` only. `absent` and `unreadable` route to the same place but mean
+    // different things — `unreadable` is a failed lookup, not evidence the
+    // peer cannot read NIP-17 — and treating them alike is the #7317 mistake.
+    await _clearLatchOnAdvertisedInbox(conversationId, inbox.state);
 
     // OK-confirm the recipient wrap: a WebSocket frame-accept is a false
     // positive on a flaky single relay (the relay may never store the event),
@@ -6653,6 +6666,43 @@ class DmRepository {
   // Send - NIP-04 fallback (Kind 4)
   // -------------------------------------------------------------------------
 
+  /// Clears a `'nip04'` latch when the peer advertises a kind-10050 DM inbox.
+  ///
+  /// Weaker evidence than a NIP-17 event from them, and deliberately so: it is
+  /// the only signal available on a thread where they never send anything. A
+  /// client that publishes a kind-10050 implements NIP-17 and can read a gift
+  /// wrap, so the cleartext twin buys them nothing.
+  ///
+  /// Best-effort. A failure leaves the thread latched and the next send
+  /// presents the same evidence again, so it must never cost the message.
+  Future<void> _clearLatchOnAdvertisedInbox(
+    String conversationId,
+    DmInboxResolution state,
+  ) async {
+    if (state != DmInboxResolution.found) return;
+    try {
+      final cleared = await _conversationsDao.clearNip04ProtocolLatch(
+        conversationId,
+        ownerPubkey: _userPubkey,
+      );
+      if (cleared) {
+        Log.info(
+          'Cleared the nip04 protocol latch on conversation $conversationId: '
+          'the recipient advertises a kind-10050 DM inbox, so the legacy '
+          'kind-4 copy is no longer published to them',
+          category: LogCategory.system,
+        );
+      }
+    } on Object catch (e) {
+      Log.warning(
+        'Could not clear the nip04 protocol latch on conversation '
+        '$conversationId from the advertised inbox: $e — the thread keeps '
+        'dual-sending until the next attempt',
+        category: LogCategory.system,
+      );
+    }
+  }
+
   /// The event id to put in a kind-4 `e` tag for a reply, or `null` when the
   /// reply target is not one the legacy recipient can resolve.
   ///
@@ -7763,12 +7813,8 @@ class DmRepository {
     );
     if (removedAt != null) return false;
 
-    final newest = bucket.reduce(
-      (a, b) => b.createdAt >= a.createdAt ? b : a,
-    );
-    final oldest = bucket.reduce(
-      (a, b) => b.createdAt < a.createdAt ? b : a,
-    );
+    final newest = bucket.reduce((a, b) => b.createdAt >= a.createdAt ? b : a);
+    final oldest = bucket.reduce((a, b) => b.createdAt < a.createdAt ? b : a);
     final messageIds = [for (final m in bucket) m.id];
 
     await _conversationsDao.runInTransaction(() async {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -4904,6 +4904,11 @@ class DmRepository {
     // latched no matter how many times we re-read the peer's kind-10050, and
     // the next foreground send would publish the twin this pass already knew
     // was unnecessary (#8519).
+    //
+    // Keying on the row's conversationId is safe even though recovery also
+    // drives GROUP rows: only the 1:1 kind-4 receive path ever writes
+    // 'nip04', so a group row can never be latched and the DAO's
+    // `WHERE dm_protocol = 'nip04'` matches nothing.
     await _clearLatchOnAdvertisedInbox(row.conversationId, inbox.state);
 
     final publishResult = await _sendRumorWithTimeout(
@@ -6680,6 +6685,16 @@ class DmRepository {
   /// the only signal available on a thread where they never send anything. A
   /// client that publishes a kind-10050 implements NIP-17 and can read a gift
   /// wrap, so the cleartext twin buys them nothing.
+  ///
+  /// The clearing is one-way: nothing re-latches a thread
+  /// (`_handleNip04Event` preserves the stored value — a property inherited
+  /// from the pre-latch upsert, not a designed guard), so a kind-10050 left
+  /// behind by a client the peer has since abandoned can permanently cut a
+  /// legacy-only reader off from the one copy they can read. Accepted:
+  /// #8519 weighs exactly this residual, the mirror cache-staleness case is
+  /// filed as #8528, and whether a later peer-authored kind-4 may re-latch
+  /// is a receive-path decision of the same "decide whether" family,
+  /// deliberately not taken here.
   ///
   /// Best-effort. A failure leaves the thread latched and the next send
   /// presents the same evidence again, so it must never cost the message.

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -6827,6 +6827,18 @@ class DmRepository {
       );
     }
 
+    // Say so on SUCCESS too, not only on the failure paths #8262 instrumented.
+    // A cleartext kind 4 leaving the device is the event worth a line: the
+    // NIP-17 leg logs `Successfully published` either way, so without this a
+    // support log for a latched thread reads as an ordinary private send with
+    // no trace that a public-metadata copy went out beside it (#8519).
+    Log.info(
+      'NIP-04 fallback: published the legacy kind-4 copy for '
+      '${pubkeyForLogs(recipientPubkey)} (event ${signed.id}) — this thread is '
+      'still latched to nip04, so its metadata is public',
+      category: LogCategory.system,
+    );
+
     return NIP17SendResult.success(
       rumorEventId: signed.id,
       messageEventId: signed.id,

--- a/mobile/packages/dm_repository/test/src/dm_advertised_inbox_unlatch_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_advertised_inbox_unlatch_test.dart
@@ -1,0 +1,291 @@
+// ABOUTME: #8519 — a peer advertising a kind-10050 proves NIP-17 capability
+// ABOUTME: without sending anything, which unlatches a one-way thread.
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockMessageService extends Mock implements NIP17MessageService {}
+
+class _FakeEvent extends Fake implements Event {}
+
+const _owner =
+    'a4f5c1b2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8';
+const _peer =
+    'b1c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0';
+const _privateKey =
+    '5426e5b8b4b0e2a1f5e8d3c7a9b2f4e6d8c0a2b4f6e8d0c2a4b6f8e0d2c4a6b8';
+
+const _baseCreatedAt = 1700000000;
+const _rumorId =
+    '2222222222222222222222222222222222222222222222222222222222222222';
+const _wrapId =
+    '3333333333333333333333333333333333333333333333333333333333333333';
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+    registerFallbackValue(Duration.zero);
+  });
+
+  // Real DAOs: the assertion is on the persisted `dm_protocol`, and on whether
+  // the SAME send skipped its kind-4 twin as a result.
+  group('unlatching from an advertised kind-10050 (#8519)', () {
+    late AppDatabase db;
+    late ConversationsDao conversationsDao;
+    late DirectMessagesDao messagesDao;
+    late ProcessedGiftWrapsDao processedDao;
+    late _MockNostrClient nostrClient;
+    late _MockMessageService messageService;
+    late DmRepository repository;
+
+    final participants = [_owner, _peer]..sort();
+    late String conversationId;
+
+    setUp(() async {
+      db = AppDatabase.test(NativeDatabase.memory());
+      conversationsDao = ConversationsDao(db);
+      messagesDao = DirectMessagesDao(db);
+      processedDao = ProcessedGiftWrapsDao(db);
+      nostrClient = _MockNostrClient();
+      messageService = _MockMessageService();
+      conversationId = DmRepository.computeConversationId(participants);
+
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(() => nostrClient.configuredRelayCount).thenReturn(1);
+      when(
+        () => nostrClient.queryEventsDetailed(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+          tempRelays: any(named: 'tempRelays'),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async =>
+            (events: const <Event>[], timedOut: false, noRelays: false),
+      );
+      // The leg OK-confirms its kind 4 (#8262), so it calls
+      // `publishEventAwaitOk`. Stubbing `publishEvent` here would leave the
+      // real call unstubbed and the capture below empty.
+      when(
+        () => nostrClient.publishEventAwaitOk(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+          timeout: any(named: 'timeout'),
+          diagnosticTag: any(named: 'diagnosticTag'),
+        ),
+      ).thenAnswer(
+        (_) async => const PublishOutcome(
+          eventId: 'nip04-reply-tag-probe',
+          acceptedBy: ['wss://relay.divine.video'],
+          rejectedBy: <String, String>{},
+          noResponseFrom: <String>[],
+        ),
+      );
+      when(
+        () => messageService.canSendTo(any()),
+      ).thenAnswer((_) async => true);
+      // Real rumor construction: the NIP-17 leg's tags are not what this file
+      // asserts, but a null rumor stops `sendMessage` before the kind-4 twin.
+      when(
+        () => messageService.buildRumor(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          eventKind: any(named: 'eventKind'),
+          additionalTags: any(named: 'additionalTags'),
+          createdAt: any(named: 'createdAt'),
+        ),
+      ).thenAnswer(
+        (inv) => Event(
+          _owner,
+          EventKind.privateDirectMessage,
+          [
+            ['p', _peer],
+          ],
+          inv.namedArguments[#content] as String,
+        ),
+      );
+      when(
+        () => messageService.sendRumor(
+          rumorEvent: any(named: 'rumorEvent'),
+          recipientPubkey: any(named: 'recipientPubkey'),
+          targetRelays: any(named: 'targetRelays'),
+          selfWrapTargetRelays: any(named: 'selfWrapTargetRelays'),
+          awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          selfWrapOnSoftUnconfirmed: any(named: 'selfWrapOnSoftUnconfirmed'),
+          recipientWrapBuildTimeout: any(named: 'recipientWrapBuildTimeout'),
+          selfWrapBuildTimeout: any(named: 'selfWrapBuildTimeout'),
+        ),
+      ).thenAnswer(
+        (_) async => NIP17SendResult.success(
+          rumorEventId: _rumorId,
+          messageEventId: _wrapId,
+          recipientPubkey: _peer,
+        ),
+      );
+
+      repository = DmRepository(
+        nostrClient: nostrClient,
+        messageService: messageService,
+        directMessagesDao: messagesDao,
+        conversationsDao: conversationsDao,
+        processedGiftWrapsDao: processedDao,
+        userPubkey: _owner,
+        signer: LocalNostrSigner(_privateKey),
+      );
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    /// A thread latched to 'nip04' so the fallback gate is open.
+    /// Makes the recipient's kind-10050 lookup answer [state].
+    ///
+    /// `found` needs a real kind-10050 authored by the recipient; the two
+    /// negative states differ only in the flags, which is exactly the
+    /// distinction #7317 says must not be collapsed.
+    void stubInboxResolution(DmInboxResolution state) {
+      when(
+        () => nostrClient.queryEventsDetailed(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+          tempRelays: any(named: 'tempRelays'),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer((_) async {
+        switch (state) {
+          case DmInboxResolution.found:
+            return (
+              events: [
+                Event.fromJson({
+                  'id': 'a' * 64,
+                  'pubkey': _peer,
+                  'created_at': _baseCreatedAt,
+                  'kind': EventKind.dmRelaysList,
+                  'tags': [
+                    ['relay', 'wss://inbox.example.com'],
+                  ],
+                  'content': '',
+                  'sig': '',
+                }),
+              ],
+              timedOut: false,
+              noRelays: false,
+            );
+          case DmInboxResolution.absent:
+            return (
+              events: const <Event>[],
+              timedOut: false,
+              noRelays: false,
+            );
+          case DmInboxResolution.unreadable:
+            // A failed read, not an answer.
+            return (events: const <Event>[], timedOut: true, noRelays: false);
+        }
+      });
+    }
+
+    Future<void> seedLatchedThread() => conversationsDao.upsertConversation(
+      id: conversationId,
+      participantPubkeys: participants.join(','),
+      isGroup: false,
+      createdAt: _baseCreatedAt,
+      lastMessageTimestamp: _baseCreatedAt,
+      ownerPubkey: _owner,
+      dmProtocol: 'nip04',
+    );
+
+    Future<String?> storedProtocol() async =>
+        (await conversationsDao.getConversation(
+          conversationId,
+          ownerPubkey: _owner,
+        ))?.dmProtocol;
+
+    Future<PublishOutcome> kind4Publish() => nostrClient.publishEventAwaitOk(
+      any(),
+      targetRelays: any(named: 'targetRelays'),
+      timeout: any(named: 'timeout'),
+      diagnosticTag: any(named: 'diagnosticTag'),
+    );
+
+    void verifyKind4Published({required bool expected}) {
+      if (expected) {
+        verify(kind4Publish).called(greaterThanOrEqualTo(1));
+      } else {
+        verifyNever(kind4Publish);
+      }
+    }
+
+    Future<void> send() async {
+      final _ = await repository.sendMessage(
+        recipientPubkey: _peer,
+        content: 'hello',
+      );
+      await pumpEventQueue();
+    }
+
+    test(
+      'an advertised kind-10050 clears the latch, and the SAME send already '
+      'skips its kind-4 twin',
+      () async {
+        await seedLatchedThread();
+        stubInboxResolution(DmInboxResolution.found);
+
+        await send();
+
+        expect(await storedProtocol(), 'nip17');
+        // The unlatch runs before the persist transaction, so the gate — which
+        // reads the protocol that transaction loads — is already closed. A
+        // later-only fix would have published one more cleartext copy.
+        verifyKind4Published(expected: false);
+      },
+    );
+
+    test(
+      'no advertised inbox leaves the thread latched and still dual-sends',
+      () async {
+        await seedLatchedThread();
+        stubInboxResolution(DmInboxResolution.absent);
+
+        await send();
+
+        // `absent` is a real answer: the peer advertises nothing, so there is
+        // no evidence they read NIP-17 and the legacy copy is still their
+        // only readable one.
+        expect(await storedProtocol(), 'nip04');
+        verifyKind4Published(expected: true);
+      },
+    );
+
+    test(
+      'an unreadable lookup is not evidence and must not unlatch (#7317)',
+      () async {
+        await seedLatchedThread();
+        stubInboxResolution(DmInboxResolution.unreadable);
+
+        await send();
+
+        // The read failed. Treating that like `absent` — or like `found` —
+        // is the mistake #7317 exists to prevent: one is an answer, the
+        // other is the absence of one.
+        expect(await storedProtocol(), 'nip04');
+        verifyKind4Published(expected: true);
+      },
+    );
+  });
+}

--- a/mobile/packages/dm_repository/test/src/dm_advertised_inbox_unlatch_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_advertised_inbox_unlatch_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: #8519 — a peer advertising a kind-10050 proves NIP-17 capability
 // ABOUTME: without sending anything, which unlatches a one-way thread.
 
+import 'dart:convert';
+
 import 'package:db_client/db_client.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:drift/native.dart';
@@ -94,9 +96,7 @@ void main() {
           noResponseFrom: <String>[],
         ),
       );
-      when(
-        () => messageService.canSendTo(any()),
-      ).thenAnswer((_) async => true);
+      when(() => messageService.canSendTo(any())).thenAnswer((_) async => true);
       // Real rumor construction: the NIP-17 leg's tags are not what this file
       // asserts, but a null rumor stops `sendMessage` before the kind-4 twin.
       when(
@@ -188,11 +188,7 @@ void main() {
               noRelays: false,
             );
           case DmInboxResolution.absent:
-            return (
-              events: const <Event>[],
-              timedOut: false,
-              noRelays: false,
-            );
+            return (events: const <Event>[], timedOut: false, noRelays: false);
           case DmInboxResolution.unreadable:
             // A failed read, not an answer.
             return (events: const <Event>[], timedOut: true, noRelays: false);
@@ -239,22 +235,19 @@ void main() {
       await pumpEventQueue();
     }
 
-    test(
-      'an advertised kind-10050 clears the latch, and the SAME send already '
-      'skips its kind-4 twin',
-      () async {
-        await seedLatchedThread();
-        stubInboxResolution(DmInboxResolution.found);
+    test('an advertised kind-10050 clears the latch, and the SAME send already '
+        'skips its kind-4 twin', () async {
+      await seedLatchedThread();
+      stubInboxResolution(DmInboxResolution.found);
 
-        await send();
+      await send();
 
-        expect(await storedProtocol(), 'nip17');
-        // The unlatch runs before the persist transaction, so the gate — which
-        // reads the protocol that transaction loads — is already closed. A
-        // later-only fix would have published one more cleartext copy.
-        verifyKind4Published(expected: false);
-      },
-    );
+      expect(await storedProtocol(), 'nip17');
+      // The unlatch runs before the persist transaction, so the gate — which
+      // reads the protocol that transaction loads — is already closed. A
+      // later-only fix would have published one more cleartext copy.
+      verifyKind4Published(expected: false);
+    });
 
     test(
       'no advertised inbox leaves the thread latched and still dual-sends',
@@ -285,6 +278,182 @@ void main() {
         // other is the absence of one.
         expect(await storedProtocol(), 'nip04');
         verifyKind4Published(expected: true);
+      },
+    );
+  });
+
+  // A sibling group, deliberately not nested inside the one above: a nested
+  // group would make that group's `setUp` a shared one and start it counting
+  // against the #8399 stub ratchet.
+  group('the retry sweep unlatches on the same evidence (#8519)', () {
+    late AppDatabase db;
+    late ConversationsDao conversationsDao;
+    late DirectMessagesDao messagesDao;
+    late ProcessedGiftWrapsDao processedDao;
+    late OutgoingDmsDao outgoingDao;
+    late _MockNostrClient nostrClient;
+    late _MockMessageService messageService;
+    late DmRepository repository;
+
+    final participants = [_owner, _peer]..sort();
+    late String conversationId;
+
+    setUp(() async {
+      db = AppDatabase.test(NativeDatabase.memory());
+      conversationsDao = ConversationsDao(db);
+      messagesDao = DirectMessagesDao(db);
+      processedDao = ProcessedGiftWrapsDao(db);
+      outgoingDao = OutgoingDmsDao(db);
+      nostrClient = _MockNostrClient();
+      messageService = _MockMessageService();
+      conversationId = DmRepository.computeConversationId(participants);
+
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(() => nostrClient.configuredRelayCount).thenReturn(1);
+      when(() => messageService.canSendTo(any())).thenAnswer((_) async => true);
+      // The sweep republishes the stored rumor; the unlatch runs before this,
+      // so the outcome does not decide the assertion either way.
+      when(
+        () => messageService.sendRumor(
+          rumorEvent: any(named: 'rumorEvent'),
+          recipientPubkey: any(named: 'recipientPubkey'),
+          targetRelays: any(named: 'targetRelays'),
+          selfWrapTargetRelays: any(named: 'selfWrapTargetRelays'),
+          awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          selfWrapOnSoftUnconfirmed: any(named: 'selfWrapOnSoftUnconfirmed'),
+          recipientWrapBuildTimeout: any(named: 'recipientWrapBuildTimeout'),
+          selfWrapBuildTimeout: any(named: 'selfWrapBuildTimeout'),
+        ),
+      ).thenAnswer(
+        (_) async => NIP17SendResult.success(
+          rumorEventId: _rumorId,
+          messageEventId: _wrapId,
+          recipientPubkey: _peer,
+        ),
+      );
+
+      repository = DmRepository(
+        nostrClient: nostrClient,
+        messageService: messageService,
+        directMessagesDao: messagesDao,
+        conversationsDao: conversationsDao,
+        processedGiftWrapsDao: processedDao,
+        outgoingDmsDao: outgoingDao,
+        userPubkey: _owner,
+        signer: LocalNostrSigner(_privateKey),
+      );
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    void stubInboxResolution(DmInboxResolution state) {
+      when(
+        () => nostrClient.queryEventsDetailed(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+          tempRelays: any(named: 'tempRelays'),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer((_) async {
+        switch (state) {
+          case DmInboxResolution.found:
+            return (
+              events: [
+                Event.fromJson({
+                  'id': 'a' * 64,
+                  'pubkey': _peer,
+                  'created_at': _baseCreatedAt,
+                  'kind': EventKind.dmRelaysList,
+                  'tags': [
+                    ['relay', 'wss://inbox.example.com'],
+                  ],
+                  'content': '',
+                  'sig': '',
+                }),
+              ],
+              timedOut: false,
+              noRelays: false,
+            );
+          case DmInboxResolution.absent:
+            return (events: const <Event>[], timedOut: false, noRelays: false);
+          case DmInboxResolution.unreadable:
+            return (events: const <Event>[], timedOut: true, noRelays: false);
+        }
+      });
+    }
+
+    /// A latched thread with one queued rumor for the sweep to drive.
+    Future<void> seedLatchedThreadWithQueuedSend() async {
+      await conversationsDao.upsertConversation(
+        id: conversationId,
+        participantPubkeys: participants.join(','),
+        isGroup: false,
+        createdAt: _baseCreatedAt,
+        lastMessageTimestamp: _baseCreatedAt,
+        ownerPubkey: _owner,
+        dmProtocol: 'nip04',
+      );
+      final rumor = Event.fromJson({
+        'id': _rumorId,
+        'pubkey': _owner,
+        'created_at': _baseCreatedAt,
+        'kind': EventKind.privateDirectMessage,
+        'tags': [
+          ['p', _peer],
+        ],
+        'content': 'hello',
+        'sig': '',
+      });
+      await outgoingDao.enqueue(
+        OutgoingDm(
+          id: _rumorId,
+          conversationId: conversationId,
+          recipientPubkey: _peer,
+          content: 'hello',
+          createdAt: _baseCreatedAt,
+          rumorEventJson: jsonEncode(rumor.toJson()),
+          recipientWrapStatus: OutgoingWrapStatus.pending,
+          selfWrapStatus: OutgoingWrapStatus.pending,
+          queuedAt: DateTime.now(),
+          ownerPubkey: _owner,
+        ),
+      );
+    }
+
+    Future<String?> storedProtocol() async =>
+        (await conversationsDao.getConversation(
+          conversationId,
+          ownerPubkey: _owner,
+        ))?.dmProtocol;
+
+    test(
+      'a sweep pass that reads an advertised kind-10050 clears the latch',
+      () async {
+        await seedLatchedThreadWithQueuedSend();
+        stubInboxResolution(DmInboxResolution.found);
+
+        final _ = await repository.recoverFullSend(rumorId: _rumorId);
+
+        // Without this the sweep could re-read the peer's inbox on every pass
+        // and still leave the next foreground send publishing a cleartext
+        // twin it already had the evidence to skip.
+        expect(await storedProtocol(), 'nip17');
+      },
+    );
+
+    test(
+      'a sweep pass on an unreadable lookup leaves the thread latched',
+      () async {
+        await seedLatchedThreadWithQueuedSend();
+        stubInboxResolution(DmInboxResolution.unreadable);
+
+        final _ = await repository.recoverFullSend(rumorId: _rumorId);
+
+        expect(await storedProtocol(), 'nip04');
       },
     );
   });


### PR DESCRIPTION
## Description

#8505 clears a `dm_protocol = 'nip04'` latch when the peer sends a NIP-17 event. That requires them to send something, so a **one-way outbound thread** — we keep sending, they never reply — never produced the evidence and kept publishing a cleartext-protocol kind 4 on every message, indefinitely.

A **kind-10050 is evidence that does not need them to speak.** The kind is defined by NIP-17 (`17.md:63`) and NIP-51 scopes it explicitly to "Where to receive [NIP-17](17.md) direct messages" (`51.md:42`), so a client advertising one implements NIP-17 and can read the gift wrap. The cleartext twin buys that peer nothing.

The signal was already in hand: `resolveDmInboxRelaysDetailed(recipientPubkey)` already runs on every 1:1 send for routing, and already distinguishes the three states. **No extra round trip.**

**Related Issue:** Closes #8519 · Relates to #8499/#8505, #8262/#8502, #7317 · Follow-ups filed: #8527, #8528

## Reproduced on device, then re-run against the fix

iPhone simulator, iOS 26.5, `local_stack` funnelcake relay. That relay's NIP-11 `supported_nips` is byte-identical to production `relay.divine.video` — **no 42, yes 4** — so it stores a kind 4 and serves it to anyone, which is the property the whole issue turns on.

A peer published a kind-10050 and one kind 4, then went silent forever. Counting kind-4 events **authored by the app** on the relay:

| | send 1 | send 2 | send 3 |
|---|---|---|---|
| `main` | 1 | 2 | 3 |
| this branch | 0 | 0 | — |

On the fixed build the first send logs `Cleared the nip04 protocol latch on conversation …: the recipient advertises a kind-10050 DM inbox`, the second logs nothing (the DAO's `WHERE dm_protocol = 'nip04'` makes it once-per-thread), and the NIP-17 leg keeps delivering — gift wraps for the peer went 0 → 5 across the run.

The decisive pre-fix observation was an instrumented resolution log, three lines above the leak, on the same call stack:

```
inbox resolution for 2cb7bbf6…: state=DmInboxResolution.found relays=[wss://nos.lol]
Sending NIP-17 encrypted message to recipient
→ relay kind-4 count 2 → 3
```

The evidence was in hand, already paid for, and discarded. (That log line was temporary and is not in this diff.)

## Two things worth review attention

**Placement is load-bearing.** The unlatch runs *before* the persist transaction, because the fallback gate reads `dmProtocol` from the row that transaction loads. Clearing there means **this** send already skips its kind-4 twin rather than only later ones — otherwise we'd knowingly publish one more cleartext copy. There is a test for it: moving the call after the transaction turns it red.

**`found` only.** `absent` and `unreadable` route to the same place but mean different things — `unreadable` is a *failed lookup*, not evidence the peer cannot read NIP-17. Collapsing them is exactly the mistake #7317 exists to prevent. Both negative states keep the thread latched, each with its own test.

It is best-effort and can never cost the message: a failure logs and leaves the thread latched, and the next send presents the same evidence again. It reuses `ConversationsDao.clearNip04ProtocolLatch` from #8505 — narrow, and upgrade-only, so it cannot invent a protocol on a thread that has none.

## Two constraints on the trade-off, found while verifying

Both sharpen the staleness question this PR asks reviewers to weigh. Neither is a reason not to ship, and both are filed rather than fixed here.

**The unlatch is irreversible.** `clearNip04ProtocolLatch` writes `dm_protocol = 'nip17'`, and `_handleNip04Event`'s `existing?.dmProtocol ?? 'nip04'` then preserves it. **No code path can re-latch a thread.** So this is a one-way door, not a decision a later inbound kind 4 can revise.

**`found` may be a stale cache hit.** The send path resolves with `requireAuthoritative: false`, which forwards `useCache: true`; `queryEventsDetailed` writes every relay result into the Drift `event` table. That table carries a 1-day `expire_at`, but **it is never applied on read** — `_buildFilterQuery` has no `expire_at` clause, and the only eviction is `deleteExpiredEvents`, called from `runStartupCleanup` in `beforeOpen`. So expiry happens at database open and nowhere else, and within a single app run an expired kind-10050 keeps being served. On top of that the `noRelays` / `timedOut` flags are applied only at the exits where nothing came back — deliberately, so a real answer is not discarded because one relay stalled. Net effect: *cached kind-10050 + zero relays participating* still returns `found`. So `found` means "we hold one", not "we read one just now".

The issue's own staleness note anticipated the *protocol* case (the peer abandoned that client). These add the *local* case, and they compose: an irreversible decision taken on a possibly-never-re-read cache row. Filed as **#8528**.

## Out of Scope

- **No change to the strongest signal.** A peer-authored NIP-17 event still unlatches via #8505; this is an additional path, not a replacement.
- **Peers who advertise no kind-10050 keep dual-sending.** `absent` is a conclusive answer and is exactly what a genuine kind-4-only client produces, so the twin may still be their only readable copy. That is a product call, filed as **#8527** — which also covers the sub-case where a peer *does* advertise an inbox but nothing survives `admitRemoteSuppliedRelays` (`ws://`, private hosts), and so reads as `absent` despite demonstrably implementing NIP-17.
- **No retry for the leg** — #8506.
- **Options 1 and 4 from #8499** (stop dual-sending; AUTH-only targets) remain available if this signal is judged too weak.

## What the three follow-up commits add

**`fix(dm): unlatch the retry sweep on the same advertised inbox`** — `recoverFullSend` already re-resolves the recipient's kind-10050 to route the wrap, so it held the same evidence and discarded it. It publishes no kind 4 itself, so this is not a second leak site; it stops a thread whose only traffic is sweep-driven from staying latched no matter how many times the inbox is re-read.

**`fix(dm): log the cleartext kind-4 twin on success, not only on failure`** — #8262 instrumented every failure path and left success silent. In the pre-fix reproduction **three cleartext events left the device without a single log line naming them**; the NIP-17 leg's `Successfully published` reads identically either way. A kind 4 leaving the device is the event worth recording, and it makes the remaining latched population measurable in the field while this drains it. Both pubkey encodings via `pubkeyForLogs`, event id whole.

**`test(dm): pin the one-way latch fix on the wire, three arms`** — asserts on what a real relay was handed over a real socket, not on a mock. Two shapes here were arrived at the hard way:

- The kind-4 leg is fired `unawaited`, so `sendMessage` returning proves nothing about it. A first cut asserted absence immediately and **passed for that reason rather than the intended one**; both arms now wait on the relay, and ARM B's positive case is what makes ARM A's negative case real.
- ARM C (`unreadable`) asserts only the latch. With the outgoing queue wired — as production wires it — `unreadable` makes `downgradeFallbackPoolDelivery` hold the send soft-unconfirmed and the **whole persist block, kind-4 gate included, is skipped**. A kind 4 is absent there for a #7317 reason, not a #8519 one. `absent` is therefore the only honest control for the dual-send half. (The package-level test sees a kind 4 on `unreadable` only because it builds `DmRepository` *without* `outgoingDmsDao`, a configuration production never uses.)

> ⚠️ **Not requested by the issue, flagged for sign-off:** the last commit adds one line to `.github/workflows/mobile_service_integration_tests.yaml`, registering the new suite in the existing loop beside its #8443 sibling. It stands up its own in-process relay and needs no Docker stack. No other workflow behaviour changes.

## Verification

- `flutter analyze packages/dm_repository` and the new e2e suite — **No issues found**
- `dm_repository`: **842 passing** (840 + 2 new)
- Coverage **94.56%** against the package's `min_coverage: 93`
- e2e `dm_oneway_latch_unlatch_test.dart`: **3/3** on an iPhone 17 Pro simulator
- Ratchets green: `pubkey_log_encoding` and `nostr_id_log_truncation` (both frozen at 0), `placeholder_tests`, `ungrouped_tests`, `shared_setup_stubs`, `skip_ceiling`, `post_close_emit`, `test_unit_structure`, `l10n_delegates`, `http_overrides_isolation`

The new package tests are a **sibling** group rather than nested, deliberately: nesting would have made the existing group's `setUp` a shared one and started it counting against the #8399 stub ratchet.

**Mutation-verified**, including the placement claim and both halves of the e2e:

| Mutation | Result |
|---|---|
| Remove the send-path unlatch | the `found` package test fails ✓ · e2e ARM A fails on the protocol ✓ |
| Remove the sweep unlatch only | exactly the new sweep test fails, nothing else ✓ |
| Unlatch on any state (the #7317 trap) | both negative tests fail ✓ |
| Move the unlatch *after* the transaction | the "same send skips its twin" test fails ✓ |
| Force the kind-4 gate open, unlatch intact | e2e ARM A fails on the **kind-4 half alone** ✓ |

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

