### PR TITLE
fix(dm): guard the unscoped DmRepository reads and writes when the owner is unknown

### DIFF
--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -87,15 +87,14 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
     emit(state.copyWith(status: ConversationStatus.loading));
 
     // Stay in loading until the repository knows whose messages to read.
-    // `dmRepositoryProvider` hands out an uncredentialed repository for the
-    // whole `identityKnown` phase of an account switch, and since #8187 the
-    // owner-scoped reads correctly return nothing there rather than every
-    // account's rows. Subscribing anyway would tick immediately with an empty
+    // Signed-out and teardown repositories have no storage owner, and since
+    // #8187 owner-scoped reads correctly return nothing there rather than
+    // every account's rows. Subscribing anyway would tick immediately empty
     // list and render the "new conversation" card over a thread that has
     // history — `mayBeIncomplete` fails open to false while uncredentialed,
     // so nothing would even qualify it. `ConversationPage` re-keys this bloc
-    // on `(dmRepository, currentPubkey)`, so credentials arriving rebuild it
-    // and re-dispatch this event against the credentialed instance.
+    // on `(dmRepository, currentPubkey)`, so a later authenticated identity
+    // rebuilds it and re-dispatches this event against an owner-scoped instance.
     if (_dmRepository.userPubkey.isEmpty) return;
 
     // Arm the one-time history drain here too, not just on inbox open.

--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -86,6 +86,18 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
   ) async {
     emit(state.copyWith(status: ConversationStatus.loading));
 
+    // Stay in loading until the repository knows whose messages to read.
+    // `dmRepositoryProvider` hands out an uncredentialed repository for the
+    // whole `identityKnown` phase of an account switch, and since #8187 the
+    // owner-scoped reads correctly return nothing there rather than every
+    // account's rows. Subscribing anyway would tick immediately with an empty
+    // list and render the "new conversation" card over a thread that has
+    // history — `mayBeIncomplete` fails open to false while uncredentialed,
+    // so nothing would even qualify it. `ConversationPage` re-keys this bloc
+    // on `(dmRepository, currentPubkey)`, so credentials arriving rebuild it
+    // and re-dispatch this event against the credentialed instance.
+    if (_dmRepository.userPubkey.isEmpty) return;
+
     // Arm the one-time history drain here too, not just on inbox open.
     // Profile → Message reaches a thread without ever passing through
     // Messages, so on a reinstall this can be the first DM surface the user

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -204,7 +204,7 @@ class ConversationListBloc
         ),
       ).debounceTime(_recomputeDebounce),
       onData: (data) {
-        // Until credentials are set, the pubkey is empty and self cannot be
+        // Without an authenticated identity, the pubkey is empty and self cannot be
         // filtered out of a conversation's participants — classifying now would
         // make every 1:1 look like a group and land in Message requests. Hold
         // the current (loading) state; stream 5 re-fires this once the real

--- a/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
+++ b/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
@@ -110,10 +110,9 @@ class DmUnreadCountCubit extends Cubit<int> with CloseGuardedEmit<int> {
   /// (#7330). This cubit lives above `MaterialApp` and survives an in-app
   /// sign-out/sign-in-as-a-different-account, so without the reset the badge
   /// keeps rendering the *previous* account's number: `dmRepositoryProvider`
-  /// hands over an uncredentialed [DmRepository] while `nostrSession` is only
-  /// `identityKnown`, its `userPubkey` is empty, and [_countUnread]'s
-  /// deliberate empty-pubkey hold re-emits the value already on screen — which
-  /// `Cubit.emit` then suppresses as unchanged.
+  /// hands over an ownerless [DmRepository] while the prior session tears down,
+  /// and [_countUnread]'s deliberate empty-pubkey hold would re-emit the value
+  /// already on screen — which `Cubit.emit` then suppresses as unchanged.
   ///
   /// This is the only place the reset belongs, because a swap is the only way
   /// an empty pubkey reaches [_countUnread]: `_userPubkeyController` is fed
@@ -121,7 +120,7 @@ class DmUnreadCountCubit extends Cubit<int> with CloseGuardedEmit<int> {
   /// the stream never emits `''`. The empty value can only arrive as the
   /// `startWith(dmRepository.userPubkey)` seed at subscribe time. Leaving the
   /// hold in [_countUnread] keeps #5374 working: at cold start the seed is
-  /// also empty, and holding a `0` there is what stops the classifier
+  /// also empty when signed out, and holding a `0` there stops the classifier
   /// misreading every followed 1:1 as a group before the identity lands.
   void setRepositories({
     required DmRepository dmRepository,
@@ -239,7 +238,7 @@ class DmUnreadCountCubit extends Cubit<int> with CloseGuardedEmit<int> {
     final followRepository = _followRepository;
     if (dmRepository == null || followRepository == null) return 0;
 
-    // Until credentials are set the pubkey is empty and self cannot be filtered
+    // Without an authenticated identity the pubkey is empty and self cannot be filtered
     // from a conversation's participants — classifying now drops every followed
     // 1:1 from the count. Keep the current count; the identity stream re-fires
     // this once the real pubkey arrives. See #5374.

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -695,6 +695,7 @@ FeedTuningRepository feedTuningRepository(Ref ref) {
 @Riverpod(keepAlive: true)
 DmRepository dmRepository(Ref ref) {
   final nostrService = ref.watch(nostrServiceProvider);
+  final session = ref.watch(nostrSessionProvider);
   final db = ref.watch(databaseProvider);
   final prefs = ref.watch(sharedPreferencesProvider);
   final reactionsRepository = ref.watch(dmReactionsRepositoryProvider);
@@ -713,6 +714,15 @@ DmRepository dmRepository(Ref ref) {
     removedConversationsDao: db.removedConversationsDao,
     syncState: DmSyncState(prefs),
     reactionsRepository: reactionsRepository,
+    // Identity is sufficient to scope local storage. Signing, publishing, and
+    // relay work remain gated below on the stronger nostrReady contract.
+    // Tearing down deliberately drops the owner so no new local operation can
+    // race the account-switch cleanup under the departing identity.
+    userPubkey:
+        session.phase == NostrSessionPhase.identityKnown ||
+            session.phase == NostrSessionPhase.nostrReady
+        ? session.pubkey
+        : null,
     // The single chokepoint for "this thread may not be deleted". Both the
     // message-request cubit and the inbox long-press reach removal through
     // this repository, so putting the policy here is what stops a caller
@@ -753,7 +763,7 @@ DmRepository dmRepository(Ref ref) {
   // signer is ready. The subscription is auth-session-scoped (not inbox-
   // scoped) so DMs are ingested even when the user never visits /inbox.
   // See docs/plans/2026-04-05-dm-scaling-fix-design.md and #2931.
-  if (ref.watch(nostrSessionProvider).isReadyForActiveClient) {
+  if (session.isReadyForActiveClient) {
     final publicKey = nostrService.publicKey;
     if (publicKey.isNotEmpty) {
       final signer = nostrService.signer;

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -1068,7 +1068,7 @@ final class DmRepositoryProvider
   }
 }
 
-String _$dmRepositoryHash() => r'a800c0cebbf2e3532819ea9cdc57540df6a16a01';
+String _$dmRepositoryHash() => r'b94feacae459841ed29479b40ebe67e37689476a';
 
 /// Provider for CommentsRepository instance
 ///

--- a/mobile/lib/screens/inbox/inbox_page.dart
+++ b/mobile/lib/screens/inbox/inbox_page.dart
@@ -57,13 +57,13 @@ class InboxPage extends ConsumerWidget {
     return MultiBlocProvider(
       // `dmRepositoryProvider` is keepAlive but its body rebuilds a
       // brand-new DmRepository whenever the nostr session advances
-      // (identityKnown -> nostrReady) or on account switch, and only the
-      // *ready* instance ever gets setCredentials()/startListening(). A
+      // (identityKnown -> nostrReady) or on account switch. Both authenticated
+      // instances are owner-scoped; only the ready one gets credentials and
+      // starts listening. A
       // BlocProvider factory runs once and captures whichever instance was
       // current at mount; if the inbox is opened during the not-ready
-      // window the ConversationListBloc stays wired to that orphaned repo,
-      // whose userPubkeyStream never fires — so the list spins forever
-      // while DMs ingest on the new instance. Re-key on the captured
+      // window the ConversationListBloc stays wired to that owner-scoped but
+      // non-listening repository, so it misses later ingestion. Re-key on the captured
       // repositories' identities so the blocs are rebuilt bound to the
       // fresh instances on every flip. The tuple carries EVERY watched
       // value a create: factory below captures whose identity can change

--- a/mobile/lib/screens/inbox/message_requests/request_preview_page.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_page.dart
@@ -42,6 +42,13 @@ class RequestPreviewPage extends ConsumerWidget {
     final dmRepository = ref.watch(dmRepositoryProvider);
     final authService = ref.watch(authServiceProvider);
     final currentPubkey = authService.currentPublicKeyHex ?? '';
+    final inviteStateStore = ref.watch(collaboratorInviteStateStoreProvider);
+    final inviteResponseService = ref.watch(
+      collaboratorResponseServiceProvider,
+    );
+    final confirmationRepository = ref.watch(
+      collaboratorConfirmationRepositoryProvider,
+    );
 
     return MultiBlocProvider(
       providers: [
@@ -49,8 +56,9 @@ class RequestPreviewPage extends ConsumerWidget {
           // Re-key on the captured auth-flippable repository, as the actions
           // cubit below already does. `load()` runs once at construction, so
           // without this the preview keeps whichever repository existed at
-          // first build — including the uncredentialed one the provider
-          // returns for the whole `identityKnown` phase of an account switch.
+          // first build. The `identityKnown` repository can read local rows,
+          // but the `nostrReady` replacement runs post-auth maintenance and
+          // receives newly ingested rows.
           // See .claude/rules/state_management.md ("Bridging Riverpod-provided
           // dependencies into BlocProvider").
           key: ValueKey(dmRepository),
@@ -78,13 +86,17 @@ class RequestPreviewPage extends ConsumerWidget {
           ),
         ),
         BlocProvider(
+          key: ValueKey((
+            inviteStateStore,
+            inviteResponseService,
+            confirmationRepository,
+            currentPubkey,
+          )),
           create: (_) => CollaboratorInviteActionsCubit(
-            stateStore: ref.watch(collaboratorInviteStateStoreProvider),
-            responseService: ref.watch(collaboratorResponseServiceProvider),
+            stateStore: inviteStateStore,
+            responseService: inviteResponseService,
             currentUserPubkey: currentPubkey,
-            confirmationRepository: ref.watch(
-              collaboratorConfirmationRepositoryProvider,
-            ),
+            confirmationRepository: confirmationRepository,
           ),
         ),
       ],

--- a/mobile/lib/screens/inbox/message_requests/request_preview_page.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_page.dart
@@ -46,6 +46,14 @@ class RequestPreviewPage extends ConsumerWidget {
     return MultiBlocProvider(
       providers: [
         BlocProvider(
+          // Re-key on the captured auth-flippable repository, as the actions
+          // cubit below already does. `load()` runs once at construction, so
+          // without this the preview keeps whichever repository existed at
+          // first build — including the uncredentialed one the provider
+          // returns for the whole `identityKnown` phase of an account switch.
+          // See .claude/rules/state_management.md ("Bridging Riverpod-provided
+          // dependencies into BlocProvider").
+          key: ValueKey(dmRepository),
           create: (_) => RequestPreviewCubit(
             dmRepository: dmRepository,
             conversationId: conversationId,

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -797,9 +797,11 @@ class DmRepository {
 
   /// Whether the repository has been initialized with auth credentials.
   ///
-  /// Read-only operations (watchConversations, watchMessages, etc.) work
-  /// regardless of initialization. Write operations (send) and the relay
-  /// subscription require initialization.
+  /// Write operations (send) and the relay subscription require this. It is
+  /// strictly stronger than "an owner is known", because it also needs a
+  /// signer — the owner-scoped reads and writes ([watchMessages],
+  /// [getConversation], [markConversationAsRead], …) gate on
+  /// [_ownerPubkey] instead, so they still serve a signer-less identity.
   bool get isInitialized => _signer != null && _userPubkey.isNotEmpty;
 
   /// Set auth credentials on the repository.
@@ -6707,12 +6709,16 @@ class DmRepository {
 
   /// Get a single conversation by ID.
   ///
-  /// Returns `null` if no conversation with the given ID exists.
+  /// Returns `null` if no conversation with the given ID exists, or if no
+  /// owner is known yet — see [watchOutgoing] for why an unknown owner reads
+  /// as nothing rather than as everything.
   Future<DmConversation?> getConversation(String conversationId) async {
+    final owner = _ownerPubkey;
+    if (owner == null) return null;
     await _awaitInitialConversationMaintenance();
     final row = await _conversationsDao.getConversation(
       conversationId,
-      ownerPubkey: _ownerPubkey,
+      ownerPubkey: owner,
     );
     return row == null ? null : _conversationFromRow(row);
   }
@@ -6918,23 +6924,28 @@ class DmRepository {
   /// Advances the conversation's read cursor (see
   /// [ConversationsDao.markAsRead]) and schedules a debounced cross-device
   /// read-state marker publish (#4977).
+  /// No-op when no owner is known: [ConversationsDao.markAsRead] drops its
+  /// owner clause entirely for a null owner, leaving a bare
+  /// `UPDATE ... WHERE id = ?` that would advance any account's cursor.
   Future<void> markConversationAsRead(String conversationId) async {
-    await _conversationsDao.markAsRead(
-      conversationId,
-      ownerPubkey: _ownerPubkey,
-    );
+    final owner = _ownerPubkey;
+    if (owner == null) return;
+    await _conversationsDao.markAsRead(conversationId, ownerPubkey: owner);
     _scheduleReadMarkerPublish();
   }
 
   /// Mark multiple conversations as read in a single batch.
   ///
-  /// No-op when [conversationIds] is empty. Advances each cursor and schedules
-  /// a single debounced read-state marker publish (#4977).
+  /// No-op when [conversationIds] is empty, or when no owner is known — see
+  /// [markConversationAsRead]. Advances each cursor and schedules a single
+  /// debounced read-state marker publish (#4977).
   Future<void> markConversationsAsRead(List<String> conversationIds) async {
     if (conversationIds.isEmpty) return;
+    final owner = _ownerPubkey;
+    if (owner == null) return;
     await _conversationsDao.markMultipleAsRead(
       conversationIds,
-      ownerPubkey: _ownerPubkey,
+      ownerPubkey: owner,
     );
     _scheduleReadMarkerPublish();
   }
@@ -7275,10 +7286,14 @@ class DmRepository {
   }
 
   /// Count the total number of messages in a conversation.
-  Future<int> countMessagesInConversation(String conversationId) {
+  ///
+  /// Returns `0` when no owner is known — see [watchOutgoing].
+  Future<int> countMessagesInConversation(String conversationId) async {
+    final owner = _ownerPubkey;
+    if (owner == null) return 0;
     return _directMessagesDao.countMessages(
       conversationId,
-      ownerPubkey: _ownerPubkey,
+      ownerPubkey: owner,
     );
   }
 
@@ -7287,9 +7302,18 @@ class DmRepository {
   // -------------------------------------------------------------------------
 
   /// Watch messages in a conversation (reactive stream).
+  ///
+  /// Emits a single empty list when no owner is known — see [watchOutgoing].
+  /// It emits rather than staying silent so a consumer combining this with
+  /// another stream still ticks; `ConversationBloc` holds its own loading
+  /// state over that window rather than rendering an empty thread.
   Stream<List<DmMessage>> watchMessages(String conversationId) {
+    final owner = _ownerPubkey;
+    if (owner == null) {
+      return Stream<List<DmMessage>>.value(const []);
+    }
     return _directMessagesDao
-        .watchMessagesForConversation(conversationId, ownerPubkey: _ownerPubkey)
+        .watchMessagesForConversation(conversationId, ownerPubkey: owner)
         .map((rows) => rows.map(_messageFromRow).toList());
   }
 
@@ -7339,14 +7363,18 @@ class DmRepository {
   }
 
   /// Get messages in a conversation.
+  ///
+  /// Returns `[]` when no owner is known — see [watchOutgoing].
   Future<List<DmMessage>> getMessages(
     String conversationId, {
     int? limit,
   }) async {
+    final owner = _ownerPubkey;
+    if (owner == null) return const [];
     final rows = await _directMessagesDao.getMessagesForConversation(
       conversationId,
       limit: limit,
-      ownerPubkey: _ownerPubkey,
+      ownerPubkey: owner,
     );
     return rows.map(_messageFromRow).toList();
   }

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -775,11 +775,11 @@ class DmRepository {
     return future.whenComplete(() => _recoveriesInFlight.remove(key));
   }
 
-  /// Broadcasts the user's pubkey whenever credentials change.
+  /// Broadcasts the user's pubkey whenever credentials are attached.
   ///
   /// Consumers that classify rows by identity (e.g. the conversation-list
   /// "Message requests" split) must re-run when this fires, otherwise a cold
-  /// start can classify with the pre-auth empty pubkey — which fails to filter
+  /// start can classify with a signed-out empty pubkey — which fails to filter
   /// self out of a conversation's participants, making every 1:1 look like a
   /// group and land in Message Requests. See #5374.
   final StreamController<String> _userPubkeyController =
@@ -789,7 +789,8 @@ class DmRepository {
   /// rebuilds during auth transitions (old unsubscribe won't kill new sub).
   String _subscriptionId = 'dm_inbox';
 
-  /// The current user's pubkey for DAO scoping, or `null` if uninitialized.
+  /// The current identity's pubkey for DAO scoping, or `null` if signed out or
+  /// tearing down.
   ///
   /// Passes through to `_ownedOrLegacy` in DAO queries, where `null` means
   /// "return all rows" (legacy/unscoped mode).
@@ -806,8 +807,10 @@ class DmRepository {
 
   /// Set auth credentials on the repository.
   ///
-  /// Called by `dmRepositoryProvider` when the user's keys become
-  /// available. Read methods work before this; send requires it.
+  /// Called by `dmRepositoryProvider` when the current identity's signer and
+  /// client become ready. Owner-scoped local operations only need the identity
+  /// supplied at construction; signing, publishing, and relay work need these
+  /// credentials.
   ///
   /// This wires credentials only — the gift-wrap subscription is opened
   /// separately by the provider via [startListening] right after this
@@ -5279,6 +5282,7 @@ class DmRepository {
   /// [deleteMessageForEveryone]'s sender-only contract enforced upstream).
   Future<int> cancelOutgoingBatch({required String rumorId}) async {
     _assertInitialized();
+    final owner = _ownerPubkey!;
     final dao = _outgoingDmsDao;
     if (dao == null) {
       throw StateError(
@@ -5318,7 +5322,7 @@ class DmRepository {
       // persisted message instead.
       final message = await _directMessagesDao.getMessageById(
         rumorId,
-        ownerPubkey: _ownerPubkey,
+        ownerPubkey: owner,
       );
       if (message != null) {
         if (message.senderPubkey != _userPubkey) return 0;
@@ -6069,10 +6073,11 @@ class DmRepository {
   /// deliver to.
   Future<void> deleteMessageForEveryone(String rumorId) async {
     _assertInitialized();
+    final owner = _ownerPubkey!;
 
     final row = await _directMessagesDao.getMessageById(
       rumorId,
-      ownerPubkey: _ownerPubkey,
+      ownerPubkey: owner,
     );
     if (row == null) {
       throw ArgumentError.value(rumorId, 'rumorId', 'message not found');
@@ -6128,7 +6133,7 @@ class DmRepository {
     await _directMessagesDao.markMessageDeletionPending(
       rumorId,
       deletionRumorJson: jsonEncode(deletion.toJson()),
-      ownerPubkey: _ownerPubkey,
+      ownerPubkey: owner,
     );
     _notifyRetryableWork();
 
@@ -6264,9 +6269,10 @@ class DmRepository {
     if (_messageService == null || _userPubkey.isEmpty) {
       return DmMessageDeletionOutcome.unavailable;
     }
+    final owner = _ownerPubkey!;
     final row = await _directMessagesDao.getMessageById(
       rumorId,
-      ownerPubkey: _ownerPubkey,
+      ownerPubkey: owner,
     );
     final storedRumor = row?.deletionRumorJson;
     if (row == null || storedRumor == null) {
@@ -6699,10 +6705,12 @@ class DmRepository {
   /// When [limit] is provided, only the top [limit] conversations are
   /// watched. Omit for all conversations.
   Stream<List<DmConversation>> watchConversations({int? limit}) {
+    final owner = _ownerPubkey;
+    if (owner == null) return Stream.value(const <DmConversation>[]);
     return _watchConversationRows(
       () => _conversationsDao.watchAllConversations(
         limit: limit,
-        ownerPubkey: _ownerPubkey,
+        ownerPubkey: owner,
       ),
     );
   }
@@ -6710,8 +6718,8 @@ class DmRepository {
   /// Get a single conversation by ID.
   ///
   /// Returns `null` if no conversation with the given ID exists, or if no
-  /// owner is known yet — see [watchOutgoing] for why an unknown owner reads
-  /// as nothing rather than as everything.
+  /// owner is known. Ownerless reads fail closed because the DAO's legacy
+  /// null-owner contract otherwise widens them to every row.
   Future<DmConversation?> getConversation(String conversationId) async {
     final owner = _ownerPubkey;
     if (owner == null) return null;
@@ -6725,9 +6733,11 @@ class DmRepository {
 
   /// Get all conversations.
   Future<List<DmConversation>> getConversations() async {
+    final owner = _ownerPubkey;
+    if (owner == null) return const [];
     await _awaitInitialConversationMaintenance();
     final rows = await _conversationsDao.getAllConversations(
-      ownerPubkey: _ownerPubkey,
+      ownerPubkey: owner,
     );
     return rows.map(_conversationFromRow).toList();
   }
@@ -6737,10 +6747,12 @@ class DmRepository {
   /// Supports pagination via [limit]. These conversations are never
   /// message requests.
   Stream<List<DmConversation>> watchAcceptedConversations({int? limit}) {
+    final owner = _ownerPubkey;
+    if (owner == null) return Stream.value(const <DmConversation>[]);
     return _watchConversationRows(
       () => _conversationsDao.watchAcceptedConversations(
         limit: limit,
-        ownerPubkey: _ownerPubkey,
+        ownerPubkey: owner,
       ),
     );
   }
@@ -6751,9 +6763,11 @@ class DmRepository {
   /// follow state) is applied by [classifyPotentialRequests]. Returned
   /// without pagination since the list is typically small and needed in full.
   Stream<List<DmConversation>> watchPotentialRequests() {
+    final owner = _ownerPubkey;
+    if (owner == null) return Stream.value(const <DmConversation>[]);
     return _watchConversationRows(
       () => _conversationsDao.watchPotentialRequestConversations(
-        ownerPubkey: _ownerPubkey,
+        ownerPubkey: owner,
       ),
     );
   }
@@ -6909,14 +6923,16 @@ class DmRepository {
 
   /// Watch unread conversation count (all conversations).
   Stream<int> watchUnreadCount() {
-    return _conversationsDao.watchUnreadCount(ownerPubkey: _ownerPubkey);
+    final owner = _ownerPubkey;
+    if (owner == null) return Stream.value(0);
+    return _conversationsDao.watchUnreadCount(ownerPubkey: owner);
   }
 
   /// Watch unread count for accepted conversations only (excludes requests).
   Stream<int> watchUnreadAcceptedCount() {
-    return _conversationsDao.watchUnreadAcceptedCount(
-      ownerPubkey: _ownerPubkey,
-    );
+    final owner = _ownerPubkey;
+    if (owner == null) return Stream.value(0);
+    return _conversationsDao.watchUnreadAcceptedCount(ownerPubkey: owner);
   }
 
   /// Mark a conversation as read.
@@ -7190,14 +7206,16 @@ class DmRepository {
   Future<ConversationRemovalOutcome> removeConversation(
     String conversationId,
   ) async {
+    final owner = _ownerPubkey;
+    if (owner == null) {
+      throw StateError('Cannot remove a conversation without a known owner.');
+    }
     if (await _isRemovalProtectedById(conversationId)) {
       return ConversationRemovalOutcome.refused;
     }
     await _conversationsDao.runInTransaction<void>(() async {
       // Snapshot the owner for the whole transaction: an account switch
       // mid-flight must not mix one account's reads with another's writes.
-      final owner = _userPubkey;
-      final ownerOrNull = owner.isEmpty ? null : owner;
       final removedAt = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       await _removedConversationsDao?.record(
         conversationId: conversationId,
@@ -7206,11 +7224,11 @@ class DmRepository {
       );
       await _directMessagesDao.deleteConversationMessages(
         conversationId,
-        ownerPubkey: ownerOrNull,
+        ownerPubkey: owner,
       );
       await _conversationsDao.deleteConversation(
         conversationId,
-        ownerPubkey: ownerOrNull,
+        ownerPubkey: owner,
       );
       await _outgoingDmsDao?.deleteForConversation(
         conversationId: conversationId,
@@ -7242,6 +7260,10 @@ class DmRepository {
     List<String> conversationIds,
   ) async {
     if (conversationIds.isEmpty) return (removed: 0, refused: 0);
+    final owner = _ownerPubkey;
+    if (owner == null) {
+      throw StateError('Cannot remove conversations without a known owner.');
+    }
 
     final removable = <String>[];
     var refused = 0;
@@ -7257,8 +7279,6 @@ class DmRepository {
     await _conversationsDao.runInTransaction<void>(() async {
       // Snapshot the owner for the whole transaction: an account switch
       // mid-flight must not mix one account's reads with another's writes.
-      final owner = _userPubkey;
-      final ownerOrNull = owner.isEmpty ? null : owner;
       final removedAt = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       await _removedConversationsDao?.recordAll(
         conversationIds: removable,
@@ -7267,11 +7287,11 @@ class DmRepository {
       );
       await _directMessagesDao.deleteMultipleConversationMessages(
         removable,
-        ownerPubkey: ownerOrNull,
+        ownerPubkey: owner,
       );
       removed = await _conversationsDao.deleteMultiple(
         removable,
-        ownerPubkey: ownerOrNull,
+        ownerPubkey: owner,
       );
       await _outgoingDmsDao?.deleteForConversations(
         conversationIds: removable,
@@ -7287,14 +7307,12 @@ class DmRepository {
 
   /// Count the total number of messages in a conversation.
   ///
-  /// Returns `0` when no owner is known — see [watchOutgoing].
+  /// Returns `0` when no owner is known. Ownerless reads fail closed because
+  /// the DAO's legacy null-owner contract otherwise widens them to every row.
   Future<int> countMessagesInConversation(String conversationId) async {
     final owner = _ownerPubkey;
     if (owner == null) return 0;
-    return _directMessagesDao.countMessages(
-      conversationId,
-      ownerPubkey: owner,
-    );
+    return _directMessagesDao.countMessages(conversationId, ownerPubkey: owner);
   }
 
   // -------------------------------------------------------------------------
@@ -7303,7 +7321,9 @@ class DmRepository {
 
   /// Watch messages in a conversation (reactive stream).
   ///
-  /// Emits a single empty list when no owner is known — see [watchOutgoing].
+  /// Emits a single empty list when no owner is known. Ownerless reads fail
+  /// closed because the DAO's legacy null-owner contract otherwise widens them
+  /// to every row.
   /// It emits rather than staying silent so a consumer combining this with
   /// another stream still ticks; `ConversationBloc` holds its own loading
   /// state over that window rather than rendering an empty thread.
@@ -7364,7 +7384,8 @@ class DmRepository {
 
   /// Get messages in a conversation.
   ///
-  /// Returns `[]` when no owner is known — see [watchOutgoing].
+  /// Returns `[]` when no owner is known. Ownerless reads fail closed because
+  /// the DAO's legacy null-owner contract otherwise widens them to every row.
   Future<List<DmMessage>> getMessages(
     String conversationId, {
     int? limit,
@@ -7811,10 +7832,11 @@ class DmRepository {
 
   /// The current user's public key.
   ///
-  /// Returns an empty string if the repository has not been initialized.
+  /// Returns an empty string if no storage owner is known. This is independent
+  /// of signer/client readiness; use [isInitialized] for publish capability.
   String get userPubkey => _userPubkey;
 
-  /// Emits the user's pubkey each time credentials are set (see
+  /// Emits the user's pubkey each time credentials are attached (see
   /// [setCredentials]). Seed a listener with the current [userPubkey] via
   /// `userPubkeyStream.startWith(repo.userPubkey)` so it has a value before the
   /// first credential change. Drives re-classification of identity-scoped

--- a/mobile/packages/dm_repository/test/src/dm_owner_scope_boundary_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_owner_scope_boundary_test.dart
@@ -1,0 +1,129 @@
+// ABOUTME: Regression coverage for #8187 — an uninitialized DmRepository must
+// ABOUTME: not read or write another account's DM rows, which the DAOs happily
+// ABOUTME: serve when handed a null owner.
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+const _ownerA =
+    'a4f5c1b2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8';
+const _ownerB =
+    'b1c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0';
+const _peer =
+    'c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0b1';
+
+const _createdAt = 1700000000;
+
+void main() {
+  // Deliberately exercises the real DAOs against a real database. The
+  // mock-based suite in dm_repository_test.dart stubs these methods with
+  // `ownerPubkey: any(named: 'ownerPubkey')`, which matches null too — so a
+  // test written there can prove the guard was reached but never that an
+  // unguarded read would actually cross accounts.
+  group('owner-scope boundary with two accounts on one device', () {
+    late AppDatabase db;
+    late ConversationsDao conversationsDao;
+    late DirectMessagesDao messagesDao;
+    late String conversationId;
+
+    setUp(() async {
+      db = AppDatabase.test(NativeDatabase.memory());
+      conversationsDao = ConversationsDao(db);
+      messagesDao = DirectMessagesDao(db);
+      conversationId = DmRepository.computeConversationId([_ownerA, _peer]);
+
+      // `conversations` keys on `id` alone, so one row per conversation id —
+      // it belongs to A. `direct_messages` keys on the rumor id, so the two
+      // accounts' messages do coexist under that one conversation.
+      await conversationsDao.upsertConversation(
+        id: conversationId,
+        participantPubkeys: '["$_ownerA","$_peer"]',
+        isGroup: false,
+        createdAt: _createdAt,
+        isRead: false,
+        ownerPubkey: _ownerA,
+      );
+
+      for (final owner in [_ownerA, _ownerB]) {
+        await messagesDao.insertMessage(
+          id: 'rumor-for-$owner',
+          conversationId: conversationId,
+          senderPubkey: _peer,
+          content: 'private to $owner',
+          createdAt: _createdAt,
+          giftWrapId: 'wrap-for-$owner',
+          ownerPubkey: owner,
+        );
+      }
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    DmRepository buildRepository({required String userPubkey}) => DmRepository(
+      nostrClient: _MockNostrClient(),
+      directMessagesDao: messagesDao,
+      conversationsDao: conversationsDao,
+      userPubkey: userPubkey,
+    );
+
+    test('a null owner really does read across accounts at the DAO', () async {
+      // The hazard the guards exist for. If this ever stops returning both
+      // rows the DAO contract changed, and the repository-level tests below
+      // would start passing for a reason that has nothing to do with #8187.
+      final unscoped = await messagesDao.getMessagesForConversation(
+        conversationId,
+      );
+
+      expect(unscoped, hasLength(2));
+      expect(
+        unscoped.map((row) => row.ownerPubkey),
+        containsAll(<String>[_ownerA, _ownerB]),
+      );
+    });
+
+    test('an initialized repository reads only its own rows', () async {
+      final repository = buildRepository(userPubkey: _ownerA);
+
+      final messages = await repository.getMessages(conversationId);
+
+      expect(messages, hasLength(1));
+      expect(messages.single.content, equals('private to $_ownerA'));
+      expect(await repository.countMessagesInConversation(conversationId), 1);
+    });
+
+    test('an uninitialized repository reads nothing, not everything', () async {
+      final repository = buildRepository(userPubkey: '');
+
+      expect(await repository.getMessages(conversationId), isEmpty);
+      expect(await repository.countMessagesInConversation(conversationId), 0);
+      expect(await repository.watchMessages(conversationId).first, isEmpty);
+      expect(await repository.getConversation(conversationId), isNull);
+    });
+
+    test('an uninitialized repository marks nobody read', () async {
+      // `ConversationsDao.markAsRead` drops its owner clause entirely for a
+      // null owner, leaving `UPDATE conversations SET is_read = 1 WHERE
+      // id = ?` — which would advance A's cursor on behalf of a caller that
+      // cannot name an owner at all.
+      final repository = buildRepository(userPubkey: '');
+
+      await repository.markConversationAsRead(conversationId);
+      await repository.markConversationsAsRead([conversationId]);
+
+      final row = await conversationsDao.getConversation(
+        conversationId,
+        ownerPubkey: _ownerA,
+      );
+      expect(row, isNotNull);
+      expect(row!.isRead, isFalse);
+    });
+  });
+}

--- a/mobile/packages/dm_repository/test/src/dm_owner_scope_boundary_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_owner_scope_boundary_test.dart
@@ -102,6 +102,12 @@ void main() {
     test('an uninitialized repository reads nothing, not everything', () async {
       final repository = buildRepository(userPubkey: '');
 
+      expect(await repository.watchConversations().first, isEmpty);
+      expect(await repository.getConversations(), isEmpty);
+      expect(await repository.watchAcceptedConversations().first, isEmpty);
+      expect(await repository.watchPotentialRequests().first, isEmpty);
+      expect(await repository.watchUnreadCount().first, 0);
+      expect(await repository.watchUnreadAcceptedCount().first, 0);
       expect(await repository.getMessages(conversationId), isEmpty);
       expect(await repository.countMessagesInConversation(conversationId), 0);
       expect(await repository.watchMessages(conversationId).first, isEmpty);
@@ -124,6 +130,29 @@ void main() {
       );
       expect(row, isNotNull);
       expect(row!.isRead, isFalse);
+    });
+
+    test('an uninitialized repository removes nobody', () async {
+      final repository = buildRepository(userPubkey: '');
+
+      await expectLater(
+        repository.removeConversation(conversationId),
+        throwsStateError,
+      );
+      await expectLater(
+        repository.removeConversations([conversationId]),
+        throwsStateError,
+      );
+
+      final conversation = await conversationsDao.getConversation(
+        conversationId,
+        ownerPubkey: _ownerA,
+      );
+      final messages = await messagesDao.getMessagesForConversation(
+        conversationId,
+      );
+      expect(conversation, isNotNull);
+      expect(messages, hasLength(2));
     });
   });
 }

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -8999,6 +8999,23 @@ void main() {
     });
 
     group('getConversation', () {
+      test('returns null when uninitialized, not a stray row', () async {
+        // #8187: an uninitialized repository passes a null owner to the DAO,
+        // which reads it as `WHERE true` — every row, every account.
+        // Assert the DAO is never reached, not just that the result is
+        // empty: the shared stubs match `ownerPubkey: any(named: ...)`,
+        // and `any()` matches null too.
+        final repository = createRepository(userPubkey: '');
+
+        expect(await repository.getConversation('any-conv'), isNull);
+        verifyNever(
+          () => mockConversationsDao.getConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      });
+
       test('returns $DmConversation when conversation exists', () async {
         final participants = [_validPubkeyA, _validPubkeyB]..sort();
         final convId = DmRepository.computeConversationId(participants);
@@ -9046,6 +9063,23 @@ void main() {
     });
 
     group('watchMessages', () {
+      test('emits an empty list when uninitialized', () async {
+        // #8187: an uninitialized repository passes a null owner to the DAO,
+        // which reads it as `WHERE true` — every row, every account.
+        // Assert the DAO is never reached, not just that the result is
+        // empty: the shared stubs match `ownerPubkey: any(named: ...)`,
+        // and `any()` matches null too.
+        final repository = createRepository(userPubkey: '');
+
+        expect(await repository.watchMessages('any-conv').first, isEmpty);
+        verifyNever(
+          () => mockDirectMessagesDao.watchMessagesForConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      });
+
       test('maps $DirectMessageRow to $DmMessage', () async {
         final convId = DmRepository.computeConversationId(
           [_validPubkeyA, _validPubkeyB],
@@ -9132,6 +9166,22 @@ void main() {
     });
 
     group('markConversationAsRead', () {
+      test('is a no-op when uninitialized', () async {
+        // #8187: `ConversationsDao.markAsRead` drops its owner clause entirely
+        // for a null owner, leaving a bare `UPDATE ... WHERE id = ?` that would
+        // advance whichever account owns that conversation id.
+        final repository = createRepository(userPubkey: '');
+
+        await repository.markConversationAsRead('any-conv');
+
+        verifyNever(
+          () => mockConversationsDao.markAsRead(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      });
+
       test('delegates to $ConversationsDao', () async {
         const convId = 'some-conversation-id';
         when(
@@ -10024,6 +10074,20 @@ void main() {
     });
 
     group('markConversationsAsRead', () {
+      test('is a no-op when uninitialized', () async {
+        // #8187: same unscoped `UPDATE` as the single-conversation write.
+        final repository = createRepository(userPubkey: '');
+
+        await repository.markConversationsAsRead(['a', 'b']);
+
+        verifyNever(
+          () => mockConversationsDao.markMultipleAsRead(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      });
+
       test('delegates to conversationsDao.markMultipleAsRead', () async {
         const convIdA =
             'aabb00112233445566778899aabbccddeeff0011223344556677889900aabb00';
@@ -10051,6 +10115,23 @@ void main() {
     });
 
     group('countMessagesInConversation', () {
+      test('returns 0 when uninitialized, not a stray count', () async {
+        // #8187: an uninitialized repository passes a null owner to the DAO,
+        // which reads it as `WHERE true` — every row, every account.
+        // Assert the DAO is never reached, not just that the result is
+        // empty: the shared stubs match `ownerPubkey: any(named: ...)`,
+        // and `any()` matches null too.
+        final repository = createRepository(userPubkey: '');
+
+        expect(await repository.countMessagesInConversation('any-conv'), 0);
+        verifyNever(
+          () => mockDirectMessagesDao.countMessages(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      });
+
       test('delegates to directMessagesDao.countMessages', () async {
         const convId =
             'aabb00112233445566778899aabbccddeeff0011223344556677889900aabb00';
@@ -15216,6 +15297,24 @@ void main() {
     });
 
     group('getMessages', () {
+      test('returns an empty list when uninitialized', () async {
+        // #8187: an uninitialized repository passes a null owner to the DAO,
+        // which reads it as `WHERE true` — every row, every account.
+        // Assert the DAO is never reached, not just that the result is
+        // empty: the shared stubs match `ownerPubkey: any(named: ...)`,
+        // and `any()` matches null too.
+        final repository = createRepository(userPubkey: '');
+
+        expect(await repository.getMessages('any-conv'), isEmpty);
+        verifyNever(
+          () => mockDirectMessagesDao.getMessagesForConversation(
+            any(),
+            limit: any(named: 'limit'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      });
+
       test('returns mapped $DmMessage list from DAO', () async {
         final participants = [_validPubkeyA, _validPubkeyB]..sort();
         final convId = DmRepository.computeConversationId(participants);

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_offline_fail_repaint_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_offline_fail_repaint_test.dart
@@ -52,6 +52,9 @@ void main() {
     ).thenAnswer((_) async {});
     // Opening a conversation arms the one-time history drain.
     when(() => repo.backfillHistoryIfNeeded()).thenAnswer((_) async {});
+    // A credentialed repository: the bloc holds its loading state while the
+    // owner is unknown (#8187), which is not the scenario under test here.
+    when(() => repo.userPubkey).thenReturn(ownerPubkey);
     // Persisted-message stream stays empty and stable; the outgoing queue
     // drives every tick — exactly the open-conversation scenario in the bug.
     when(

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -113,6 +113,9 @@ void main() {
       when(
         () => mockDmRepository.backfillHistoryIfNeeded(),
       ).thenAnswer((_) async {});
+      // A credentialed repository is the ordinary fixture; the owner-unknown
+      // window has its own group below.
+      when(() => mockDmRepository.userPubkey).thenReturn(senderPubkey);
     });
 
     ConversationBloc buildBloc() => ConversationBloc(
@@ -137,6 +140,28 @@ void main() {
     });
 
     group('ConversationStarted', () {
+      blocTest<ConversationBloc, ConversationState>(
+        'stays loading while the repository owner is unknown, rather than '
+        'reporting the thread as empty',
+        setUp: () {
+          // #8187: `dmRepositoryProvider` serves an uncredentialed repository
+          // for the whole `identityKnown` phase of an account switch, where
+          // the owner-scoped reads return nothing. Emitting `loaded` there
+          // would render the "new conversation" card over a thread that has
+          // history.
+          when(() => mockDmRepository.userPubkey).thenReturn('');
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const ConversationStarted()),
+        expect: () => [
+          const ConversationState(status: ConversationStatus.loading),
+        ],
+        verify: (_) {
+          verifyNever(() => mockDmRepository.watchMessages(any()));
+          verifyNever(() => mockDmRepository.markConversationAsRead(any()));
+        },
+      );
+
       blocTest<ConversationBloc, ConversationState>(
         'emits [loading, loaded] when messages stream emits successfully',
         setUp: () {

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -144,11 +144,9 @@ void main() {
         'stays loading while the repository owner is unknown, rather than '
         'reporting the thread as empty',
         setUp: () {
-          // #8187: `dmRepositoryProvider` serves an uncredentialed repository
-          // for the whole `identityKnown` phase of an account switch, where
-          // the owner-scoped reads return nothing. Emitting `loaded` there
-          // would render the "new conversation" card over a thread that has
-          // history.
+          // #8187: signed-out and teardown repositories have no storage owner,
+          // so owner-scoped reads return nothing. Emitting `loaded` there would
+          // render the "new conversation" card over a thread that has history.
           when(() => mockDmRepository.userPubkey).thenReturn('');
         },
         build: buildBloc,

--- a/mobile/test/providers/dm_repository_provider_test.dart
+++ b/mobile/test/providers/dm_repository_provider_test.dart
@@ -224,6 +224,13 @@ void main() {
 
     test('does NOT open subscription before Nostr session is ready', () async {
       // ARRANGE — pre-auth or initialization-pending state
+      await database.conversationsDao.upsertConversation(
+        id: 'identity-known-conversation',
+        participantPubkeys: '["$testPubkey","$_ordinaryPeerPubkey"]',
+        isGroup: false,
+        createdAt: 1,
+        ownerPubkey: testPubkey,
+      );
       final container = createContainer(
         readiness: const NostrSessionReadiness.identityKnown(
           pubkey: testPubkey,
@@ -243,6 +250,28 @@ void main() {
           subscriptionId: any(named: 'subscriptionId'),
         ),
       );
+      expect(repository.isInitialized, isFalse);
+      expect(
+        repository.userPubkey,
+        equals(testPubkey),
+        reason: 'identityKnown scopes local storage before signing is ready',
+      );
+      expect(
+        await repository.getConversation('identity-known-conversation'),
+        isNotNull,
+        reason: 'local history must not wait for signer/client initialization',
+      );
+    });
+
+    test('drops the storage owner while the session is tearing down', () {
+      final container = createContainer(
+        readiness: const NostrSessionReadiness.tearingDown(pubkey: testPubkey),
+      );
+      addTearDown(container.dispose);
+
+      final repository = container.read(dmRepositoryProvider);
+
+      expect(repository.userPubkey, isEmpty);
       expect(repository.isInitialized, isFalse);
     });
 

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -649,6 +649,10 @@ void main() {
         () => mockAuthService.authStateStream,
       ).thenAnswer((_) => const Stream<AuthState>.empty());
 
+      // Credentialed: the conversation bloc holds its loading state while the
+      // repository owner is unknown (#8187), so the route under test would
+      // never reach its loaded content.
+      when(() => mockDmRepository.userPubkey).thenReturn(currentPubkey);
       when(mockDmRepository.backfillHistoryIfNeeded).thenAnswer((_) async {});
       when(
         () => mockDmRepository.markConversationAsRead(any()),

--- a/mobile/test/screens/inbox/conversation/conversation_page_repo_swap_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_page_repo_swap_test.dart
@@ -77,6 +77,10 @@ void main() {
       // (ConversationStarted) and marks the conversation as read.
       // Stub both mocks so the bloc can run without throwing.
       for (final repo in [mockRepoA, mockRepoB]) {
+        // Both stand in for credentialed repositories: the bloc holds its
+        // loading state while the owner is unknown (#8187), which would
+        // otherwise mask the re-keying this file exists to pin.
+        when(() => repo.userPubkey).thenReturn(testPubkey);
         when(() => repo.markConversationAsRead(any())).thenAnswer((_) async {});
         when(repo.backfillHistoryIfNeeded).thenAnswer((_) async {});
         when(
@@ -291,6 +295,7 @@ void main() {
       mockResponseSvcA = _MockCollaboratorResponseService();
       mockResponseSvcB = _MockCollaboratorResponseService();
 
+      when(() => mockDmRepository.userPubkey).thenReturn(testPubkey);
       when(
         () => mockDmRepository.backfillHistoryIfNeeded(),
       ).thenAnswer((_) async {});

--- a/mobile/test/screens/inbox/conversation/conversation_page_repo_swap_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_page_repo_swap_test.dart
@@ -156,6 +156,61 @@ void main() {
     );
 
     testWidgets(
+      'holds loading on the owner-unknown repository and subscribes only '
+      'once a credentialed repository arrives (#8187)',
+      (tester) async {
+        // repoA stands in for the uncredentialed instance
+        // dmRepositoryProvider serves for the whole identityKnown phase of
+        // an account switch: owner unknown, so ConversationBloc must hold
+        // loading and never reach the owner-scoped reads (which would
+        // otherwise return every account's rows at the DAO). repoB is the
+        // credentialed instance that arrives at nostrReady.
+        when(() => mockRepoA.userPubkey).thenReturn('');
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            mockAuthService: mockAuthService,
+            additionalOverrides: [
+              isDmRestrictedProvider.overrideWithValue(false),
+              dmRepositoryProvider.overrideWith((ref) {
+                final v = ref.watch(_dmRepoSwap);
+                return v == 0 ? mockRepoA : mockRepoB;
+              }),
+              fetchUserProfileProvider(
+                otherPubkey,
+              ).overrideWith((ref) async => null),
+            ],
+            home: const ConversationPage(
+              conversationId: testConversationId,
+              participantPubkeys: [otherPubkey],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // The uncredentialed bloc stayed in loading: it never subscribed to
+        // messages and never advanced a read cursor on the owner-unknown
+        // repository. Removing the bloc's owner guard reddens this line.
+        verifyNever(() => mockRepoA.watchMessages(any()));
+        verifyNever(() => mockRepoA.markConversationAsRead(any()));
+
+        // Credentials arrive: dmRepositoryProvider rebuilds, the composite
+        // ValueKey flips, and the recreated bloc re-dispatches
+        // ConversationStarted against the credentialed repository.
+        final providerScope = ProviderScope.containerOf(
+          tester.element(find.byType(ConversationPage)),
+        );
+        providerScope.read(_dmRepoSwap.notifier).state = 1;
+        await tester.pump();
+
+        // Recovery: the credentialed repository is now subscribed. Without
+        // the re-key the bloc would keep the owner-unknown repository and
+        // spin in loading forever.
+        verify(() => mockRepoB.watchMessages(any())).called(1);
+      },
+    );
+
+    testWidgets(
       'preserves the same ConversationBloc when the dmRepository identity '
       'does not change across rebuilds',
       (tester) async {

--- a/mobile/test/screens/inbox/conversation/conversation_page_repo_swap_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_page_repo_swap_test.dart
@@ -160,8 +160,8 @@ void main() {
       'once a credentialed repository arrives (#8187)',
       (tester) async {
         // repoA stands in for the uncredentialed instance
-        // dmRepositoryProvider serves for the whole identityKnown phase of
-        // an account switch: owner unknown, so ConversationBloc must hold
+        // dmRepositoryProvider serves while signed out or tearing down:
+        // owner unknown, so ConversationBloc must hold
         // loading and never reach the owner-scoped reads (which would
         // otherwise return every account's rows at the DAO). repoB is the
         // credentialed instance that arrives at nostrReady.

--- a/mobile/test/screens/inbox/conversation/conversation_page_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_page_test.dart
@@ -111,6 +111,14 @@ void main() {
     });
 
     group('renders', () {
+      // Only these tests pump the page and build a ConversationBloc, which
+      // holds its loading state while the repository owner is unknown
+      // (#8187). Declared here rather than in the shared setUp so the
+      // dependency sits beside the tests that have it.
+      setUp(() {
+        when(() => mockDmRepository.userPubkey).thenReturn(testPubkey);
+      });
+
       testWidgets('renders $ConversationView', (tester) async {
         await tester.pumpWidget(
           testMaterialApp(

--- a/mobile/test/screens/inbox/inbox_page_test.dart
+++ b/mobile/test/screens/inbox/inbox_page_test.dart
@@ -195,12 +195,12 @@ void main() {
     });
 
     // The keepAlive `dmRepositoryProvider` rebuilds a brand-new DmRepository
-    // on the identityKnown -> nostrReady transition, and only the *ready*
-    // instance ever gets setCredentials() — so only its userPubkeyStream
-    // delivers a pubkey. A keyless BlocProvider strands the bloc on the
-    // orphaned not-ready instance and the inbox spins forever while DMs
-    // ingest on the fresh one. These pin the ValueKey rebind fix in
-    // inbox_page.dart. See .claude/rules/state_management.md.
+    // on the identityKnown -> nostrReady transition. The first instance can
+    // read owner-scoped local history, but only the ready instance receives
+    // credentials, post-auth maintenance, and newly ingested DMs. A keyless
+    // BlocProvider strands the bloc on the superseded instance. These pin the
+    // ValueKey rebind fix in inbox_page.dart. See
+    // .claude/rules/state_management.md.
     group('rebinds ConversationListBloc when dmRepositoryProvider flips', () {
       void stubInbox(_MockDmRepository repo, {required String userPubkey}) {
         when(
@@ -279,7 +279,7 @@ void main() {
         'over a fresh instance',
         (tester) async {
           final readyRepo = _MockDmRepository();
-          // Bloc mounts against the not-ready instance (empty pubkey).
+          // Model the signed-out/teardown instance (empty pubkey).
           stubInbox(mockDmRepository, userPubkey: '');
           stubInbox(readyRepo, userPubkey: testPubkey);
 

--- a/mobile/test/screens/inbox/message_requests/message_requests_page_test.dart
+++ b/mobile/test/screens/inbox/message_requests/message_requests_page_test.dart
@@ -179,9 +179,10 @@ void main() {
     });
 
     // Same defect as InboxPage: the keepAlive `dmRepositoryProvider` rebuilds a
-    // fresh DmRepository on the identityKnown -> nostrReady transition, and only
-    // the ready instance's userPubkeyStream ever delivers a pubkey. A keyless
-    // BlocProvider strands the requests list on the orphaned not-ready repo.
+    // fresh DmRepository on the identityKnown -> nostrReady transition. The
+    // identity-known instance can read scoped local history, but only the ready
+    // instance receives credentials, maintenance, and newly ingested DMs. A
+    // keyless BlocProvider strands the requests list on the superseded repo.
     // Pins the ValueKey rebind fix in message_requests_page.dart.
     testWidgets(
       'recreates ConversationListBloc when dmRepositoryProvider hands over '
@@ -244,7 +245,7 @@ void main() {
           isNot(same(blocA)),
           reason:
               'a keyless BlocProvider strands the requests list on the '
-              'orphaned not-ready DmRepository; the ValueKey must rebuild it '
+              'superseded DmRepository; the ValueKey must rebuild it '
               'bound to the ready instance',
         );
       },

--- a/mobile/test/screens/inbox/message_requests/request_preview_page_test.dart
+++ b/mobile/test/screens/inbox/message_requests/request_preview_page_test.dart
@@ -3,8 +3,11 @@
 // ABOUTME: with RequestPreviewCubit and MessageRequestActionsCubit provided.
 
 import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/dm/message_requests/request_preview_cubit.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/official_accounts_providers.dart';
 import 'package:openvine/providers/protected_minor_providers.dart';
@@ -209,6 +212,72 @@ void main() {
 
           expect(find.byType(RequestPreviewView), findsOneWidget);
           verifyNever(() => mockGoRouter.go(any()));
+        },
+      );
+    });
+
+    group('repository identity', () {
+      testWidgets(
+        'rebuilds $RequestPreviewCubit when the DM repository identity '
+        'changes',
+        (tester) async {
+          // `dmRepositoryProvider` returns a brand-new, uncredentialed
+          // repository for the whole `identityKnown` phase of an account
+          // switch, and a credentialed one once the session is ready. The
+          // preview's `load()` runs once at construction, so the provider
+          // must be re-keyed or it keeps reading through the first instance
+          // forever. See #8187.
+          final readyRepository = _MockDmRepository();
+          when(() => readyRepository.userPubkey).thenReturn(testPubkey);
+          when(
+            () => readyRepository.countMessagesInConversation(any()),
+          ).thenAnswer((_) async => 7);
+          when(
+            () =>
+                readyRepository.getMessages(any(), limit: any(named: 'limit')),
+          ).thenAnswer((_) async => const []);
+          when(
+            () => readyRepository.getConversation(any()),
+          ).thenAnswer((_) async => null);
+
+          final activeRepository = StateProvider<DmRepository>(
+            (ref) => mockDmRepository,
+          );
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              home: const RequestPreviewPage(
+                conversationId: conversationId,
+                participantPubkeys: [otherPubkey],
+              ),
+              mockAuthService: mockAuthService,
+              additionalOverrides: [
+                dmRepositoryProvider.overrideWith(
+                  (ref) => ref.watch(activeRepository),
+                ),
+                goRouterProvider.overrideWithValue(mockGoRouter),
+                isDmRestrictedProvider.overrideWithValue(false),
+                officialAccountsServiceProvider.overrideWithValue(
+                  mockOfficials,
+                ),
+              ],
+            ),
+          );
+          await tester.pump();
+
+          verify(
+            () => mockDmRepository.countMessagesInConversation(conversationId),
+          ).called(1);
+
+          ProviderScope.containerOf(
+            tester.element(find.byType(RequestPreviewView)),
+          ).read(activeRepository.notifier).state = readyRepository;
+          await tester.pump();
+          await tester.pump();
+
+          verify(
+            () => readyRepository.countMessagesInConversation(conversationId),
+          ).called(1);
         },
       );
     });

--- a/mobile/test/screens/inbox/message_requests/request_preview_page_test.dart
+++ b/mobile/test/screens/inbox/message_requests/request_preview_page_test.dart
@@ -221,9 +221,9 @@ void main() {
         'rebuilds $RequestPreviewCubit when the DM repository identity '
         'changes',
         (tester) async {
-          // `dmRepositoryProvider` returns a brand-new, uncredentialed
-          // repository for the whole `identityKnown` phase of an account
-          // switch, and a credentialed one once the session is ready. The
+          // `dmRepositoryProvider` returns a brand-new owner-scoped repository
+          // for `identityKnown`, then a credentialed one once the session is
+          // ready. The
           // preview's `load()` runs once at construction, so the provider
           // must be re-keyed or it keeps reading through the first instance
           // forever. See #8187.

--- a/mobile/test/widgets/app_shell_badge_scope_account_switch_test.dart
+++ b/mobile/test/widgets/app_shell_badge_scope_account_switch_test.dart
@@ -329,8 +329,8 @@ void main() {
       );
 
       testWidgets(
-        'counts the incoming account own unread conversations once the '
-        'session reaches nostrReady',
+        'counts the incoming account own unread conversations as soon as the '
+        'identity is known',
         (tester) async {
           await seedUnreadConversation(
             id: 'a-convo',
@@ -354,9 +354,10 @@ void main() {
 
           await switchToAccountB(tester);
 
-          // Not-yet-credentialed window: account A's single unread is gone and
-          // account B's two are not counted yet either.
-          expect(find.text('badge=0'), findsOneWidget);
+          // Identity is enough to scope local storage. Account A's unread is
+          // gone and account B's two are visible without waiting for the
+          // signer/client to become ready.
+          expect(find.text('badge=2'), findsOneWidget);
 
           driveSessionTo(
             NostrSessionReadiness.nostrReady(
@@ -366,6 +367,8 @@ void main() {
           );
           await tester.pump(const Duration(milliseconds: 250));
 
+          // Full client readiness must preserve the already-correct local
+          // count while it enables relay-backed work.
           expect(find.text('badge=2'), findsOneWidget);
 
           await disposeSession(tester);


### PR DESCRIPTION
Closes #8187
Closes #8526

## Why

Both DM DAOs deliberately treat a null owner as legacy/unscoped mode (`WHERE true`). That compatibility contract is unsafe at the public repository boundary: an owner-dependent operation must never widen from one account to every account just because identity is temporarily unavailable.

The Nostr session has two distinct readiness levels:

- `identityKnown` is sufficient to scope local storage.
- `nostrReady` is required for signing, publishing, subscriptions, and post-auth maintenance.

Previously `dmRepositoryProvider` waited for `nostrReady` before attaching either concern, manufacturing an ownerless local-storage window during client initialization.

## What changed

- Construct `DmRepository` with the identity pubkey during both `identityKnown` and `nostrReady`, so local history remains available while the signer/client initializes.
- Drop the owner during `signedOut` and `tearingDown`, and keep signing and relay work gated on `nostrReady`.
- Fail closed across every public owner-dependent DM read and write, including all methods inventoried by #8187/#8526 and the single/bulk conversation removals found by the final boundary audit.
- Keep ownerless conversation state loading instead of rendering a false empty thread.
- Re-key Riverpod-captured DM and collaborator cubits when their dependency identities change.
- Correct the repository lifecycle docs and ownerless-read rationale.

The DAO's nullable-owner legacy mode remains intact for its explicit migration/compatibility callers; the public `DmRepository` boundary no longer reaches it accidentally.

## Behavior

Local DM history renders during `identityKnown`; it no longer waits for up to the full Nostr client initialization window. Sending and relay ingestion still wait for `nostrReady`. During sign-out/teardown, owner-dependent reads return empty and mutations refuse instead of touching another account's rows.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test packages/dm_repository` — 848 passed
- `flutter test test/providers/dm_repository_provider_test.dart test/blocs/dm test/screens/inbox` — 971 passed
- Pre-push changed-file suite — 731 passed
- Generated provider output verified and committed
- Ratchets: shared setup stubs, grouped tests, placeholder tests, skip ceiling, Nostr ID logging, pubkey logging, and post-close emits — green

The real-DAO regression suite keeps two accounts' rows in one database. It proves the DAO's null-owner widening behavior, then proves an ownerless repository reads nothing, marks nobody read, and cannot remove either account's conversations or messages.
