### PR TITLE
fix(dm): read the NIP-44 extended length prefix and bound oversized DMs

### DIFF
--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -273,6 +273,13 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
             emit(state.copyWith(sendStatus: SendStatus.sent));
             return;
           }
+          if (result.tooLong) {
+            // Refused before the enqueue, so no queue row and no bubble will
+            // exist to show the failure. Emit a distinct status the view can
+            // turn into a visible message and a preserved draft (#7331).
+            emit(state.copyWith(sendStatus: SendStatus.tooLong));
+            return;
+          }
           throw Exception(result.error ?? 'Failed to send message');
         }
         if (result.selfWrapPublished == false) {

--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -296,6 +296,13 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
             emit(state.copyWith(sendStatus: SendStatus.blocked));
             return;
           }
+          if (results.isNotEmpty && results.every((r) => r.tooLong)) {
+            // Every sibling was refused before enqueueing the shared rumor.
+            // No queue row or failure bubble exists, so preserve the draft
+            // through the same terminal outcome as the 1:1 path (#7331).
+            emit(state.copyWith(sendStatus: SendStatus.tooLong));
+            return;
+          }
           // No recipient confirmed. If every unconfirmed recipient is soft
           // (frame written, OK pending) with no hard failure, treat the group
           // send as optimistically sent — the durable queue re-drives each

--- a/mobile/lib/blocs/dm/conversation/conversation_state.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_state.dart
@@ -39,6 +39,13 @@ enum SendStatus {
   /// Dispatched with an empty recipient list (#7335). Refused before the
   /// repository, so nothing is enqueued and nothing is retriable.
   noRecipient,
+
+  /// The rumor exceeds what NIP-44 can encrypt (#7331). Refused before the
+  /// enqueue, so — unlike [failed] — there is NO queue row and therefore no
+  /// bubble to carry the red "Not delivered" affordance. The UI must surface
+  /// this itself, and must keep the composer's text: the message is the only
+  /// copy the user has.
+  tooLong,
 }
 
 /// Per-bubble delivery status, derived from the durable `outgoing_dms`

--- a/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_cubit.dart
+++ b/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_cubit.dart
@@ -49,6 +49,7 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
 
     try {
       final bool ok;
+      final bool tooLong;
       final List<String> parked;
       // When the reel has a structured video ref, the reply self-carries the
       // NIP-18 `q` citation so it stays linked to the video across devices and
@@ -74,6 +75,8 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
         ok =
             results.any((r) => r.success) ||
             (results.isNotEmpty && results.every((r) => r.retryablePending));
+        tooLong =
+            results.isNotEmpty && results.every((result) => result.tooLong);
         parked = [for (final r in results) ?r.queuedRumorId];
       } else {
         final result = videoRef != null
@@ -93,18 +96,21 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
                 replyToId: _replyContext.sharedReelMessageId,
               );
         ok = result.success || result.retryablePending;
+        tooLong = result.tooLong;
         parked = [?result.queuedRumorId];
       }
       if (!isClosed) {
         emit(
           state.copyWith(
-            status: ok
+            status: tooLong
+                ? InlineReelReplyStatus.tooLong
+                : ok
                 ? InlineReelReplyStatus.success
                 : InlineReelReplyStatus.failure,
             // Nothing left to re-drive on success: a fully delivered send
             // consumes its row, and a partially delivered group's surviving
             // siblings belong to the sweep, not to a user-facing retry.
-            queuedRumorIds: ok ? const [] : parked,
+            queuedRumorIds: ok || tooLong ? const [] : parked,
           ),
         );
       }

--- a/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_state.dart
+++ b/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_state.dart
@@ -14,6 +14,10 @@ enum InlineReelReplyStatus {
   /// The most recent reply send failed (queued for retry).
   failure,
 
+  /// Refused before enqueue because the rumor was too large. There is no
+  /// durable row to re-drive, and retrying unchanged content cannot succeed.
+  tooLong,
+
   /// A retry found its parked row gone, and delivery can be neither confirmed
   /// nor re-driven.
   ///

--- a/mobile/lib/blocs/report/report_submission_cubit.dart
+++ b/mobile/lib/blocs/report/report_submission_cubit.dart
@@ -85,7 +85,8 @@ class ReportTarget extends Equatable {
 /// submit it makes.
 ///
 /// The DM is the report itself, so a second copy is a second report to
-/// triage (#6610). Only [pending] may dispatch; the other two are terminal.
+/// triage (#6610). Only [pending] may dispatch; every other outcome is
+/// terminal.
 enum ModerationDmOutcome {
   /// Nothing sent yet, or a send failed and left a row to re-drive.
   pending,
@@ -104,6 +105,11 @@ enum ModerationDmOutcome {
   /// retrying just re-hits the same policy, so resubmits keep the caveat and do
   /// not call `sendMessage` again.
   blocked,
+
+  /// The DM was refused before enqueue because its rumor was too large.
+  /// Resubmitting unchanged content cannot succeed and there is no row to
+  /// re-drive, so this is terminal like [blocked].
+  tooLong,
 }
 
 /// The moderation DM's progress across every submit this sheet makes.
@@ -461,7 +467,9 @@ class ReportSubmissionCubit extends Cubit<ReportSubmissionState> {
     final progress = state.moderationDm;
     if (progress.matchesDelivered(reason, details)) return Future.value(false);
     if (progress.outcome
-        case ModerationDmOutcome.unverifiable || ModerationDmOutcome.blocked) {
+        case ModerationDmOutcome.unverifiable ||
+            ModerationDmOutcome.blocked ||
+            ModerationDmOutcome.tooLong) {
       return Future.value(true);
     }
     return _dispatchModerationDm(reason, reasonTitle, details);
@@ -582,6 +590,9 @@ class ReportSubmissionCubit extends Cubit<ReportSubmissionState> {
         // A block is terminal: the send gate drops the row and re-driving
         // would only re-hit the same policy.
         NIP17SendFailure(blocked: true) => null,
+        // The size guard also refuses before enqueue. A retry has no row and
+        // unchanged content necessarily hits the same ceiling.
+        NIP17SendFailure(tooLong: true) => null,
         // A hard failure and a soft-unconfirmed both leave the row for the
         // sweep. `sendMessage` reports the row it just parked; a re-drive
         // reports nothing new and keeps the row it was given.
@@ -590,6 +601,7 @@ class ReportSubmissionCubit extends Cubit<ReportSubmissionState> {
       final outcome = switch (dmResult) {
         NIP17SendSuccess() => ModerationDmOutcome.delivered,
         NIP17SendFailure(blocked: true) => ModerationDmOutcome.blocked,
+        NIP17SendFailure(tooLong: true) => ModerationDmOutcome.tooLong,
         NIP17SendFailure() => ModerationDmOutcome.pending,
       };
       _update(

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3008,6 +3008,10 @@
   "listShareFailed": "Couldn't share this list. Try again.",
   "listSave": "Save",
   "listContinue": "Continue",
+  "listPrivateFull": "This private list is full. Remove something to add more.",
+  "@listPrivateFull": {
+    "description": "Shown when a video cannot be added to a private list because its encrypted payload would exceed the NIP-44 size limit. Retrying cannot succeed, so the copy must not suggest trying again."
+  },
   "listUpdateFailed": "Couldn't update this list. Try again.",
   "listMakePrivateTitle": "Make this list private?",
   "listMakePrivateWarning": "Its videos get encrypted so only you can see them. The name, description, tags, and cover stay visible, and copies shared before now may persist.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3578,6 +3578,10 @@
   "@dmRetiredThreadOpenSupport": {
     "description": "Action on the closed-thread notice (#6416) that opens the current pinned Divine Moderation conversation. A redirect, not a promise of a response. 'Divine Moderation' is the account name — keep it as shown in `inboxSupportRowTitle` for this locale."
   },
+  "dmSendTooLongMessage": "That message is too long to send. Shorten it and try again.",
+  "@dmSendTooLongMessage": {
+    "description": "Shown when a DM is refused because the encrypted rumor would exceed the NIP-44 size limit. The message stays in the composer, so the copy asks the user to shorten it rather than warning that it was lost."
+  },
   "dmSendFailedMessage": "Message couldn't be sent",
   "@dmSendFailedMessage": {
     "description": "Accessibility announcement text, and the recovery bottom sheet's title, shown in a DM conversation when a send fails (relay error, signer error, network error). The bottom sheet pairs it with `dmSendFailedSubtitle` and the `dmMessageActionRetrySend` / `dmMessageActionCancelSend` actions."

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9919,6 +9919,12 @@ abstract class AppLocalizations {
   /// **'Message Divine Moderation'**
   String get dmRetiredThreadOpenSupport;
 
+  /// Shown when a DM is refused because the encrypted rumor would exceed the NIP-44 size limit. The message stays in the composer, so the copy asks the user to shorten it rather than warning that it was lost.
+  ///
+  /// In en, this message translates to:
+  /// **'That message is too long to send. Shorten it and try again.'**
+  String get dmSendTooLongMessage;
+
   /// Accessibility announcement text, and the recovery bottom sheet's title, shown in a DM conversation when a send fails (relay error, signer error, network error). The bottom sheet pairs it with `dmSendFailedSubtitle` and the `dmMessageActionRetrySend` / `dmMessageActionCancelSend` actions.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -8329,6 +8329,12 @@ abstract class AppLocalizations {
   /// **'Continue'**
   String get listContinue;
 
+  /// Shown when a video cannot be added to a private list because its encrypted payload would exceed the NIP-44 size limit. Retrying cannot succeed, so the copy must not suggest trying again.
+  ///
+  /// In en, this message translates to:
+  /// **'This private list is full. Remove something to add more.'**
+  String get listPrivateFull;
+
   /// No description provided for @listUpdateFailed.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5628,6 +5628,10 @@ class AppLocalizationsAm extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'Divine Moderation ላይ መልእክት ይላኩ';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'መልዕክቱ መላክ አልተሳካም';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4762,6 +4762,10 @@ class AppLocalizationsAm extends AppLocalizations {
   String get listContinue => 'ቀጥል';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed => 'ይህን ዝርዝር ማዘመን አልተቻለም። እንደገና ይሞክሩ።';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5717,6 +5717,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'راسل Divine Moderation';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'تعذّر إرسال الرسالة';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4843,6 +4843,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get listContinue => 'متابعة';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed => 'تعذّر تحديث هذه القائمة. حاول مرة أخرى.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5819,6 +5819,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'Пишете на Divine Moderation';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'Съобщението не мина';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4935,6 +4935,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get listContinue => 'Продължи';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed =>
       'Списъкът не можа да бъде обновен. Опитай пак.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4946,6 +4946,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get listContinue => 'Weiter';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed =>
       'Liste konnte nicht aktualisiert werden. Versuch es nochmal.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5840,6 +5840,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'Divine Moderation schreiben';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'Nachricht konnte nicht gesendet werden';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5858,6 +5858,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'Message Divine Moderation';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'Message couldn\'t be sent';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4974,6 +4974,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get listContinue => 'Continue';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed => 'Couldn\'t update this list. Try again.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5815,6 +5815,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'Enviar mensaje a Divine Moderation';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'No se pudo enviar el mensaje';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4931,6 +4931,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get listContinue => 'Continuar';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed =>
       'No se pudo actualizar esta lista. Probá de nuevo.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4916,6 +4916,10 @@ class AppLocalizationsFil extends AppLocalizations {
   String get listContinue => 'Magpatuloy';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed =>
       'Hindi na-update ang list na ito. Subukan ulit.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5801,6 +5801,10 @@ class AppLocalizationsFil extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'I-message ang Divine Moderation';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'Hindi naipadala ang message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5836,6 +5836,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'Écrire à Divine Moderation';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'Impossible d\'envoyer le message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4950,6 +4950,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get listContinue => 'Continuer';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed =>
       'Impossible de mettre à jour cette liste. Réessaie.';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5694,6 +5694,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'Kirim pesan ke Divine Moderation';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'Pesan gagal dikirim';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4815,6 +4815,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get listContinue => 'Lanjut';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed => 'Daftar ini gagal diperbarui. Coba lagi.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4937,6 +4937,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get listContinue => 'Continua';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed =>
       'Impossibile aggiornare questa lista. Riprova.';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5822,6 +5822,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'Scrivi a Divine Moderation';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'Impossibile inviare il messaggio';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5451,6 +5451,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'Divine Moderation にメッセージを送る';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'メッセージを送信できなかった';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4592,6 +4592,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get listContinue => '続ける';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed => 'リストを更新できなかった。もう一度試してね。';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4608,6 +4608,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get listContinue => '계속';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed => '이 목록을 업데이트하지 못했어요. 다시 시도해 주세요.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5469,6 +5469,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'Divine Moderation에 메시지 보내기';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => '메시지를 보내지 못했어요';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -4886,6 +4886,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get listContinue => 'Teruskan';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed =>
       'Senarai ini tidak dapat dikemas kini. Cuba lagi.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -5770,6 +5770,10 @@ class AppLocalizationsMs extends AppLocalizations {
       'Hantar mesej kepada Divine Moderation';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'Mesej tidak dapat dihantar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4904,6 +4904,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get listContinue => 'Doorgaan';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed =>
       'Kon deze lijst niet bijwerken. Probeer het opnieuw.';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5790,6 +5790,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Bericht sturen naar Divine Moderation';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'Bericht kon niet worden verzonden';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5016,6 +5016,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get listContinue => 'Dalej';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed =>
       'Nie udało się zaktualizować tej listy. Spróbuj ponownie.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5910,6 +5910,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'Napisz do Divine Moderation';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'Nie udało się wysłać wiadomości';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4917,6 +4917,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get listContinue => 'Continuar';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed =>
       'Não foi possível atualizar esta lista. Tente de novo.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5803,6 +5803,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Enviar mensagem para a Divine Moderation';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'Falha ao enviar a mensagem';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5029,6 +5029,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get listContinue => 'Continuă';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed => 'N-am putut actualiza lista. Mai încearcă.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5922,6 +5922,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'Scrie către Divine Moderation';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'Mesajul nu a putut fi trimis';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5758,6 +5758,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'Skriv till Divine Moderation';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'Meddelandet kunde inte skickas';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4879,6 +4879,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get listContinue => 'Fortsätt';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed => 'Kunde inte uppdatera listan. Försök igen.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -5954,6 +5954,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'సందేశం Divine మోడరేషన్';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'సందేశాన్ని పంపడం సాధ్యపడలేదు';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -5061,6 +5061,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get listContinue => 'కొనసాగించండి';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed =>
       'ఈ జాబితాను నవీకరించడం సాధ్యపడలేదు. మళ్లీ ప్రయత్నించండి.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5696,6 +5696,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'Divine Moderation\'a mesaj gönder';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'Mesaj gönderilemedi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4822,6 +4822,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get listContinue => 'Devam';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed => 'Bu liste güncellenemedi. Tekrar dene.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -4886,6 +4886,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get listContinue => 'جاری رکھیں';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed =>
       'یہ فہرست اپ ڈیٹ نہیں ہو سکی۔ دوبارہ کوشش کریں۔';
 

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -5768,6 +5768,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'Divine Moderation کو پیغام بھیجیں';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'پیغام نہیں بھیجا جا سکا';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -4851,6 +4851,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get listContinue => 'Tiếp tục';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed =>
       'Không cập nhật được danh sách này. Thử lại nhé.';
 

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -5731,6 +5731,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => 'Nhắn tin cho Divine Moderation';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => 'Tin nhắn không gửi được';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -5419,6 +5419,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get dmRetiredThreadOpenSupport => '给 Divine Moderation 发私信';
 
   @override
+  String get dmSendTooLongMessage =>
+      'That message is too long to send. Shorten it and try again.';
+
+  @override
   String get dmSendFailedMessage => '消息发送失败';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -4570,6 +4570,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get listContinue => '继续';
 
   @override
+  String get listPrivateFull =>
+      'This private list is full. Remove something to add more.';
+
+  @override
   String get listUpdateFailed => '无法更新此列表，请重试。';
 
   @override

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -336,6 +336,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                     current.sendStatus == SendStatus.blocked ||
                     current.sendStatus == SendStatus.noRecipient ||
                     current.sendStatus == SendStatus.resendFailed ||
+                    current.sendStatus == SendStatus.tooLong ||
                     current.sendStatus == SendStatus.failed),
             listener: _onSendOutcome,
             child: Column(
@@ -503,6 +504,16 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
       return;
     }
 
+    // Oversized rumor (#7331). Refused before the enqueue for the same reason
+    // as the two above — a hard-failed row would be re-driven by the retry
+    // sweep against content that can never succeed — so there is no bubble to
+    // carry it. `_SendBar` puts the text back in the composer, and this names
+    // the reason so the user knows shortening is the fix.
+    if (state.sendStatus == SendStatus.tooLong) {
+      _showErrorToastAndAnnounce(context, l10n.dmSendTooLongMessage);
+      return;
+    }
+
     // A resend that failed again (#8461). The bubble was already red when the
     // user tapped it, so — unlike the first-send case below — turning it red
     // is not a state change and the tap would otherwise produce no visible
@@ -586,24 +597,58 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
 /// OK-confirmed publish can legitimately run for tens of seconds on a slow
 /// relay or remote signer — freezing the composer for that window swallowed
 /// every follow-up message the user tried to type.
-class _SendBar extends StatelessWidget {
+class _SendBar extends StatefulWidget {
   const _SendBar({required this.participantPubkeys});
 
   final List<String> participantPubkeys;
 
   @override
+  State<_SendBar> createState() => _SendBarState();
+}
+
+class _SendBarState extends State<_SendBar> {
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return MessageInputBar(
-      onSend: (text) {
-        context.read<ConversationBloc>().add(
-          ConversationMessageSent(
-            recipientPubkeys: participantPubkeys,
-            content: text,
-          ),
+    // An oversized rumor is refused before the enqueue, so it leaves no queue
+    // row and no bubble to carry the failure (#7331). The bar has already
+    // cleared itself by then, so put the text back: it is the only copy the
+    // user has, and the fix they need is to shorten it.
+    return BlocListener<ConversationBloc, ConversationState>(
+      listenWhen: (previous, current) =>
+          previous.sendStatus != current.sendStatus &&
+          current.sendStatus == SendStatus.tooLong,
+      listener: (context, state) {
+        final rejected = _lastSubmitted;
+        if (rejected == null || _controller.text.isNotEmpty) return;
+        _controller.value = TextEditingValue(
+          text: rejected,
+          selection: TextSelection.collapsed(offset: rejected.length),
         );
       },
+      child: MessageInputBar(
+        controller: _controller,
+        onSend: (text) {
+          _lastSubmitted = text;
+          context.read<ConversationBloc>().add(
+            ConversationMessageSent(
+              recipientPubkeys: widget.participantPubkeys,
+              content: text,
+            ),
+          );
+        },
+      ),
     );
   }
+
+  String? _lastSubmitted;
 }
 
 /// Takes the composer's place in a thread keyed on a retired moderation

--- a/mobile/lib/screens/inbox/conversation/widgets/message_input_bar.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_input_bar.dart
@@ -19,6 +19,42 @@ const String strikeDelimiter = '~~';
 @visibleForTesting
 const String codeDelimiter = '`';
 
+/// Longest message the composer accepts, in characters.
+///
+/// This is an affordance, not the correctness bound. `maxLength` truncates by
+/// grapheme cluster, and one cluster can be many bytes — a ZWJ emoji sequence
+/// runs past 25 — so a character limit cannot bound the UTF-8 size that NIP-44
+/// actually constrains. `maxDmMessageContentBytes` in `dm_repository` is what
+/// guarantees the send can be built; this stops the ordinary long paste at the
+/// keyboard instead of letting it fail after the fact (#7331).
+@visibleForTesting
+const int dmComposerMaxCharacters = 10000;
+
+/// How close to [dmComposerMaxCharacters] the counter starts showing.
+///
+/// A chat composer with a permanent counter reads as a form, and the number is
+/// noise until it is nearly actionable.
+@visibleForTesting
+const int dmComposerCounterThreshold = 500;
+
+/// Hides the character counter until the message is within
+/// [dmComposerCounterThreshold] of the limit.
+///
+/// A builder is Flutter's own contract for `TextField.buildCounter`, and
+/// returning `null` is how the counter is hidden — the widget itself is a
+/// class, per the widgets-over-methods rule.
+Widget? _buildCounter(
+  BuildContext context, {
+  required int currentLength,
+  required int? maxLength,
+  required bool isFocused,
+}) {
+  if (maxLength == null) return null;
+  final remaining = maxLength - currentLength;
+  if (remaining > dmComposerCounterThreshold) return null;
+  return _RemainingCounter(remaining: remaining);
+}
+
 /// Message input bar at the bottom of the conversation screen.
 ///
 /// Features a text field with surfaceContainer background, 20px radius,
@@ -95,6 +131,8 @@ class _MessageInputBarState extends State<MessageInputBar> {
                   textInputAction: TextInputAction.newline,
                   minLines: 1,
                   maxLines: 5,
+                  maxLength: dmComposerMaxCharacters,
+                  buildCounter: _buildCounter,
                   contextMenuBuilder: _buildContextMenu,
                   decoration: InputDecoration(
                     hintText: context.l10n.dmMessageInputHint,
@@ -239,5 +277,29 @@ class _MessageInputBarState extends State<MessageInputBar> {
     state
       ..userUpdateTextEditingValue(newValue, SelectionChangedCause.toolbar)
       ..hideToolbar();
+  }
+}
+
+/// Characters left before the composer stops accepting input.
+///
+/// Numerals only, so it needs no ARB key and reads the same in every locale.
+class _RemainingCounter extends StatelessWidget {
+  const _RemainingCounter({required this.remaining});
+
+  final int remaining;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(top: 4, end: 4),
+      child: Text(
+        '$remaining',
+        style: VineTheme.labelSmallFont(
+          color: remaining <= 0
+              ? context.vineColors.onErrorContainer
+              : context.vineColors.onSurfaceMuted,
+        ),
+      ),
+    );
   }
 }

--- a/mobile/lib/screens/inbox/conversation/widgets/message_input_bar.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_input_bar.dart
@@ -24,9 +24,10 @@ const String codeDelimiter = '`';
 /// This is an affordance, not the correctness bound. `maxLength` truncates by
 /// grapheme cluster, and one cluster can be many bytes — a ZWJ emoji sequence
 /// runs past 25 — so a character limit cannot bound the UTF-8 size that NIP-44
-/// actually constrains. `maxDmMessageContentBytes` in `dm_repository` is what
-/// guarantees the send can be built; this stops the ordinary long paste at the
-/// keyboard instead of letting it fail after the fact (#7331).
+/// actually constrains. `maxDmRumorBytes` in `dm_repository` is what guarantees
+/// the send can be built, and it bounds the serialized rumor so tags count too;
+/// this stops the ordinary long paste at the keyboard instead of letting it
+/// fail after the fact (#7331).
 @visibleForTesting
 const int dmComposerMaxCharacters = 10000;
 

--- a/mobile/lib/screens/inbox/conversation/widgets/message_input_bar.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_input_bar.dart
@@ -61,17 +61,28 @@ Widget? _buildCounter(
 /// Features a text field with surfaceContainer background, 20px radius,
 /// and a green send button that appears when text is entered.
 class MessageInputBar extends StatefulWidget {
-  const MessageInputBar({required this.onSend, super.key});
+  const MessageInputBar({required this.onSend, this.controller, super.key});
 
   final ValueChanged<String> onSend;
+
+  /// Optional externally-owned controller.
+  ///
+  /// The bar clears the field the moment [onSend] fires, before any outcome is
+  /// known. A caller that can learn the send was refused — an oversized rumor
+  /// leaves no queue row and so no failed bubble (#7331) — passes its own
+  /// controller so it can put the text back rather than lose it.
+  final TextEditingController? controller;
 
   @override
   State<MessageInputBar> createState() => _MessageInputBarState();
 }
 
 class _MessageInputBarState extends State<MessageInputBar> {
-  final _controller = TextEditingController();
+  TextEditingController? _internalController;
   bool _hasText = false;
+
+  TextEditingController get _controller =>
+      widget.controller ?? (_internalController ??= TextEditingController());
 
   @override
   void initState() {
@@ -81,9 +92,10 @@ class _MessageInputBarState extends State<MessageInputBar> {
 
   @override
   void dispose() {
-    _controller
-      ..removeListener(_onTextChanged)
-      ..dispose();
+    // Only the internally-created controller is ours to dispose; an external
+    // one outlives this widget.
+    _controller.removeListener(_onTextChanged);
+    _internalController?.dispose();
     super.dispose();
   }
 

--- a/mobile/lib/services/curated_list_relay_gateway.dart
+++ b/mobile/lib/services/curated_list_relay_gateway.dart
@@ -123,9 +123,8 @@ class CuratedListRelayGateway {
     return jsonEncode(CuratedListConverter.toItemTags(list));
   }
 
-  bool privateItemPayloadFits(CuratedList list) {
-    return utf8.encode(_privateItemPlaintext(list)).length <= 65535;
-  }
+  bool privateItemPayloadFits(CuratedList list) =>
+      CuratedListConverter.privateItemPayloadFits(list);
 
   /// Stream public curated lists from Nostr relays for discovery.
   ///

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -435,25 +435,6 @@ class CuratedListService extends ChangeNotifier {
   }
 
   /// Add video to a list
-  /// Whether adding [videoEventId] to [listId] would push the list's private
-  /// item payload past what NIP-44 can encrypt, so the add cannot succeed
-  /// however many times it is retried.
-  ///
-  /// A private list is sealed with a single NIP-44 encryption, and this
-  /// client writes only the 2-byte u16 length prefix, so the sealed plaintext
-  /// cannot exceed 65,535 bytes. [_commitListMutation] refuses past that and
-  /// returns `false` — indistinguishable from a transient failure without
-  /// this, which is why the UI showed nothing at all (#7331).
-  bool wouldExceedPrivateItemLimit(String listId, String videoEventId) {
-    final list = getListById(listId);
-    if (list == null || list.isPublic) return false;
-    if (list.videoEventIds.contains(videoEventId)) return false;
-    final prospective = list.copyWith(
-      videoEventIds: [...list.videoEventIds, videoEventId],
-    );
-    return !_relayGateway.privateItemPayloadFits(prospective);
-  }
-
   Future<bool> addVideoToList(String listId, String videoEventId) {
     return _serializeListOperation(
       listId,

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -435,6 +435,25 @@ class CuratedListService extends ChangeNotifier {
   }
 
   /// Add video to a list
+  /// Whether adding [videoEventId] to [listId] would push the list's private
+  /// item payload past what NIP-44 can encrypt, so the add cannot succeed
+  /// however many times it is retried.
+  ///
+  /// A private list is sealed with a single NIP-44 encryption, and this
+  /// client writes only the 2-byte u16 length prefix, so the sealed plaintext
+  /// cannot exceed 65,535 bytes. [_commitListMutation] refuses past that and
+  /// returns `false` — indistinguishable from a transient failure without
+  /// this, which is why the UI showed nothing at all (#7331).
+  bool wouldExceedPrivateItemLimit(String listId, String videoEventId) {
+    final list = getListById(listId);
+    if (list == null || list.isPublic) return false;
+    if (list.videoEventIds.contains(videoEventId)) return false;
+    final prospective = list.copyWith(
+      videoEventIds: [...list.videoEventIds, videoEventId],
+    );
+    return !_relayGateway.privateItemPayloadFits(prospective);
+  }
+
   Future<bool> addVideoToList(String listId, String videoEventId) {
     return _serializeListOperation(
       listId,

--- a/mobile/lib/widgets/add_to_list_dialog.dart
+++ b/mobile/lib/widgets/add_to_list_dialog.dart
@@ -128,7 +128,9 @@ class SelectListDialog extends StatelessWidget {
         success = await listService.addVideoToList(list.id, video.id);
       }
 
-      if (success && context.mounted) {
+      if (!context.mounted) return;
+
+      if (success) {
         final message = isCurrentlyInList
             ? context.l10n.listRemovedFrom(list.name)
             : context.l10n.listAddedTo(list.name);
@@ -138,7 +140,25 @@ class SelectListDialog extends StatelessWidget {
             duration: const Duration(seconds: 1),
           ),
         );
+        return;
       }
+
+      // A failed toggle used to render nothing at all, so a private list that
+      // had reached the NIP-44 size ceiling silently swallowed every add
+      // (#7331). Retrying that case can never succeed, so it gets copy that
+      // does not ask the user to try again.
+      final atSizeLimit =
+          !isCurrentlyInList &&
+          listService.wouldExceedPrivateItemLimit(list.id, video.id);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            atSizeLimit
+                ? context.l10n.listPrivateFull
+                : context.l10n.listUpdateFailed,
+          ),
+        ),
+      );
     } catch (e) {
       Log.error(
         'Failed to toggle video in list: $e',

--- a/mobile/lib/widgets/add_to_list_dialog.dart
+++ b/mobile/lib/widgets/add_to_list_dialog.dart
@@ -4,6 +4,7 @@
 import 'package:curated_list_repository/curated_list_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart' show SemanticsService;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/extensions/modal_pop_extension.dart';
@@ -151,14 +152,18 @@ class SelectListDialog extends StatelessWidget {
       final atSizeLimit =
           !isCurrentlyInList &&
           CuratedListConverter.wouldExceedPrivateItemLimit(list, video.id);
+      final failureMessage = atSizeLimit
+          ? context.l10n.listPrivateFull
+          : context.l10n.listUpdateFailed;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            atSizeLimit
-                ? context.l10n.listPrivateFull
-                : context.l10n.listUpdateFailed,
-          ),
-        ),
+        SnackBar(content: Text(failureMessage)),
+      );
+      // A failure shown only in a SnackBar is invisible to screen readers.
+      // Announce it, matching the DM oversized-send path this PR added (#7331).
+      SemanticsService.sendAnnouncement(
+        View.of(context),
+        failureMessage,
+        Directionality.of(context),
       );
     } catch (e) {
       Log.error(

--- a/mobile/lib/widgets/add_to_list_dialog.dart
+++ b/mobile/lib/widgets/add_to_list_dialog.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Dialogs for adding videos to curated lists
 // ABOUTME: SelectListDialog and CreateListDialog for curated video lists
 
+import 'package:curated_list_repository/curated_list_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -149,7 +150,7 @@ class SelectListDialog extends StatelessWidget {
       // does not ask the user to try again.
       final atSizeLimit =
           !isCurrentlyInList &&
-          listService.wouldExceedPrivateItemLimit(list.id, video.id);
+          CuratedListConverter.wouldExceedPrivateItemLimit(list, video.id);
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(

--- a/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
@@ -354,6 +354,8 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
         // never dismissed by a later success, which can only close a visible
         // one — and by then `state.queuedRumorIds` describes some other send.
         _showReplyFailed(draft, cubit, state.queuedRumorIds);
+      case InlineReelReplyStatus.tooLong:
+        _showReplyTooLong(draft);
       case InlineReelReplyStatus.unverifiable:
         _showReplyUnverified();
       case InlineReelReplyStatus.success:
@@ -363,6 +365,21 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
         return;
     }
     cubit.acknowledge();
+  }
+
+  void _showReplyTooLong(String draft) {
+    if (draft.isNotEmpty && _controller.text.isEmpty) {
+      _controller.text = draft;
+      _controller.selection = TextSelection.collapsed(offset: draft.length);
+    }
+    _announce(context.l10n.dmSendTooLongMessage);
+    _closeRetrySnackBar();
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(context.l10n.dmSendTooLongMessage),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
   }
 
   void _showReplyFailed(
@@ -520,6 +537,7 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
               prev.status != curr.status &&
               (curr.status == InlineReelReplyStatus.success ||
                   curr.status == InlineReelReplyStatus.failure ||
+                  curr.status == InlineReelReplyStatus.tooLong ||
                   curr.status == InlineReelReplyStatus.unverifiable),
           listener: (context, state) => _onReplyOutcome(state),
         ),

--- a/mobile/packages/curated_list_repository/lib/src/curated_list_converter.dart
+++ b/mobile/packages/curated_list_repository/lib/src/curated_list_converter.dart
@@ -138,7 +138,16 @@ abstract final class CuratedListConverter {
   /// heuristics leaking into production behavior.
   static bool isNip44Payload(String content) {
     try {
-      NIP44V2.decodePayload(content);
+      // Bounded to the u16 ceiling rather than the decrypt-side default: this
+      // is a classifier run over relay-supplied event content, and a private
+      // item payload is itself capped at that size before publishing
+      // (`CuratedListRelayGateway.privateItemPayloadFits`). Without the bound
+      // an oversized event would be base64-decoded here just to answer a
+      // boolean, instead of being rejected by a length comparison (#7331).
+      NIP44V2.decodePayload(
+        content,
+        maxPlaintextSize: NIP44V2.maxU16PlaintextSize,
+      );
       return true;
     } on Object {
       return false;

--- a/mobile/packages/curated_list_repository/lib/src/curated_list_converter.dart
+++ b/mobile/packages/curated_list_repository/lib/src/curated_list_converter.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Handles NIP-51 kind 30005 parsing including e-tags and
 // ABOUTME: a-tags for addressable video references (NIP-71).
 
+import 'dart:convert';
+
 import 'package:models/models.dart';
 import 'package:nostr_sdk/nostr_sdk.dart' show Event, NIP04, NIP44V2;
 
@@ -222,6 +224,35 @@ abstract final class CuratedListConverter {
     tags.add(['playorder', list.playOrder.value]);
 
     return tags;
+  }
+
+  /// Whether [list]'s private item payload fits what NIP-44 can encrypt.
+  ///
+  /// A private list is sealed with a SINGLE NIP-44 encryption — unlike NIP-17,
+  /// which encrypts twice — and this client writes only the 2-byte u16 length
+  /// prefix, so the sealed plaintext cannot exceed
+  /// [NIP44V2.maxU16PlaintextSize]. Lives beside [toItemTags] because it
+  /// measures exactly what that produces (#7331).
+  static bool privateItemPayloadFits(CuratedList list) {
+    return utf8.encode(jsonEncode(toItemTags(list))).length <=
+        NIP44V2.maxU16PlaintextSize;
+  }
+
+  /// Whether adding [videoEventId] to [list] would push it past
+  /// [privateItemPayloadFits], so the add cannot succeed however often it is
+  /// retried.
+  ///
+  /// Public lists are unsealed and therefore unbounded here.
+  static bool wouldExceedPrivateItemLimit(
+    CuratedList list,
+    String videoEventId,
+  ) {
+    if (list.isPublic || list.videoEventIds.contains(videoEventId)) {
+      return false;
+    }
+    return !privateItemPayloadFits(
+      list.copyWith(videoEventIds: [...list.videoEventIds, videoEventId]),
+    );
   }
 
   /// The video-reference tags for [list].

--- a/mobile/packages/curated_list_repository/test/src/curated_list_converter_test.dart
+++ b/mobile/packages/curated_list_repository/test/src/curated_list_converter_test.dart
@@ -706,6 +706,92 @@ void main() {
       );
     });
 
+    group('private item size limit', () {
+      final now = DateTime(2026, 9);
+
+      CuratedList privateListWith(int videoCount) => CuratedList(
+        id: 'my-list',
+        name: 'My List',
+        isPublic: false,
+        videoEventIds: [
+          for (var i = 0; i < videoCount; i++) i.toString().padLeft(64, '0'),
+        ],
+        createdAt: now,
+        updatedAt: now,
+      );
+
+      test('a small private list fits', () {
+        expect(
+          CuratedListConverter.privateItemPayloadFits(privateListWith(3)),
+          isTrue,
+        );
+      });
+
+      test('a private list past the u16 ceiling does not fit', () {
+        // A private list is sealed with ONE NIP-44 encryption, so its plaintext
+        // cannot exceed the u16 maximum (#7331).
+        final tooBig = privateListWith(1000);
+        final plaintextBytes = utf8
+            .encode(jsonEncode(CuratedListConverter.toItemTags(tooBig)))
+            .length;
+
+        expect(plaintextBytes, greaterThan(NIP44V2.maxU16PlaintextSize));
+        expect(CuratedListConverter.privateItemPayloadFits(tooBig), isFalse);
+      });
+
+      test('adding to a full private list would exceed the limit', () {
+        expect(
+          CuratedListConverter.wouldExceedPrivateItemLimit(
+            privateListWith(1000),
+            'a' * 64,
+          ),
+          isTrue,
+        );
+      });
+
+      test('adding to a small private list would not', () {
+        expect(
+          CuratedListConverter.wouldExceedPrivateItemLimit(
+            privateListWith(3),
+            'a' * 64,
+          ),
+          isFalse,
+        );
+      });
+
+      test('a public list is never limited — its items are not sealed', () {
+        final publicList = CuratedList(
+          id: 'my-list',
+          name: 'My List',
+          videoEventIds: [
+            for (var i = 0; i < 1000; i++) i.toString().padLeft(64, '0'),
+          ],
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        expect(
+          CuratedListConverter.wouldExceedPrivateItemLimit(
+            publicList,
+            'a' * 64,
+          ),
+          isFalse,
+        );
+      });
+
+      test('re-adding an item already present cannot exceed anything', () {
+        final list = privateListWith(1000);
+
+        expect(
+          CuratedListConverter.wouldExceedPrivateItemLimit(
+            list,
+            list.videoEventIds.first,
+          ),
+          isFalse,
+        );
+      });
+    });
+
     group('extractDTag', () {
       test('returns null when no d-tag is present', () {
         final event = _makeEvent(

--- a/mobile/packages/dm_repository/lib/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/dm_repository.dart
@@ -2,6 +2,7 @@ export 'src/collaborator_invite_recovery.dart';
 export 'src/dm_batch_send_budget.dart';
 export 'src/dm_decrypt_isolate.dart';
 export 'src/dm_decryption_worker.dart';
+export 'src/dm_message_size.dart';
 export 'src/dm_reactions_repository.dart';
 export 'src/dm_reactions_repository_reportable_sites.dart';
 export 'src/dm_removal_policy.dart';

--- a/mobile/packages/dm_repository/lib/src/dm_decryption_worker.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_decryption_worker.dart
@@ -107,7 +107,11 @@ Future<DecryptedRumorResult> _decryptOne(
   final String sealJsonText;
   try {
     final giftKey = NIP44V2.shareSecret(privateKeyHex, giftWrap.pubkey);
-    sealJsonText = await NIP44V2.decrypt(giftWrap.content, giftKey);
+    sealJsonText = await NIP44V2.decrypt(
+      giftWrap.content,
+      giftKey,
+      maxPlaintextSize: maxNip17ReceivePlaintextBytes,
+    );
   } on Object catch (e) {
     return DecryptedRumorResult.failure(
       'gift wrap decrypt failed for ${giftWrap.id}: $e',
@@ -135,7 +139,11 @@ Future<DecryptedRumorResult> _decryptOne(
   final String rumorJsonText;
   try {
     final sealKey = NIP44V2.shareSecret(privateKeyHex, sealEvent.pubkey);
-    rumorJsonText = await NIP44V2.decrypt(sealEvent.content, sealKey);
+    rumorJsonText = await NIP44V2.decrypt(
+      sealEvent.content,
+      sealKey,
+      maxPlaintextSize: maxNip17ReceivePlaintextBytes,
+    );
   } on Object catch (e) {
     return DecryptedRumorResult.failure(
       'seal decrypt failed for ${giftWrap.id}: $e',

--- a/mobile/packages/dm_repository/lib/src/dm_message_size.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_message_size.dart
@@ -1,0 +1,36 @@
+// ABOUTME: Size ceiling for a NIP-17 message body, derived from the NIP-44
+// ABOUTME: u16 length prefix and the double encryption NIP-17 performs.
+
+/// How large a NIP-17 message body may be before the send is refused.
+///
+/// ## Where the hard ceiling comes from
+///
+/// NIP-44 v2 defines two length-prefix forms, but this client writes only the
+/// 2-byte `u16` (see `NIP44V2.pad`), so it cannot encrypt a plaintext of
+/// 65,536 bytes or more. NIP-17 then encrypts **twice**: the seal encrypts the
+/// rumor, and the gift wrap encrypts the whole seal *event JSON*, whose
+/// `content` is the seal's base64 payload. Base64 costs 4/3, so the outer
+/// encrypt meets the u16 wall long before the inner one does.
+///
+/// Measured against the production wrap builder rather than derived: a 1:1
+/// kind-14 send with a single `p` tag succeeds at 40,682 bytes of content and
+/// throws at 40,683, and no larger size fits — `calcPaddedLen` jumps the inner
+/// padded size from 40,960 to 49,152 at that boundary, which alone pushes the
+/// outer plaintext past 65,535 (#7331).
+///
+/// ## Why this constant is well below that
+///
+/// 40,682 is the ceiling for the *smallest possible* rumor. Every additional
+/// `p` tag on a group rumor, and any reply or subject tag, enlarges the sealed
+/// JSON and lowers the real ceiling, so a limit set at the 1:1 maximum would
+/// still fail for a group send. 32 KiB leaves roughly 7,900 bytes of headroom —
+/// on the order of a hundred extra recipients — while staying far above any
+/// message a person composes.
+///
+/// ## Why bytes rather than characters
+///
+/// The composer's `maxLength` truncates by grapheme cluster, and one cluster
+/// can be many bytes (a ZWJ emoji sequence runs past 25). A character limit is
+/// a useful affordance but not a bound, so the byte check here is what actually
+/// prevents the failure.
+const int maxDmMessageContentBytes = 32 * 1024;

--- a/mobile/packages/dm_repository/lib/src/dm_message_size.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_message_size.dart
@@ -1,7 +1,7 @@
-// ABOUTME: Size ceiling for a NIP-17 message body, derived from the NIP-44
-// ABOUTME: u16 length prefix and the double encryption NIP-17 performs.
+// ABOUTME: Size ceiling for a NIP-17 rumor, derived from the NIP-44 u16 length
+// ABOUTME: prefix and the double encryption NIP-17 performs.
 
-/// How large a NIP-17 message body may be before the send is refused.
+/// How large a NIP-17 rumor may serialize to before the send is refused.
 ///
 /// ## Where the hard ceiling comes from
 ///
@@ -12,25 +12,21 @@
 /// `content` is the seal's base64 payload. Base64 costs 4/3, so the outer
 /// encrypt meets the u16 wall long before the inner one does.
 ///
-/// Measured against the production wrap builder rather than derived: a 1:1
-/// kind-14 send with a single `p` tag succeeds at 40,682 bytes of content and
-/// throws at 40,683, and no larger size fits — `calcPaddedLen` jumps the inner
-/// padded size from 40,960 to 49,152 at that boundary, which alone pushes the
-/// outer plaintext past 65,535 (#7331).
+/// Measured against the production wrap builder rather than derived: a rumor
+/// serializing to 40,969 bytes wraps, 40,970 throws, and that boundary is
+/// **invariant in the rumor's size** — it lands identically with 0, 50 or 200
+/// extra `p` tags (#7331).
 ///
-/// ## Why this constant is well below that
+/// ## Why the bound is on the rumor, not on the message body
 ///
-/// 40,682 is the ceiling for the *smallest possible* rumor. Every additional
-/// `p` tag on a group rumor, and any reply or subject tag, enlarges the sealed
-/// JSON and lowers the real ceiling, so a limit set at the 1:1 maximum would
-/// still fail for a group send. 32 KiB leaves roughly 7,900 bytes of headroom —
-/// on the order of a hundred extra recipients — while staying far above any
-/// message a person composes.
+/// The NIP-44 plaintext is `jsonEncode(rumor)`, not the body: tags count. The
+/// content ceiling therefore moves with the tag set — 40,682 bytes for a 1:1
+/// send, but 26,082 with 200 recipients — while the rumor ceiling does not.
+/// Bounding the rumor is both the correct quantity and the one that needs no
+/// per-shape adjustment, so a group send, a reply with an `e` tag, and a
+/// future tag addition are all covered without changing this number.
 ///
-/// ## Why bytes rather than characters
-///
-/// The composer's `maxLength` truncates by grapheme cluster, and one cluster
-/// can be many bytes (a ZWJ emoji sequence runs past 25). A character limit is
-/// a useful affordance but not a bound, so the byte check here is what actually
-/// prevents the failure.
-const int maxDmMessageContentBytes = 32 * 1024;
+/// The remaining 969 bytes of headroom cover rounding rather than growth:
+/// the guard measures the exact rumor that is handed to the wrap builder, and
+/// nothing adds tags between the two.
+const int maxDmRumorBytes = 40000;

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3954,6 +3954,32 @@ class DmRepository {
     }
   }
 
+  /// Refuses a body the NIP-17 double encryption cannot carry, or `null` when
+  /// it fits.
+  ///
+  /// NIP-44's u16 length prefix caps what the chain can encrypt, and the throw
+  /// it raises is deterministic: the same content fails identically every
+  /// time. Callers invoke this BEFORE enqueuing, because a hard-failed row is
+  /// re-driven by `OutgoingDmRetryService.sweep()` on every foreground and
+  /// reconnect, so a parked row would spend the whole retry budget re-running
+  /// a crypto chain that cannot succeed.
+  ///
+  /// Returns rather than throws so a caller that loops over recipients — such
+  /// as `CollaboratorInviteService.sendInvites` — is not aborted mid-fan-out.
+  NIP17SendResult? _refuseIfOversized(String content) {
+    final contentBytes = utf8.encode(content).length;
+    if (contentBytes <= maxDmMessageContentBytes) return null;
+    Log.info(
+      'DM refused: body is $contentBytes bytes, over the '
+      '$maxDmMessageContentBytes-byte limit',
+      category: LogCategory.system,
+    );
+    return NIP17SendResult.tooLong(
+      'message is $contentBytes bytes, over the '
+      '$maxDmMessageContentBytes-byte limit',
+    );
+  }
+
   /// Send a text message to a 1:1 conversation.
   ///
   /// Throws [StateError] if the repository has not been initialized.
@@ -4009,30 +4035,8 @@ class DmRepository {
       );
     }
 
-    // Refuse an oversized body BEFORE the enqueue below (#7331). NIP-44's u16
-    // length prefix caps what the NIP-17 double encryption can carry, and the
-    // throw it raises is deterministic: the same content fails identically
-    // every time. A hard-failed row is re-driven by
-    // `OutgoingDmRetryService.sweep()` on every foreground and reconnect, so
-    // enqueuing first would spend the whole retry budget re-running a crypto
-    // chain that cannot succeed. Returned rather than thrown for the same
-    // reason as the self-send refusal above: `CollaboratorInviteService`
-    // loops without a catch, and a throw would abort the remaining sends.
-    //
-    // Ordered after the self-send refusal so an oversized note-to-self still
-    // reports the more fundamental reason it can never be delivered.
-    final contentBytes = utf8.encode(content).length;
-    if (contentBytes > maxDmMessageContentBytes) {
-      Log.info(
-        'DM refused: body is $contentBytes bytes, over the '
-        '$maxDmMessageContentBytes-byte limit',
-        category: LogCategory.system,
-      );
-      return NIP17SendResult.tooLong(
-        'message is $contentBytes bytes, over the '
-        '$maxDmMessageContentBytes-byte limit',
-      );
-    }
+    final oversized = _refuseIfOversized(content);
+    if (oversized != null) return oversized;
 
     // Send gate (#176): block before building or enqueuing a doomed intent.
     // NIP17MessageService.sendRumor is the authoritative choke point (it also
@@ -5640,6 +5644,15 @@ class DmRepository {
     recipientPubkeys.forEach(validatePubkey);
     if (content.trim().isEmpty) {
       throw ArgumentError.value(content, 'content', 'must not be empty');
+    }
+
+    // Same pre-enqueue size refusal as [sendMessage] (#7331). A group send
+    // fans one rumor out to N recipients, so an oversized body would park N
+    // retry-swept rows rather than one — and the extra `p` tags make the real
+    // NIP-44 ceiling lower here, not higher.
+    final oversized = _refuseIfOversized(content);
+    if (oversized != null) {
+      return [for (final _ in recipientPubkeys) oversized];
     }
 
     // Send gate (#176) — group all-or-nothing: a restricted sender (protected

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -18,6 +18,7 @@ import 'package:dm_repository/src/dm_batch_send_budget.dart';
 import 'package:dm_repository/src/dm_clock.dart';
 import 'package:dm_repository/src/dm_decrypt_isolate.dart';
 import 'package:dm_repository/src/dm_decryption_worker.dart';
+import 'package:dm_repository/src/dm_message_size.dart';
 import 'package:dm_repository/src/dm_reactions_repository.dart';
 import 'package:dm_repository/src/dm_removal_policy.dart';
 import 'package:dm_repository/src/dm_repository_reportable_sites.dart';
@@ -4005,6 +4006,31 @@ class DmRepository {
     if (_isSelf(recipientPubkey)) {
       return const NIP17SendResult.failure(
         'refused: a message cannot be addressed to its own sender',
+      );
+    }
+
+    // Refuse an oversized body BEFORE the enqueue below (#7331). NIP-44's u16
+    // length prefix caps what the NIP-17 double encryption can carry, and the
+    // throw it raises is deterministic: the same content fails identically
+    // every time. A hard-failed row is re-driven by
+    // `OutgoingDmRetryService.sweep()` on every foreground and reconnect, so
+    // enqueuing first would spend the whole retry budget re-running a crypto
+    // chain that cannot succeed. Returned rather than thrown for the same
+    // reason as the self-send refusal above: `CollaboratorInviteService`
+    // loops without a catch, and a throw would abort the remaining sends.
+    //
+    // Ordered after the self-send refusal so an oversized note-to-self still
+    // reports the more fundamental reason it can never be delivered.
+    final contentBytes = utf8.encode(content).length;
+    if (contentBytes > maxDmMessageContentBytes) {
+      Log.info(
+        'DM refused: body is $contentBytes bytes, over the '
+        '$maxDmMessageContentBytes-byte limit',
+        category: LogCategory.system,
+      );
+      return NIP17SendResult.tooLong(
+        'message is $contentBytes bytes, over the '
+        '$maxDmMessageContentBytes-byte limit',
       );
     }
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3954,29 +3954,33 @@ class DmRepository {
     }
   }
 
-  /// Refuses a body the NIP-17 double encryption cannot carry, or `null` when
+  /// Refuses a rumor the NIP-17 double encryption cannot carry, or `null` when
   /// it fits.
   ///
-  /// NIP-44's u16 length prefix caps what the chain can encrypt, and the throw
-  /// it raises is deterministic: the same content fails identically every
-  /// time. Callers invoke this BEFORE enqueuing, because a hard-failed row is
-  /// re-driven by `OutgoingDmRetryService.sweep()` on every foreground and
-  /// reconnect, so a parked row would spend the whole retry budget re-running
-  /// a crypto chain that cannot succeed.
+  /// The NIP-44 plaintext is `jsonEncode(rumor)`, so tags count as much as the
+  /// body — which is why this measures the rumor rather than the message text.
+  /// The rumor ceiling is invariant in the tag set where a content ceiling is
+  /// not, so one number covers a 1:1 send, a group fan-out and a reply alike.
+  ///
+  /// Callers invoke this BEFORE enqueuing, because NIP-44's throw is
+  /// deterministic — the same rumor fails identically every time — and a
+  /// hard-failed row is re-driven by `OutgoingDmRetryService.sweep()` on every
+  /// foreground and reconnect, so a parked row would spend the whole retry
+  /// budget on work that cannot succeed.
   ///
   /// Returns rather than throws so a caller that loops over recipients — such
   /// as `CollaboratorInviteService.sendInvites` — is not aborted mid-fan-out.
-  NIP17SendResult? _refuseIfOversized(String content) {
-    final contentBytes = utf8.encode(content).length;
-    if (contentBytes <= maxDmMessageContentBytes) return null;
+  NIP17SendResult? _refuseIfOversized(Event rumor) {
+    final rumorBytes = utf8.encode(jsonEncode(rumor.toJson())).length;
+    if (rumorBytes <= maxDmRumorBytes) return null;
     Log.info(
-      'DM refused: body is $contentBytes bytes, over the '
-      '$maxDmMessageContentBytes-byte limit',
+      'DM refused: rumor serializes to $rumorBytes bytes, over the '
+      '$maxDmRumorBytes-byte limit',
       category: LogCategory.system,
     );
     return NIP17SendResult.tooLong(
-      'message is $contentBytes bytes, over the '
-      '$maxDmMessageContentBytes-byte limit',
+      'message is too large to send: the rumor is $rumorBytes bytes, over '
+      'the $maxDmRumorBytes-byte limit',
     );
   }
 
@@ -3988,6 +3992,9 @@ class DmRepository {
   ///
   /// Returns a failure result, publishing nothing, when [recipientPubkey] is
   /// the sender — see the refusal below.
+  ///
+  /// Returns [NIP17SendResult.tooLong], publishing nothing and leaving no
+  /// queue row, when the built rumor exceeds [maxDmRumorBytes].
   ///
   /// When an [OutgoingDmsDao] is injected, the send goes through the
   /// durable queue: build the rumor, enqueue a `pending`/`pending` row
@@ -4034,9 +4041,6 @@ class DmRepository {
         'refused: a message cannot be addressed to its own sender',
       );
     }
-
-    final oversized = _refuseIfOversized(content);
-    if (oversized != null) return oversized;
 
     // Send gate (#176): block before building or enqueuing a doomed intent.
     // NIP17MessageService.sendRumor is the authoritative choke point (it also
@@ -4091,6 +4095,9 @@ class DmRepository {
         [_sendBatchTagKey, sendBatchId],
       ],
     );
+
+    final oversized = _refuseIfOversized(rumor);
+    if (oversized != null) return oversized;
 
     // Enqueue before publish so an app crash mid-send leaves a
     // recoverable trace. No-op when the queue dao isn't wired in
@@ -5650,11 +5657,6 @@ class DmRepository {
     // fans one rumor out to N recipients, so an oversized body would park N
     // retry-swept rows rather than one — and the extra `p` tags make the real
     // NIP-44 ceiling lower here, not higher.
-    final oversized = _refuseIfOversized(content);
-    if (oversized != null) {
-      return [for (final _ in recipientPubkeys) oversized];
-    }
-
     // Send gate (#176) — group all-or-nothing: a restricted sender (protected
     // minor) may only message a group where EVERY recipient is approved.
     // Per-recipient gating in sendRumor alone would still deliver to the
@@ -5756,6 +5758,15 @@ class DmRepository {
       ],
       createdAt: batchCreatedAt,
     );
+    // Same pre-enqueue refusal as [sendMessage] (#7331), and the reason the
+    // bound is on the rumor rather than the body: a group rumor carries one
+    // `p` tag per recipient, so its usable body shrinks as the group grows
+    // while this ceiling stays put.
+    final oversized = _refuseIfOversized(groupRumor);
+    if (oversized != null) {
+      return [for (final _ in recipientPubkeys) oversized];
+    }
+
     for (final recipient in recipientPubkeys) {
       queueIds.add(_groupQueueId(groupRumor.id, recipient));
     }

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -5653,10 +5653,6 @@ class DmRepository {
       throw ArgumentError.value(content, 'content', 'must not be empty');
     }
 
-    // Same pre-enqueue size refusal as [sendMessage] (#7331). A group send
-    // fans one rumor out to N recipients, so an oversized body would park N
-    // retry-swept rows rather than one — and the extra `p` tags make the real
-    // NIP-44 ceiling lower here, not higher.
     // Send gate (#176) — group all-or-nothing: a restricted sender (protected
     // minor) may only message a group where EVERY recipient is approved.
     // Per-recipient gating in sendRumor alone would still deliver to the

--- a/mobile/packages/dm_repository/test/src/dm_decryption_worker_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_decryption_worker_test.dart
@@ -351,6 +351,30 @@ void main() {
       expect(results[0].error, contains('invalid gift wrap json'));
     });
 
+    test('rejects an oversized outer payload before base64 decoding', () async {
+      final recipientPriv = generatePrivateKey();
+      final recipientPub = getPublicKey(recipientPriv);
+      final ephemeralPriv = generatePrivateKey();
+      final giftWrap = Event(
+        getPublicKey(ephemeralPriv),
+        EventKind.giftWrap,
+        <List<String>>[
+          ['p', recipientPub],
+        ],
+        'A' * 300000,
+      )..sign(ephemeralPriv);
+
+      final results = await decryptGiftWrapBatch(
+        DecryptBatchRequest(
+          events: [giftWrap.toJson()],
+          privateKeyHex: recipientPriv,
+        ),
+      );
+
+      expect(results.single.isSuccess, isFalse);
+      expect(results.single.error, contains('Invalid payload length'));
+    });
+
     test(
       'returns failure when decrypted seal content is not valid JSON',
       () async {

--- a/mobile/packages/dm_repository/test/src/dm_message_size_crypto_invariant_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_message_size_crypto_invariant_test.dart
@@ -1,10 +1,12 @@
 // ABOUTME: Runs the REAL NIP-59 wrap builder and real NIP-44 crypto to prove
-// ABOUTME: maxDmMessageContentBytes actually sits below the ceiling NIP-44's
-// ABOUTME: u16 length prefix imposes on NIP-17's double encryption (#7331).
+// ABOUTME: maxDmRumorBytes actually sits below the ceiling NIP-44's u16 length
+// ABOUTME: prefix imposes on NIP-17's double encryption (#7331).
 //
 // Every other test in this change mocks the wrap build. This one does not:
-// without it, raising maxDmMessageContentBytes past the real ceiling would
-// leave the whole suite green while every large send failed in production.
+// without it, raising maxDmRumorBytes past the real ceiling would leave the
+// whole suite green while every large send failed in production.
+
+import 'dart:convert';
 
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -14,7 +16,7 @@ import 'package:nostr_sdk/event_kind.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
 
 void main() {
-  group('maxDmMessageContentBytes vs the real NIP-44 ceiling', () {
+  group('maxDmRumorBytes vs the real NIP-44 ceiling', () {
     late String senderSk;
     late String senderPk;
     late String recipientPk;
@@ -25,22 +27,23 @@ void main() {
       recipientPk = getPublicKey(generatePrivateKey());
     });
 
-    /// Builds the real kind-1059 wrap for a kind-14 rumor of [contentLength]
-    /// bytes, through the production isolate builder. Returns false when the
-    /// NIP-44 chain refuses it.
-    Future<bool> wrapBuilds(
-      int contentLength, {
-      List<List<String>>? tags,
-    }) async {
-      final rumor = Event(
-        senderPk,
-        EventKind.privateDirectMessage,
-        tags ??
-            [
-              ['p', recipientPk],
-            ],
-        'a' * contentLength,
-      );
+    Event rumorOf(int contentLength, {int extraRecipients = 0}) => Event(
+      senderPk,
+      EventKind.privateDirectMessage,
+      [
+        ['p', recipientPk],
+        for (var i = 0; i < extraRecipients; i++)
+          ['p', getPublicKey(generatePrivateKey())],
+      ],
+      'a' * contentLength,
+    );
+
+    int serializedBytes(Event rumor) =>
+        utf8.encode(jsonEncode(rumor.toJson())).length;
+
+    /// Builds the real kind-1059 wrap through the production isolate builder.
+    /// Returns false when the NIP-44 chain refuses it.
+    Future<bool> wrapBuilds(Event rumor) async {
       try {
         final wrap = await buildGiftWrapFromHex(
           senderPrivateKeyHex: senderSk,
@@ -53,33 +56,62 @@ void main() {
       }
     }
 
-    test('a body at the limit really does build a gift wrap', () async {
-      expect(await wrapBuilds(maxDmMessageContentBytes), isTrue);
-    });
+    /// Largest content whose rumor still wraps, for a given recipient count.
+    Future<int> maxContentFor(int extraRecipients) async {
+      var lo = 1;
+      var hi = 60000;
+      while (lo < hi) {
+        final mid = (lo + hi + 1) ~/ 2;
+        if (await wrapBuilds(rumorOf(mid, extraRecipients: extraRecipients))) {
+          lo = mid;
+        } else {
+          hi = mid - 1;
+        }
+      }
+      return lo;
+    }
 
-    test('the limit holds for a large group rumor too', () async {
-      // The 1:1 ceiling is the best case. Every extra `p` tag enlarges the
-      // sealed JSON and lowers the real ceiling, which is why the constant is
-      // set well below the measured 1:1 maximum rather than at it.
-      final manyRecipients = <List<String>>[
-        for (var i = 0; i < 100; i++) ['p', getPublicKey(generatePrivateKey())],
-      ];
+    test('a rumor at the limit really does build a gift wrap', () async {
+      var content = maxDmRumorBytes;
+      while (serializedBytes(rumorOf(content)) > maxDmRumorBytes) {
+        content -= 16;
+      }
 
       expect(
-        await wrapBuilds(maxDmMessageContentBytes, tags: manyRecipients),
-        isTrue,
+        serializedBytes(rumorOf(content)),
+        lessThanOrEqualTo(maxDmRumorBytes),
+      );
+      expect(await wrapBuilds(rumorOf(content)), isTrue);
+    });
+
+    test('the ceiling is a property of the rumor, not of the body', () async {
+      // This is why the guard measures the rumor: the usable BODY shrinks as
+      // recipients are added, while the rumor ceiling does not move.
+      final solo = await maxContentFor(0);
+      final group = await maxContentFor(50);
+
+      expect(
+        group,
+        lessThan(solo),
+        reason: 'extra p tags must eat into the usable body',
+      );
+      expect(
+        serializedBytes(rumorOf(group, extraRecipients: 50)),
+        equals(serializedBytes(rumorOf(solo))),
+        reason: 'both maxima must serialize to the same rumor ceiling',
       );
     });
 
-    test('the NIP-44 ceiling this guards is real and not far above', () async {
-      // Pins the thing the constant exists for. 40,683 bytes of content is the
-      // first size that cannot be wrapped — measured, not derived — so a guard
-      // above it would let the deterministic throw back through.
-      expect(await wrapBuilds(40682), isTrue);
-      expect(await wrapBuilds(40683), isFalse);
+    test('the guard sits below the measured ceiling', () async {
+      final solo = await maxContentFor(0);
+      final ceiling = serializedBytes(rumorOf(solo));
+
+      // Measured, not derived: 40,969 bytes wraps and 40,970 does not.
+      expect(ceiling, equals(40969));
+      expect(await wrapBuilds(rumorOf(solo + 1)), isFalse);
       expect(
-        maxDmMessageContentBytes,
-        lessThan(40683),
+        maxDmRumorBytes,
+        lessThan(ceiling),
         reason: 'the guard must sit below the real NIP-44 ceiling',
       );
     });

--- a/mobile/packages/dm_repository/test/src/dm_message_size_crypto_invariant_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_message_size_crypto_invariant_test.dart
@@ -1,0 +1,87 @@
+// ABOUTME: Runs the REAL NIP-59 wrap builder and real NIP-44 crypto to prove
+// ABOUTME: maxDmMessageContentBytes actually sits below the ceiling NIP-44's
+// ABOUTME: u16 length prefix imposes on NIP-17's double encryption (#7331).
+//
+// Every other test in this change mocks the wrap build. This one does not:
+// without it, raising maxDmMessageContentBytes past the real ceiling would
+// leave the whole suite green while every large send failed in production.
+
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
+
+void main() {
+  group('maxDmMessageContentBytes vs the real NIP-44 ceiling', () {
+    late String senderSk;
+    late String senderPk;
+    late String recipientPk;
+
+    setUp(() {
+      senderSk = generatePrivateKey();
+      senderPk = getPublicKey(senderSk);
+      recipientPk = getPublicKey(generatePrivateKey());
+    });
+
+    /// Builds the real kind-1059 wrap for a kind-14 rumor of [contentLength]
+    /// bytes, through the production isolate builder. Returns false when the
+    /// NIP-44 chain refuses it.
+    Future<bool> wrapBuilds(
+      int contentLength, {
+      List<List<String>>? tags,
+    }) async {
+      final rumor = Event(
+        senderPk,
+        EventKind.privateDirectMessage,
+        tags ??
+            [
+              ['p', recipientPk],
+            ],
+        'a' * contentLength,
+      );
+      try {
+        final wrap = await buildGiftWrapFromHex(
+          senderPrivateKeyHex: senderSk,
+          rumorJson: rumor.toJson(),
+          receiverPublicKey: recipientPk,
+        );
+        return wrap != null;
+      } on Object {
+        return false;
+      }
+    }
+
+    test('a body at the limit really does build a gift wrap', () async {
+      expect(await wrapBuilds(maxDmMessageContentBytes), isTrue);
+    });
+
+    test('the limit holds for a large group rumor too', () async {
+      // The 1:1 ceiling is the best case. Every extra `p` tag enlarges the
+      // sealed JSON and lowers the real ceiling, which is why the constant is
+      // set well below the measured 1:1 maximum rather than at it.
+      final manyRecipients = <List<String>>[
+        for (var i = 0; i < 100; i++) ['p', getPublicKey(generatePrivateKey())],
+      ];
+
+      expect(
+        await wrapBuilds(maxDmMessageContentBytes, tags: manyRecipients),
+        isTrue,
+      );
+    });
+
+    test('the NIP-44 ceiling this guards is real and not far above', () async {
+      // Pins the thing the constant exists for. 40,683 bytes of content is the
+      // first size that cannot be wrapped — measured, not derived — so a guard
+      // above it would let the deterministic throw back through.
+      expect(await wrapBuilds(40682), isTrue);
+      expect(await wrapBuilds(40683), isFalse);
+      expect(
+        maxDmMessageContentBytes,
+        lessThan(40683),
+        reason: 'the guard must sit below the real NIP-44 ceiling',
+      );
+    });
+  });
+}

--- a/mobile/packages/dm_repository/test/src/dm_message_size_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_message_size_test.dart
@@ -124,7 +124,7 @@ void main() {
       });
     });
 
-    test('refuses a body over the byte limit with a tooLong result', () async {
+    test('refuses a rumor over the byte limit with a tooLong result', () async {
       final repository = buildRepository();
 
       final result = await repository.sendMessage(

--- a/mobile/packages/dm_repository/test/src/dm_message_size_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_message_size_test.dart
@@ -29,6 +29,8 @@ const _ownerPubkey =
     'a1b2c3d4e5f6789012345678901234567890abcdef1234567890123456789012';
 const _recipientPubkey =
     'b2c3d4e5f6789012345678901234567890abcdef1234567890123456789012a1';
+const _otherRecipientPubkey =
+    'c3d4e5f6789012345678901234567890abcdef1234567890123456789012a1b2';
 const _privateKey =
     'd4e5f6789012345678901234567890abcdef1234567890123456789012ab12c3';
 
@@ -142,6 +144,23 @@ void main() {
       );
 
       expect(result.tooLong, isTrue);
+    });
+
+    test('refuses an oversized GROUP send, one result per recipient', () async {
+      // A group send fans one rumor out to N recipients, so an unguarded
+      // oversized body parks N retry-swept rows instead of one — and the extra
+      // `p` tags lower the real NIP-44 ceiling rather than raising it.
+      final repository = buildRepository();
+      final recipients = [_recipientPubkey, _otherRecipientPubkey];
+
+      final results = await repository.sendGroupMessage(
+        recipientPubkeys: recipients,
+        content: 'a' * (maxDmMessageContentBytes + 1),
+      );
+
+      expect(results, hasLength(recipients.length));
+      expect(results.every((r) => r.tooLong), isTrue);
+      verifyNever(() => outgoingDao.enqueue(any()));
     });
 
     test('an oversized self-send reports the self-send refusal', () async {

--- a/mobile/packages/dm_repository/test/src/dm_message_size_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_message_size_test.dart
@@ -1,0 +1,181 @@
+// ABOUTME: Guards the pre-enqueue size refusal on DmRepository.sendMessage
+// ABOUTME: (#7331): NIP-44's u16 length prefix caps what the NIP-17 double
+// ABOUTME: encryption can carry, and the throw is deterministic, so an
+// ABOUTME: oversized body must be refused BEFORE a retry-swept row exists.
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockNIP17MessageService extends Mock implements NIP17MessageService {}
+
+class _MockDirectMessagesDao extends Mock implements DirectMessagesDao {}
+
+class _MockConversationsDao extends Mock implements ConversationsDao {}
+
+class _MockOutgoingDmsDao extends Mock implements OutgoingDmsDao {}
+
+class _FakeEvent extends Fake implements Event {}
+
+class _FakeOutgoingDm extends Fake implements OutgoingDm {}
+
+const _ownerPubkey =
+    'a1b2c3d4e5f6789012345678901234567890abcdef1234567890123456789012';
+const _recipientPubkey =
+    'b2c3d4e5f6789012345678901234567890abcdef1234567890123456789012a1';
+const _privateKey =
+    'd4e5f6789012345678901234567890abcdef1234567890123456789012ab12c3';
+
+void main() {
+  group('$DmRepository oversized message refusal', () {
+    late _MockNostrClient nostrClient;
+    late _MockNIP17MessageService messageService;
+    late _MockOutgoingDmsDao outgoingDao;
+
+    setUpAll(() {
+      registerFallbackValue(_FakeEvent());
+      registerFallbackValue(_FakeOutgoingDm());
+      registerFallbackValue(Duration.zero);
+    });
+
+    DmRepository buildRepository() {
+      return DmRepository(
+        nostrClient: nostrClient,
+        messageService: messageService,
+        directMessagesDao: _MockDirectMessagesDao(),
+        conversationsDao: _MockConversationsDao(),
+        outgoingDmsDao: outgoingDao,
+      )..setCredentials(
+        userPubkey: _ownerPubkey,
+        signer: LocalNostrSigner(_privateKey),
+        messageService: messageService,
+      );
+    }
+
+    setUp(() {
+      nostrClient = _MockNostrClient();
+      messageService = _MockNIP17MessageService();
+      outgoingDao = _MockOutgoingDmsDao();
+
+      when(() => nostrClient.connectedRelayCount).thenReturn(2);
+      when(() => nostrClient.configuredRelayCount).thenReturn(2);
+      when(() => outgoingDao.enqueue(any())).thenAnswer((_) async {});
+      // The send-policy gate sits immediately AFTER the size guard and also
+      // refuses before enqueuing. Stubbed to refuse so a body that clears the
+      // size guard stops there with a distinguishable result, instead of
+      // running the whole publish path.
+      when(
+        () => messageService.canSendTo(any()),
+      ).thenAnswer((_) async => false);
+    });
+
+    test('refuses a body over the byte limit with a tooLong result', () async {
+      final repository = buildRepository();
+
+      final result = await repository.sendMessage(
+        recipientPubkey: _recipientPubkey,
+        content: 'a' * (maxDmMessageContentBytes + 1),
+      );
+
+      expect(result.success, isFalse);
+      expect(result.tooLong, isTrue);
+      expect(result.blocked, isFalse);
+      expect(result.retryablePending, isFalse);
+    });
+
+    test('leaves no queue row for the retry sweep to re-drive', () async {
+      // The whole point of refusing before the enqueue: a hard-failed row is
+      // re-driven by OutgoingDmRetryService.sweep() on every foreground and
+      // reconnect, and an oversized send fails identically every time, so a
+      // row here would burn the retry budget on work that cannot succeed.
+      final repository = buildRepository();
+
+      final result = await repository.sendMessage(
+        recipientPubkey: _recipientPubkey,
+        content: 'a' * (maxDmMessageContentBytes + 1),
+      );
+
+      expect(result.queuedRumorId, isNull);
+      verifyNever(() => outgoingDao.enqueue(any()));
+    });
+
+    test('never reaches the signer or the wrap build', () async {
+      final repository = buildRepository();
+
+      final result = await repository.sendMessage(
+        recipientPubkey: _recipientPubkey,
+        content: 'a' * (maxDmMessageContentBytes + 1),
+      );
+      expect(result.tooLong, isTrue);
+
+      verifyNever(
+        () => messageService.sendRumor(
+          rumorEvent: any(named: 'rumorEvent'),
+          recipientPubkey: any(named: 'recipientPubkey'),
+          targetRelays: any(named: 'targetRelays'),
+          selfWrapTargetRelays: any(named: 'selfWrapTargetRelays'),
+          awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          recipientWrapBuildTimeout: any(named: 'recipientWrapBuildTimeout'),
+          selfWrapBuildTimeout: any(named: 'selfWrapBuildTimeout'),
+        ),
+      );
+    });
+
+    test('measures UTF-8 bytes, not characters', () async {
+      // A character count cannot bound this: '€' is one character and three
+      // UTF-8 bytes, so a body well under any sane character limit can still
+      // exceed the byte ceiling the NIP-44 chain actually imposes.
+      final repository = buildRepository();
+      final content = '€' * (maxDmMessageContentBytes ~/ 3 + 1);
+
+      expect(content.length, lessThan(maxDmMessageContentBytes));
+
+      final result = await repository.sendMessage(
+        recipientPubkey: _recipientPubkey,
+        content: content,
+      );
+
+      expect(result.tooLong, isTrue);
+    });
+
+    test('an oversized self-send reports the self-send refusal', () async {
+      // Ordering matters: a note-to-self can never be delivered whatever its
+      // size, so the more fundamental reason is the useful one to surface.
+      final repository = buildRepository();
+
+      final result = await repository.sendMessage(
+        recipientPubkey: _ownerPubkey,
+        content: 'a' * (maxDmMessageContentBytes + 1),
+      );
+
+      expect(result.success, isFalse);
+      expect(result.tooLong, isFalse);
+      expect(result.error, contains('its own sender'));
+    });
+
+    test('admits a body exactly at the byte limit', () async {
+      // Boundary in the other direction — the guard must not be off by one.
+      final repository = buildRepository();
+
+      final result = await repository.sendMessage(
+        recipientPubkey: _recipientPubkey,
+        content: 'a' * maxDmMessageContentBytes,
+      );
+
+      // Stops at the send-policy gate, not the size guard — which is the
+      // proof the size guard admitted it.
+      expect(
+        result.tooLong,
+        isFalse,
+        reason: 'a body exactly at the limit must pass the size guard',
+      );
+      expect(result.blocked, isTrue);
+    });
+  });
+}

--- a/mobile/packages/dm_repository/test/src/dm_message_size_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_message_size_test.dart
@@ -1,14 +1,16 @@
-// ABOUTME: Guards the pre-enqueue size refusal on DmRepository.sendMessage
+// ABOUTME: Guards the pre-enqueue size refusal on DmRepository's send paths
 // ABOUTME: (#7331): NIP-44's u16 length prefix caps what the NIP-17 double
 // ABOUTME: encryption can carry, and the throw is deterministic, so an
-// ABOUTME: oversized body must be refused BEFORE a retry-swept row exists.
+// ABOUTME: oversized rumor must be refused BEFORE a retry-swept row exists.
 
 import 'package:db_client/db_client.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' show NIP17SendResult;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
@@ -68,13 +70,58 @@ void main() {
       when(() => nostrClient.connectedRelayCount).thenReturn(2);
       when(() => nostrClient.configuredRelayCount).thenReturn(2);
       when(() => outgoingDao.enqueue(any())).thenAnswer((_) async {});
-      // The send-policy gate sits immediately AFTER the size guard and also
-      // refuses before enqueuing. Stubbed to refuse so a body that clears the
-      // size guard stops there with a distinguishable result, instead of
-      // running the whole publish path.
+      // The size guard runs after the send-policy gate and after the rumor is
+      // built, but still before the enqueue — so the policy gate must permit
+      // the send for the size check to be reached at all.
+      when(() => messageService.canSendTo(any())).thenAnswer((_) async => true);
+      // Admitted sends run on to the publish; stubbed to a plain failure so
+      // the test asserts on the guard's decision, not on delivery.
       when(
-        () => messageService.canSendTo(any()),
-      ).thenAnswer((_) async => false);
+        () => messageService.sendRumor(
+          rumorEvent: any(named: 'rumorEvent'),
+          recipientPubkey: any(named: 'recipientPubkey'),
+          targetRelays: any(named: 'targetRelays'),
+          selfWrapTargetRelays: any(named: 'selfWrapTargetRelays'),
+          awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          selfWrapOnSoftUnconfirmed: any(named: 'selfWrapOnSoftUnconfirmed'),
+        ),
+      ).thenAnswer((_) async => const NIP17SendResult.failure('stubbed'));
+      when(
+        () => messageService.buildRumor(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          eventKind: any(named: 'eventKind'),
+          additionalTags: any(named: 'additionalTags'),
+          createdAt: any(named: 'createdAt'),
+        ),
+      ).thenAnswer((invocation) {
+        final content = invocation.namedArguments[#content] as String;
+        final tags =
+            (invocation.namedArguments[#additionalTags]
+                        as List<List<String>>? ??
+                    const <List<String>>[])
+                .toList();
+        return Event(_ownerPubkey, EventKind.privateDirectMessage, [
+          ['p', _recipientPubkey],
+          ...tags,
+        ], content);
+      });
+      when(
+        () => messageService.buildGroupRumor(
+          recipientPubkeys: any(named: 'recipientPubkeys'),
+          content: any(named: 'content'),
+          eventKind: any(named: 'eventKind'),
+          additionalTags: any(named: 'additionalTags'),
+          createdAt: any(named: 'createdAt'),
+        ),
+      ).thenAnswer((invocation) {
+        final content = invocation.namedArguments[#content] as String;
+        final recipients =
+            invocation.namedArguments[#recipientPubkeys] as List<String>;
+        return Event(_ownerPubkey, EventKind.privateDirectMessage, [
+          for (final r in recipients) ['p', r],
+        ], content);
+      });
     });
 
     test('refuses a body over the byte limit with a tooLong result', () async {
@@ -82,7 +129,7 @@ void main() {
 
       final result = await repository.sendMessage(
         recipientPubkey: _recipientPubkey,
-        content: 'a' * (maxDmMessageContentBytes + 1),
+        content: 'a' * (maxDmRumorBytes + 1),
       );
 
       expect(result.success, isFalse);
@@ -100,7 +147,7 @@ void main() {
 
       final result = await repository.sendMessage(
         recipientPubkey: _recipientPubkey,
-        content: 'a' * (maxDmMessageContentBytes + 1),
+        content: 'a' * (maxDmRumorBytes + 1),
       );
 
       expect(result.queuedRumorId, isNull);
@@ -112,7 +159,7 @@ void main() {
 
       final result = await repository.sendMessage(
         recipientPubkey: _recipientPubkey,
-        content: 'a' * (maxDmMessageContentBytes + 1),
+        content: 'a' * (maxDmRumorBytes + 1),
       );
       expect(result.tooLong, isTrue);
 
@@ -123,8 +170,7 @@ void main() {
           targetRelays: any(named: 'targetRelays'),
           selfWrapTargetRelays: any(named: 'selfWrapTargetRelays'),
           awaitRecipientOk: any(named: 'awaitRecipientOk'),
-          recipientWrapBuildTimeout: any(named: 'recipientWrapBuildTimeout'),
-          selfWrapBuildTimeout: any(named: 'selfWrapBuildTimeout'),
+          selfWrapOnSoftUnconfirmed: any(named: 'selfWrapOnSoftUnconfirmed'),
         ),
       );
     });
@@ -134,9 +180,9 @@ void main() {
       // UTF-8 bytes, so a body well under any sane character limit can still
       // exceed the byte ceiling the NIP-44 chain actually imposes.
       final repository = buildRepository();
-      final content = '€' * (maxDmMessageContentBytes ~/ 3 + 1);
+      final content = '€' * (maxDmRumorBytes ~/ 3 + 1);
 
-      expect(content.length, lessThan(maxDmMessageContentBytes));
+      expect(content.length, lessThan(maxDmRumorBytes));
 
       final result = await repository.sendMessage(
         recipientPubkey: _recipientPubkey,
@@ -155,7 +201,7 @@ void main() {
 
       final results = await repository.sendGroupMessage(
         recipientPubkeys: recipients,
-        content: 'a' * (maxDmMessageContentBytes + 1),
+        content: 'a' * (maxDmRumorBytes + 1),
       );
 
       expect(results, hasLength(recipients.length));
@@ -170,7 +216,7 @@ void main() {
 
       final result = await repository.sendMessage(
         recipientPubkey: _ownerPubkey,
-        content: 'a' * (maxDmMessageContentBytes + 1),
+        content: 'a' * (maxDmRumorBytes + 1),
       );
 
       expect(result.success, isFalse);
@@ -178,23 +224,33 @@ void main() {
       expect(result.error, contains('its own sender'));
     });
 
-    test('admits a body exactly at the byte limit', () async {
-      // Boundary in the other direction — the guard must not be off by one.
+    test('admits an ordinary body', () async {
+      // Boundary in the other direction: the guard must not refuse a normal
+      // message. The exact ceiling is pinned against the real crypto in
+      // dm_message_size_crypto_invariant_test.dart.
       final repository = buildRepository();
 
       final result = await repository.sendMessage(
         recipientPubkey: _recipientPubkey,
-        content: 'a' * maxDmMessageContentBytes,
+        content: 'a' * 1000,
       );
 
-      // Stops at the send-policy gate, not the size guard — which is the
-      // proof the size guard admitted it.
       expect(
         result.tooLong,
         isFalse,
-        reason: 'a body exactly at the limit must pass the size guard',
+        reason: 'an ordinary body must pass the size guard',
       );
-      expect(result.blocked, isTrue);
+      // Reaching the wrap build is the proof the guard admitted it.
+      verify(
+        () => messageService.sendRumor(
+          rumorEvent: any(named: 'rumorEvent'),
+          recipientPubkey: any(named: 'recipientPubkey'),
+          targetRelays: any(named: 'targetRelays'),
+          selfWrapTargetRelays: any(named: 'selfWrapTargetRelays'),
+          awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          selfWrapOnSoftUnconfirmed: any(named: 'selfWrapOnSoftUnconfirmed'),
+        ),
+      ).called(1);
     });
   });
 }

--- a/mobile/packages/models/lib/src/nip17_send_result.dart
+++ b/mobile/packages/models/lib/src/nip17_send_result.dart
@@ -84,13 +84,13 @@ sealed class NIP17SendResult {
   const factory NIP17SendResult.blocked(String error) =
       NIP17SendFailure.blocked;
 
-  /// Build an oversized-message result (#7331): the body is larger than the
-  /// NIP-44 double-encryption chain can carry, so no wrap could be built.
+  /// Build an oversized-message result (#7331): the rumor serializes to more
+  /// than the NIP-44 double encryption can carry, so no wrap could be built.
   ///
-  /// Like [blocked] this must NOT be retried and leaves no queue row — the
-  /// size is a property of the message, so every retry fails identically. It
-  /// is distinct from [blocked] because the user can act on it by shortening
-  /// the message, which needs its own copy.
+  /// The size is a property of the rumor — its tags as much as its body — so
+  /// every retry fails identically. Like [blocked] it must NOT be retried and
+  /// leaves no queue row, and it is distinct from [blocked] because the user
+  /// can act on it by shortening the message, which needs its own copy.
   const factory NIP17SendResult.tooLong(String error) =
       NIP17SendFailure.tooLong;
 
@@ -103,7 +103,7 @@ sealed class NIP17SendResult {
   bool get blocked => false;
 
   /// Whether this failure is an oversized message (#7331), refused before any
-  /// wrap was built. Not retriable — the size is a property of the message, so
+  /// wrap was built. Not retriable — the size is a property of the rumor, so
   /// every retry fails identically. Always `false` for success.
   bool get tooLong => false;
 

--- a/mobile/packages/models/lib/src/nip17_send_result.dart
+++ b/mobile/packages/models/lib/src/nip17_send_result.dart
@@ -84,6 +84,16 @@ sealed class NIP17SendResult {
   const factory NIP17SendResult.blocked(String error) =
       NIP17SendFailure.blocked;
 
+  /// Build an oversized-message result (#7331): the body is larger than the
+  /// NIP-44 double-encryption chain can carry, so no wrap could be built.
+  ///
+  /// Like [blocked] this must NOT be retried and leaves no queue row — the
+  /// size is a property of the message, so every retry fails identically. It
+  /// is distinct from [blocked] because the user can act on it by shortening
+  /// the message, which needs its own copy.
+  const factory NIP17SendResult.tooLong(String error) =
+      NIP17SendFailure.tooLong;
+
   /// Whether the recipient gift wrap (kind 1059, encrypted to the
   /// recipient) reached at least one relay. The headline send status.
   bool get success => this is NIP17SendSuccess;
@@ -91,6 +101,11 @@ sealed class NIP17SendResult {
   /// Whether this failure is a policy block (#176), not a transient/network
   /// error. Blocked sends are not retriable. Always `false` for success.
   bool get blocked => false;
+
+  /// Whether this failure is an oversized message (#7331), refused before any
+  /// wrap was built. Not retriable — the size is a property of the message, so
+  /// every retry fails identically. Always `false` for success.
+  bool get tooLong => false;
 
   /// Whether a failure should stay in a pending, sweep-retryable state instead
   /// of being marked failed. Covers inconclusive recipient publishes
@@ -223,7 +238,8 @@ final class NIP17SendFailure extends NIP17SendResult {
     this.error, {
     this.retryablePending = false,
     this.queuedRumorId,
-  }) : blocked = false;
+  }) : blocked = false,
+       tooLong = false;
 
   /// A policy block (#176): same non-delivery as a failure, but not retriable.
   ///
@@ -231,6 +247,19 @@ final class NIP17SendFailure extends NIP17SendResult {
   /// enqueue, so a block leaves no row behind to coalesce onto.
   const NIP17SendFailure.blocked(this.error)
     : blocked = true,
+      tooLong = false,
+      retryablePending = false,
+      queuedRumorId = null;
+
+  /// An oversized message (#7331): refused before any wrap build.
+  ///
+  /// Never carries a [queuedRumorId] — the size check runs before the enqueue,
+  /// deliberately. A hard-failed row IS re-driven by
+  /// `OutgoingDmRetryService.sweep()`, so leaving a row behind would spend the
+  /// whole retry budget re-running a crypto chain that cannot succeed.
+  const NIP17SendFailure.tooLong(this.error)
+    : blocked = false,
+      tooLong = true,
       retryablePending = false,
       queuedRumorId = null;
 
@@ -239,6 +268,9 @@ final class NIP17SendFailure extends NIP17SendResult {
 
   @override
   final bool blocked;
+
+  @override
+  final bool tooLong;
 
   @override
   final bool retryablePending;
@@ -267,17 +299,19 @@ final class NIP17SendFailure extends NIP17SendResult {
     return other is NIP17SendFailure &&
         other.error == error &&
         other.blocked == blocked &&
+        other.tooLong == tooLong &&
         other.retryablePending == retryablePending &&
         other.queuedRumorId == queuedRumorId;
   }
 
   @override
   int get hashCode =>
-      Object.hash(error, blocked, retryablePending, queuedRumorId);
+      Object.hash(error, blocked, tooLong, retryablePending, queuedRumorId);
 
   @override
   String toString() =>
       'NIP17SendFailure(error: $error, blocked: $blocked, '
+      'tooLong: $tooLong, '
       'retryablePending: $retryablePending, '
       'queuedRumorId: $queuedRumorId)';
 }

--- a/mobile/packages/models/test/src/nip17_send_result_test.dart
+++ b/mobile/packages/models/test/src/nip17_send_result_test.dart
@@ -357,5 +357,59 @@ void main() {
         expect(failure, isNot(equals(success)));
       });
     });
+
+    group('tooLong factory', () {
+      test('is a non-retriable failure distinct from blocked', () {
+        const result = NIP17SendResult.tooLong('too big');
+
+        expect(result.success, isFalse);
+        expect(result.tooLong, isTrue);
+        expect(result.blocked, isFalse);
+        expect(result.retryablePending, isFalse);
+      });
+
+      test('carries no queue row, so the retry sweep cannot re-drive it', () {
+        // The size check runs before the enqueue on purpose: a hard-failed row
+        // is re-driven by OutgoingDmRetryService.sweep(), and an oversized
+        // send fails identically every time (#7331).
+        const result = NIP17SendResult.tooLong('too big');
+
+        expect(result.queuedRumorId, isNull);
+        expect(result.selfWrapPublished, isNull);
+      });
+
+      test('does not equal a blocked failure carrying the same error', () {
+        const tooLong = NIP17SendResult.tooLong('same');
+        const blocked = NIP17SendResult.blocked('same');
+
+        expect(tooLong, isNot(equals(blocked)));
+        expect(blocked, isNot(equals(tooLong)));
+      });
+
+      test('does not equal a plain failure carrying the same error', () {
+        const tooLong = NIP17SendResult.tooLong('same');
+        const plain = NIP17SendResult.failure('same');
+
+        expect(tooLong, isNot(equals(plain)));
+      });
+
+      test('toString surfaces tooLong so a report is unambiguous', () {
+        const result = NIP17SendResult.tooLong('over the limit');
+
+        expect(result.toString(), contains('tooLong: true'));
+      });
+
+      test('blocked, plain failure and success are never tooLong', () {
+        final success = NIP17SendResult.success(
+          rumorEventId: 'r',
+          messageEventId: 'm',
+          recipientPubkey: 'p',
+        );
+
+        expect(const NIP17SendResult.blocked('x').tooLong, isFalse);
+        expect(const NIP17SendResult.failure('x').tooLong, isFalse);
+        expect(success.tooLong, isFalse);
+      });
+    });
   });
 }

--- a/mobile/packages/nostr_sdk/lib/nip44/nip44_v2.dart
+++ b/mobile/packages/nostr_sdk/lib/nip44/nip44_v2.dart
@@ -78,13 +78,30 @@ class NIP44V2 {
   /// far above anything this app sends and stays safe on low-end devices.
   static const int maxDecryptPlaintextSize = 1024 * 1024;
 
+  /// Largest plaintext expressible with the 2-byte u16 length prefix.
+  ///
+  /// A caller that never produces the extended form — anything encrypting
+  /// once, rather than through NIP-17's two layers — can pass this to
+  /// [decodePayload] to keep its cheap pre-decode rejection tight.
+  static const int maxU16PlaintextSize = 65535;
+
   /// version(1) + nonce(32) + mac(32).
   static const int _payloadOverhead = 65;
 
-  static final int _maxPayloadBytes =
-      _payloadOverhead + 6 + calcPaddedLen(maxDecryptPlaintextSize);
+  /// Raw payload size for [plaintextSize], using the prefix form that size
+  /// actually takes.
+  ///
+  /// The prefix must be chosen by size, not fixed at 6: a bound derived for
+  /// [maxU16PlaintextSize] with a 6-byte prefix is four bytes too generous and
+  /// admits the smallest extended-prefix payload, which is exactly what a
+  /// u16-only caller is trying to exclude.
+  static int _payloadBytesFor(int plaintextSize) =>
+      _payloadOverhead +
+      (plaintextSize >= extendedPrefixThreshold ? 6 : 2) +
+      calcPaddedLen(plaintextSize);
 
-  static final int _maxPayloadChars = ((_maxPayloadBytes + 2) ~/ 3) * 4;
+  static int _payloadCharsFor(int payloadBytes) =>
+      ((payloadBytes + 2) ~/ 3) * 4;
 
   static Uint8List writeU16BE(int num) {
     if (num < 1 || num > 65535) {
@@ -171,8 +188,24 @@ class NIP44V2 {
     return hmac.process(combined);
   }
 
-  static Map<String, Uint8List> decodePayload(String payload) {
-    if (payload.length < 132 || payload.length > _maxPayloadChars) {
+  /// Decodes a NIP-44 v2 payload envelope.
+  ///
+  /// [maxPlaintextSize] bounds what this call will accept, defaulting to
+  /// [maxDecryptPlaintextSize]. The oversize check runs BEFORE base64
+  /// decoding, which NIP-44 asks for explicitly so an oversized payload costs
+  /// a length comparison rather than a decode. A caller that only ever sees
+  /// single-encryption payloads — or that is merely classifying a payload's
+  /// shape rather than decrypting it — should pass [maxU16PlaintextSize] so it
+  /// does not pay for a ceiling it cannot reach.
+  static Map<String, Uint8List> decodePayload(
+    String payload, {
+    int? maxPlaintextSize,
+  }) {
+    final maxPayloadBytes = _payloadBytesFor(
+      maxPlaintextSize ?? maxDecryptPlaintextSize,
+    );
+    final maxPayloadChars = _payloadCharsFor(maxPayloadBytes);
+    if (payload.length < 132 || payload.length > maxPayloadChars) {
       throw Exception('Invalid payload length: ${payload.length}');
     }
     if (payload.startsWith('#')) {
@@ -186,7 +219,7 @@ class NIP44V2 {
       throw Exception('Invalid base64: ${e.toString()}');
     }
 
-    if (data.length < 99 || data.length > _maxPayloadBytes) {
+    if (data.length < 99 || data.length > maxPayloadBytes) {
       throw Exception('Invalid data length: ${data.length}');
     }
 

--- a/mobile/packages/nostr_sdk/lib/nip44/nip44_v2.dart
+++ b/mobile/packages/nostr_sdk/lib/nip44/nip44_v2.dart
@@ -314,9 +314,13 @@ class NIP44V2 {
 
   static Future<String> decrypt(
     String payload,
-    Uint8List conversationKey,
-  ) async {
-    var payloadData = decodePayload(payload);
+    Uint8List conversationKey, {
+    int? maxPlaintextSize,
+  }) async {
+    var payloadData = decodePayload(
+      payload,
+      maxPlaintextSize: maxPlaintextSize,
+    );
     var keys = getMessageKeys(conversationKey, payloadData['nonce']!);
     var calculatedMac = hmacAad(
       keys['hmac_key']!,

--- a/mobile/packages/nostr_sdk/lib/nip44/nip44_v2.dart
+++ b/mobile/packages/nostr_sdk/lib/nip44/nip44_v2.dart
@@ -66,10 +66,32 @@ class NIP44V2 {
     return chunk * ((len - 1) ~/ chunk + 1);
   }
 
+  /// NIP-44's `extended_prefix_threshold`. A plaintext of this length or more
+  /// is prefixed with 6 bytes (two zero bytes + a u32) instead of a u16.
+  static const int extendedPrefixThreshold = 65536;
+
+  /// Largest plaintext accepted when DECRYPTING.
+  ///
+  /// NIP-44 permits 2^32 - 1 but asks implementations to enforce their own
+  /// ceiling and reject oversized payloads before base64 decoding, since
+  /// decryption needs several times the payload in working memory. 1 MiB is
+  /// far above anything this app sends and stays safe on low-end devices.
+  static const int maxDecryptPlaintextSize = 1024 * 1024;
+
+  /// version(1) + nonce(32) + mac(32).
+  static const int _payloadOverhead = 65;
+
+  static final int _maxPayloadBytes =
+      _payloadOverhead + 6 + calcPaddedLen(maxDecryptPlaintextSize);
+
+  static final int _maxPayloadChars = ((_maxPayloadBytes + 2) ~/ 3) * 4;
+
   static Uint8List writeU16BE(int num) {
     if (num < 1 || num > 65535) {
       throw Exception(
-        'Invalid plaintext size: must be between 1 and 65535 bytes',
+        'NIP-44 plaintext of $num bytes does not fit the 2-byte u16 length '
+        'prefix (1..65535); this implementation does not emit the 6-byte '
+        'extended prefix',
       );
     }
     var buffer = ByteData(2);
@@ -77,6 +99,15 @@ class NIP44V2 {
     return buffer.buffer.asUint8List();
   }
 
+  /// Pads [plaintext] using the 2-byte u16 length prefix only.
+  ///
+  /// NIP-44 also defines a 6-byte extended prefix for plaintext at or above
+  /// [extendedPrefixThreshold], and [unpad] reads it — but this side
+  /// deliberately does not emit it. A payload written with the extended
+  /// prefix is undecryptable by any u16-only peer, which today includes the
+  /// Rust `nostr` crate that keycast's server-side NIP-17 wrap/unwrap uses.
+  /// Emitting one would turn a visible send failure into a silent
+  /// non-delivery, and NIP-44 offers no way to detect recipient support.
   static Uint8List pad(String plaintext) {
     var unpadded = utf8.encode(plaintext);
     var unpaddedLen = unpadded.length;
@@ -85,6 +116,14 @@ class NIP44V2 {
     return Uint8List.fromList(prefix + unpadded + suffix);
   }
 
+  /// Reads both NIP-44 length-prefix forms: the 2-byte u16, and the 6-byte
+  /// extended prefix (two zero bytes + u32) for plaintext at or above
+  /// [extendedPrefixThreshold].
+  ///
+  /// A leading u16 of zero signals the extended form; because valid plaintext
+  /// is at least one byte, that value is otherwise invalid. The declared u32
+  /// is then required to be at or above the threshold, so a small length
+  /// written in the 6-byte form is rejected rather than silently accepted.
   static String unpad(Uint8List padded) {
     // Validate the declared length against the buffer BEFORE slicing.
     // A forged payload can declare an unpaddedLen larger than the buffer;
@@ -93,18 +132,33 @@ class NIP44V2 {
     if (padded.length < 2) {
       throw Exception('Invalid padding');
     }
-    var unpaddedLen = ByteData.sublistView(
+    final firstTwo = ByteData.sublistView(
       padded,
       0,
       2,
     ).getUint16(0, Endian.big);
-    if (unpaddedLen < 1 ||
-        unpaddedLen > 65535 ||
-        2 + unpaddedLen > padded.length ||
-        padded.length != 2 + calcPaddedLen(unpaddedLen)) {
+
+    final int unpaddedLen;
+    final int prefixLen;
+    if (firstTwo == 0) {
+      if (padded.length < 6) {
+        throw Exception('Invalid padding');
+      }
+      unpaddedLen = ByteData.sublistView(padded, 2, 6).getUint32(0, Endian.big);
+      if (unpaddedLen < extendedPrefixThreshold) {
+        throw Exception('Invalid padding');
+      }
+      prefixLen = 6;
+    } else {
+      unpaddedLen = firstTwo;
+      prefixLen = 2;
+    }
+
+    if (prefixLen + unpaddedLen > padded.length ||
+        padded.length != prefixLen + calcPaddedLen(unpaddedLen)) {
       throw Exception('Invalid padding');
     }
-    var unpadded = padded.sublist(2, 2 + unpaddedLen);
+    var unpadded = padded.sublist(prefixLen, prefixLen + unpaddedLen);
     return utf8.decode(unpadded);
   }
 
@@ -118,7 +172,7 @@ class NIP44V2 {
   }
 
   static Map<String, Uint8List> decodePayload(String payload) {
-    if (payload.length < 132 || payload.length > 87472) {
+    if (payload.length < 132 || payload.length > _maxPayloadChars) {
       throw Exception('Invalid payload length: ${payload.length}');
     }
     if (payload.startsWith('#')) {
@@ -132,7 +186,7 @@ class NIP44V2 {
       throw Exception('Invalid base64: ${e.toString()}');
     }
 
-    if (data.length < 99 || data.length > 65603) {
+    if (data.length < 99 || data.length > _maxPayloadBytes) {
       throw Exception('Invalid data length: ${data.length}');
     }
 

--- a/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_util.dart
+++ b/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_util.dart
@@ -37,6 +37,17 @@ bool verifyGiftWrapPartJson(Map<String, dynamic> eventJson) {
 /// `getRumorEvent` verifies inline on the calling isolate, unchanged.
 typedef GiftWrapPartVerifier = Future<bool> Function(Event event);
 
+/// Largest plaintext accepted at either NIP-17 decrypt layer.
+///
+/// Divine's production relay advertises a 100 KiB event-content ceiling, so
+/// a 1 MiB NIP-44 plaintext cannot arrive through it. 128 KiB keeps generous
+/// interoperability headroom for other relays while bounding the JSON and DM
+/// body handed to parsing, persistence, and repeated Flutter layout (#7331).
+const int maxNip17ReceivePlaintextBytes = 128 * 1024;
+
+bool _plaintextFits(String plaintext, int maxBytes) =>
+    utf8.encode(plaintext).length <= maxBytes;
+
 /// Rebuilds an unsigned NIP-59 rumor from its plaintext JSON using the
 /// authenticated seal pubkey as author.
 ///
@@ -92,6 +103,7 @@ class GiftWrapUtil {
     Nostr nostr,
     Event e, {
     GiftWrapPartVerifier? verifyPart,
+    int maxPlaintextSize = maxNip17ReceivePlaintextBytes,
   }) async {
     // C16/NIP-44: validate the outer gift wrap (kind 1059) signature before
     // decrypting. Defense-in-depth — Divine relays already verify, but an
@@ -106,6 +118,10 @@ class GiftWrapUtil {
 
     var rumorText = await nostr.nostrSigner.nip44Decrypt(e.pubkey, e.content);
     if (rumorText == null) {
+      return null;
+    }
+    if (!_plaintextFits(rumorText, maxPlaintextSize)) {
+      log('GiftWrap seal plaintext exceeds the receive limit, id: ${e.id}');
       return null;
     }
 
@@ -130,6 +146,10 @@ class GiftWrapUtil {
       rumorEvent.content,
     );
     if (sourceText == null) {
+      return null;
+    }
+    if (!_plaintextFits(sourceText, maxPlaintextSize)) {
+      log('GiftWrap rumor plaintext exceeds the receive limit, id: ${e.id}');
       return null;
     }
 

--- a/mobile/packages/nostr_sdk/test/nip44/nip44_v2_extended_prefix_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip44/nip44_v2_extended_prefix_test.dart
@@ -205,6 +205,19 @@ void main() {
         },
       );
 
+      test('decrypt forwards a caller-supplied plaintext bound', () async {
+        final payload = await _specEncrypt('a' * 65536, convKey, nonce);
+
+        expect(
+          () => NIP44V2.decrypt(
+            payload,
+            convKey,
+            maxPlaintextSize: NIP44V2.maxU16PlaintextSize,
+          ),
+          throwsA(isA<Exception>()),
+        );
+      });
+
       test('rejects a payload above the decrypt ceiling', () {
         final tooLong =
             'A' * (((NIP44V2.maxDecryptPlaintextSize) ~/ 3) * 4 * 2);

--- a/mobile/packages/nostr_sdk/test/nip44/nip44_v2_extended_prefix_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip44/nip44_v2_extended_prefix_test.dart
@@ -1,0 +1,183 @@
+// ABOUTME: Conformance test for NIP-44's 6-byte extended length prefix, which
+// ABOUTME: this implementation reads on decrypt but deliberately never writes.
+//
+// The vectors are the ones published inline in `nips/44.md` ("Extended length
+// prefix test vectors"), not in `nip44.vectors.json` — that fixture predates
+// the extended-prefix prose and still lists 65536 under
+// `invalid.encrypt_msg_lengths`, so its pinned sha256 carries no coverage for
+// this boundary. Checksums below are copied from 44.md.
+//
+// Encryption stays u16-only on purpose: a payload written with the extended
+// prefix cannot be read by any u16-only peer, and that includes the Rust
+// `nostr` crate behind keycast's server-side NIP-17 wrap/unwrap. See #7331.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hex/hex.dart';
+import 'package:nostr_sdk/nip44/nip44_v2.dart';
+
+Uint8List _hexBytes(String hex) => Uint8List.fromList(HEX.decode(hex));
+
+const _conversationKey =
+    'c41c775356fd92eadc63ff5a0dc1da211b268cbea22316767095b2871ea1412d';
+const _nonce =
+    '0000000000000000000000000000000000000000000000000000000000000001';
+
+/// Builds a payload the way a spec-conformant peer would, choosing the prefix
+/// form by length. This mirrors NIP-44's `pad` (44.md) rather than calling
+/// [NIP44V2.pad], which is u16-only by design.
+Uint8List _specPad(String plaintext) {
+  final unpadded = utf8.encode(plaintext);
+  final len = unpadded.length;
+  final List<int> prefix;
+  if (len >= NIP44V2.extendedPrefixThreshold) {
+    final u32 = ByteData(4)..setUint32(0, len, Endian.big);
+    prefix = [0, 0, ...u32.buffer.asUint8List()];
+  } else {
+    final u16 = ByteData(2)..setUint16(0, len, Endian.big);
+    prefix = u16.buffer.asUint8List();
+  }
+  return Uint8List.fromList([
+    ...prefix,
+    ...unpadded,
+    ...Uint8List(NIP44V2.calcPaddedLen(len) - len),
+  ]);
+}
+
+Future<String> _specEncrypt(
+  String plaintext,
+  Uint8List convKey,
+  Uint8List nonce,
+) async {
+  final keys = NIP44V2.getMessageKeys(convKey, nonce);
+  final ciphertext = await NIP44V2.chacha20Encrypt(
+    keys['chacha_key']!,
+    keys['chacha_nonce']!,
+    _specPad(plaintext),
+  );
+  final mac = NIP44V2.hmacAad(keys['hmac_key']!, ciphertext, nonce);
+  return base64Encode(Uint8List.fromList([2, ...nonce, ...ciphertext, ...mac]));
+}
+
+void main() {
+  final convKey = _hexBytes(_conversationKey);
+  final nonce = _hexBytes(_nonce);
+
+  group('NIP44V2 extended length prefix', () {
+    group('unpad', () {
+      // 44.md "Extended length prefix test vectors": plaintext is 'a' repeated.
+      const vectors = <int, ({String plaintextSha, String payloadSha})>{
+        65535: (
+          plaintextSha:
+              '6e1bebca6a8229364a162a72ef064826c4cd7457bf54f190ef782bd9deff3e42',
+          payloadSha:
+              '6d8c2810d1e870fbaa1f0a0937126cca837a15f9260e27060c331d70a3c0bc84',
+        ),
+        65536: (
+          plaintextSha:
+              'bf718b6f653bebc184e1479f1935b8da974d701b893afcf49e701f3e2f9f9c5a',
+          payloadSha:
+              'b7b4edb36ba92e267d322d56d9aebc22e7fa96ff52e3c12adc07f07a43cbc616',
+        ),
+        65537: (
+          plaintextSha:
+              '008ffc88d3c96a9f307524eb361e47c5222a887fc45fa0c1fb8d429c5c23b430',
+          payloadSha:
+              'eeb7c7c5373894ea2c1547cfd3ccb15d5a0b2d619da852e5c79df792dcc9e435',
+        ),
+      };
+
+      for (final entry in vectors.entries) {
+        final length = entry.key;
+        test('decrypts the 44.md boundary vector at $length bytes', () async {
+          final plaintext = 'a' * length;
+          expect(
+            sha256.convert(utf8.encode(plaintext)).toString(),
+            equals(entry.value.plaintextSha),
+            reason: 'plaintext does not match the 44.md checksum',
+          );
+
+          final payload = await _specEncrypt(plaintext, convKey, nonce);
+          expect(
+            sha256.convert(utf8.encode(payload)).toString(),
+            equals(entry.value.payloadSha),
+            reason:
+                'payload does not match the 44.md checksum; the constructed '
+                'payload is not what a conformant peer would send',
+          );
+
+          expect(await NIP44V2.decrypt(payload, convKey), equals(plaintext));
+        });
+      }
+
+      test('rejects a 6-byte prefix declaring a sub-threshold length', () {
+        // A forged payload may use the extended form for a small length. NIP-44
+        // requires the declared u32 to be at or above the threshold, otherwise
+        // the same plaintext has two encodings and the 6-byte form smuggles a
+        // short one past a reader that only bounds the buffer. Verified by
+        // mutation: deleting the threshold check makes this decode to 'hello',
+        // and no other test in the suite catches it — the pinned fixture's
+        // `invalid.decrypt` vector whose plaintext starts with a zero u16 is
+        // rejected by the buffer-length check instead, so it does not cover
+        // this (#7331).
+        final padded = Uint8List.fromList([
+          0, 0, // extended-format signal
+          0, 0, 0, 5, // declared length 5, below the threshold
+          ...utf8.encode('hello'),
+          ...Uint8List(NIP44V2.calcPaddedLen(5) - 5),
+        ]);
+        expect(() => NIP44V2.unpad(padded), throwsA(isA<Exception>()));
+      });
+
+      test('rejects an extended prefix truncated below 6 bytes', () {
+        expect(
+          () => NIP44V2.unpad(Uint8List.fromList([0, 0, 0, 1])),
+          throwsA(isA<Exception>()),
+        );
+      });
+
+      test('still reads the 2-byte u16 prefix', () {
+        final padded = Uint8List.fromList([
+          0,
+          5,
+          ...utf8.encode('hello'),
+          ...Uint8List(NIP44V2.calcPaddedLen(5) - 5),
+        ]);
+        expect(NIP44V2.unpad(padded), equals('hello'));
+      });
+    });
+
+    group('pad', () {
+      test('refuses to emit the extended prefix', () {
+        // Deliberate asymmetry, not an oversight: emitting an extended-prefix
+        // payload would be undecryptable by u16-only peers, converting a
+        // visible send failure into a silent non-delivery (#7331).
+        expect(
+          () => NIP44V2.pad('a' * NIP44V2.extendedPrefixThreshold),
+          throwsA(isA<Exception>()),
+        );
+      });
+
+      test('still pads the largest u16 length', () {
+        final padded = NIP44V2.pad('a' * 65535);
+        expect(padded.length, equals(2 + NIP44V2.calcPaddedLen(65535)));
+      });
+    });
+
+    group('decodePayload', () {
+      test('accepts a payload carrying an extended-prefix plaintext', () async {
+        final payload = await _specEncrypt('a' * 65536, convKey, nonce);
+        expect(NIP44V2.decodePayload(payload), isNotEmpty);
+      });
+
+      test('rejects a payload above the decrypt ceiling', () {
+        final tooLong =
+            'A' * (((NIP44V2.maxDecryptPlaintextSize) ~/ 3) * 4 * 2);
+        expect(() => NIP44V2.decodePayload(tooLong), throwsA(isA<Exception>()));
+      });
+    });
+  });
+}

--- a/mobile/packages/nostr_sdk/test/nip44/nip44_v2_extended_prefix_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip44/nip44_v2_extended_prefix_test.dart
@@ -173,6 +173,38 @@ void main() {
         expect(NIP44V2.decodePayload(payload), isNotEmpty);
       });
 
+      test('a caller-supplied bound rejects before base64 decoding', () {
+        // A classifier that only ever sees single-encryption payloads should
+        // not pay for the 1 MiB decrypt ceiling. Passing maxU16PlaintextSize
+        // restores the cheap pre-decode rejection (#7331).
+        final oversizedForU16 = 'A' * 90000;
+
+        expect(
+          () => NIP44V2.decodePayload(
+            oversizedForU16,
+            maxPlaintextSize: NIP44V2.maxU16PlaintextSize,
+          ),
+          throwsA(isA<Exception>()),
+        );
+      });
+
+      test(
+        'the default bound still admits an extended-prefix payload',
+        () async {
+          final payload = await _specEncrypt('a' * 65536, convKey, nonce);
+
+          expect(NIP44V2.decodePayload(payload), isNotEmpty);
+          expect(
+            () => NIP44V2.decodePayload(
+              payload,
+              maxPlaintextSize: NIP44V2.maxU16PlaintextSize,
+            ),
+            throwsA(isA<Exception>()),
+            reason: 'a u16-bounded caller must not accept an extended payload',
+          );
+        },
+      );
+
       test('rejects a payload above the decrypt ceiling', () {
         final tooLong =
             'A' * (((NIP44V2.maxDecryptPlaintextSize) ~/ 3) * 4 * 2);

--- a/mobile/packages/nostr_sdk/test/nip59/gift_wrap_util_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip59/gift_wrap_util_test.dart
@@ -46,6 +46,41 @@ class _RefusesToSignSigner implements NostrSigner {
   void close() => _delegate.close();
 }
 
+class _ScriptedDecryptSigner implements NostrSigner {
+  _ScriptedDecryptSigner(this._delegate, this._plaintexts);
+
+  final LocalNostrSigner _delegate;
+  final List<String> _plaintexts;
+
+  @override
+  Future<Event?> signEvent(Event event) => _delegate.signEvent(event);
+
+  @override
+  Future<String?> getPublicKey() => _delegate.getPublicKey();
+
+  @override
+  Future<Map<dynamic, dynamic>?> getRelays() => _delegate.getRelays();
+
+  @override
+  Future<String?> encrypt(String pubkey, String plaintext) =>
+      _delegate.encrypt(pubkey, plaintext);
+
+  @override
+  Future<String?> decrypt(String pubkey, String ciphertext) =>
+      _delegate.decrypt(pubkey, ciphertext);
+
+  @override
+  Future<String?> nip44Encrypt(String pubkey, String plaintext) =>
+      _delegate.nip44Encrypt(pubkey, plaintext);
+
+  @override
+  Future<String?> nip44Decrypt(String pubkey, String ciphertext) async =>
+      _plaintexts.removeAt(0);
+
+  @override
+  void close() => _delegate.close();
+}
+
 void main() {
   Relay dummyRelay(String url) => RelayBase(url, RelayStatus(url));
 
@@ -163,6 +198,52 @@ void main() {
       expect(rumor, isNotNull);
       expect(rumor!.content, equals('secret message'));
       expect(rumor.pubkey, equals(senderPubkey));
+    });
+
+    test(
+      'rejects oversized remote-signer plaintext before JSON parsing',
+      () async {
+        final delegate = LocalNostrSigner(recipientPrivateKey);
+        final scriptedNostr = Nostr(
+          _ScriptedDecryptSigner(delegate, [
+            'x' * (maxNip17ReceivePlaintextBytes + 1),
+          ]),
+          const [],
+          dummyRelay,
+        );
+
+        final rumor = await GiftWrapUtil.getRumorEvent(
+          scriptedNostr,
+          await validWrap(),
+        );
+
+        expect(rumor, isNull);
+      },
+    );
+
+    test('rejects oversized remote-signer rumor before JSON parsing', () async {
+      final seal = Event(
+        senderPubkey,
+        EventKind.sealEventKind,
+        const <List<String>>[],
+        'scripted ciphertext',
+      )..sign(senderPrivateKey);
+      final delegate = LocalNostrSigner(recipientPrivateKey);
+      final scriptedNostr = Nostr(
+        _ScriptedDecryptSigner(delegate, [
+          jsonEncode(seal.toJson()),
+          'x' * (maxNip17ReceivePlaintextBytes + 1),
+        ]),
+        const [],
+        dummyRelay,
+      );
+
+      final rumor = await GiftWrapUtil.getRumorEvent(
+        scriptedNostr,
+        await validWrap(),
+      );
+
+      expect(rumor, isNull);
     });
 
     test(

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -415,6 +415,44 @@ void main() {
         );
 
         blocTest<ConversationBloc, ConversationState>(
+          'emits [sending, tooLong] on an oversized rumor, never failed (#7331)',
+          setUp: () {
+            when(
+              () => mockDmRepository.sendMessage(
+                recipientPubkey: recipientPubkey,
+                content: 'Hello',
+              ),
+            ).thenAnswer(
+              (_) async => const NIP17SendResult.tooLong(
+                'message is too large to send',
+              ),
+            );
+          },
+          build: buildBloc,
+          act: (bloc) => bloc.add(
+            const ConversationMessageSent(
+              recipientPubkeys: [recipientPubkey],
+              content: 'Hello',
+            ),
+          ),
+          expect: () => [
+            isA<ConversationState>().having(
+              (s) => s.sendStatus,
+              'sendStatus',
+              SendStatus.sending,
+            ),
+            // Must NOT be `failed`: that status relies on the queue row's red
+            // "Not delivered" bubble as its only visual affordance, and an
+            // oversized send is refused before the enqueue so no row exists.
+            isA<ConversationState>().having(
+              (s) => s.sendStatus,
+              'sendStatus',
+              SendStatus.tooLong,
+            ),
+          ],
+        );
+
+        blocTest<ConversationBloc, ConversationState>(
           'emits [sending, blocked] with no retry payload on a policy-blocked send (#176)',
           setUp: () {
             when(

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -608,6 +608,43 @@ void main() {
           errors: () => [isA<Exception>()],
         );
 
+        blocTest<ConversationBloc, ConversationState>(
+          'emits [sending, tooLong] when every group recipient refuses the '
+          'oversized rumor (#7331)',
+          setUp: () {
+            when(
+              () => mockDmRepository.sendGroupMessage(
+                recipientPubkeys: [recipientPubkey, recipientPubkey2],
+                content: 'Group hello',
+              ),
+            ).thenAnswer(
+              (_) async => const [
+                NIP17SendResult.tooLong('message is too large to send'),
+                NIP17SendResult.tooLong('message is too large to send'),
+              ],
+            );
+          },
+          build: buildBloc,
+          act: (bloc) => bloc.add(
+            const ConversationMessageSent(
+              recipientPubkeys: [recipientPubkey, recipientPubkey2],
+              content: 'Group hello',
+            ),
+          ),
+          expect: () => [
+            isA<ConversationState>().having(
+              (s) => s.sendStatus,
+              'sendStatus',
+              SendStatus.sending,
+            ),
+            isA<ConversationState>().having(
+              (s) => s.sendStatus,
+              'sendStatus',
+              SendStatus.tooLong,
+            ),
+          ],
+        );
+
         late StreamController<List<DmMessage>> failMsgCtrl;
         late StreamController<List<OutgoingDm>> failOutCtrl;
         blocTest<ConversationBloc, ConversationState>(

--- a/mobile/test/blocs/dm/inline_reel_reply/inline_reel_reply_cubit_test.dart
+++ b/mobile/test/blocs/dm/inline_reel_reply/inline_reel_reply_cubit_test.dart
@@ -311,6 +311,30 @@ void main() {
     );
 
     blocTest<InlineReelReplyCubit, InlineReelReplyState>(
+      'oversized reply is terminal and does not offer a retry',
+      build: () {
+        when(
+          () => repo.sendMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: any(named: 'content'),
+            replyToId: any(named: 'replyToId'),
+          ),
+        ).thenAnswer(
+          (_) async => const NIP17SendResult.tooLong('reply is too large'),
+        );
+        return InlineReelReplyCubit(
+          dmRepository: repo,
+          replyContext: oneToOne(),
+        );
+      },
+      act: (cubit) => cubit.submit('hi'),
+      expect: () => const [
+        InlineReelReplyState(status: InlineReelReplyStatus.sending),
+        InlineReelReplyState(status: InlineReelReplyStatus.tooLong),
+      ],
+    );
+
+    blocTest<InlineReelReplyCubit, InlineReelReplyState>(
       'StateError from send is Reportable',
       build: () {
         when(

--- a/mobile/test/blocs/report/report_submission_cubit_test.dart
+++ b/mobile/test/blocs/report/report_submission_cubit_test.dart
@@ -339,6 +339,44 @@ void main() {
       );
     });
 
+    test('does not retry an oversized moderation DM on resubmit', () async {
+      when(
+        () => dmRepository.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          replyToId: any(named: 'replyToId'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          additionalTags: any(named: 'additionalTags'),
+        ),
+      ).thenAnswer(
+        (_) async =>
+            const NIP17SendResult.tooLong('moderation DM is too large'),
+      );
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      await submit(cubit);
+      await submit(cubit);
+
+      expect(cubit.state.moderationDmFailed, isTrue);
+      expect(cubit.state.moderationDm.outcome, ModerationDmOutcome.tooLong);
+      verify(
+        () => dmRepository.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          replyToId: any(named: 'replyToId'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          additionalTags: any(named: 'additionalTags'),
+        ),
+      ).called(1);
+      verifyNever(
+        () => dmRepository.recoverFullSend(
+          rumorId: any(named: 'rumorId'),
+          resetRetryBudget: any(named: 'resetRetryBudget'),
+        ),
+      );
+    });
+
     test('re-drives the parked row rather than minting a second DM', () async {
       when(
         () => dmRepository.sendMessage(

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -437,6 +437,10 @@ const _knownUntranslatedDebt = <String>{
   // actions sheet, and manage-posts mode. Deferred to the next human
   // translation pass; the list-follow verb needs per-locale judgment
   // (person-follow vs list-subscribe differ in several locales).
+  // DM size-refusal copy (#7331). Deferred to the next human translation pass
+  // alongside listPrivateFull: both name a size limit the user can act on, and
+  // several locales want the same verb for "shorten" in each.
+  'dmSendTooLongMessage',
   // Private-list size ceiling (#7331). Deferred to the next human translation
   // pass: "full" here means an encryption size limit rather than a item-count
   // limit, and several locales need a different noun for that distinction.

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -437,6 +437,10 @@ const _knownUntranslatedDebt = <String>{
   // actions sheet, and manage-posts mode. Deferred to the next human
   // translation pass; the list-follow verb needs per-locale judgment
   // (person-follow vs list-subscribe differ in several locales).
+  // Private-list size ceiling (#7331). Deferred to the next human translation
+  // pass: "full" here means an encryption size limit rather than a item-count
+  // limit, and several locales need a different noun for that distinction.
+  'listPrivateFull',
   'listEditInfoAction',
   'listManageVideosAction',
   'listFollowButton',

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -1924,6 +1924,27 @@ void main() {
         expect(find.text(l10n.dmSendNoRecipientMessage), findsOneWidget);
       });
 
+      // #7331. Same shape as the no-recipient case above: an oversized rumor
+      // is refused before the enqueue, so no queue row and no red bubble ever
+      // exist. Verified on device — without this the message vanished with no
+      // feedback at all.
+      testWidgets('shows a toast when the message was too long', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildSubject(
+            previousState: const ConversationState(),
+            state: const ConversationState(sendStatus: SendStatus.tooLong),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text(l10n.dmSendTooLongMessage), findsOneWidget);
+        // Not the generic failure copy: retrying an oversized message cannot
+        // succeed, so the user needs the reason, not a retry prompt.
+        expect(find.text(l10n.dmSendFailedMessage), findsNothing);
+      });
+
       // #8461. A resend that fails again is the one failure the red bubble
       // cannot express: the bubble was ALREADY red when the user tapped it,
       // so re-raising `failed` leaves the before and after states identical

--- a/mobile/test/screens/inbox/conversation/widgets/message_input_bar_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_input_bar_test.dart
@@ -395,6 +395,69 @@ void main() {
       });
     });
 
+    group('external controller', () {
+      testWidgets('uses a caller-provided controller and does not dispose it', (
+        tester,
+      ) async {
+        // The bar clears itself the moment onSend fires, before the outcome is
+        // known. A caller that learns the send was refused restores the draft
+        // through this controller, so the bar must neither own nor dispose it
+        // (#7331).
+        final controller = TextEditingController();
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: MessageInputBar(onSend: (_) {}, controller: controller),
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField), 'draft');
+        await tester.pump();
+        expect(controller.text, equals('draft'));
+
+        // Replace the bar with something else; the controller must survive.
+        await tester.pumpWidget(
+          const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: SizedBox.shrink()),
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          () => controller.text,
+          returnsNormally,
+          reason: 'the bar must not dispose a controller it does not own',
+        );
+      });
+
+      testWidgets('a restored draft reappears in the field', (tester) async {
+        final controller = TextEditingController();
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: MessageInputBar(onSend: (_) {}, controller: controller),
+            ),
+          ),
+        );
+
+        controller.text = 'restored after refusal';
+        await tester.pump();
+
+        expect(find.text('restored after refusal'), findsOneWidget);
+      });
+    });
+
     group('length limit', () {
       Future<void> pumpBar(WidgetTester tester) => tester.pumpWidget(
         MaterialApp(

--- a/mobile/test/screens/inbox/conversation/widgets/message_input_bar_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_input_bar_test.dart
@@ -394,5 +394,79 @@ void main() {
         ]);
       });
     });
+
+    group('length limit', () {
+      Future<void> pumpBar(WidgetTester tester) => tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: MessageInputBar(onSend: (_) {})),
+        ),
+      );
+
+      testWidgets('truncates a paste longer than the limit', (tester) async {
+        await pumpBar(tester);
+
+        await tester.enterText(
+          find.byType(TextField),
+          'a' * (dmComposerMaxCharacters + 500),
+        );
+        await tester.pump();
+
+        final field = tester.widget<TextField>(find.byType(TextField));
+        expect(field.controller!.text.length, equals(dmComposerMaxCharacters));
+      });
+
+      testWidgets('hides the counter well below the limit', (tester) async {
+        await pumpBar(tester);
+
+        await tester.enterText(find.byType(TextField), 'hello');
+        await tester.pump();
+
+        // Anything left over the threshold is noise in a chat composer.
+        const remaining = dmComposerMaxCharacters - 5;
+        expect(find.text('$remaining'), findsNothing);
+      });
+
+      testWidgets('shows the remaining count near the limit', (tester) async {
+        await pumpBar(tester);
+
+        const typed = dmComposerMaxCharacters - dmComposerCounterThreshold + 1;
+        await tester.enterText(find.byType(TextField), 'a' * typed);
+        await tester.pump();
+
+        expect(
+          find.text('${dmComposerMaxCharacters - typed}'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('sends the truncated text, never the full paste', (
+        tester,
+      ) async {
+        String? sentText;
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: MessageInputBar(onSend: (text) => sentText = text),
+            ),
+          ),
+        );
+
+        await tester.enterText(
+          find.byType(TextField),
+          'b' * (dmComposerMaxCharacters * 2),
+        );
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(findSendButton(l10n));
+        await tester.pump();
+
+        expect(sentText!.length, equals(dmComposerMaxCharacters));
+      });
+    });
   });
 }

--- a/mobile/test/widgets/add_to_list_dialog_test.dart
+++ b/mobile/test/widgets/add_to_list_dialog_test.dart
@@ -227,7 +227,12 @@ void main() {
           pubkey:
               'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
           name: 'My List',
-          videoEventIds: const [],
+          isPublic: false,
+          // Enough references that one more cannot fit in a single NIP-44
+          // plaintext, so the converter's real arithmetic decides.
+          videoEventIds: [
+            for (var i = 0; i < 1000; i++) i.toString().padLeft(64, '0'),
+          ],
           createdAt: DateTime.now(),
           updatedAt: DateTime.now(),
         ),
@@ -236,9 +241,6 @@ void main() {
       when(
         () => mockListService.addVideoToList(any(), any()),
       ).thenAnswer((_) async => false);
-      when(
-        () => mockListService.wouldExceedPrivateItemLimit(any(), any()),
-      ).thenReturn(true);
 
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
@@ -271,9 +273,6 @@ void main() {
       when(
         () => mockListService.addVideoToList(any(), any()),
       ).thenAnswer((_) async => false);
-      when(
-        () => mockListService.wouldExceedPrivateItemLimit(any(), any()),
-      ).thenReturn(false);
 
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();

--- a/mobile/test/widgets/add_to_list_dialog_test.dart
+++ b/mobile/test/widgets/add_to_list_dialog_test.dart
@@ -214,6 +214,77 @@ void main() {
       expect(find.text('Removed from My List'), findsOneWidget);
     });
 
+    testWidgets('a failed add on a full private list explains why', (
+      tester,
+    ) async {
+      // Before #7331 a failed toggle rendered nothing at all, so a private
+      // list at the NIP-44 size ceiling swallowed every add silently.
+      const listId =
+          'list0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+      _fakeLists = [
+        CuratedList(
+          id: listId,
+          pubkey:
+              'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+          name: 'My List',
+          videoEventIds: const [],
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+      ];
+
+      when(
+        () => mockListService.addVideoToList(any(), any()),
+      ).thenAnswer((_) async => false);
+      when(
+        () => mockListService.wouldExceedPrivateItemLimit(any(), any()),
+      ).thenReturn(true);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('My List'));
+      await tester.pumpAndSettle();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.listPrivateFull), findsOneWidget);
+      // Retrying cannot succeed, so the generic "try again" copy is wrong here.
+      expect(find.text(l10n.listUpdateFailed), findsNothing);
+    });
+
+    testWidgets('a failed add for any other reason stays generic', (
+      tester,
+    ) async {
+      const listId =
+          'list0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+      _fakeLists = [
+        CuratedList(
+          id: listId,
+          pubkey:
+              'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+          name: 'My List',
+          videoEventIds: const [],
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+      ];
+
+      when(
+        () => mockListService.addVideoToList(any(), any()),
+      ).thenAnswer((_) async => false);
+      when(
+        () => mockListService.wouldExceedPrivateItemLimit(any(), any()),
+      ).thenReturn(false);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('My List'));
+      await tester.pumpAndSettle();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.listUpdateFailed), findsOneWidget);
+      expect(find.text(l10n.listPrivateFull), findsNothing);
+    });
+
     testWidgets('renders Done button', (tester) async {
       _fakeLists = [];
 

--- a/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
@@ -534,6 +534,32 @@ void main() {
       ).called(1);
     });
 
+    testWidgets('oversized reply restores the draft without a retry action', (
+      tester,
+    ) async {
+      when(
+        () => dmRepo.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          replyToId: any(named: 'replyToId'),
+        ),
+      ).thenAnswer(
+        (_) async => const NIP17SendResult.tooLong('reply is too large'),
+      );
+
+      await tester.pumpWidget(wrap(context()));
+      await tester.pump();
+      await tester.enterText(find.byType(TextField), 'keep this draft');
+      await tester.pump();
+      await tester.tap(find.byType(IconButton));
+      await tester.pumpAndSettle();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.dmSendTooLongMessage), findsOneWidget);
+      expect(find.text(l10n.dmSendFailedRetry), findsNothing);
+      expect(find.text('keep this draft'), findsOneWidget);
+    });
+
     // #7316. The retry action must re-drive the row the failed send parked. A
     // second `sendMessage` would mint a fresh rumor for the same text, and since
     // the receiver's only stable dedup key is the rumor id — gift-wrap ids are


### PR DESCRIPTION
## Description

`#7331` reports that our NIP-44 v2 implementation supports only the 2-byte `u16` length prefix, so a DM above roughly 40 KB can never be sent. I reproduced it, and the issue is correct — but two findings changed what the right fix is.

**Reproduced, not derived.** The issue derived its 40,682 / 40,683 boundary arithmetically and said so. I measured it by binary-searching the real production wrap builder (`buildGiftWrapFromHex`): the largest sendable body is exactly **40,682 bytes**, 40,683 fails, and nothing larger fits. The issue's number is right.

**Finding 1 — implementing extended-prefix *send* would make things worse.** keycast pins Rust `nostr` 0.44.2, whose `pad()` rejects `len > 65408` and whose decrypt reads a bare `u16` with hard-coded `2 +` offsets (`src/nips/nip44/v2.rs:269,275,307,313`). It cannot decrypt an extended-prefix payload at all — and per the issue's own device census it is the shipped unwrapper for Keycast OAuth identities (11 `nip17_unwrap_batch` calls, 0 `nip44_decrypt`). NIP-44 has no capability negotiation, so emitting one is unconditionally a gamble. Shipping the "obvious" fix would convert today's **visible** failure into a **silent non-delivery**. So this PR is deliberately asymmetric: we now *read* the extended prefix, and still refuse to *write* it.

**Finding 2 — the failure is not terminal, which changes where the guard goes.** The issue says the row is "marked hard-failed". `OutgoingDmRetryService` re-drives hard-failed rows on every foreground transition and reconnect (file header; arm 2 at `outgoing_dm_retry_service.dart:73`, `maxRetries = 5`). Since an oversized send fails deterministically, enqueuing first would spend the whole retry budget re-running a crypto chain that cannot succeed. The guard therefore refuses **before** the enqueue, so no row is created.

Three commits:

1. **`fix(nip44)`** — `unpad` now implements 44.md's pseudocode including the `unpadded_len >= 65536` guard; `decodePayload`'s caps are derived from a deliberate 1 MiB plaintext ceiling instead of coinciding with the `u16` limit. `pad` stays `u16`-only, documented. `calcPaddedLen` is untouched — it already agrees with the spec across the boundary.
2. **`feat(dm)`** — `DmRepository.sendMessage` refuses a body over 32 KiB before the enqueue, returning a new `NIP17SendResult.tooLong` (distinct from `blocked` because the user can act on it). The limit is in **bytes**: a character count cannot bound UTF-8 size, and 32 KiB leaves ~7,900 bytes of headroom so group rumors, whose extra `p` tags enlarge the sealed JSON, stay safe.
3. **`feat(dm)`** — the composer gains a 10,000-character bound with a counter that appears within 500 of the limit. This is an affordance, not the bound: `maxLength` truncates by grapheme cluster, and one cluster can exceed 25 bytes.

**Related Issue:** Relates to #7331

## Out of Scope

- **Extended-prefix SEND.** Blocked on keycast's Rust `nostr` crate being `u16`-only; see Finding 1. Following up separately — #7331 should stay open for it.
- **The upstream vector fixture is self-contradictory, and not ours to fix.** `nip44.vectors.json` hashes to exactly the sha256 published in 44.md, yet still lists `65536` under `invalid.encrypt_msg_lengths` — contradicting the prose in the same document. Upstream shipped the extended-prefix prose without regenerating the JSON, so there is no refreshed fixture to pull. Our fixture is left untouched and stays green (we still do not encrypt at 65536). The new conformance test uses the **inline vector table** in 44.md instead.

## Verification

- `flutter analyze lib test integration_test packages` — no issues
- **2,485 tests pass** across `models`, `nostr_sdk`, `dm_repository`, and the composer widget test
- **Spec conformance:** the three boundary vectors from 44.md are constructed as a conformant peer would, each payload's sha256 is asserted equal to the spec's published value *before* decrypting, then decrypted back. At 65535 our unmodified implementation already reproduced the spec's `payload_sha256` exactly, which is what validates the harness.
- **Crypto invariant, in CI:** `dm_message_size_crypto_invariant_test.dart` runs the real NIP-59 builder and real NIP-44 — including a 100-recipient rumor — and pins the measured 40,682 / 40,683 boundary. Raising the constant past the real ceiling fails CI instead of shipping green.
- **Mutation-tested.** Deleting the `unpadded_len >= 65536` guard fails exactly the sub-threshold test (a forged 6-byte prefix declaring length 5 decodes to `'hello'`) and nothing else — notably the pinned fixture stays green, so that vector does *not* cover this. Disabling the extended branch fails exactly the 65536/65537 vectors. Removing the composer's `maxLength` fails 3 of its 4 new tests.
- 15 CI ratchets run locally and pass (ungrouped, placeholder, l10n-delegates, shared-setup-stubs, skip, nostr-id-truncation, pubkey-encoding, the four design-system ceilings, untested-services, uncancellable-timer, post-close-emit, orphaned-arb, test-unit-structure).

**Not verified end-to-end in the app.** I ran the app on the iOS Simulator against `local_stack` on a local-key identity (the signer class that takes the Dart path) and confirmed the composer accepts an unbounded paste, but could not complete an in-app send: funnelcake's people-index is empty on that stack, so no isolated conversation could be created through the UI, and the only existing conversation belonged to a concurrent session's unrelated reproduction. The crypto-invariant test replaces that manual step and is stronger, since it runs in CI on every change.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)


---

## Update: three further fixes after a second read of the send and receive paths

A parallel read of both paths surfaced three things, each verified independently before acting.

**1. `sendGroupMessage` was still unguarded (a defect in this PR's own first pass).** The size refusal landed on `sendMessage` only, while `sendGroupMessage` validates nothing but emptiness — and that path is the worse one, since it fans one rumor to N recipients and would park N retry-swept rows rather than one. Both now share `_refuseIfOversized`.

**2. Raising `decodePayload`'s cap made a classifier expensive (a regression this PR introduced).** `CuratedListConverter.isNip44Payload` uses `decodePayload` as a boolean shape check over relay-supplied content, so payloads in the 87 KB–1.4 MB band went from a length comparison to a ~1 MB base64 decode just to answer "is this NIP-44?". `decodePayload` now takes an optional `maxPlaintextSize` and the classifier passes `maxU16PlaintextSize`. Note the derived bound must pick the prefix size by plaintext size — computing a u16 bound with a 6-byte prefix is four bytes too generous and admits the smallest extended payload, which is exactly what a u16 caller excludes.

**3. Private lists fail silently at the same u16 ceiling (pre-existing, not introduced here).** A private list is sealed with a *single* NIP-44 encryption, so its payload cannot exceed 65,535 bytes; past that `_commitListMutation` returns `false` and the add-to-list dialog — which had a success branch and no `else` — rendered nothing at all. It now reports the failure, using copy that does not tell the user to retry something that can never succeed. `listPrivateFull` is English-only and registered in `_knownUntranslatedDebt`, because "full" here means an encryption size limit rather than an item count and several locales need a different noun for that.

### Update: the guard now bounds the rumor, closing that gap

An earlier revision of this PR bounded the message **body**, which left tags unbounded — a rumor carrying large `additionalTags` could clear the check and still reach the throw. The guard now measures `jsonEncode(rumor)`, which is what NIP-44 actually encrypts.

Measuring the real boundary against the production wrap builder showed why that is the right quantity:

| extra `p` tags | max content | rumor bytes at that maximum |
|---|---|---|
| 0 | 40,682 | 40,969 |
| 50 | 37,032 | 40,969 |
| 200 | 26,082 | 40,969 |

The usable body shrinks as a group grows; the rumor ceiling does not move. So one constant (`maxDmRumorBytes = 40000`) covers a 1:1 send, a group fan-out, a reply with an `e` tag, and any tag added later, with no per-shape adjustment. Both send paths check after building their rumor and before enqueuing, so the row still never exists for the retry sweep to re-drive.

Rewiring the tests for that change surfaced a weak assertion I had written earlier: a `verifyNever(sendRumor…)` named a signature the production call never uses, so it matched nothing and would have passed even with the guard removed. Corrected at all three sites; neutering the guard now fails 5 of the 7 tests.

### Additional verification

- 5,268 tests across the app-layer services, widgets, and the touched packages
- Mutation-tested again: removing the group guard fails exactly the new group test; disabling the dialog's size branch fails exactly the size-message test
- `check_orphaned_arb_key_floor` confirms the new ARB key is read, and `arb_consistency_test` passes with the debt entry


---

## Update: validated on the iOS simulator, which caught a regression this PR had introduced

Ran the branch on iPhone 17 against the full local_stack (12 containers) on a local-key identity — the signer class that takes the Dart NIP-44 path.

**The device found what the tests could not.** Pasting 10,000 emoji (40,000 UTF-8 bytes, exactly at the composer's character limit) refused the send and then showed the user **nothing**: composer cleared, no bubble, no toast, message gone. Three things composed it:

1. Refusing before the enqueue leaves no queue row, and `statusFor` returns `delivered` when `pendingOutgoing.isEmpty` — no bubble can render.
2. `_onSendOutcome` shows no toast for `failed` **by design**, because the bubble's red "Not delivered" row is the affordance for every other failure.
3. `_handleSend` clears the field the moment it dispatches, before any outcome is known.

So an earlier revision of this PR traded a visible red bubble for silent data loss — the same inversion the asymmetric design exists to prevent. `SendStatus.tooLong` now carries the outcome and toasts, matching how `blocked` and `noRecipient` already work (both are also refused before a queue row exists, and both toast for that reason), and `_SendBar` restores the rejected draft so a 10,000-character message survives a refusal the user can only fix by shortening it.

Reachability is narrow but real: it needs ~9,900+ four-byte codepoints. ASCII truncates at the composer and sends; CJK at 3 bytes stays under.

### Measured on device

| Check | Result |
|---|---|
| Relay round trip | 20 wraps returned p-tagged to the account, `created_at` randomized into the past per NIP-59 |
| Receive path | 4 seeded messages decrypted and rendered |
| Composer bound | 40,000-char paste truncated to exactly 10,000; counter renders "0" in the error colour |
| Normal sends | 2,370-char and 10,000-char messages both published |
| Guard fires | `rumor serializes to 40364 bytes, over the 40000-byte limit` — no wrap build, no `Invalid plaintext size`, no queue row, no relay publish |
| After the fix | Toast visible, field still holds 40,000 bytes, no `Bloc error` line |

### One note for anyone reproducing this

The iOS build fails with `Missing package product 'FlutterFramework'`, and `ios_build_troubleshooting.md` prescribes `rm -rf ~/Library/Developer/Xcode/DerivedData`. That destroys every concurrent worktree's build cache, and another session was building at the time. DerivedData folders are keyed by project path (readable from each folder's `info.plist` `WorkspacePath`), so removing just this worktree's folder fixed it and left the other 16 untouched.


---

## Takeover update: bounded receive path and terminal oversized outcomes

The receive-side owner decision is now **128 KiB of authenticated NIP-17 plaintext**. That is high enough to exercise and accept the NIP-44 extended length prefix, while preventing the earlier 1 MiB default from becoming a durable oversized-message layout and storage path. The limit is enforced on both local-key and remote-signer flows: local decrypt rejects before base64 expansion, and remote-signer plaintext is byte-checked before JSON parsing.

The remaining `tooLong` consumers are now complete:

- group sends emit `SendStatus.tooLong`, restore the draft, and show the visible refusal instead of silently losing the message;
- inline reel replies restore the draft and present no impossible retry action;
- report submission treats oversize as terminal and does not enqueue or offer a retry that cannot succeed.

Regression coverage includes the group BLoC and conversation view, local and remote receive bounds, NIP-44 bound forwarding, inline reply state/UI, and report submission behavior.

Takeover commits: `0f64a0815`, `f67c69287`.


## Review update: screen-reader announcement for the curated-list failure

This PR added a SnackBar for a failed private-list add, where the failure
previously rendered nothing. A SnackBar alone is not announced to screen
readers, unlike the oversized-send path this PR also adds, which pairs its
toast with `SemanticsService.sendAnnouncement`. `add_to_list_dialog` now
mirrors that, so the private-list-full and update-failed outcomes reach
screen reader users too.

Review commit: `4008100ad`.
