### PR TITLE
fix(dm): stop scoring a delete-for-everyone as sent when the recipient's inbox could not be read

### DIFF
--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -63,7 +63,7 @@ jobs:
       #
       # The list is explicit rather than a glob over integration_test/e2e/,
       # because `service` and "runnable on a Linux CI runner" are different
-      # axes. Every suite in that directory is tagged `service`; these seven
+      # axes. Every suite in that directory is tagged `service`; these eight
       # are the ones this runner can actually execute. The remaining four are
       # excluded
       # for reasons no workflow change can fix:
@@ -88,7 +88,8 @@ jobs:
             integration_test/e2e/reel_reply_retry_double_send_test.dart \
             integration_test/e2e/block_leaves_kind3_follow_test.dart \
             integration_test/e2e/dm_group_delete_for_everyone_test.dart \
-            integration_test/e2e/dm_reaction_unreadable_inbox_test.dart; do
+            integration_test/e2e/dm_reaction_unreadable_inbox_test.dart \
+            integration_test/e2e/dm_deletion_unreadable_inbox_test.dart; do
             echo "── $suite"
             xvfb-run -a flutter test "$suite" --tags service -d linux
           done

--- a/mobile/integration_test/e2e/dm_deletion_unreadable_inbox_test.dart
+++ b/mobile/integration_test/e2e/dm_deletion_unreadable_inbox_test.dart
@@ -313,7 +313,9 @@ void main() {
       'retracted — #8515 must not over-fire on absence',
       (tester) async {
         // EOSE with no event: the relays answered, the recipient advertises
-        // nothing. The default pool IS where they read, so the OK is real.
+        // nothing. Routing still falls back to the pool — the deliberate #570
+        // deviation from NIP-17's "clients shouldn't try" — and that OK is
+        // scored as delivery because we keep the deviation.
         final relay = await FakeRelay.start();
         addTearDown(relay.stop);
         final stack = await buildStack(relay);

--- a/mobile/integration_test/e2e/dm_deletion_unreadable_inbox_test.dart
+++ b/mobile/integration_test/e2e/dm_deletion_unreadable_inbox_test.dart
@@ -1,0 +1,381 @@
+// ABOUTME: E2E regression for #8515 — a delete-for-everyone published while the
+// ABOUTME: recipient's kind-10050 inbox is UNREADABLE falls back to the default
+// ABOUTME: pool and must stay `deletion_pending` with its rumor retained, never
+// ABOUTME: be scored as `deletion_sent`. Drives a real DmRepository + NostrClient
+// ABOUTME: over real sockets, wired as repository_providers.dart wires them.
+// ABOUTME: Requires: NO Docker stack — every dependency here is local.
+
+@Tags(['service'])
+library;
+
+import 'dart:convert';
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay_base.dart';
+import 'package:nostr_sdk/relay/relay_status.dart';
+import 'package:nostr_sdk/relay/web_socket_connection_manager.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../helpers/fake_relay.dart';
+
+/// Redirects the public hostnames a relay list advertises onto the in-process
+/// relay. A `ws://127.0.0.1` host can never *be* an admitted target
+/// (`isRemoteSuppliedRelayUrlAllowed` refuses loopback by design), so an
+/// advertised inbox has to be reached through a redirect like this one.
+class _RedirectFactory implements WebSocketChannelFactory {
+  _RedirectFactory(this.port);
+
+  final int port;
+  final List<String> requested = [];
+
+  @override
+  WebSocketChannel create(Uri uri) {
+    requested.add(uri.toString());
+    return WebSocketChannel.connect(
+      Uri.parse('ws://127.0.0.1:$port${uri.path}'),
+    );
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const senderKey =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+  const recipientKey =
+      '2222222222222222222222222222222222222222222222222222222222222222';
+  final senderPubkey = getPublicKey(senderKey);
+  final recipientPubkey = getPublicKey(recipientKey);
+
+  final conversationId = DmRepository.computeConversationId([
+    senderPubkey,
+    recipientPubkey,
+  ]);
+
+  /// A kind-10050 the recipient signs, advertising one admissible public host.
+  Map<String, dynamic> recipientInbox() {
+    final event = Event(
+      recipientPubkey,
+      10050,
+      [
+        ['relay', 'wss://inbox-1.example'],
+      ],
+      '',
+      createdAt: 1700000000,
+    )..sign(recipientKey);
+    return event.toJson();
+  }
+
+  /// Builds the real stack the way `repository_providers.dart` does. The
+  /// deletion path resolves inboxes inside `DmRepository` itself, so unlike the
+  /// reaction sibling (#8443) there is no resolver port to inject — the wiring
+  /// under test is entirely internal to `_fanOutDeletion`.
+  Future<({DmRepository repository, AppDatabase db, Nostr nostr})> buildStack(
+    FakeRelay relay,
+  ) async {
+    final factory = _RedirectFactory(relay.port);
+    final signer = LocalNostrSigner(senderKey);
+
+    RelayBase gen(String url) =>
+        RelayBase(url, RelayStatus(url), channelFactory: factory);
+    final nostr = Nostr(signer, [], gen, channelFactory: factory);
+
+    final relayManager = RelayManager(
+      config: RelayManagerConfig(
+        defaultRelayUrl: relay.url,
+        storage: InMemoryRelayStorage(),
+        autoReconnect: false,
+      ),
+      relayPool: nostr.relayPool,
+    );
+    final client = NostrClient.forTesting(
+      nostr: nostr,
+      relayManager: relayManager,
+    );
+
+    final db = AppDatabase.test(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final messageService = NIP17MessageService(
+      signer: signer,
+      senderPublicKey: senderPubkey,
+      nostrService: client,
+    );
+
+    // `outgoingDmsDao` is wired deliberately: production never builds this
+    // repository without the queue, and a repository built without it can pin
+    // behaviour that cannot occur (learned on #8519's e2e control).
+    final repository = DmRepository(
+      nostrClient: client,
+      directMessagesDao: db.directMessagesDao,
+      conversationsDao: db.conversationsDao,
+      outgoingDmsDao: db.outgoingDmsDao,
+      userPubkey: senderPubkey,
+      signer: signer,
+      messageService: messageService,
+    );
+    addTearDown(repository.stopListening);
+
+    addTearDown(nostr.relayPool.removeAll);
+    await client.initialize();
+
+    await db.conversationsDao.upsertConversation(
+      id: conversationId,
+      participantPubkeys: jsonEncode([senderPubkey, recipientPubkey]),
+      isGroup: false,
+      createdAt: 1700000000,
+      ownerPubkey: senderPubkey,
+    );
+
+    return (repository: repository, db: db, nostr: nostr);
+  }
+
+  /// Seeds a retractable OWN message row directly through the DAO.
+  ///
+  /// Deliberately NOT `sendMessage`: a real send resolves the recipient's
+  /// kind-10050 and the answer is cached, after which the deletion's own
+  /// lookup is served from cache and reports `found` no matter how the relay
+  /// behaves afterwards. That defeats every arm below. Seeding the row leaves
+  /// the deletion as the FIRST resolution of this recipient, which is exactly
+  /// the shape the device reproduction needs too.
+  Future<String> seedOwnMessage(AppDatabase db, String rumorId) async {
+    await db.directMessagesDao.insertMessage(
+      id: rumorId,
+      conversationId: conversationId,
+      senderPubkey: senderPubkey,
+      content: 'message that will be retracted',
+      createdAt: 1700000100,
+      giftWrapId: 'wrap-$rumorId',
+      ownerPubkey: senderPubkey,
+    );
+    return rumorId;
+  }
+
+  /// `deleteMessageForEveryone` writes `deletion_pending` at its durability
+  /// boundary BEFORE any wire attempt, then drives the first attempt
+  /// unawaited. So "has a status" is true immediately and says nothing —
+  /// this waits for a TERMINAL status instead, and returns the row still
+  /// pending when the window elapses, which is itself the outcome under test.
+  Future<DirectMessageRow?> settledDeletionRow(
+    AppDatabase db,
+    String rumorId, {
+    Duration window = const Duration(seconds: 20),
+  }) async {
+    final deadline = DateTime.now().add(window);
+    DirectMessageRow? row;
+    while (DateTime.now().isBefore(deadline)) {
+      row = await db.directMessagesDao.getMessageById(
+        rumorId,
+        ownerPubkey: senderPubkey,
+      );
+      final status = row?.deletionPublishStatus;
+      if (status != null && status != 'deletion_pending') return row;
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    }
+    return row;
+  }
+
+  /// Restores the production budget after a test shortens it.
+  setUp(() {
+    DmRepository.inboxResolutionBudget = DmSendBudget.inboxResolution;
+  });
+  tearDown(() {
+    DmRepository.inboxResolutionBudget = DmSendBudget.inboxResolution;
+  });
+
+  group('#8515 delete-for-everyone on an unreadable DM inbox', () {
+    testWidgets(
+      'ARM A: a deletion whose inbox lookup exceeded its budget stays '
+      'deletion_pending and KEEPS its rumor, even though the pool confirmed '
+      'the kind-5 wrap',
+      (tester) async {
+        // The relay serves the inbox, but resolution is abandoned before it
+        // can answer — the `on TimeoutException` exit in `_queryOwnDmInbox`,
+        // documented as "Deliberately `failed`, never `absent`".
+        final relay = await FakeRelay.start(reply: recipientInbox());
+        addTearDown(relay.stop);
+        final stack = await buildStack(relay);
+
+        final rumorId = await seedOwnMessage(
+          stack.db,
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        );
+
+        DmRepository.inboxResolutionBudget = const Duration(milliseconds: 1);
+        final detailed = await stack.repository.resolveDmInboxRelaysDetailed(
+          recipientPubkey,
+        );
+        expect(
+          detailed.state,
+          DmInboxResolution.unreadable,
+          reason: 'precondition: the inbox must be UNREADABLE, not absent',
+        );
+        expect(detailed.relays, isNull);
+
+        await stack.repository.deleteMessageForEveryone(rumorId);
+        final row = await settledDeletionRow(stack.db, rumorId);
+
+        // Before #8515 this was `deletion_sent` with `deletionRumorJson`
+        // NULLed — a retraction the recipient never saw, and a row
+        // `getRetryableOwnMessageDeletions` could never select again because
+        // it requires BOTH `deletion_pending` AND a non-null rumor. That is
+        // why the false positive here is unrepairable rather than merely
+        // unconfirmed.
+        expect(row?.deletionPublishStatus, 'deletion_pending');
+        expect(
+          row?.deletionRumorJson,
+          isNotNull,
+          reason: 'the sweep needs the stored rumor to re-resolve and re-drive',
+        );
+        expect(
+          row?.isDeleted,
+          isTrue,
+          reason:
+              'the bubble stays hidden either way — the fix is durable, not '
+              'visual',
+        );
+      },
+    );
+
+    testWidgets(
+      'ARM B: the retry sweep does not settle it either — a persistently '
+      'unreadable inbox must not let retryMessageDeletion consume the row the '
+      'first attempt preserved',
+      (tester) async {
+        // This arm's subject is the RETRY, not which route produced
+        // `unreadable`, so it takes the deterministic one. A short budget
+        // alone is a race against a relay that can still answer — at 1ms the
+        // in-process socket sometimes wins, resolution comes back `found`,
+        // and the arm silently stops testing anything. Stalling the kind-10050
+        // REQ makes the budget expire every time.
+        final relay = await FakeRelay.start(
+          reply: recipientInbox(),
+          stallReqForKinds: const {EventKind.dmRelaysList},
+        );
+        addTearDown(relay.stop);
+        final stack = await buildStack(relay);
+
+        final rumorId = await seedOwnMessage(
+          stack.db,
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        );
+
+        DmRepository.inboxResolutionBudget = const Duration(seconds: 1);
+        expect(
+          (await stack.repository.resolveDmInboxRelaysDetailed(
+            recipientPubkey,
+          )).state,
+          DmInboxResolution.unreadable,
+          reason: 'precondition: the inbox must be UNREADABLE, not absent',
+        );
+
+        await stack.repository.deleteMessageForEveryone(rumorId);
+        await settledDeletionRow(stack.db, rumorId);
+
+        // Same failure #7317's review round caught on `recoverFullSend`: a
+        // send-path fix the sweep then undoes is worth 160 seconds and nothing
+        // else. Pre-#8515 this returned `unavailable`, not `unconfirmed` —
+        // the first drive had already cleared the stored rumor, so the retry
+        // could not even attempt. That is the unrepairability, made visible.
+        final outcome = await stack.repository.retryMessageDeletion(
+          rumorId: rumorId,
+        );
+        expect(outcome, DmMessageDeletionOutcome.unconfirmed);
+
+        final row = await stack.db.directMessagesDao.getMessageById(
+          rumorId,
+          ownerPubkey: senderPubkey,
+        );
+        expect(row?.deletionPublishStatus, 'deletion_pending');
+        expect(row?.deletionRumorJson, isNotNull);
+
+        final retryable = await stack.repository.retryableMessageDeletions();
+        expect(
+          retryable.map((t) => t.rumorId),
+          contains(rumorId),
+          reason: 'the row must remain on the sweep worklist',
+        );
+      },
+    );
+
+    testWidgets(
+      'ARM C (control): a genuinely ABSENT inbox is still legitimately '
+      'retracted — #8515 must not over-fire on absence',
+      (tester) async {
+        // EOSE with no event: the relays answered, the recipient advertises
+        // nothing. The default pool IS where they read, so the OK is real.
+        final relay = await FakeRelay.start();
+        addTearDown(relay.stop);
+        final stack = await buildStack(relay);
+
+        final rumorId = await seedOwnMessage(
+          stack.db,
+          'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+        );
+
+        final detailed = await stack.repository.resolveDmInboxRelaysDetailed(
+          recipientPubkey,
+        );
+        expect(
+          detailed.state,
+          DmInboxResolution.absent,
+          reason: 'precondition: the inbox must be ABSENT, not unreadable',
+        );
+
+        await stack.repository.deleteMessageForEveryone(rumorId);
+        final row = await settledDeletionRow(stack.db, rumorId);
+
+        expect(row?.deletionPublishStatus, 'deletion_sent');
+        expect(
+          row?.deletionRumorJson,
+          isNull,
+          reason: 'a delivered retraction has nothing left to replay',
+        );
+      },
+    );
+
+    testWidgets(
+      'ARM D: a relay that accepts the kind-10050 REQ and never settles it is '
+      'the other route into unreadable, and holds the deletion the same way',
+      (tester) async {
+        // No budget hook: the relay accepts the REQ and never terminates it,
+        // so `queryEventsDetailed` reports `timedOut` and the deletion path
+        // maps it to `unreadable`. This is the shape the device patrol
+        // reproduces with `docker pause`.
+        final relay = await FakeRelay.start(
+          reply: recipientInbox(),
+          stallReqForKinds: const {EventKind.dmRelaysList},
+        );
+        addTearDown(relay.stop);
+        final stack = await buildStack(relay);
+
+        final rumorId = await seedOwnMessage(
+          stack.db,
+          'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+        );
+
+        final detailed = await stack.repository.resolveDmInboxRelaysDetailed(
+          recipientPubkey,
+        );
+        expect(detailed.state, DmInboxResolution.unreadable);
+
+        await stack.repository.deleteMessageForEveryone(rumorId);
+        final row = await settledDeletionRow(stack.db, rumorId);
+
+        expect(row?.deletionPublishStatus, 'deletion_pending');
+        expect(row?.deletionRumorJson, isNotNull);
+      },
+      timeout: const Timeout(Duration(minutes: 3)),
+    );
+  });
+}

--- a/mobile/integration_test/e2e/dm_deletion_unreadable_inbox_test.dart
+++ b/mobile/integration_test/e2e/dm_deletion_unreadable_inbox_test.dart
@@ -199,10 +199,18 @@ void main() {
       'deletion_pending and KEEPS its rumor, even though the pool confirmed '
       'the kind-5 wrap',
       (tester) async {
-        // The relay serves the inbox, but resolution is abandoned before it
-        // can answer — the `on TimeoutException` exit in `_queryOwnDmInbox`,
-        // documented as "Deliberately `failed`, never `absent`".
-        final relay = await FakeRelay.start(reply: recipientInbox());
+        // The relay accepts the kind-10050 REQ and never settles it, so the
+        // 1ms budget expires into the `on TimeoutException` exit in
+        // `_queryOwnDmInbox`, documented as "Deliberately `failed`, never
+        // `absent`". The stall is what makes this deterministic: a short
+        // budget alone races a relay that can still answer (see ARM B), and
+        // the routing lookup inside `deleteMessageForEveryone` is unguarded,
+        // so a race winner would route to the advertised inbox and settle the
+        // row `deletion_sent` — red, and flaky.
+        final relay = await FakeRelay.start(
+          reply: recipientInbox(),
+          stallReqForKinds: const {EventKind.dmRelaysList},
+        );
         addTearDown(relay.stop);
         final stack = await buildStack(relay);
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -6306,8 +6306,11 @@ class DmRepository {
   /// falls back to the default pool, and the pool's `OK` is downgraded to a
   /// soft failure through [downgradeFallbackPoolDelivery] — the same rule the
   /// 1:1 send and its retry apply (#7317) and the reaction fan-out applies
-  /// (#8443). A recipient who genuinely advertises NO inbox is left alone:
-  /// the pool is where they read, so that `OK` is real delivery.
+  /// (#8443). A recipient who genuinely advertises NO inbox is also left
+  /// alone, on different terms: the pool fallback stays because reachability
+  /// is preserved (#570) — a deliberate deviation from NIP-17's "clients
+  /// shouldn't try" — and its `OK` is scored as delivery because we keep
+  /// that deviation, not because NIP-17 licenses it.
   ///
   /// Scoring the unreadable case as landed is #8515, and it is not merely a
   /// mislabel: [DirectMessagesDao.markMessageDeletionSent] clears the stored

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3460,8 +3460,8 @@ class DmRepository {
   /// Routing only needs the relays, so this signature stays. A caller that
   /// also REPORTS delivery must use [resolveDmInboxRelaysDetailed] instead:
   /// scoring a fallback-pool `OK` as delivered on an unreadable inbox is
-  /// #7317. `sendGroupMessage` (#8434) and `_fanOutDeletion` still resolve
-  /// through here and inherit that collapse.
+  /// #7317. `sendGroupMessage` (#8434) still resolves through here and
+  /// inherits that collapse.
   Future<List<String>?> resolveDmInboxRelays(String pubkey) async {
     return (await resolveDmInboxRelaysDetailed(pubkey)).relays;
   }
@@ -6300,6 +6300,25 @@ class DmRepository {
   /// the sweep re-drives the whole rumor and the recipients that already have
   /// it dedup on the (identical) rumor id. Mirrors
   /// `DmReactionsRepository._fanOutRumor`.
+  ///
+  /// A recipient's wrap "lands" only when the relay that confirmed it is one
+  /// the recipient reads. When their kind-10050 could not be READ the wrap
+  /// falls back to the default pool, and the pool's `OK` is downgraded to a
+  /// soft failure through [downgradeFallbackPoolDelivery] — the same rule the
+  /// 1:1 send and its retry apply (#7317) and the reaction fan-out applies
+  /// (#8443). A recipient who genuinely advertises NO inbox is left alone:
+  /// the pool is where they read, so that `OK` is real delivery.
+  ///
+  /// Scoring the unreadable case as landed is #8515, and it is not merely a
+  /// mislabel: [DirectMessagesDao.markMessageDeletionSent] clears the stored
+  /// rumor, and `getRetryableOwnMessageDeletions` selects on `deletion_pending`
+  /// AND a non-null rumor — so the row leaves the sweep's worklist on two
+  /// counts and the retraction becomes unrecoverable.
+  ///
+  /// Unlike `_fanOutRumor`, the aggregate failure does NOT carry
+  /// `retryablePending`. Nothing can observe it here: this result is consumed
+  /// only by [_driveMessageDeletion], which branches on `blocked` alone and
+  /// returns a [DmMessageDeletionOutcome], so the flag would be dead weight.
   Future<NIP17SendResult> _fanOutDeletion({
     required Event deletion,
     required List<String> recipients,
@@ -6310,23 +6329,28 @@ class DmRepository {
     // recipient's own inbox — a false "confirmed" for a recipient who only
     // reads their advertised inbox. Resolution never throws (it degrades to
     // null → default pool), so a failed lookup cannot abort the fan-out.
-    final inboxByRecipient = <String, List<String>?>{};
+    //
+    // Resolved through the DETAILED reader: routing only needs the relays, but
+    // this fan-out also REPORTS delivery, and `absent` and `unreadable` both
+    // route to the pool while meaning opposite things (#8515).
+    final inboxByRecipient = <String, DmInboxLookup>{};
     final selfWrapRelays = _selfWrapTargetRelays();
     await Future.wait([
       for (final recipient in recipients)
-        resolveDmInboxRelays(
+        resolveDmInboxRelaysDetailed(
           recipient,
-        ).then((relays) => inboxByRecipient[recipient] = relays),
+        ).then((inbox) => inboxByRecipient[recipient] = inbox),
     ]);
     final selfWrapTargets = await selfWrapRelays;
     NIP17SendSuccess? lastSuccess;
     final failures = <NIP17SendFailure>[];
     for (final recipient in recipients) {
-      final result = await _messageService!
+      final inbox = inboxByRecipient[recipient];
+      final published = await _messageService!
           .sendRumor(
             rumorEvent: deletion,
             recipientPubkey: recipient,
-            targetRelays: inboxByRecipient[recipient],
+            targetRelays: inbox?.relays,
             selfWrapTargetRelays: selfWrapTargets,
             awaitRecipientOk: true,
           )
@@ -6342,6 +6366,13 @@ class DmRepository {
               retryablePending: true,
             ),
           );
+      // A pool `OK` for a recipient whose inbox we could not READ is not
+      // delivery: the retraction may be sitting where they never look, and
+      // `markMessageDeletionSent` would clear the stored rumor, taking the row
+      // off the sweep's worklist for good (#8515).
+      final result = inbox == null
+          ? published
+          : downgradeFallbackPoolDelivery(published, inbox.state);
       switch (result) {
         case NIP17SendSuccess():
           lastSuccess = result;

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -13906,6 +13906,184 @@ void main() {
           ),
         );
       });
+
+      group('#8515 an unreadable recipient inbox is not delivery', () {
+        void stubInboxLookup(
+          ({List<Event> events, bool timedOut, bool noRelays}) answer,
+        ) {
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => answer);
+        }
+
+        void stubDeletionWrapConfirmed() {
+          when(
+            () => mockMessageService.sendRumor(
+              rumorEvent: any(named: 'rumorEvent'),
+              recipientPubkey: any(named: 'recipientPubkey'),
+              targetRelays: any(named: 'targetRelays'),
+              selfWrapTargetRelays: any(named: 'selfWrapTargetRelays'),
+              awaitRecipientOk: any(named: 'awaitRecipientOk'),
+            ),
+          ).thenAnswer(
+            (invocation) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId,
+              recipientPubkey:
+                  invocation.namedArguments[#recipientPubkey] as String,
+            ),
+          );
+        }
+
+        test(
+          'a fallback-pool OK on an unreadable inbox leaves the row pending '
+          'and its stored rumor intact, so the sweep can re-drive it',
+          () async {
+            // The recipient DOES advertise an inbox; our pool just could not
+            // read it. The wrap still lands on the default pool and the relay
+            // still says OK - which is exactly the false positive. Scoring it
+            // sent would ALSO null `deletionRumorJson`, taking the row off
+            // `getRetryableOwnMessageDeletions` for good.
+            stubPendingDeletion();
+            stubInboxLookup(unansweredList(noRelays: true));
+            stubDeletionWrapConfirmed();
+            final repo = createRepository();
+
+            final outcome = await repo.retryMessageDeletion(
+              rumorId: _rumorEventId,
+            );
+
+            expect(outcome, equals(DmMessageDeletionOutcome.unconfirmed));
+            verifyNever(
+              () => mockDirectMessagesDao.markMessageDeletionSent(
+                _rumorEventId,
+                ownerPubkey: any(named: 'ownerPubkey'),
+              ),
+            );
+          },
+        );
+
+        test(
+          'the wrap is still routed to the default pool - #8515 changes what '
+          'is REPORTED, never where an unreadable-inbox wrap is sent',
+          () async {
+            stubPendingDeletion();
+            stubInboxLookup(unansweredList(timedOut: true));
+            stubDeletionWrapConfirmed();
+            final repo = createRepository();
+
+            await repo.retryMessageDeletion(rumorId: _rumorEventId);
+
+            final captured = verify(
+              () => mockMessageService.sendRumor(
+                rumorEvent: any(named: 'rumorEvent'),
+                recipientPubkey: any(named: 'recipientPubkey'),
+                targetRelays: captureAny(named: 'targetRelays'),
+                selfWrapTargetRelays: any(named: 'selfWrapTargetRelays'),
+                awaitRecipientOk: any(named: 'awaitRecipientOk'),
+              ),
+            ).captured;
+            expect(
+              captured.single,
+              isNull,
+              reason:
+                  'null targetRelays IS the default-pool fallback; '
+                  'reachability is preserved (#570) and only the delivery '
+                  'claim changes',
+            );
+          },
+        );
+
+        test(
+          'a recipient who genuinely advertises NO inbox is still retracted - '
+          'the pool is where they read, so that OK is real delivery',
+          () async {
+            // setUp stubs queryEventsDetailed -> answeredList([]): the relays
+            // answered and there is no kind-10050. Conclusive absence.
+            stubPendingDeletion();
+            stubInboxLookup(answeredList(const <Event>[]));
+            stubDeletionWrapConfirmed();
+            final repo = createRepository();
+
+            final outcome = await repo.retryMessageDeletion(
+              rumorId: _rumorEventId,
+            );
+
+            expect(outcome, equals(DmMessageDeletionOutcome.sent));
+            verify(
+              () => mockDirectMessagesDao.markMessageDeletionSent(
+                _rumorEventId,
+                ownerPubkey: any(named: 'ownerPubkey'),
+              ),
+            ).called(1);
+          },
+        );
+
+        test(
+          'one unreadable member holds the whole GROUP retraction pending - '
+          'one row cannot record a partial fan-out',
+          () async {
+            stubPendingDeletion();
+            when(
+              () => mockConversationsDao.getConversation(
+                conversationId,
+                ownerPubkey: any(named: 'ownerPubkey'),
+              ),
+            ).thenAnswer(
+              (_) async => ConversationRow(
+                id: conversationId,
+                participantPubkeys:
+                    '["$_validPubkeyA","$_validPubkeyB","$_validPubkeyC"]',
+                isGroup: true,
+                createdAt: 1700000000,
+                isRead: true,
+                currentUserHasSent: true,
+              ),
+            );
+            // Readable for B, unreadable for C: the aggregate must follow the
+            // worst member, because settling the row would clear the one
+            // stored rumor both members share.
+            when(
+              () => mockNostrClient.queryEventsDetailed(
+                any(),
+                subscriptionId: any(named: 'subscriptionId'),
+                useCache: any(named: 'useCache'),
+                tempRelays: any(named: 'tempRelays'),
+                requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+                timeout: any(named: 'timeout'),
+              ),
+            ).thenAnswer((invocation) async {
+              final filters = invocation.positionalArguments.first as List;
+              final authors =
+                  (filters.first as nostr_filter.Filter).authors ?? const [];
+              return authors.contains(_validPubkeyC)
+                  ? unansweredList(noRelays: true)
+                  : answeredList(const <Event>[]);
+            });
+            stubDeletionWrapConfirmed();
+            final repo = createRepository();
+
+            final outcome = await repo.retryMessageDeletion(
+              rumorId: _rumorEventId,
+            );
+
+            expect(outcome, equals(DmMessageDeletionOutcome.unconfirmed));
+            verifyNever(
+              () => mockDirectMessagesDao.markMessageDeletionSent(
+                _rumorEventId,
+                ownerPubkey: any(named: 'ownerPubkey'),
+              ),
+            );
+          },
+        );
+      });
     });
 
     group('retryableMessageDeletions', () {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -14003,7 +14003,8 @@ void main() {
 
         test(
           'a recipient who genuinely advertises NO inbox is still retracted - '
-          'the pool is where they read, so that OK is real delivery',
+          'the deliberate #570 pool fallback stays, and its OK is scored as '
+          'delivery because we keep that deviation',
           () async {
             // setUp stubs queryEventsDetailed -> answeredList([]): the relays
             // answered and there is no kind-10050. Conclusive absence.


### PR DESCRIPTION
Closes #8515

## What

`DmRepository._fanOutDeletion` resolved each recipient with the flattening `resolveDmInboxRelays`, which returns `null` for two different facts: *the recipient advertises no inbox* and *we could not read the inbox they advertise*. Both route the gift-wrapped kind-5 to the default pool, so one pool `OK` settled the row as `deletion_sent` — telling the sender a message was retracted while the retraction sat on relays the recipient never queries.

It now resolves through `resolveDmInboxRelaysDetailed` and applies the shared `downgradeFallbackPoolDelivery` per recipient — the same rule the 1:1 send and its retry (#7317, PR #8436) and the reaction fan-out (#8443, PR #8514) already apply. This was the last of the three siblings; the resolver's own dartdoc named it, and that note is now updated.

**Routing does not change.** An unreadable inbox still falls back to the pool, so reachability is preserved (#570). Only the delivery *claim* changes.

**There is no second call site to fix.** A reviewer who read #8436 will look for one, because there the send path and `recoverFullSend` were two independent publish sites and both needed the edit. Deletions converge: `deleteMessageForEveryone` and `retryMessageDeletion` both funnel through `_driveMessageDeletion` → `_fanOutDeletion`, so the single downgrade covers the initial drive and the sweep. mbradley's standard from that review still binds and is met — mutating that one call turns both the initial-drive coverage (e2e arms A and D) and the retry coverage (the repository tests) red.

## Why it is worse than the sibling paths

`markMessageDeletionSent` calls `_settleMessageDeletion(retainRumor: false)`, which NULLs `deletionRumorJson`; `getRetryableOwnMessageDeletions` selects on `deletion_pending` **and** a non-null rumor. So a false `sent` dropped the row off the sweep's worklist on two independent counts and destroyed the retraction's stored event identity. It was unrecoverable, not merely unconfirmed — unlike `sendGroupMessage`, where the row survives and can be re-resolved.

The e2e demonstrates this rather than asserting it: before the fix, `retryMessageDeletion` returns `unavailable`, because there is no stored rumor left to replay.

## Protocol basis

NIP-17 §Publishing: *"Clients MUST only publish events to the relays listed in the recipient's kind 10050 event. If such a list is not found that indicates the user is not ready to receive messages and clients shouldn't try."*

NIP-17 §Delete says a deletion travels *"as part of the conversation"*, so the wrapped kind-5 inherits that routing rule. NIP-17 names only two states — list found, list not found — and is **silent** on a lookup that failed, which is exactly the gap this fixes. NIP-09 defines no delivery receipt, so the client's own bookkeeping is the only answer to "did the retraction reach them?", which is what the bug corrupted.

**One correction to how this repo has been describing the absent branch, including in my own first draft of this PR.** The codebase justifies leaving `absent` alone with "the pool is where they read, so the OK is real delivery" (`DmInboxResolution`'s dartdoc, predating this PR). That is **not** a spec reading. NIP-17's actual prescription for a missing list is *"clients shouldn't try"* — do not publish at all. Divine's pool fallback on `absent` is a deliberate product deviation from a MUST (#570), not something NIP-17 licenses.

This does not change the fix — `absent` behaviour is untouched here either way — but it means the honest framing is *"we keep the existing deliberate deviation"* rather than *"the spec says this OK is real"*. Worth someone deciding on purpose; I have not changed the shared dartdoc, since rewording it is #7317/#570 territory rather than this PR's.

One thing a reviewer may raise: NIP-09 says *"clients SHOULD broadcast deletion request events to other relays which don't have it."* That governs the **public** kind-5. Here the kind-5 is a rumor sealed inside a kind-1059 and is never public, so the wrap's routing is governed by NIP-17.

## Reproduction

Reproduced on an iPhone-class iOS simulator against unmodified `main`, driving a real `DmRepository` + `NostrClient` + `NIP17MessageService` over real sockets. Both routes into `unreadable` reproduce it:

| Arm | Route | Before | After |
|---|---|---|---|
| A | resolution budget expires | `deletion_sent` | `deletion_pending`, rumor kept |
| B | retry after A | `unavailable` (rumor already destroyed) | `unconfirmed`, row stays on the worklist |
| C | **control** — genuinely absent inbox | `deletion_sent` | `deletion_sent` (unchanged) |
| D | relay accepts the kind-10050 REQ and never settles it | `deletion_sent` | `deletion_pending`, rumor kept |

ARM C passing before *and* after is what makes the rest meaningful: the defect is the absent/unreadable collapse, not "deletions are scored wrong".

## Deliberate omissions

- **`retryablePending` is not propagated** the way `_fanOutRumor` does. The call graph is closed — `_fanOutDeletion`'s result reaches only `_driveMessageDeletion`, which branches on `blocked` and returns a `DmMessageDeletionOutcome` — so the flag would be unobservable. The asymmetry is documented at the function.
- **Group fan-out semantics are unchanged.** One unreadable member still holds the whole retraction pending, because one row cannot record a partial fan-out and settling it would clear the single rumor every member shares. Re-driving is safe: NIP-09 makes re-applying a deletion a no-op. Pinned by a test.
- **No terminal state for a persistently unreadable deletion.** The row stays `deletion_pending` indefinitely, mirroring what shipped for reactions — the #8443 takeover deliberately removed an age-based expiry because age is not proof of non-delivery. The policy question is #8516.
- `sendGroupMessage` still collapses the two states; that is #8434 and stays out of scope.

## User-visible change

None, by design. `deletion_pending` and `deletion_sent` both leave the row soft-deleted, so the bubble is hidden either way. The value is durable: the row survives and the sweep keeps re-resolving. What the user is told about a blocked or unconfirmed deletion is #8201.

## Testing

- 4 repository tests: unreadable holds pending, routing stays pool-bound, **absent still delivers**, one unreadable group member holds the whole fan-out.
- 4-arm e2e (`integration_test/e2e/dm_deletion_unreadable_inbox_test.dart`) using the existing `FakeRelay` + `stallReqForKinds` harness — no Docker stack needed.
- Mutation-checked: neutering only the downgrade turns exactly the two delivery-claim tests red, while the routing-invariance and absent-control tests correctly stay green.
- `flutter analyze lib test integration_test` clean; full `dm_repository` suite 841 passed, 0 failed.
