### PR TITLE
fix(dm): resolve DM send-target peers through the shared naming chain

### DIFF
--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -349,7 +349,13 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
             selectedRecipients: const [],
             actionResult: ShareSheetSendSuccess(
               recipientNames: [
-                for (final r in delivered) r.displayName ?? 'user',
+                // Non-null for every selectable row — both pickers resolve the
+                // name through `dmPeerDisplayName` before selection. The
+                // generated fallback is the naming chain's own floor for a
+                // peer with no profile, and unlike a bare 'user' it is neither
+                // English nor a second answer to "who is this".
+                for (final r in delivered)
+                  r.displayName ?? UserProfile.defaultDisplayNameFor(r.pubkey),
               ],
               recipientPubkey: single?.pubkey,
               conversationId: single == null

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -701,8 +701,6 @@
     "shareFindPeople": "ሰዎችን ያግኙ",
     "shareFindPeopleMultiline": "አግኝ\nሰዎች",
     "shareSent": "ተልኳል።",
-    "shareContactFallback": "ተገናኝ",
-    "shareUserFallback": "ተጠቃሚ",
     "shareSelectedRecipientAnnouncement": "{name} ተመርጧል",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4415,7 +4413,6 @@
     "deleteAccountSuccess": "የመሰረዝ ጥያቄዎች ተልከዋል። ከዚህ መሣሪያ ወጥተዋል።",
     "deleteAccountSuccessContentUnverified": "የመለያ ስረዛ ተጠይቋል። የአንዳንድ ነባር ልጥፎች ስረዛ በተናጠል ማረጋገጥ አልተቻለም።",
     "deleteAccountWarningBody": "ይህ ለመለያዎ እና ለይዘትዎ የመሰረዝ ጥያቄዎችን ይልካል፣ የሚቻል ከሆነ የDivine መለያዎን ይሰርዛል እና ከዚህ መሣሪያ ያስወጣዎታል። አንዳንድ ቅብብሎሾች፣ ደንበኞች እና የፍለጋ ማውጫዎች ቅጂዎችን ሊይዙ ይችላሉ። ሌሎች የገቡ መሣሪያዎች እዚያ ቁልፎችን እስኪያስወግዱ ድረስ ንቁ ሆነው ይቆያሉ።",
-    "findPeopleAnonymousUser": "ስም-አልባ",
     "findPeopleNoContacts": "ምንም እውቂያዎች አልተገኙም።\nእዚህ ለማየት ሰዎችን መከተል ይጀምሩ።",
     "geoBlockedCityLabel": "ከተማ",
     "geoBlockedCountryLabel": "ሀገር",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -602,8 +602,6 @@
     "shareFindPeople": "ابحث عن أشخاص",
     "shareFindPeopleMultiline": "ابحثعن أشخاص",
     "shareSent": "تم الإرسال",
-    "shareContactFallback": "جهة اتصال",
-    "shareUserFallback": "مستخدم",
     "shareSelectedRecipientAnnouncement": "تم تحديد {name}",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4283,7 +4281,6 @@
     "deleteAccountSuccess": "تم إرسال طلبات الحذف. تم تسجيل خروجك من هذا الجهاز.",
     "deleteAccountSuccessContentUnverified": "تم طلب حذف الحساب. تعذّر تأكيد حذف بعض المنشورات الحالية بشكل فردي.",
     "deleteAccountWarningBody": "هذا يرسل طلبات حذف لحسابك ومحتواك، ويحذف حساب Divine الخاص بك عند الإمكان، ويسجّل خروجك من هذا الجهاز. قد تحتفظ بعض المحوّلات والعملاء وفهارس البحث بنسخ. تبقى الأجهزة الأخرى المسجّلة الدخول نشطة حتى تزيل المفاتيح منها.",
-    "findPeopleAnonymousUser": "مجهول",
     "findPeopleNoContacts": "لم يتم العثور على جهات اتصال.\nابدأ بمتابعة الأشخاص لتراهم هنا.",
     "geoBlockedCityLabel": "المدينة",
     "geoBlockedCountryLabel": "الدولة",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -646,8 +646,6 @@
     "shareFindPeople": "Намери хора",
     "shareFindPeopleMultiline": "Намери\nхора",
     "shareSent": "Изпратено",
-    "shareContactFallback": "Контакт",
-    "shareUserFallback": "Потребител",
     "shareSelectedRecipientAnnouncement": "Избран е {name}",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4421,7 +4419,6 @@
     "deleteAccountSuccess": "Заявките за изтриване са изпратени. Отписан си на това устройство.",
     "deleteAccountSuccessContentUnverified": "Заявено е изтриване на акаунта. Изтриването на някои съществуващи публикации не можа да бъде потвърдено поотделно.",
     "deleteAccountWarningBody": "Това изпраща заявки за изтриване на акаунта и съдържанието ти, изтрива акаунта ти в Divine, когато е възможно, и те отписва на това устройство. Някои релета, клиенти и индекси за търсене може да запазят копия. Другите устройства с вход остават активни, докато не премахнеш ключовете там.",
-    "findPeopleAnonymousUser": "Анонимен",
     "findPeopleNoContacts": "Няма намерени контакти.\nЗапочни да следваш хора, за да ги виждаш тук.",
     "geoBlockedCityLabel": "Град",
     "geoBlockedCountryLabel": "Държава",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -602,8 +602,6 @@
     "shareFindPeople": "Leute finden",
     "shareFindPeopleMultiline": "Leute\nfinden",
     "shareSent": "Gesendet",
-    "shareContactFallback": "Kontakt",
-    "shareUserFallback": "Nutzer",
     "shareSelectedRecipientAnnouncement": "{name} ausgewählt",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4283,7 +4281,6 @@
     "deleteAccountSuccess": "Löschanfragen gesendet. Du bist auf diesem Gerät abgemeldet.",
     "deleteAccountSuccessContentUnverified": "Kontolöschung angefragt. Für einige vorhandene Beiträge konnte die Löschung nicht einzeln bestätigt werden.",
     "deleteAccountWarningBody": "Das sendet Löschanfragen für dein Konto und deine Inhalte, löscht dein Divine-Konto wenn möglich und meldet dich auf diesem Gerät ab. Einige Relays, Clients und Suchindizes behalten möglicherweise Kopien. Andere angemeldete Geräte bleiben aktiv, bis du dort die Schlüssel entfernst.",
-    "findPeopleAnonymousUser": "Anonym",
     "findPeopleNoContacts": "Keine Kontakte gefunden.\nFolge Leuten, um sie hier zu sehen.",
     "geoBlockedCityLabel": "Stadt",
     "geoBlockedCountryLabel": "Land",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1122,8 +1122,6 @@
   "shareFindPeople": "Find people",
   "shareFindPeopleMultiline": "Find\npeople",
   "shareSent": "Sent",
-  "shareContactFallback": "Contact",
-  "shareUserFallback": "User",
   "shareSelectedRecipientAnnouncement": "Selected {name}",
   "@shareSelectedRecipientAnnouncement": {
     "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4502,7 +4500,6 @@
   "@deleteAccountWarningBody": {
     "description": "Warning body in the delete-account confirmation dialog, shown above the type-to-confirm field. Be clear that Nostr deletion is request-based, not a guarantee that every relay, client, cache, search index, or other signed-in device will forget the account."
   },
-  "findPeopleAnonymousUser": "Anonymous",
   "findPeopleNoContacts": "No contacts found.\nStart following people to see them here.",
   "geoBlockedCityLabel": "City",
   "geoBlockedCountryLabel": "Country",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -602,8 +602,6 @@
     "shareFindPeople": "Buscar personas",
     "shareFindPeopleMultiline": "Buscar\npersonas",
     "shareSent": "Enviado",
-    "shareContactFallback": "Contacto",
-    "shareUserFallback": "Usuario",
     "shareSelectedRecipientAnnouncement": "{name} seleccionado",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4283,7 +4281,6 @@
     "deleteAccountSuccess": "Solicitudes de eliminación enviadas. Se cerró tu sesión en este dispositivo.",
     "deleteAccountSuccessContentUnverified": "Eliminación de cuenta solicitada. No se pudo confirmar de forma individual la eliminación de algunas publicaciones existentes.",
     "deleteAccountWarningBody": "Esto envía solicitudes de eliminación de tu cuenta y contenido, elimina tu cuenta de Divine cuando es posible y cierra tu sesión en este dispositivo. Algunos relays, clientes e índices de búsqueda pueden conservar copias. Otros dispositivos con la sesión iniciada siguen activos hasta que quites las claves ahí.",
-    "findPeopleAnonymousUser": "Anónimo",
     "findPeopleNoContacts": "No se encontraron contactos.\nEmpezá a seguir personas para verlas acá.",
     "geoBlockedCityLabel": "Ciudad",
     "geoBlockedCountryLabel": "País",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -470,8 +470,6 @@
     "shareFindPeople": "Maghanap ng tao",
     "shareFindPeopleMultiline": "Maghanap\nng tao",
     "shareSent": "Naipadala",
-    "shareContactFallback": "Contact",
-    "shareUserFallback": "User",
     "shareSelectedRecipientAnnouncement": "Napili si {name}",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -3239,7 +3237,6 @@
     "deleteAccountSuccess": "Naipadala na ang mga deletion request. Naka-log out ka na sa device na ito.",
     "deleteAccountSuccessContentUnverified": "Na-request na ang pag-delete ng account. May ilang existing na post na hindi makumpirma nang isa-isa para sa pag-delete.",
     "deleteAccountWarningBody": "Nagpapadala ito ng mga deletion request para sa account at content mo, binubura ang Divine account mo kapag posible, at nila-log out ka sa device na ito. Ang ilang relay, client, at search index ay maaaring may kopya pa rin. Ang iba pang naka-log in na device ay mananatiling aktibo hanggang alisin mo ang mga key doon.",
-    "findPeopleAnonymousUser": "Anonymous",
     "findPeopleNoContacts": "Walang nakitang contact.\nSimulang sundan ang mga tao para makita sila dito.",
     "geoBlockedCityLabel": "Lungsod",
     "geoBlockedCountryLabel": "Bansa",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -602,8 +602,6 @@
     "shareFindPeople": "Trouver des gens",
     "shareFindPeopleMultiline": "Trouver\ndes gens",
     "shareSent": "Envoyé",
-    "shareContactFallback": "Contact",
-    "shareUserFallback": "Utilisateur",
     "shareSelectedRecipientAnnouncement": "{name} sélectionné",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4283,7 +4281,6 @@
     "deleteAccountSuccess": "Demandes de suppression envoyées. Tu es déconnecté sur cet appareil.",
     "deleteAccountSuccessContentUnverified": "Suppression du compte demandée. La suppression de certaines publications existantes n'a pas pu être confirmée individuellement.",
     "deleteAccountWarningBody": "Ça envoie des demandes de suppression pour ton compte et ton contenu, supprime ton compte Divine quand c'est possible et te déconnecte sur cet appareil. Certains relays, clients et index de recherche peuvent garder des copies. Les autres appareils connectés restent actifs jusqu'à ce que tu y retires les clés.",
-    "findPeopleAnonymousUser": "Anonyme",
     "findPeopleNoContacts": "Aucun contact trouvé.\nCommence à suivre des gens pour les voir ici.",
     "geoBlockedCityLabel": "Ville",
     "geoBlockedCountryLabel": "Pays",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -602,8 +602,6 @@
     "shareFindPeople": "Cari orang",
     "shareFindPeopleMultiline": "Cari\norang",
     "shareSent": "Terkirim",
-    "shareContactFallback": "Kontak",
-    "shareUserFallback": "Pengguna",
     "shareSelectedRecipientAnnouncement": "{name} dipilih",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4283,7 +4281,6 @@
     "deleteAccountSuccess": "Permintaan penghapusan terkirim. Kamu keluar dari akun di perangkat ini.",
     "deleteAccountSuccessContentUnverified": "Penghapusan akun sudah diminta. Penghapusan beberapa postingan yang ada tidak bisa dikonfirmasi satu per satu.",
     "deleteAccountWarningBody": "Ini mengirim permintaan penghapusan untuk akun dan kontenmu, menghapus akun Divine-mu jika memungkinkan, dan mengeluarkanmu dari akun di perangkat ini. Beberapa relay, klien, dan indeks pencarian mungkin menyimpan salinan. Perangkat lain yang masih masuk tetap aktif sampai kamu menghapus kuncinya di sana.",
-    "findPeopleAnonymousUser": "Anonim",
     "findPeopleNoContacts": "Tidak ada kontak ditemukan.\nMulai ikuti orang untuk melihat mereka di sini.",
     "geoBlockedCityLabel": "Kota",
     "geoBlockedCountryLabel": "Negara",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -602,8 +602,6 @@
     "shareFindPeople": "Trova persone",
     "shareFindPeopleMultiline": "Trova\npersone",
     "shareSent": "Inviato",
-    "shareContactFallback": "Contatto",
-    "shareUserFallback": "Utente",
     "shareSelectedRecipientAnnouncement": "{name} selezionato",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4283,7 +4281,6 @@
     "deleteAccountSuccess": "Richieste di eliminazione inviate. Sei disconnesso su questo dispositivo.",
     "deleteAccountSuccessContentUnverified": "Eliminazione dell'account richiesta. Per alcuni post esistenti non è stato possibile confermare l'eliminazione singolarmente.",
     "deleteAccountWarningBody": "Questo invia richieste di eliminazione per il tuo account e i tuoi contenuti, elimina il tuo account Divine quando possibile e ti disconnette su questo dispositivo. Alcuni relay, client e indici di ricerca potrebbero conservare copie. Gli altri dispositivi con l'accesso effettuato restano attivi finché non rimuovi le chiavi lì.",
-    "findPeopleAnonymousUser": "Anonimo",
     "findPeopleNoContacts": "Nessun contatto trovato.\nInizia a seguire persone per vederle qui.",
     "geoBlockedCityLabel": "Città",
     "geoBlockedCountryLabel": "Paese",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -602,8 +602,6 @@
     "shareFindPeople": "ユーザーを検索",
     "shareFindPeopleMultiline": "ユーザーを\n検索",
     "shareSent": "送信済み",
-    "shareContactFallback": "連絡先",
-    "shareUserFallback": "ユーザー",
     "shareSelectedRecipientAnnouncement": "{name}を選択しました",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4283,7 +4281,6 @@
     "deleteAccountSuccess": "削除リクエストを送信したよ。このデバイスからサインアウトしたよ。",
     "deleteAccountSuccessContentUnverified": "アカウントの削除をリクエストしたよ。既存の投稿の一部は、個別に削除を確認できなかったよ。",
     "deleteAccountWarningBody": "これはアカウントとコンテンツの削除リクエストを送信して、可能なら Divine アカウントを削除し、このデバイスからサインアウトするよ。一部のリレーやクライアント、検索インデックスにはコピーが残ることがあるよ。ほかのサインイン中のデバイスは、そこで鍵を削除するまで有効なままだよ。",
-    "findPeopleAnonymousUser": "匿名",
     "findPeopleNoContacts": "連絡先が見つからないよ。\n誰かをフォローすると、ここに表示されるよ。",
     "geoBlockedCityLabel": "市区町村",
     "geoBlockedCountryLabel": "国",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -411,8 +411,6 @@
     "shareFindPeople": "사람 찾기",
     "shareFindPeopleMultiline": "사람\n찾기",
     "shareSent": "보냄",
-    "shareContactFallback": "연락처",
-    "shareUserFallback": "사용자",
     "shareSelectedRecipientAnnouncement": "{name}님 선택됨",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -3821,7 +3819,6 @@
     "deleteAccountSuccess": "삭제 요청을 보냈어요. 이 기기에서 로그아웃됐어요.",
     "deleteAccountSuccessContentUnverified": "계정 삭제를 요청했어요. 기존 게시물 중 일부는 개별적으로 삭제를 확인하지 못했어요.",
     "deleteAccountWarningBody": "이건 계정과 콘텐츠의 삭제 요청을 보내고, 가능하면 Divine 계정을 삭제하고, 이 기기에서 로그아웃해요. 일부 릴레이, 클라이언트, 검색 색인에는 사본이 남을 수 있어요. 로그인된 다른 기기는 거기서 키를 제거할 때까지 계속 활성 상태예요.",
-    "findPeopleAnonymousUser": "익명",
     "findPeopleNoContacts": "연락처를 찾을 수 없어요.\n사람들을 팔로우하면 여기에 나타나요.",
     "geoBlockedCityLabel": "도시",
     "geoBlockedCountryLabel": "국가",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -839,8 +839,6 @@
   "shareFindPeople": "Cari orang",
   "shareFindPeopleMultiline": "Cari\norang",
   "shareSent": "Dihantar",
-  "shareContactFallback": "Kenalan",
-  "shareUserFallback": "Pengguna",
   "shareSelectedRecipientAnnouncement": "{name} dipilih",
   "@shareSelectedRecipientAnnouncement": {
     "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -3737,7 +3735,6 @@
   "@deleteAccountWarningBody": {
     "description": "Warning body in the delete-account confirmation dialog, shown above the type-to-confirm field. Be clear that Nostr deletion is request-based, not a guarantee that every relay, client, cache, search index, or other signed-in device will forget the account."
   },
-  "findPeopleAnonymousUser": "Tanpa nama",
   "findPeopleNoContacts": "Tiada kenalan ditemui.\nMula mengikuti orang untuk melihat mereka di sini.",
   "geoBlockedCityLabel": "Bandar",
   "geoBlockedCountryLabel": "Negara",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -602,8 +602,6 @@
     "shareFindPeople": "Mensen zoeken",
     "shareFindPeopleMultiline": "Mensen\nzoeken",
     "shareSent": "Verzonden",
-    "shareContactFallback": "Contact",
-    "shareUserFallback": "Gebruiker",
     "shareSelectedRecipientAnnouncement": "{name} geselecteerd",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4283,7 +4281,6 @@
     "deleteAccountSuccess": "Verwijderverzoeken verstuurd. Je bent op dit apparaat afgemeld.",
     "deleteAccountSuccessContentUnverified": "Accountverwijdering aangevraagd. Voor sommige bestaande posts kon de verwijdering niet afzonderlijk worden bevestigd.",
     "deleteAccountWarningBody": "Dit stuurt verwijderverzoeken voor je account en content, verwijdert je Divine-account waar mogelijk en meldt je op dit apparaat af. Sommige relays, clients en zoekindexen kunnen kopieën bewaren. Andere aangemelde apparaten blijven actief totdat je daar de sleutels verwijdert.",
-    "findPeopleAnonymousUser": "Anoniem",
     "findPeopleNoContacts": "Geen contacten gevonden.\nBegin mensen te volgen om ze hier te zien.",
     "geoBlockedCityLabel": "Stad",
     "geoBlockedCountryLabel": "Land",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -602,8 +602,6 @@
     "shareFindPeople": "Znajdź ludzi",
     "shareFindPeopleMultiline": "Znajdź\nludzi",
     "shareSent": "Wysłano",
-    "shareContactFallback": "Kontakt",
-    "shareUserFallback": "Użytkownik",
     "shareSelectedRecipientAnnouncement": "Wybrano {name}",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4283,7 +4281,6 @@
     "deleteAccountSuccess": "Żądania usunięcia wysłane. Wylogowano cię na tym urządzeniu.",
     "deleteAccountSuccessContentUnverified": "Wysłano żądanie usunięcia konta. Usunięcia niektórych istniejących postów nie udało się potwierdzić osobno.",
     "deleteAccountWarningBody": "To wysyła żądania usunięcia twojego konta i treści, usuwa twoje konto Divine, gdy to możliwe, i wylogowuje cię na tym urządzeniu. Niektóre przekaźniki, klienty i indeksy wyszukiwania mogą zachować kopie. Inne zalogowane urządzenia pozostają aktywne, dopóki nie usuniesz na nich kluczy.",
-    "findPeopleAnonymousUser": "Anonim",
     "findPeopleNoContacts": "Nie znaleziono kontaktów.\nZacznij obserwować ludzi, aby zobaczyć ich tutaj.",
     "geoBlockedCityLabel": "Miasto",
     "geoBlockedCountryLabel": "Kraj",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -602,8 +602,6 @@
     "shareFindPeople": "Encontrar pessoas",
     "shareFindPeopleMultiline": "Encontrar\npessoas",
     "shareSent": "Enviado",
-    "shareContactFallback": "Contato",
-    "shareUserFallback": "Usuário",
     "shareSelectedRecipientAnnouncement": "{name} selecionado",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4283,7 +4281,6 @@
     "deleteAccountSuccess": "Solicitações de exclusão enviadas. Você foi desconectado neste dispositivo.",
     "deleteAccountSuccessContentUnverified": "Exclusão da conta solicitada. Não foi possível confirmar individualmente a exclusão de algumas publicações existentes.",
     "deleteAccountWarningBody": "Isso envia solicitações de exclusão da sua conta e do seu conteúdo, exclui sua conta Divine quando possível e desconecta você neste dispositivo. Alguns relays, clientes e índices de busca podem manter cópias. Outros dispositivos conectados continuam ativos até você remover as chaves lá.",
-    "findPeopleAnonymousUser": "Anônimo",
     "findPeopleNoContacts": "Nenhum contato encontrado.\nComece a seguir pessoas para vê-las aqui.",
     "geoBlockedCityLabel": "Cidade",
     "geoBlockedCountryLabel": "País",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -602,8 +602,6 @@
     "shareFindPeople": "Găsește oameni",
     "shareFindPeopleMultiline": "Găsește\noameni",
     "shareSent": "Trimis",
-    "shareContactFallback": "Contact",
-    "shareUserFallback": "Utilizator",
     "shareSelectedRecipientAnnouncement": "{name} selectat",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4283,7 +4281,6 @@
     "deleteAccountSuccess": "Cereri de ștergere trimise. Ai fost deconectat pe acest dispozitiv.",
     "deleteAccountSuccessContentUnverified": "Ștergerea contului a fost solicitată. Ștergerea unor postări existente nu a putut fi confirmată individual.",
     "deleteAccountWarningBody": "Aceasta trimite cereri de ștergere pentru contul și conținutul tău, șterge contul tău Divine când e posibil și te deconectează pe acest dispozitiv. Unele relay-uri, clienți și indexuri de căutare pot păstra copii. Alte dispozitive conectate rămân active până când elimini cheile de pe ele.",
-    "findPeopleAnonymousUser": "Anonim",
     "findPeopleNoContacts": "Niciun contact găsit.\nÎncepe să urmărești oameni ca să-i vezi aici.",
     "geoBlockedCityLabel": "Oraș",
     "geoBlockedCountryLabel": "Țară",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -602,8 +602,6 @@
     "shareFindPeople": "Hitta personer",
     "shareFindPeopleMultiline": "Hitta\npersoner",
     "shareSent": "Skickat",
-    "shareContactFallback": "Kontakt",
-    "shareUserFallback": "Användare",
     "shareSelectedRecipientAnnouncement": "{name} vald",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4283,7 +4281,6 @@
     "deleteAccountSuccess": "Raderingsförfrågningar skickade. Du är utloggad på den här enheten.",
     "deleteAccountSuccessContentUnverified": "Radering av kontot har begärts. Raderingen av vissa befintliga inlägg kunde inte bekräftas individuellt.",
     "deleteAccountWarningBody": "Det här skickar raderingsförfrågningar för ditt konto och innehåll, tar bort ditt Divine-konto när det går och loggar ut dig på den här enheten. Vissa reläer, klienter och sökindex kan behålla kopior. Andra inloggade enheter förblir aktiva tills du tar bort nycklarna där.",
-    "findPeopleAnonymousUser": "Anonym",
     "findPeopleNoContacts": "Inga kontakter hittades.\nBörja följa personer för att se dem här.",
     "geoBlockedCityLabel": "Stad",
     "geoBlockedCountryLabel": "Land",

--- a/mobile/lib/l10n/app_te.arb
+++ b/mobile/lib/l10n/app_te.arb
@@ -1119,8 +1119,6 @@
   "shareFindPeople": "వ్యక్తులను కనుగొనండి",
   "shareFindPeopleMultiline": "\nవ్యక్తులను కనుగొనండి",
   "shareSent": "పంపబడింది",
-  "shareContactFallback": "సంప్రదించండి",
-  "shareUserFallback": "వినియోగదారు",
   "shareSelectedRecipientAnnouncement": "ఎంచుకోబడింది{name}",
   "@shareSelectedRecipientAnnouncement": {
     "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4517,7 +4515,6 @@
   "@deleteAccountWarningBody": {
     "description": "Warning body in the delete-account confirmation dialog, shown above the type-to-confirm field. Be clear that Nostr deletion is request-based, not a guarantee that every relay, client, cache, search index, or other signed-in device will forget the account."
   },
-  "findPeopleAnonymousUser": "అజ్ఞాత",
   "findPeopleNoContacts": "పరిచయాలు ఏవీ కనుగొనబడలేదు.\nవ్యక్తులను ఇక్కడ చూడటానికి వారిని అనుసరించడం ప్రారంభించండి.",
   "geoBlockedCityLabel": "నగరం",
   "geoBlockedCountryLabel": "దేశం",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -602,8 +602,6 @@
     "shareFindPeople": "Kişi bul",
     "shareFindPeopleMultiline": "Kişi\nbul",
     "shareSent": "Gönderildi",
-    "shareContactFallback": "Kişi",
-    "shareUserFallback": "Kullanıcı",
     "shareSelectedRecipientAnnouncement": "{name} seçildi",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -4283,7 +4281,6 @@
     "deleteAccountSuccess": "Silme istekleri gönderildi. Bu cihazda oturumun kapatıldı.",
     "deleteAccountSuccessContentUnverified": "Hesap silme isteği gönderildi. Mevcut bazı gönderilerin silinmesi tek tek doğrulanamadı.",
     "deleteAccountWarningBody": "Bu, hesabın ve içeriğin için silme istekleri gönderir, mümkün olduğunda Divine hesabını siler ve bu cihazda oturumunu kapatır. Bazı röleler, istemciler ve arama dizinleri kopyaları saklayabilir. Oturum açmış diğer cihazlar, oradaki anahtarları kaldırana kadar aktif kalır.",
-    "findPeopleAnonymousUser": "Anonim",
     "findPeopleNoContacts": "Kişi bulunamadı.\nBurada görmek için insanları takip etmeye başla.",
     "geoBlockedCityLabel": "Şehir",
     "geoBlockedCountryLabel": "Ülke",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -839,8 +839,6 @@
   "shareFindPeople": "لوگ تلاش کریں",
   "shareFindPeopleMultiline": "لوگ\nتلاش کریں",
   "shareSent": "بھیج دیا",
-  "shareContactFallback": "رابطہ",
-  "shareUserFallback": "صارف",
   "shareSelectedRecipientAnnouncement": "{name} منتخب ہوئے",
   "@shareSelectedRecipientAnnouncement": {
     "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -3737,7 +3735,6 @@
   "@deleteAccountWarningBody": {
     "description": "Warning body in the delete-account confirmation dialog, shown above the type-to-confirm field. Be clear that Nostr deletion is request-based, not a guarantee that every relay, client, cache, search index, or other signed-in device will forget the account."
   },
-  "findPeopleAnonymousUser": "گمنام",
   "findPeopleNoContacts": "کوئی رابطہ نہیں ملا۔\nلوگوں کو یہاں دیکھنے کے لیے انہیں فالو کرنا شروع کریں۔",
   "geoBlockedCityLabel": "شہر",
   "geoBlockedCountryLabel": "ملک",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -839,8 +839,6 @@
   "shareFindPeople": "Tìm người",
   "shareFindPeopleMultiline": "Tìm\nngười",
   "shareSent": "Đã gửi",
-  "shareContactFallback": "Liên hệ",
-  "shareUserFallback": "Người dùng",
   "shareSelectedRecipientAnnouncement": "Đã chọn {name}",
   "@shareSelectedRecipientAnnouncement": {
     "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -3737,7 +3735,6 @@
   "@deleteAccountWarningBody": {
     "description": "Warning body in the delete-account confirmation dialog, shown above the type-to-confirm field. Be clear that Nostr deletion is request-based, not a guarantee that every relay, client, cache, search index, or other signed-in device will forget the account."
   },
-  "findPeopleAnonymousUser": "Ẩn danh",
   "findPeopleNoContacts": "Không tìm thấy liên hệ nào.\nBắt đầu theo dõi mọi người để thấy họ ở đây.",
   "geoBlockedCityLabel": "Thành phố",
   "geoBlockedCountryLabel": "Quốc gia",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -839,8 +839,6 @@
   "shareFindPeople": "找人",
   "shareFindPeopleMultiline": "寻找\n朋友",
   "shareSent": "已发送",
-  "shareContactFallback": "联系人",
-  "shareUserFallback": "用户",
   "shareSelectedRecipientAnnouncement": "已选择 {name}",
   "@shareSelectedRecipientAnnouncement": {
     "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
@@ -3737,7 +3735,6 @@
   "@deleteAccountWarningBody": {
     "description": "Warning body in the delete-account confirmation dialog, shown above the type-to-confirm field. Be clear that Nostr deletion is request-based, not a guarantee that every relay, client, cache, search index, or other signed-in device will forget the account."
   },
-  "findPeopleAnonymousUser": "匿名用户",
   "findPeopleNoContacts": "没有找到联系人。\n开始关注一些人，他们就会出现在这里。",
   "geoBlockedCityLabel": "城市",
   "geoBlockedCountryLabel": "国家/地区",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -3023,18 +3023,6 @@ abstract class AppLocalizations {
   /// **'Sent'**
   String get shareSent;
 
-  /// No description provided for @shareContactFallback.
-  ///
-  /// In en, this message translates to:
-  /// **'Contact'**
-  String get shareContactFallback;
-
-  /// No description provided for @shareUserFallback.
-  ///
-  /// In en, this message translates to:
-  /// **'User'**
-  String get shareUserFallback;
-
   /// Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.
   ///
   /// In en, this message translates to:
@@ -12045,12 +12033,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'This sends deletion requests for your account and content, deletes your Divine account when possible, and signs you out on this device. Some relays, clients, and search indexes may keep copies. Other signed-in devices stay active until you remove the keys there.'**
   String get deleteAccountWarningBody;
-
-  /// No description provided for @findPeopleAnonymousUser.
-  ///
-  /// In en, this message translates to:
-  /// **'Anonymous'**
-  String get findPeopleAnonymousUser;
 
   /// No description provided for @findPeopleNoContacts.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1719,12 +1719,6 @@ class AppLocalizationsAm extends AppLocalizations {
   String get shareSent => 'ተልኳል።';
 
   @override
-  String get shareContactFallback => 'ተገናኝ';
-
-  @override
-  String get shareUserFallback => 'ተጠቃሚ';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name ተመርጧል';
   }
@@ -6880,9 +6874,6 @@ class AppLocalizationsAm extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'ይህ ለመለያዎ እና ለይዘትዎ የመሰረዝ ጥያቄዎችን ይልካል፣ የሚቻል ከሆነ የDivine መለያዎን ይሰርዛል እና ከዚህ መሣሪያ ያስወጣዎታል። አንዳንድ ቅብብሎሾች፣ ደንበኞች እና የፍለጋ ማውጫዎች ቅጂዎችን ሊይዙ ይችላሉ። ሌሎች የገቡ መሣሪያዎች እዚያ ቁልፎችን እስኪያስወግዱ ድረስ ንቁ ሆነው ይቆያሉ።';
-
-  @override
-  String get findPeopleAnonymousUser => 'ስም-አልባ';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1747,12 +1747,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get shareSent => 'تم الإرسال';
 
   @override
-  String get shareContactFallback => 'جهة اتصال';
-
-  @override
-  String get shareUserFallback => 'مستخدم';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return 'تم تحديد $name';
   }
@@ -6996,9 +6990,6 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'هذا يرسل طلبات حذف لحسابك ومحتواك، ويحذف حساب Divine الخاص بك عند الإمكان، ويسجّل خروجك من هذا الجهاز. قد تحتفظ بعض المحوّلات والعملاء وفهارس البحث بنسخ. تبقى الأجهزة الأخرى المسجّلة الدخول نشطة حتى تزيل المفاتيح منها.';
-
-  @override
-  String get findPeopleAnonymousUser => 'مجهول';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1783,12 +1783,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get shareSent => 'Изпратено';
 
   @override
-  String get shareContactFallback => 'Контакт';
-
-  @override
-  String get shareUserFallback => 'Потребител';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return 'Избран е $name';
   }
@@ -7116,9 +7110,6 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'Това изпраща заявки за изтриване на акаунта и съдържанието ти, изтрива акаунта ти в Divine, когато е възможно, и те отписва на това устройство. Някои релета, клиенти и индекси за търсене може да запазят копия. Другите устройства с вход остават активни, докато не премахнеш ключовете там.';
-
-  @override
-  String get findPeopleAnonymousUser => 'Анонимен';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1785,12 +1785,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get shareSent => 'Gesendet';
 
   @override
-  String get shareContactFallback => 'Kontakt';
-
-  @override
-  String get shareUserFallback => 'Nutzer';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name ausgewählt';
   }
@@ -7134,9 +7128,6 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'Das sendet Löschanfragen für dein Konto und deine Inhalte, löscht dein Divine-Konto wenn möglich und meldet dich auf diesem Gerät ab. Einige Relays, Clients und Suchindizes behalten möglicherweise Kopien. Andere angemeldete Geräte bleiben aktiv, bis du dort die Schlüssel entfernst.';
-
-  @override
-  String get findPeopleAnonymousUser => 'Anonym';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1767,12 +1767,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get shareSent => 'Sent';
 
   @override
-  String get shareContactFallback => 'Contact';
-
-  @override
-  String get shareUserFallback => 'User';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return 'Selected $name';
   }
@@ -7149,9 +7143,6 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'This sends deletion requests for your account and content, deletes your Divine account when possible, and signs you out on this device. Some relays, clients, and search indexes may keep copies. Other signed-in devices stay active until you remove the keys there.';
-
-  @override
-  String get findPeopleAnonymousUser => 'Anonymous';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1781,12 +1781,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get shareSent => 'Enviado';
 
   @override
-  String get shareContactFallback => 'Contacto';
-
-  @override
-  String get shareUserFallback => 'Usuario';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name seleccionado';
   }
@@ -7115,9 +7109,6 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'Esto envía solicitudes de eliminación de tu cuenta y contenido, elimina tu cuenta de Divine cuando es posible y cierra tu sesión en este dispositivo. Algunos relays, clientes e índices de búsqueda pueden conservar copias. Otros dispositivos con la sesión iniciada siguen activos hasta que quites las claves ahí.';
-
-  @override
-  String get findPeopleAnonymousUser => 'Anónimo';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1757,12 +1757,6 @@ class AppLocalizationsFil extends AppLocalizations {
   String get shareSent => 'Naipadala';
 
   @override
-  String get shareContactFallback => 'Contact';
-
-  @override
-  String get shareUserFallback => 'User';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return 'Napili si $name';
   }
@@ -7095,9 +7089,6 @@ class AppLocalizationsFil extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'Nagpapadala ito ng mga deletion request para sa account at content mo, binubura ang Divine account mo kapag posible, at nila-log out ka sa device na ito. Ang ilang relay, client, at search index ay maaaring may kopya pa rin. Ang iba pang naka-log in na device ay mananatiling aktibo hanggang alisin mo ang mga key doon.';
-
-  @override
-  String get findPeopleAnonymousUser => 'Anonymous';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1793,12 +1793,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get shareSent => 'Envoyé';
 
   @override
-  String get shareContactFallback => 'Contact';
-
-  @override
-  String get shareUserFallback => 'Utilisateur';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name sélectionné';
   }
@@ -7138,9 +7132,6 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'Ça envoie des demandes de suppression pour ton compte et ton contenu, supprime ton compte Divine quand c\'est possible et te déconnecte sur cet appareil. Certains relays, clients et index de recherche peuvent garder des copies. Les autres appareils connectés restent actifs jusqu\'à ce que tu y retires les clés.';
-
-  @override
-  String get findPeopleAnonymousUser => 'Anonyme';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1694,12 +1694,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get shareSent => 'Terkirim';
 
   @override
-  String get shareContactFallback => 'Kontak';
-
-  @override
-  String get shareUserFallback => 'Pengguna';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name dipilih';
   }
@@ -6970,9 +6964,6 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'Ini mengirim permintaan penghapusan untuk akun dan kontenmu, menghapus akun Divine-mu jika memungkinkan, dan mengeluarkanmu dari akun di perangkat ini. Beberapa relay, klien, dan indeks pencarian mungkin menyimpan salinan. Perangkat lain yang masih masuk tetap aktif sampai kamu menghapus kuncinya di sana.';
-
-  @override
-  String get findPeopleAnonymousUser => 'Anonim';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1790,12 +1790,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get shareSent => 'Inviato';
 
   @override
-  String get shareContactFallback => 'Contatto';
-
-  @override
-  String get shareUserFallback => 'Utente';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name selezionato';
   }
@@ -7119,9 +7113,6 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'Questo invia richieste di eliminazione per il tuo account e i tuoi contenuti, elimina il tuo account Divine quando possibile e ti disconnette su questo dispositivo. Alcuni relay, client e indici di ricerca potrebbero conservare copie. Gli altri dispositivi con l\'accesso effettuato restano attivi finché non rimuovi le chiavi lì.';
-
-  @override
-  String get findPeopleAnonymousUser => 'Anonimo';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1614,12 +1614,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get shareSent => '送信済み';
 
   @override
-  String get shareContactFallback => '連絡先';
-
-  @override
-  String get shareUserFallback => 'ユーザー';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$nameを選択しました';
   }
@@ -6682,9 +6676,6 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'これはアカウントとコンテンツの削除リクエストを送信して、可能なら Divine アカウントを削除し、このデバイスからサインアウトするよ。一部のリレーやクライアント、検索インデックスにはコピーが残ることがあるよ。ほかのサインイン中のデバイスは、そこで鍵を削除するまで有効なままだよ。';
-
-  @override
-  String get findPeopleAnonymousUser => '匿名';
 
   @override
   String get findPeopleNoContacts => '連絡先が見つからないよ。\n誰かをフォローすると、ここに表示されるよ。';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1623,12 +1623,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get shareSent => '보냄';
 
   @override
-  String get shareContactFallback => '연락처';
-
-  @override
-  String get shareUserFallback => '사용자';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name님 선택됨';
   }
@@ -6699,9 +6693,6 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       '이건 계정과 콘텐츠의 삭제 요청을 보내고, 가능하면 Divine 계정을 삭제하고, 이 기기에서 로그아웃해요. 일부 릴레이, 클라이언트, 검색 색인에는 사본이 남을 수 있어요. 로그인된 다른 기기는 거기서 키를 제거할 때까지 계속 활성 상태예요.';
-
-  @override
-  String get findPeopleAnonymousUser => '익명';
 
   @override
   String get findPeopleNoContacts => '연락처를 찾을 수 없어요.\n사람들을 팔로우하면 여기에 나타나요.';

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -1740,12 +1740,6 @@ class AppLocalizationsMs extends AppLocalizations {
   String get shareSent => 'Dihantar';
 
   @override
-  String get shareContactFallback => 'Kenalan';
-
-  @override
-  String get shareUserFallback => 'Pengguna';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name dipilih';
   }
@@ -7054,9 +7048,6 @@ class AppLocalizationsMs extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'Ini menghantar permintaan pemadaman untuk akaun dan kandungan anda, memadam akaun Divine anda apabila boleh, dan melog keluar anda pada peranti ini. Sesetengah relay, klien dan indeks carian mungkin menyimpan salinan. Peranti lain yang dilog masuk kekal aktif sehingga anda mengalih keluar kunci di situ.';
-
-  @override
-  String get findPeopleAnonymousUser => 'Tanpa nama';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1771,12 +1771,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get shareSent => 'Verzonden';
 
   @override
-  String get shareContactFallback => 'Contact';
-
-  @override
-  String get shareUserFallback => 'Gebruiker';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name geselecteerd';
   }
@@ -7077,9 +7071,6 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'Dit stuurt verwijderverzoeken voor je account en content, verwijdert je Divine-account waar mogelijk en meldt je op dit apparaat af. Sommige relays, clients en zoekindexen kunnen kopieën bewaren. Andere aangemelde apparaten blijven actief totdat je daar de sleutels verwijdert.';
-
-  @override
-  String get findPeopleAnonymousUser => 'Anoniem';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1799,12 +1799,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get shareSent => 'Wysłano';
 
   @override
-  String get shareContactFallback => 'Kontakt';
-
-  @override
-  String get shareUserFallback => 'Użytkownik';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return 'Wybrano $name';
   }
@@ -7210,9 +7204,6 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'To wysyła żądania usunięcia twojego konta i treści, usuwa twoje konto Divine, gdy to możliwe, i wylogowuje cię na tym urządzeniu. Niektóre przekaźniki, klienty i indeksy wyszukiwania mogą zachować kopie. Inne zalogowane urządzenia pozostają aktywne, dopóki nie usuniesz na nich kluczy.';
-
-  @override
-  String get findPeopleAnonymousUser => 'Anonim';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1776,12 +1776,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get shareSent => 'Enviado';
 
   @override
-  String get shareContactFallback => 'Contato';
-
-  @override
-  String get shareUserFallback => 'Usuário';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name selecionado';
   }
@@ -7097,9 +7091,6 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'Isso envia solicitações de exclusão da sua conta e do seu conteúdo, exclui sua conta Divine quando possível e desconecta você neste dispositivo. Alguns relays, clientes e índices de busca podem manter cópias. Outros dispositivos conectados continuam ativos até você remover as chaves lá.';
-
-  @override
-  String get findPeopleAnonymousUser => 'Anônimo';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1809,12 +1809,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get shareSent => 'Trimis';
 
   @override
-  String get shareContactFallback => 'Contact';
-
-  @override
-  String get shareUserFallback => 'Utilizator';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name selectat';
   }
@@ -7220,9 +7214,6 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'Aceasta trimite cereri de ștergere pentru contul și conținutul tău, șterge contul tău Divine când e posibil și te deconectează pe acest dispozitiv. Unele relay-uri, clienți și indexuri de căutare pot păstra copii. Alte dispozitive conectate rămân active până când elimini cheile de pe ele.';
-
-  @override
-  String get findPeopleAnonymousUser => 'Anonim';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1755,12 +1755,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get shareSent => 'Skickat';
 
   @override
-  String get shareContactFallback => 'Kontakt';
-
-  @override
-  String get shareUserFallback => 'Användare';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name vald';
   }
@@ -7039,9 +7033,6 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'Det här skickar raderingsförfrågningar för ditt konto och innehåll, tar bort ditt Divine-konto när det går och loggar ut dig på den här enheten. Vissa reläer, klienter och sökindex kan behålla kopior. Andra inloggade enheter förblir aktiva tills du tar bort nycklarna där.';
-
-  @override
-  String get findPeopleAnonymousUser => 'Anonym';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -1800,12 +1800,6 @@ class AppLocalizationsTe extends AppLocalizations {
   String get shareSent => 'పంపబడింది';
 
   @override
-  String get shareContactFallback => 'సంప్రదించండి';
-
-  @override
-  String get shareUserFallback => 'వినియోగదారు';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return 'ఎంచుకోబడింది$name';
   }
@@ -7275,9 +7269,6 @@ class AppLocalizationsTe extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'ఇది మీ ఖాతా మరియు కంటెంట్ కోసం తొలగింపు అభ్యర్థనలను పంపుతుంది, సాధ్యమైనప్పుడు మీ Divine ఖాతాను తొలగిస్తుంది మరియు ఈ పరికరంలో మిమ్మల్ని సైన్ అవుట్ చేస్తుంది. కొన్ని రిలేలు, క్లయింట్లు మరియు శోధన సూచికలు కాపీలను ఉంచవచ్చు. మీరు అక్కడ ఉన్న కీలను తీసివేసే వరకు ఇతర సైన్ ఇన్ చేసిన పరికరాలు సక్రియంగా ఉంటాయి.';
-
-  @override
-  String get findPeopleAnonymousUser => 'అజ్ఞాత';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1695,12 +1695,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get shareSent => 'Gönderildi';
 
   @override
-  String get shareContactFallback => 'Kişi';
-
-  @override
-  String get shareUserFallback => 'Kullanıcı';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name seçildi';
   }
@@ -6969,9 +6963,6 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'Bu, hesabın ve içeriğin için silme istekleri gönderir, mümkün olduğunda Divine hesabını siler ve bu cihazda oturumunu kapatır. Bazı röleler, istemciler ve arama dizinleri kopyaları saklayabilir. Oturum açmış diğer cihazlar, oradaki anahtarları kaldırana kadar aktif kalır.';
-
-  @override
-  String get findPeopleAnonymousUser => 'Anonim';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -1760,12 +1760,6 @@ class AppLocalizationsUr extends AppLocalizations {
   String get shareSent => 'بھیج دیا';
 
   @override
-  String get shareContactFallback => 'رابطہ';
-
-  @override
-  String get shareUserFallback => 'صارف';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name منتخب ہوئے';
   }
@@ -7043,9 +7037,6 @@ class AppLocalizationsUr extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'یہ آپ کے اکاؤنٹ اور مواد کے لیے حذف کی درخواستیں بھیجتا ہے، ممکن ہونے پر آپ کا Divine اکاؤنٹ حذف کرتا ہے، اور اس ڈیوائس پر آپ کو سائن آؤٹ کرتا ہے۔ کچھ ریلے، کلائنٹس اور سرچ انڈیکسز کے پاس کاپیاں رہ سکتی ہیں۔ دیگر سائن اِن ڈیوائسز اس وقت تک فعال رہتی ہیں جب تک آپ وہاں کلیدیں نہ ہٹا دیں۔';
-
-  @override
-  String get findPeopleAnonymousUser => 'گمنام';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -1730,12 +1730,6 @@ class AppLocalizationsVi extends AppLocalizations {
   String get shareSent => 'Đã gửi';
 
   @override
-  String get shareContactFallback => 'Liên hệ';
-
-  @override
-  String get shareUserFallback => 'Người dùng';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return 'Đã chọn $name';
   }
@@ -7015,9 +7009,6 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       'Thao tác này gửi yêu cầu xóa cho tài khoản và nội dung của bạn, xóa tài khoản Divine của bạn khi có thể, và đăng xuất bạn trên thiết bị này. Một số relay, ứng dụng và chỉ mục tìm kiếm có thể vẫn giữ bản sao. Các thiết bị đã đăng nhập khác vẫn hoạt động cho đến khi bạn gỡ khóa ở đó.';
-
-  @override
-  String get findPeopleAnonymousUser => 'Ẩn danh';
 
   @override
   String get findPeopleNoContacts =>

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -1629,12 +1629,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get shareSent => '已发送';
 
   @override
-  String get shareContactFallback => '联系人';
-
-  @override
-  String get shareUserFallback => '用户';
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '已选择 $name';
   }
@@ -6629,9 +6623,6 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get deleteAccountWarningBody =>
       '这会为你的账号和内容发送删除请求，尽可能删除你的 Divine 账号，并在此设备上退出登录。部分中继、客户端和搜索索引可能保留副本。其他已登录设备会保持登录，直到你在那些设备上移除密钥。';
-
-  @override
-  String get findPeopleAnonymousUser => '匿名用户';
 
   @override
   String get findPeopleNoContacts => '没有找到联系人。\n开始关注一些人，他们就会出现在这里。';

--- a/mobile/lib/screens/inbox/bloc/new_message_search_bloc.dart
+++ b/mobile/lib/screens/inbox/bloc/new_message_search_bloc.dart
@@ -69,7 +69,9 @@ class NewMessageSearchBloc
     );
 
     emit(
-      state.copyWith(status: NewMessageSearchStatus.idle, contacts: profiles),
+      _withRecomputedSearch(
+        state.copyWith(status: NewMessageSearchStatus.idle, contacts: profiles),
+      ),
     );
   }
 
@@ -85,19 +87,20 @@ class NewMessageSearchBloc
           status: NewMessageSearchStatus.idle,
           query: '',
           results: const [],
+          networkResults: const [],
         ),
       );
       return;
     }
 
     // Filter contacts locally for immediate display
-    final filtered = _filterContacts(state.contacts, query);
-
     emit(
-      state.copyWith(
-        status: NewMessageSearchStatus.searching,
-        query: query,
-        results: filtered,
+      _withRecomputedSearch(
+        state.copyWith(
+          status: NewMessageSearchStatus.searching,
+          query: query,
+          networkResults: const [],
+        ),
       ),
     );
 
@@ -114,12 +117,12 @@ class NewMessageSearchBloc
         category: LogCategory.api,
       );
 
-      final merged = _mergeWithLocal(networkResults, filtered);
-
       emit(
-        state.copyWith(
-          status: NewMessageSearchStatus.searchSuccess,
-          results: merged,
+        _withRecomputedSearch(
+          state.copyWith(
+            status: NewMessageSearchStatus.searchSuccess,
+            networkResults: networkResults,
+          ),
         ),
       );
     } on Exception {
@@ -137,6 +140,7 @@ class NewMessageSearchBloc
         status: NewMessageSearchStatus.idle,
         query: '',
         results: const [],
+        networkResults: const [],
       ),
     );
   }
@@ -159,10 +163,19 @@ class NewMessageSearchBloc
   /// `ConversationListBloc`: it lets a row be found by a string it does not
   /// show — a vanished peer surfacing under a generated "Adjective Animal N"
   /// the viewer has never seen — and hides it from the name it does show.
-  List<UserProfile> _filterContacts(List<UserProfile> contacts, String query) {
+  static List<UserProfile> _filterContacts(
+    List<UserProfile> contacts,
+    String query, {
+    required Set<String> vanishedPubkeys,
+    required DmPeerLabels? labels,
+  }) {
     final lower = query.toLowerCase();
     return contacts.where((profile) {
-      final name = _peerName(profile).toLowerCase();
+      final name = _peerNameFor(
+        profile,
+        vanishedPubkeys: vanishedPubkeys,
+        labels: labels,
+      ).toLowerCase();
       final nip05 = (profile.nip05 ?? '').toLowerCase();
       return name.contains(lower) || nip05.contains(lower);
     }).toList();
@@ -204,12 +217,32 @@ class NewMessageSearchBloc
     return contacts.toList()..sort((a, b) => key(a).compareTo(key(b)));
   }
 
-  /// The name `_UserTile` renders for [profile], against the current state.
-  String _peerName(UserProfile profile) => _peerNameFor(
-    profile,
-    vanishedPubkeys: state.vanishedPubkeys,
-    labels: state.peerLabels,
-  );
+  /// Re-sorts contacts and re-runs the active rendered-name match against all
+  /// candidates. Both naming inputs arrive asynchronously, so every state
+  /// transition that changes either input must pass through here.
+  NewMessageSearchState _withRecomputedSearch(NewMessageSearchState next) {
+    final contacts = _sortedByPeerName(
+      next.contacts,
+      vanishedPubkeys: next.vanishedPubkeys,
+      labels: next.peerLabels,
+    );
+    if (!next.isSearchActive) return next.copyWith(contacts: contacts);
+
+    List<UserProfile> matching(List<UserProfile> candidates) => _filterContacts(
+      candidates,
+      next.query,
+      vanishedPubkeys: next.vanishedPubkeys,
+      labels: next.peerLabels,
+    );
+
+    return next.copyWith(
+      contacts: contacts,
+      results: _mergeWithLocal(
+        matching(next.networkResults),
+        matching(contacts),
+      ),
+    );
+  }
 
   /// (Re)points the vanished-set subscription at the profile repository.
   void _subscribeToVanishedPubkeys() {
@@ -233,16 +266,13 @@ class NewMessageSearchBloc
       return;
     }
     emit(
-      state.copyWith(
-        vanishedPubkeys: event.pubkeys,
-        // Both inputs land asynchronously — the tombstone stream on its first
-        // Drift emission, the labels on the first didChangeDependencies — and
-        // either can arrive after the contact list is already sorted. Without
-        // this the order stays keyed on the raw names.
-        contacts: _sortedByPeerName(
-          state.contacts,
+      _withRecomputedSearch(
+        state.copyWith(
           vanishedPubkeys: event.pubkeys,
-          labels: state.peerLabels,
+          // Both inputs land asynchronously — the tombstone stream on its first
+          // Drift emission, the labels on the first didChangeDependencies — and
+          // either can arrive after the contact list is already sorted. Without
+          // this the order stays keyed on the raw names.
         ),
       ),
     );
@@ -254,12 +284,9 @@ class NewMessageSearchBloc
   ) {
     if (event.labels == state.peerLabels) return;
     emit(
-      state.copyWith(
-        peerLabels: event.labels,
-        contacts: _sortedByPeerName(
-          state.contacts,
-          vanishedPubkeys: state.vanishedPubkeys,
-          labels: event.labels,
+      _withRecomputedSearch(
+        state.copyWith(
+          peerLabels: event.labels,
         ),
       ),
     );

--- a/mobile/lib/screens/inbox/bloc/new_message_search_bloc.dart
+++ b/mobile/lib/screens/inbox/bloc/new_message_search_bloc.dart
@@ -168,16 +168,65 @@ class NewMessageSearchBloc
     String query, {
     required Set<String> vanishedPubkeys,
     required DmPeerLabels? labels,
+  }) => contacts
+      .where(
+        (profile) => _matchesRenderedName(
+          profile,
+          query,
+          vanishedPubkeys: vanishedPubkeys,
+          labels: labels,
+        ),
+      )
+      .toList();
+
+  /// Whether [query] matches the name [profile]'s row renders, or its NIP-05.
+  static bool _matchesRenderedName(
+    UserProfile profile,
+    String query, {
+    required Set<String> vanishedPubkeys,
+    required DmPeerLabels? labels,
   }) {
     final lower = query.toLowerCase();
-    return contacts.where((profile) {
-      final name = _peerNameFor(
+    final name = _peerNameFor(
+      profile,
+      vanishedPubkeys: vanishedPubkeys,
+      labels: labels,
+    ).toLowerCase();
+    final nip05 = (profile.nip05 ?? '').toLowerCase();
+    return name.contains(lower) || nip05.contains(lower);
+  }
+
+  /// [networkResults] minus the peers the viewer would only meet under a
+  /// substitute name.
+  ///
+  /// These candidates arrive already matched, by a search this filter cannot
+  /// reproduce: `searchUsers` merges Funnelcake REST with NIP-50 relay search,
+  /// and the house matcher scores bio, an `npub` prefix and fuzzy tokens, none
+  /// of which the local substring pass can see. Re-running that pass over
+  /// every candidate drops each result the query did not literally spell —
+  /// including the npub paste `NewMessageSheet` documents as a supported
+  /// query. So only a peer Divine renames is re-checked, which is where the
+  /// backend really did match a name the row will never show (#8421).
+  static List<UserProfile> _visibleNetworkResults(
+    List<UserProfile> networkResults,
+    String query, {
+    required Set<String> vanishedPubkeys,
+    required DmPeerLabels? labels,
+  }) {
+    if (labels == null) return networkResults;
+    return networkResults.where((profile) {
+      final substitute = dmPeerSubstituteName(
+        isVanished: vanishedPubkeys.contains(profile.pubkey),
+        isModeration: isModerationAccount(profile.pubkey),
+        labels: labels,
+      );
+      if (substitute == null) return true;
+      return _matchesRenderedName(
         profile,
+        query,
         vanishedPubkeys: vanishedPubkeys,
         labels: labels,
-      ).toLowerCase();
-      final nip05 = (profile.nip05 ?? '').toLowerCase();
-      return name.contains(lower) || nip05.contains(lower);
+      );
     }).toList();
   }
 
@@ -228,18 +277,21 @@ class NewMessageSearchBloc
     );
     if (!next.isSearchActive) return next.copyWith(contacts: contacts);
 
-    List<UserProfile> matching(List<UserProfile> candidates) => _filterContacts(
-      candidates,
-      next.query,
-      vanishedPubkeys: next.vanishedPubkeys,
-      labels: next.peerLabels,
-    );
-
     return next.copyWith(
       contacts: contacts,
       results: _mergeWithLocal(
-        matching(next.networkResults),
-        matching(contacts),
+        _visibleNetworkResults(
+          next.networkResults,
+          next.query,
+          vanishedPubkeys: next.vanishedPubkeys,
+          labels: next.peerLabels,
+        ),
+        _filterContacts(
+          contacts,
+          next.query,
+          vanishedPubkeys: next.vanishedPubkeys,
+          labels: next.peerLabels,
+        ),
       ),
     );
   }
@@ -267,13 +319,10 @@ class NewMessageSearchBloc
     }
     emit(
       _withRecomputedSearch(
-        state.copyWith(
-          vanishedPubkeys: event.pubkeys,
-          // Both inputs land asynchronously — the tombstone stream on its first
-          // Drift emission, the labels on the first didChangeDependencies — and
-          // either can arrive after the contact list is already sorted. Without
-          // this the order stays keyed on the raw names.
-        ),
+        // Both naming inputs land asynchronously — the tombstone stream on its
+        // first Drift emission, the labels on the first didChangeDependencies
+        // — so either can arrive after the list is sorted and matched.
+        state.copyWith(vanishedPubkeys: event.pubkeys),
       ),
     );
   }
@@ -284,11 +333,7 @@ class NewMessageSearchBloc
   ) {
     if (event.labels == state.peerLabels) return;
     emit(
-      _withRecomputedSearch(
-        state.copyWith(
-          peerLabels: event.labels,
-        ),
-      ),
+      _withRecomputedSearch(state.copyWith(peerLabels: event.labels)),
     );
   }
 

--- a/mobile/lib/screens/inbox/bloc/new_message_search_bloc.dart
+++ b/mobile/lib/screens/inbox/bloc/new_message_search_bloc.dart
@@ -1,11 +1,16 @@
 // ABOUTME: BLoC for the new message recipient search sheet.
 // ABOUTME: Loads followed contacts and merges them with network search results.
 
+import 'dart:async';
+
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart';
 import 'package:nostr_sdk/nip19/pubkeys_equal.dart';
+import 'package:openvine/blocs/close_guard.dart';
+import 'package:openvine/blocs/dm/dm_peer_name.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/constants/search_constants.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -31,11 +36,17 @@ class NewMessageSearchBloc
       transformer: debounceRestartable(),
     );
     on<NewMessageSearchCleared>(_onCleared);
+    on<NewMessageSearchPeerLabelsChanged>(_onPeerLabelsChanged);
+    on<_NewMessageSearchVanishedPubkeysChanged>(_onVanishedPubkeysChanged);
+    _subscribeToVanishedPubkeys();
   }
 
   final ProfileRepository _profileRepository;
   final FollowRepository _followRepository;
   final String _currentUserPubkey;
+
+  /// Live mirror of the durable `vanished_profiles` table.
+  StreamSubscription<Set<String>>? _vanishedSubscription;
 
   Future<void> _onStarted(
     NewMessageSearchStarted event,
@@ -48,12 +59,14 @@ class NewMessageSearchBloc
       (pk) => _profileRepository.getCachedProfile(pubkey: pk),
     );
     final results = await Future.wait(futures);
-    final profiles = results.whereType<UserProfile>().toList()
-      ..sort(
-        (a, b) => a.bestDisplayName.toLowerCase().compareTo(
-          b.bestDisplayName.toLowerCase(),
-        ),
-      );
+    // Ordered by the name the row renders, not the raw kind-0 one: a vanished
+    // peer sorts under "Deleted account" and the moderation account under
+    // "Divine Moderation", so the alphabetical run matches what is on screen.
+    final profiles = _sortedByPeerName(
+      results.whereType<UserProfile>().toList(),
+      vanishedPubkeys: state.vanishedPubkeys,
+      labels: state.peerLabels,
+    );
 
     emit(
       state.copyWith(status: NewMessageSearchStatus.idle, contacts: profiles),
@@ -140,17 +153,122 @@ class NewMessageSearchBloc
   /// client may be upper-case hex.
   bool _isSelf(String pubkey) => pubkeysEqual(pubkey, _currentUserPubkey);
 
-  /// Filters contacts by display name or NIP-05.
-  static List<UserProfile> _filterContacts(
-    List<UserProfile> contacts,
-    String query,
-  ) {
+  /// Filters contacts by the name the row renders, or by NIP-05.
+  ///
+  /// Matching the raw `bestDisplayName` is the defect #8204 fixed in
+  /// `ConversationListBloc`: it lets a row be found by a string it does not
+  /// show — a vanished peer surfacing under a generated "Adjective Animal N"
+  /// the viewer has never seen — and hides it from the name it does show.
+  List<UserProfile> _filterContacts(List<UserProfile> contacts, String query) {
     final lower = query.toLowerCase();
     return contacts.where((profile) {
-      final name = profile.bestDisplayName.toLowerCase();
+      final name = _peerName(profile).toLowerCase();
       final nip05 = (profile.nip05 ?? '').toLowerCase();
       return name.contains(lower) || nip05.contains(lower);
     }).toList();
+  }
+
+  /// The name `_UserTile` renders for [profile], resolved the same way.
+  ///
+  /// Takes its inputs rather than reading `state`, so an ordering can be
+  /// recomputed against a state that has not been emitted yet.
+  ///
+  /// Falls back to the profile-or-generated value while [labels] is null,
+  /// which is the pre-delivery window only.
+  static String _peerNameFor(
+    UserProfile profile, {
+    required Set<String> vanishedPubkeys,
+    required DmPeerLabels? labels,
+  }) {
+    if (labels == null) return profile.bestDisplayName;
+    return dmPeerName(
+      pubkeyHex: profile.pubkey,
+      isVanished: vanishedPubkeys.contains(profile.pubkey),
+      isModeration: isModerationAccount(profile.pubkey),
+      labels: labels,
+      profileName: profile.bestDisplayName,
+    );
+  }
+
+  /// [contacts] ordered by the name each row renders.
+  static List<UserProfile> _sortedByPeerName(
+    List<UserProfile> contacts, {
+    required Set<String> vanishedPubkeys,
+    required DmPeerLabels? labels,
+  }) {
+    String key(UserProfile p) => _peerNameFor(
+      p,
+      vanishedPubkeys: vanishedPubkeys,
+      labels: labels,
+    ).toLowerCase();
+    return contacts.toList()..sort((a, b) => key(a).compareTo(key(b)));
+  }
+
+  /// The name `_UserTile` renders for [profile], against the current state.
+  String _peerName(UserProfile profile) => _peerNameFor(
+    profile,
+    vanishedPubkeys: state.vanishedPubkeys,
+    labels: state.peerLabels,
+  );
+
+  /// (Re)points the vanished-set subscription at the profile repository.
+  void _subscribeToVanishedPubkeys() {
+    _vanishedSubscription = _profileRepository.watchVanishedPubkeys().listen(
+      // A stream callback resumes outside the handler that started it, so the
+      // add has to be guarded — `close()` does not cancel it.
+      (pubkeys) => addIfOpen(_NewMessageSearchVanishedPubkeysChanged(pubkeys)),
+      onError: (Object error, StackTrace stackTrace) {
+        // Drift / IO failures are expected here and are not Reportable.
+        addError(error, stackTrace);
+      },
+    );
+  }
+
+  void _onVanishedPubkeysChanged(
+    _NewMessageSearchVanishedPubkeysChanged event,
+    Emitter<NewMessageSearchState> emit,
+  ) {
+    if (event.pubkeys.length == state.vanishedPubkeys.length &&
+        event.pubkeys.containsAll(state.vanishedPubkeys)) {
+      return;
+    }
+    emit(
+      state.copyWith(
+        vanishedPubkeys: event.pubkeys,
+        // Both inputs land asynchronously — the tombstone stream on its first
+        // Drift emission, the labels on the first didChangeDependencies — and
+        // either can arrive after the contact list is already sorted. Without
+        // this the order stays keyed on the raw names.
+        contacts: _sortedByPeerName(
+          state.contacts,
+          vanishedPubkeys: event.pubkeys,
+          labels: state.peerLabels,
+        ),
+      ),
+    );
+  }
+
+  void _onPeerLabelsChanged(
+    NewMessageSearchPeerLabelsChanged event,
+    Emitter<NewMessageSearchState> emit,
+  ) {
+    if (event.labels == state.peerLabels) return;
+    emit(
+      state.copyWith(
+        peerLabels: event.labels,
+        contacts: _sortedByPeerName(
+          state.contacts,
+          vanishedPubkeys: state.vanishedPubkeys,
+          labels: event.labels,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Future<void> close() {
+    unawaited(_vanishedSubscription?.cancel());
+    return super.close();
   }
 
   /// Merges network results with local contacts, deduplicating by pubkey.

--- a/mobile/lib/screens/inbox/bloc/new_message_search_event.dart
+++ b/mobile/lib/screens/inbox/bloc/new_message_search_event.dart
@@ -30,3 +30,30 @@ final class NewMessageSearchQueryChanged extends NewMessageSearchEvent {
 final class NewMessageSearchCleared extends NewMessageSearchEvent {
   const NewMessageSearchCleared();
 }
+
+/// The localized [DmPeerLabels] the sheet resolved from its `BuildContext`.
+///
+/// Pushed down rather than read here, for the same reason
+/// `ConversationListPeerLabelsChanged` exists: the substitutes are ARB
+/// strings, the matcher is a BLoC, and only one of them can see a
+/// `BuildContext`.
+final class NewMessageSearchPeerLabelsChanged extends NewMessageSearchEvent {
+  const NewMessageSearchPeerLabelsChanged(this.labels);
+
+  final DmPeerLabels labels;
+
+  @override
+  List<Object?> get props => [labels];
+}
+
+/// The live vanished set changed. Private: only this BLoC's own subscription
+/// to `ProfileRepository.watchVanishedPubkeys()` raises it.
+final class _NewMessageSearchVanishedPubkeysChanged
+    extends NewMessageSearchEvent {
+  const _NewMessageSearchVanishedPubkeysChanged(this.pubkeys);
+
+  final Set<String> pubkeys;
+
+  @override
+  List<Object?> get props => [pubkeys];
+}

--- a/mobile/lib/screens/inbox/bloc/new_message_search_state.dart
+++ b/mobile/lib/screens/inbox/bloc/new_message_search_state.dart
@@ -28,6 +28,8 @@ final class NewMessageSearchState extends Equatable {
     this.contacts = const [],
     this.query = '',
     this.results = const [],
+    this.vanishedPubkeys = const {},
+    this.peerLabels,
   });
 
   /// Current status of the search flow.
@@ -42,6 +44,21 @@ final class NewMessageSearchState extends Equatable {
   /// Search results: filtered contacts merged with network results.
   final List<UserProfile> results;
 
+  /// Pubkeys carrying a NIP-62 vanish tombstone, mirrored live from
+  /// `ProfileRepository.watchVanishedPubkeys()`.
+  ///
+  /// Held in state rather than sampled at match time so the sort and the
+  /// filter see the same set the row renders with, the way
+  /// `ConversationListBloc` holds it for the inbox index.
+  final Set<String> vanishedPubkeys;
+
+  /// The substitute strings [dmPeerName] needs, pushed down from the sheet.
+  ///
+  /// Null until the first `didChangeDependencies` delivers them — matching on
+  /// a substitute needs the translated string, and there is nothing better to
+  /// match on before it arrives.
+  final DmPeerLabels? peerLabels;
+
   /// Whether a search query is active.
   bool get isSearchActive => query.isNotEmpty;
 
@@ -50,15 +67,26 @@ final class NewMessageSearchState extends Equatable {
     List<UserProfile>? contacts,
     String? query,
     List<UserProfile>? results,
+    Set<String>? vanishedPubkeys,
+    DmPeerLabels? peerLabels,
   }) {
     return NewMessageSearchState(
       status: status ?? this.status,
       contacts: contacts ?? this.contacts,
       query: query ?? this.query,
       results: results ?? this.results,
+      vanishedPubkeys: vanishedPubkeys ?? this.vanishedPubkeys,
+      peerLabels: peerLabels ?? this.peerLabels,
     );
   }
 
   @override
-  List<Object> get props => [status, contacts, query, results];
+  List<Object?> get props => [
+    status,
+    contacts,
+    query,
+    results,
+    vanishedPubkeys,
+    peerLabels,
+  ];
 }

--- a/mobile/lib/screens/inbox/bloc/new_message_search_state.dart
+++ b/mobile/lib/screens/inbox/bloc/new_message_search_state.dart
@@ -28,6 +28,7 @@ final class NewMessageSearchState extends Equatable {
     this.contacts = const [],
     this.query = '',
     this.results = const [],
+    this.networkResults = const [],
     this.vanishedPubkeys = const {},
     this.peerLabels,
   });
@@ -43,6 +44,12 @@ final class NewMessageSearchState extends Equatable {
 
   /// Search results: filtered contacts merged with network results.
   final List<UserProfile> results;
+
+  /// Unfiltered candidates returned by the current network query.
+  ///
+  /// Retained separately so a late tombstone or locale change can re-run the
+  /// rendered-name match instead of leaving [results] keyed on stale labels.
+  final List<UserProfile> networkResults;
 
   /// Pubkeys carrying a NIP-62 vanish tombstone, mirrored live from
   /// `ProfileRepository.watchVanishedPubkeys()`.
@@ -67,6 +74,7 @@ final class NewMessageSearchState extends Equatable {
     List<UserProfile>? contacts,
     String? query,
     List<UserProfile>? results,
+    List<UserProfile>? networkResults,
     Set<String>? vanishedPubkeys,
     DmPeerLabels? peerLabels,
   }) {
@@ -75,6 +83,7 @@ final class NewMessageSearchState extends Equatable {
       contacts: contacts ?? this.contacts,
       query: query ?? this.query,
       results: results ?? this.results,
+      networkResults: networkResults ?? this.networkResults,
       vanishedPubkeys: vanishedPubkeys ?? this.vanishedPubkeys,
       peerLabels: peerLabels ?? this.peerLabels,
     );
@@ -86,6 +95,7 @@ final class NewMessageSearchState extends Equatable {
     contacts,
     query,
     results,
+    networkResults,
     vanishedPubkeys,
     peerLabels,
   ];

--- a/mobile/lib/screens/inbox/new_message_sheet.dart
+++ b/mobile/lib/screens/inbox/new_message_sheet.dart
@@ -5,10 +5,13 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/bloc/bloc.dart';
+import 'package:openvine/screens/inbox/widgets/dm_peer_identity.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:profile_repository/profile_repository.dart';
 
@@ -61,9 +64,36 @@ class NewMessageSheet extends StatelessWidget {
         followRepository: followRepository,
         currentUserPubkey: currentUserPubkey,
       )..add(const NewMessageSearchStarted()),
-      child: const _NewMessageSheetView(),
+      child: const _PeerLabelSync(child: _NewMessageSheetView()),
     );
   }
+}
+
+/// Feeds the sheet's [DmPeerLabels] down to the BLoC that matches on them.
+///
+/// The sort and the search filter resolve peer names through [dmPeerName],
+/// which needs already-translated substitutes; only a widget can read them.
+/// Mirrors the inbox's own `_PeerLabelSync`.
+class _PeerLabelSync extends StatefulWidget {
+  const _PeerLabelSync({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_PeerLabelSync> createState() => _PeerLabelSyncState();
+}
+
+class _PeerLabelSyncState extends State<_PeerLabelSync> {
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    context.read<NewMessageSearchBloc>().add(
+      NewMessageSearchPeerLabelsChanged(dmPeerLabels(context)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
 }
 
 class _NewMessageSheetView extends StatefulWidget {
@@ -290,14 +320,36 @@ class _UserProfileList extends StatelessWidget {
   }
 }
 
-class _UserTile extends StatelessWidget {
+/// One candidate recipient row.
+///
+/// A send-target picker names its peer through the same chain the inbox rows
+/// use, or the two disagree about who an account is: this row said
+/// "Aeontropy" over their photo while the thread with the same pubkey said
+/// "Deleted account", and gave Divine's own moderation account a generic
+/// placeholder avatar (#8421).
+class _UserTile extends ConsumerWidget {
   const _UserTile({required this.profile, required this.onTap});
 
   final UserProfile profile;
   final VoidCallback onTap;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isVanished = ref.watch(profileVanishedProvider(profile.pubkey));
+    final displayName = dmPeerDisplayName(
+      context,
+      pubkeyHex: profile.pubkey,
+      isVanished: isVanished,
+      profile: profile,
+    );
+    final avatar = dmPeerAvatar(
+      pubkeyHex: profile.pubkey,
+      isVanished: isVanished,
+      pictureUrl: profile.picture,
+    );
+    // A vanished account's NIP-05 identifies it as surely as its name does.
+    final handle = isVanished ? '' : profile.handle;
+
     return InkWell(
       onTap: onTap,
       child: Padding(
@@ -305,10 +357,11 @@ class _UserTile extends StatelessWidget {
         child: Row(
           children: [
             UserAvatar(
-              imageUrl: profile.picture,
-              name: profile.bestDisplayName,
+              imageUrl: avatar.imageUrl,
+              name: displayName,
               placeholderSeed: profile.pubkey,
               size: 40,
+              contentOverride: avatar.contentOverride,
             ),
             const SizedBox(width: 16),
             Expanded(
@@ -317,16 +370,16 @@ class _UserTile extends StatelessWidget {
                 spacing: 2,
                 children: [
                   Text(
-                    profile.bestDisplayName,
+                    displayName,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: VineTheme.titleMediumFont(
                       color: context.vineColors.primaryText,
                     ),
                   ),
-                  if (profile.handle.isNotEmpty)
+                  if (handle.isNotEmpty)
                     Text(
-                      profile.handle,
+                      handle,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: VineTheme.bodyMediumFont(

--- a/mobile/lib/screens/inbox/widgets/dm_peer_identity.dart
+++ b/mobile/lib/screens/inbox/widgets/dm_peer_identity.dart
@@ -7,6 +7,7 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/dm_peer_name.dart';
 import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/screens/inbox/widgets/moderation_identity.dart';
 
 /// The peer's name when it resolves without a profile lookup.
 ///
@@ -102,4 +103,33 @@ String dmPeerDisplayName(
   },
   displayNameOverride: displayNameOverride,
   isResolving: isResolving,
+);
+
+/// The avatar artwork a DM peer surface shows, resolved the same way
+/// [dmPeerDisplayName] resolves the name beside it.
+///
+/// The two halves have to agree or a row contradicts itself — a vanished peer
+/// named "Deleted account" over their own photo still identifies them, and the
+/// moderation account named "Divine Moderation" beside a generic placeholder
+/// reads as an impersonator. Both substitutions were already written out by
+/// hand at every inbox row ([ConversationTile] is the reference); this is that
+/// pair in one place so a new surface cannot ship with the name step and
+/// without the picture step, which is exactly how #8421's send-target pickers
+/// diverged.
+///
+/// [contentOverride] carries the bundled moderation wordmark because the
+/// account's kind-0 `picture` is a hosted SVG whose `<style>` block
+/// `vector_graphics_compiler` discards — see [ModerationAvatar]. Pass the
+/// record straight into [UserAvatar]'s matching parameters.
+({String? imageUrl, Widget? contentOverride}) dmPeerAvatar({
+  required String pubkeyHex,
+  required bool isVanished,
+  String? pictureUrl,
+}) => (
+  // A vanish is the one branch that must also drop the artwork: the name
+  // substitution alone would leave the account recognisable by its face.
+  imageUrl: isVanished ? null : pictureUrl,
+  contentOverride: isModerationAccount(pubkeyHex)
+      ? const ModerationAvatar()
+      : null,
 );

--- a/mobile/lib/widgets/find_people_sheet.dart
+++ b/mobile/lib/widgets/find_people_sheet.dart
@@ -6,9 +6,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/dm/dm_peer_name.dart';
 import 'package:openvine/blocs/user_search/user_search_bloc.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/screens/inbox/widgets/dm_peer_identity.dart';
 import 'package:openvine/services/video_sharing_service.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 
@@ -274,7 +278,7 @@ class _SearchResultsList extends StatelessWidget {
           results[index].pubkey,
           results[index],
         );
-        return _UserResultTile(user: user, onTap: () => onSelectUser(user));
+        return _UserResultTile(user: user, onTap: onSelectUser);
       },
     );
   }
@@ -315,33 +319,66 @@ class _ContactsList extends StatelessWidget {
       itemCount: contacts.length,
       itemBuilder: (context, index) {
         final contact = contacts[index];
-        return _UserResultTile(
-          user: contact,
-          onTap: () => onSelectUser(contact),
-        );
+        return _UserResultTile(user: contact, onTap: onSelectUser);
       },
     );
   }
 }
 
-class _UserResultTile extends StatelessWidget {
+/// One search result, as a DM send target.
+///
+/// Find People routes straight into `DmRepository.sendMessage`, so it names
+/// its peer through the same chain the inbox rows use. Its search reaches
+/// third-party NIP-50 relays, which a NIP-62 vanish addressed elsewhere never
+/// obliged to forget — so a deleted account's kind 0 can and does come back
+/// here under its real name (#8421).
+class _UserResultTile extends ConsumerWidget {
   const _UserResultTile({required this.user, required this.onTap});
 
   final ShareableUser user;
-  final VoidCallback onTap;
+  final ValueChanged<ShareableUser> onTap;
 
   @override
-  Widget build(BuildContext context) {
-    final handle = user.handle;
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isVanished = ref.watch(profileVanishedProvider(user.pubkey));
+    // `dmPeerName` rather than the `profile:`-shaped wrapper: a
+    // [ShareableUser] already carries the step-4 value (it is built from
+    // `UserProfile.bestDisplayName`), and it is NOT a `displayNameOverride` —
+    // that step outranks moderation, which would let the moderation account's
+    // own kind-0 name win over the shared label.
+    final displayName = dmPeerName(
+      pubkeyHex: user.pubkey,
+      isVanished: isVanished,
+      isModeration: isModerationAccount(user.pubkey),
+      labels: dmPeerLabels(context),
+      profileName: user.displayName,
+    );
+    final avatar = dmPeerAvatar(
+      pubkeyHex: user.pubkey,
+      isVanished: isVanished,
+      pictureUrl: user.picture,
+    );
+    // A vanished account's NIP-05 identifies it as surely as its name does.
+    final handle = isVanished ? null : user.handle;
+    // Hand the resolved identity on, so the share sheet's selection chip and
+    // its success snackbar name the peer the way this row did.
+    final resolved = ShareableUser(
+      pubkey: user.pubkey,
+      displayName: displayName,
+      handle: handle,
+      picture: avatar.imageUrl,
+    );
 
     return ListTile(
       leading: UserAvatar(
-        imageUrl: user.picture,
+        imageUrl: avatar.imageUrl,
+        name: displayName,
         placeholderSeed: user.pubkey,
         size: 48,
+        contentOverride: avatar.contentOverride,
       ),
       title: Text(
-        user.displayName ?? context.l10n.findPeopleAnonymousUser,
+        displayName,
         style: VineTheme.titleMediumFont(color: context.vineColors.primaryText),
       ),
       // No npub fallback: a row without a nip05 or a name shows the name
@@ -355,7 +392,7 @@ class _UserResultTile extends StatelessWidget {
               ),
               overflow: TextOverflow.ellipsis,
             ),
-      onTap: onTap,
+      onTap: () => onTap(resolved),
       contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
     );
   }

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -12,9 +12,11 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/dm/dm_peer_name.dart';
 import 'package:openvine/blocs/owner_video_actions/owner_video_actions_cubit.dart';
 import 'package:openvine/blocs/share_sheet/share_sheet_bloc.dart';
 import 'package:openvine/blocs/video_crosspost/video_crosspost_cubit.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
@@ -25,6 +27,7 @@ import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/providers/video_clip_import_provider.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
+import 'package:openvine/screens/inbox/widgets/dm_peer_identity.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
 import 'package:openvine/services/video_clip_import_service.dart';
 import 'package:openvine/services/video_sharing_service.dart';
@@ -257,8 +260,13 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
               SemanticsService.sendAnnouncement(
                 View.of(context),
                 context.l10n.shareSelectedRecipientAnnouncement(
+                  // Non-null for every selectable row: `_ContactItem` and
+                  // `FindPeopleSheet` both resolve the name through
+                  // `dmPeerDisplayName` before handing the recipient over.
                   state.selectedRecipients.last.displayName ??
-                      context.l10n.shareUserFallback,
+                      UserProfile.defaultDisplayNameFor(
+                        state.selectedRecipients.last.pubkey,
+                      ),
                 ),
                 Directionality.of(context),
               );

--- a/mobile/lib/widgets/video_feed_item/actions/share_with_section.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_with_section.dart
@@ -93,7 +93,7 @@ class _ShareWithSection extends StatelessWidget {
                             child: _ContactItem(
                               user: _skeletonContact,
                               isSelected: false,
-                              onTap: () {},
+                              onTap: (_) {},
                             ),
                           ),
                         ),
@@ -105,7 +105,7 @@ class _ShareWithSection extends StatelessWidget {
                       child: _ContactItem(
                         user: contact,
                         isSelected: selectedPubkeys.contains(contact.pubkey),
-                        onTap: () => onContactTapped(contact),
+                        onTap: onContactTapped,
                       ),
                     );
                   },
@@ -172,7 +172,14 @@ class _FindPeopleItem extends StatelessWidget {
   }
 }
 
-class _ContactItem extends StatelessWidget {
+/// One contact in the "Share with" row.
+///
+/// The row is a DM send target — tapping it selects a recipient that
+/// `ShareSheetBloc` hands to `DmRepository.sendMessage` — so it resolves its
+/// peer through the same chain the inbox rows use, and hands the *resolved*
+/// [ShareableUser] to [onTap] so the selection chip, the screen-reader
+/// announcement and the success snackbar all name the same account (#8421).
+class _ContactItem extends ConsumerWidget {
   const _ContactItem({
     required this.user,
     required this.isSelected,
@@ -181,17 +188,43 @@ class _ContactItem extends StatelessWidget {
 
   final ShareableUser user;
   final bool isSelected;
-  final VoidCallback onTap;
+  final ValueChanged<ShareableUser> onTap;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isVanished = ref.watch(profileVanishedProvider(user.pubkey));
+    // `dmPeerName` rather than the `profile:`-shaped wrapper: a
+    // [ShareableUser] already carries the step-4 value (it is built from
+    // `UserProfile.bestDisplayName`), and it is NOT a `displayNameOverride` —
+    // that step outranks moderation, which would let the moderation account's
+    // own kind-0 name win over the shared label.
+    final displayName = dmPeerName(
+      pubkeyHex: user.pubkey,
+      isVanished: isVanished,
+      isModeration: isModerationAccount(user.pubkey),
+      labels: dmPeerLabels(context),
+      profileName: user.displayName,
+    );
+    final avatar = dmPeerAvatar(
+      pubkeyHex: user.pubkey,
+      isVanished: isVanished,
+      pictureUrl: user.picture,
+    );
+    final resolved = ShareableUser(
+      pubkey: user.pubkey,
+      displayName: displayName,
+      // A vanished account's NIP-05 identifies it as surely as its name does.
+      handle: isVanished ? null : user.handle,
+      picture: avatar.imageUrl,
+    );
+
     return Semantics(
       button: true,
       selected: isSelected,
-      label: user.displayName ?? context.l10n.shareContactFallback,
+      label: displayName,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: onTap,
+        onTap: () => onTap(resolved),
         child: SizedBox(
           width: _ShareWithSection._itemWidth,
           child: Column(
@@ -201,9 +234,10 @@ class _ContactItem extends StatelessWidget {
               Stack(
                 children: [
                   UserAvatar(
-                    imageUrl: user.picture,
-                    name: user.displayName,
+                    imageUrl: avatar.imageUrl,
+                    name: displayName,
                     size: _ShareWithSection._avatarSize,
+                    contentOverride: avatar.contentOverride,
                   ),
                   if (isSelected)
                     Positioned(
@@ -226,7 +260,7 @@ class _ContactItem extends StatelessWidget {
                 ],
               ),
               Text(
-                user.displayName ?? context.l10n.shareUserFallback,
+                displayName,
                 style: TextStyle(
                   color: isSelected
                       ? context.vineColors.accentPositive

--- a/mobile/test/screens/inbox/bloc/new_message_search_bloc_test.dart
+++ b/mobile/test/screens/inbox/bloc/new_message_search_bloc_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for NewMessageSearchBloc — contact loading, filtering,
 // ABOUTME: network search, and merge behavior.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
@@ -116,10 +118,7 @@ void main() {
         },
         wait: debounceDuration,
         verify: (bloc) {
-          expect(
-            bloc.state.results.map((r) => r.pubkey),
-            ['a' * 64],
-          );
+          expect(bloc.state.results.map((r) => r.pubkey), ['a' * 64]);
         },
       );
 
@@ -646,6 +645,95 @@ void main() {
         build: createBloc,
         act: (bloc) => loadThenSearch(bloc, 'Aeontropy'),
         verify: (bloc) => expect(bloc.state.results, isEmpty),
+      );
+
+      blocTest<NewMessageSearchBloc, NewMessageSearchState>(
+        'filters network results by the name their row renders',
+        setUp: () {
+          stubVanished({vanishedPubkey});
+          when(() => mockFollowRepo.followingPubkeys).thenReturn([]);
+          when(
+            () => mockProfileRepo.searchUsers(
+              query: 'Aeontropy',
+              limit: any(named: 'limit'),
+              sortBy: any(named: 'sortBy'),
+            ),
+          ).thenAnswer(
+            (_) async => [createTestProfile(vanishedPubkey, 'Aeontropy')],
+          );
+        },
+        build: createBloc,
+        act: (bloc) => loadThenSearch(bloc, 'Aeontropy'),
+        verify: (bloc) => expect(bloc.state.results, isEmpty),
+      );
+
+      test(
+        're-filters an active search when a tombstone arrives later',
+        () async {
+          final vanished = StreamController<Set<String>>();
+          when(
+            mockProfileRepo.watchVanishedPubkeys,
+          ).thenAnswer((_) => vanished.stream);
+          when(
+            () => mockFollowRepo.followingPubkeys,
+          ).thenReturn([vanishedPubkey]);
+          stubContact(vanishedPubkey, 'Aeontropy');
+          stubNoNetworkResults();
+          final bloc = createBloc();
+          addTearDown(() async {
+            await bloc.close();
+            await vanished.close();
+          });
+
+          bloc
+            ..add(const NewMessageSearchPeerLabelsChanged(labels))
+            ..add(const NewMessageSearchStarted());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          bloc.add(const NewMessageSearchQueryChanged('Aeontropy'));
+          await Future<void>.delayed(debounceDuration * 2);
+          expect(
+            bloc.state.results.map((p) => p.pubkey),
+            contains(vanishedPubkey),
+          );
+
+          vanished.add({vanishedPubkey});
+          await Future<void>.delayed(Duration.zero);
+
+          expect(bloc.state.results, isEmpty);
+        },
+      );
+
+      test(
+        're-filters an active search when localized labels change',
+        () async {
+          stubVanished({vanishedPubkey});
+          when(
+            () => mockFollowRepo.followingPubkeys,
+          ).thenReturn([vanishedPubkey]);
+          stubContact(vanishedPubkey, 'Aeontropy');
+          stubNoNetworkResults();
+          final bloc = createBloc();
+          addTearDown(bloc.close);
+
+          await loadThenSearch(bloc, 'Removed');
+          expect(bloc.state.results, isEmpty);
+
+          bloc.add(
+            const NewMessageSearchPeerLabelsChanged(
+              DmPeerLabels(
+                deletedAccount: 'Removed account',
+                moderation: 'Divine Moderation',
+                retiredConversationClosed: 'Conversation closed',
+              ),
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          expect(
+            bloc.state.results.map((p) => p.pubkey),
+            contains(vanishedPubkey),
+          );
+        },
       );
 
       blocTest<NewMessageSearchBloc, NewMessageSearchState>(

--- a/mobile/test/screens/inbox/bloc/new_message_search_bloc_test.dart
+++ b/mobile/test/screens/inbox/bloc/new_message_search_bloc_test.dart
@@ -572,6 +572,8 @@ void main() {
           'b75b9a3131f4263add94ba20beb352a11032684f2dac07a7e1af827c6f3c1505';
       const alice =
           'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const aliceNpub =
+          'npub1424242424242424242424242424242424242424242424242424qamrcaj';
       const labels = DmPeerLabels(
         deletedAccount: 'Deleted account',
         moderation: 'Divine Moderation',
@@ -665,6 +667,51 @@ void main() {
         build: createBloc,
         act: (bloc) => loadThenSearch(bloc, 'Aeontropy'),
         verify: (bloc) => expect(bloc.state.results, isEmpty),
+      );
+
+      // The two below are the other half of that filter: it may only drop a
+      // peer Divine renames. `searchUsers` merges Funnelcake REST with NIP-50
+      // relay search and scores bio, npub prefix and fuzzy tokens, so a
+      // candidate whose rendered name does not literally spell the query is
+      // the normal case, not a mismatch.
+      void stubNetworkResult(String query, UserProfile profile) {
+        when(
+          () => mockProfileRepo.searchUsers(
+            query: query,
+            limit: any(named: 'limit'),
+            sortBy: any(named: 'sortBy'),
+          ),
+        ).thenAnswer((_) async => [profile]);
+      }
+
+      blocTest<NewMessageSearchBloc, NewMessageSearchState>(
+        'keeps a network result matched outside the name its row renders',
+        setUp: () {
+          stubVanished(const {});
+          when(() => mockFollowRepo.followingPubkeys).thenReturn([]);
+          // Models a bio match: the repository returns Alice for a query
+          // her rendered name does not contain.
+          stubNetworkResult('photographer', createTestProfile(alice, 'Alice'));
+        },
+        build: createBloc,
+        act: (bloc) => loadThenSearch(bloc, 'photographer'),
+        verify: (bloc) =>
+            expect(bloc.state.results.map((p) => p.pubkey), [alice]),
+      );
+
+      blocTest<NewMessageSearchBloc, NewMessageSearchState>(
+        'keeps a network result found by the npub this sheet accepts',
+        setUp: () {
+          stubVanished(const {});
+          when(() => mockFollowRepo.followingPubkeys).thenReturn([]);
+          stubNetworkResult(aliceNpub, createTestProfile(alice, 'Alice'));
+        },
+        build: createBloc,
+        // `NewMessageSheet` documents npub as a supported query and decodes
+        // nothing itself, so dropping this result removes the paste path.
+        act: (bloc) => loadThenSearch(bloc, aliceNpub),
+        verify: (bloc) =>
+            expect(bloc.state.results.map((p) => p.pubkey), [alice]),
       );
 
       test(

--- a/mobile/test/screens/inbox/bloc/new_message_search_bloc_test.dart
+++ b/mobile/test/screens/inbox/bloc/new_message_search_bloc_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/dm/dm_peer_name.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/screens/inbox/bloc/new_message_search_bloc.dart';
 import 'package:profile_repository/profile_repository.dart';
 
@@ -26,6 +28,12 @@ void main() {
     setUp(() {
       mockProfileRepo = _MockProfileRepository();
       mockFollowRepo = _MockFollowRepository();
+      // The BLoC mirrors the durable vanish tombstones so its sort and filter
+      // can resolve names the way the row renders them; every construction
+      // needs the stream to exist.
+      when(
+        mockProfileRepo.watchVanishedPubkeys,
+      ).thenAnswer((_) => const Stream<Set<String>>.empty());
     });
 
     NewMessageSearchBloc createBloc() => NewMessageSearchBloc(
@@ -555,6 +563,137 @@ void main() {
         const state = NewMessageSearchState();
         expect(state.isSearchActive, isFalse);
       });
+    });
+
+    // #8421: a send-target picker that matches on the raw kind-0 name lets a
+    // row be found by a string it does not show, and hides it from the one it
+    // does — the same defect #8204 fixed in ConversationListBloc.
+    group('peer-name resolution', () {
+      const vanishedPubkey =
+          'b75b9a3131f4263add94ba20beb352a11032684f2dac07a7e1af827c6f3c1505';
+      const alice =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const labels = DmPeerLabels(
+        deletedAccount: 'Deleted account',
+        moderation: 'Divine Moderation',
+        retiredConversationClosed: 'Conversation closed',
+      );
+
+      void stubContact(String pubkey, String name) {
+        when(
+          () => mockProfileRepo.getCachedProfile(pubkey: pubkey),
+        ).thenAnswer((_) async => createTestProfile(pubkey, name));
+      }
+
+      void stubNoNetworkResults() {
+        when(
+          () => mockProfileRepo.searchUsers(
+            query: any(named: 'query'),
+            limit: any(named: 'limit'),
+            sortBy: any(named: 'sortBy'),
+          ),
+        ).thenAnswer((_) async => []);
+      }
+
+      void stubVanished(Set<String> pubkeys) {
+        when(
+          mockProfileRepo.watchVanishedPubkeys,
+        ).thenAnswer((_) => Stream.value(pubkeys));
+      }
+
+      Future<void> loadThenSearch(
+        NewMessageSearchBloc bloc,
+        String query,
+      ) async {
+        bloc
+          ..add(const NewMessageSearchPeerLabelsChanged(labels))
+          ..add(const NewMessageSearchStarted());
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        bloc.add(NewMessageSearchQueryChanged(query));
+        await Future<void>.delayed(debounceDuration * 2);
+      }
+
+      blocTest<NewMessageSearchBloc, NewMessageSearchState>(
+        'finds a vanished peer by the substitute their row renders',
+        setUp: () {
+          stubVanished({vanishedPubkey});
+          when(
+            () => mockFollowRepo.followingPubkeys,
+          ).thenReturn([vanishedPubkey]);
+          stubContact(vanishedPubkey, 'Aeontropy');
+          stubNoNetworkResults();
+        },
+        build: createBloc,
+        act: (bloc) => loadThenSearch(bloc, 'Deleted'),
+        verify: (bloc) {
+          expect(
+            bloc.state.results.map((p) => p.pubkey),
+            contains(vanishedPubkey),
+          );
+        },
+      );
+
+      blocTest<NewMessageSearchBloc, NewMessageSearchState>(
+        'does not surface a vanished peer under their own kind-0 name',
+        setUp: () {
+          stubVanished({vanishedPubkey});
+          when(
+            () => mockFollowRepo.followingPubkeys,
+          ).thenReturn([vanishedPubkey]);
+          stubContact(vanishedPubkey, 'Aeontropy');
+          stubNoNetworkResults();
+        },
+        build: createBloc,
+        act: (bloc) => loadThenSearch(bloc, 'Aeontropy'),
+        verify: (bloc) => expect(bloc.state.results, isEmpty),
+      );
+
+      blocTest<NewMessageSearchBloc, NewMessageSearchState>(
+        'finds the moderation account by the name its row shows',
+        setUp: () {
+          stubVanished(const {});
+          when(
+            () => mockFollowRepo.followingPubkeys,
+          ).thenReturn([kModerationPubkeyHex]);
+          stubContact(kModerationPubkeyHex, 'moderation-bot-v2');
+          stubNoNetworkResults();
+        },
+        build: createBloc,
+        act: (bloc) => loadThenSearch(bloc, 'Divine Moderation'),
+        verify: (bloc) {
+          expect(
+            bloc.state.results.map((p) => p.pubkey),
+            contains(kModerationPubkeyHex),
+          );
+        },
+      );
+
+      blocTest<NewMessageSearchBloc, NewMessageSearchState>(
+        'orders contacts by the rendered name, not the raw one',
+        setUp: () {
+          stubVanished({vanishedPubkey});
+          when(
+            () => mockFollowRepo.followingPubkeys,
+          ).thenReturn([alice, vanishedPubkey]);
+          stubContact(alice, 'Aaron');
+          // Raw, "Aardvark" sorts first; rendered, "Deleted account" sorts
+          // last. The two orders disagree, so only one of them can pass.
+          stubContact(vanishedPubkey, 'Aardvark');
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc
+            ..add(const NewMessageSearchPeerLabelsChanged(labels))
+            ..add(const NewMessageSearchStarted());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        },
+        verify: (bloc) {
+          expect(
+            bloc.state.contacts.map((p) => p.displayName),
+            equals(['Aaron', 'Aardvark']),
+          );
+        },
+      );
     });
   });
 }

--- a/mobile/test/screens/inbox/new_message_sheet_test.dart
+++ b/mobile/test/screens/inbox/new_message_sheet_test.dart
@@ -1,0 +1,158 @@
+// ABOUTME: Pins the new-message picker to the shared DM peer naming chain.
+// ABOUTME: A send-target row must name and picture its peer exactly as the
+// ABOUTME: inbox row for the same pubkey does (#8421).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/config/official_accounts.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/screens/inbox/new_message_sheet.dart';
+import 'package:openvine/screens/inbox/widgets/moderation_identity.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+class _MockProfileRepository extends Mock implements ProfileRepository {}
+
+class _MockFollowRepository extends Mock implements FollowRepository {}
+
+void main() {
+  group(NewMessageSheet, () {
+    const currentUserPubkey =
+        'facade00facade00facade00facade00facade00facade00facade00facade00';
+    const vanishedPubkey =
+        'b75b9a3131f4263add94ba20beb352a11032684f2dac07a7e1af827c6f3c1505';
+
+    late _MockProfileRepository profileRepository;
+    late _MockFollowRepository followRepository;
+    late AppLocalizations l10n;
+
+    setUp(() {
+      profileRepository = _MockProfileRepository();
+      followRepository = _MockFollowRepository();
+      l10n = lookupAppLocalizations(const Locale('en'));
+      when(
+        profileRepository.watchVanishedPubkeys,
+      ).thenAnswer((_) => const Stream<Set<String>>.empty());
+    });
+
+    UserProfile profileFor(String pubkey, String displayName) => UserProfile(
+      pubkey: pubkey,
+      displayName: displayName,
+      picture: 'https://example.invalid/$pubkey.png',
+      rawData: const {},
+      createdAt: DateTime(2026),
+      eventId:
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    );
+
+    Future<void> pumpPickerWith(
+      WidgetTester tester, {
+      required UserProfile contact,
+      bool isVanished = false,
+    }) async {
+      when(
+        () => followRepository.followingPubkeys,
+      ).thenReturn([contact.pubkey]);
+      when(
+        () => profileRepository.getCachedProfile(pubkey: contact.pubkey),
+      ).thenAnswer((_) async => contact);
+
+      await tester.pumpWidget(
+        testMaterialApp(
+          additionalOverrides: [
+            profileVanishedProvider(
+              contact.pubkey,
+            ).overrideWith((ref) => isVanished),
+          ],
+          home: NewMessageSheet(
+            profileRepository: profileRepository,
+            followRepository: followRepository,
+            currentUserPubkey: currentUserPubkey,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    group('renders', () {
+      testWidgets('names a vanished peer "Deleted account", not their kind-0 '
+          'name', (tester) async {
+        await pumpPickerWith(
+          tester,
+          contact: profileFor(vanishedPubkey, 'Aeontropy'),
+          isVanished: true,
+        );
+
+        expect(find.text(l10n.profileDeletedAccountName), findsOneWidget);
+        // The whole point: the picker's search reaches third-party NIP-50
+        // relays a vanish addressed elsewhere never obliged to forget, so the
+        // real name is genuinely available here and must not be rendered.
+        expect(find.text('Aeontropy'), findsNothing);
+      });
+
+      testWidgets("loads a live peer's photo", (tester) async {
+        // The control for the vanish case below: without it, a green
+        // `findsNothing` there could just mean the finder is dead.
+        await pumpPickerWith(
+          tester,
+          contact: profileFor(vanishedPubkey, 'Aeontropy'),
+        );
+
+        expect(find.byType(VineCachedImage), findsOneWidget);
+      });
+
+      testWidgets("drops a vanished peer's photo, not just their name", (
+        tester,
+      ) async {
+        await pumpPickerWith(
+          tester,
+          contact: profileFor(vanishedPubkey, 'Aeontropy'),
+          isVanished: true,
+        );
+
+        expect(find.byType(VineCachedImage), findsNothing);
+      });
+
+      testWidgets('gives the moderation account its bundled wordmark', (
+        tester,
+      ) async {
+        await pumpPickerWith(
+          tester,
+          contact: profileFor(kModerationPubkeyHex, 'Divine Moderation'),
+        );
+
+        expect(find.byType(ModerationAvatar), findsOneWidget);
+      });
+
+      testWidgets('names the moderation account from the shared label, not '
+          'its kind-0 name', (tester) async {
+        // The current key's kind 0 happens to match the label, so a raw render
+        // is indistinguishable today. Give it a different one: the row must
+        // still read "Divine Moderation".
+        await pumpPickerWith(
+          tester,
+          contact: profileFor(kModerationPubkeyHex, 'moderation-bot-v2'),
+        );
+
+        expect(find.text(l10n.inboxSupportRowTitle), findsOneWidget);
+        expect(find.text('moderation-bot-v2'), findsNothing);
+      });
+
+      testWidgets('renders an ordinary peer under their own name', (
+        tester,
+      ) async {
+        const peer =
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        await pumpPickerWith(tester, contact: profileFor(peer, 'Alice'));
+
+        expect(find.text('Alice'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/mobile/test/screens/inbox/widgets/dm_peer_identity_test.dart
+++ b/mobile/test/screens/inbox/widgets/dm_peer_identity_test.dart
@@ -7,6 +7,7 @@ import 'package:models/models.dart';
 import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/inbox/widgets/dm_peer_identity.dart';
+import 'package:openvine/screens/inbox/widgets/moderation_identity.dart';
 
 import '../../../helpers/test_provider_overrides.dart';
 
@@ -236,6 +237,60 @@ void main() {
       );
 
       expect(find.text('lookup required'), findsOneWidget);
+    });
+  });
+
+  group('dmPeerAvatar', () {
+    const picture = 'https://example.invalid/peer.png';
+
+    test("keeps a live peer's picture and adds no override", () {
+      final avatar = dmPeerAvatar(
+        pubkeyHex: pubkey,
+        isVanished: false,
+        pictureUrl: picture,
+      );
+
+      expect(avatar.imageUrl, picture);
+      expect(avatar.contentOverride, isNull);
+    });
+
+    test("drops a vanished peer's picture", () {
+      final avatar = dmPeerAvatar(
+        pubkeyHex: pubkey,
+        isVanished: true,
+        pictureUrl: picture,
+      );
+
+      expect(avatar.imageUrl, isNull);
+    });
+
+    test('substitutes the bundled wordmark for the moderation account', () {
+      final avatar = dmPeerAvatar(
+        pubkeyHex: kModerationPubkeyHex,
+        isVanished: false,
+        pictureUrl: picture,
+      );
+
+      expect(avatar.contentOverride, isA<ModerationAvatar>());
+    });
+
+    test('substitutes the wordmark for a retired moderation key too', () {
+      final avatar = dmPeerAvatar(
+        pubkeyHex: kLegacyModerationPubkeys.first,
+        isVanished: false,
+      );
+
+      expect(avatar.contentOverride, isA<ModerationAvatar>());
+    });
+
+    test('a vanish drops the picture even for the moderation account', () {
+      final avatar = dmPeerAvatar(
+        pubkeyHex: kModerationPubkeyHex,
+        isVanished: true,
+        pictureUrl: picture,
+      );
+
+      expect(avatar.imageUrl, isNull);
     });
   });
 }

--- a/mobile/test/widgets/find_people_sheet_test.dart
+++ b/mobile/test/widgets/find_people_sheet_test.dart
@@ -9,7 +9,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/screens/inbox/widgets/moderation_identity.dart';
 import 'package:openvine/services/video_sharing_service.dart';
 import 'package:openvine/widgets/find_people_sheet.dart';
 import 'package:profile_repository/profile_repository.dart';
@@ -31,6 +34,7 @@ void main() {
     Widget createTestWidget({
       List<ShareableUser> contacts = const [],
       Duration? searchTimeout = const Duration(seconds: 20),
+      List<dynamic> extraOverrides = const [],
     }) {
       return testMaterialApp(
         home: Builder(
@@ -65,6 +69,7 @@ void main() {
         additionalOverrides: [
           profileRepositoryProvider.overrideWithValue(mockProfileRepo),
           profileReadRepositoryProvider.overrideWithValue(mockProfileRepo),
+          ...extraOverrides,
         ],
       );
     }
@@ -583,6 +588,129 @@ void main() {
           ).called(1);
         },
       );
+    });
+
+    // #8421: Find People routes straight into DmRepository.sendMessage, and
+    // its search reaches third-party NIP-50 relays a NIP-62 vanish addressed
+    // elsewhere never obliged to forget. So a deleted account's kind 0 does
+    // come back here, and the row must not present it as an identity.
+    group('DM peer identity', () {
+      const vanishedPubkey =
+          'b75b9a3131f4263add94ba20beb352a11032684f2dac07a7e1af827c6f3c1505';
+
+      Future<void> openWith(
+        WidgetTester tester, {
+        required ShareableUser contact,
+        bool isVanished = false,
+      }) async {
+        await tester.pumpWidget(
+          createTestWidget(
+            contacts: [contact],
+            searchTimeout: null,
+            extraOverrides: [
+              profileVanishedProvider(
+                contact.pubkey,
+              ).overrideWith((ref) => isVanished),
+            ],
+          ),
+        );
+        await tester.tap(find.text('Open Sheet'));
+        await tester.pumpAndSettle();
+      }
+
+      testWidgets('names a vanished peer "Deleted account"', (tester) async {
+        await openWith(
+          tester,
+          contact: const ShareableUser(
+            pubkey: vanishedPubkey,
+            displayName: 'Aeontropy',
+            handle: '@aeontropy',
+          ),
+          isVanished: true,
+        );
+
+        expect(find.text('Deleted account'), findsOneWidget);
+        expect(find.text('Aeontropy'), findsNothing);
+      });
+
+      testWidgets(
+        "hides a vanished peer's handle, which identifies them too",
+        (
+          tester,
+        ) async {
+          await openWith(
+            tester,
+            contact: const ShareableUser(
+              pubkey: vanishedPubkey,
+              displayName: 'Aeontropy',
+              handle: '@aeontropy',
+            ),
+            isVanished: true,
+          );
+
+          expect(find.text('@aeontropy'), findsNothing);
+        },
+      );
+
+      testWidgets('gives the moderation account its bundled wordmark and '
+          'shared name', (tester) async {
+        await openWith(
+          tester,
+          contact: const ShareableUser(
+            pubkey: kModerationPubkeyHex,
+            displayName: 'moderation-bot-v2',
+          ),
+        );
+
+        expect(find.byType(ModerationAvatar), findsOneWidget);
+        expect(find.text('Divine Moderation'), findsOneWidget);
+        expect(find.text('moderation-bot-v2'), findsNothing);
+      });
+
+      testWidgets('hands the resolved identity on, so the share sheet cannot '
+          'name the peer differently', (tester) async {
+        const contact = ShareableUser(
+          pubkey: vanishedPubkey,
+          displayName: 'Aeontropy',
+          handle: '@aeontropy',
+          picture: 'https://example.invalid/a.png',
+        );
+        ShareableUser? result;
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            home: Builder(
+              builder: (context) => Scaffold(
+                body: ElevatedButton(
+                  onPressed: () async {
+                    result = await FindPeopleSheet.show(
+                      context,
+                      contacts: const [contact],
+                      currentUserPubkey: currentUserPubkey,
+                    );
+                  },
+                  child: const Text('Open Sheet'),
+                ),
+              ),
+            ),
+            additionalOverrides: [
+              profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+              profileReadRepositoryProvider.overrideWithValue(mockProfileRepo),
+              profileVanishedProvider(
+                vanishedPubkey,
+              ).overrideWith((ref) => true),
+            ],
+          ),
+        );
+        await tester.tap(find.text('Open Sheet'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Deleted account'));
+        await tester.pumpAndSettle();
+
+        expect(result?.displayName, 'Deleted account');
+        expect(result?.handle, isNull);
+        expect(result?.picture, isNull);
+      });
     });
   });
 }

--- a/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
@@ -12,9 +12,12 @@ import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/share_sheet/share_sheet_bloc.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/auth_state.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/screens/inbox/widgets/moderation_identity.dart';
 import 'package:openvine/services/video_sharing_service.dart';
 import 'package:openvine/widgets/video_feed_item/actions/share_action_button.dart';
 import 'package:profile_repository/profile_repository.dart';
@@ -379,6 +382,86 @@ void main() {
           when(
             () => mockVideoSharingService.recentlySharedWith,
           ).thenReturn([alice, bob]);
+        });
+
+        // #8421: the "Share with" row is a DM send target — tapping a contact
+        // hands it to ShareSheetBloc, which routes to DmRepository.sendMessage
+        // — so it must name and picture its peer the way the inbox does.
+        group('DM peer identity', () {
+          const vanished = ShareableUser(
+            pubkey:
+                'b75b9a3131f4263add94ba20beb352a1'
+                '1032684f2dac07a7e1af827c6f3c1505',
+            displayName: 'Aeontropy',
+            picture: 'https://example.invalid/aeontropy.png',
+          );
+          const moderation = ShareableUser(
+            pubkey: kModerationPubkeyHex,
+            displayName: 'moderation-bot-v2',
+          );
+
+          Future<void> pumpWithContact(
+            WidgetTester tester,
+            ShareableUser contact, {
+            bool isVanished = false,
+          }) async {
+            when(
+              () => mockVideoSharingService.recentlySharedWith,
+            ).thenReturn([contact]);
+
+            await tester.pumpWidget(
+              testMaterialApp(
+                home: Scaffold(body: ShareActionButton(video: testVideo)),
+                additionalOverrides: [
+                  videoSharingServiceProvider.overrideWith(
+                    (ref) => mockVideoSharingService,
+                  ),
+                  profileVanishedProvider(
+                    contact.pubkey,
+                  ).overrideWith((ref) => isVanished),
+                ],
+                mockAuthService: createMockAuthService(),
+                mockProfileRepository: mockProfileRepository,
+                mockFollowRepository: mockFollowRepository,
+              ),
+            );
+            await tester.tap(find.byType(ShareActionButton));
+            await tester.pumpAndSettle();
+          }
+
+          testWidgets('names a vanished peer "Deleted account"', (
+            tester,
+          ) async {
+            await pumpWithContact(tester, vanished, isVanished: true);
+
+            expect(
+              find.text(l10n.profileDeletedAccountName),
+              findsOneWidget,
+            );
+            expect(find.text('Aeontropy'), findsNothing);
+          });
+
+          testWidgets('gives the moderation account its bundled wordmark and '
+              'shared name', (tester) async {
+            await pumpWithContact(tester, moderation);
+
+            expect(find.byType(ModerationAvatar), findsOneWidget);
+            expect(find.text(l10n.inboxSupportRowTitle), findsOneWidget);
+            expect(find.text('moderation-bot-v2'), findsNothing);
+          });
+
+          testWidgets('announces the resolved name when a peer is selected', (
+            tester,
+          ) async {
+            await pumpWithContact(tester, vanished, isVanished: true);
+
+            await tester.tap(find.text(l10n.profileDeletedAccountName));
+            await tester.pumpAndSettle();
+
+            // The selection chip in the composer header names the recipient
+            // the row named, not the kind-0 identity behind it.
+            expect(find.text('Aeontropy'), findsNothing);
+          });
         });
 
         Future<void> pumpOpenSheet(WidgetTester tester) async {


### PR DESCRIPTION
Closes #8421.

## What was actually wrong

I validated every claim on the issue by executing the paths rather than reading them, and the picture that survives is narrower than the title but real, and reachable in ways the issue did not name.

**Confirmed.** Both DM send-target pickers resolve peer identity themselves instead of through `dmPeerName` — no vanish step, no moderation step — and `NewMessageSearchBloc` sorts and filters on the raw `bestDisplayName` rather than the rendered one. That second half is #8204's defect in a different BLoC: a row can be found by a string it does not show, and hidden from the one it does.

**Confirmed live on the simulator.** Searching the new-message picker for the moderation account gives it a **generic placeholder avatar**, where the inbox row for the same pubkey shows the bundled Divine wordmark. Before / after:

| `main` | this branch |
|---|---|
| generic orange placeholder | Divine wordmark, matching the inbox |

The *name* happens to match today only because the current moderation key's kind 0 is literally `Divine Moderation`. Nothing holds that; the picker was reading the account's own metadata, not the label.

**Reachability, measured against production rather than argued.** `NostrClient.queryUsers` fans out to `relay.nostr.band`, `search.nos.today` and `nostr.wine`. NIP-62 obliges a relay to delete only *"if their service URL is tagged in the event"* — the duty is per-relay and addressed to relays, and the NIP says nothing at all about client display. So a vanish published to Divine's relay leaves those three still serving the kind 0. I queried them with the exact filter the picker builds (`{kinds:[0], limit:100, search:"<query>"}`) for three pubkeys funnelcake reports as `has_vanish_request: true` with a null profile — i.e. accounts for which Divine writes the local tombstone and every inbox surface already says "Deleted account". Two of the three relays returned their kind 0, with real name and picture. funnelcake's own search correctly excludes them; the exposure is the NIP-50 leg, and `searchUsers` applies only the block filter, never the tombstone.

**Corrected — the issue's own correction is right, but not for the reason it gives.** `shareUserFallback` ("User") really is unreachable, and it is *not* because `hasVisibleIdentity` filters the row out: `ShareSheetBloc._onContactsLoadRequested` explicitly **includes** cache misses on its first pass (`includeMisses: true`), so a profile-less contact does reach the widget. It is unreachable because `_ShareWithSection` routes any `!hasVisibleIdentity` contact into the skeleton branch and renders `_skeletonContact` instead. Same conclusion, different mechanism — worth recording, because the mechanism is what a future change would break.

## What this changes

**`dmPeerAvatar`** — the avatar half of the chain, beside `dmPeerDisplayName`. Drop a vanished account's photo; substitute the bundled wordmark for the moderation account. Those two rules were written out by hand at each of the five inbox rows, so a new surface could take the name step and skip the picture step — which is exactly what happened here. Additive; the existing rows are untouched.

**The new-message picker** resolves through `dmPeerName` / `dmPeerAvatar`, and its BLoC mirrors `watchVanishedPubkeys()` and takes its labels from the sheet the way `ConversationListBloc` does, so the sort and the search match the string on screen. Both inputs arrive asynchronously, so the contact order is recomputed when either lands after the list — a test caught that.

**The share row and Find People** do the same, and the *resolved* recipient is handed on with the selection, so the selection chip, the screen-reader announcement and the success snackbar stop re-deriving the name three more ways. `shareUserFallback`, `shareContactFallback`, `findPeopleAnonymousUser` and a hardcoded English `'user'` in `ShareSheetBloc` are gone — four different answers to "who is this", replaced by the chain's own generated fallback. The ARB keys are deleted from all 23 locales.

## Not decided here

Whether a vanished account should be **offered as a DM send target at all** is a product call, not a naming one. This PR makes the picker stop misnaming them; it does not remove them. Flagging it rather than deciding it.

`isResolving` is deliberately not threaded into either picker: both build their rows *from* profiles, and `bestDisplayName` is never null, so the step is unreachable there by construction.

## Verification

- Every new test fails on `main` and passes here — the three widget suites fail on assertions (`+2 -4`, `+16 -4`, `+20 -3`), not on compilation.
- `flutter analyze lib test integration_test` clean; `dart format --set-exit-if-changed` clean.
- 1192 tests green across `test/screens/inbox`, `test/widgets/find_people_sheet_test.dart`, `test/widgets/video_feed_item/actions`, `test/blocs/share_sheet`, `test/blocs/dm`.
- `arb_consistency_test` green; orphaned-ARB, post-close-emit, shared-setup-stub, ungrouped-test, placeholder-test, l10n-delegate, skip and test-unit ratchets all green.
- Driven end-to-end on the iOS simulator against production, before and after.
