### PR TITLE
fix(profile): resolve people-picker and shared-row identity through the vanished step

### DIFF
--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -566,7 +566,7 @@
     "description": "Remove-conversation confirmation for a direct-message peer whose account was deleted. Complete copy without a display-name placeholder so each locale controls its grammar."
   },
   "@profileDeletedAccountName": {
-    "description": "Stands in for the display name of an account that requested deletion. A noun phrase used where a person's name would normally appear — the inbox row, the conversation header, and the following bar."
+    "description": "Stands in for the display name of an account that requested deletion. A noun phrase used wherever a person's name would normally appear, in DM and non-DM surfaces alike — the inbox row, the conversation header, the following bar, the profile screen and header, the people picker, and the shared people row."
   },
   "inboxConversationDeletedAccountSubtitle": "This account was deleted",
   "@inboxConversationDeletedAccountSubtitle": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -1406,7 +1406,7 @@ abstract class AppLocalizations {
   /// **'Message'**
   String get profileMessageLabel;
 
-  /// Stands in for the display name of an account that requested deletion. A noun phrase used where a person's name would normally appear — the inbox row, the conversation header, and the following bar.
+  /// Stands in for the display name of an account that requested deletion. A noun phrase used wherever a person's name would normally appear, in DM and non-DM surfaces alike — the inbox row, the conversation header, the following bar, the profile screen and header, the people picker, and the shared people row.
   ///
   /// In en, this message translates to:
   /// **'Deleted account'**

--- a/mobile/lib/widgets/profile/new_people_list_sheet.dart
+++ b/mobile/lib/widgets/profile/new_people_list_sheet.dart
@@ -4,12 +4,15 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/people_lists/bloc/people_lists_bloc.dart';
 import 'package:openvine/features/people_lists/curated_lists_gate.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/widgets/user_picker_sheet.dart';
+import 'package:openvine/widgets/vanished_account_identity.dart';
 
 /// Shows the "New people list" bottom sheet.
 ///
@@ -156,7 +159,14 @@ class _NewPeopleListSheetBodyState extends State<_NewPeopleListSheetBody> {
   }
 }
 
-class _CollaboratorsRow extends StatelessWidget {
+/// The picked collaborators, summarised on one line.
+///
+/// Resolves each name rather than reading `bestDisplayName` off the profile
+/// the picker handed back. `UserPickerSheet` substitutes at render time, so a
+/// consumer that keeps the `UserProfile` and formats its own text — as this
+/// one does — does not inherit that and would name a deleted account here
+/// after the picker itself stopped.
+class _CollaboratorsRow extends ConsumerWidget {
   const _CollaboratorsRow({
     required this.collaborators,
     required this.onTap,
@@ -168,8 +178,16 @@ class _CollaboratorsRow extends StatelessWidget {
   final AppLocalizations l10n;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final hasCollaborators = collaborators.isNotEmpty;
+    final names = [
+      for (final profile in collaborators)
+        vanishedAccountName(
+          context,
+          isVanished: ref.watch(profileVanishedProvider(profile.pubkey)),
+          fallbackName: profile.bestDisplayName,
+        ),
+    ].join(', ');
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -191,9 +209,7 @@ class _CollaboratorsRow extends StatelessWidget {
                 Expanded(
                   child: hasCollaborators
                       ? Text(
-                          collaborators
-                              .map((p) => p.bestDisplayName)
-                              .join(', '),
+                          names,
                           style: VineTheme.titleMediumFont(
                             color: context.vineColors.primaryText,
                           ),

--- a/mobile/lib/widgets/profile/profile_header_identity.dart
+++ b/mobile/lib/widgets/profile/profile_header_identity.dart
@@ -136,12 +136,20 @@ class _ProfileHeaderNameRow extends ConsumerWidget {
     final textStyle = VineTheme.titleLargeFont(
       color: context.vineColors.primaryText,
     );
-    final isOgViner = ref.watch(
-      ogVinerCacheServiceProvider.select(
-        (service) => service.isOgViner(userIdHex),
-      ),
-    );
-    final showCheckmark = shouldShowSpecialProfileCheckmark(userIdHex);
+    // Every chit beside the name is gated on !isVanished for the reason the
+    // comment below gives: all three rosters are compiled in, so none of them
+    // can drop an account that vanishes after release. Only the beta chit
+    // carried the gate until now, which left a vanished team pubkey rendering
+    // "Deleted account" with a checkmark beside it.
+    final isOgViner =
+        !isVanished &&
+        ref.watch(
+          ogVinerCacheServiceProvider.select(
+            (service) => service.isOgViner(userIdHex),
+          ),
+        );
+    final showCheckmark =
+        !isVanished && shouldShowSpecialProfileCheckmark(userIdHex);
     // The beta chit yields to both the checkmark and the OG Viner chit, so a
     // name never carries two of them. The Viner rosters are disjoint by
     // construction; many team accounts also appear on the beta roster, so the

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -13,8 +13,11 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/user_search/user_search_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/database_provider.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/user_avatar.dart';
+import 'package:openvine/widgets/vanished_account_identity.dart';
 
 /// Filter mode for user search in [UserPickerSheet].
 enum UserPickerFilterMode {
@@ -125,6 +128,15 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
   // For mutualFollowsOnly: local follow list search
   List<UserProfile> _followProfiles = [];
   List<UserProfile> _filteredFollowProfiles = [];
+
+  /// Pubkeys carrying a NIP-62 vanish tombstone, mirrored from
+  /// [vanishedProfilePubkeysProvider].
+  ///
+  /// Held rather than sampled per row so the sort and the filter resolve
+  /// against the same set, and so one subscription covers a list of any
+  /// length. It can arrive after the list is already sorted, which is what
+  /// [_onVanishedPubkeysChanged] re-derives against.
+  Set<String> _vanishedPubkeys = const {};
   bool _followListLoaded = false;
   StreamSubscription<List<String>>? _followersSubscription;
   final _selectedProfiles = <UserProfile>[];
@@ -201,18 +213,24 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
       final cached = await profileRepo.getCachedProfiles(
         pubkeys: followingPubkeys,
       );
-      candidates =
-          cached
-              .where(
-                (profile) =>
-                    !blocklistRepository.shouldFilterFromFeeds(profile.pubkey),
-              )
-              .toList()
-            ..sort(
-              (a, b) => a.bestDisplayName.toLowerCase().compareTo(
-                b.bestDisplayName.toLowerCase(),
-              ),
-            );
+      if (!mounted) return;
+      // Seed from the current value rather than waiting for the listener:
+      // `ref.listen` fires on change only, so a set that already arrived
+      // before this widget mounted would never reach the first sort.
+      _vanishedPubkeys =
+          ref.read(vanishedProfilePubkeysProvider).value ?? const {};
+      // Sorted after the await, never before: `_deletedAccountLabel` is an
+      // inherited-widget read and this method is kicked off from initState. A
+      // vanished row sorts where "Deleted account" puts it, not where the name
+      // it no longer shows would.
+      candidates = _sortedByRenderedName(
+        cached
+            .where(
+              (profile) =>
+                  !blocklistRepository.shouldFilterFromFeeds(profile.pubkey),
+            )
+            .toList(),
+      );
     } catch (_) {
       if (mounted) {
         setState(() {
@@ -243,11 +261,15 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
         // state before the slower ones answer would flash "you follow nobody".
         if (mutuals.isEmpty && !_followListLoaded) return;
 
+        // Sorted here rather than once at load: this listener re-assigns the
+        // list on every follower source, so a re-sort triggered by a late
+        // vanish set would otherwise be overwritten by the next emission.
+        final ordered = _sortedByRenderedName(mutuals);
         setState(() {
-          _followProfiles = mutuals;
+          _followProfiles = ordered;
           _filteredFollowProfiles = _matchingFollowProfiles(
             _searchController.text,
-            mutuals,
+            ordered,
           );
           _followListLoaded = true;
         });
@@ -256,11 +278,12 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
       // usable instead of hanging in loading.
       onError: (Object _) {
         if (!mounted) return;
+        final ordered = _sortedByRenderedName(candidates);
         setState(() {
-          _followProfiles = candidates;
+          _followProfiles = ordered;
           _filteredFollowProfiles = _matchingFollowProfiles(
             _searchController.text,
-            candidates,
+            ordered,
           );
           _followListLoaded = true;
         });
@@ -320,10 +343,53 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
     if (trimmed.isEmpty) return profiles;
 
     return profiles.where((profile) {
-      final name = profile.bestDisplayName.toLowerCase();
-      final nip05 = (profile.nip05 ?? '').toLowerCase();
+      final isVanished = _vanishedPubkeys.contains(profile.pubkey);
+      final name = _renderedName(profile).toLowerCase();
+      // A vanished account's NIP-05 identifies it as surely as its name, so it
+      // is neither rendered nor matchable — otherwise the row stays findable by
+      // a string it no longer shows.
+      final nip05 = isVanished ? '' : (profile.nip05 ?? '').toLowerCase();
       return name.contains(trimmed) || nip05.contains(trimmed);
     }).toList();
+  }
+
+  /// The substitute a vanished row shows in place of its name.
+  ///
+  /// An inherited-widget read, so it is unavailable until `initState` has
+  /// returned — every caller below runs after that point.
+  String get _deletedAccountLabel => context.l10n.profileDeletedAccountName;
+
+  /// The name the row for [profile] renders.
+  String _renderedName(UserProfile profile) => vanishedAccountNameFrom(
+    isVanished: _vanishedPubkeys.contains(profile.pubkey),
+    deletedAccountLabel: _deletedAccountLabel,
+    fallbackName: profile.bestDisplayName,
+  );
+
+  /// [profiles] ordered by the name each row renders.
+  List<UserProfile> _sortedByRenderedName(List<UserProfile> profiles) {
+    String key(UserProfile p) => _renderedName(p).toLowerCase();
+    return profiles.toList()..sort((a, b) => key(a).compareTo(key(b)));
+  }
+
+  /// Re-derives the follow list against a newly delivered vanished set.
+  ///
+  /// The tombstone stream emits after the first frame, so a list sorted at load
+  /// time is keyed on the pre-substitution names until this runs.
+  void _onVanishedPubkeysChanged(Set<String> pubkeys) {
+    if (!mounted) return;
+    if (pubkeys.length == _vanishedPubkeys.length &&
+        pubkeys.containsAll(_vanishedPubkeys)) {
+      return;
+    }
+    setState(() {
+      _vanishedPubkeys = pubkeys;
+      _followProfiles = _sortedByRenderedName(_followProfiles);
+      _filteredFollowProfiles = _matchingFollowProfiles(
+        _searchController.text,
+        _followProfiles,
+      );
+    });
   }
 
   void _onUserSelected(UserProfile profile) {
@@ -365,6 +431,15 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
     if (_profileRepoMissing) {
       return const _ProfileRepoUnavailable();
     }
+
+    // One subscription for the whole sheet rather than one per row: the rows
+    // are unbounded and every one of them asks the same question.
+    // The sort and the filter need the whole set; each row watches its own
+    // pubkey through profileVanishedProvider, which derives from this same
+    // stream — the shape every inbox row already uses.
+    ref.listen(vanishedProfilePubkeysProvider, (_, next) {
+      _onVanishedPubkeysChanged(next.value ?? const {});
+    });
 
     final hintText =
         widget.searchHint ??
@@ -545,7 +620,15 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
 }
 
 /// A tile displaying a user profile in the search results.
-class _UserSearchTile extends StatelessWidget {
+/// One candidate row.
+///
+/// A NIP-62 vanished account must not be named or pictured here: this picker
+/// feeds badge awards (kind 8, which NIP-58 calls "immutable and
+/// non-transferable"), people lists (kind 30000) and video `p` tags (kind
+/// 34236), so a wrong identity is published permanently and in public. The
+/// `allUsers` mode reaches third-party NIP-50 relays that a vanish addressed
+/// elsewhere never obliged to forget, so the pre-vanish kind 0 does come back.
+class _UserSearchTile extends ConsumerWidget {
   const _UserSearchTile({
     required this.profile,
     required this.onTap,
@@ -560,12 +643,23 @@ class _UserSearchTile extends StatelessWidget {
   final bool isSelected;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final textColor = context.vineColors.onSurface;
+    final isVanished = ref.watch(profileVanishedProvider(profile.pubkey));
+    final displayName = vanishedAccountName(
+      context,
+      isVanished: isVanished,
+      fallbackName: profile.bestDisplayName,
+    );
     final action = isDisabled
-        ? context.l10n.userPickerAlreadyAddedSemantics(profile.bestDisplayName)
-        : context.l10n.userPickerSelectSemantics(profile.bestDisplayName);
-    final nip05 = profile.nip05;
+        ? context.l10n.userPickerAlreadyAddedSemantics(displayName)
+        : context.l10n.userPickerSelectSemantics(displayName);
+    // `shortDisplayNip05`, not the raw field: every other identity string here
+    // is sanitized, and this one arrives from relay search results. An unpaired
+    // UTF-16 surrogate in a kind 0 crashes the paragraph builder, which is what
+    // `text_sanitizer` exists to prevent. It also renders `@rabble` rather than
+    // the `_@rabble.divine.video` long form every other row avoids.
+    final nip05 = isVanished ? null : profile.shortDisplayNip05;
 
     return Semantics(
       button: true,
@@ -585,8 +679,11 @@ class _UserSearchTile extends StatelessWidget {
                 Opacity(
                   opacity: isDisabled ? 0.5 : 1.0,
                   child: UserAvatar(
-                    imageUrl: profile.picture,
-                    name: profile.bestDisplayName,
+                    imageUrl: vanishedAccountPictureUrl(
+                      isVanished: isVanished,
+                      pictureUrl: profile.picture,
+                    ),
+                    name: displayName,
                     placeholderSeed: profile.pubkey,
                     size: 40,
                   ),
@@ -596,14 +693,14 @@ class _UserSearchTile extends StatelessWidget {
                     crossAxisAlignment: .start,
                     children: [
                       Text(
-                        profile.bestDisplayName,
+                        displayName,
                         maxLines: 1,
                         overflow: .ellipsis,
                         style: VineTheme.titleMediumFont(color: textColor),
                       ),
-                      if (profile.nip05 != null && profile.nip05!.isNotEmpty)
+                      if (nip05 != null && nip05.isNotEmpty)
                         Text(
-                          profile.nip05!,
+                          nip05,
                           maxLines: 1,
                           overflow: .ellipsis,
                           style: VineTheme.bodyMediumFont(color: textColor),
@@ -987,14 +1084,14 @@ class _UserPickerTitle extends StatelessWidget {
   }
 }
 
-class _SelectedChipsRow extends StatelessWidget {
+class _SelectedChipsRow extends ConsumerWidget {
   const _SelectedChipsRow({required this.profiles, required this.onRemove});
 
   final List<UserProfile> profiles;
   final ValueChanged<UserProfile> onRemove;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
       child: Wrap(
@@ -1004,7 +1101,13 @@ class _SelectedChipsRow extends StatelessWidget {
           for (final profile in profiles)
             _SelectionChip(
               key: ValueKey(profile.pubkey),
-              label: profile.bestDisplayName,
+              label: vanishedAccountName(
+                context,
+                isVanished: ref.watch(
+                  profileVanishedProvider(profile.pubkey),
+                ),
+                fallbackName: profile.bestDisplayName,
+              ),
               onRemove: () => onRemove(profile),
             ),
         ],

--- a/mobile/lib/widgets/user_profile_tile.dart
+++ b/mobile/lib/widgets/user_profile_tile.dart
@@ -18,6 +18,7 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/utils/user_identifier_line_resolver.dart';
 import 'package:openvine/widgets/unfollow_confirmation_sheet.dart';
 import 'package:openvine/widgets/user_avatar.dart';
+import 'package:openvine/widgets/vanished_account_identity.dart';
 
 /// A tile widget for displaying user profile information in lists.
 ///
@@ -73,6 +74,10 @@ class UserProfileTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final profile = ref.watch(userProfileReactiveProvider(pubkey)).value;
+    // The picker that feeds the badge screens resolves this; so must the rows
+    // it hands off to, or awarding a badge to a deleted account shows their old
+    // name on the screen that confirms it (#8421 adjacent).
+    final isVanished = ref.watch(profileVanishedProvider(pubkey));
     final authService = ref.watch(authServiceProvider);
     final isCurrentUser = pubkey == authService.currentPublicKeyHex;
     final profileListFeaturesEnabled = ref.watch(
@@ -87,10 +92,17 @@ class UserProfileTile extends ConsumerWidget {
     final showAddToList =
         profileListFeaturesEnabled && curatedListsEnabled && !isCurrentUser;
 
-    final displayName =
-        profile?.bestDisplayName ?? UserProfile.defaultDisplayNameFor(pubkey);
+    final displayName = vanishedAccountName(
+      context,
+      isVanished: isVanished,
+      fallbackName:
+          profile?.bestDisplayName ?? UserProfile.defaultDisplayNameFor(pubkey),
+    );
 
-    final claimedNip05 = profile?.shortDisplayNip05;
+    // Dropped for a vanished account for the same reason as the name, and
+    // nulling it also skips the NIP-05 verification lookup — there is nothing
+    // left to verify a claim against.
+    final claimedNip05 = isVanished ? null : profile?.shortDisplayNip05;
     final verificationStatus = claimedNip05 != null && claimedNip05.isNotEmpty
         ? ref
               .watch(nip05VerificationProvider(pubkey))
@@ -122,7 +134,10 @@ class UserProfileTile extends ConsumerWidget {
             children: [
               // Avatar with border (matching video player style)
               UserAvatar(
-                imageUrl: profile?.picture,
+                imageUrl: vanishedAccountPictureUrl(
+                  isVanished: isVanished,
+                  pictureUrl: profile?.picture,
+                ),
                 name: displayName,
                 placeholderSeed: pubkey,
                 size: 48,

--- a/mobile/lib/widgets/user_profile_tile.dart
+++ b/mobile/lib/widgets/user_profile_tile.dart
@@ -103,23 +103,30 @@ class UserProfileTile extends ConsumerWidget {
     // nulling it also skips the NIP-05 verification lookup — there is nothing
     // left to verify a claim against.
     final claimedNip05 = isVanished ? null : profile?.shortDisplayNip05;
+    // The whole second line goes with it. `resolveUserIdentifierLine` falls
+    // through to relationship and follower count when it has no handle, so
+    // dropping only the handle would have swapped "@alice" for "Follows you ·
+    // 5K followers" on a deleted account — quieter than the name, and still
+    // social proof about someone who asked to be erased.
     final verificationStatus = claimedNip05 != null && claimedNip05.isNotEmpty
         ? ref
               .watch(nip05VerificationProvider(pubkey))
               .whenOrNull(data: (status) => status)
         : null;
 
-    final uniqueIdentifier = resolveUserIdentifierLine(
-      l10n: context.l10n,
-      locale: Localizations.localeOf(context).toLanguageTag(),
-      handle: claimedNip05,
-      verificationStatus: verificationStatus,
-      isOwnProfile: isCurrentUser,
-      relationship:
-          ref.watch(followRelationshipProvider(pubkey)).value ??
-          FollowRelationship.none,
-      followerCount: profile?.restFollowerCount,
-    );
+    final uniqueIdentifier = isVanished
+        ? null
+        : resolveUserIdentifierLine(
+            l10n: context.l10n,
+            locale: Localizations.localeOf(context).toLanguageTag(),
+            handle: claimedNip05,
+            verificationStatus: verificationStatus,
+            isOwnProfile: isCurrentUser,
+            relationship:
+                ref.watch(followRelationshipProvider(pubkey)).value ??
+                FollowRelationship.none,
+            followerCount: profile?.restFollowerCount,
+          );
 
     return Semantics(
       identifier: 'user_profile_tile_$pubkey',

--- a/mobile/lib/widgets/vanished_account_identity.dart
+++ b/mobile/lib/widgets/vanished_account_identity.dart
@@ -1,0 +1,60 @@
+// ABOUTME: The name and picture a NON-DM surface shows for a NIP-62 vanished
+// ABOUTME: account. Deliberately narrower than the DM chain: no moderation
+// ABOUTME: step, because that substitution is scoped to inbox surfaces.
+
+import 'package:flutter/widgets.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+/// The name to render for [fallbackName]'s account, substituting the
+/// deleted-account label when the account published a NIP-62 request to vanish.
+///
+/// Four non-DM surfaces already spell this out by hand — `other_profile_screen`,
+/// `profile_header_widget`, `profile_header_identity` and `profile_banner_layer`
+/// — and the people picker and the shared people row shipped without it. This is
+/// that one line, in one place, so a new people surface gets it by calling
+/// rather than by remembering.
+///
+/// Deliberately **not** `dmPeerName`. That chain carries a moderation step bound
+/// to the inbox-namespaced `inboxSupportRowTitle`, and
+/// `moderation_identity.dart` scopes the substitution to DM surfaces: a badge
+/// picker naming an account "Divine Moderation" would be inventing an identity
+/// the rest of the app does not use outside the inbox.
+///
+/// [fallbackName] is the caller's already-resolved name — `bestDisplayName`, or
+/// whatever placeholder that surface uses when no profile has arrived. It is
+/// only consulted when the account has not vanished, so a caller may pass a
+/// stale value without leaking it.
+String vanishedAccountName(
+  BuildContext context, {
+  required bool isVanished,
+  required String fallbackName,
+}) => vanishedAccountNameFrom(
+  isVanished: isVanished,
+  deletedAccountLabel: context.l10n.profileDeletedAccountName,
+  fallbackName: fallbackName,
+);
+
+/// [vanishedAccountName] without a [BuildContext], for a caller that sorts or
+/// filters on the rendered name outside a `build`.
+///
+/// The split exists for the same reason `dmPeerName` sits apart from
+/// `dmPeerDisplayName`: an ordering has to key on the string the row shows, and
+/// the code that computes an ordering is not always holding a context. Pass the
+/// already-resolved `profileDeletedAccountName` as [deletedAccountLabel] so both
+/// paths substitute the same string.
+String vanishedAccountNameFrom({
+  required bool isVanished,
+  required String deletedAccountLabel,
+  required String fallbackName,
+}) => isVanished ? deletedAccountLabel : fallbackName;
+
+/// The avatar URL to render, dropped for a vanished account.
+///
+/// The name substitution alone is not enough: a row reading "Deleted account"
+/// over the account's own photo still identifies them to anyone who recognises
+/// the face. Returns null so `UserAvatar` falls back to its pubkey-seeded
+/// placeholder, which is what the profile header already does.
+String? vanishedAccountPictureUrl({
+  required bool isVanished,
+  String? pictureUrl,
+}) => isVanished ? null : pictureUrl;

--- a/mobile/test/widgets/profile/new_people_list_sheet_test.dart
+++ b/mobile/test/widgets/profile/new_people_list_sheet_test.dart
@@ -2,18 +2,33 @@
 // ABOUTME: The sheet reads the lazily-registered global PeopleListsBloc.
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/features/people_lists/bloc/people_lists_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/widgets/profile/new_people_list_sheet.dart';
+import 'package:profile_repository/profile_repository.dart';
+import 'package:rxdart/rxdart.dart';
 
 class _MockPeopleListsBloc extends MockBloc<PeopleListsEvent, PeopleListsState>
     implements PeopleListsBloc {}
+
+class _MockProfileRepository extends Mock implements ProfileRepository {}
+
+class _MockFollowRepository extends Mock implements FollowRepository {}
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
 
 void main() {
   group('showNewPeopleListSheet', () {
@@ -61,6 +76,77 @@ void main() {
       },
     );
 
+    // The summary line keeps the `UserProfile` the picker handed back and
+    // formats its own text, so it does not inherit the picker's own
+    // substitution — a deleted collaborator was still named here after the
+    // picker itself stopped naming them.
+    testWidgets('names a vanished collaborator "Deleted account"', (
+      tester,
+    ) async {
+      const vanishedPubkey =
+          'b75b9a3131f4263add94ba20beb352a1'
+          '1032684f2dac07a7e1af827c6f3c1505';
+      final collaborator = UserProfile(
+        pubkey: vanishedPubkey,
+        displayName: 'Aeontropy',
+        rawData: const {},
+        createdAt: DateTime(2026),
+        eventId: 'e' * 64,
+      );
+
+      final profileRepo = _MockProfileRepository();
+      when(
+        () => profileRepo.getCachedProfiles(pubkeys: any(named: 'pubkeys')),
+      ).thenAnswer((_) async => [collaborator]);
+      when(
+        () => profileRepo.getCachedProfile(pubkey: any(named: 'pubkey')),
+      ).thenAnswer((_) async => collaborator);
+
+      final followRepo = _MockFollowRepository();
+      when(() => followRepo.followingPubkeys).thenReturn([vanishedPubkey]);
+      when(() => followRepo.isInitialized).thenReturn(true);
+      when(() => followRepo.followingCount).thenReturn(1);
+      when(
+        () => followRepo.followingStream,
+      ).thenAnswer(
+        (_) => BehaviorSubject<List<String>>.seeded([
+          vanishedPubkey,
+        ]).stream,
+      );
+      when(
+        followRepo.streamMyFollowers,
+      ).thenAnswer((_) => Stream.value([vanishedPubkey]));
+      when(followRepo.getMyFollowers).thenAnswer((_) async => [vanishedPubkey]);
+
+      final blocklist = _MockContentBlocklistRepository();
+      when(() => blocklist.shouldFilterFromFeeds(any())).thenReturn(false);
+
+      await tester.pumpWidget(
+        _buildSubject(
+          curatedListsEnabled: true,
+          createBloc: () => bloc,
+          extraOverrides: [
+            vanishedProfilePubkeysProvider.overrideWith(
+              (ref) => Stream.value({vanishedPubkey}),
+            ),
+            profileRepositoryProvider.overrideWithValue(profileRepo),
+            followRepositoryProvider.overrideWithValue(followRepo),
+            contentBlocklistRepositoryProvider.overrideWithValue(blocklist),
+          ],
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.listCollaboratorsNone));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.profileDeletedAccountName).last);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Aeontropy'), findsNothing);
+      expect(find.text(l10n.profileDeletedAccountName), findsWidgets);
+    });
+
     testWidgets('opens when curatedLists is on', (tester) async {
       await tester.pumpWidget(
         _buildSubject(curatedListsEnabled: true, createBloc: () => bloc),
@@ -79,12 +165,14 @@ void main() {
 Widget _buildSubject({
   required bool curatedListsEnabled,
   required PeopleListsBloc Function() createBloc,
+  List<dynamic> extraOverrides = const [],
 }) {
   return ProviderScope(
     overrides: [
       isFeatureEnabledProvider(
         FeatureFlag.curatedLists,
       ).overrideWithValue(curatedListsEnabled),
+      ...extraOverrides,
     ],
     child: BlocProvider<PeopleListsBloc>(
       create: (_) => createBloc(),

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -719,6 +719,30 @@ void main() {
       expect(find.byType(OgBetaBadge), findsNothing);
     });
 
+    testWidgets('hides the verified checkmark on a vanished account', (
+      tester,
+    ) async {
+      final teamPubkey = kDivineTeamPubkeys.first;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          userIdHex: teamPubkey,
+          isOwnProfile: false,
+          suppliedProfile: createTestProfile(
+            displayName: 'Team Member',
+            pubkey: teamPubkey,
+          ),
+          isVanished: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Same reasoning as the OG Beta chit above, and the same kind of
+      // roster: `kDivineTeamPubkeys` is compiled in, so it cannot drop a
+      // member who vanishes after release.
+      expect(find.byType(SpecialProfileCheckmark), findsNothing);
+    });
+
     testWidgets('opens checkmark explainer from profile header target', (
       tester,
     ) async {

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -743,6 +743,31 @@ void main() {
       expect(find.byType(SpecialProfileCheckmark), findsNothing);
     });
 
+    testWidgets('hides the OG Viner chit on a vanished account', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({
+        ogVinerPubkeysCacheKey: jsonEncode([testUserHex]),
+      });
+      final prefs = await SharedPreferences.getInstance();
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          userIdHex: testUserHex,
+          isOwnProfile: false,
+          suppliedProfile: createTestProfile(displayName: 'OG User'),
+          sharedPreferences: prefs,
+          isVanished: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Same reasoning as the OG Beta chit and the checkmark above: a vanished
+      // account renders profileDeletedAccountName, and the OG Viner roster is a
+      // cached set that cannot drop someone who vanishes after release.
+      expect(find.byType(OgVinerBadge), findsNothing);
+    });
+
     testWidgets('opens checkmark explainer from profile header target', (
       tester,
     ) async {

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -13,9 +13,12 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/user_picker_sheet.dart';
 import 'package:profile_repository/profile_repository.dart';
+// Riverpod 3 exports `Override` from `misc.dart`, not the main entry point.
+import 'package:riverpod/misc.dart';
 import 'package:rxdart/rxdart.dart';
 
 /// Mock for ProfileRepository
@@ -111,6 +114,18 @@ _MockFollowRepository _createMockFollowRepository({
   return mock;
 }
 
+/// No account carries a NIP-62 tombstone.
+///
+/// Every scope needs it: `UserPickerSheet` resolves each row's name and avatar
+/// through `profileVanishedProvider`, which derives from this stream, and
+/// without an override that reaches the real database.
+// ignore: specify_nonobvious_property_types
+final _noVanishedProfiles = _vanishedProfiles(const {});
+
+/// [pubkeys] carry a tombstone; nothing else does.
+Override _vanishedProfiles(Set<String> pubkeys) =>
+    vanishedProfilePubkeysProvider.overrideWith((ref) => Stream.value(pubkeys));
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -122,6 +137,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(),
               ),
@@ -160,6 +176,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(),
               ),
@@ -204,6 +221,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(),
               ),
@@ -236,6 +254,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(),
               ),
@@ -263,6 +282,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(),
               ),
@@ -297,6 +317,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(),
               ),
@@ -326,6 +347,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(),
               ),
@@ -381,6 +403,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(mockProfileRepo),
               profileReadRepositoryProvider.overrideWithValue(mockProfileRepo),
               followRepositoryProvider.overrideWithValue(mockFollowRepo),
@@ -417,6 +440,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(),
               ),
@@ -452,6 +476,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(),
               ),
@@ -503,6 +528,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(mockProfileRepo),
               profileReadRepositoryProvider.overrideWithValue(mockProfileRepo),
               followRepositoryProvider.overrideWithValue(mockFollowRepo),
@@ -553,6 +579,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(cachedProfiles: [profile]),
               ),
@@ -623,6 +650,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(cachedProfiles: profiles),
               ),
@@ -697,6 +725,7 @@ void main() {
           await tester.pumpWidget(
             ProviderScope(
               overrides: [
+                _noVanishedProfiles,
                 profileRepositoryProvider.overrideWithValue(
                   _createMockProfileRepository(cachedProfiles: profiles),
                 ),
@@ -766,6 +795,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(cachedProfiles: [profile]),
               ),
@@ -833,6 +863,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(mockProfileRepo),
               profileReadRepositoryProvider.overrideWithValue(mockProfileRepo),
               followRepositoryProvider.overrideWithValue(mockFollowRepo),
@@ -882,6 +913,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(cachedProfiles: profiles),
               ),
@@ -938,6 +970,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(cachedProfiles: [profile]),
               ),
@@ -1001,6 +1034,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(mockProfileRepo),
               profileReadRepositoryProvider.overrideWithValue(mockProfileRepo),
               followRepositoryProvider.overrideWithValue(mockFollowRepo),
@@ -1053,6 +1087,7 @@ void main() {
           await tester.pumpWidget(
             ProviderScope(
               overrides: [
+                _noVanishedProfiles,
                 profileRepositoryProvider.overrideWithValue(mockProfileRepo),
                 profileReadRepositoryProvider.overrideWithValue(
                   mockProfileRepo,
@@ -1089,6 +1124,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(),
               ),
@@ -1119,6 +1155,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(),
               ),
@@ -1176,6 +1213,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(mockProfileRepo),
               profileReadRepositoryProvider.overrideWithValue(mockProfileRepo),
               followRepositoryProvider.overrideWithValue(
@@ -1287,6 +1325,7 @@ void main() {
           await tester.pumpWidget(
             ProviderScope(
               overrides: [
+                _noVanishedProfiles,
                 profileRepositoryProvider.overrideWithValue(mockProfileRepo),
                 profileReadRepositoryProvider.overrideWithValue(
                   mockProfileRepo,
@@ -1330,6 +1369,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(),
               ),
@@ -1417,6 +1457,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(mockProfileRepo),
               profileReadRepositoryProvider.overrideWithValue(mockProfileRepo),
               followRepositoryProvider.overrideWithValue(
@@ -1472,6 +1513,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(),
               ),
@@ -1501,6 +1543,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
                 _createMockProfileRepository(),
               ),
@@ -1533,6 +1576,7 @@ void main() {
           await tester.pumpWidget(
             ProviderScope(
               overrides: [
+                _noVanishedProfiles,
                 profileRepositoryProvider.overrideWithValue(null),
                 profileReadRepositoryProvider.overrideWithValue(null),
                 followRepositoryProvider.overrideWithValue(
@@ -1568,6 +1612,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(null),
               profileReadRepositoryProvider.overrideWithValue(null),
               followRepositoryProvider.overrideWithValue(
@@ -1602,6 +1647,174 @@ void main() {
     });
   });
 
+  // #8421 adjacent: this picker feeds badge awards (kind 8, which NIP-58
+  // calls "immutable and non-transferable"), people lists (kind 30000) and
+  // video `p` tags (kind 34236). A wrong identity here is published
+  // permanently and in public, and `allUsers` mode reaches third-party
+  // NIP-50 relays that a vanish addressed elsewhere never obliged to forget.
+  group('vanished accounts', () {
+    const vanishedPubkey =
+        'b75b9a3131f4263add94ba20beb352a1'
+        '1032684f2dac07a7e1af827c6f3c1505';
+    const livePubkey =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    UserProfile profileFor(String pubkey, String name, {String? nip05}) =>
+        UserProfile(
+          pubkey: pubkey,
+          displayName: name,
+          nip05: nip05,
+          picture: 'https://example.invalid/$pubkey.png',
+          rawData: const {},
+          createdAt: DateTime(2026),
+          eventId: 'e' * 64,
+        );
+
+    Future<void> pumpPicker(
+      WidgetTester tester, {
+      required List<UserProfile> profiles,
+      required Set<String> vanished,
+      UserPickerFilterMode filterMode = UserPickerFilterMode.mutualFollowsOnly,
+    }) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            _vanishedProfiles(vanished),
+            profileRepositoryProvider.overrideWithValue(
+              _createMockProfileRepository(
+                cachedProfiles: profiles,
+                searchResults: profiles,
+              ),
+            ),
+            followRepositoryProvider.overrideWithValue(
+              _createMockFollowRepository(
+                followingPubkeys: [for (final p in profiles) p.pubkey],
+              ),
+            ),
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              _createMockContentBlocklistRepository(),
+            ),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: UserPickerSheet(title: 'Title', filterMode: filterMode),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('names a vanished follow "Deleted account"', (tester) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await pumpPicker(
+        tester,
+        profiles: [profileFor(vanishedPubkey, 'Aeontropy')],
+        vanished: {vanishedPubkey},
+      );
+
+      expect(find.text(l10n.profileDeletedAccountName), findsOneWidget);
+      expect(find.text('Aeontropy'), findsNothing);
+    });
+
+    testWidgets("hides a vanished account's NIP-05, which identifies it too", (
+      tester,
+    ) async {
+      await pumpPicker(
+        tester,
+        profiles: [
+          profileFor(
+            vanishedPubkey,
+            'Aeontropy',
+            nip05: 'aeontropy@example.com',
+          ),
+        ],
+        vanished: {vanishedPubkey},
+      );
+
+      expect(find.text('aeontropy@example.com'), findsNothing);
+    });
+
+    testWidgets('announces the substitute, not the name it no longer shows', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await pumpPicker(
+        tester,
+        profiles: [profileFor(vanishedPubkey, 'Aeontropy')],
+        vanished: {vanishedPubkey},
+      );
+
+      expect(
+        find.bySemanticsLabel(
+          l10n.userPickerSelectSemantics(l10n.profileDeletedAccountName),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('leaves a live account untouched', (tester) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await pumpPicker(
+        tester,
+        profiles: [profileFor(livePubkey, 'Alice')],
+        vanished: const {},
+      );
+
+      expect(find.text('Alice'), findsOneWidget);
+      expect(find.text(l10n.profileDeletedAccountName), findsNothing);
+    });
+
+    testWidgets('orders rows by the rendered name, not the raw one', (
+      tester,
+    ) async {
+      // Raw, "Aardvark" sorts first; rendered, "Deleted account" sorts last.
+      // The two orders disagree, so only one of them can pass.
+      await pumpPicker(
+        tester,
+        profiles: [
+          profileFor(vanishedPubkey, 'Aardvark'),
+          profileFor(livePubkey, 'Aaron'),
+        ],
+        vanished: {vanishedPubkey},
+      );
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      final rendered = tester
+          .widgetList<Text>(find.byType(Text))
+          .map((t) => t.data)
+          .whereType<String>()
+          .where(
+            (t) => t == 'Aaron' || t == l10n.profileDeletedAccountName,
+          )
+          .toList();
+      expect(rendered, ['Aaron', l10n.profileDeletedAccountName]);
+    });
+
+    testWidgets(
+      'renders a divine NIP-05 in the short form every other row uses',
+      (tester) async {
+        // The raw `nip05` field is the long form and skips the sanitizer;
+        // `shortDisplayNip05` is what the rest of the app renders and runs the
+        // value through `text_sanitizer` on the way. Relay search results are
+        // arbitrary kind-0 JSON, so this row is a display boundary.
+        await pumpPicker(
+          tester,
+          profiles: [
+            profileFor(livePubkey, 'Alice', nip05: '_@alice.divine.video'),
+          ],
+          vanished: const {},
+        );
+
+        expect(find.text('@alice'), findsOneWidget);
+        expect(find.text('_@alice.divine.video'), findsNothing);
+      },
+    );
+  });
+
   group('showUserPickerSheet', () {
     testWidgets('a short drag on the results keeps the picker and its picks', (
       tester,
@@ -1628,6 +1841,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            _noVanishedProfiles,
             profileRepositoryProvider.overrideWithValue(
               _createMockProfileRepository(cachedProfiles: profiles),
             ),

--- a/mobile/test/widgets/user_profile_tile_test.dart
+++ b/mobile/test/widgets/user_profile_tile_test.dart
@@ -1,0 +1,114 @@
+// ABOUTME: Pins UserProfileTile to the vanished-account substitution.
+// ABOUTME: This is the row the badge screens, follower/following lists and
+// ABOUTME: engagement lists all render, so the picker and the screens it feeds
+// ABOUTME: have to agree about who an account is (#8421 adjacent).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/widgets/user_profile_tile.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+void main() {
+  const pubkey =
+      'b75b9a3131f4263add94ba20beb352a1'
+      '1032684f2dac07a7e1af827c6f3c1505';
+
+  late AppLocalizations l10n;
+
+  setUp(() {
+    l10n = lookupAppLocalizations(const Locale('en'));
+  });
+
+  UserProfile profileWith({String? nip05}) => UserProfile(
+    pubkey: pubkey,
+    displayName: 'Aeontropy',
+    nip05: nip05,
+    picture: 'https://example.invalid/aeontropy.png',
+    rawData: const {},
+    createdAt: DateTime(2026),
+    eventId: 'e' * 64,
+  );
+
+  Future<void> pumpTile(
+    WidgetTester tester, {
+    required bool isVanished,
+    UserProfile? profile,
+  }) async {
+    await tester.pumpWidget(
+      testMaterialApp(
+        additionalOverrides: [
+          // Overridden directly rather than through
+          // `vanishedProfilePubkeysProvider`: the derived provider reads
+          // `.value`, which is null until the source stream's first microtask,
+          // and that window outlives the pump.
+          profileVanishedProvider(pubkey).overrideWith((ref) => isVanished),
+          if (profile != null)
+            userProfileReactiveProvider(
+              pubkey,
+            ).overrideWith((ref) => Stream.value(profile)),
+        ],
+        home: const Scaffold(
+          body: UserProfileTile(pubkey: pubkey, showFollowButton: false),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group(UserProfileTile, () {
+    group('renders', () {
+      testWidgets('names a live account from its profile', (tester) async {
+        await pumpTile(tester, isVanished: false, profile: profileWith());
+
+        expect(find.text('Aeontropy'), findsOneWidget);
+        expect(find.text(l10n.profileDeletedAccountName), findsNothing);
+      });
+
+      testWidgets('names a vanished account "Deleted account"', (tester) async {
+        await pumpTile(tester, isVanished: true, profile: profileWith());
+
+        expect(find.text(l10n.profileDeletedAccountName), findsOneWidget);
+        expect(find.text('Aeontropy'), findsNothing);
+      });
+
+      testWidgets("loads a live account's photo", (tester) async {
+        // The control for the case below: without it a green findsNothing
+        // there could mean the finder is dead rather than the branch taken.
+        await pumpTile(tester, isVanished: false, profile: profileWith());
+
+        expect(find.byType(VineCachedImage), findsOneWidget);
+      });
+
+      testWidgets("drops a vanished account's photo", (tester) async {
+        await pumpTile(tester, isVanished: true, profile: profileWith());
+
+        expect(find.byType(VineCachedImage), findsNothing);
+      });
+
+      testWidgets("hides a vanished account's NIP-05", (tester) async {
+        await pumpTile(
+          tester,
+          isVanished: true,
+          profile: profileWith(nip05: '_@aeontropy.divine.video'),
+        );
+
+        expect(find.text('@aeontropy'), findsNothing);
+      });
+
+      testWidgets("keeps a live account's NIP-05", (tester) async {
+        await pumpTile(
+          tester,
+          isVanished: false,
+          profile: profileWith(nip05: '_@aeontropy.divine.video'),
+        );
+
+        expect(find.text('@aeontropy'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/mobile/test/widgets/user_profile_tile_test.dart
+++ b/mobile/test/widgets/user_profile_tile_test.dart
@@ -5,8 +5,10 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/follow_relationship_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/widgets/user_profile_tile.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
@@ -38,6 +40,7 @@ void main() {
     WidgetTester tester, {
     required bool isVanished,
     UserProfile? profile,
+    FollowRelationship relationship = FollowRelationship.none,
   }) async {
     await tester.pumpWidget(
       testMaterialApp(
@@ -47,6 +50,9 @@ void main() {
           // `.value`, which is null until the source stream's first microtask,
           // and that window outlives the pump.
           profileVanishedProvider(pubkey).overrideWith((ref) => isVanished),
+          followRelationshipProvider(
+            pubkey,
+          ).overrideWith((ref) => Stream.value(relationship)),
           if (profile != null)
             userProfileReactiveProvider(
               pubkey,
@@ -98,6 +104,41 @@ void main() {
         );
 
         expect(find.text('@aeontropy'), findsNothing);
+      });
+
+      testWidgets(
+        "drops the whole second line, not just a vanished account's NIP-05",
+        (tester) async {
+          // `resolveUserIdentifierLine` falls through to relationship and
+          // follower count when it has no handle, so nulling only the handle
+          // swaps "@aeontropy" for social proof about the deleted account
+          // rather than removing the line. The mutual relationship is what
+          // makes that fall-through reachable here.
+          await pumpTile(
+            tester,
+            isVanished: true,
+            profile: profileWith(nip05: '_@aeontropy.divine.video'),
+            relationship: FollowRelationship.mutual,
+          );
+
+          expect(find.text(l10n.socialProofMutual), findsNothing);
+          expect(find.text('@aeontropy'), findsNothing);
+        },
+      );
+
+      testWidgets('keeps the relationship line on a live account', (
+        tester,
+      ) async {
+        // The control: without it the assertion above could pass because the
+        // line never renders, rather than because the vanish branch drops it.
+        await pumpTile(
+          tester,
+          isVanished: false,
+          profile: profileWith(),
+          relationship: FollowRelationship.mutual,
+        );
+
+        expect(find.text(l10n.socialProofMutual), findsOneWidget);
       });
 
       testWidgets("keeps a live account's NIP-05", (tester) async {

--- a/mobile/test/widgets/vanished_account_identity_test.dart
+++ b/mobile/test/widgets/vanished_account_identity_test.dart
@@ -1,0 +1,137 @@
+// ABOUTME: Pins the non-DM vanished-account substitution.
+// ABOUTME: Narrower than the DM chain on purpose — no moderation step.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/config/official_accounts.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/vanished_account_identity.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+void main() {
+  late AppLocalizations l10n;
+
+  setUp(() {
+    l10n = lookupAppLocalizations(const Locale('en'));
+  });
+
+  Widget buildSubject(String Function(BuildContext context) resolve) {
+    return testMaterialApp(
+      home: Builder(builder: (context) => Text(resolve(context))),
+    );
+  }
+
+  group('vanishedAccountName', () {
+    testWidgets('substitutes the deleted-account label when vanished', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildSubject(
+          (context) => vanishedAccountName(
+            context,
+            isVanished: true,
+            fallbackName: 'Aeontropy',
+          ),
+        ),
+      );
+
+      expect(find.text(l10n.profileDeletedAccountName), findsOneWidget);
+      expect(find.text('Aeontropy'), findsNothing);
+    });
+
+    testWidgets('returns the caller name when not vanished', (tester) async {
+      await tester.pumpWidget(
+        buildSubject(
+          (context) => vanishedAccountName(
+            context,
+            isVanished: false,
+            fallbackName: 'Aeontropy',
+          ),
+        ),
+      );
+
+      expect(find.text('Aeontropy'), findsOneWidget);
+    });
+
+    testWidgets('leaves the moderation account alone', (tester) async {
+      // The moderation substitution is scoped to DM surfaces
+      // (moderation_identity.dart). A people picker naming an account
+      // "Divine Moderation" would invent an identity the rest of the app does
+      // not use outside the inbox.
+      await tester.pumpWidget(
+        buildSubject(
+          (context) => vanishedAccountName(
+            context,
+            isVanished: false,
+            fallbackName: 'moderation-bot-v2',
+          ),
+        ),
+      );
+
+      expect(find.text('moderation-bot-v2'), findsOneWidget);
+      expect(find.text(l10n.inboxSupportRowTitle), findsNothing);
+    });
+  });
+
+  group('vanishedAccountNameFrom', () {
+    test('substitutes the supplied label when vanished', () {
+      expect(
+        vanishedAccountNameFrom(
+          isVanished: true,
+          deletedAccountLabel: 'Deleted account',
+          fallbackName: 'Aeontropy',
+        ),
+        'Deleted account',
+      );
+    });
+
+    test('returns the caller name when not vanished', () {
+      expect(
+        vanishedAccountNameFrom(
+          isVanished: false,
+          deletedAccountLabel: 'Deleted account',
+          fallbackName: 'Aeontropy',
+        ),
+        'Aeontropy',
+      );
+    });
+
+    test('agrees with the context-taking variant for a moderation key', () {
+      expect(
+        vanishedAccountNameFrom(
+          isVanished: false,
+          deletedAccountLabel: 'Deleted account',
+          fallbackName: kModerationPubkeyHex,
+        ),
+        kModerationPubkeyHex,
+      );
+    });
+  });
+
+  group('vanishedAccountPictureUrl', () {
+    test('drops the picture when vanished', () {
+      expect(
+        vanishedAccountPictureUrl(
+          isVanished: true,
+          pictureUrl: 'https://example.invalid/a.png',
+        ),
+        isNull,
+      );
+    });
+
+    test('keeps the picture when not vanished', () {
+      expect(
+        vanishedAccountPictureUrl(
+          isVanished: false,
+          pictureUrl: 'https://example.invalid/a.png',
+        ),
+        'https://example.invalid/a.png',
+      );
+    });
+
+    test('tolerates a profile that has no picture', () {
+      expect(vanishedAccountPictureUrl(isVanished: false), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Description

The people picker rendered a NIP-62 vanished account under its real name, photo and NIP-05, and its sort and filter matched the same raw values — so a deleted account could be found by a string no row shows. `UserProfileTile`, the row the picker hands off to, did the same. Every other identity surface already substitutes `profileDeletedAccountName`.

The reach matters more here than in a DM. `allUsers` mode runs `searchUsersProgressive`, whose Phase 3 queries `relay.nostr.band`, `search.nos.today` and `nostr.wine`. NIP-62 obliges a relay to delete only "if their service URL is tagged in the event" and says nothing about client display, so a vanish addressed to Divine's relay leaves those three serving the kind 0 — I queried them with the app's exact filter for three pubkeys funnelcake reports as vanished, and two returned name and picture. Neither network phase consults the tombstone. And a pick is published permanently in public: kind 8 badge awards, which NIP-58 calls "immutable and non-transferable", kind 30000 people lists, and kind 34236 `p` tags.

Four commits, one concern each. The shared helper is deliberately narrower than `dmPeerName` — no moderation step, because `moderation_identity.dart` scopes that substitution to DM surfaces and a badge picker naming an account "Divine Moderation" would invent an identity the app does not use outside the inbox.

**Related Issue:** Closes #8535

## Out of Scope

- **Whether a vanished account stays selectable.** This names it correctly and leaves it pickable; #8421 left the same question open for the share sheet, and it is a product call rather than a naming one.
- **Three findings reported on #8535, not fixed here** — the signed-in user is selectable (no `excludedPubkey` passed to `UserSearchBloc`), `UserSearchLoadMore` is never dispatched so pagination is dead on that path, and the two data paths use different blocklist filters.
- **Migrating this 1118-line `ConsumerStatefulWidget` to BLoC.** A real layering violation, far past scope for an identity fix.

One commit is not requested by the issue and is called out as such: `showCheckmark` carried no `!isVanished` term while `isOgBetaTester` two lines below did, under a comment stating the rule for both — so a vanished Divine-team pubkey rendered "Deleted account" with a blue checkmark.

## Verification

- Every new test fails on `origin/main` on an assertion and passes here: 5 of 6 picker tests, 3 of 6 tile tests, and the checkmark test. Proven by stashing `lib/` and re-running.
- `flutter analyze lib test integration_test` and `dart format --set-exit-if-changed` clean.
- 685 tests green across `test/widgets/user_picker_sheet_test.dart`, `user_profile_tile_test.dart`, `vanished_account_identity_test.dart`, `test/widgets/profile`, `test/blocs/user_search`, `test/screens/badges`, `test/widgets/video_metadata`, and ARB consistency.
- Ratchets green: orphaned-ARB, l10n-delegate, shared-setup-stub, ungrouped-test, placeholder-test, post-close-emit, skip, test-unit, layer-direction.
- Built and ran on the iOS simulator with no new exceptions. **I could not drive to a picker there**: reaching one needs a badge, a video draft, or a follow graph, and the test account has none. The one exception in the run (`setState() during build` on the home feed, Riverpod-internal stack) also appears in two runs from a branch without this change, so it predates it.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
