### PR TITLE
fix(moderation): scope adult-content verification to the active account

### DIFF
--- a/mobile/lib/blocs/safety_settings/safety_settings_cubit.dart
+++ b/mobile/lib/blocs/safety_settings/safety_settings_cubit.dart
@@ -112,7 +112,13 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState>
     final previous = state.isAgeVerified;
     emit(state.copyWith(isAgeVerified: value));
     try {
-      await _ageVerificationService.setAdultContentVerified(value);
+      final saved = await _ageVerificationService.setAdultContentVerified(
+        value,
+      );
+      if (!saved) {
+        emitIfOpen(state.copyWith(isAgeVerified: previous));
+        return;
+      }
       if (value) {
         await _contentFilterService.unlockAdultCategories();
       } else {

--- a/mobile/lib/providers/featured_tabs_providers.dart
+++ b/mobile/lib/providers/featured_tabs_providers.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Rebuilds with the Funnelcake client so a relay/env swap propagates.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/repositories/featured_tabs_repository.dart';
@@ -19,8 +20,15 @@ final featuredTabsRepositoryProvider = Provider<FeaturedTabsRepository>((ref) {
 });
 
 /// Whether the current viewer has completed Divine's existing 18+ verification.
+///
+/// Verification is scoped per account (#7816) and the service reads it live,
+/// but this provider caches its answer. Watching the auth state re-evaluates
+/// it on every account switch so a verified account's answer never carries
+/// over to the next account on the same device.
 final featuredTabViewerIsAdultProvider = FutureProvider<bool>((ref) async {
-  ref.watch(adultContentVerificationVersionProvider);
+  ref
+    ..watch(currentAuthStateProvider)
+    ..watch(adultContentVerificationVersionProvider);
   final service = ref.watch(ageVerificationServiceProvider);
   await service.initialized;
   return service.isAdultContentVerified;

--- a/mobile/lib/providers/moderation_providers.dart
+++ b/mobile/lib/providers/moderation_providers.dart
@@ -145,16 +145,13 @@ Future<void> _clearAdultMediaAccessCaches(Ref ref) async {
 }
 
 /// Age verification service for content creation restrictions
-/// keepAlive ensures the service persists and maintains in-memory verification state
-/// even when widgets that watch it dispose and rebuild
+/// keepAlive preserves one coordinator and callback instance. Verification
+/// values are read synchronously from preferences for the active account.
 @Riverpod(keepAlive: true)
 AgeVerificationService ageVerificationService(Ref ref) {
-  // Rebuild on account swap so the (keepAlive) service's in-memory cache is
-  // reloaded for the new account rather than serving the previous account's
-  // verification. Every swap transits a non-authenticated auth state (#7816).
-  ref.watch(currentAuthStateProvider);
   final authService = ref.read(authServiceProvider);
   final service = AgeVerificationService(
+    preferences: ref.watch(sharedPreferencesProvider),
     isProtectedMinor: () => ref.read(isProtectedMinorProvider),
     currentPubkeyHex: () => authService.currentPublicKeyHex,
     onAdultMediaAccessRevoked: () => _clearAdultMediaAccessCaches(ref),

--- a/mobile/lib/providers/moderation_providers.dart
+++ b/mobile/lib/providers/moderation_providers.dart
@@ -149,8 +149,14 @@ Future<void> _clearAdultMediaAccessCaches(Ref ref) async {
 /// even when widgets that watch it dispose and rebuild
 @Riverpod(keepAlive: true)
 AgeVerificationService ageVerificationService(Ref ref) {
+  // Rebuild on account swap so the (keepAlive) service's in-memory cache is
+  // reloaded for the new account rather than serving the previous account's
+  // verification. Every swap transits a non-authenticated auth state (#7816).
+  ref.watch(currentAuthStateProvider);
+  final authService = ref.read(authServiceProvider);
   final service = AgeVerificationService(
     isProtectedMinor: () => ref.read(isProtectedMinorProvider),
+    currentPubkeyHex: () => authService.currentPublicKeyHex,
     onAdultMediaAccessRevoked: () => _clearAdultMediaAccessCaches(ref),
     onAdultContentVerificationChanged: () {
       if (ref.mounted) {

--- a/mobile/lib/providers/moderation_providers.g.dart
+++ b/mobile/lib/providers/moderation_providers.g.dart
@@ -244,7 +244,7 @@ final class AgeVerificationServiceProvider
 }
 
 String _$ageVerificationServiceHash() =>
-    r'95d51cda0ad3f784cc0aee7eec46478bd4e6139c';
+    r'52f4f2e1fff38afe62316445dcd3fab39f794bc6';
 
 /// Content filter service for per-category Show/Warn/Hide preferences.
 /// keepAlive ensures preferences persist and are consistent across the app.

--- a/mobile/lib/providers/moderation_providers.g.dart
+++ b/mobile/lib/providers/moderation_providers.g.dart
@@ -188,15 +188,15 @@ final class CanTargetUserFamily extends $Family
 }
 
 /// Age verification service for content creation restrictions
-/// keepAlive ensures the service persists and maintains in-memory verification state
-/// even when widgets that watch it dispose and rebuild
+/// keepAlive preserves one coordinator and callback instance. Verification
+/// values are read synchronously from preferences for the active account.
 
 @ProviderFor(ageVerificationService)
 final ageVerificationServiceProvider = AgeVerificationServiceProvider._();
 
 /// Age verification service for content creation restrictions
-/// keepAlive ensures the service persists and maintains in-memory verification state
-/// even when widgets that watch it dispose and rebuild
+/// keepAlive preserves one coordinator and callback instance. Verification
+/// values are read synchronously from preferences for the active account.
 
 final class AgeVerificationServiceProvider
     extends
@@ -207,8 +207,8 @@ final class AgeVerificationServiceProvider
         >
     with $Provider<AgeVerificationService> {
   /// Age verification service for content creation restrictions
-  /// keepAlive ensures the service persists and maintains in-memory verification state
-  /// even when widgets that watch it dispose and rebuild
+  /// keepAlive preserves one coordinator and callback instance. Verification
+  /// values are read synchronously from preferences for the active account.
   AgeVerificationServiceProvider._()
     : super(
         from: null,
@@ -244,7 +244,7 @@ final class AgeVerificationServiceProvider
 }
 
 String _$ageVerificationServiceHash() =>
-    r'52f4f2e1fff38afe62316445dcd3fab39f794bc6';
+    r'2b83bb9538d76af5d6c9c0a67255e983a346dc93';
 
 /// Content filter service for per-category Show/Warn/Hide preferences.
 /// keepAlive ensures preferences persist and are consistent across the app.

--- a/mobile/lib/services/age_verification_service.dart
+++ b/mobile/lib/services/age_verification_service.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Service for managing age verification status across app sessions
-// ABOUTME: Stores verification status using SharedPreferences for persistence
+// ABOUTME: Stores verification status per account in SharedPreferences
 
 import 'package:flutter/material.dart';
 import 'package:openvine/widgets/age_verification_dialog.dart';
@@ -9,17 +9,26 @@ import 'package:unified_logger/unified_logger.dart';
 class AgeVerificationService {
   AgeVerificationService({
     bool Function()? isProtectedMinor,
+    String? Function()? currentPubkeyHex,
     Future<void> Function()? onAdultMediaAccessRevoked,
     VoidCallback? onAdultContentVerificationChanged,
   }) : _isProtectedMinor = isProtectedMinor ?? _notProtected,
+       _currentPubkeyHex = currentPubkeyHex ?? _noPubkey,
        _onAdultMediaAccessRevoked = onAdultMediaAccessRevoked,
        _onAdultContentVerificationChanged = onAdultContentVerificationChanged;
 
   static bool _notProtected() => false;
+  static String? _noPubkey() => null;
 
   /// Whether the current account is a protected minor. When true, adult content
   /// is force-locked off and the self-attestation bypass is unavailable (#175).
   final bool Function() _isProtectedMinor;
+
+  /// The active account's pubkey hex, or null when unauthenticated.
+  /// Verification is scoped per account (#7816); a null pubkey resolves to
+  /// unverified and makes writes a no-op.
+  final String? Function() _currentPubkeyHex;
+
   final Future<void> Function()? _onAdultMediaAccessRevoked;
   final VoidCallback? _onAdultContentVerificationChanged;
 
@@ -28,6 +37,33 @@ class AgeVerificationService {
   static const String _adultContentVerifiedKey = 'adult_content_verified';
   static const String _adultContentVerificationDateKey =
       'adult_content_verification_date';
+
+  /// Legacy device-global keys, pre-#7816. Adopted for the first authenticated
+  /// account that loads after upgrade, then deleted so no other account can
+  /// inherit them.
+  static const List<String> _globalBaseKeys = [
+    _ageVerifiedKey,
+    _verificationDateKey,
+    _adultContentVerifiedKey,
+    _adultContentVerificationDateKey,
+  ];
+
+  /// Every per-account preference key for [pubkeyHex].
+  static List<String> accountKeys(String pubkeyHex) =>
+      _globalBaseKeys.map((base) => '${base}_$pubkeyHex').toList();
+
+  /// Removes every age / adult-content verification key for [pubkeyHex].
+  ///
+  /// Called on destructive account deletion so a re-used identity does not
+  /// resurrect a deleted account's verification (#7816).
+  static Future<void> purgeAccount(
+    SharedPreferences prefs,
+    String pubkeyHex,
+  ) async {
+    for (final key in accountKeys(pubkeyHex)) {
+      await prefs.remove(key);
+    }
+  }
 
   bool? _isAgeVerified;
   DateTime? _verificationDate;
@@ -45,6 +81,14 @@ class AgeVerificationService {
   Future<void> get initialized =>
       _initializeFuture ??= _loadVerificationStatus();
 
+  /// The scoped key for [base] under the active account, or null when no
+  /// account is active.
+  String? _scopedKey(String base) {
+    final pubkey = _currentPubkeyHex();
+    if (pubkey == null || pubkey.isEmpty) return null;
+    return '${base}_$pubkey';
+  }
+
   Future<void> initialize() async {
     await initialized;
   }
@@ -52,20 +96,33 @@ class AgeVerificationService {
   Future<void> _loadVerificationStatus() async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      _isAgeVerified = prefs.getBool(_ageVerifiedKey);
-      _isAdultContentVerified = prefs.getBool(_adultContentVerifiedKey);
+      await _migrateGlobalKeys(prefs);
 
-      final dateMillis = prefs.getInt(_verificationDateKey);
-      if (dateMillis != null) {
-        _verificationDate = DateTime.fromMillisecondsSinceEpoch(dateMillis);
+      final ageKey = _scopedKey(_ageVerifiedKey);
+      if (ageKey == null) {
+        _isAgeVerified = null;
+        _verificationDate = null;
+        _isAdultContentVerified = null;
+        _adultContentVerificationDate = null;
+        return;
       }
 
-      final adultDateMillis = prefs.getInt(_adultContentVerificationDateKey);
-      if (adultDateMillis != null) {
-        _adultContentVerificationDate = DateTime.fromMillisecondsSinceEpoch(
-          adultDateMillis,
-        );
-      }
+      _isAgeVerified = prefs.getBool(ageKey);
+      _isAdultContentVerified = prefs.getBool(
+        _scopedKey(_adultContentVerifiedKey)!,
+      );
+
+      final dateMillis = prefs.getInt(_scopedKey(_verificationDateKey)!);
+      _verificationDate = dateMillis == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(dateMillis);
+
+      final adultDateMillis = prefs.getInt(
+        _scopedKey(_adultContentVerificationDateKey)!,
+      );
+      _adultContentVerificationDate = adultDateMillis == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(adultDateMillis);
       _onAdultContentVerificationChanged?.call();
     } catch (e) {
       Log.error(
@@ -76,18 +133,53 @@ class AgeVerificationService {
     }
   }
 
+  /// Migrates legacy device-global verification keys to the active account.
+  ///
+  /// Adopts each global value for the current account when the account has no
+  /// scoped value yet, then removes the global keys so a second account can
+  /// never inherit them. No-op while unauthenticated, leaving the globals in
+  /// place until an account claims them (#7816).
+  Future<void> _migrateGlobalKeys(SharedPreferences prefs) async {
+    final pubkey = _currentPubkeyHex();
+    if (pubkey == null || pubkey.isEmpty) return;
+    if (!_globalBaseKeys.any(prefs.containsKey)) return;
+
+    for (final base in _globalBaseKeys) {
+      final scoped = '${base}_$pubkey';
+      if (prefs.containsKey(base) && !prefs.containsKey(scoped)) {
+        final value = prefs.get(base);
+        if (value is bool) {
+          await prefs.setBool(scoped, value);
+        } else if (value is int) {
+          await prefs.setInt(scoped, value);
+        }
+      }
+      await prefs.remove(base);
+    }
+  }
+
   Future<void> setAgeVerified(bool verified) async {
+    final key = _scopedKey(_ageVerifiedKey);
+    final dateKey = _scopedKey(_verificationDateKey);
+    if (key == null || dateKey == null) {
+      Log.warning(
+        'No active account; skipping age verification write',
+        name: 'AgeVerificationService',
+        category: LogCategory.system,
+      );
+      return;
+    }
     try {
       final prefs = await SharedPreferences.getInstance();
 
-      await prefs.setBool(_ageVerifiedKey, verified);
+      await prefs.setBool(key, verified);
 
       if (verified) {
         final now = DateTime.now();
-        await prefs.setInt(_verificationDateKey, now.millisecondsSinceEpoch);
+        await prefs.setInt(dateKey, now.millisecondsSinceEpoch);
         _verificationDate = now;
       } else {
-        await prefs.remove(_verificationDateKey);
+        await prefs.remove(dateKey);
         _verificationDate = null;
       }
 
@@ -124,20 +216,27 @@ class AgeVerificationService {
       );
       return;
     }
+    final key = _scopedKey(_adultContentVerifiedKey);
+    final dateKey = _scopedKey(_adultContentVerificationDateKey);
+    if (key == null || dateKey == null) {
+      Log.warning(
+        'No active account; skipping adult-content verification write',
+        name: 'AgeVerificationService',
+        category: LogCategory.system,
+      );
+      return;
+    }
     try {
       final prefs = await SharedPreferences.getInstance();
 
-      await prefs.setBool(_adultContentVerifiedKey, verified);
+      await prefs.setBool(key, verified);
 
       if (verified) {
         final now = DateTime.now();
-        await prefs.setInt(
-          _adultContentVerificationDateKey,
-          now.millisecondsSinceEpoch,
-        );
+        await prefs.setInt(dateKey, now.millisecondsSinceEpoch);
         _adultContentVerificationDate = now;
       } else {
-        await prefs.remove(_adultContentVerificationDateKey);
+        await prefs.remove(dateKey);
         _adultContentVerificationDate = null;
       }
 
@@ -197,10 +296,10 @@ class AgeVerificationService {
   Future<void> clearVerificationStatus() async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      await prefs.remove(_ageVerifiedKey);
-      await prefs.remove(_verificationDateKey);
-      await prefs.remove(_adultContentVerifiedKey);
-      await prefs.remove(_adultContentVerificationDateKey);
+      for (final base in _globalBaseKeys) {
+        final key = _scopedKey(base);
+        if (key != null) await prefs.remove(key);
+      }
 
       _isAgeVerified = null;
       _verificationDate = null;

--- a/mobile/lib/services/age_verification_service.dart
+++ b/mobile/lib/services/age_verification_service.dart
@@ -8,17 +8,21 @@ import 'package:unified_logger/unified_logger.dart';
 
 class AgeVerificationService {
   AgeVerificationService({
+    required SharedPreferences preferences,
     bool Function()? isProtectedMinor,
     String? Function()? currentPubkeyHex,
     Future<void> Function()? onAdultMediaAccessRevoked,
     VoidCallback? onAdultContentVerificationChanged,
-  }) : _isProtectedMinor = isProtectedMinor ?? _notProtected,
+  }) : _preferences = preferences,
+       _isProtectedMinor = isProtectedMinor ?? _notProtected,
        _currentPubkeyHex = currentPubkeyHex ?? _noPubkey,
        _onAdultMediaAccessRevoked = onAdultMediaAccessRevoked,
        _onAdultContentVerificationChanged = onAdultContentVerificationChanged;
 
   static bool _notProtected() => false;
   static String? _noPubkey() => null;
+
+  final SharedPreferences _preferences;
 
   /// Whether the current account is a protected minor. When true, adult content
   /// is force-locked off and the self-attestation bypass is unavailable (#175).
@@ -38,9 +42,8 @@ class AgeVerificationService {
   static const String _adultContentVerificationDateKey =
       'adult_content_verification_date';
 
-  /// Legacy device-global keys, pre-#7816. Adopted for the first authenticated
-  /// account that loads after upgrade, then deleted so no other account can
-  /// inherit them.
+  /// Legacy device-global keys, pre-#7816. Their account ownership cannot be
+  /// recovered safely, so they are deleted during initialization.
   static const List<String> _globalBaseKeys = [
     _ageVerifiedKey,
     _verificationDateKey,
@@ -52,145 +55,63 @@ class AgeVerificationService {
   static List<String> accountKeys(String pubkeyHex) =>
       _globalBaseKeys.map((base) => '${base}_$pubkeyHex').toList();
 
-  /// Removes every age / adult-content verification key for [pubkeyHex].
-  ///
-  /// Called on destructive account deletion so a re-used identity does not
-  /// resurrect a deleted account's verification (#7816).
-  static Future<void> purgeAccount(
-    SharedPreferences prefs,
-    String pubkeyHex,
-  ) async {
-    for (final key in accountKeys(pubkeyHex)) {
-      await prefs.remove(key);
-    }
-  }
-
-  bool? _isAgeVerified;
-  DateTime? _verificationDate;
-  bool? _isAdultContentVerified;
-  DateTime? _adultContentVerificationDate;
   Future<void>? _initializeFuture;
 
-  bool get isAgeVerified => _isAgeVerified ?? false;
-  DateTime? get verificationDate => _verificationDate;
-  bool get isAdultContentVerified =>
-      !_isProtectedMinor() && (_isAdultContentVerified ?? false);
-  DateTime? get adultContentVerificationDate => _adultContentVerificationDate;
+  bool get isAgeVerified => _readBool(_ageVerifiedKey);
 
-  /// Completes when persisted age-verification state has loaded.
-  Future<void> get initialized =>
-      _initializeFuture ??= _loadVerificationStatus();
+  DateTime? get verificationDate => _readDate(_verificationDateKey);
+
+  bool get isAdultContentVerified =>
+      !_isProtectedMinor() && _readBool(_adultContentVerifiedKey);
+
+  DateTime? get adultContentVerificationDate =>
+      _readDate(_adultContentVerificationDateKey);
+
+  /// Completes after unsafe legacy device-global verification has been removed.
+  Future<void> get initialized => _initializeFuture ??= _initialize();
 
   /// The scoped key for [base] under the active account, or null when no
   /// account is active.
-  String? _scopedKey(String base) {
-    final pubkey = _currentPubkeyHex();
+  static String? _scopedKey(String base, String? pubkey) {
     if (pubkey == null || pubkey.isEmpty) return null;
     return '${base}_$pubkey';
   }
 
-  Future<void> initialize() async {
-    await initialized;
+  bool _readBool(String base) {
+    final key = _scopedKey(base, _currentPubkeyHex());
+    return key != null && (_preferences.getBool(key) ?? false);
   }
 
-  Future<void> _loadVerificationStatus() async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      await _migrateGlobalKeys(prefs);
-
-      final ageKey = _scopedKey(_ageVerifiedKey);
-      if (ageKey == null) {
-        _isAgeVerified = null;
-        _verificationDate = null;
-        _isAdultContentVerified = null;
-        _adultContentVerificationDate = null;
-        return;
-      }
-
-      _isAgeVerified = prefs.getBool(ageKey);
-      _isAdultContentVerified = prefs.getBool(
-        _scopedKey(_adultContentVerifiedKey)!,
-      );
-
-      final dateMillis = prefs.getInt(_scopedKey(_verificationDateKey)!);
-      _verificationDate = dateMillis == null
-          ? null
-          : DateTime.fromMillisecondsSinceEpoch(dateMillis);
-
-      final adultDateMillis = prefs.getInt(
-        _scopedKey(_adultContentVerificationDateKey)!,
-      );
-      _adultContentVerificationDate = adultDateMillis == null
-          ? null
-          : DateTime.fromMillisecondsSinceEpoch(adultDateMillis);
-      _onAdultContentVerificationChanged?.call();
-    } catch (e) {
-      Log.error(
-        'Error loading age verification status: $e',
-        name: 'AgeVerificationService',
-        category: LogCategory.system,
-      );
-    }
+  DateTime? _readDate(String base) {
+    final key = _scopedKey(base, _currentPubkeyHex());
+    final millis = key == null ? null : _preferences.getInt(key);
+    return millis == null ? null : DateTime.fromMillisecondsSinceEpoch(millis);
   }
 
-  /// Migrates legacy device-global verification keys to the active account.
-  ///
-  /// Adopts each global value for the current account when the account has no
-  /// scoped value yet, then removes the global keys so a second account can
-  /// never inherit them. No-op while unauthenticated, leaving the globals in
-  /// place until an account claims them (#7816). Adopt-if-absent plus an
-  /// idempotent delete makes a repeated run for the same account harmless.
-  Future<void> _migrateGlobalKeys(SharedPreferences prefs) async {
-    final pubkey = _currentPubkeyHex();
-    if (pubkey == null || pubkey.isEmpty) return;
-    if (!_globalBaseKeys.any(prefs.containsKey)) return;
-
+  Future<void> _initialize() async {
     for (final base in _globalBaseKeys) {
-      final scoped = '${base}_$pubkey';
-      if (prefs.containsKey(base) && !prefs.containsKey(scoped)) {
-        final value = prefs.get(base);
-        if (value is bool) {
-          await prefs.setBool(scoped, value);
-        } else if (value is int) {
-          await prefs.setInt(scoped, value);
-        }
-      }
-      await prefs.remove(base);
+      await _preferences.remove(base);
     }
+    _onAdultContentVerificationChanged?.call();
   }
 
-  Future<void> setAgeVerified(bool verified) async {
-    final key = _scopedKey(_ageVerifiedKey);
-    final dateKey = _scopedKey(_verificationDateKey);
-    if (key == null || dateKey == null) {
-      Log.warning(
-        'No active account; skipping age verification write',
-        name: 'AgeVerificationService',
-        category: LogCategory.system,
-      );
-      return;
-    }
+  Future<void> initialize() => initialized;
+
+  Future<bool> setAgeVerified(bool verified) async {
     try {
-      final prefs = await SharedPreferences.getInstance();
-
-      await prefs.setBool(key, verified);
-
-      if (verified) {
-        final now = DateTime.now();
-        await prefs.setInt(dateKey, now.millisecondsSinceEpoch);
-        _verificationDate = now;
-      } else {
-        await prefs.remove(dateKey);
-        _verificationDate = null;
-      }
-
-      _isAgeVerified = verified;
+      final written = await _writeVerification(
+        verified: verified,
+        valueBase: _ageVerifiedKey,
+        dateBase: _verificationDateKey,
+      );
+      if (!written) return false;
 
       Log.debug(
         'Age verification status updated: $verified',
         name: 'AgeVerificationService',
         category: LogCategory.system,
       );
+      return true;
     } catch (e) {
       Log.error(
         'Error saving age verification status: $e',
@@ -202,46 +123,26 @@ class AgeVerificationService {
   }
 
   Future<bool> checkAgeVerification() async {
-    if (_isAgeVerified == null) {
-      await _loadVerificationStatus();
-    }
+    await initialized;
     return isAgeVerified;
   }
 
-  Future<void> setAdultContentVerified(bool verified) async {
+  Future<bool> setAdultContentVerified(bool verified) async {
     if (verified && _isProtectedMinor()) {
       Log.warning(
         'Blocked adult-content verification for a protected minor',
         name: 'AgeVerificationService',
         category: LogCategory.system,
       );
-      return;
-    }
-    final key = _scopedKey(_adultContentVerifiedKey);
-    final dateKey = _scopedKey(_adultContentVerificationDateKey);
-    if (key == null || dateKey == null) {
-      Log.warning(
-        'No active account; skipping adult-content verification write',
-        name: 'AgeVerificationService',
-        category: LogCategory.system,
-      );
-      return;
+      return false;
     }
     try {
-      final prefs = await SharedPreferences.getInstance();
-
-      await prefs.setBool(key, verified);
-
-      if (verified) {
-        final now = DateTime.now();
-        await prefs.setInt(dateKey, now.millisecondsSinceEpoch);
-        _adultContentVerificationDate = now;
-      } else {
-        await prefs.remove(dateKey);
-        _adultContentVerificationDate = null;
-      }
-
-      _isAdultContentVerified = verified;
+      final written = await _writeVerification(
+        verified: verified,
+        valueBase: _adultContentVerifiedKey,
+        dateBase: _adultContentVerificationDateKey,
+      );
+      if (!written) return false;
       _onAdultContentVerificationChanged?.call();
       if (!verified) {
         await _notifyAdultMediaAccessRevoked();
@@ -252,6 +153,7 @@ class AgeVerificationService {
         name: 'AgeVerificationService',
         category: LogCategory.system,
       );
+      return true;
     } catch (e) {
       Log.error(
         'Error saving adult content verification status: $e',
@@ -263,11 +165,50 @@ class AgeVerificationService {
   }
 
   Future<bool> checkAdultContentVerification() async {
-    if (_isAdultContentVerified == null) {
-      await _loadVerificationStatus();
-    }
+    await initialized;
     return isAdultContentVerified;
   }
+
+  Future<bool> _writeVerification({
+    required bool verified,
+    required String valueBase,
+    required String dateBase,
+  }) async {
+    final pubkey = _currentPubkeyHex();
+    final valueKey = _scopedKey(valueBase, pubkey);
+    final dateKey = _scopedKey(dateBase, pubkey);
+    if (valueKey == null || dateKey == null) {
+      Log.warning(
+        'No active account; skipping verification write',
+        name: 'AgeVerificationService',
+        category: LogCategory.system,
+      );
+      return false;
+    }
+
+    final previousValue = _preferences.getBool(valueKey);
+    final previousDate = _preferences.getInt(dateKey);
+    await _preferences.setBool(valueKey, verified);
+    if (verified) {
+      await _preferences.setInt(dateKey, DateTime.now().millisecondsSinceEpoch);
+    } else {
+      await _preferences.remove(dateKey);
+    }
+
+    if (_currentPubkeyHex() == pubkey) return true;
+
+    await _restoreBool(valueKey, previousValue);
+    await _restoreInt(dateKey, previousDate);
+    return false;
+  }
+
+  Future<void> _restoreBool(String key, bool? value) => value == null
+      ? _preferences.remove(key)
+      : _preferences.setBool(key, value);
+
+  Future<void> _restoreInt(String key, int? value) => value == null
+      ? _preferences.remove(key)
+      : _preferences.setInt(key, value);
 
   /// Check if user can view adult content, showing verification dialog if needed
   Future<bool> verifyAdultContentAccess(BuildContext context) async {
@@ -281,46 +222,18 @@ class AgeVerificationService {
     if (!context.mounted) return false;
 
     // Show verification dialog
+    final pubkey = _currentPubkeyHex();
+    if (pubkey == null || pubkey.isEmpty) return false;
     final verified = await AgeVerificationDialog.show(
       context,
       type: AgeVerificationType.adultContent,
     );
 
-    if (verified) {
-      await setAdultContentVerified(true);
-      return true;
+    if (verified && _currentPubkeyHex() == pubkey) {
+      return setAdultContentVerified(true);
     }
 
     return false;
-  }
-
-  Future<void> clearVerificationStatus() async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      for (final base in _globalBaseKeys) {
-        final key = _scopedKey(base);
-        if (key != null) await prefs.remove(key);
-      }
-
-      _isAgeVerified = null;
-      _verificationDate = null;
-      _isAdultContentVerified = null;
-      _adultContentVerificationDate = null;
-      _onAdultContentVerificationChanged?.call();
-      await _notifyAdultMediaAccessRevoked();
-
-      Log.debug(
-        'Age verification status cleared',
-        name: 'AgeVerificationService',
-        category: LogCategory.system,
-      );
-    } catch (e) {
-      Log.error(
-        'Error clearing age verification status: $e',
-        name: 'AgeVerificationService',
-        category: LogCategory.system,
-      );
-    }
   }
 
   Future<void> _notifyAdultMediaAccessRevoked() async {

--- a/mobile/lib/services/age_verification_service.dart
+++ b/mobile/lib/services/age_verification_service.dart
@@ -138,7 +138,8 @@ class AgeVerificationService {
   /// Adopts each global value for the current account when the account has no
   /// scoped value yet, then removes the global keys so a second account can
   /// never inherit them. No-op while unauthenticated, leaving the globals in
-  /// place until an account claims them (#7816).
+  /// place until an account claims them (#7816). Adopt-if-absent plus an
+  /// idempotent delete makes a repeated run for the same account harmless.
   Future<void> _migrateGlobalKeys(SharedPreferences prefs) async {
     final pubkey = _currentPubkeyHex();
     if (pubkey == null || pubkey.isEmpty) return;

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -3166,9 +3166,12 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
       // Account deletion purges the leaving account's per-account
       // age/adult-content verification. A non-destructive switch keeps it so
-      // the account resumes its own verification on return (#7816).
-      if (deleteLocalUserData && currentPubkey != null) {
-        await AgeVerificationService.purgeAccount(prefs, currentPubkey);
+      // the account resumes its own verification on return (#7816). Key it on
+      // currentPublicKeyHex — the same accessor the service scopes writes with —
+      // so the purge target always matches the stored keys.
+      final ageVerificationPubkey = currentPublicKeyHex;
+      if (deleteLocalUserData && ageVerificationPubkey != null) {
+        await AgeVerificationService.purgeAccount(prefs, ageVerificationPubkey);
       }
 
       // Clear user-specific cached data on explicit logout.

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -23,7 +23,6 @@ import 'package:openvine/models/auth_user_profile.dart';
 import 'package:openvine/models/authentication_source.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/models/signer_readiness.dart';
-import 'package:openvine/services/age_verification_service.dart';
 import 'package:openvine/services/auth/known_accounts_registry.dart';
 import 'package:openvine/services/auth/nostr_connect_coordinator.dart';
 import 'package:openvine/services/auth/nostr_identity.dart';
@@ -3163,16 +3162,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // initialize() can reconnect to the same external signer.
       await prefs.remove('age_verified_16_plus');
       await prefs.remove('terms_accepted_at');
-
-      // Account deletion purges the leaving account's per-account
-      // age/adult-content verification. A non-destructive switch keeps it so
-      // the account resumes its own verification on return (#7816). Key it on
-      // currentPublicKeyHex — the same accessor the service scopes writes with —
-      // so the purge target always matches the stored keys.
-      final ageVerificationPubkey = currentPublicKeyHex;
-      if (deleteLocalUserData && ageVerificationPubkey != null) {
-        await AgeVerificationService.purgeAccount(prefs, ageVerificationPubkey);
-      }
 
       // Clear user-specific cached data on explicit logout.
       // Owner-scoped local rows (drafts, clips, uploads, etc.) are only

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -23,6 +23,7 @@ import 'package:openvine/models/auth_user_profile.dart';
 import 'package:openvine/models/authentication_source.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/models/signer_readiness.dart';
+import 'package:openvine/services/age_verification_service.dart';
 import 'package:openvine/services/auth/known_accounts_registry.dart';
 import 'package:openvine/services/auth/nostr_connect_coordinator.dart';
 import 'package:openvine/services/auth/nostr_identity.dart';
@@ -3162,6 +3163,13 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // initialize() can reconnect to the same external signer.
       await prefs.remove('age_verified_16_plus');
       await prefs.remove('terms_accepted_at');
+
+      // Account deletion purges the leaving account's per-account
+      // age/adult-content verification. A non-destructive switch keeps it so
+      // the account resumes its own verification on return (#7816).
+      if (deleteLocalUserData && currentPubkey != null) {
+        await AgeVerificationService.purgeAccount(prefs, currentPubkey);
+      }
 
       // Clear user-specific cached data on explicit logout.
       // Owner-scoped local rows (drafts, clips, uploads, etc.) are only

--- a/mobile/lib/services/media_auth_interceptor.dart
+++ b/mobile/lib/services/media_auth_interceptor.dart
@@ -22,8 +22,8 @@ class MediaAuthInterceptor {
   final ContentFilterService _contentFilterService;
   final MediaViewerAuthService _mediaViewerAuthService;
 
-  /// Awaits the persisted verification and content-filter state so gate
-  /// decisions read loaded values rather than cold-start in-memory defaults.
+  /// Awaits legacy verification cleanup and persisted content-filter loading
+  /// before making a gate decision.
   Future<void> _awaitModerationServicesReady() => Future.wait([
     _ageVerificationService.initialized,
     _contentFilterService.initialized,

--- a/mobile/lib/services/user_data_cleanup_service.dart
+++ b/mobile/lib/services/user_data_cleanup_service.dart
@@ -3,6 +3,7 @@
 
 import 'package:creator_sync/creator_sync.dart';
 import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
+import 'package:openvine/services/age_verification_service.dart';
 import 'package:openvine/services/creator_sync/prefs_sync_state_store.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -227,6 +228,14 @@ class UserDataCleanupService {
           await _prefs.remove(cursorKey);
           clearedCount++;
           clearedKeys.add(cursorKey);
+        }
+      }
+
+      for (final key in AgeVerificationService.accountKeys(userPubkey)) {
+        if (_prefs.containsKey(key)) {
+          await _prefs.remove(key);
+          clearedCount++;
+          clearedKeys.add(key);
         }
       }
     }

--- a/mobile/lib/widgets/camera_fab.dart
+++ b/mobile/lib/widgets/camera_fab.dart
@@ -26,8 +26,8 @@ class CameraFAB extends ConsumerWidget {
           if (!scaffoldContext.mounted) return;
           final result = await AgeVerificationDialog.show(scaffoldContext);
           if (result) {
-            await ageVerificationService.setAgeVerified(true);
-            if (scaffoldContext.mounted) {
+            final saved = await ageVerificationService.setAgeVerified(true);
+            if (saved && scaffoldContext.mounted) {
               await scaffoldContext.pushToCameraWithPermission();
             }
           } else {

--- a/mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart
+++ b/mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart
@@ -68,7 +68,7 @@ void main() {
       when(() => ageService.isAdultContentVerified).thenReturn(false);
       when(
         () => ageService.setAdultContentVerified(any()),
-      ).thenAnswer((_) async {});
+      ).thenAnswer((_) async => true);
 
       when(filterService.unlockAdultCategories).thenAnswer((_) async {});
       when(filterService.lockAdultCategories).thenAnswer((_) async {});
@@ -252,6 +252,34 @@ void main() {
           videoEventService.filterAdultContentFromExistingVideos,
         ).called(1);
         verifyNever(filterService.unlockAdultCategories);
+      },
+    );
+
+    blocTest<SafetySettingsCubit, SafetySettingsState>(
+      'setAgeVerified reverts without unlocking when account binding is lost',
+      seed: () => const SafetySettingsState(status: SafetySettingsStatus.ready),
+      setUp: () {
+        when(
+          () => ageService.setAdultContentVerified(true),
+        ).thenAnswer((_) async => false);
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.setAgeVerified(true),
+      expect: () => [
+        isA<SafetySettingsState>().having(
+          (s) => s.isAgeVerified,
+          'optimistic isAgeVerified',
+          true,
+        ),
+        isA<SafetySettingsState>().having(
+          (s) => s.isAgeVerified,
+          'restored isAgeVerified',
+          false,
+        ),
+      ],
+      verify: (_) {
+        verifyNever(filterService.unlockAdultCategories);
+        verifyNever(filterService.lockAdultCategories);
       },
     );
 

--- a/mobile/test/providers/age_verification_provider_test.dart
+++ b/mobile/test/providers/age_verification_provider_test.dart
@@ -3,26 +3,36 @@
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+class _MockAuthService extends Mock implements AuthService {}
+
 void main() {
+  const pubkey =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+
   group('ageVerificationServiceProvider', () {
     setUp(() {
       SharedPreferences.setMockInitialValues({});
     });
 
-    // ageVerificationServiceProvider now consults isProtectedMinorProvider,
-    // which needs sharedPreferencesProvider and an auth state. Pin auth to
-    // unauthenticated so the protected-minor signal resolves to false, leaving
-    // these tests' adult-content assertions unaffected.
+    // ageVerificationServiceProvider consults isProtectedMinorProvider (needs
+    // sharedPreferencesProvider and an auth state) and scopes verification to
+    // the active account's pubkey (#7816). Pin auth to unauthenticated so the
+    // protected-minor signal resolves to false without a network fetch, and
+    // supply a mock AuthService pubkey so per-account writes persist.
     Future<ProviderContainer> buildContainer() async {
       final prefs = await SharedPreferences.getInstance();
+      final authService = _MockAuthService();
+      when(() => authService.currentPublicKeyHex).thenReturn(pubkey);
       final container = ProviderContainer(
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
+          authServiceProvider.overrideWithValue(authService),
           currentAuthStateProvider.overrideWithValue(AuthState.unauthenticated),
         ],
       );

--- a/mobile/test/providers/age_verification_provider_test.dart
+++ b/mobile/test/providers/age_verification_provider_test.dart
@@ -14,6 +14,8 @@ class _MockAuthService extends Mock implements AuthService {}
 void main() {
   const pubkey =
       '1111111111111111111111111111111111111111111111111111111111111111';
+  const pubkeyB =
+      '2222222222222222222222222222222222222222222222222222222222222222';
 
   group('ageVerificationServiceProvider', () {
     setUp(() {
@@ -145,6 +147,55 @@ void main() {
           reason: 'Verification should persist across reads (iteration $i)',
         );
       }
+    });
+
+    test('rebuilds and re-scopes the service when the account switches', () async {
+      // Guards the #7816 invariant: because the service caches verification in
+      // memory, a keepAlive instance must be rebuilt on account swap so the
+      // switched-in account does not inherit the previous account's value.
+      // Removing `ref.watch(currentAuthStateProvider)` from the provider makes
+      // this test fail (serviceB would be the same instance, still reporting A's
+      // verification).
+      final prefs = await SharedPreferences.getInstance();
+      final authService = _MockAuthService();
+      when(() => authService.currentPublicKeyHex).thenReturn(pubkey);
+
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          authServiceProvider.overrideWithValue(authService),
+          currentAuthStateProvider.overrideWithValue(AuthState.unauthenticated),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final serviceA = container.read(ageVerificationServiceProvider);
+      await serviceA.initialize();
+      await serviceA.setAdultContentVerified(true);
+      expect(serviceA.isAdultContentVerified, isTrue);
+
+      // Account swap: new pubkey, and the auth state transits a non-authenticated
+      // value (every real swap does), which must rebuild the keepAlive service.
+      when(() => authService.currentPublicKeyHex).thenReturn(pubkeyB);
+      container.updateOverrides([
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        authServiceProvider.overrideWithValue(authService),
+        currentAuthStateProvider.overrideWithValue(AuthState.authenticating),
+      ]);
+
+      final serviceB = container.read(ageVerificationServiceProvider);
+      await serviceB.initialize();
+
+      expect(
+        identical(serviceA, serviceB),
+        isFalse,
+        reason: 'account swap must rebuild the service, not reuse the cache',
+      );
+      expect(
+        serviceB.isAdultContentVerified,
+        isFalse,
+        reason: 'the switched-in account must not inherit prior verification',
+      );
     });
   });
 }

--- a/mobile/test/providers/age_verification_provider_test.dart
+++ b/mobile/test/providers/age_verification_provider_test.dart
@@ -89,8 +89,8 @@ void main() {
 
       // First, set up verification in SharedPreferences
       SharedPreferences.setMockInitialValues({
-        'adult_content_verified': true,
-        'adult_content_verification_date':
+        'adult_content_verified_$pubkey': true,
+        'adult_content_verification_date_$pubkey':
             DateTime.now().millisecondsSinceEpoch,
       });
 
@@ -149,13 +149,7 @@ void main() {
       }
     });
 
-    test('rebuilds and re-scopes the service when the account switches', () async {
-      // Guards the #7816 invariant: because the service caches verification in
-      // memory, a keepAlive instance must be rebuilt on account swap so the
-      // switched-in account does not inherit the previous account's value.
-      // Removing `ref.watch(currentAuthStateProvider)` from the provider makes
-      // this test fail (serviceB would be the same instance, still reporting A's
-      // verification).
+    test('same service reads the newly active account after a switch', () async {
       final prefs = await SharedPreferences.getInstance();
       final authService = _MockAuthService();
       when(() => authService.currentPublicKeyHex).thenReturn(pubkey);
@@ -174,8 +168,8 @@ void main() {
       await serviceA.setAdultContentVerified(true);
       expect(serviceA.isAdultContentVerified, isTrue);
 
-      // Account swap: new pubkey, and the auth state transits a non-authenticated
-      // value (every real swap does), which must rebuild the keepAlive service.
+      // Account swap: the service reads through the live pubkey accessor, so it
+      // does not need a provider rebuild or an asynchronous cache reload.
       when(() => authService.currentPublicKeyHex).thenReturn(pubkeyB);
       container.updateOverrides([
         sharedPreferencesProvider.overrideWithValue(prefs),
@@ -188,8 +182,8 @@ void main() {
 
       expect(
         identical(serviceA, serviceB),
-        isFalse,
-        reason: 'account swap must rebuild the service, not reuse the cache',
+        isTrue,
+        reason: 'account swap must not require a service rebuild',
       );
       expect(
         serviceB.isAdultContentVerified,

--- a/mobile/test/providers/featured_tabs_providers_test.dart
+++ b/mobile/test/providers/featured_tabs_providers_test.dart
@@ -4,9 +4,11 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/featured_tabs_providers.dart';
 import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/services/age_verification_service.dart';
+import 'package:openvine/services/auth_service.dart';
 
 class _MockAgeVerificationService extends Mock
     implements AgeVerificationService {}
@@ -26,10 +28,27 @@ void main() {
         ageVerificationServiceProvider.overrideWithValue(
           ageVerificationService,
         ),
+        currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
       ],
     );
     addTearDown(container.dispose);
     return container;
+  }
+
+  /// Every account swap transits a non-authenticated auth state before the
+  /// new account reports authenticated (see isProtectedMinorProvider).
+  void switchAccount(ProviderContainer container) {
+    for (final authState in [
+      AuthState.authenticating,
+      AuthState.authenticated,
+    ]) {
+      container.updateOverrides([
+        ageVerificationServiceProvider.overrideWithValue(
+          ageVerificationService,
+        ),
+        currentAuthStateProvider.overrideWithValue(authState),
+      ]);
+    }
   }
 
   group('featuredTabAgeGateProvider', () {
@@ -75,5 +94,26 @@ void main() {
 
       expect(container.read(featuredTabAgeGateProvider), isFalse);
     });
+
+    test(
+      're-gates when the auth state changes to an unverified account',
+      () async {
+        var verified = true;
+        when(
+          () => ageVerificationService.isAdultContentVerified,
+        ).thenAnswer((_) => verified);
+        final container = createContainer();
+        await container.read(featuredTabViewerIsAdultProvider.future);
+        expect(container.read(featuredTabAgeGateProvider), isFalse);
+
+        // Account switch: the service now answers for the new account, but
+        // nothing bumps the verification version. Only the auth state moves.
+        verified = false;
+        switchAccount(container);
+        await container.read(featuredTabViewerIsAdultProvider.future);
+
+        expect(container.read(featuredTabAgeGateProvider), isTrue);
+      },
+    );
   });
 }

--- a/mobile/test/screens/safety_settings_screen_test.dart
+++ b/mobile/test/screens/safety_settings_screen_test.dart
@@ -406,7 +406,7 @@ void main() {
         // Arrange - stub the methods the screen will call
         when(
           () => mockAgeVerificationService.setAdultContentVerified(true),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => true);
         when(
           mockContentFilterService.unlockAdultCategories,
         ).thenAnswer((_) async {});

--- a/mobile/test/services/age_verification_protected_minor_test.dart
+++ b/mobile/test/services/age_verification_protected_minor_test.dart
@@ -9,13 +9,21 @@ void main() {
   const pubkey =
       '1111111111111111111111111111111111111111111111111111111111111111';
 
-  setUp(() => SharedPreferences.setMockInitialValues({}));
+  late SharedPreferences preferences;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    preferences = await SharedPreferences.getInstance();
+  });
 
   group(AgeVerificationService, () {
     test(
       'isAdultContentVerified is false for a protected minor even if stored true',
       () async {
-        final service = AgeVerificationService(isProtectedMinor: () => true);
+        final service = AgeVerificationService(
+          preferences: preferences,
+          isProtectedMinor: () => true,
+        );
         await service.initialize();
         await service.setAdultContentVerified(true); // rejected below
         expect(service.isAdultContentVerified, false);
@@ -27,6 +35,7 @@ void main() {
       () async {
         var protected = true;
         final service = AgeVerificationService(
+          preferences: preferences,
           isProtectedMinor: () => protected,
         );
         await service.initialize();
@@ -39,6 +48,7 @@ void main() {
 
     test('non-protected account behaves normally', () async {
       final service = AgeVerificationService(
+        preferences: preferences,
         isProtectedMinor: () => false,
         currentPubkeyHex: () => pubkey,
       );
@@ -48,7 +58,10 @@ void main() {
     });
 
     test('defaults to not-protected when no callback supplied', () async {
-      final service = AgeVerificationService(currentPubkeyHex: () => pubkey);
+      final service = AgeVerificationService(
+        preferences: preferences,
+        currentPubkeyHex: () => pubkey,
+      );
       await service.initialize();
       await service.setAdultContentVerified(true);
       expect(service.isAdultContentVerified, true);

--- a/mobile/test/services/age_verification_protected_minor_test.dart
+++ b/mobile/test/services/age_verification_protected_minor_test.dart
@@ -6,6 +6,9 @@ import 'package:openvine/services/age_verification_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  const pubkey =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
   group(AgeVerificationService, () {
@@ -35,14 +38,17 @@ void main() {
     );
 
     test('non-protected account behaves normally', () async {
-      final service = AgeVerificationService(isProtectedMinor: () => false);
+      final service = AgeVerificationService(
+        isProtectedMinor: () => false,
+        currentPubkeyHex: () => pubkey,
+      );
       await service.initialize();
       await service.setAdultContentVerified(true);
       expect(service.isAdultContentVerified, true);
     });
 
     test('defaults to not-protected when no callback supplied', () async {
-      final service = AgeVerificationService();
+      final service = AgeVerificationService(currentPubkeyHex: () => pubkey);
       await service.initialize();
       await service.setAdultContentVerified(true);
       expect(service.isAdultContentVerified, true);

--- a/mobile/test/services/age_verification_protected_minor_test.dart
+++ b/mobile/test/services/age_verification_protected_minor_test.dart
@@ -20,12 +20,16 @@ void main() {
     test(
       'isAdultContentVerified is false for a protected minor even if stored true',
       () async {
+        SharedPreferences.setMockInitialValues({
+          'adult_content_verified_$pubkey': true,
+        });
+        preferences = await SharedPreferences.getInstance();
         final service = AgeVerificationService(
           preferences: preferences,
           isProtectedMinor: () => true,
+          currentPubkeyHex: () => pubkey,
         );
         await service.initialize();
-        await service.setAdultContentVerified(true); // rejected below
         expect(service.isAdultContentVerified, false);
       },
     );
@@ -37,9 +41,10 @@ void main() {
         final service = AgeVerificationService(
           preferences: preferences,
           isProtectedMinor: () => protected,
+          currentPubkeyHex: () => pubkey,
         );
         await service.initialize();
-        await service.setAdultContentVerified(true);
+        expect(await service.setAdultContentVerified(true), isFalse);
         // Even after lifting the protection, nothing was persisted as true.
         protected = false;
         expect(service.isAdultContentVerified, false);

--- a/mobile/test/services/age_verification_service_test.dart
+++ b/mobile/test/services/age_verification_service_test.dart
@@ -7,18 +7,21 @@ void main() {
       '1111111111111111111111111111111111111111111111111111111111111111';
   const pubkeyB =
       '2222222222222222222222222222222222222222222222222222222222222222';
+  late SharedPreferences preferences;
 
   AgeVerificationService buildService({
     String? pubkey = pubkeyA,
     bool Function()? isProtectedMinor,
   }) => AgeVerificationService(
+    preferences: preferences,
     currentPubkeyHex: () => pubkey,
     isProtectedMinor: isProtectedMinor,
   );
 
   group('AgeVerificationService', () {
-    setUp(() {
+    setUp(() async {
       SharedPreferences.setMockInitialValues({});
+      preferences = await SharedPreferences.getInstance();
     });
 
     group('age verification (creator gate)', () {
@@ -108,6 +111,43 @@ void main() {
           expect(accountAAgain.isAdultContentVerified, isTrue);
         },
       );
+
+      test(
+        'reads the active account after auth resolves without reinitializing',
+        () async {
+          final prefs = await SharedPreferences.getInstance();
+          await prefs.setBool('adult_content_verified_$pubkeyA', true);
+          String? activePubkey;
+          final service = AgeVerificationService(
+            preferences: preferences,
+            currentPubkeyHex: () => activePubkey,
+          );
+
+          await service.initialized;
+          expect(service.isAdultContentVerified, isFalse);
+
+          activePubkey = pubkeyA;
+
+          expect(service.isAdultContentVerified, isTrue);
+        },
+      );
+
+      test('aborts a write if the active account changes', () async {
+        var activePubkey = pubkeyA;
+        final service = AgeVerificationService(
+          preferences: preferences,
+          currentPubkeyHex: () => activePubkey,
+        );
+        await service.initialize();
+
+        final write = service.setAdultContentVerified(true);
+        activePubkey = pubkeyB;
+        await write;
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.containsKey('adult_content_verified_$pubkeyA'), isFalse);
+        expect(service.isAdultContentVerified, isFalse);
+      });
     });
 
     group('no active account (fail-safe)', () {
@@ -166,7 +206,7 @@ void main() {
     });
 
     group('legacy global-key migration', () {
-      test('adopts a legacy global value for the active account', () async {
+      test('deletes legacy global values without granting them', () async {
         SharedPreferences.setMockInitialValues({
           'adult_content_verified': true,
           'adult_content_verification_date':
@@ -176,93 +216,11 @@ void main() {
         final service = buildService();
         await service.initialize();
 
-        expect(service.isAdultContentVerified, isTrue);
-      });
-
-      test('deletes the legacy global keys after adoption', () async {
-        SharedPreferences.setMockInitialValues({
-          'adult_content_verified': true,
-          'adult_content_verification_date':
-              DateTime.now().millisecondsSinceEpoch,
-        });
-
-        final service = buildService();
-        await service.initialize();
-
+        expect(service.isAdultContentVerified, isFalse);
         final prefs = await SharedPreferences.getInstance();
         expect(prefs.containsKey('adult_content_verified'), isFalse);
         expect(prefs.containsKey('adult_content_verification_date'), isFalse);
-      });
-
-      test('a second account never inherits a migrated legacy value', () async {
-        SharedPreferences.setMockInitialValues({
-          'adult_content_verified': true,
-        });
-
-        final accountA = buildService();
-        await accountA.initialize();
-        expect(accountA.isAdultContentVerified, isTrue);
-
-        final accountB = buildService(pubkey: pubkeyB);
-        await accountB.initialize();
-        expect(accountB.isAdultContentVerified, isFalse);
-      });
-
-      test('retains the legacy global while no account is active', () async {
-        SharedPreferences.setMockInitialValues({
-          'adult_content_verified': true,
-        });
-
-        final service = buildService(pubkey: null);
-        await service.initialize();
-
-        // Not adopted (no account) and not deleted (waiting for one).
-        expect(service.isAdultContentVerified, isFalse);
-        final prefs = await SharedPreferences.getInstance();
-        expect(prefs.containsKey('adult_content_verified'), isTrue);
-      });
-    });
-
-    group('clearVerificationStatus', () {
-      test('clears only the active account', () async {
-        final accountA = buildService();
-        await accountA.initialize();
-        await accountA.setAdultContentVerified(true);
-
-        final accountB = buildService(pubkey: pubkeyB);
-        await accountB.initialize();
-        await accountB.setAdultContentVerified(true);
-
-        await accountA.clearVerificationStatus();
-
-        expect(accountA.isAdultContentVerified, isFalse);
-
-        final accountBReload = buildService(pubkey: pubkeyB);
-        await accountBReload.initialize();
-        expect(accountBReload.isAdultContentVerified, isTrue);
-      });
-    });
-
-    group('purgeAccount', () {
-      test('removes only the target account keys', () async {
-        final accountA = buildService();
-        await accountA.initialize();
-        await accountA.setAdultContentVerified(true);
-
-        final accountB = buildService(pubkey: pubkeyB);
-        await accountB.initialize();
-        await accountB.setAdultContentVerified(true);
-
-        final prefs = await SharedPreferences.getInstance();
-        await AgeVerificationService.purgeAccount(prefs, pubkeyA);
-
-        final accountAReload = buildService();
-        await accountAReload.initialize();
-        expect(accountAReload.isAdultContentVerified, isFalse);
-
-        final accountBReload = buildService(pubkey: pubkeyB);
-        await accountBReload.initialize();
-        expect(accountBReload.isAdultContentVerified, isTrue);
+        expect(prefs.containsKey('adult_content_verified_$pubkeyA'), isFalse);
       });
     });
 
@@ -270,6 +228,7 @@ void main() {
       test('fires when adult verification is revoked', () async {
         var clearCount = 0;
         final service = AgeVerificationService(
+          preferences: preferences,
           currentPubkeyHex: () => pubkeyA,
           onAdultMediaAccessRevoked: () async => clearCount++,
         );
@@ -277,20 +236,6 @@ void main() {
         await service.setAdultContentVerified(true);
 
         await service.setAdultContentVerified(false);
-
-        expect(clearCount, equals(1));
-      });
-
-      test('fires when verification status is cleared', () async {
-        var clearCount = 0;
-        final service = AgeVerificationService(
-          currentPubkeyHex: () => pubkeyA,
-          onAdultMediaAccessRevoked: () async => clearCount++,
-        );
-        await service.initialize();
-        await service.setAdultContentVerified(true);
-
-        await service.clearVerificationStatus();
 
         expect(clearCount, equals(1));
       });

--- a/mobile/test/services/age_verification_service_test.dart
+++ b/mobile/test/services/age_verification_service_test.dart
@@ -3,51 +3,275 @@ import 'package:openvine/services/age_verification_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  const pubkeyA =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+  const pubkeyB =
+      '2222222222222222222222222222222222222222222222222222222222222222';
+
+  AgeVerificationService buildService({
+    String? pubkey = pubkeyA,
+    bool Function()? isProtectedMinor,
+  }) => AgeVerificationService(
+    currentPubkeyHex: () => pubkey,
+    isProtectedMinor: isProtectedMinor,
+  );
+
   group('AgeVerificationService', () {
-    late AgeVerificationService service;
-
     setUp(() {
-      // Reset SharedPreferences before each test
       SharedPreferences.setMockInitialValues({});
-      service = AgeVerificationService();
     });
 
-    test('should initialize with age not verified', () async {
-      await service.initialize();
-      expect(service.isAgeVerified, false);
-      expect(service.verificationDate, isNull);
+    group('age verification (creator gate)', () {
+      test('starts unverified for a fresh account', () async {
+        final service = buildService();
+        await service.initialize();
+
+        expect(service.isAgeVerified, isFalse);
+        expect(service.verificationDate, isNull);
+      });
+
+      test('persists a true value for the active account', () async {
+        final service = buildService();
+        await service.initialize();
+
+        await service.setAgeVerified(true);
+
+        expect(service.isAgeVerified, isTrue);
+        expect(service.verificationDate, isNotNull);
+      });
+
+      test('persists across instances for the same account', () async {
+        final first = buildService();
+        await first.initialize();
+        await first.setAgeVerified(true);
+
+        final second = buildService();
+        await second.initialize();
+
+        expect(second.isAgeVerified, isTrue);
+      });
+
+      test('is scoped per account', () async {
+        final accountA = buildService();
+        await accountA.initialize();
+        await accountA.setAgeVerified(true);
+
+        final accountB = buildService(pubkey: pubkeyB);
+        await accountB.initialize();
+
+        expect(accountB.isAgeVerified, isFalse);
+      });
     });
 
-    test('should save age verification status as true', () async {
-      await service.initialize();
+    group('adult-content verification', () {
+      test('starts unverified for a fresh account', () async {
+        final service = buildService();
+        await service.initialize();
 
-      await service.setAgeVerified(true);
+        expect(service.isAdultContentVerified, isFalse);
+      });
 
-      expect(service.isAgeVerified, true);
-      expect(service.verificationDate, isNotNull);
-      expect(
-        service.verificationDate!.difference(DateTime.now()).inSeconds.abs(),
-        lessThan(2),
+      test('persists a true value for the active account', () async {
+        final service = buildService();
+        await service.initialize();
+
+        await service.setAdultContentVerified(true);
+
+        expect(service.isAdultContentVerified, isTrue);
+        expect(service.adultContentVerificationDate, isNotNull);
+      });
+
+      test('does not leak between accounts', () async {
+        final accountA = buildService();
+        await accountA.initialize();
+        await accountA.setAdultContentVerified(true);
+
+        final accountB = buildService(pubkey: pubkeyB);
+        await accountB.initialize();
+
+        expect(accountB.isAdultContentVerified, isFalse);
+      });
+
+      test(
+        'a second account keeps its own state after switching back',
+        () async {
+          final accountA = buildService();
+          await accountA.initialize();
+          await accountA.setAdultContentVerified(true);
+
+          final accountB = buildService(pubkey: pubkeyB);
+          await accountB.initialize();
+          expect(accountB.isAdultContentVerified, isFalse);
+
+          final accountAAgain = buildService();
+          await accountAAgain.initialize();
+          expect(accountAAgain.isAdultContentVerified, isTrue);
+        },
       );
     });
 
-    test('should save age verification status as false', () async {
-      await service.initialize();
+    group('no active account (fail-safe)', () {
+      test('resolves to unverified when no account is signed in', () async {
+        final service = buildService(pubkey: null);
+        await service.initialize();
 
-      await service.setAgeVerified(false);
+        expect(service.isAgeVerified, isFalse);
+        expect(service.isAdultContentVerified, isFalse);
+      });
 
-      expect(service.isAgeVerified, false);
-      expect(service.verificationDate, isNull);
+      test('does not persist a write when no account is signed in', () async {
+        final service = buildService(pubkey: null);
+        await service.initialize();
+
+        await service.setAdultContentVerified(true);
+
+        expect(service.isAdultContentVerified, isFalse);
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getKeys().any((k) => k.startsWith('adult_content_verified')),
+          isFalse,
+        );
+      });
+
+      test('checkAdultContentVerification returns false', () async {
+        final service = buildService(pubkey: null);
+
+        expect(await service.checkAdultContentVerification(), isFalse);
+      });
     });
 
-    test(
-      'clears adult media caches when adult verification is revoked',
-      () async {
+    group('protected minor lock', () {
+      test('overrides a per-account stored true', () async {
+        // Seed a real per-account true, then read it as a protected minor.
+        final adult = buildService();
+        await adult.initialize();
+        await adult.setAdultContentVerified(true);
+
+        final minor = buildService(isProtectedMinor: () => true);
+        await minor.initialize();
+
+        expect(minor.isAdultContentVerified, isFalse);
+      });
+
+      test('rejects a verification write for a protected minor', () async {
+        final minor = buildService(isProtectedMinor: () => true);
+        await minor.initialize();
+
+        await minor.setAdultContentVerified(true);
+
+        final adult = buildService();
+        await adult.initialize();
+        expect(adult.isAdultContentVerified, isFalse);
+      });
+    });
+
+    group('legacy global-key migration', () {
+      test('adopts a legacy global value for the active account', () async {
+        SharedPreferences.setMockInitialValues({
+          'adult_content_verified': true,
+          'adult_content_verification_date':
+              DateTime.now().millisecondsSinceEpoch,
+        });
+
+        final service = buildService();
+        await service.initialize();
+
+        expect(service.isAdultContentVerified, isTrue);
+      });
+
+      test('deletes the legacy global keys after adoption', () async {
+        SharedPreferences.setMockInitialValues({
+          'adult_content_verified': true,
+          'adult_content_verification_date':
+              DateTime.now().millisecondsSinceEpoch,
+        });
+
+        final service = buildService();
+        await service.initialize();
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.containsKey('adult_content_verified'), isFalse);
+        expect(prefs.containsKey('adult_content_verification_date'), isFalse);
+      });
+
+      test('a second account never inherits a migrated legacy value', () async {
+        SharedPreferences.setMockInitialValues({
+          'adult_content_verified': true,
+        });
+
+        final accountA = buildService();
+        await accountA.initialize();
+        expect(accountA.isAdultContentVerified, isTrue);
+
+        final accountB = buildService(pubkey: pubkeyB);
+        await accountB.initialize();
+        expect(accountB.isAdultContentVerified, isFalse);
+      });
+
+      test('retains the legacy global while no account is active', () async {
+        SharedPreferences.setMockInitialValues({
+          'adult_content_verified': true,
+        });
+
+        final service = buildService(pubkey: null);
+        await service.initialize();
+
+        // Not adopted (no account) and not deleted (waiting for one).
+        expect(service.isAdultContentVerified, isFalse);
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.containsKey('adult_content_verified'), isTrue);
+      });
+    });
+
+    group('clearVerificationStatus', () {
+      test('clears only the active account', () async {
+        final accountA = buildService();
+        await accountA.initialize();
+        await accountA.setAdultContentVerified(true);
+
+        final accountB = buildService(pubkey: pubkeyB);
+        await accountB.initialize();
+        await accountB.setAdultContentVerified(true);
+
+        await accountA.clearVerificationStatus();
+
+        expect(accountA.isAdultContentVerified, isFalse);
+
+        final accountBReload = buildService(pubkey: pubkeyB);
+        await accountBReload.initialize();
+        expect(accountBReload.isAdultContentVerified, isTrue);
+      });
+    });
+
+    group('purgeAccount', () {
+      test('removes only the target account keys', () async {
+        final accountA = buildService();
+        await accountA.initialize();
+        await accountA.setAdultContentVerified(true);
+
+        final accountB = buildService(pubkey: pubkeyB);
+        await accountB.initialize();
+        await accountB.setAdultContentVerified(true);
+
+        final prefs = await SharedPreferences.getInstance();
+        await AgeVerificationService.purgeAccount(prefs, pubkeyA);
+
+        final accountAReload = buildService();
+        await accountAReload.initialize();
+        expect(accountAReload.isAdultContentVerified, isFalse);
+
+        final accountBReload = buildService(pubkey: pubkeyB);
+        await accountBReload.initialize();
+        expect(accountBReload.isAdultContentVerified, isTrue);
+      });
+    });
+
+    group('adult media access revoke callback', () {
+      test('fires when adult verification is revoked', () async {
         var clearCount = 0;
-        service = AgeVerificationService(
-          onAdultMediaAccessRevoked: () async {
-            clearCount++;
-          },
+        final service = AgeVerificationService(
+          currentPubkeyHex: () => pubkeyA,
+          onAdultMediaAccessRevoked: () async => clearCount++,
         );
         await service.initialize();
         await service.setAdultContentVerified(true);
@@ -55,46 +279,13 @@ void main() {
         await service.setAdultContentVerified(false);
 
         expect(clearCount, equals(1));
-      },
-    );
+      });
 
-    test('should persist age verification status across instances', () async {
-      // First instance sets verification
-      await service.initialize();
-      await service.setAgeVerified(true);
-      final firstDate = service.verificationDate;
-
-      // Create new instance and check persistence
-      final newService = AgeVerificationService();
-      await newService.initialize();
-
-      expect(newService.isAgeVerified, true);
-      expect(
-        newService.verificationDate?.millisecondsSinceEpoch,
-        equals(firstDate?.millisecondsSinceEpoch),
-      );
-    });
-
-    test('should clear verification status', () async {
-      await service.initialize();
-      await service.setAgeVerified(true);
-
-      expect(service.isAgeVerified, true);
-
-      await service.clearVerificationStatus();
-
-      expect(service.isAgeVerified, false);
-      expect(service.verificationDate, isNull);
-    });
-
-    test(
-      'clears adult media caches when verification status is cleared',
-      () async {
+      test('fires when verification status is cleared', () async {
         var clearCount = 0;
-        service = AgeVerificationService(
-          onAdultMediaAccessRevoked: () async {
-            clearCount++;
-          },
+        final service = AgeVerificationService(
+          currentPubkeyHex: () => pubkeyA,
+          onAdultMediaAccessRevoked: () async => clearCount++,
         );
         await service.initialize();
         await service.setAdultContentVerified(true);
@@ -102,48 +293,7 @@ void main() {
         await service.clearVerificationStatus();
 
         expect(clearCount, equals(1));
-      },
-    );
-
-    test(
-      'checkAgeVerification should load status if not initialized',
-      () async {
-        // Don't call initialize
-        SharedPreferences.setMockInitialValues({
-          'age_verified': true,
-          'age_verification_date': DateTime.now().millisecondsSinceEpoch,
-        });
-
-        final result = await service.checkAgeVerification();
-
-        expect(result, true);
-        expect(service.isAgeVerified, true);
-      },
-    );
-
-    test('should handle SharedPreferences errors gracefully', () async {
-      // This test would require mocking SharedPreferences to throw errors
-      // For now, we just verify the service initializes without throwing
-      await expectLater(service.initialize(), completes);
-    });
-
-    test('notifies when adult verification loads or changes', () async {
-      var notificationCount = 0;
-      service = AgeVerificationService(
-        onAdultContentVerificationChanged: () => notificationCount++,
-      );
-
-      await service.initialize();
-      expect(notificationCount, 1);
-
-      await service.setAdultContentVerified(true);
-      expect(notificationCount, 2);
-
-      await service.setAdultContentVerified(false);
-      expect(notificationCount, 3);
-
-      await service.clearVerificationStatus();
-      expect(notificationCount, 4);
+      });
     });
   });
 }

--- a/mobile/test/services/auth_service_signout_cleanup_test.dart
+++ b/mobile/test/services/auth_service_signout_cleanup_test.dart
@@ -163,10 +163,9 @@ void main() {
     });
 
     test('signOut clears configured and user-removed relays', () async {
-      await prefs.setStringList(
-        SharedPreferencesRelayStorage.defaultKey,
-        ['wss://relay.divine.video'],
-      );
+      await prefs.setStringList(SharedPreferencesRelayStorage.defaultKey, [
+        'wss://relay.divine.video',
+      ]);
       await prefs.setStringList(
         SharedPreferencesRelayStorage.defaultRemovedRelaysKey,
         ['wss://relay.divine.video'],
@@ -345,22 +344,19 @@ void main() {
       },
     );
 
-    test(
-      'non-destructive signOut without a current pubkey skips cache '
-      'invalidation',
-      () async {
-        await cacheDao.write(
-          key: 'aa11:my_followers',
-          payload: '{"pubkeys":["a"],"count":1}',
-        );
-        when(() => mockKeyStorage.clearCache()).thenReturn(null);
+    test('non-destructive signOut without a current pubkey skips cache '
+        'invalidation', () async {
+      await cacheDao.write(
+        key: 'aa11:my_followers',
+        payload: '{"pubkeys":["a"],"count":1}',
+      );
+      when(() => mockKeyStorage.clearCache()).thenReturn(null);
 
-        await authService.signOut();
+      await authService.signOut();
 
-        expect(cacheDao.deletePrefixCalls, isEmpty);
-        expect(cacheDao.store, isNotEmpty);
-      },
-    );
+      expect(cacheDao.deletePrefixCalls, isEmpty);
+      expect(cacheDao.store, isNotEmpty);
+    });
 
     group('account-scoped CacheSync invalidation (multi-account)', () {
       const pubkeyA =
@@ -422,32 +418,29 @@ void main() {
         },
       );
 
-      test(
-        'signOut completes despite a throwing invalidatePrefix',
-        () async {
-          // The cache-layer failure must NOT abort the rest of signOut.
-          // Without the try/catch around CacheSync.invalidatePrefix, a
-          // disk error would short-circuit key cleanup, signer
-          // teardown, and the auth-state transition.
-          cacheDao.throwOnDeletePrefix = StateError(
-            'cache layer simulated failure',
-          );
+      test('signOut completes despite a throwing invalidatePrefix', () async {
+        // The cache-layer failure must NOT abort the rest of signOut.
+        // Without the try/catch around CacheSync.invalidatePrefix, a
+        // disk error would short-circuit key cleanup, signer
+        // teardown, and the auth-state transition.
+        cacheDao.throwOnDeletePrefix = StateError(
+          'cache layer simulated failure',
+        );
 
-          await authService.signOut();
+        await authService.signOut();
 
-          // The invalidation was attempted with the right prefix...
-          expect(cacheDao.deletePrefixCalls, equals([pubkeyA]));
-          // ...the throw was swallowed and signOut still completed...
-          expect(authService.authState, equals(AuthState.unauthenticated));
-          // ...and because the fake throws before any rows are removed,
-          // every seeded entry (A's and B's) is still on disk. This pins
-          // the contract that a failed invalidation leaves the cache in
-          // its pre-call state — no partial cleanup.
-          expect(cacheDao.store['$pubkeyA:my_followers'], isNotNull);
-          expect(cacheDao.store['$pubkeyA:my_following'], isNotNull);
-          expect(cacheDao.store['$pubkeyB:my_followers'], isNotNull);
-        },
-      );
+        // The invalidation was attempted with the right prefix...
+        expect(cacheDao.deletePrefixCalls, equals([pubkeyA]));
+        // ...the throw was swallowed and signOut still completed...
+        expect(authService.authState, equals(AuthState.unauthenticated));
+        // ...and because the fake throws before any rows are removed,
+        // every seeded entry (A's and B's) is still on disk. This pins
+        // the contract that a failed invalidation leaves the cache in
+        // its pre-call state — no partial cleanup.
+        expect(cacheDao.store['$pubkeyA:my_followers'], isNotNull);
+        expect(cacheDao.store['$pubkeyA:my_following'], isNotNull);
+        expect(cacheDao.store['$pubkeyB:my_followers'], isNotNull);
+      });
     });
 
     test('signOut should set auth state to unauthenticated', () async {
@@ -714,6 +707,46 @@ void main() {
         // deleteKeys() called only once (pre-flight), not twice
         verify(() => mockKeyStorage.deleteKeys()).called(1);
       });
+    });
+
+    group('age verification per-account cleanup (#7816)', () {
+      test(
+        'destructive account deletion purges the account age keys',
+        () async {
+          final keyContainer = SecureKeyContainer.fromNsec(testNsec);
+          final pubkey = keyContainer.publicKeyHex;
+          authService.debugSetCurrentKeyContainer(keyContainer);
+          await prefs.setBool('adult_content_verified_$pubkey', true);
+          await prefs.setBool('age_verified_$pubkey', true);
+
+          when(() => mockKeyStorage.deleteKeys()).thenAnswer((_) async => {});
+          when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+
+          await authService.signOut(
+            deleteKeys: true,
+            deleteLocalUserData: true,
+          );
+
+          expect(prefs.containsKey('adult_content_verified_$pubkey'), isFalse);
+          expect(prefs.containsKey('age_verified_$pubkey'), isFalse);
+        },
+      );
+
+      test(
+        'non-destructive account switch keeps the account age keys',
+        () async {
+          final keyContainer = SecureKeyContainer.fromNsec(testNsec);
+          final pubkey = keyContainer.publicKeyHex;
+          authService.debugSetCurrentKeyContainer(keyContainer);
+          await prefs.setBool('adult_content_verified_$pubkey', true);
+
+          when(() => mockKeyStorage.clearCache()).thenReturn(null);
+
+          await authService.signOut();
+
+          expect(prefs.getBool('adult_content_verified_$pubkey'), isTrue);
+        },
+      );
     });
   });
 }

--- a/mobile/test/services/auth_service_signout_cleanup_test.dart
+++ b/mobile/test/services/auth_service_signout_cleanup_test.dart
@@ -163,9 +163,10 @@ void main() {
     });
 
     test('signOut clears configured and user-removed relays', () async {
-      await prefs.setStringList(SharedPreferencesRelayStorage.defaultKey, [
-        'wss://relay.divine.video',
-      ]);
+      await prefs.setStringList(
+        SharedPreferencesRelayStorage.defaultKey,
+        ['wss://relay.divine.video'],
+      );
       await prefs.setStringList(
         SharedPreferencesRelayStorage.defaultRemovedRelaysKey,
         ['wss://relay.divine.video'],
@@ -344,19 +345,22 @@ void main() {
       },
     );
 
-    test('non-destructive signOut without a current pubkey skips cache '
-        'invalidation', () async {
-      await cacheDao.write(
-        key: 'aa11:my_followers',
-        payload: '{"pubkeys":["a"],"count":1}',
-      );
-      when(() => mockKeyStorage.clearCache()).thenReturn(null);
+    test(
+      'non-destructive signOut without a current pubkey skips cache '
+      'invalidation',
+      () async {
+        await cacheDao.write(
+          key: 'aa11:my_followers',
+          payload: '{"pubkeys":["a"],"count":1}',
+        );
+        when(() => mockKeyStorage.clearCache()).thenReturn(null);
 
-      await authService.signOut();
+        await authService.signOut();
 
-      expect(cacheDao.deletePrefixCalls, isEmpty);
-      expect(cacheDao.store, isNotEmpty);
-    });
+        expect(cacheDao.deletePrefixCalls, isEmpty);
+        expect(cacheDao.store, isNotEmpty);
+      },
+    );
 
     group('account-scoped CacheSync invalidation (multi-account)', () {
       const pubkeyA =
@@ -418,29 +422,32 @@ void main() {
         },
       );
 
-      test('signOut completes despite a throwing invalidatePrefix', () async {
-        // The cache-layer failure must NOT abort the rest of signOut.
-        // Without the try/catch around CacheSync.invalidatePrefix, a
-        // disk error would short-circuit key cleanup, signer
-        // teardown, and the auth-state transition.
-        cacheDao.throwOnDeletePrefix = StateError(
-          'cache layer simulated failure',
-        );
+      test(
+        'signOut completes despite a throwing invalidatePrefix',
+        () async {
+          // The cache-layer failure must NOT abort the rest of signOut.
+          // Without the try/catch around CacheSync.invalidatePrefix, a
+          // disk error would short-circuit key cleanup, signer
+          // teardown, and the auth-state transition.
+          cacheDao.throwOnDeletePrefix = StateError(
+            'cache layer simulated failure',
+          );
 
-        await authService.signOut();
+          await authService.signOut();
 
-        // The invalidation was attempted with the right prefix...
-        expect(cacheDao.deletePrefixCalls, equals([pubkeyA]));
-        // ...the throw was swallowed and signOut still completed...
-        expect(authService.authState, equals(AuthState.unauthenticated));
-        // ...and because the fake throws before any rows are removed,
-        // every seeded entry (A's and B's) is still on disk. This pins
-        // the contract that a failed invalidation leaves the cache in
-        // its pre-call state — no partial cleanup.
-        expect(cacheDao.store['$pubkeyA:my_followers'], isNotNull);
-        expect(cacheDao.store['$pubkeyA:my_following'], isNotNull);
-        expect(cacheDao.store['$pubkeyB:my_followers'], isNotNull);
-      });
+          // The invalidation was attempted with the right prefix...
+          expect(cacheDao.deletePrefixCalls, equals([pubkeyA]));
+          // ...the throw was swallowed and signOut still completed...
+          expect(authService.authState, equals(AuthState.unauthenticated));
+          // ...and because the fake throws before any rows are removed,
+          // every seeded entry (A's and B's) is still on disk. This pins
+          // the contract that a failed invalidation leaves the cache in
+          // its pre-call state — no partial cleanup.
+          expect(cacheDao.store['$pubkeyA:my_followers'], isNotNull);
+          expect(cacheDao.store['$pubkeyA:my_following'], isNotNull);
+          expect(cacheDao.store['$pubkeyB:my_followers'], isNotNull);
+        },
+      );
     });
 
     test('signOut should set auth state to unauthenticated', () async {
@@ -707,46 +714,6 @@ void main() {
         // deleteKeys() called only once (pre-flight), not twice
         verify(() => mockKeyStorage.deleteKeys()).called(1);
       });
-    });
-
-    group('age verification per-account cleanup (#7816)', () {
-      test(
-        'destructive account deletion purges the account age keys',
-        () async {
-          final keyContainer = SecureKeyContainer.fromNsec(testNsec);
-          final pubkey = keyContainer.publicKeyHex;
-          authService.debugSetCurrentKeyContainer(keyContainer);
-          await prefs.setBool('adult_content_verified_$pubkey', true);
-          await prefs.setBool('age_verified_$pubkey', true);
-
-          when(() => mockKeyStorage.deleteKeys()).thenAnswer((_) async => {});
-          when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
-
-          await authService.signOut(
-            deleteKeys: true,
-            deleteLocalUserData: true,
-          );
-
-          expect(prefs.containsKey('adult_content_verified_$pubkey'), isFalse);
-          expect(prefs.containsKey('age_verified_$pubkey'), isFalse);
-        },
-      );
-
-      test(
-        'non-destructive account switch keeps the account age keys',
-        () async {
-          final keyContainer = SecureKeyContainer.fromNsec(testNsec);
-          final pubkey = keyContainer.publicKeyHex;
-          authService.debugSetCurrentKeyContainer(keyContainer);
-          await prefs.setBool('adult_content_verified_$pubkey', true);
-
-          when(() => mockKeyStorage.clearCache()).thenReturn(null);
-
-          await authService.signOut();
-
-          expect(prefs.getBool('adult_content_verified_$pubkey'), isTrue);
-        },
-      );
     });
   });
 }

--- a/mobile/test/services/content_filter_service_test.dart
+++ b/mobile/test/services/content_filter_service_test.dart
@@ -13,10 +13,15 @@ void main() {
   group(ContentFilterService, () {
     late ContentFilterService service;
     late AgeVerificationService ageService;
+    late SharedPreferences preferences;
 
-    setUp(() {
+    setUp(() async {
       SharedPreferences.setMockInitialValues({});
-      ageService = AgeVerificationService(currentPubkeyHex: () => _testPubkey);
+      preferences = await SharedPreferences.getInstance();
+      ageService = AgeVerificationService(
+        preferences: preferences,
+        currentPubkeyHex: () => _testPubkey,
+      );
       service = ContentFilterService(ageVerificationService: ageService);
     });
 
@@ -494,6 +499,7 @@ void main() {
         await service.unlockAdultCategories();
 
         final newAgeService = AgeVerificationService(
+          preferences: preferences,
           currentPubkeyHex: () => _testPubkey,
         );
         await newAgeService.initialize();
@@ -607,30 +613,33 @@ void main() {
         },
       );
 
-      test('returns warn when opted-in adult categories have mixed non-hide '
-          'preferences', () async {
-        await ageService.initialize();
-        await ageService.setAdultContentVerified(true);
-        await service.initialize();
+      test(
+        'returns warn when opted-in adult categories have mixed non-hide '
+        'preferences',
+        () async {
+          await ageService.initialize();
+          await ageService.setAdultContentVerified(true);
+          await service.initialize();
 
-        await service.setPreference(
-          ContentLabel.nudity,
-          ContentFilterPreference.show,
-        );
-        await service.setPreference(
-          ContentLabel.sexual,
-          ContentFilterPreference.warn,
-        );
-        await service.setPreference(
-          ContentLabel.porn,
-          ContentFilterPreference.hide,
-        );
+          await service.setPreference(
+            ContentLabel.nudity,
+            ContentFilterPreference.show,
+          );
+          await service.setPreference(
+            ContentLabel.sexual,
+            ContentFilterPreference.warn,
+          );
+          await service.setPreference(
+            ContentLabel.porn,
+            ContentFilterPreference.hide,
+          );
 
-        expect(
-          service.adultPlaybackPreference,
-          equals(ContentFilterPreference.warn),
-        );
-      });
+          expect(
+            service.adultPlaybackPreference,
+            equals(ContentFilterPreference.warn),
+          );
+        },
+      );
 
       test(
         'returns hide when any configurable adult category remains hidden',
@@ -686,6 +695,7 @@ void main() {
         () async {
           var clearCount = 0;
           ageService = AgeVerificationService(
+            preferences: preferences,
             currentPubkeyHex: () => _testPubkey,
           );
           service = ContentFilterService(
@@ -817,6 +827,7 @@ void main() {
         await migrationService.initialize();
 
         final restartedAgeService = AgeVerificationService(
+          preferences: preferences,
           currentPubkeyHex: () => _testPubkey,
         );
         await restartedAgeService.initialize();

--- a/mobile/test/services/content_filter_service_test.dart
+++ b/mobile/test/services/content_filter_service_test.dart
@@ -6,6 +6,9 @@ import 'package:openvine/services/age_verification_service.dart';
 import 'package:openvine/services/content_filter_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+const _testPubkey =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+
 void main() {
   group(ContentFilterService, () {
     late ContentFilterService service;
@@ -13,7 +16,7 @@ void main() {
 
     setUp(() {
       SharedPreferences.setMockInitialValues({});
-      ageService = AgeVerificationService();
+      ageService = AgeVerificationService(currentPubkeyHex: () => _testPubkey);
       service = ContentFilterService(ageVerificationService: ageService);
     });
 
@@ -490,7 +493,9 @@ void main() {
 
         await service.unlockAdultCategories();
 
-        final newAgeService = AgeVerificationService();
+        final newAgeService = AgeVerificationService(
+          currentPubkeyHex: () => _testPubkey,
+        );
         await newAgeService.initialize();
         final newService = ContentFilterService(
           ageVerificationService: newAgeService,
@@ -602,33 +607,30 @@ void main() {
         },
       );
 
-      test(
-        'returns warn when opted-in adult categories have mixed non-hide '
-        'preferences',
-        () async {
-          await ageService.initialize();
-          await ageService.setAdultContentVerified(true);
-          await service.initialize();
+      test('returns warn when opted-in adult categories have mixed non-hide '
+          'preferences', () async {
+        await ageService.initialize();
+        await ageService.setAdultContentVerified(true);
+        await service.initialize();
 
-          await service.setPreference(
-            ContentLabel.nudity,
-            ContentFilterPreference.show,
-          );
-          await service.setPreference(
-            ContentLabel.sexual,
-            ContentFilterPreference.warn,
-          );
-          await service.setPreference(
-            ContentLabel.porn,
-            ContentFilterPreference.hide,
-          );
+        await service.setPreference(
+          ContentLabel.nudity,
+          ContentFilterPreference.show,
+        );
+        await service.setPreference(
+          ContentLabel.sexual,
+          ContentFilterPreference.warn,
+        );
+        await service.setPreference(
+          ContentLabel.porn,
+          ContentFilterPreference.hide,
+        );
 
-          expect(
-            service.adultPlaybackPreference,
-            equals(ContentFilterPreference.warn),
-          );
-        },
-      );
+        expect(
+          service.adultPlaybackPreference,
+          equals(ContentFilterPreference.warn),
+        );
+      });
 
       test(
         'returns hide when any configurable adult category remains hidden',
@@ -683,7 +685,9 @@ void main() {
         'clears caches when passive adult thumbnail access is revoked',
         () async {
           var clearCount = 0;
-          ageService = AgeVerificationService();
+          ageService = AgeVerificationService(
+            currentPubkeyHex: () => _testPubkey,
+          );
           service = ContentFilterService(
             ageVerificationService: ageService,
             onAdultMediaAccessRevoked: () async {
@@ -812,7 +816,9 @@ void main() {
         );
         await migrationService.initialize();
 
-        final restartedAgeService = AgeVerificationService();
+        final restartedAgeService = AgeVerificationService(
+          currentPubkeyHex: () => _testPubkey,
+        );
         await restartedAgeService.initialize();
         final restartedService = ContentFilterService(
           ageVerificationService: restartedAgeService,

--- a/mobile/test/services/media_auth_interceptor_preference_test.dart
+++ b/mobile/test/services/media_auth_interceptor_preference_test.dart
@@ -53,173 +53,195 @@ void main() {
   });
 
   group('MediaAuthInterceptor - preference handling', () {
-    test('handleUnauthorizedMedia blocks verified users at default preferences '
-        'even after unlock', () async {
-      SharedPreferences.setMockInitialValues({});
+    test(
+      'handleUnauthorizedMedia blocks verified users at default preferences '
+      'even after unlock',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final preferences = await SharedPreferences.getInstance();
 
-      final realAgeVerificationService = AgeVerificationService(
-        currentPubkeyHex: () => _testPubkey,
-      );
-      await realAgeVerificationService.initialize();
-      await realAgeVerificationService.setAdultContentVerified(true);
+        final realAgeVerificationService = AgeVerificationService(
+          preferences: preferences,
+          currentPubkeyHex: () => _testPubkey,
+        );
+        await realAgeVerificationService.initialize();
+        await realAgeVerificationService.setAdultContentVerified(true);
 
-      final realContentFilterService = ContentFilterService(
-        ageVerificationService: realAgeVerificationService,
-      );
-      await realContentFilterService.initialize();
-      await realContentFilterService.unlockAdultCategories();
+        final realContentFilterService = ContentFilterService(
+          ageVerificationService: realAgeVerificationService,
+        );
+        await realContentFilterService.initialize();
+        await realContentFilterService.unlockAdultCategories();
 
-      final interceptor = MediaAuthInterceptor(
-        ageVerificationService: realAgeVerificationService,
-        contentFilterService: realContentFilterService,
-        mediaViewerAuthService: mockMediaViewerAuthService,
-      );
+        final interceptor = MediaAuthInterceptor(
+          ageVerificationService: realAgeVerificationService,
+          contentFilterService: realContentFilterService,
+          mediaViewerAuthService: mockMediaViewerAuthService,
+        );
 
-      when(() => mockMediaViewerAuthService.canCreateHeaders).thenReturn(true);
-      when(() => mockContext.mounted).thenReturn(true);
+        when(
+          () => mockMediaViewerAuthService.canCreateHeaders,
+        ).thenReturn(true);
+        when(() => mockContext.mounted).thenReturn(true);
 
-      // Adult categories stay hidden after unlock; playback stays blocked
-      // until the user opts in via Content Filters.
-      expect(
-        realContentFilterService.adultPlaybackPreference,
-        ContentFilterPreference.hide,
-      );
-      expect(await interceptor.canAutoAuthorizeAdultMedia(), isFalse);
+        // Adult categories stay hidden after unlock; playback stays blocked
+        // until the user opts in via Content Filters.
+        expect(
+          realContentFilterService.adultPlaybackPreference,
+          ContentFilterPreference.hide,
+        );
+        expect(await interceptor.canAutoAuthorizeAdultMedia(), isFalse);
 
-      final result = await interceptor.handleUnauthorizedMedia(
-        context: mockContext,
-        sha256Hash: 'abc123',
-        category: 'nudity',
-      );
+        final result = await interceptor.handleUnauthorizedMedia(
+          context: mockContext,
+          sha256Hash: 'abc123',
+          category: 'nudity',
+        );
 
-      expect(result, isA<ViewerAuthBlockedByPreference>());
-      verifyNever(
-        () => mockMediaViewerAuthService.createAuthHeaders(
-          sha256Hash: any(named: 'sha256Hash'),
-          url: any(named: 'url'),
-          serverUrl: any(named: 'serverUrl'),
-        ),
-      );
-    });
+        expect(result, isA<ViewerAuthBlockedByPreference>());
+        verifyNever(
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        );
+      },
+    );
 
-    test('handleUnauthorizedMedia blocks verified users after only a partial '
-        'adult-category opt-in', () async {
-      SharedPreferences.setMockInitialValues({});
+    test(
+      'handleUnauthorizedMedia blocks verified users after only a partial '
+      'adult-category opt-in',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final preferences = await SharedPreferences.getInstance();
 
-      final realAgeVerificationService = AgeVerificationService(
-        currentPubkeyHex: () => _testPubkey,
-      );
-      await realAgeVerificationService.initialize();
-      await realAgeVerificationService.setAdultContentVerified(true);
+        final realAgeVerificationService = AgeVerificationService(
+          preferences: preferences,
+          currentPubkeyHex: () => _testPubkey,
+        );
+        await realAgeVerificationService.initialize();
+        await realAgeVerificationService.setAdultContentVerified(true);
 
-      final realContentFilterService = ContentFilterService(
-        ageVerificationService: realAgeVerificationService,
-      );
-      await realContentFilterService.initialize();
-      await realContentFilterService.setPreference(
-        ContentLabel.nudity,
-        ContentFilterPreference.warn,
-      );
+        final realContentFilterService = ContentFilterService(
+          ageVerificationService: realAgeVerificationService,
+        );
+        await realContentFilterService.initialize();
+        await realContentFilterService.setPreference(
+          ContentLabel.nudity,
+          ContentFilterPreference.warn,
+        );
 
-      final interceptor = MediaAuthInterceptor(
-        ageVerificationService: realAgeVerificationService,
-        contentFilterService: realContentFilterService,
-        mediaViewerAuthService: mockMediaViewerAuthService,
-      );
+        final interceptor = MediaAuthInterceptor(
+          ageVerificationService: realAgeVerificationService,
+          contentFilterService: realContentFilterService,
+          mediaViewerAuthService: mockMediaViewerAuthService,
+        );
 
-      when(() => mockMediaViewerAuthService.canCreateHeaders).thenReturn(true);
+        when(
+          () => mockMediaViewerAuthService.canCreateHeaders,
+        ).thenReturn(true);
 
-      expect(
-        realContentFilterService.adultPlaybackPreference,
-        ContentFilterPreference.hide,
-      );
-      expect(await interceptor.canAutoAuthorizeAdultMedia(), isFalse);
+        expect(
+          realContentFilterService.adultPlaybackPreference,
+          ContentFilterPreference.hide,
+        );
+        expect(await interceptor.canAutoAuthorizeAdultMedia(), isFalse);
 
-      final result = await interceptor.handleUnauthorizedMedia(
-        context: mockContext,
-        sha256Hash: 'abc123',
-        category: 'nudity',
-      );
+        final result = await interceptor.handleUnauthorizedMedia(
+          context: mockContext,
+          sha256Hash: 'abc123',
+          category: 'nudity',
+        );
 
-      expect(result, isA<ViewerAuthBlockedByPreference>());
-      verifyNever(
-        () => mockMediaViewerAuthService.createAuthHeaders(
-          sha256Hash: any(named: 'sha256Hash'),
-          url: any(named: 'url'),
-          serverUrl: any(named: 'serverUrl'),
-        ),
-      );
-    });
+        expect(result, isA<ViewerAuthBlockedByPreference>());
+        verifyNever(
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        );
+      },
+    );
 
-    test('handleUnauthorizedMedia creates auth headers after an explicit '
-        'per-category opt-in', () async {
-      SharedPreferences.setMockInitialValues({});
+    test(
+      'handleUnauthorizedMedia creates auth headers after an explicit '
+      'per-category opt-in',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final preferences = await SharedPreferences.getInstance();
 
-      final realAgeVerificationService = AgeVerificationService(
-        currentPubkeyHex: () => _testPubkey,
-      );
-      await realAgeVerificationService.initialize();
-      await realAgeVerificationService.setAdultContentVerified(true);
+        final realAgeVerificationService = AgeVerificationService(
+          preferences: preferences,
+          currentPubkeyHex: () => _testPubkey,
+        );
+        await realAgeVerificationService.initialize();
+        await realAgeVerificationService.setAdultContentVerified(true);
 
-      final realContentFilterService = ContentFilterService(
-        ageVerificationService: realAgeVerificationService,
-      );
-      await realContentFilterService.initialize();
-      await realContentFilterService.setPreference(
-        ContentLabel.nudity,
-        ContentFilterPreference.warn,
-      );
-      await realContentFilterService.setPreference(
-        ContentLabel.sexual,
-        ContentFilterPreference.warn,
-      );
+        final realContentFilterService = ContentFilterService(
+          ageVerificationService: realAgeVerificationService,
+        );
+        await realContentFilterService.initialize();
+        await realContentFilterService.setPreference(
+          ContentLabel.nudity,
+          ContentFilterPreference.warn,
+        );
+        await realContentFilterService.setPreference(
+          ContentLabel.sexual,
+          ContentFilterPreference.warn,
+        );
 
-      final interceptor = MediaAuthInterceptor(
-        ageVerificationService: realAgeVerificationService,
-        contentFilterService: realContentFilterService,
-        mediaViewerAuthService: mockMediaViewerAuthService,
-      );
+        final interceptor = MediaAuthInterceptor(
+          ageVerificationService: realAgeVerificationService,
+          contentFilterService: realContentFilterService,
+          mediaViewerAuthService: mockMediaViewerAuthService,
+        );
 
-      when(() => mockMediaViewerAuthService.canCreateHeaders).thenReturn(true);
-      when(
-        () => mockMediaViewerAuthService.createAuthHeaders(
-          sha256Hash: any(named: 'sha256Hash'),
-          url: any(named: 'url'),
-          serverUrl: any(named: 'serverUrl'),
-        ),
-      ).thenAnswer(
-        (_) async => const ViewerAuthAuthorized({
-          'Authorization': 'Nostr unlockedToken',
-        }),
-      );
+        when(
+          () => mockMediaViewerAuthService.canCreateHeaders,
+        ).thenReturn(true);
+        when(
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        ).thenAnswer(
+          (_) async => const ViewerAuthAuthorized({
+            'Authorization': 'Nostr unlockedToken',
+          }),
+        );
 
-      when(() => mockContext.mounted).thenReturn(true);
+        when(() => mockContext.mounted).thenReturn(true);
 
-      expect(
-        realContentFilterService.adultPlaybackPreference,
-        ContentFilterPreference.warn,
-      );
-      expect(await interceptor.canAutoAuthorizeAdultMedia(), isTrue);
+        expect(
+          realContentFilterService.adultPlaybackPreference,
+          ContentFilterPreference.warn,
+        );
+        expect(await interceptor.canAutoAuthorizeAdultMedia(), isTrue);
 
-      final result = await interceptor.handleUnauthorizedMedia(
-        context: mockContext,
-        sha256Hash: 'abc123',
-        category: 'nudity',
-      );
+        final result = await interceptor.handleUnauthorizedMedia(
+          context: mockContext,
+          sha256Hash: 'abc123',
+          category: 'nudity',
+        );
 
-      expect(result, isA<ViewerAuthAuthorized>());
-      expect(
-        result.headersOrNull,
-        equals({'Authorization': 'Nostr unlockedToken'}),
-      );
-      verifyNever(
-        () => mockAgeVerificationService.verifyAdultContentAccess(any()),
-      );
-      verify(
-        () =>
-            mockMediaViewerAuthService.createAuthHeaders(sha256Hash: 'abc123'),
-      ).called(1);
-    });
+        expect(result, isA<ViewerAuthAuthorized>());
+        expect(
+          result.headersOrNull,
+          equals({'Authorization': 'Nostr unlockedToken'}),
+        );
+        verifyNever(
+          () => mockAgeVerificationService.verifyAdultContentAccess(any()),
+        );
+        verify(
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: 'abc123',
+          ),
+        ).called(1);
+      },
+    );
 
     test(
       'handleUnauthorizedMedia reports a preference block when verified user '
@@ -257,41 +279,46 @@ void main() {
       },
     );
 
-    test('handleUnauthorizedMedia keeps adult media blocked after verification '
-        'when preferences still hide it', () async {
-      when(
-        () => mockContentFilterService.adultPlaybackPreference,
-      ).thenReturn(ContentFilterPreference.hide);
-      when(
-        () => mockAgeVerificationService.isAdultContentVerified,
-      ).thenReturn(false);
-      when(() => mockContext.mounted).thenReturn(true);
-      when(
-        () => mockAgeVerificationService.verifyAdultContentAccess(any()),
-      ).thenAnswer((_) async => true);
-      when(
-        () => mockContentFilterService.unlockAdultCategories(),
-      ).thenAnswer((_) async {});
+    test(
+      'handleUnauthorizedMedia keeps adult media blocked after verification '
+      'when preferences still hide it',
+      () async {
+        when(
+          () => mockContentFilterService.adultPlaybackPreference,
+        ).thenReturn(ContentFilterPreference.hide);
+        when(
+          () => mockAgeVerificationService.isAdultContentVerified,
+        ).thenReturn(false);
+        when(() => mockContext.mounted).thenReturn(true);
+        when(
+          () => mockAgeVerificationService.verifyAdultContentAccess(any()),
+        ).thenAnswer((_) async => true);
+        when(
+          () => mockContentFilterService.unlockAdultCategories(),
+        ).thenAnswer((_) async {});
 
-      final result = await interceptor.handleUnauthorizedMedia(
-        context: mockContext,
-        sha256Hash: 'abc123',
-        category: 'nudity',
-      );
+        final result = await interceptor.handleUnauthorizedMedia(
+          context: mockContext,
+          sha256Hash: 'abc123',
+          category: 'nudity',
+        );
 
-      expect(result, isA<ViewerAuthBlockedByPreference>());
-      verify(
-        () => mockAgeVerificationService.verifyAdultContentAccess(any()),
-      ).called(1);
-      verify(() => mockContentFilterService.unlockAdultCategories()).called(1);
-      verifyNever(
-        () => mockMediaViewerAuthService.createAuthHeaders(
-          sha256Hash: any(named: 'sha256Hash'),
-          url: any(named: 'url'),
-          serverUrl: any(named: 'serverUrl'),
-        ),
-      );
-    });
+        expect(result, isA<ViewerAuthBlockedByPreference>());
+        verify(
+          () => mockAgeVerificationService.verifyAdultContentAccess(any()),
+        ).called(1);
+        verify(
+          () => mockContentFilterService.unlockAdultCategories(),
+        ).called(1);
+        verifyNever(
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        );
+      },
+    );
 
     test(
       'handleUnauthorizedMedia auto-creates auth when alwaysShow and verified',
@@ -405,8 +432,9 @@ void main() {
             serverUrl: any(named: 'serverUrl'),
           ),
         ).thenAnswer(
-          (_) async =>
-              const ViewerAuthAuthorized({'Authorization': 'Nostr warnToken'}),
+          (_) async => const ViewerAuthAuthorized({
+            'Authorization': 'Nostr warnToken',
+          }),
         );
 
         final result = await interceptor.createAutoAuthHeadersForAdultMedia(

--- a/mobile/test/services/media_auth_interceptor_preference_test.dart
+++ b/mobile/test/services/media_auth_interceptor_preference_test.dart
@@ -12,6 +12,9 @@ import 'package:openvine/services/media_auth_interceptor.dart';
 import 'package:openvine/services/media_viewer_auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+const _testPubkey =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+
 class MockAgeVerificationService extends Mock
     implements AgeVerificationService {}
 
@@ -50,183 +53,173 @@ void main() {
   });
 
   group('MediaAuthInterceptor - preference handling', () {
-    test(
-      'handleUnauthorizedMedia blocks verified users at default preferences '
-      'even after unlock',
-      () async {
-        SharedPreferences.setMockInitialValues({});
+    test('handleUnauthorizedMedia blocks verified users at default preferences '
+        'even after unlock', () async {
+      SharedPreferences.setMockInitialValues({});
 
-        final realAgeVerificationService = AgeVerificationService();
-        await realAgeVerificationService.initialize();
-        await realAgeVerificationService.setAdultContentVerified(true);
+      final realAgeVerificationService = AgeVerificationService(
+        currentPubkeyHex: () => _testPubkey,
+      );
+      await realAgeVerificationService.initialize();
+      await realAgeVerificationService.setAdultContentVerified(true);
 
-        final realContentFilterService = ContentFilterService(
-          ageVerificationService: realAgeVerificationService,
-        );
-        await realContentFilterService.initialize();
-        await realContentFilterService.unlockAdultCategories();
+      final realContentFilterService = ContentFilterService(
+        ageVerificationService: realAgeVerificationService,
+      );
+      await realContentFilterService.initialize();
+      await realContentFilterService.unlockAdultCategories();
 
-        final interceptor = MediaAuthInterceptor(
-          ageVerificationService: realAgeVerificationService,
-          contentFilterService: realContentFilterService,
-          mediaViewerAuthService: mockMediaViewerAuthService,
-        );
+      final interceptor = MediaAuthInterceptor(
+        ageVerificationService: realAgeVerificationService,
+        contentFilterService: realContentFilterService,
+        mediaViewerAuthService: mockMediaViewerAuthService,
+      );
 
-        when(
-          () => mockMediaViewerAuthService.canCreateHeaders,
-        ).thenReturn(true);
-        when(() => mockContext.mounted).thenReturn(true);
+      when(() => mockMediaViewerAuthService.canCreateHeaders).thenReturn(true);
+      when(() => mockContext.mounted).thenReturn(true);
 
-        // Adult categories stay hidden after unlock; playback stays blocked
-        // until the user opts in via Content Filters.
-        expect(
-          realContentFilterService.adultPlaybackPreference,
-          ContentFilterPreference.hide,
-        );
-        expect(await interceptor.canAutoAuthorizeAdultMedia(), isFalse);
+      // Adult categories stay hidden after unlock; playback stays blocked
+      // until the user opts in via Content Filters.
+      expect(
+        realContentFilterService.adultPlaybackPreference,
+        ContentFilterPreference.hide,
+      );
+      expect(await interceptor.canAutoAuthorizeAdultMedia(), isFalse);
 
-        final result = await interceptor.handleUnauthorizedMedia(
-          context: mockContext,
-          sha256Hash: 'abc123',
-          category: 'nudity',
-        );
+      final result = await interceptor.handleUnauthorizedMedia(
+        context: mockContext,
+        sha256Hash: 'abc123',
+        category: 'nudity',
+      );
 
-        expect(result, isA<ViewerAuthBlockedByPreference>());
-        verifyNever(
-          () => mockMediaViewerAuthService.createAuthHeaders(
-            sha256Hash: any(named: 'sha256Hash'),
-            url: any(named: 'url'),
-            serverUrl: any(named: 'serverUrl'),
-          ),
-        );
-      },
-    );
+      expect(result, isA<ViewerAuthBlockedByPreference>());
+      verifyNever(
+        () => mockMediaViewerAuthService.createAuthHeaders(
+          sha256Hash: any(named: 'sha256Hash'),
+          url: any(named: 'url'),
+          serverUrl: any(named: 'serverUrl'),
+        ),
+      );
+    });
 
-    test(
-      'handleUnauthorizedMedia blocks verified users after only a partial '
-      'adult-category opt-in',
-      () async {
-        SharedPreferences.setMockInitialValues({});
+    test('handleUnauthorizedMedia blocks verified users after only a partial '
+        'adult-category opt-in', () async {
+      SharedPreferences.setMockInitialValues({});
 
-        final realAgeVerificationService = AgeVerificationService();
-        await realAgeVerificationService.initialize();
-        await realAgeVerificationService.setAdultContentVerified(true);
+      final realAgeVerificationService = AgeVerificationService(
+        currentPubkeyHex: () => _testPubkey,
+      );
+      await realAgeVerificationService.initialize();
+      await realAgeVerificationService.setAdultContentVerified(true);
 
-        final realContentFilterService = ContentFilterService(
-          ageVerificationService: realAgeVerificationService,
-        );
-        await realContentFilterService.initialize();
-        await realContentFilterService.setPreference(
-          ContentLabel.nudity,
-          ContentFilterPreference.warn,
-        );
+      final realContentFilterService = ContentFilterService(
+        ageVerificationService: realAgeVerificationService,
+      );
+      await realContentFilterService.initialize();
+      await realContentFilterService.setPreference(
+        ContentLabel.nudity,
+        ContentFilterPreference.warn,
+      );
 
-        final interceptor = MediaAuthInterceptor(
-          ageVerificationService: realAgeVerificationService,
-          contentFilterService: realContentFilterService,
-          mediaViewerAuthService: mockMediaViewerAuthService,
-        );
+      final interceptor = MediaAuthInterceptor(
+        ageVerificationService: realAgeVerificationService,
+        contentFilterService: realContentFilterService,
+        mediaViewerAuthService: mockMediaViewerAuthService,
+      );
 
-        when(
-          () => mockMediaViewerAuthService.canCreateHeaders,
-        ).thenReturn(true);
+      when(() => mockMediaViewerAuthService.canCreateHeaders).thenReturn(true);
 
-        expect(
-          realContentFilterService.adultPlaybackPreference,
-          ContentFilterPreference.hide,
-        );
-        expect(await interceptor.canAutoAuthorizeAdultMedia(), isFalse);
+      expect(
+        realContentFilterService.adultPlaybackPreference,
+        ContentFilterPreference.hide,
+      );
+      expect(await interceptor.canAutoAuthorizeAdultMedia(), isFalse);
 
-        final result = await interceptor.handleUnauthorizedMedia(
-          context: mockContext,
-          sha256Hash: 'abc123',
-          category: 'nudity',
-        );
+      final result = await interceptor.handleUnauthorizedMedia(
+        context: mockContext,
+        sha256Hash: 'abc123',
+        category: 'nudity',
+      );
 
-        expect(result, isA<ViewerAuthBlockedByPreference>());
-        verifyNever(
-          () => mockMediaViewerAuthService.createAuthHeaders(
-            sha256Hash: any(named: 'sha256Hash'),
-            url: any(named: 'url'),
-            serverUrl: any(named: 'serverUrl'),
-          ),
-        );
-      },
-    );
+      expect(result, isA<ViewerAuthBlockedByPreference>());
+      verifyNever(
+        () => mockMediaViewerAuthService.createAuthHeaders(
+          sha256Hash: any(named: 'sha256Hash'),
+          url: any(named: 'url'),
+          serverUrl: any(named: 'serverUrl'),
+        ),
+      );
+    });
 
-    test(
-      'handleUnauthorizedMedia creates auth headers after an explicit '
-      'per-category opt-in',
-      () async {
-        SharedPreferences.setMockInitialValues({});
+    test('handleUnauthorizedMedia creates auth headers after an explicit '
+        'per-category opt-in', () async {
+      SharedPreferences.setMockInitialValues({});
 
-        final realAgeVerificationService = AgeVerificationService();
-        await realAgeVerificationService.initialize();
-        await realAgeVerificationService.setAdultContentVerified(true);
+      final realAgeVerificationService = AgeVerificationService(
+        currentPubkeyHex: () => _testPubkey,
+      );
+      await realAgeVerificationService.initialize();
+      await realAgeVerificationService.setAdultContentVerified(true);
 
-        final realContentFilterService = ContentFilterService(
-          ageVerificationService: realAgeVerificationService,
-        );
-        await realContentFilterService.initialize();
-        await realContentFilterService.setPreference(
-          ContentLabel.nudity,
-          ContentFilterPreference.warn,
-        );
-        await realContentFilterService.setPreference(
-          ContentLabel.sexual,
-          ContentFilterPreference.warn,
-        );
+      final realContentFilterService = ContentFilterService(
+        ageVerificationService: realAgeVerificationService,
+      );
+      await realContentFilterService.initialize();
+      await realContentFilterService.setPreference(
+        ContentLabel.nudity,
+        ContentFilterPreference.warn,
+      );
+      await realContentFilterService.setPreference(
+        ContentLabel.sexual,
+        ContentFilterPreference.warn,
+      );
 
-        final interceptor = MediaAuthInterceptor(
-          ageVerificationService: realAgeVerificationService,
-          contentFilterService: realContentFilterService,
-          mediaViewerAuthService: mockMediaViewerAuthService,
-        );
+      final interceptor = MediaAuthInterceptor(
+        ageVerificationService: realAgeVerificationService,
+        contentFilterService: realContentFilterService,
+        mediaViewerAuthService: mockMediaViewerAuthService,
+      );
 
-        when(
-          () => mockMediaViewerAuthService.canCreateHeaders,
-        ).thenReturn(true);
-        when(
-          () => mockMediaViewerAuthService.createAuthHeaders(
-            sha256Hash: any(named: 'sha256Hash'),
-            url: any(named: 'url'),
-            serverUrl: any(named: 'serverUrl'),
-          ),
-        ).thenAnswer(
-          (_) async => const ViewerAuthAuthorized({
-            'Authorization': 'Nostr unlockedToken',
-          }),
-        );
+      when(() => mockMediaViewerAuthService.canCreateHeaders).thenReturn(true);
+      when(
+        () => mockMediaViewerAuthService.createAuthHeaders(
+          sha256Hash: any(named: 'sha256Hash'),
+          url: any(named: 'url'),
+          serverUrl: any(named: 'serverUrl'),
+        ),
+      ).thenAnswer(
+        (_) async => const ViewerAuthAuthorized({
+          'Authorization': 'Nostr unlockedToken',
+        }),
+      );
 
-        when(() => mockContext.mounted).thenReturn(true);
+      when(() => mockContext.mounted).thenReturn(true);
 
-        expect(
-          realContentFilterService.adultPlaybackPreference,
-          ContentFilterPreference.warn,
-        );
-        expect(await interceptor.canAutoAuthorizeAdultMedia(), isTrue);
+      expect(
+        realContentFilterService.adultPlaybackPreference,
+        ContentFilterPreference.warn,
+      );
+      expect(await interceptor.canAutoAuthorizeAdultMedia(), isTrue);
 
-        final result = await interceptor.handleUnauthorizedMedia(
-          context: mockContext,
-          sha256Hash: 'abc123',
-          category: 'nudity',
-        );
+      final result = await interceptor.handleUnauthorizedMedia(
+        context: mockContext,
+        sha256Hash: 'abc123',
+        category: 'nudity',
+      );
 
-        expect(result, isA<ViewerAuthAuthorized>());
-        expect(
-          result.headersOrNull,
-          equals({'Authorization': 'Nostr unlockedToken'}),
-        );
-        verifyNever(
-          () => mockAgeVerificationService.verifyAdultContentAccess(any()),
-        );
-        verify(
-          () => mockMediaViewerAuthService.createAuthHeaders(
-            sha256Hash: 'abc123',
-          ),
-        ).called(1);
-      },
-    );
+      expect(result, isA<ViewerAuthAuthorized>());
+      expect(
+        result.headersOrNull,
+        equals({'Authorization': 'Nostr unlockedToken'}),
+      );
+      verifyNever(
+        () => mockAgeVerificationService.verifyAdultContentAccess(any()),
+      );
+      verify(
+        () =>
+            mockMediaViewerAuthService.createAuthHeaders(sha256Hash: 'abc123'),
+      ).called(1);
+    });
 
     test(
       'handleUnauthorizedMedia reports a preference block when verified user '
@@ -264,46 +257,41 @@ void main() {
       },
     );
 
-    test(
-      'handleUnauthorizedMedia keeps adult media blocked after verification '
-      'when preferences still hide it',
-      () async {
-        when(
-          () => mockContentFilterService.adultPlaybackPreference,
-        ).thenReturn(ContentFilterPreference.hide);
-        when(
-          () => mockAgeVerificationService.isAdultContentVerified,
-        ).thenReturn(false);
-        when(() => mockContext.mounted).thenReturn(true);
-        when(
-          () => mockAgeVerificationService.verifyAdultContentAccess(any()),
-        ).thenAnswer((_) async => true);
-        when(
-          () => mockContentFilterService.unlockAdultCategories(),
-        ).thenAnswer((_) async {});
+    test('handleUnauthorizedMedia keeps adult media blocked after verification '
+        'when preferences still hide it', () async {
+      when(
+        () => mockContentFilterService.adultPlaybackPreference,
+      ).thenReturn(ContentFilterPreference.hide);
+      when(
+        () => mockAgeVerificationService.isAdultContentVerified,
+      ).thenReturn(false);
+      when(() => mockContext.mounted).thenReturn(true);
+      when(
+        () => mockAgeVerificationService.verifyAdultContentAccess(any()),
+      ).thenAnswer((_) async => true);
+      when(
+        () => mockContentFilterService.unlockAdultCategories(),
+      ).thenAnswer((_) async {});
 
-        final result = await interceptor.handleUnauthorizedMedia(
-          context: mockContext,
-          sha256Hash: 'abc123',
-          category: 'nudity',
-        );
+      final result = await interceptor.handleUnauthorizedMedia(
+        context: mockContext,
+        sha256Hash: 'abc123',
+        category: 'nudity',
+      );
 
-        expect(result, isA<ViewerAuthBlockedByPreference>());
-        verify(
-          () => mockAgeVerificationService.verifyAdultContentAccess(any()),
-        ).called(1);
-        verify(
-          () => mockContentFilterService.unlockAdultCategories(),
-        ).called(1);
-        verifyNever(
-          () => mockMediaViewerAuthService.createAuthHeaders(
-            sha256Hash: any(named: 'sha256Hash'),
-            url: any(named: 'url'),
-            serverUrl: any(named: 'serverUrl'),
-          ),
-        );
-      },
-    );
+      expect(result, isA<ViewerAuthBlockedByPreference>());
+      verify(
+        () => mockAgeVerificationService.verifyAdultContentAccess(any()),
+      ).called(1);
+      verify(() => mockContentFilterService.unlockAdultCategories()).called(1);
+      verifyNever(
+        () => mockMediaViewerAuthService.createAuthHeaders(
+          sha256Hash: any(named: 'sha256Hash'),
+          url: any(named: 'url'),
+          serverUrl: any(named: 'serverUrl'),
+        ),
+      );
+    });
 
     test(
       'handleUnauthorizedMedia auto-creates auth when alwaysShow and verified',
@@ -417,9 +405,8 @@ void main() {
             serverUrl: any(named: 'serverUrl'),
           ),
         ).thenAnswer(
-          (_) async => const ViewerAuthAuthorized({
-            'Authorization': 'Nostr warnToken',
-          }),
+          (_) async =>
+              const ViewerAuthAuthorized({'Authorization': 'Nostr warnToken'}),
         );
 
         final result = await interceptor.createAutoAuthHeadersForAdultMedia(

--- a/mobile/test/services/nsfw_content_filter_test.dart
+++ b/mobile/test/services/nsfw_content_filter_test.dart
@@ -93,7 +93,7 @@ void main() {
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
-      ageService = AgeVerificationService();
+      ageService = AgeVerificationService(currentPubkeyHex: () => _testPubkey);
       contentFilterService = ContentFilterService(
         ageVerificationService: ageService,
       );

--- a/mobile/test/services/nsfw_content_filter_test.dart
+++ b/mobile/test/services/nsfw_content_filter_test.dart
@@ -93,7 +93,10 @@ void main() {
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
-      ageService = AgeVerificationService(currentPubkeyHex: () => _testPubkey);
+      ageService = AgeVerificationService(
+        preferences: prefs,
+        currentPubkeyHex: () => _testPubkey,
+      );
       contentFilterService = ContentFilterService(
         ageVerificationService: ageService,
       );

--- a/mobile/test/services/user_data_cleanup_service_test.dart
+++ b/mobile/test/services/user_data_cleanup_service_test.dart
@@ -114,6 +114,47 @@ void main() {
     });
 
     group('clearUserSpecificData', () {
+      const verificationPubkey =
+          'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+
+      test('destructive delete purges only that account verification', () async {
+        const otherPubkey =
+            'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+        await prefs.setBool(
+          'adult_content_verified_$verificationPubkey',
+          true,
+        );
+        await prefs.setBool('adult_content_verified_$otherPubkey', true);
+
+        await service.clearUserSpecificData(
+          deleteUserData: true,
+          userPubkey: verificationPubkey,
+        );
+
+        expect(
+          prefs.containsKey('adult_content_verified_$verificationPubkey'),
+          isFalse,
+        );
+        expect(prefs.getBool('adult_content_verified_$otherPubkey'), isTrue);
+      });
+
+      test('account switch preserves scoped verification', () async {
+        await prefs.setBool(
+          'adult_content_verified_$verificationPubkey',
+          true,
+        );
+
+        await service.clearUserSpecificData(
+          isIdentityChange: true,
+          userPubkey: verificationPubkey,
+        );
+
+        expect(
+          prefs.getBool('adult_content_verified_$verificationPubkey'),
+          isTrue,
+        );
+      });
+
       test('clears all user-specific keys from SharedPreferences', () async {
         // Set up some user-specific data
         await prefs.setStringList('curated_lists', ['list1']);

--- a/mobile/test/services/video_event_service_content_filter_test.dart
+++ b/mobile/test/services/video_event_service_content_filter_test.dart
@@ -103,6 +103,7 @@ void main() {
     );
 
     ageVerificationService = AgeVerificationService(
+      preferences: prefs,
       currentPubkeyHex: () =>
           '1111111111111111111111111111111111111111111111111111111111111111',
     );

--- a/mobile/test/services/video_event_service_content_filter_test.dart
+++ b/mobile/test/services/video_event_service_content_filter_test.dart
@@ -102,7 +102,10 @@ void main() {
       '1111111111111111111111111111111111111111111111111111111111111111',
     );
 
-    ageVerificationService = AgeVerificationService();
+    ageVerificationService = AgeVerificationService(
+      currentPubkeyHex: () =>
+          '1111111111111111111111111111111111111111111111111111111111111111',
+    );
     await ageVerificationService.initialize();
     contentFilterService = ContentFilterService(
       ageVerificationService: ageVerificationService,

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -15,7 +15,8 @@ import 'package:openvine/models/content_label.dart';
 import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
-import 'package:openvine/services/auth_service.dart' show AuthState;
+import 'package:openvine/services/auth_service.dart'
+    show AuthService, AuthState;
 import 'package:openvine/services/content_filter_service.dart';
 import 'package:openvine/services/media_auth_interceptor.dart';
 import 'package:openvine/services/media_viewer_auth_service.dart';
@@ -56,6 +57,8 @@ class _SyncImageProvider extends ImageProvider<_SyncImageProvider> {
 }
 
 class _MockMediaAuthInterceptor extends Mock implements MediaAuthInterceptor {}
+
+class _MockAuthService extends Mock implements AuthService {}
 
 class _MockMediaViewerAuthService extends Mock
     implements MediaViewerAuthService {}
@@ -670,13 +673,20 @@ void main() {
           (_) async =>
               const ViewerAuthAuthorized({'Authorization': 'Nostr token'}),
         );
+        final authService = _MockAuthService();
+        when(() => authService.currentPublicKeyHex).thenReturn(
+          '1111111111111111111111111111111111111111111111111111111111111111',
+        );
 
         await tester.pumpWidget(
           ProviderScope(
-            overrides: _passiveAuthProviderOverridesWithRealServices(
-              mediaViewerAuthService: mediaViewerAuthService,
-              sharedPreferences: sharedPreferences,
-            ),
+            overrides: [
+              ..._passiveAuthProviderOverridesWithRealServices(
+                mediaViewerAuthService: mediaViewerAuthService,
+                sharedPreferences: sharedPreferences,
+              ),
+              authServiceProvider.overrideWithValue(authService),
+            ],
             child: MaterialApp(
               localizationsDelegates: AppLocalizations.localizationsDelegates,
               supportedLocales: AppLocalizations.supportedLocales,


### PR DESCRIPTION
## Description

Adult-content and age verification was stored in device-global preferences, allowing one account's attestation to affect another account on the same device.

This change scopes all four verification values to the active account and makes the active account the source of truth on every read and write:

- Verification keys are namespaced by full pubkey, and synchronous getters read the active account directly from the injected `SharedPreferences` snapshot. There is no account-sensitive in-memory cache or re-scope window.
- No active account, an unresolved account during cold start, or an account change during a write fails closed as unverified. Interrupted writes are rolled back and cannot unlock the newly active account.
- Legacy device-global verification is deleted without adoption. Because ownership cannot be established, existing users re-attest once after upgrade rather than granting the value according to load order.
- Normal account switching preserves each account's scoped verification. Destructive account deletion removes only that account's verification keys.
- The protected-minor lock remains authoritative over stored verification.

**Related Issue:** Closes #7816

## Out of Scope

- No change to verification UX, copy, localization, or the protected-minor / age-review flow.

## Verification

- Regression coverage includes cold start before auth resolves, account isolation and restoration, account changes during writes and dialogs, null-account fail-closed behavior, deletion of legacy globals without granting them, protected-minor override, and destructive-versus-nondestructive cleanup.
- `flutter analyze --no-pub lib test integration_test`
- Focused moderation and media suite: 239 tests passed after rebasing onto current `origin/main`.
- Pre-push changed-file suite: 253 tests passed; generated-file checks and analysis passed.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
