### PR TITLE
fix(explore): require 18+ verification for restricted featured tabs

### DIFF
--- a/mobile/lib/blocs/featured_tabs/featured_tabs_cubit.dart
+++ b/mobile/lib/blocs/featured_tabs/featured_tabs_cubit.dart
@@ -19,17 +19,17 @@ part 'featured_tabs_state.dart';
 class FeaturedTabsCubit extends Cubit<FeaturedTabsState> {
   /// Creates the cubit over [repository].
   ///
-  /// [viewerIsMinor] is read at each refresh rather than captured once, so an
-  /// age-up or account switch is reflected on the next poll.
+  /// [gateAgeRestrictedContent] is read at each refresh rather than captured
+  /// once, so an age-up or account switch is reflected on the next poll.
   FeaturedTabsCubit({
     required FeaturedTabsRepository repository,
-    required bool Function() viewerIsMinor,
+    required bool Function() gateAgeRestrictedContent,
   }) : _repository = repository,
-       _viewerIsMinor = viewerIsMinor,
+       _gateAgeRestrictedContent = gateAgeRestrictedContent,
        super(const FeaturedTabsState());
 
   final FeaturedTabsRepository _repository;
-  final bool Function() _viewerIsMinor;
+  final bool Function() _gateAgeRestrictedContent;
 
   Timer? _pollTimer;
 
@@ -54,7 +54,9 @@ class FeaturedTabsCubit extends Cubit<FeaturedTabsState> {
     final generation = ++_refreshGeneration;
     emit(state.copyWith(status: FeaturedTabsStatus.loading));
 
-    final snapshot = await _repository.refresh(viewerIsMinor: _viewerIsMinor());
+    final snapshot = await _repository.refresh(
+      gateAgeRestrictedContent: _gateAgeRestrictedContent(),
+    );
     if (isClosed || generation != _refreshGeneration) return;
 
     emit(

--- a/mobile/lib/providers/featured_tabs_providers.dart
+++ b/mobile/lib/providers/featured_tabs_providers.dart
@@ -18,12 +18,22 @@ final featuredTabsRepositoryProvider = Provider<FeaturedTabsRepository>((ref) {
   return repository;
 });
 
-/// Whether the current viewer is gated as a protected minor.
+/// Whether age-restricted featured tabs should be gated for the current viewer
+/// (#7675).
 ///
-/// Reuses the #175 content-lock seam rather than the fail-closed DM seam: a
-/// featured tab is ordinary discovery content, so an absent age signal should
-/// not withhold it. Tabs still default to hidden for a known minor unless the
-/// configuration explicitly opts in.
+/// Age-restricted tabs are curated tabs an operator did NOT mark minor-safe, so
+/// this seam takes the fail-CLOSED conditional posture of the #176 DM and #182
+/// key-management surfaces — [isDmRestrictedProvider] — rather than the
+/// fail-OPEN #175 content lock. An unresolved Keycast check therefore hides
+/// age-restricted tabs where a Keycast verdict could plausibly apply (OAuth
+/// accounts, previously-Keycast self-custody), closing the gap where a
+/// non-Keycast minor would otherwise be shown them. Pure self-custody accounts,
+/// which Keycast can never produce a verdict for, stay permissive so adults are
+/// not blocked by an unanswerable check.
+///
+/// The value therefore means "treat as minor-gated for this surface", not
+/// strictly "is a minor" — matching the unknown-is-restricted posture #176/#182
+/// already use.
 final featuredTabViewerIsMinorProvider = Provider<bool>((ref) {
-  return ref.watch(isProtectedMinorProvider);
+  return ref.watch(isDmRestrictedProvider);
 });

--- a/mobile/lib/providers/featured_tabs_providers.dart
+++ b/mobile/lib/providers/featured_tabs_providers.dart
@@ -31,9 +31,8 @@ final featuredTabsRepositoryProvider = Provider<FeaturedTabsRepository>((ref) {
 /// which Keycast can never produce a verdict for, stay permissive so adults are
 /// not blocked by an unanswerable check.
 ///
-/// The value therefore means "treat as minor-gated for this surface", not
-/// strictly "is a minor" — matching the unknown-is-restricted posture #176/#182
-/// already use.
-final featuredTabViewerIsMinorProvider = Provider<bool>((ref) {
+/// True for unknown and still-loading states too, not only a confirmed
+/// minor — the unknown-is-gated posture #176/#182 already use.
+final featuredTabAgeGateProvider = Provider<bool>((ref) {
   return ref.watch(isDmRestrictedProvider);
 });

--- a/mobile/lib/providers/featured_tabs_providers.dart
+++ b/mobile/lib/providers/featured_tabs_providers.dart
@@ -3,7 +3,7 @@
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/providers/curation_providers.dart';
-import 'package:openvine/providers/protected_minor_providers.dart';
+import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/repositories/featured_tabs_repository.dart';
 
 /// Repository backing the server-configured featured Explore tab.
@@ -18,21 +18,24 @@ final featuredTabsRepositoryProvider = Provider<FeaturedTabsRepository>((ref) {
   return repository;
 });
 
-/// Whether age-restricted featured tabs should be gated for the current viewer
-/// (#7675).
+/// Whether the current viewer has completed Divine's existing 18+ verification.
+final featuredTabViewerIsAdultProvider = FutureProvider<bool>((ref) async {
+  ref.watch(adultContentVerificationVersionProvider);
+  final service = ref.watch(ageVerificationServiceProvider);
+  await service.initialized;
+  return service.isAdultContentVerified;
+});
+
+/// Whether featured tabs marked unavailable to under-18 viewers stay hidden.
 ///
-/// Age-restricted tabs are curated tabs an operator did NOT mark minor-safe, so
-/// this seam takes the fail-CLOSED conditional posture of the #176 DM and #182
-/// key-management surfaces — [isDmRestrictedProvider] — rather than the
-/// fail-OPEN #175 content lock. An unresolved Keycast check therefore hides
-/// age-restricted tabs where a Keycast verdict could plausibly apply (OAuth
-/// accounts, previously-Keycast self-custody), closing the gap where a
-/// non-Keycast minor would otherwise be shown them. Pure self-custody accounts,
-/// which Keycast can never produce a verdict for, stay permissive so adults are
-/// not blocked by an unanswerable check.
-///
-/// True for unknown and still-loading states too, not only a confirmed
-/// minor — the unknown-is-gated posture #176/#182 already use.
+/// Loading and unverified states fail closed. Protected-minor accounts also
+/// stay gated because [AgeVerificationService] prevents them from completing
+/// adult-content verification.
 final featuredTabAgeGateProvider = Provider<bool>((ref) {
-  return ref.watch(isDmRestrictedProvider);
+  final viewerIsAdult = ref.watch(featuredTabViewerIsAdultProvider);
+  return viewerIsAdult.when(
+    data: (isAdult) => !isAdult,
+    error: (_, _) => true,
+    loading: () => true,
+  );
 });

--- a/mobile/lib/providers/moderation_providers.dart
+++ b/mobile/lib/providers/moderation_providers.dart
@@ -121,6 +121,19 @@ class AdultMediaAccessRevocationVersion extends Notifier<int> {
   void increment() => state++;
 }
 
+/// Increments after persisted 18+ verification loads or changes.
+final adultContentVerificationVersionProvider =
+    NotifierProvider<AdultContentVerificationVersion, int>(
+      AdultContentVerificationVersion.new,
+    );
+
+class AdultContentVerificationVersion extends Notifier<int> {
+  @override
+  int build() => 0;
+
+  void increment() => state++;
+}
+
 Future<void> _clearAdultMediaAccessCaches(Ref ref) async {
   try {
     await clearOpenVineImageCache();
@@ -139,6 +152,11 @@ AgeVerificationService ageVerificationService(Ref ref) {
   final service = AgeVerificationService(
     isProtectedMinor: () => ref.read(isProtectedMinorProvider),
     onAdultMediaAccessRevoked: () => _clearAdultMediaAccessCaches(ref),
+    onAdultContentVerificationChanged: () {
+      if (ref.mounted) {
+        ref.read(adultContentVerificationVersionProvider.notifier).increment();
+      }
+    },
   );
   service.initialize(); // Initialize asynchronously
   return service;

--- a/mobile/lib/providers/moderation_providers.g.dart
+++ b/mobile/lib/providers/moderation_providers.g.dart
@@ -244,7 +244,7 @@ final class AgeVerificationServiceProvider
 }
 
 String _$ageVerificationServiceHash() =>
-    r'b424f868519d8f8b563d3b0cc23e3e78d189c073';
+    r'95d51cda0ad3f784cc0aee7eec46478bd4e6139c';
 
 /// Content filter service for per-category Show/Warn/Hide preferences.
 /// keepAlive ensures preferences persist and are consistent across the app.

--- a/mobile/lib/repositories/featured_tabs_repository.dart
+++ b/mobile/lib/repositories/featured_tabs_repository.dart
@@ -95,10 +95,13 @@ class FeaturedTabsRepository {
   /// fresher than [cacheTtl], and to an empty snapshot once that has elapsed.
   /// Callers get a resolved answer, not an error to interpret.
   ///
-  /// [viewerIsMinor] hides tabs that have not explicitly opted in to a minor
-  /// audience. The public config endpoint is shared-cacheable and therefore
-  /// not personalized, so this gate is the client's responsibility.
-  Future<FeaturedTabsSnapshot> refresh({required bool viewerIsMinor}) async {
+  /// [gateAgeRestrictedContent] hides tabs that have not explicitly opted
+  /// in to a minor audience. The public config endpoint is shared-cacheable
+  /// and therefore not personalized, so this gate is the client's
+  /// responsibility.
+  Future<FeaturedTabsSnapshot> refresh({
+    required bool gateAgeRestrictedContent,
+  }) async {
     final sequence = ++_refreshSequence;
     try {
       final response = await _apiClient.getFeaturedTabs();
@@ -111,9 +114,12 @@ class FeaturedTabsRepository {
         _cached = response;
         _cachedAt = _now();
       }
-      return _resolve(response, viewerIsMinor: viewerIsMinor);
+      return _resolve(
+        response,
+        gateAgeRestrictedContent: gateAgeRestrictedContent,
+      );
     } on FunnelcakeException {
-      return _fromCache(viewerIsMinor: viewerIsMinor);
+      return _fromCache(gateAgeRestrictedContent: gateAgeRestrictedContent);
     }
   }
 
@@ -148,7 +154,7 @@ class FeaturedTabsRepository {
     _cachedAt = null;
   }
 
-  FeaturedTabsSnapshot _fromCache({required bool viewerIsMinor}) {
+  FeaturedTabsSnapshot _fromCache({required bool gateAgeRestrictedContent}) {
     final cached = _cached;
     final cachedAt = _cachedAt;
     if (cached == null || cachedAt == null) {
@@ -158,17 +164,21 @@ class FeaturedTabsRepository {
       clearCache();
       return const FeaturedTabsSnapshot();
     }
-    return _resolve(cached, viewerIsMinor: viewerIsMinor);
+    return _resolve(cached, gateAgeRestrictedContent: gateAgeRestrictedContent);
   }
 
   FeaturedTabsSnapshot _resolve(
     FeaturedTabsResponse response, {
-    required bool viewerIsMinor,
+    required bool gateAgeRestrictedContent,
   }) {
     final now = _now();
     FeaturedTabConfig? eligible;
     for (final tab in response.tabs) {
-      if (_isEligible(tab, now: now, viewerIsMinor: viewerIsMinor)) {
+      if (_isEligible(
+        tab,
+        now: now,
+        gateAgeRestrictedContent: gateAgeRestrictedContent,
+      )) {
         eligible = tab;
         break;
       }
@@ -182,12 +192,12 @@ class FeaturedTabsRepository {
   bool _isEligible(
     FeaturedTabConfig tab, {
     required DateTime now,
-    required bool viewerIsMinor,
+    required bool gateAgeRestrictedContent,
   }) {
     if (!tab.enabled) return false;
     if (!tab.hasContent) return false;
     if (!tab.isWithinWindow(now)) return false;
-    if (viewerIsMinor && !tab.visibleToMinors) return false;
+    if (gateAgeRestrictedContent && !tab.visibleToMinors) return false;
     // The tab bar's label is compiled client-side, so the renderability floor
     // is an id to fetch and attribute the tab with.
     return tab.id.isNotEmpty;

--- a/mobile/lib/repositories/featured_tabs_repository.dart
+++ b/mobile/lib/repositories/featured_tabs_repository.dart
@@ -95,8 +95,8 @@ class FeaturedTabsRepository {
   /// fresher than [cacheTtl], and to an empty snapshot once that has elapsed.
   /// Callers get a resolved answer, not an error to interpret.
   ///
-  /// [gateAgeRestrictedContent] hides tabs that have not explicitly opted
-  /// in to a minor audience. The public config endpoint is shared-cacheable
+  /// [gateAgeRestrictedContent] hides tabs whose dashboard configuration does
+  /// not allow viewers under 18. The public config endpoint is shared-cacheable
   /// and therefore not personalized, so this gate is the client's
   /// responsibility.
   Future<FeaturedTabsSnapshot> refresh({

--- a/mobile/lib/screens/explore/explore_screen.dart
+++ b/mobile/lib/screens/explore/explore_screen.dart
@@ -96,7 +96,8 @@ class ExploreScreen extends ConsumerWidget {
           key: ValueKey(featuredTabsRepository),
           create: (_) => FeaturedTabsCubit(
             repository: featuredTabsRepository,
-            viewerIsMinor: () => ref.read(featuredTabViewerIsMinorProvider),
+            gateAgeRestrictedContent: () =>
+                ref.read(featuredTabAgeGateProvider),
           )..refresh(),
         ),
       ],

--- a/mobile/lib/screens/explore/explore_view.dart
+++ b/mobile/lib/screens/explore/explore_view.dart
@@ -129,7 +129,7 @@ class _ExploreViewState extends ConsumerState<ExploreView>
       onResume: () => context.read<FeaturedTabsCubit>().refresh(),
     );
     _minorStatusSubscription = ref.listenManual<bool>(
-      featuredTabViewerIsMinorProvider,
+      featuredTabAgeGateProvider,
       (previous, next) {
         if (previous != null && previous != next) {
           context.read<FeaturedTabsCubit>().refresh();

--- a/mobile/lib/screens/explore/explore_view.dart
+++ b/mobile/lib/screens/explore/explore_view.dart
@@ -68,7 +68,7 @@ class _ExploreViewState extends ConsumerState<ExploreView>
   /// Refetches the featured configuration on foreground so a backend kill
   /// switch lands without waiting out the poll interval.
   late final AppLifecycleListener _lifecycleListener;
-  ProviderSubscription<bool>? _minorStatusSubscription;
+  ProviderSubscription<bool>? _featuredTabAgeGateSubscription;
 
   ExploreTabsCubit get _tabs => context.read<ExploreTabsCubit>();
   ExploreTabsState get _tabsState => _tabs.state;
@@ -128,7 +128,7 @@ class _ExploreViewState extends ConsumerState<ExploreView>
     _lifecycleListener = AppLifecycleListener(
       onResume: () => context.read<FeaturedTabsCubit>().refresh(),
     );
-    _minorStatusSubscription = ref.listenManual<bool>(
+    _featuredTabAgeGateSubscription = ref.listenManual<bool>(
       featuredTabAgeGateProvider,
       (previous, next) {
         if (previous != null && previous != next) {
@@ -205,7 +205,7 @@ class _ExploreViewState extends ConsumerState<ExploreView>
   @override
   void dispose() {
     _lifecycleListener.dispose();
-    _minorStatusSubscription?.close();
+    _featuredTabAgeGateSubscription?.close();
     super.dispose();
   }
 

--- a/mobile/lib/services/age_verification_service.dart
+++ b/mobile/lib/services/age_verification_service.dart
@@ -10,8 +10,10 @@ class AgeVerificationService {
   AgeVerificationService({
     bool Function()? isProtectedMinor,
     Future<void> Function()? onAdultMediaAccessRevoked,
+    VoidCallback? onAdultContentVerificationChanged,
   }) : _isProtectedMinor = isProtectedMinor ?? _notProtected,
-       _onAdultMediaAccessRevoked = onAdultMediaAccessRevoked;
+       _onAdultMediaAccessRevoked = onAdultMediaAccessRevoked,
+       _onAdultContentVerificationChanged = onAdultContentVerificationChanged;
 
   static bool _notProtected() => false;
 
@@ -19,6 +21,7 @@ class AgeVerificationService {
   /// is force-locked off and the self-attestation bypass is unavailable (#175).
   final bool Function() _isProtectedMinor;
   final Future<void> Function()? _onAdultMediaAccessRevoked;
+  final VoidCallback? _onAdultContentVerificationChanged;
 
   static const String _ageVerifiedKey = 'age_verified';
   static const String _verificationDateKey = 'age_verification_date';
@@ -63,6 +66,7 @@ class AgeVerificationService {
           adultDateMillis,
         );
       }
+      _onAdultContentVerificationChanged?.call();
     } catch (e) {
       Log.error(
         'Error loading age verification status: $e',
@@ -138,6 +142,7 @@ class AgeVerificationService {
       }
 
       _isAdultContentVerified = verified;
+      _onAdultContentVerificationChanged?.call();
       if (!verified) {
         await _notifyAdultMediaAccessRevoked();
       }
@@ -201,6 +206,7 @@ class AgeVerificationService {
       _verificationDate = null;
       _isAdultContentVerified = null;
       _adultContentVerificationDate = null;
+      _onAdultContentVerificationChanged?.call();
       await _notifyAdultMediaAccessRevoked();
 
       Log.debug(

--- a/mobile/test/blocs/featured_tabs/featured_tabs_cubit_test.dart
+++ b/mobile/test/blocs/featured_tabs/featured_tabs_cubit_test.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Tests for FeaturedTabsCubit refresh, polling, and viewer gating.
+// ABOUTME: Tests FeaturedTabsCubit refresh, polling, and 18+ viewer gating.
 // ABOUTME: Absence of a tab is the expected outcome, not an error state.
 
 import 'dart:async';

--- a/mobile/test/blocs/featured_tabs/featured_tabs_cubit_test.dart
+++ b/mobile/test/blocs/featured_tabs/featured_tabs_cubit_test.dart
@@ -34,14 +34,16 @@ void main() {
 
     void stubSnapshot(FeaturedTabsSnapshot snapshot) {
       when(
-        () => repository.refresh(viewerIsMinor: any(named: 'viewerIsMinor')),
+        () => repository.refresh(
+          gateAgeRestrictedContent: any(named: 'gateAgeRestrictedContent'),
+        ),
       ).thenAnswer((_) async => snapshot);
     }
 
-    FeaturedTabsCubit buildCubit({bool viewerIsMinor = false}) {
+    FeaturedTabsCubit buildCubit({bool gateAgeRestrictedContent = false}) {
       return FeaturedTabsCubit(
         repository: repository,
-        viewerIsMinor: () => viewerIsMinor,
+        gateAgeRestrictedContent: () => gateAgeRestrictedContent,
       );
     }
 
@@ -86,12 +88,14 @@ void main() {
 
     test('passes the current viewer age gate to the repository', () async {
       stubSnapshot(const FeaturedTabsSnapshot());
-      final cubit = buildCubit(viewerIsMinor: true);
+      final cubit = buildCubit(gateAgeRestrictedContent: true);
       addTearDown(cubit.close);
 
       await cubit.refresh();
 
-      verify(() => repository.refresh(viewerIsMinor: true)).called(1);
+      verify(
+        () => repository.refresh(gateAgeRestrictedContent: true),
+      ).called(1);
     });
 
     test('surfaces the server poll interval on the state', () async {
@@ -139,7 +143,9 @@ void main() {
         async.flushMicrotasks();
 
         verify(
-          () => repository.refresh(viewerIsMinor: any(named: 'viewerIsMinor')),
+          () => repository.refresh(
+            gateAgeRestrictedContent: any(named: 'gateAgeRestrictedContent'),
+          ),
         ).called(1);
 
         unawaited(cubit.close());
@@ -167,7 +173,9 @@ void main() {
         async.flushMicrotasks();
 
         verifyNever(
-          () => repository.refresh(viewerIsMinor: any(named: 'viewerIsMinor')),
+          () => repository.refresh(
+            gateAgeRestrictedContent: any(named: 'gateAgeRestrictedContent'),
+          ),
         );
       });
     });
@@ -181,7 +189,9 @@ void main() {
       final afterKill = Completer<FeaturedTabsSnapshot>();
       var call = 0;
       when(
-        () => repository.refresh(viewerIsMinor: any(named: 'viewerIsMinor')),
+        () => repository.refresh(
+          gateAgeRestrictedContent: any(named: 'gateAgeRestrictedContent'),
+        ),
       ).thenAnswer((_) {
         call++;
         return call == 1 ? beforeKill.future : afterKill.future;

--- a/mobile/test/providers/featured_tabs_providers_test.dart
+++ b/mobile/test/providers/featured_tabs_providers_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/providers/featured_tabs_providers.dart';
 import 'package:openvine/providers/protected_minor_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/protected_minor_sticky_store.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
@@ -111,6 +112,30 @@ void main() {
         );
 
         expect(container.read(featuredTabViewerIsMinorProvider), isFalse);
+      },
+    );
+
+    test(
+      'gates an unresolved check on a previously-Keycast self-custody account '
+      '(tabs hidden)',
+      () async {
+        // A self-held key that was Keycast-custodial on this device can still
+        // receive a verdict, so an unresolved check must fail closed here. This
+        // pins the sticky wasKeycastAccountFor branch, distinct from the OAuth
+        // branch above — and shares the importedKeys source with the permissive
+        // test, proving the gate keys off the Keycast marker, not the source.
+        await ProtectedMinorStickyStore(
+          prefs: prefs,
+        ).markKeycastAccount(pubkey);
+        when(
+          () => authService.authenticationSource,
+        ).thenReturn(AuthenticationSource.importedKeys);
+        final container = containerWith(
+          authState: AuthState.authenticated,
+          status: () => Completer<ProtectedMinorStatus>().future,
+        );
+
+        expect(container.read(featuredTabViewerIsMinorProvider), isTrue);
       },
     );
   });

--- a/mobile/test/providers/featured_tabs_providers_test.dart
+++ b/mobile/test/providers/featured_tabs_providers_test.dart
@@ -1,0 +1,117 @@
+// ABOUTME: Tests featuredTabViewerIsMinorProvider (#7675) — the middle-path gate
+// ABOUTME: for age-restricted featured tabs. Mirrors the #176/#182 fail-CLOSED
+// ABOUTME: posture: an unresolved Keycast check hides age-restricted tabs only
+// ABOUTME: where a Keycast verdict could apply, staying permissive for pure
+// ABOUTME: self-custody accounts Keycast can never answer for.
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/models/protected_minor_status.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/featured_tabs_providers.dart';
+import 'package:openvine/providers/protected_minor_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final pubkey = 'a' * 64;
+
+  late SharedPreferences prefs;
+  late _MockAuthService authService;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    authService = _MockAuthService();
+    when(() => authService.currentPublicKeyHex).thenReturn(pubkey);
+    when(
+      () => authService.authenticationSource,
+    ).thenReturn(AuthenticationSource.divineOAuth);
+  });
+
+  ProviderContainer containerWith({
+    required AuthState authState,
+    Future<ProtectedMinorStatus> Function()? status,
+  }) {
+    final container = ProviderContainer(
+      overrides: [
+        currentAuthStateProvider.overrideWithValue(authState),
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        authServiceProvider.overrideWithValue(authService),
+        if (status != null)
+          protectedMinorStatusProvider.overrideWith((ref) => status()),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('featuredTabViewerIsMinorProvider', () {
+    test('gates a trusted protected-minor verdict (tabs hidden)', () async {
+      final container = containerWith(
+        authState: AuthState.authenticated,
+        status: () async => ProtectedMinorStatus.protected(),
+      );
+      await container.read(protectedMinorStatusProvider.future);
+
+      expect(container.read(featuredTabViewerIsMinorProvider), isTrue);
+    });
+
+    test(
+      'does not gate a trusted not-protected verdict (tabs shown)',
+      () async {
+        final container = containerWith(
+          authState: AuthState.authenticated,
+          status: () async => ProtectedMinorStatus.notProtected(),
+        );
+        await container.read(protectedMinorStatusProvider.future);
+
+        expect(container.read(featuredTabViewerIsMinorProvider), isFalse);
+      },
+    );
+
+    test(
+      'gates an unresolved check on a could-be-checked account (tabs hidden)',
+      () {
+        // Load-bearing: this is the #7675 gap the middle path closes. An OAuth
+        // account whose Keycast verdict is unresolved (cold start, offline,
+        // suppressed) must hide age-restricted tabs. The prior fail-OPEN
+        // isProtectedMinorProvider backing returned false here — showing the
+        // tabs to a possible minor.
+        final container = containerWith(
+          authState: AuthState.authenticated,
+          status: () => Completer<ProtectedMinorStatus>().future,
+        );
+
+        expect(container.read(featuredTabViewerIsMinorProvider), isTrue);
+      },
+    );
+
+    test(
+      'does not gate an unresolved check on a pure self-custody account '
+      '(tabs shown)',
+      () {
+        // The middle path must not over-block: a self-custody account Keycast
+        // can never produce a verdict for stays permissive even while the
+        // check is unresolved.
+        when(
+          () => authService.authenticationSource,
+        ).thenReturn(AuthenticationSource.importedKeys);
+        final container = containerWith(
+          authState: AuthState.authenticated,
+          status: () => Completer<ProtectedMinorStatus>().future,
+        );
+
+        expect(container.read(featuredTabViewerIsMinorProvider), isFalse);
+      },
+    );
+  });
+}

--- a/mobile/test/providers/featured_tabs_providers_test.dart
+++ b/mobile/test/providers/featured_tabs_providers_test.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Tests featuredTabViewerIsMinorProvider (#7675) — the middle-path gate
+// ABOUTME: Tests featuredTabAgeGateProvider (#7675) — the middle-path gate
 // ABOUTME: for age-restricted featured tabs. Mirrors the #176/#182 fail-CLOSED
 // ABOUTME: posture: an unresolved Keycast check hides age-restricted tabs only
 // ABOUTME: where a Keycast verdict could apply, staying permissive for pure
@@ -55,7 +55,7 @@ void main() {
     return container;
   }
 
-  group('featuredTabViewerIsMinorProvider', () {
+  group('featuredTabAgeGateProvider', () {
     test('gates a trusted protected-minor verdict (tabs hidden)', () async {
       final container = containerWith(
         authState: AuthState.authenticated,
@@ -63,7 +63,7 @@ void main() {
       );
       await container.read(protectedMinorStatusProvider.future);
 
-      expect(container.read(featuredTabViewerIsMinorProvider), isTrue);
+      expect(container.read(featuredTabAgeGateProvider), isTrue);
     });
 
     test(
@@ -75,7 +75,7 @@ void main() {
         );
         await container.read(protectedMinorStatusProvider.future);
 
-        expect(container.read(featuredTabViewerIsMinorProvider), isFalse);
+        expect(container.read(featuredTabAgeGateProvider), isFalse);
       },
     );
 
@@ -92,7 +92,7 @@ void main() {
           status: () => Completer<ProtectedMinorStatus>().future,
         );
 
-        expect(container.read(featuredTabViewerIsMinorProvider), isTrue);
+        expect(container.read(featuredTabAgeGateProvider), isTrue);
       },
     );
 
@@ -111,7 +111,7 @@ void main() {
           status: () => Completer<ProtectedMinorStatus>().future,
         );
 
-        expect(container.read(featuredTabViewerIsMinorProvider), isFalse);
+        expect(container.read(featuredTabAgeGateProvider), isFalse);
       },
     );
 
@@ -135,7 +135,7 @@ void main() {
           status: () => Completer<ProtectedMinorStatus>().future,
         );
 
-        expect(container.read(featuredTabViewerIsMinorProvider), isTrue);
+        expect(container.read(featuredTabAgeGateProvider), isTrue);
       },
     );
   });

--- a/mobile/test/providers/featured_tabs_providers_test.dart
+++ b/mobile/test/providers/featured_tabs_providers_test.dart
@@ -1,54 +1,31 @@
-// ABOUTME: Tests featuredTabAgeGateProvider (#7675) — the middle-path gate
-// ABOUTME: for age-restricted featured tabs. Mirrors the #176/#182 fail-CLOSED
-// ABOUTME: posture: an unresolved Keycast check hides age-restricted tabs only
-// ABOUTME: where a Keycast verdict could apply, staying permissive for pure
-// ABOUTME: self-custody accounts Keycast can never answer for.
-
-import 'dart:async';
+// ABOUTME: Tests the 18+ verification gate for dashboard-configured featured tabs.
+// ABOUTME: Unverified and still-loading viewers fail closed until verification resolves.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:openvine/models/protected_minor_status.dart';
-import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/featured_tabs_providers.dart';
-import 'package:openvine/providers/protected_minor_providers.dart';
-import 'package:openvine/providers/shared_preferences_provider.dart';
-import 'package:openvine/services/auth_service.dart';
-import 'package:openvine/services/protected_minor_sticky_store.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:openvine/providers/moderation_providers.dart';
+import 'package:openvine/services/age_verification_service.dart';
 
-class _MockAuthService extends Mock implements AuthService {}
+class _MockAgeVerificationService extends Mock
+    implements AgeVerificationService {}
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
+  late _MockAgeVerificationService ageVerificationService;
 
-  final pubkey = 'a' * 64;
-
-  late SharedPreferences prefs;
-  late _MockAuthService authService;
-
-  setUp(() async {
-    SharedPreferences.setMockInitialValues({});
-    prefs = await SharedPreferences.getInstance();
-    authService = _MockAuthService();
-    when(() => authService.currentPublicKeyHex).thenReturn(pubkey);
-    when(
-      () => authService.authenticationSource,
-    ).thenReturn(AuthenticationSource.divineOAuth);
+  setUp(() {
+    ageVerificationService = _MockAgeVerificationService();
+    when(() => ageVerificationService.initialized).thenAnswer((_) async {});
+    when(() => ageVerificationService.isAdultContentVerified).thenReturn(false);
   });
 
-  ProviderContainer containerWith({
-    required AuthState authState,
-    Future<ProtectedMinorStatus> Function()? status,
-  }) {
+  ProviderContainer createContainer() {
     final container = ProviderContainer(
       overrides: [
-        currentAuthStateProvider.overrideWithValue(authState),
-        sharedPreferencesProvider.overrideWithValue(prefs),
-        authServiceProvider.overrideWithValue(authService),
-        if (status != null)
-          protectedMinorStatusProvider.overrideWith((ref) => status()),
+        ageVerificationServiceProvider.overrideWithValue(
+          ageVerificationService,
+        ),
       ],
     );
     addTearDown(container.dispose);
@@ -56,87 +33,47 @@ void main() {
   }
 
   group('featuredTabAgeGateProvider', () {
-    test('gates a trusted protected-minor verdict (tabs hidden)', () async {
-      final container = containerWith(
-        authState: AuthState.authenticated,
-        status: () async => ProtectedMinorStatus.protected(),
-      );
-      await container.read(protectedMinorStatusProvider.future);
+    test('gates while persisted adult verification is loading', () {
+      final container = createContainer();
 
       expect(container.read(featuredTabAgeGateProvider), isTrue);
     });
 
-    test(
-      'does not gate a trusted not-protected verdict (tabs shown)',
-      () async {
-        final container = containerWith(
-          authState: AuthState.authenticated,
-          status: () async => ProtectedMinorStatus.notProtected(),
-        );
-        await container.read(protectedMinorStatusProvider.future);
+    test('gates a viewer without 18+ verification', () async {
+      final container = createContainer();
 
-        expect(container.read(featuredTabAgeGateProvider), isFalse);
-      },
-    );
+      await container.read(featuredTabViewerIsAdultProvider.future);
 
-    test(
-      'gates an unresolved check on a could-be-checked account (tabs hidden)',
-      () {
-        // Load-bearing: this is the #7675 gap the middle path closes. An OAuth
-        // account whose Keycast verdict is unresolved (cold start, offline,
-        // suppressed) must hide age-restricted tabs. The prior fail-OPEN
-        // isProtectedMinorProvider backing returned false here — showing the
-        // tabs to a possible minor.
-        final container = containerWith(
-          authState: AuthState.authenticated,
-          status: () => Completer<ProtectedMinorStatus>().future,
-        );
+      expect(container.read(featuredTabAgeGateProvider), isTrue);
+    });
 
-        expect(container.read(featuredTabAgeGateProvider), isTrue);
-      },
-    );
+    test('does not gate an 18+ verified viewer', () async {
+      when(
+        () => ageVerificationService.isAdultContentVerified,
+      ).thenReturn(true);
+      final container = createContainer();
 
-    test(
-      'does not gate an unresolved check on a pure self-custody account '
-      '(tabs shown)',
-      () {
-        // The middle path must not over-block: a self-custody account Keycast
-        // can never produce a verdict for stays permissive even while the
-        // check is unresolved.
-        when(
-          () => authService.authenticationSource,
-        ).thenReturn(AuthenticationSource.importedKeys);
-        final container = containerWith(
-          authState: AuthState.authenticated,
-          status: () => Completer<ProtectedMinorStatus>().future,
-        );
+      await container.read(featuredTabViewerIsAdultProvider.future);
 
-        expect(container.read(featuredTabAgeGateProvider), isFalse);
-      },
-    );
+      expect(container.read(featuredTabAgeGateProvider), isFalse);
+    });
 
-    test(
-      'gates an unresolved check on a previously-Keycast self-custody account '
-      '(tabs hidden)',
-      () async {
-        // A self-held key that was Keycast-custodial on this device can still
-        // receive a verdict, so an unresolved check must fail closed here. This
-        // pins the sticky wasKeycastAccountFor branch, distinct from the OAuth
-        // branch above — and shares the importedKeys source with the permissive
-        // test, proving the gate keys off the Keycast marker, not the source.
-        await ProtectedMinorStickyStore(
-          prefs: prefs,
-        ).markKeycastAccount(pubkey);
-        when(
-          () => authService.authenticationSource,
-        ).thenReturn(AuthenticationSource.importedKeys);
-        final container = containerWith(
-          authState: AuthState.authenticated,
-          status: () => Completer<ProtectedMinorStatus>().future,
-        );
+    test('recomputes when adult verification changes', () async {
+      var verified = false;
+      when(
+        () => ageVerificationService.isAdultContentVerified,
+      ).thenAnswer((_) => verified);
+      final container = createContainer();
+      await container.read(featuredTabViewerIsAdultProvider.future);
+      expect(container.read(featuredTabAgeGateProvider), isTrue);
 
-        expect(container.read(featuredTabAgeGateProvider), isTrue);
-      },
-    );
+      verified = true;
+      container
+          .read(adultContentVerificationVersionProvider.notifier)
+          .increment();
+      await container.read(featuredTabViewerIsAdultProvider.future);
+
+      expect(container.read(featuredTabAgeGateProvider), isFalse);
+    });
   });
 }

--- a/mobile/test/repositories/featured_tabs_repository_test.dart
+++ b/mobile/test/repositories/featured_tabs_repository_test.dart
@@ -66,7 +66,9 @@ void main() {
       test('returns the tab when every gate passes', () async {
         stubTabs([_tab()]);
 
-        final snapshot = await buildRepository().refresh(viewerIsMinor: false);
+        final snapshot = await buildRepository().refresh(
+          gateAgeRestrictedContent: false,
+        );
 
         expect(snapshot.hasTab, isTrue);
         expect(snapshot.tab?.id, equals('ft_a1b2c3d4'));
@@ -75,7 +77,9 @@ void main() {
       test('drops a disabled tab', () async {
         stubTabs([_tab(enabled: false)]);
 
-        final snapshot = await buildRepository().refresh(viewerIsMinor: false);
+        final snapshot = await buildRepository().refresh(
+          gateAgeRestrictedContent: false,
+        );
 
         expect(snapshot.hasTab, isFalse);
       });
@@ -83,7 +87,9 @@ void main() {
       test('drops a tab with no server-side content', () async {
         stubTabs([_tab(hasContent: false)]);
 
-        final snapshot = await buildRepository().refresh(viewerIsMinor: false);
+        final snapshot = await buildRepository().refresh(
+          gateAgeRestrictedContent: false,
+        );
 
         expect(snapshot.hasTab, isFalse);
       });
@@ -91,7 +97,9 @@ void main() {
       test('drops a tab whose window has not opened', () async {
         stubTabs([_tab(startsAt: clock.add(const Duration(days: 1)))]);
 
-        final snapshot = await buildRepository().refresh(viewerIsMinor: false);
+        final snapshot = await buildRepository().refresh(
+          gateAgeRestrictedContent: false,
+        );
 
         expect(snapshot.hasTab, isFalse);
       });
@@ -99,7 +107,9 @@ void main() {
       test('drops a tab whose window has closed', () async {
         stubTabs([_tab(endsAt: clock.subtract(const Duration(days: 1)))]);
 
-        final snapshot = await buildRepository().refresh(viewerIsMinor: false);
+        final snapshot = await buildRepository().refresh(
+          gateAgeRestrictedContent: false,
+        );
 
         expect(snapshot.hasTab, isFalse);
       });
@@ -107,7 +117,9 @@ void main() {
       test('hides a non-opted-in tab from a minor viewer', () async {
         stubTabs([_tab()]);
 
-        final snapshot = await buildRepository().refresh(viewerIsMinor: true);
+        final snapshot = await buildRepository().refresh(
+          gateAgeRestrictedContent: true,
+        );
 
         expect(snapshot.hasTab, isFalse);
       });
@@ -115,7 +127,9 @@ void main() {
       test('shows an opted-in tab to a minor viewer', () async {
         stubTabs([_tab(visibleToMinors: true)]);
 
-        final snapshot = await buildRepository().refresh(viewerIsMinor: true);
+        final snapshot = await buildRepository().refresh(
+          gateAgeRestrictedContent: true,
+        );
 
         expect(snapshot.hasTab, isTrue);
       });
@@ -123,7 +137,9 @@ void main() {
       test('drops a tab with no id to fetch or attribute', () async {
         stubTabs([_tab(id: '')]);
 
-        final snapshot = await buildRepository().refresh(viewerIsMinor: false);
+        final snapshot = await buildRepository().refresh(
+          gateAgeRestrictedContent: false,
+        );
 
         expect(snapshot.hasTab, isFalse);
       });
@@ -131,7 +147,9 @@ void main() {
       test('returns no tab when the server sends an empty list', () async {
         stubTabs(const []);
 
-        final snapshot = await buildRepository().refresh(viewerIsMinor: false);
+        final snapshot = await buildRepository().refresh(
+          gateAgeRestrictedContent: false,
+        );
 
         expect(snapshot.hasTab, isFalse);
       });
@@ -146,7 +164,7 @@ void main() {
           ]);
 
           final snapshot = await buildRepository().refresh(
-            viewerIsMinor: false,
+            gateAgeRestrictedContent: false,
           );
 
           expect(snapshot.tab?.id, equals('ft_winner'));
@@ -156,7 +174,9 @@ void main() {
       test('surfaces the server poll interval', () async {
         stubTabs([_tab()], pollSeconds: 120);
 
-        final snapshot = await buildRepository().refresh(viewerIsMinor: false);
+        final snapshot = await buildRepository().refresh(
+          gateAgeRestrictedContent: false,
+        );
 
         expect(snapshot.pollInterval, equals(const Duration(seconds: 120)));
       });
@@ -166,11 +186,13 @@ void main() {
       test('serves the cached tab through a transient failure', () async {
         final repository = buildRepository();
         stubTabs([_tab()]);
-        await repository.refresh(viewerIsMinor: false);
+        await repository.refresh(gateAgeRestrictedContent: false);
 
         stubFailure();
         clock = clock.add(const Duration(minutes: 1));
-        final snapshot = await repository.refresh(viewerIsMinor: false);
+        final snapshot = await repository.refresh(
+          gateAgeRestrictedContent: false,
+        );
 
         expect(snapshot.hasTab, isTrue);
       });
@@ -178,11 +200,13 @@ void main() {
       test('drops the tab once the cache passes its TTL', () async {
         final repository = buildRepository();
         stubTabs([_tab()]);
-        await repository.refresh(viewerIsMinor: false);
+        await repository.refresh(gateAgeRestrictedContent: false);
 
         stubFailure();
         clock = clock.add(FeaturedTabsRepository.defaultCacheTtl);
-        final snapshot = await repository.refresh(viewerIsMinor: false);
+        final snapshot = await repository.refresh(
+          gateAgeRestrictedContent: false,
+        );
 
         expect(snapshot.hasTab, isFalse);
       });
@@ -194,7 +218,7 @@ void main() {
         // widened to absorb a failed poll.
         final repository = buildRepository();
         stubTabs([_tab()]);
-        await repository.refresh(viewerIsMinor: false);
+        await repository.refresh(gateAgeRestrictedContent: false);
 
         stubFailure();
         clock = clock.add(
@@ -202,7 +226,7 @@ void main() {
         );
 
         expect(
-          (await repository.refresh(viewerIsMinor: false)).hasTab,
+          (await repository.refresh(gateAgeRestrictedContent: false)).hasTab,
           isTrue,
         );
       });
@@ -221,8 +245,8 @@ void main() {
         });
 
         final repository = buildRepository();
-        final stale = repository.refresh(viewerIsMinor: false);
-        final fresh = repository.refresh(viewerIsMinor: false);
+        final stale = repository.refresh(gateAgeRestrictedContent: false);
+        final fresh = repository.refresh(gateAgeRestrictedContent: false);
 
         afterKill.complete(
           const FeaturedTabsResponse(
@@ -242,7 +266,9 @@ void main() {
 
         stubFailure();
         clock = clock.add(const Duration(minutes: 1));
-        final snapshot = await repository.refresh(viewerIsMinor: false);
+        final snapshot = await repository.refresh(
+          gateAgeRestrictedContent: false,
+        );
 
         expect(
           snapshot.hasTab,
@@ -254,7 +280,9 @@ void main() {
       test('returns no tab when the first fetch fails with no cache', () async {
         stubFailure();
 
-        final snapshot = await buildRepository().refresh(viewerIsMinor: false);
+        final snapshot = await buildRepository().refresh(
+          gateAgeRestrictedContent: false,
+        );
 
         expect(snapshot.hasTab, isFalse);
       });
@@ -262,14 +290,16 @@ void main() {
       test('recovers on the next successful fetch after expiry', () async {
         final repository = buildRepository();
         stubTabs([_tab()]);
-        await repository.refresh(viewerIsMinor: false);
+        await repository.refresh(gateAgeRestrictedContent: false);
 
         stubFailure();
         clock = clock.add(FeaturedTabsRepository.defaultCacheTtl);
-        await repository.refresh(viewerIsMinor: false);
+        await repository.refresh(gateAgeRestrictedContent: false);
 
         stubTabs([_tab()]);
-        final snapshot = await repository.refresh(viewerIsMinor: false);
+        final snapshot = await repository.refresh(
+          gateAgeRestrictedContent: false,
+        );
 
         expect(snapshot.hasTab, isTrue);
       });
@@ -277,10 +307,12 @@ void main() {
       test('re-gates the cached config for the current viewer', () async {
         final repository = buildRepository();
         stubTabs([_tab()]);
-        await repository.refresh(viewerIsMinor: false);
+        await repository.refresh(gateAgeRestrictedContent: false);
 
         stubFailure();
-        final snapshot = await repository.refresh(viewerIsMinor: true);
+        final snapshot = await repository.refresh(
+          gateAgeRestrictedContent: true,
+        );
 
         expect(snapshot.hasTab, isFalse);
       });
@@ -288,11 +320,13 @@ void main() {
       test('stops serving a cached tab after clearCache', () async {
         final repository = buildRepository();
         stubTabs([_tab()]);
-        await repository.refresh(viewerIsMinor: false);
+        await repository.refresh(gateAgeRestrictedContent: false);
 
         repository.clearCache();
         stubFailure();
-        final snapshot = await repository.refresh(viewerIsMinor: false);
+        final snapshot = await repository.refresh(
+          gateAgeRestrictedContent: false,
+        );
 
         expect(snapshot.hasTab, isFalse);
       });
@@ -300,10 +334,12 @@ void main() {
       test('drops a tab the server has since killed', () async {
         final repository = buildRepository();
         stubTabs([_tab()]);
-        await repository.refresh(viewerIsMinor: false);
+        await repository.refresh(gateAgeRestrictedContent: false);
 
         stubTabs(const []);
-        final snapshot = await repository.refresh(viewerIsMinor: false);
+        final snapshot = await repository.refresh(
+          gateAgeRestrictedContent: false,
+        );
 
         expect(snapshot.hasTab, isFalse);
       });

--- a/mobile/test/repositories/featured_tabs_repository_test.dart
+++ b/mobile/test/repositories/featured_tabs_repository_test.dart
@@ -114,7 +114,7 @@ void main() {
         expect(snapshot.hasTab, isFalse);
       });
 
-      test('hides a non-opted-in tab from a minor viewer', () async {
+      test('hides an 18+ tab from an unverified viewer', () async {
         stubTabs([_tab()]);
 
         final snapshot = await buildRepository().refresh(
@@ -124,7 +124,7 @@ void main() {
         expect(snapshot.hasTab, isFalse);
       });
 
-      test('shows an opted-in tab to a minor viewer', () async {
+      test('shows an under-18-enabled tab to an unverified viewer', () async {
         stubTabs([_tab(visibleToMinors: true)]);
 
         final snapshot = await buildRepository().refresh(

--- a/mobile/test/screens/explore/explore_view_tab_selection_test.dart
+++ b/mobile/test/screens/explore/explore_view_tab_selection_test.dart
@@ -68,7 +68,9 @@ class _StagedFeaturedTabsRepository implements FeaturedTabsRepository {
   int refreshCount = 0;
 
   @override
-  Future<FeaturedTabsSnapshot> refresh({required bool viewerIsMinor}) async {
+  Future<FeaturedTabsSnapshot> refresh({
+    required bool gateAgeRestrictedContent,
+  }) async {
     refreshCount++;
     return refreshCount == 1
         ? const FeaturedTabsSnapshot(pollInterval: _pollInterval)
@@ -146,7 +148,7 @@ void main() {
             FeatureFlag.integratedApps,
           ).overrideWithValue(false),
           featuredTabsRepositoryProvider.overrideWithValue(repository),
-          featuredTabViewerIsMinorProvider.overrideWithValue(false),
+          featuredTabAgeGateProvider.overrideWithValue(false),
         ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/mobile/test/screens/explore/explore_view_tab_selection_test.dart
+++ b/mobile/test/screens/explore/explore_view_tab_selection_test.dart
@@ -3,6 +3,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart' show StateProvider;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
@@ -48,6 +50,8 @@ class _FakeCuratedListsState extends CuratedListsState {
 }
 
 const _pollInterval = Duration(seconds: 30);
+
+final _testFeaturedTabAgeGateProvider = StateProvider<bool>((ref) => true);
 
 const _featuredConfig = FeaturedTabConfig(
   id: 'ft_a1b2c3d4',
@@ -148,7 +152,9 @@ void main() {
             FeatureFlag.integratedApps,
           ).overrideWithValue(false),
           featuredTabsRepositoryProvider.overrideWithValue(repository),
-          featuredTabAgeGateProvider.overrideWithValue(false),
+          featuredTabAgeGateProvider.overrideWith(
+            (ref) => ref.watch(_testFeaturedTabAgeGateProvider),
+          ),
         ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -174,6 +180,24 @@ void main() {
   }
 
   group('ExploreView tab selection', () {
+    testWidgets('refreshes featured tabs when 18+ verification resolves', (
+      tester,
+    ) async {
+      final repository = _StagedFeaturedTabsRepository();
+      await pumpExplore(tester, repository: repository);
+      expect(repository.refreshCount, 1);
+      expect(find.text('Spotlight'), findsNothing);
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ExploreScreen)),
+      );
+      container.read(_testFeaturedTabAgeGateProvider.notifier).state = false;
+      await tester.pumpAndSettle();
+
+      expect(repository.refreshCount, 2);
+      expect(find.text('Spotlight'), findsOneWidget);
+    });
+
     testWidgets('a later availability change keeps the user on their tab', (
       tester,
     ) async {

--- a/mobile/test/screens/explore/tabs/featured_videos_tab_test.dart
+++ b/mobile/test/screens/explore/tabs/featured_videos_tab_test.dart
@@ -82,7 +82,7 @@ void main() {
       router = MockGoRouter();
       when(
         () => featuredRepository.refresh(
-          viewerIsMinor: any(named: 'viewerIsMinor'),
+          gateAgeRestrictedContent: any(named: 'gateAgeRestrictedContent'),
         ),
       ).thenAnswer(
         // Zero cadence keeps the cubit from arming a poll timer that would
@@ -91,7 +91,7 @@ void main() {
       );
       featuredTabsCubit = FeaturedTabsCubit(
         repository: featuredRepository,
-        viewerIsMinor: () => false,
+        gateAgeRestrictedContent: () => false,
       );
       addTearDown(featuredTabsCubit.close);
       when(

--- a/mobile/test/services/age_verification_service_test.dart
+++ b/mobile/test/services/age_verification_service_test.dart
@@ -127,26 +127,23 @@ void main() {
       await expectLater(service.initialize(), completes);
     });
 
-    test('should notify listeners when verification status changes', () async {
+    test('notifies when adult verification loads or changes', () async {
+      var notificationCount = 0;
+      service = AgeVerificationService(
+        onAdultContentVerificationChanged: () => notificationCount++,
+      );
+
       await service.initialize();
+      expect(notificationCount, 1);
 
-      // Note: AgeVerificationService no longer extends ChangeNotifier
-      // This test of listener functionality is no longer applicable
-      // var notificationCount = 0;
-      // service.addListener(() {
-      //   notificationCount++;
-      // });
+      await service.setAdultContentVerified(true);
+      expect(notificationCount, 2);
 
-      // Skip the listener test - just verify the state changes work
-
-      await service.setAgeVerified(true);
-      expect(service.isAgeVerified, true);
-
-      await service.setAgeVerified(false);
-      expect(service.isAgeVerified, false);
+      await service.setAdultContentVerified(false);
+      expect(notificationCount, 3);
 
       await service.clearVerificationStatus();
-      expect(service.isAgeVerified, false);
+      expect(notificationCount, 4);
     });
   });
 }


### PR DESCRIPTION
## Problem

Featured tabs can be configured in the dashboard as unavailable to viewers under 18. Mobile previously treated that setting as a protected-minor check, which covers only Keycast's 13–15 account status and does not implement the dashboard's 18+ contract.

## Fix

The featured-tab gate now uses Divine's existing adult-content verification state:

| Dashboard setting | Viewer state | Result |
|---|---|---|
| Allow under 18 | Any | Show the tab |
| 18+ only | Adult verified | Show the tab |
| 18+ only | Unverified or loading | Hide the tab |
| 18+ only | Protected minor | Hide the tab |

Persisted verification loads fail closed. When adult verification changes while Explore is mounted, the gate updates and refreshes the featured-tab configuration immediately. Protected-minor accounts remain unable to enable adult verification through the existing `AgeVerificationService` lock.

This does not change the dashboard schema, featured-tab ordering, polling, deep-link behavior, or content filtering outside the featured tab.

## Verification

- `flutter analyze lib test`
- Featured-tabs provider, repository, cubit, widget, and tab tests
- Age-verification service, protected-minor, and provider tests
- Pre-push analyze, generated-file verification, and changed-file tests

Closes #7675
