### PR TITLE
ci(android): send release builds to internal testing first

### DIFF
--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -90,6 +90,12 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         )
         self.assertNotIn("PROJECT_BUILD_NUMBER + 8", self.contents)
 
+    def test_android_release_publishes_to_internal_track(self) -> None:
+        block = self._workflow_block("android-build")
+        self.assertRegex(block, r"(?m)^        track: internal$")
+        self.assertNotIn("submit_as_draft", block)
+        self.assertNotIn("track: production", block)
+
     def test_shorebird_supporters_defines_are_optional(self) -> None:
         self.assertIn("optional_names = %w[", self.contents)
         self.assertIn("SUPPORTERS_API_BASE_URL", self.contents)

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1099,13 +1099,10 @@ workflows:
     publishing:
       google_play:
         credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
-        track: production
-        # Upload as a draft instead of rolling out a release. Rolling out a
-        # production release fails the build until the one-time Play Console
-        # "Foreground service permissions" declaration is completed (required
-        # on every track). A draft upload succeeds; promote it to a live
-        # release in the Play Console after completing that declaration.
-        submit_as_draft: true
+        # Ship the exact Shorebird-enabled release to internal testers first.
+        # Promote this same Play artifact manually after testing; do not rebuild
+        # it for broader testing or production.
+        track: internal
 
   # Patch workflows ship a Dart-only fix to an already-released build over the
   # air. They publish to Shorebird, not to Play or the App Store, and are

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -65,6 +65,12 @@ From `mobile/`:
 ./build_android.sh release
 ```
 
+Store release artifacts are built by the Codemagic `android-build` workflow (a
+Shorebird release), not by these local commands. The Android AAB built here is
+plain `flutter build` output — not a Shorebird release — so it cannot be
+patched and never ships to Play; treat it as a verification artifact (see
+section 7).
+
 - [ ] iOS archive completed successfully in Xcode Organizer.
 - [ ] Android release AAB exists at `build/app/outputs/bundle/release/app-release.aab`.
 - [ ] If using the Play upload helper, verify `android/play-store-service-account.json` is present before running `./deploy_android.sh`.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -87,10 +87,10 @@ From `mobile/`:
 - [ ] Confirm app ID is still `co.openvine.app`.
 - [ ] Confirm the manifest still removes Advertising ID and unused location/Bluetooth permissions.
 - [ ] Verify the current release notes and tester notes are ready.
-- [ ] Upload the AAB to the intended track:
-  - Manual Play Console upload, or
-  - `./deploy_android.sh internal|closed|production`
-- [ ] Verify release track assignment and staged rollout settings.
+- [ ] Cut the release through the Codemagic `android-build` workflow: it publishes the signed, Shorebird-enabled AAB to Play's **internal testing** track. Do not rebuild for broader distribution; promote that exact Play artifact after internal testing passes.
+- [ ] Verify the new release is live on the internal testing track in Play Console and available to internal testers.
+- [ ] Promote the artifact deliberately in Play Console — internal testing to broader testing or production — with a staged production rollout, verifying each hop. This promotion is the release decision; the Codemagic build alone ships nothing to production.
+- [ ] `./deploy_android.sh` uploads a plain `flutter build` AAB, not a Shorebird release, so its binaries cannot be patched. Use it only for throwaway manual test lanes, never as the production release path.
 
 ## 8. Final Sign-Off
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -95,7 +95,7 @@ section 7).
 - [ ] Verify the current release notes and tester notes are ready.
 - [ ] Cut the release through the Codemagic `android-build` workflow: it publishes the signed, Shorebird-enabled AAB to Play's **internal testing** track. Do not rebuild for broader distribution; promote that exact Play artifact after internal testing passes.
 - [ ] Verify the new release is live on the internal testing track in Play Console and available to internal testers.
-- [ ] Promote the artifact deliberately in Play Console — internal testing to broader testing or production — with a staged production rollout, verifying each hop. This promotion is the release decision; the Codemagic build alone ships nothing to production.
+- [ ] Promote the artifact deliberately in Play Console — internal testing to broader testing or production — with a staged production rollout, verifying each hop, and advance the staged rollout to 100% or record why it is being held. This promotion is the release decision; the Codemagic build alone ships nothing to production.
 - [ ] `./deploy_android.sh` uploads a plain `flutter build` AAB, not a Shorebird release, so its binaries cannot be patched. Use it only for throwaway manual test lanes, never as the production release path.
 
 ## 8. Final Sign-Off

--- a/mobile/docs/ANDROID_DEPLOYMENT.md
+++ b/mobile/docs/ANDROID_DEPLOYMENT.md
@@ -3,7 +3,14 @@
 Status: Launch-critical
 Validated against: `mobile/build_android.sh`, `mobile/deploy_android.sh`, `mobile/android/app/build.gradle.kts`, and `mobile/android/app/src/main/AndroidManifest.xml` on 2026-03-19.
 
-This is the current Android release path for Divine.
+Store releases ship through the Codemagic `android-build` workflow, which
+publishes the signed, Shorebird-enabled AAB to Play's internal testing track;
+after internal testing passes, promote that exact Play artifact in the Play
+Console (see [docs/RELEASE_CHECKLIST.md](../../docs/RELEASE_CHECKLIST.md#7-android-submission-checklist)).
+This guide covers the local build and manual upload lanes. They produce a plain
+`flutter build` AAB that is not a Shorebird release and cannot be patched, so
+use them for local verification and throwaway test lanes — never as the
+production release path.
 
 ## App Metadata
 
@@ -27,7 +34,15 @@ What the script does:
 3. Runs `flutter clean`, `flutter pub get`, and `build_runner`.
 4. Builds a signed release AAB for Play Console upload.
 
+`./build_android.sh` runs `flutter build appbundle`, not `shorebird release`.
+The AAB it produces is for local verification and manual test lanes only; it
+cannot receive Shorebird patches and must not be promoted to production.
+
 ## Upload Options
+
+The lanes below upload a plain `flutter build` AAB for throwaway manual
+testing. Production releases come from Codemagic as described above; do not
+use `./deploy_android.sh production` to ship.
 
 ### Manual Play Console upload
 

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -187,8 +187,10 @@ it for Beta App Review. After the full external cohort passes, perform a manual
 App Store promotion by selecting that exact build for the marketing version and
 submitting it for App Store Review. Do not rebuild between those gates; the
 binary reviewed for public release must be the Shorebird binary exercised by
-both tester cohorts. Android continues to upload to Play as a draft, with
-promotion to production remaining manual.
+both tester cohorts. Android uploads the same Shorebird-enabled release to
+Play's internal testing track first. After internal testing passes, promote
+that exact Play artifact to broader testing and then production manually; do
+not rebuild between gates.
 
 Release commands pass `--public-key-path`, so every new store binary only
 accepts signed Shorebird patches. A release built without the public key cannot


### PR DESCRIPTION
## Problem

Android store builds currently upload to a draft on the production track. That skips the intended internal-testing gate and makes it harder to test and later promote the exact artifact that will ship.

## Fix

Publish the signed, Shorebird-enabled AAB to Google Play Internal testing. After validation, release owners can promote that exact Play artifact to broader testing and production without rebuilding it.

This changes release automation: a successful `android-build` will become available to configured internal testers instead of creating a production-track draft. It does not promote anything to production or change iOS publishing.

## Verification

- `ruby -e 'require "yaml"; YAML.safe_load(File.read("codemagic.yaml"), aliases: true)'`
- `.codex/scripts/test-config.sh`
- `cd mobile && flutter test test/tools/codemagic_groups_test.dart` (11 tests)
- Structural assertion that `android-build` uses `track: internal` without `submit_as_draft`
- Pre-push Codemagic variable-group guard

## Review follow-ups (commits added during review)

- Aligned the Android release docs with the internal-track path: docs/RELEASE_CHECKLIST.md (§5 local builds are verification artifacts; §7 names the Codemagic android-build → internal testing flow, the manual promotion, and requires staged rollouts to be advanced to 100% or have the hold recorded) and mobile/docs/ANDROID_DEPLOYMENT.md (no longer presents the manual upload lanes as the release path; marks their plain `flutter build` AABs as unpatchable and throwaway-only).
- Committed the structural assertion as a real guard: `test_codemagic_shorebird_config.py::test_android_release_publishes_to_internal_track` pins `android-build` to `track: internal` with no `submit_as_draft` and no `track: production`.
- Closes #6848, whose recommended behavior this PR follows; its #6847 precondition is complete. Full validation: 78 CI-config unit tests OK, codemagic_groups 11/11, YAML parse, test-config.sh.
