### PR TITLE
fix(notifications): request Inbox refresh after foreground push

### DIFF
--- a/mobile/lib/notifications/services/notification_refresh_coordinator.dart
+++ b/mobile/lib/notifications/services/notification_refresh_coordinator.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Coalesces authoritative notification refresh triggers.
-// ABOUTME: Used by app resume to keep the repository snapshot fresh.
+// ABOUTME: Used by app resume and foreground push to keep snapshots fresh.
 
 import 'dart:async';
 
@@ -16,6 +16,9 @@ enum NotificationRefreshReason {
 
   /// App is foreground and idle enough to opportunistically warm notifications.
   foregroundIdleWarmup,
+
+  /// A foreground push arrived that may have a corresponding Inbox item.
+  pushReceived,
 }
 
 /// Forwards an unexpected refresh failure to the crash reporter.
@@ -32,20 +35,39 @@ class NotificationRefreshCoordinator {
   NotificationRefreshCoordinator({
     required NotificationRepository repository,
     Duration cooldown = const Duration(seconds: 30),
+    Duration pushDebounce = const Duration(seconds: 3),
     DateTime Function()? now,
     NotificationRefreshErrorReporter? errorReporter,
   }) : _repository = repository,
        _cooldown = cooldown,
+       _pushDebounce = pushDebounce,
        _now = now ?? DateTime.now,
        _reportError = errorReporter ?? _reportToCrashlytics;
 
   final NotificationRepository _repository;
   final Duration _cooldown;
+  final Duration _pushDebounce;
   final DateTime Function() _now;
   final NotificationRefreshErrorReporter _reportError;
 
   DateTime? _lastSuccessAt;
   Future<void>? _inFlight;
+  Timer? _pushDebounceTimer;
+  bool _disposed = false;
+
+  /// Schedules one authoritative refresh after a foreground push burst ends.
+  ///
+  /// Every arrival resets the trailing debounce. The eventual refresh waits
+  /// for an earlier refresh to finish and bypasses only its success cooldown:
+  /// the repository's deep-pagination protection still applies.
+  void schedulePushRefresh() {
+    if (_disposed) return;
+    _pushDebounceTimer?.cancel();
+    _pushDebounceTimer = Timer(_pushDebounce, () {
+      _pushDebounceTimer = null;
+      unawaited(_refreshAfterPushBurst());
+    });
+  }
 
   /// Requests an authoritative first-page refresh.
   ///
@@ -58,6 +80,12 @@ class NotificationRefreshCoordinator {
   Future<void> refresh({
     required NotificationRefreshReason reason,
     bool force = false,
+  }) => _refresh(reason: reason, force: force);
+
+  Future<void> _refresh({
+    required NotificationRefreshReason reason,
+    bool force = false,
+    bool bypassCooldown = false,
   }) {
     final inFlight = _inFlight;
     if (inFlight != null) return inFlight;
@@ -74,6 +102,7 @@ class NotificationRefreshCoordinator {
 
     final lastSuccessAt = _lastSuccessAt;
     if (!force &&
+        !bypassCooldown &&
         lastSuccessAt != null &&
         _now().difference(lastSuccessAt) < _cooldown) {
       return Future<void>.value();
@@ -84,6 +113,23 @@ class NotificationRefreshCoordinator {
     });
     _inFlight = future;
     return future;
+  }
+
+  Future<void> _refreshAfterPushBurst() async {
+    final inFlight = _inFlight;
+    if (inFlight != null) await inFlight;
+    if (_disposed) return;
+    await _refresh(
+      reason: NotificationRefreshReason.pushReceived,
+      bypassCooldown: true,
+    );
+  }
+
+  /// Cancels pending burst work owned by this coordinator.
+  void dispose() {
+    _disposed = true;
+    _pushDebounceTimer?.cancel();
+    _pushDebounceTimer = null;
   }
 
   Future<void> _runRefresh(NotificationRefreshReason reason) async {
@@ -153,5 +199,9 @@ final notificationRefreshCoordinatorProvider =
     Provider<NotificationRefreshCoordinator?>((ref) {
       final repository = ref.watch(notificationRepositoryProvider);
       if (repository == null) return null;
-      return NotificationRefreshCoordinator(repository: repository);
+      final coordinator = NotificationRefreshCoordinator(
+        repository: repository,
+      );
+      ref.onDispose(coordinator.dispose);
+      return coordinator;
     });

--- a/mobile/lib/notifications/services/notification_refresh_coordinator.dart
+++ b/mobile/lib/notifications/services/notification_refresh_coordinator.dart
@@ -36,37 +36,53 @@ class NotificationRefreshCoordinator {
     required NotificationRepository repository,
     Duration cooldown = const Duration(seconds: 30),
     Duration pushDebounce = const Duration(seconds: 3),
+    Duration pushMaxWait = const Duration(seconds: 10),
+    Duration pushMinimumInterval = const Duration(seconds: 10),
     DateTime Function()? now,
     NotificationRefreshErrorReporter? errorReporter,
   }) : _repository = repository,
        _cooldown = cooldown,
        _pushDebounce = pushDebounce,
+       _pushMaxWait = pushMaxWait,
+       _pushMinimumInterval = pushMinimumInterval,
        _now = now ?? DateTime.now,
        _reportError = errorReporter ?? _reportToCrashlytics;
 
   final NotificationRepository _repository;
   final Duration _cooldown;
   final Duration _pushDebounce;
+  final Duration _pushMaxWait;
+  final Duration _pushMinimumInterval;
   final DateTime Function() _now;
   final NotificationRefreshErrorReporter _reportError;
 
   DateTime? _lastSuccessAt;
   Future<void>? _inFlight;
   Timer? _pushDebounceTimer;
+  Timer? _pushMaxWaitTimer;
   bool _disposed = false;
 
   /// Schedules one authoritative refresh after a foreground push burst ends.
   ///
-  /// Every arrival resets the trailing debounce. The eventual refresh waits
-  /// for an earlier refresh to finish and bypasses only its success cooldown:
-  /// the repository's deep-pagination protection still applies.
+  /// Every arrival resets the trailing debounce, while a separate maximum-wait
+  /// timer prevents a sustained stream from postponing the refresh forever.
+  /// Successful requests retain a short rate floor. The eventual refresh
+  /// waits for an earlier refresh to finish and bypasses only the general
+  /// success cooldown: the repository's deep-pagination protection still
+  /// applies.
   void schedulePushRefresh() {
     if (_disposed) return;
     _pushDebounceTimer?.cancel();
-    _pushDebounceTimer = Timer(_pushDebounce, () {
-      _pushDebounceTimer = null;
-      unawaited(_refreshAfterPushBurst());
-    });
+    _pushDebounceTimer = Timer(_pushDebounce, _completePushBurst);
+    _pushMaxWaitTimer ??= Timer(_pushMaxWait, _completePushBurst);
+  }
+
+  void _completePushBurst() {
+    _pushDebounceTimer?.cancel();
+    _pushDebounceTimer = null;
+    _pushMaxWaitTimer?.cancel();
+    _pushMaxWaitTimer = null;
+    unawaited(_refreshAfterPushBurst());
   }
 
   /// Requests an authoritative first-page refresh.
@@ -119,6 +135,20 @@ class NotificationRefreshCoordinator {
     final inFlight = _inFlight;
     if (inFlight != null) await inFlight;
     if (_disposed) return;
+
+    final lastSuccessAt = _lastSuccessAt;
+    if (lastSuccessAt != null) {
+      final elapsed = _now().difference(lastSuccessAt);
+      if (elapsed < _pushMinimumInterval) {
+        final remaining = _pushMinimumInterval - elapsed;
+        _pushDebounceTimer?.cancel();
+        _pushMaxWaitTimer?.cancel();
+        _pushMaxWaitTimer = null;
+        _pushDebounceTimer = Timer(remaining, _completePushBurst);
+        return;
+      }
+    }
+
     await _refresh(
       reason: NotificationRefreshReason.pushReceived,
       bypassCooldown: true,
@@ -130,6 +160,8 @@ class NotificationRefreshCoordinator {
     _disposed = true;
     _pushDebounceTimer?.cancel();
     _pushDebounceTimer = null;
+    _pushMaxWaitTimer?.cancel();
+    _pushMaxWaitTimer = null;
   }
 
   Future<void> _runRefresh(NotificationRefreshReason reason) async {

--- a/mobile/lib/providers/notifications_providers.dart
+++ b/mobile/lib/providers/notifications_providers.dart
@@ -7,6 +7,7 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/models/notification_preferences.dart';
+import 'package:openvine/notifications/services/notification_refresh_coordinator.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
@@ -289,7 +290,10 @@ PushNotificationSessionCoordinator? pushNotificationSync(Ref ref) {
     message,
   ) {
     final pushService = ref.read(pushNotificationServiceProvider);
-    pushService?.handleForegroundMessage(message.data);
+    if (pushService != null) {
+      unawaited(pushService.handleForegroundMessage(message.data));
+    }
+    ref.read(notificationRefreshCoordinatorProvider)?.schedulePushRefresh();
   });
 
   ref.onDispose(() {

--- a/mobile/lib/providers/notifications_providers.g.dart
+++ b/mobile/lib/providers/notifications_providers.g.dart
@@ -79,4 +79,4 @@ final class PushNotificationSyncProvider
 }
 
 String _$pushNotificationSyncHash() =>
-    r'6cdcb5f909f6463828420979de4373f3c7a3fc3e';
+    r'f7354ba7cce018a60ce5b99d7d187cfa23ad10dc';

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -608,7 +608,7 @@ class NotificationRepository {
   /// Runs only when the snapshot is still empty (avoids racing the first
   /// REST response). Cached rows are surfaced as lightweight placeholders
   /// — video-anchored rows stay video-anchored when reconstructable, and
-  /// the next REST/WS arrival replaces them with fully enriched items.
+  /// the next REST arrival replaces them with fully enriched items.
   Future<void> _hydrateFromCache() async {
     try {
       if (_snapshot.value.items.isNotEmpty) return;

--- a/mobile/test/notifications/services/notification_refresh_coordinator_test.dart
+++ b/mobile/test/notifications/services/notification_refresh_coordinator_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:notification_repository/notification_repository.dart';
@@ -32,10 +33,12 @@ void main() {
 
     NotificationRefreshCoordinator buildCoordinator({
       Duration cooldown = const Duration(seconds: 30),
+      Duration pushDebounce = const Duration(seconds: 3),
     }) {
       return NotificationRefreshCoordinator(
         repository: repository,
         cooldown: cooldown,
+        pushDebounce: pushDebounce,
         now: () => now,
         errorReporter: (error, stackTrace, {reason}) =>
             reportedErrors.add((error: error, reason: reason)),
@@ -170,6 +173,99 @@ void main() {
       await coordinator.refresh(reason: NotificationRefreshReason.appResume);
 
       expect(reportedErrors, isEmpty);
+    });
+
+    group('foreground push refresh', () {
+      test('trailing-debounces a burst into one refresh', () {
+        fakeAsync((async) {
+          final coordinator = buildCoordinator();
+
+          coordinator.schedulePushRefresh();
+          async.elapse(const Duration(seconds: 1));
+          coordinator.schedulePushRefresh();
+          async.elapse(const Duration(seconds: 1));
+          coordinator.schedulePushRefresh();
+
+          async.elapse(const Duration(milliseconds: 2999));
+          verifyNever(() => repository.refreshApplied());
+
+          async.elapse(const Duration(milliseconds: 1));
+          async.flushMicrotasks();
+          verify(() => repository.refreshApplied()).called(1);
+        });
+      });
+
+      test('preserves the deep-pagination guard', () {
+        fakeAsync((async) {
+          when(() => repository.hasPaginatedBeyondFirstPage).thenReturn(true);
+          final coordinator = buildCoordinator();
+
+          coordinator.schedulePushRefresh();
+          async.elapse(const Duration(seconds: 3));
+          async.flushMicrotasks();
+
+          verifyNever(() => repository.refreshApplied());
+        });
+      });
+
+      test('dispose cancels a pending refresh', () {
+        fakeAsync((async) {
+          final coordinator = buildCoordinator();
+
+          coordinator.schedulePushRefresh();
+          coordinator.dispose();
+          async.elapse(const Duration(seconds: 3));
+          async.flushMicrotasks();
+
+          verifyNever(() => repository.refreshApplied());
+        });
+      });
+
+      test('a failed push refresh does not suppress the next burst', () {
+        fakeAsync((async) {
+          when(
+            () => repository.refreshApplied(),
+          ).thenThrow(Exception('timeout'));
+          final coordinator = buildCoordinator();
+
+          coordinator.schedulePushRefresh();
+          async.elapse(const Duration(seconds: 3));
+          async.flushMicrotasks();
+
+          when(
+            () => repository.refreshApplied(),
+          ).thenAnswer((_) async => true);
+          coordinator.schedulePushRefresh();
+          async.elapse(const Duration(seconds: 3));
+          async.flushMicrotasks();
+
+          verify(() => repository.refreshApplied()).called(2);
+        });
+      });
+
+      test('refreshes after an earlier refresh finishes', () {
+        fakeAsync((async) {
+          final firstRefresh = Completer<bool>();
+          var calls = 0;
+          when(() => repository.refreshApplied()).thenAnswer((_) {
+            calls += 1;
+            return calls == 1 ? firstRefresh.future : Future.value(true);
+          });
+          final coordinator = buildCoordinator();
+
+          unawaited(
+            coordinator.refresh(reason: NotificationRefreshReason.appResume),
+          );
+          coordinator.schedulePushRefresh();
+          async.elapse(const Duration(seconds: 3));
+          async.flushMicrotasks();
+          expect(calls, 1);
+
+          firstRefresh.complete(true);
+          async.flushMicrotasks();
+          expect(calls, 2);
+        });
+      });
     });
   });
 }

--- a/mobile/test/notifications/services/notification_refresh_coordinator_test.dart
+++ b/mobile/test/notifications/services/notification_refresh_coordinator_test.dart
@@ -314,7 +314,11 @@ void main() {
             calls += 1;
             return calls == 1 ? firstRefresh.future : Future.value(true);
           });
-          final coordinator = buildCoordinator();
+          // Zero floor: under the default, the first refresh's success defers
+          // the burst, so this passes with or without the guard it pins.
+          final coordinator = buildCoordinator(
+            pushMinimumInterval: Duration.zero,
+          );
 
           unawaited(
             coordinator.refresh(reason: NotificationRefreshReason.appResume),

--- a/mobile/test/notifications/services/notification_refresh_coordinator_test.dart
+++ b/mobile/test/notifications/services/notification_refresh_coordinator_test.dart
@@ -4,13 +4,18 @@
 import 'dart:async';
 
 import 'package:fake_async/fake_async.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:notification_repository/notification_repository.dart';
+import 'package:openvine/notifications/providers/notification_repository_provider.dart';
 import 'package:openvine/notifications/services/notification_refresh_coordinator.dart';
 
 class _MockNotificationRepository extends Mock
     implements NotificationRepository {}
+
+final _repoSwap = StateProvider<int>((_) => 0);
 
 void main() {
   group(NotificationRefreshCoordinator, () {
@@ -221,6 +226,18 @@ void main() {
         });
       });
 
+      test('schedulePushRefresh after dispose never refreshes', () {
+        fakeAsync((async) {
+          final coordinator = buildCoordinator()..dispose();
+
+          coordinator.schedulePushRefresh();
+          async.elapse(const Duration(seconds: 3));
+          async.flushMicrotasks();
+
+          verifyNever(() => repository.refreshApplied());
+        });
+      });
+
       test('a failed push refresh does not suppress the next burst', () {
         fakeAsync((async) {
           when(
@@ -290,6 +307,59 @@ void main() {
           firstRefresh.complete(true);
           async.flushMicrotasks();
           expect(calls, 2);
+        });
+      });
+    });
+
+    group('notificationRefreshCoordinatorProvider', () {
+      test('disposing the container cancels a scheduled push refresh', () {
+        fakeAsync((async) {
+          final container = ProviderContainer(
+            overrides: [
+              notificationRepositoryProvider.overrideWithValue(repository),
+            ],
+          );
+          final coordinator = container.read(
+            notificationRefreshCoordinatorProvider,
+          );
+          expect(coordinator, isNotNull);
+
+          coordinator!.schedulePushRefresh();
+          container.dispose();
+          async.elapse(const Duration(seconds: 3));
+          async.flushMicrotasks();
+
+          verifyNever(() => repository.refreshApplied());
+        });
+      });
+
+      test('a repository swap disposes the outgoing coordinator', () {
+        fakeAsync((async) {
+          final repositoryB = _MockNotificationRepository();
+          when(repositoryB.refreshApplied).thenAnswer((_) async => true);
+          when(() => repositoryB.isClosed).thenReturn(false);
+          when(() => repositoryB.hasPaginatedBeyondFirstPage).thenReturn(false);
+          final container = ProviderContainer(
+            overrides: [
+              notificationRepositoryProvider.overrideWith(
+                (ref) => ref.watch(_repoSwap) == 0 ? repository : repositoryB,
+              ),
+            ],
+          );
+          addTearDown(container.dispose);
+          final first = container.read(
+            notificationRefreshCoordinatorProvider,
+          )!;
+
+          first.schedulePushRefresh();
+          container.read(_repoSwap.notifier).state = 1;
+          final next = container.read(notificationRefreshCoordinatorProvider);
+          async.elapse(const Duration(seconds: 3));
+          async.flushMicrotasks();
+
+          expect(next, isNot(same(first)));
+          verifyNever(() => repository.refreshApplied());
+          verifyNever(repositoryB.refreshApplied);
         });
       });
     });

--- a/mobile/test/notifications/services/notification_refresh_coordinator_test.dart
+++ b/mobile/test/notifications/services/notification_refresh_coordinator_test.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Tests for notification refresh coalescing on app resume.
+// ABOUTME: Tests for notification refresh coalescing on resume and push.
 // ABOUTME: Guards cooldown consumption and failure routing semantics.
 
 import 'dart:async';
@@ -240,6 +240,32 @@ void main() {
           async.flushMicrotasks();
 
           verify(() => repository.refreshApplied()).called(2);
+        });
+      });
+
+      test('dispose during an in-flight refresh drops the queued push '
+          'refresh', () {
+        fakeAsync((async) {
+          final firstRefresh = Completer<bool>();
+          var calls = 0;
+          when(() => repository.refreshApplied()).thenAnswer((_) {
+            calls += 1;
+            return calls == 1 ? firstRefresh.future : Future.value(true);
+          });
+          final coordinator = buildCoordinator();
+
+          unawaited(
+            coordinator.refresh(reason: NotificationRefreshReason.appResume),
+          );
+          coordinator.schedulePushRefresh();
+          async.elapse(const Duration(seconds: 3));
+          async.flushMicrotasks();
+          expect(calls, 1);
+
+          coordinator.dispose();
+          firstRefresh.complete(true);
+          async.flushMicrotasks();
+          expect(calls, 1);
         });
       });
 

--- a/mobile/test/notifications/services/notification_refresh_coordinator_test.dart
+++ b/mobile/test/notifications/services/notification_refresh_coordinator_test.dart
@@ -39,11 +39,15 @@ void main() {
     NotificationRefreshCoordinator buildCoordinator({
       Duration cooldown = const Duration(seconds: 30),
       Duration pushDebounce = const Duration(seconds: 3),
+      Duration pushMaxWait = const Duration(seconds: 10),
+      Duration pushMinimumInterval = const Duration(seconds: 10),
     }) {
       return NotificationRefreshCoordinator(
         repository: repository,
         cooldown: cooldown,
         pushDebounce: pushDebounce,
+        pushMaxWait: pushMaxWait,
+        pushMinimumInterval: pushMinimumInterval,
         now: () => now,
         errorReporter: (error, stackTrace, {reason}) =>
             reportedErrors.add((error: error, reason: reason)),
@@ -200,6 +204,46 @@ void main() {
         });
       });
 
+      test('refreshes at the maximum wait during a sustained burst', () {
+        fakeAsync((async) {
+          final coordinator = buildCoordinator();
+
+          for (var second = 0; second < 10; second += 1) {
+            coordinator.schedulePushRefresh();
+            if (second < 9) async.elapse(const Duration(seconds: 1));
+          }
+
+          async.elapse(const Duration(milliseconds: 999));
+          verifyNever(() => repository.refreshApplied());
+
+          async.elapse(const Duration(milliseconds: 1));
+          async.flushMicrotasks();
+          verify(() => repository.refreshApplied()).called(1);
+        });
+      });
+
+      test('enforces a minimum interval between successful push refreshes', () {
+        fakeAsync((async) {
+          final coordinator = buildCoordinator();
+
+          coordinator.schedulePushRefresh();
+          async.elapse(const Duration(seconds: 3));
+          async.flushMicrotasks();
+          verify(() => repository.refreshApplied()).called(1);
+
+          now = now.add(const Duration(seconds: 4));
+          coordinator.schedulePushRefresh();
+          async.elapse(const Duration(seconds: 3));
+          async.flushMicrotasks();
+          verifyNever(() => repository.refreshApplied());
+
+          now = now.add(const Duration(seconds: 6));
+          async.elapse(const Duration(seconds: 6));
+          async.flushMicrotasks();
+          verify(() => repository.refreshApplied()).called(1);
+        });
+      });
+
       test('preserves the deep-pagination guard', () {
         fakeAsync((async) {
           when(() => repository.hasPaginatedBeyondFirstPage).thenReturn(true);
@@ -219,6 +263,7 @@ void main() {
 
           coordinator.schedulePushRefresh();
           coordinator.dispose();
+          expect(async.pendingTimers, isEmpty);
           async.elapse(const Duration(seconds: 3));
           async.flushMicrotasks();
 
@@ -305,6 +350,11 @@ void main() {
           expect(calls, 1);
 
           firstRefresh.complete(true);
+          async.flushMicrotasks();
+          expect(calls, 1);
+
+          now = now.add(const Duration(seconds: 10));
+          async.elapse(const Duration(seconds: 10));
           async.flushMicrotasks();
           expect(calls, 2);
         });

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -13,6 +13,7 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/models/notification_preferences.dart';
+import 'package:openvine/notifications/services/notification_refresh_coordinator.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -34,6 +35,9 @@ class _MockNostrClient extends Mock implements NostrClient {}
 class _MockNostrSigner extends Mock implements NostrSigner {}
 
 class _MockNotificationService extends Mock implements NotificationService {}
+
+class _MockNotificationRefreshCoordinator extends Mock
+    implements NotificationRefreshCoordinator {}
 
 class _FakeEvent extends Fake implements Event {
   @override
@@ -357,6 +361,46 @@ void main() {
   }
 
   group('pushNotificationSync', () {
+    test(
+      'foreground message schedules an authoritative Inbox refresh',
+      () async {
+        final messages = StreamController<RemoteMessage>.broadcast();
+        final refreshCoordinator = _MockNotificationRefreshCoordinator();
+        addTearDown(messages.close);
+        when(
+          () => pushService.handleForegroundMessage(any()),
+        ).thenAnswer((_) async {});
+        when(refreshCoordinator.schedulePushRefresh).thenReturn(null);
+        when(
+          () => messaging.getNotificationSettings(),
+        ).thenAnswer((_) async => _settings(AuthorizationStatus.authorized));
+        final container = buildContainer(
+          extraOverrides: [
+            firebaseOnMessageProvider.overrideWithValue(messages.stream),
+            notificationRefreshCoordinatorProvider.overrideWithValue(
+              refreshCoordinator,
+            ),
+          ],
+        );
+
+        container.read(pushNotificationSyncProvider);
+        messages.add(
+          const RemoteMessage(
+            data: {'title': 'New like', 'body': 'Someone'},
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        verify(
+          () => pushService.handleForegroundMessage(const {
+            'title': 'New like',
+            'body': 'Someone',
+          }),
+        ).called(1);
+        verify(refreshCoordinator.schedulePushRefresh).called(1);
+      },
+    );
+
     test(
       'does not publish stale registration when auth changes mid-flight',
       () async {


### PR DESCRIPTION
## Description

Foreground FCM arrivals now request an authoritative Inbox refresh through the existing notification refresh coordinator. The coordinator waits for a three-second trailing debounce, caps sustained bursts at ten seconds, and enforces a ten-second floor between successful requests. It retains in-flight coalescing, immediate retry after failures, and deep-pagination protection.

The coordinator owns and cancels both timers with its provider lifecycle. The stale repository comment claiming a WebSocket notification arrival path is also corrected.

This is the mobile-side refresh trigger only. The Inbox API reads a server-side model populated by a five-minute materializer, so a request immediately after a push can still return the previous snapshot. The backend freshness work remains necessary before #8551 is complete.

**Related issue:** Part of #8551

## Out of Scope

- Making newly ingested notification events immediately visible to the Inbox API
- Refreshing when a kept-alive Inbox becomes visible, tracked separately by #7548
- Changing local-notification rendering or push-registration behavior

## Verification

- `flutter test test/notifications/services/notification_refresh_coordinator_test.dart test/providers/push_notification_sync_test.dart` (70 tests)
- `flutter analyze`
- `bash scripts/check_uncancellable_timer_wait.sh`
- Generated-file verification in the pre-push hook
- Regression coverage for foreground-message wiring, burst debounce, maximum wait, request-rate floor, deep-pagination protection, failures, in-flight handoff, and coordinator disposal

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that causes existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
