### PR TITLE
fix(dm): make message restore recover when the relay pool has gone idle

### DIFF
--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -63,10 +63,9 @@ jobs:
       #
       # The list is explicit rather than a glob over integration_test/e2e/,
       # because `service` and "runnable on a Linux CI runner" are different
-      # axes. Every suite in that directory is tagged `service`; these eight
+      # axes. Every suite in that directory is tagged `service`; these ten
       # are the ones this runner can actually execute. The remaining four are
-      # excluded
-      # for reasons no workflow change can fix:
+      # excluded for reasons no workflow change can fix:
       #
       #   c2pa_init                         — c2pa_flutter ships android/ and
       #                                       ios/ only, no desktop impl.

--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -90,7 +90,8 @@ jobs:
             integration_test/e2e/dm_group_delete_for_everyone_test.dart \
             integration_test/e2e/dm_reaction_unreadable_inbox_test.dart \
             integration_test/e2e/dm_deletion_unreadable_inbox_test.dart \
-            integration_test/e2e/dm_oneway_latch_unlatch_test.dart; do
+            integration_test/e2e/dm_oneway_latch_unlatch_test.dart \
+            integration_test/e2e/dm_history_drain_idle_pool_test.dart; do
             echo "── $suite"
             xvfb-run -a flutter test "$suite" --tags service -d linux
           done

--- a/mobile/integration_test/e2e/dm_history_drain_idle_pool_test.dart
+++ b/mobile/integration_test/e2e/dm_history_drain_idle_pool_test.dart
@@ -1,0 +1,214 @@
+// ABOUTME: End-to-end proof for #8550 against a real relay pool: a DM history
+// ABOUTME: drain issued into an idle-disconnected pool reconnects first instead
+// ABOUTME: of failing as "no relay answered", and a drain that had to defer
+// ABOUTME: resumes on its own once a relay connects — no Retry tap needed.
+
+@Tags(['service'])
+library;
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay_base.dart';
+import 'package:nostr_sdk/relay/relay_status.dart';
+import 'package:nostr_sdk/relay/web_socket_connection_manager.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../helpers/fake_relay.dart';
+
+/// Every URL the stack dials lands on the in-process relay, so the pool
+/// relay and the account's advertised inbox can share one public-looking
+/// hostname exactly as they do for a divine account in production.
+class _RedirectFactory implements WebSocketChannelFactory {
+  _RedirectFactory(this.port);
+
+  final int port;
+
+  @override
+  WebSocketChannel create(Uri uri) => WebSocketChannel.connect(
+    Uri.parse('ws://127.0.0.1:$port${uri.path}'),
+  );
+}
+
+/// The one relay in the pool, and the one relay the account's kind-10050
+/// advertises — the shape the drain's own-inbox temp relays take for every
+/// divine account, and the shape that defeated the reconnect-first guard.
+const _poolRelay = 'wss://pool.example';
+
+const _dmInboxKind = 10050;
+
+typedef _Stack = ({DmRepository repository, NostrClient client, Nostr nostr});
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const userKey =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+  final userPubkey = getPublicKey(userKey);
+
+  Map<String, dynamic> ownInbox() {
+    final event = Event(
+      userPubkey,
+      _dmInboxKind,
+      [
+        ['relay', _poolRelay],
+      ],
+      '',
+      createdAt: 1700000000,
+    )..sign(userKey);
+    return event.toJson();
+  }
+
+  Future<FakeRelay> startRelay({int port = 0}) => FakeRelay.start(
+    reply: ownInbox(),
+    replyForKinds: const {_dmInboxKind},
+    port: port,
+  );
+
+  Future<_Stack> buildStack(FakeRelay relay) async {
+    final factory = _RedirectFactory(relay.port);
+    final signer = LocalNostrSigner(userKey);
+
+    RelayBase gen(String url) =>
+        RelayBase(url, RelayStatus(url), channelFactory: factory);
+    final nostr = Nostr(signer, [], gen, channelFactory: factory);
+
+    final relayManager = RelayManager(
+      config: RelayManagerConfig(
+        defaultRelayUrl: _poolRelay,
+        storage: InMemoryRelayStorage(),
+        autoReconnect: false,
+        // The manager dials pool relays with its own factory, so the pool's
+        // public-looking URL needs the same redirect the temp relays get.
+        webSocketChannelFactory: factory,
+      ),
+      relayPool: nostr.relayPool,
+    );
+    final client = NostrClient.forTesting(
+      nostr: nostr,
+      relayManager: relayManager,
+    );
+
+    final db = AppDatabase.test(NativeDatabase.memory());
+    addTearDown(db.close);
+    SharedPreferences.setMockInitialValues(const <String, Object>{});
+
+    final repository = DmRepository(
+      nostrClient: client,
+      directMessagesDao: db.directMessagesDao,
+      conversationsDao: db.conversationsDao,
+      outgoingDmsDao: db.outgoingDmsDao,
+      userPubkey: userPubkey,
+      signer: signer,
+      syncState: DmSyncState(await SharedPreferences.getInstance()),
+      messageService: NIP17MessageService(
+        signer: signer,
+        senderPublicKey: userPubkey,
+        nostrService: client,
+      ),
+    );
+    addTearDown(repository.stopListening);
+    addTearDown(nostr.relayPool.removeAll);
+
+    await client.initialize();
+    return (repository: repository, client: client, nostr: nostr);
+  }
+
+  /// Polls [condition] on real time; integration tests run without a fake
+  /// clock, and the relay manager only re-reads pool state every few seconds.
+  Future<void> waitUntil(
+    bool Function() condition, {
+    required String reason,
+    Duration timeout = const Duration(seconds: 20),
+  }) async {
+    final deadline = DateTime.now().add(timeout);
+    while (!condition()) {
+      if (DateTime.now().isAfter(deadline)) fail('timed out: $reason');
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+  }
+
+  /// Brings the stack to the state the reporter's device was in: signed in,
+  /// the account's own inbox resolved and memoized while the pool was up,
+  /// and every pool socket since dropped by the SDK's idle timeout.
+  Future<void> idleOutThePool(_Stack stack) async {
+    await waitUntil(
+      () => stack.client.connectedRelayCount == 1,
+      reason: 'the pool relay never connected',
+    );
+    await stack.repository.startListening();
+    // The idle timeout drops the socket exactly like this: state
+    // disconnected, and no reconnect scheduled by anyone.
+    for (final url in stack.client.configuredRelays) {
+      await stack.nostr.relayPool.getRelay(url)?.disconnect();
+    }
+    await waitUntil(
+      () => stack.client.connectedRelayCount == 0,
+      reason: 'the relay manager never noticed the dropped socket',
+    );
+  }
+
+  group('#8550 DM history drain against an idle pool', () {
+    testWidgets(
+      'a drain issued into an idle-disconnected pool reconnects first and '
+      'completes instead of failing as "no relay answered"',
+      (tester) async {
+        final relay = await startRelay();
+        addTearDown(relay.stop);
+        final stack = await buildStack(relay);
+        await idleOutThePool(stack);
+
+        await stack.repository.backfillHistoryIfNeeded();
+
+        expect(
+          stack.repository.isHistoryRecoveryComplete,
+          isTrue,
+          reason:
+              'the page must bring the pool back before fanning out, not '
+              'read a fan-out nobody took as a deferral',
+        );
+        expect(stack.client.connectedRelayCount, 1);
+      },
+    );
+
+    testWidgets(
+      'a drain deferred while the relay was unreachable resumes on its own '
+      'once the relay connects, without another inbox open or Retry',
+      (tester) async {
+        final relay = await startRelay();
+        final stack = await buildStack(relay);
+        await idleOutThePool(stack);
+        final port = relay.port;
+        // Not merely idle: the relay is gone, so the reconnect the page
+        // attempts cannot help and the drain has to defer.
+        await relay.stop();
+
+        await stack.repository.backfillHistoryIfNeeded();
+        expect(
+          stack.repository.isHistoryRecoveryComplete,
+          isFalse,
+          reason: 'nothing could answer while the relay was down',
+        );
+
+        final revived = await startRelay(port: port);
+        addTearDown(revived.stop);
+        // What the app's next reconnect sweep, or a resume from background,
+        // does for the pool.
+        await stack.client.retryDisconnectedRelays();
+
+        await waitUntil(
+          () => stack.repository.isHistoryRecoveryComplete,
+          reason: 'the deferred drain never resumed after the relay connected',
+        );
+      },
+    );
+  });
+}

--- a/mobile/integration_test/helpers/fake_relay.dart
+++ b/mobile/integration_test/helpers/fake_relay.dart
@@ -23,14 +23,18 @@ class FakeRelay {
   FakeRelay._(
     this._server,
     this.reply,
+    this.replyForKinds,
     this.okConfirms,
     this.broadcast,
     this.stallReqForKinds,
   );
 
-  /// Starts a relay on an ephemeral loopback port.
+  /// Starts a relay on a loopback port — ephemeral unless [port] is given.
   ///
   /// [reply] is the event served for any `REQ`; null answers `EOSE` only.
+  /// [replyForKinds] narrows that to `REQ` frames naming one of those kinds,
+  /// so a relay can hand back a kind-10050 to the inbox lookup while every
+  /// other subscription still reads as empty.
   /// Set [okConfirms] false to model a relay that accepts the frame but never
   /// confirms it. Set [broadcast] true to fan a published `EVENT` out to every
   /// other open subscription — off by default so existing tests, which assert
@@ -40,16 +44,22 @@ class FakeRelay {
   /// `queryEventsDetailed` report `timedOut` — an `EOSE` is a conclusive
   /// "nothing here", so a relay answering EOSE cannot stand in for one that
   /// could not be read.
+  /// Pass a stopped relay's [FakeRelay.port] as [port] to bring "the same
+  /// relay" back, which is what a client that remembers the URL sees when a
+  /// relay recovers.
   static Future<FakeRelay> start({
     Map<String, dynamic>? reply,
+    Set<int> replyForKinds = const <int>{},
     bool okConfirms = true,
     bool broadcast = false,
     Set<int> stallReqForKinds = const <int>{},
+    int port = 0,
   }) async {
-    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
     final relay = FakeRelay._(
       server,
       reply,
+      replyForKinds,
       okConfirms,
       broadcast,
       stallReqForKinds,
@@ -67,6 +77,9 @@ class FakeRelay {
   /// records what it is handed but does not serve it, so "publish, then open a
   /// cold session that loads it" has to be staged explicitly.
   Map<String, dynamic>? reply;
+
+  /// Kinds whose `REQ` is answered with [reply]; empty means every `REQ`.
+  final Set<int> replyForKinds;
 
   /// Whether an inbound `EVENT` is answered with `OK … true`.
   final bool okConfirms;
@@ -163,7 +176,7 @@ class FakeRelay {
           final subId = frame[1] as String;
           _subscriptions[socket]?.add(subId);
           if (_isStalled(frame)) return;
-          if (reply != null) {
+          if (reply != null && _wantsReply(frame)) {
             send(<dynamic>['EVENT', subId, reply]);
           }
           send(<dynamic>['EOSE', subId]);
@@ -182,14 +195,20 @@ class FakeRelay {
   }
 
   /// Whether this `REQ` frame names a kind in [stallReqForKinds].
-  bool _isStalled(List<dynamic> frame) {
-    if (stallReqForKinds.isEmpty) return false;
+  bool _isStalled(List<dynamic> frame) =>
+      stallReqForKinds.isNotEmpty && _namesAnyKind(frame, stallReqForKinds);
+
+  /// Whether [reply] is owed to this `REQ` frame; see [replyForKinds].
+  bool _wantsReply(List<dynamic> frame) =>
+      replyForKinds.isEmpty || _namesAnyKind(frame, replyForKinds);
+
+  bool _namesAnyKind(List<dynamic> frame, Set<int> wanted) {
     for (final filter in frame.skip(2)) {
       if (filter is! Map) continue;
       final kinds = filter['kinds'];
       if (kinds is! List) continue;
       for (final kind in kinds) {
-        if (kind is int && stallReqForKinds.contains(kind)) return true;
+        if (kind is int && wanted.contains(kind)) return true;
       }
     }
     return false;

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1934,13 +1934,14 @@ class DmRepository {
   /// and waits for "the next inbox open". But the inbox is already open,
   /// showing the restore-paused banner, and its Retry re-runs the drain
   /// against whatever the pool looks like at that instant — against an
-  /// idle-disconnected pool that is the same failure again. So mirror the
-  /// labeler and feed services: hold a one-shot listener on the relay status
-  /// stream and re-run the drain when a relay the deferral did not have
-  /// becomes connected. At most one listener is armed at a time, a new run
-  /// supersedes it, and teardown cancels it. A page-cap pause deliberately
-  /// does not arm one: that budget resumes on the next inbox open by design.
-  /// See #8550.
+  /// idle-disconnected pool that is the same failure again. Like the labeler
+  /// and feed services, this holds a one-shot relay-status listener, but uses
+  /// a finer trigger: it re-runs the drain when any relay the deferral did not
+  /// have becomes connected. A relay that repeatedly reconnects without
+  /// answering can therefore re-drive the bounded drain. At most one listener
+  /// is armed at a time, a new run supersedes it, and teardown cancels it. A
+  /// page-cap pause deliberately does not arm one: that budget resumes on the
+  /// next inbox open by design. See #8550.
   void _resumeDrainWhenRelayConnects(String pubkey, int generation) {
     unawaited(_drainRelayReadySubscription?.cancel());
     _drainRelayReadySubscription = null;

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -521,6 +521,12 @@ class DmRepository {
 
   StreamSubscription<Event>? _giftWrapSubscription;
   Timer? _reconnectTimer;
+
+  /// One-shot relay-status listener armed by a deferred history drain, so
+  /// the drain resumes when a relay connects instead of waiting for the next
+  /// inbox open. See [_resumeDrainWhenRelayConnects].
+  StreamSubscription<Map<String, RelayConnectionStatus>>?
+  _drainRelayReadySubscription;
   late bool _disposed = false;
 
   /// Guards against a double-subscribe race: [startListening] now awaits the
@@ -880,6 +886,8 @@ class DmRepository {
     _subscribing = false;
     _disposed = true;
     _eventLock = null;
+    unawaited(_drainRelayReadySubscription?.cancel());
+    _drainRelayReadySubscription = null;
     // Drop the in-flight history drain and decrypt-retry pass so the next
     // user can start fresh; the running loops bail on the _userPubkey change.
     _historyDrain = null;
@@ -1621,6 +1629,10 @@ class DmRepository {
     // drain on the stopListening() path, but a stop immediately followed by a
     // restart on this instance clears it again under an in-flight drain.
     final gen = _resetGeneration;
+    // A run in progress supersedes a resume armed by an earlier deferral; if
+    // this run defers too it arms a fresh one against the pool it saw.
+    unawaited(_drainRelayReadySubscription?.cancel());
+    _drainRelayReadySubscription = null;
     // One-time forced re-drain: installs that completed under an older,
     // buggy drain (pre-#5202) are stuck with historyDrainComplete=true while
     // the relay still holds unrecovered history. A drain-version bump clears
@@ -1760,6 +1772,7 @@ class DmRepository {
                 category: LogCategory.system,
               );
             }
+            _resumeDrainWhenRelayConnects(pubkey, gen);
             return;
           }
           reachedEnd = true;
@@ -1851,6 +1864,7 @@ class DmRepository {
             'completion to the next inbox open.',
             category: LogCategory.system,
           );
+          _resumeDrainWhenRelayConnects(pubkey, gen);
         }
       } else if (reachedEnd) {
         // Reached the end of what the answering relays hold, but an earlier
@@ -1863,6 +1877,7 @@ class DmRepository {
           'next inbox open.',
           category: LogCategory.system,
         );
+        _resumeDrainWhenRelayConnects(pubkey, gen);
       } else {
         // Page cap hit: leave historyDrainComplete unset and the cursor
         // persisted so the next inbox open resumes the remaining history
@@ -1912,6 +1927,54 @@ class DmRepository {
     }
   }
 
+  /// Resumes a deferred history drain once a relay that was not connected
+  /// when the drain gave up connects.
+  ///
+  /// Every relay-availability deferral leaves `historyDrainComplete` unset
+  /// and waits for "the next inbox open". But the inbox is already open,
+  /// showing the restore-paused banner, and its Retry re-runs the drain
+  /// against whatever the pool looks like at that instant — against an
+  /// idle-disconnected pool that is the same failure again. So mirror the
+  /// labeler and feed services: hold a one-shot listener on the relay status
+  /// stream and re-run the drain when a relay the deferral did not have
+  /// becomes connected. At most one listener is armed at a time, a new run
+  /// supersedes it, and teardown cancels it. A page-cap pause deliberately
+  /// does not arm one: that budget resumes on the next inbox open by design.
+  /// See #8550.
+  void _resumeDrainWhenRelayConnects(String pubkey, int generation) {
+    unawaited(_drainRelayReadySubscription?.cancel());
+    _drainRelayReadySubscription = null;
+    if (_ingestSessionEnded(pubkey, generation)) return;
+    final connectedAtDeferral = <String>{
+      for (final entry in _nostrClient.relayStatuses.entries)
+        if (entry.value.isConnected) entry.key,
+    };
+    Log.info(
+      'DM history drain for ${pubkeyForLogs(pubkey)} will resume when a relay '
+      'connects (connected now: ${connectedAtDeferral.length}/'
+      '${_nostrClient.configuredRelayCount})',
+      category: LogCategory.system,
+    );
+    _drainRelayReadySubscription = _nostrClient.relayStatusStream.listen((
+      statuses,
+    ) {
+      final newlyConnected = statuses.entries.any(
+        (entry) =>
+            entry.value.isConnected && !connectedAtDeferral.contains(entry.key),
+      );
+      if (!newlyConnected) return;
+      unawaited(_drainRelayReadySubscription?.cancel());
+      _drainRelayReadySubscription = null;
+      if (_ingestSessionEnded(pubkey, generation)) return;
+      Log.info(
+        'Resuming DM history drain for ${pubkeyForLogs(pubkey)} after a relay '
+        'connected',
+        category: LogCategory.system,
+      );
+      unawaited(backfillHistoryIfNeeded());
+    });
+  }
+
   /// Stops listening for incoming DMs and tears this repository down.
   ///
   /// This is the production disposal path — `dmRepositoryProvider` wires it to
@@ -1934,6 +1997,8 @@ class DmRepository {
     _resetGeneration++;
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
+    await _drainRelayReadySubscription?.cancel();
+    _drainRelayReadySubscription = null;
     // Drop the loop handles so a later startListening() starts a fresh pass
     // rather than re-awaiting a stale future, and reclaim the drain-scoped
     // decrypt isolate holding this user's key now rather than whenever the

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -6013,6 +6013,16 @@ void main() {
 
     group('backfillHistoryIfNeeded', () {
       setUp(stubReadCursorRowMatched);
+      // A deferred drain arms a relay-status listener (#8550). Default to a
+      // pool with nothing connected and a stream that never speaks, so the
+      // deferral tests below exercise the deferral itself; the resume tests
+      // swap in a controllable stream.
+      setUp(() {
+        when(() => mockNostrClient.relayStatuses).thenReturn(const {});
+        when(
+          () => mockNostrClient.relayStatusStream,
+        ).thenAnswer((_) => const Stream.empty());
+      });
 
       // Kind-5 deletions with no tags flow through _handleIncomingEvent
       // with zero decryption / DAO side effects, so they exercise the
@@ -7640,6 +7650,269 @@ void main() {
         await stop;
         await retry;
       });
+
+      // ---------------------------------------------------------------
+      // Relay-ready resume after a relay-availability deferral (#8550)
+      // ---------------------------------------------------------------
+
+      /// Routes the drain's relay-status reads through a stream the test
+      /// drives, with [connectedNow] as the pool at deferral time.
+      StreamController<Map<String, RelayConnectionStatus>> stubRelayStatus({
+        Map<String, RelayConnectionStatus> connectedNow = const {},
+      }) {
+        final controller =
+            StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+        addTearDown(controller.close);
+        when(() => mockNostrClient.relayStatuses).thenReturn(connectedNow);
+        when(
+          () => mockNostrClient.relayStatusStream,
+        ).thenAnswer((_) => controller.stream);
+        return controller;
+      }
+
+      Map<String, RelayConnectionStatus> connected(List<String> urls) => {
+        for (final url in urls) url: RelayConnectionStatus.connected(url),
+      };
+
+      /// Answers the first gift-wrap page as one nothing answered and every
+      /// later page (gift-wrap and NIP-04 alike) as authoritative and empty,
+      /// so a resumed run can complete.
+      void stubUnansweredThenExhausted() {
+        var giftWrapPages = 0;
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            useCache: any(named: 'useCache'),
+            tempRelays: any(named: 'tempRelays'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer((inv) async {
+          final filter =
+              (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                  .single;
+          if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
+            return answeredPage(const <Event>[]);
+          }
+          giftWrapPages++;
+          return giftWrapPages == 1
+              ? unansweredPage(noRelays: true)
+              : answeredPage(const <Event>[]);
+        });
+      }
+
+      _FakeDmSyncState armedSyncState() => _FakeDmSyncState()
+        ..oldestOverride = 100
+        ..drainVersionOverride = DmSyncState.currentDrainVersion;
+
+      /// Waits for the drain a relay-status emission started, without the
+      /// test itself invoking the drain: a test-side `backfillHistoryIfNeeded`
+      /// would run the recovery it is trying to prove happened on its own.
+      Future<void> untilMarkedComplete(_FakeDmSyncState syncState) async {
+        for (
+          var i = 0;
+          i < 200 && syncState.markedCompletePubkeys.isEmpty;
+          i++
+        ) {
+          await Future<void>.delayed(Duration.zero);
+        }
+      }
+
+      test(
+        'resumes on its own once a relay connects after a page no relay '
+        'answered (#8550)',
+        () async {
+          final relayStatus = stubRelayStatus();
+          stubUnansweredThenExhausted();
+          final syncState = armedSyncState();
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          expect(syncState.markedCompletePubkeys, isEmpty);
+          expect(
+            relayStatus.hasListener,
+            isTrue,
+            reason: 'a deferred drain must wait for a relay to connect',
+          );
+
+          relayStatus.add(connected(['wss://relay.example']));
+          await untilMarkedComplete(syncState);
+
+          expect(syncState.markedCompletePubkeys, [_validPubkeyA]);
+          expect(
+            relayStatus.hasListener,
+            isFalse,
+            reason: 'the resume is one-shot',
+          );
+        },
+      );
+
+      test(
+        'does not resume for a relay that was already connected when the '
+        'drain deferred',
+        () async {
+          final relayStatus = stubRelayStatus(
+            connectedNow: connected(['wss://a.example']),
+          );
+          stubUnansweredThenExhausted();
+          final syncState = armedSyncState();
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+          expect(relayStatus.hasListener, isTrue);
+
+          // The same relay reporting again is not new capacity.
+          relayStatus.add(connected(['wss://a.example']));
+          await pumpEventQueue();
+          expect(syncState.markedCompletePubkeys, isEmpty);
+          expect(relayStatus.hasListener, isTrue);
+
+          relayStatus.add(connected(['wss://a.example', 'wss://b.example']));
+          await untilMarkedComplete(syncState);
+          expect(syncState.markedCompletePubkeys, [_validPubkeyA]);
+        },
+      );
+
+      test(
+        'stops waiting for a relay once the repository is torn down',
+        () async {
+          final relayStatus = stubRelayStatus();
+          stubUnansweredThenExhausted();
+          final syncState = armedSyncState();
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+          expect(relayStatus.hasListener, isTrue);
+
+          await repository.stopListening();
+
+          expect(relayStatus.hasListener, isFalse);
+          relayStatus.add(connected(['wss://relay.example']));
+          await pumpEventQueue();
+          expect(syncState.markedCompletePubkeys, isEmpty);
+        },
+      );
+
+      test(
+        'resumes after a run in which not every relay settled a page',
+        () async {
+          final relayStatus = stubRelayStatus();
+          var giftWrapPages = 0;
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((inv) async {
+            final filter =
+                (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                    .single;
+            if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
+              return answeredPage(const <Event>[]);
+            }
+            giftWrapPages++;
+            // Run 1: one relay answered a page, another never did; the next
+            // page is authoritative and empty. Run 2: exhausted at once.
+            return giftWrapPages == 1
+                ? partialPage([deletion(500)])
+                : answeredPage(const <Event>[]);
+          });
+          final syncState = armedSyncState();
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          expect(syncState.markedCompletePubkeys, isEmpty);
+          expect(relayStatus.hasListener, isTrue);
+
+          relayStatus.add(connected(['wss://relay.example']));
+          await untilMarkedComplete(syncState);
+          expect(syncState.markedCompletePubkeys, [_validPubkeyA]);
+        },
+      );
+
+      test(
+        'resumes after outgoing NIP-04 recovery found no live relay',
+        () async {
+          final relayStatus = stubRelayStatus();
+          var nip04Pages = 0;
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((inv) async {
+            final filter =
+                (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                    .single;
+            // The drain's own kind-10050 inbox lookup has the same
+            // `authors`-only shape; only the kind-4 pass is under test.
+            if (filter.authors != null &&
+                (filter.kinds?.contains(EventKind.directMessage) ?? false)) {
+              nip04Pages++;
+              return nip04Pages == 1
+                  ? unansweredPage(noRelays: true)
+                  : answeredPage(const <Event>[]);
+            }
+            return answeredPage(const <Event>[]);
+          });
+          final syncState = armedSyncState();
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          expect(syncState.markedCompletePubkeys, isEmpty);
+          expect(relayStatus.hasListener, isTrue);
+
+          relayStatus.add(connected(['wss://relay.example']));
+          await untilMarkedComplete(syncState);
+          expect(syncState.markedCompletePubkeys, [_validPubkeyA]);
+        },
+      );
+
+      test(
+        'does not arm a relay-ready resume after a page-cap pause',
+        () async {
+          final relayStatus = stubRelayStatus();
+          // Every gift-wrap page carries one event below the cursor, so the run
+          // spends its whole page budget without reaching the end.
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((inv) async {
+            final filter =
+                (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                    .single;
+            if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
+              return answeredPage(const <Event>[]);
+            }
+            return answeredPage([deletion((filter.until ?? 1000) - 1)]);
+          });
+          final syncState = armedSyncState()..oldestOverride = 100000;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          expect(syncState.markedCompletePubkeys, isEmpty);
+          expect(
+            relayStatus.hasListener,
+            isFalse,
+            reason: 'a page-cap pause resumes on the next inbox open by design',
+          );
+        },
+      );
     });
 
     // -----------------------------------------------------------------

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -965,8 +965,21 @@ class NostrClient {
     // pool has finished connecting — would otherwise short-circuit to an
     // empty result (RelayPool completes immediately when no relay accepts
     // the REQ). Reconnect first, mirroring publish()/subscribe(). See #5202.
-    if (_relayManager.connectedRelays.isEmpty &&
-        (effectiveTempRelays == null || effectiveTempRelays.isEmpty)) {
+    //
+    // A temp relay outside the pool answers on its own socket, so a lookup
+    // that names one keeps its no-wait path. A temp relay that IS a pool
+    // member does not: RelayPool resolves it to the pooled relay object, and
+    // with the pool idled out (the SDK drops every socket after 90s of
+    // silence and nothing reconnects it unasked) nobody takes the REQ. The DM
+    // history drain dials the account's own kind-10050 inbox this way, and
+    // for a divine account that list is the pool itself — so every page it
+    // issued into an idle pool failed within milliseconds as "no relay
+    // answered", and the Retry that re-issued the same page could never
+    // recover. See #8550.
+    final canAnswerWithoutPool =
+        _relayManager.connectedRelays.isEmpty &&
+        _hasRelayOutsidePool(effectiveTempRelays);
+    if (_relayManager.connectedRelays.isEmpty && !canAnswerWithoutPool) {
       try {
         await retryDisconnectedRelays().timeout(remainingTimeout());
       } on TimeoutException {
@@ -979,8 +992,7 @@ class NostrClient {
     // see from here; the fan-out's own account of who took the REQ is folded
     // in below.
     final noConnectedRelays =
-        _relayManager.connectedRelays.isEmpty &&
-        (effectiveTempRelays == null || effectiveTempRelays.isEmpty);
+        _relayManager.connectedRelays.isEmpty && !canAnswerWithoutPool;
     final filtersJson = filters.map((f) => f.toJson()).toList();
     Future<({List<Event> events, bool timedOut, bool noRelaysParticipated})>
     runWebSocketQuery() => _nostr.queryEventsDetailed(
@@ -1444,6 +1456,21 @@ class NostrClient {
     if (relays == null) return null;
     final allowed = relays.where(_relayManager.isRelayAllowed).toList();
     return allowed.isEmpty ? null : allowed;
+  }
+
+  /// Whether [tempRelays] names at least one relay the pool does not own.
+  ///
+  /// Only such a relay can answer a fan-out while every pooled relay is
+  /// disconnected: `RelayPool` hands a temp address that matches a pool
+  /// member to the pooled relay object rather than opening a socket of its
+  /// own. Compared on normalized URLs, since the pool stores them that way
+  /// and a trailing slash must not make a pool member look like an outsider.
+  bool _hasRelayOutsidePool(List<String>? tempRelays) {
+    if (tempRelays == null || tempRelays.isEmpty) return false;
+    final pooled = _relayManager.configuredRelays.toSet();
+    return tempRelays.any(
+      (url) => !pooled.contains(normalizeRelayUrl(url) ?? url),
+    );
   }
 
   /// Removes a relay connection.

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -477,6 +477,9 @@ void main() {
         () async {
           when(() => mockRelayManager.connectedRelays).thenReturn([]);
           when(
+            () => mockRelayManager.configuredRelays,
+          ).thenReturn(['wss://relay.example.com']);
+          when(
             mockRelayManager.retryDisconnectedRelays,
           ).thenAnswer((_) async {});
           when(
@@ -495,6 +498,85 @@ void main() {
               Filter(kinds: const [1059]),
             ],
             tempRelays: const ['wss://temp.example.com'],
+            useCache: false,
+          );
+
+          verifyNever(mockRelayManager.retryDisconnectedRelays);
+        },
+      );
+
+      test(
+        'reconnects before querying when every tempRelay is a disconnected '
+        'pool relay (#8550)',
+        () async {
+          // The DM history drain dials the account's own kind-10050 inbox as
+          // tempRelays, and for a divine account that list names the pool's
+          // own relays. RelayPool resolves those to the pooled relay objects,
+          // so once the pool has idled out nobody can take the REQ: the
+          // tempRelays exemption must not skip the reconnect.
+          when(() => mockRelayManager.connectedRelays).thenReturn([]);
+          when(
+            () => mockRelayManager.configuredRelays,
+          ).thenReturn(['wss://relay.example.com']);
+          when(
+            mockRelayManager.retryDisconnectedRelays,
+          ).thenAnswer((_) async {});
+          when(
+            () => mockNostr.queryEvents(
+              any(),
+              id: any(named: 'id'),
+              tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              sendAfterAuth: any(named: 'sendAfterAuth'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => <Event>[]);
+
+          await client.queryEvents(
+            [
+              Filter(kinds: const [1059]),
+            ],
+            // Trailing slash: the pool membership check has to normalize.
+            tempRelays: const ['wss://relay.example.com/'],
+            useCache: false,
+          );
+
+          verify(mockRelayManager.retryDisconnectedRelays).called(1);
+        },
+      );
+
+      test(
+        'does not reconnect when a tempRelay lies outside the pool, even '
+        'with the pool disconnected',
+        () async {
+          // An outside relay can answer on its own connection, so a lookup
+          // that names one keeps today's no-wait path.
+          when(() => mockRelayManager.connectedRelays).thenReturn([]);
+          when(
+            () => mockRelayManager.configuredRelays,
+          ).thenReturn(['wss://relay.example.com']);
+          when(
+            mockRelayManager.retryDisconnectedRelays,
+          ).thenAnswer((_) async {});
+          when(
+            () => mockNostr.queryEvents(
+              any(),
+              id: any(named: 'id'),
+              tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              sendAfterAuth: any(named: 'sendAfterAuth'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => <Event>[]);
+
+          await client.queryEvents(
+            [
+              Filter(kinds: const [1059]),
+            ],
+            tempRelays: const [
+              'wss://relay.example.com',
+              'wss://temp.example.com',
+            ],
             useCache: false,
           );
 


### PR DESCRIPTION
## Problem

The Messages tab shows "Some chats haven't finished restoring" and tapping **Retry** does nothing. The banner is the DM history-drain gate: it stays up while the one-time history recovery has not marked itself complete, and Retry simply re-runs that recovery.

Reproduced end to end on the iOS simulator against production relays, on the exact commit the reporter's build was made from (`197088f85`, per the release provenance record for 1.0.22+855). What actually happens:

1. The relay SDK drops every pool socket after 90 seconds without traffic (`WebSocketConfig` heartbeat 30 s, idle timeout 90 s) and nothing reconnects them until some caller asks.
2. The history drain dials the account's own kind-10050 inbox relays as `tempRelays`. Since #8378 every account has that list, and for a Divine account it names the pool's own relays.
3. `NostrClient.queryEventsDetailed` skipped its reconnect-first step (#5202) whenever `tempRelays` was non-empty, assuming a temp relay answers on its own socket. A temp address that names a pool member is handed to the pooled relay object instead, so with the pool idle every page fanned out into three disconnected relays (`Disconnected, skipping reconnect (skipReconnect=true)` ×3), nobody took the REQ, and the drain deferred as "empty page that no relay answered" within 3–13 ms.
4. Retry re-issued the same page into the same dead pool and failed the same way (two taps, 3 ms each), and the deferred drain had no way to resume other than the next inbox open.

Positive control: backgrounding and foregrounding the app force-reconnects the pool, after which the same Retry completed the drain in 33 s (18 pages, 1,590 events) and the banner cleared. The relay-side rule that a page must be settled by every relay was not the blocker.

The issue's own hypothesis (the live DM subscription is never re-issued to relays that connect later) is not what happens: the pool re-sends every saved subscription on each reconnect (`autoSubscribe: re-sending N subscriptions`, `re-issuing N saved REQs`) and the DM subscription received EOSE from every relay after each of three reconnect cycles. Those lines are `dart:developer` logs that the support export does not capture, which is why a healthy session shows exactly one "Starting DM subscription" line.

## Fix

Three implementation/test commits, plus one review-clarification commit:

- **`nostr_client`** — run the bounded reconnect sweep whenever the pool has no connected relay unless at least one temp relay lies outside the pool. Lookups that name an outside relay (indexers, a peer's inbox) keep today's no-wait path; a pooled-only fan-out stops being issued into a dead pool.
- **`dm_repository`** — a drain that defers for relay availability (a page no relay answered, a page not every relay settled, an outgoing-NIP-04 pass with no live relay) arms a one-shot listener on the relay status stream and re-runs itself once a relay that was not connected at deferral time connects. A new run supersedes the listener, teardown and account switch cancel it, and a page-cap pause deliberately does not arm one (that budget resumes on the next inbox open by design).

## Deliberately left alone

- The completeness rule (`requireAllRelaysSettled` on every drain page) is unchanged.
- The relay list is unchanged. `relay.damus.io` refused the WebSocket upgrade with HTTP 503 on every probe today; it is one of the four `safeFallbackRelays`, so one pool slot is dead in practice. Noted here, not changed.
- The over-long subscription ids that nos.lol and relay.primal.net reject are tracked in #8430.
- No bloc change: Retry already re-runs both recovery passes, pinned by the existing `ConversationListRestoreRetryRequested` test.

## Verification

- `nostr_client`: two new tests (pooled-only temp relays reconnect first; an outside temp relay keeps the no-wait path); 203/203 green.
- `dm_repository`: six new leaf tests in `backfillHistoryIfNeeded` covering resume after each deferral kind, one-shot firing, ignoring relays already connected at deferral time, teardown cancelling the wait, and no re-arm after a page cap; 453/453 green.
- New service-lane integration test `dm_history_drain_idle_pool_test.dart` against a real relay pool and the in-process `FakeRelay`: an idle-disconnected pool reconnects first and the drain completes; a drain deferred while the relay was unreachable resumes on its own when the relay comes back. `FakeRelay` gained `replyForKinds` and a fixed `port` for the restart; the suite is added to the CI list.
- CI-only ratchets run locally: shared-setup stubs, ungrouped tests, placeholder tests, pubkey log encoding, Nostr id truncation, uncancellable timer waits, skip ceiling, post-close emit — all pass.
- `flutter analyze` clean after rebasing onto current `main`.
- Rebased package suites: `nostr_client` 203/203 and `dm_repository` 453/453 green.
- Service integration test: both cases pass locally on macOS; CI runs the authoritative Linux lane.

Refs #8550
