### PR TITLE
fix(follow): order the contact list by created_at, not by p-tag count

### DIFF
--- a/.agents/skills/nostr-replaceable-event-mutation-overwrite/SKILL.md
+++ b/.agents/skills/nostr-replaceable-event-mutation-overwrite/SKILL.md
@@ -10,7 +10,7 @@ description: |
   client using React, Flutter, or similar reactive frameworks where query state may not be loaded
   when a mutation fires.
 author: Claude Code
-version: 1.0.0
+version: 1.1.0
 date: 2026-03-23
 ---
 
@@ -61,15 +61,24 @@ mutationFn: async ({ targetPubkey, currentContactList }) => {
       .sort((a, b) => b.created_at - a.created_at)[0] || null;
 
     if (relayContactList) {
-      // Use whichever has more data to prevent loss
-      const relayCount = relayContactList.tags.filter(t => t[0] === 'p').length;
-      const passedCount = currentContactList?.tags.filter(t => t[0] === 'p').length ?? 0;
-      if (relayCount >= passedCount) {
+      // NIP-01 already fixes which copy of a replaceable event wins:
+      // the higher created_at, and on an exact tie the lower event id.
+      // Never compare tag counts — a shorter list is what a legitimate
+      // unfollow produces.
+      const passed = currentContactList;
+      const isNewer =
+        !passed ||
+        relayContactList.created_at > passed.created_at ||
+        (relayContactList.created_at === passed.created_at &&
+          relayContactList.id < passed.id);
+      if (isNewer) {
         bestContactList = relayContactList;
       }
     }
   } catch {
-    // Fall back to passed contact list
+    // The read failed. It cannot be told apart from "the relay holds
+    // nothing", so refuse to publish rather than replacing from a guess.
+    throw new Error('Could not confirm the current list. Please try again.');
   }
 
   if (!bestContactList) {
@@ -80,13 +89,24 @@ mutationFn: async ({ targetPubkey, currentContactList }) => {
 }
 ```
 
-### 2. "Best of Both" Strategy
+### 2. Newest Wins, Per NIP-01
 
-Compare the relay's version against the UI's cached version and use whichever has MORE data
-(more tags, more fields, etc.). This protects against:
-- Stale relay (UI cache is newer from a recent local action)
-- Stale UI cache (relay has updates from another client)
-- Null UI cache (query hasn't loaded on fresh session)
+Order the relay's version against the cached one by `created_at`, and on an exact tie by
+the lower event id. That is the rule relays themselves apply, so it is the only choice
+that converges.
+
+**Do not compare tag counts.** "Use whichever has MORE data" looks safe and is not: the
+newer, authoritative list is *shorter* whenever the user removed someone, so preferring
+the longer copy silently resurrects every unfollow, unmuted account, or deleted relay —
+and republishes it. The heuristic cannot tell "this copy is stale" from "the user removed
+something", because those two produce the identical shape.
+
+A source that carries no timestamp at all — a bare cached array, a derived REST index —
+has unknowable freshness, not old freshness. It may seed an empty state, but it must lose
+to any copy that can name a `created_at`.
+
+Worked example, including the persistence migration that gives the local cache a
+timestamp to be ordered by: divinevideo/divine-mobile#8266.
 
 ### 3. Refuse to Publish on Total Failure
 
@@ -101,10 +121,19 @@ update AND clear profile fields). The unfollow path is just as dangerous as foll
 
 ## Verification
 
+Cold-start overwrite:
+
 1. Open the app in a private/incognito browser window
 2. Log in with an account that has multiple follows
 3. Navigate to a profile and tap Follow IMMEDIATELY (before the page fully loads)
 4. Check that the follow count increased by 1 (not reset to 1)
+
+Cross-device removal — the case a tag-count heuristic passes and still corrupts:
+
+5. On a second client, unfollow two of several accounts
+6. Cold-start the first client and confirm the removals are still gone
+7. Follow one new account there, then read the relay's kind 3 back and confirm
+   the two removed accounts did not reappear in its `p` tags
 
 ## Example
 

--- a/.claude/skills/nostr-replaceable-event-mutation-overwrite/SKILL.md
+++ b/.claude/skills/nostr-replaceable-event-mutation-overwrite/SKILL.md
@@ -10,7 +10,7 @@ description: |
   client using React, Flutter, or similar reactive frameworks where query state may not be loaded
   when a mutation fires.
 author: Claude Code
-version: 1.0.0
+version: 1.1.0
 date: 2026-03-23
 ---
 
@@ -61,15 +61,24 @@ mutationFn: async ({ targetPubkey, currentContactList }) => {
       .sort((a, b) => b.created_at - a.created_at)[0] || null;
 
     if (relayContactList) {
-      // Use whichever has more data to prevent loss
-      const relayCount = relayContactList.tags.filter(t => t[0] === 'p').length;
-      const passedCount = currentContactList?.tags.filter(t => t[0] === 'p').length ?? 0;
-      if (relayCount >= passedCount) {
+      // NIP-01 already fixes which copy of a replaceable event wins:
+      // the higher created_at, and on an exact tie the lower event id.
+      // Never compare tag counts — a shorter list is what a legitimate
+      // unfollow produces.
+      const passed = currentContactList;
+      const isNewer =
+        !passed ||
+        relayContactList.created_at > passed.created_at ||
+        (relayContactList.created_at === passed.created_at &&
+          relayContactList.id < passed.id);
+      if (isNewer) {
         bestContactList = relayContactList;
       }
     }
   } catch {
-    // Fall back to passed contact list
+    // The read failed. It cannot be told apart from "the relay holds
+    // nothing", so refuse to publish rather than replacing from a guess.
+    throw new Error('Could not confirm the current list. Please try again.');
   }
 
   if (!bestContactList) {
@@ -80,13 +89,24 @@ mutationFn: async ({ targetPubkey, currentContactList }) => {
 }
 ```
 
-### 2. "Best of Both" Strategy
+### 2. Newest Wins, Per NIP-01
 
-Compare the relay's version against the UI's cached version and use whichever has MORE data
-(more tags, more fields, etc.). This protects against:
-- Stale relay (UI cache is newer from a recent local action)
-- Stale UI cache (relay has updates from another client)
-- Null UI cache (query hasn't loaded on fresh session)
+Order the relay's version against the cached one by `created_at`, and on an exact tie by
+the lower event id. That is the rule relays themselves apply, so it is the only choice
+that converges.
+
+**Do not compare tag counts.** "Use whichever has MORE data" looks safe and is not: the
+newer, authoritative list is *shorter* whenever the user removed someone, so preferring
+the longer copy silently resurrects every unfollow, unmuted account, or deleted relay —
+and republishes it. The heuristic cannot tell "this copy is stale" from "the user removed
+something", because those two produce the identical shape.
+
+A source that carries no timestamp at all — a bare cached array, a derived REST index —
+has unknowable freshness, not old freshness. It may seed an empty state, but it must lose
+to any copy that can name a `created_at`.
+
+Worked example, including the persistence migration that gives the local cache a
+timestamp to be ordered by: divinevideo/divine-mobile#8266.
 
 ### 3. Refuse to Publish on Total Failure
 
@@ -101,10 +121,19 @@ update AND clear profile fields). The unfollow path is just as dangerous as foll
 
 ## Verification
 
+Cold-start overwrite:
+
 1. Open the app in a private/incognito browser window
 2. Log in with an account that has multiple follows
 3. Navigate to a profile and tap Follow IMMEDIATELY (before the page fully loads)
 4. Check that the follow count increased by 1 (not reset to 1)
+
+Cross-device removal — the case a tag-count heuristic passes and still corrupts:
+
+5. On a second client, unfollow two of several accounts
+6. Cold-start the first client and confirm the removals are still gone
+7. Follow one new account there, then read the relay's kind 3 back and confirm
+   the two removed accounts did not reappear in its `p` tags
 
 ## Example
 

--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -63,8 +63,8 @@ jobs:
       #
       # The list is explicit rather than a glob over integration_test/e2e/,
       # because `service` and "runnable on a Linux CI runner" are different
-      # axes. Every suite in that directory is tagged `service`; these ten
-      # are the ones this runner can actually execute. The remaining four are
+      # axes. Every suite in that directory is tagged `service`; these eleven
+      # are the ones this runner can actually execute. The remaining five are
       # excluded for reasons no workflow change can fix:
       #
       #   c2pa_init                         — c2pa_flutter ships android/ and
@@ -72,6 +72,11 @@ jobs:
       #   video_creation_flow               — needs the invite service.
       #   deleted_video_visible_to_others   — needs the full stack.
       #   dm_optimistic_survives_watch_race — needs the full stack.
+      #   contact_list_freshness_docker     — needs the full stack. It is the
+      #                                       real-relay twin of
+      #                                       contact_list_freshness, which is
+      #                                       in the list above; run it locally
+      #                                       against local_stack.
       #
       # local_stack cannot start on a GitHub runner at all:
       # divine-invite-darshan:e2e is a private GHCR package, compose resolves
@@ -86,6 +91,7 @@ jobs:
             integration_test/e2e/dm_self_wrap_inbox_relays_test.dart \
             integration_test/e2e/reel_reply_retry_double_send_test.dart \
             integration_test/e2e/block_leaves_kind3_follow_test.dart \
+            integration_test/e2e/contact_list_freshness_test.dart \
             integration_test/e2e/dm_group_delete_for_everyone_test.dart \
             integration_test/e2e/dm_reaction_unreadable_inbox_test.dart \
             integration_test/e2e/dm_deletion_unreadable_inbox_test.dart \

--- a/mobile/integration_test/e2e/contact_list_freshness_docker_test.dart
+++ b/mobile/integration_test/e2e/contact_list_freshness_docker_test.dart
@@ -1,0 +1,285 @@
+// ABOUTME: #8266 against the real funnelcake relay in local_stack, not a fake.
+// ABOUTME: Proves the cross-device unfollow survives a cold start and is not
+// ABOUTME: republished, over a relay that really enforces NIP-01 replacement.
+// ABOUTME: Requires: local_stack up (funnelcake-relay on localhost:47777).
+
+@Tags(['service'])
+library;
+
+import 'dart:convert';
+
+import 'package:cache_sync/cache_sync.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/nip02/contact.dart';
+import 'package:nostr_sdk/nip02/contact_list.dart';
+import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay_base.dart';
+import 'package:nostr_sdk/relay/relay_status.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:openvine/models/environment_config.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+class _MemoryCacheDao implements CacheDao {
+  final Map<String, String> _entries = {};
+
+  @override
+  Future<String?> read(String key) async => _entries[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String payload,
+    Duration? ttl,
+  }) async => _entries[key] = payload;
+
+  @override
+  Future<void> delete(String key) async => _entries.remove(key);
+
+  @override
+  Future<void> deletePrefix(String prefix) async =>
+      _entries.removeWhere((key, _) => key.startsWith(prefix));
+
+  @override
+  Future<int> totalPayloadBytes() async =>
+      _entries.values.fold<int>(0, (sum, v) => sum + v.length);
+
+  @override
+  Future<void> evictOldest(int bytesToFree) async {
+    // Intentional no-op: a per-test map has no size limit to enforce.
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  // A physical device cannot reach the Mac's loopback, so the host is
+  // overridable: pass --dart-define=LOCAL_STACK_HOST=<mac LAN ip> when running
+  // on a device. The simulator and macOS keep the loopback default.
+  const hostOverride = String.fromEnvironment('LOCAL_STACK_HOST');
+  final relayHost = hostOverride.isEmpty ? localHost : hostOverride;
+  final relayUrl = 'ws://$relayHost:$localRelayPort';
+
+  // A fresh identity per run, so a previous run's kind 3 on the relay cannot
+  // decide this one. The relay really replaces kind 3 per pubkey, so reusing
+  // a key would carry state across runs.
+  final ownerKey = generatePrivateKey();
+  final owner = getPublicKey(ownerKey);
+  final alice = getPublicKey(generatePrivateKey());
+  final bob = getPublicKey(generatePrivateKey());
+  final carol = getPublicKey(generatePrivateKey());
+  final dave = getPublicKey(generatePrivateKey());
+
+  Future<NostrClient> buildClient() async {
+    RelayBase gen(String url) => RelayBase(url, RelayStatus(url));
+    final nostr = Nostr(LocalNostrSigner(ownerKey), [], gen);
+    final relayManager = RelayManager(
+      config: RelayManagerConfig(
+        defaultRelayUrl: relayUrl,
+        storage: InMemoryRelayStorage(),
+        autoReconnect: false,
+      ),
+      relayPool: nostr.relayPool,
+    );
+    final client = NostrClient.forTesting(
+      nostr: nostr,
+      relayManager: relayManager,
+    );
+    addTearDown(nostr.relayPool.removeAll);
+    await client.initialize();
+    return client;
+  }
+
+  /// [startupRelayReadAnswers] false models the one condition the repository
+  /// itself cannot distinguish: `_loadFromRelay` returns null for both "the
+  /// relay holds nothing" and "nobody answered", logging them identically as
+  /// *No kind 3 contact list found on relay*. A transient network at launch
+  /// puts a session there, and it is the window in which a wrong hydration
+  /// base is not corrected before the next follow republishes it.
+  ///
+  /// Everything else stays on the real relay — the publish, NIP-01
+  /// replacement, and the read-back.
+  Future<FollowRepository> buildRepository(
+    List<Event> personalEventCache, {
+    bool startupRelayReadAnswers = true,
+  }) async => FollowRepository(
+    nostrClient: await buildClient(),
+    indexerRelayUrls: const [],
+    isCacheInitialized: () => true,
+    getCachedEventsByKind: (kind) => kind == EventKind.contactList
+        ? (personalEventCache.toList()
+            ..sort((a, b) => b.createdAt.compareTo(a.createdAt)))
+        : const [],
+    cacheUserEvent: personalEventCache.add,
+    queryContactList: startupRelayReadAnswers
+        ? null
+        : ({
+            required Stream<Event> eventStream,
+            required String pubkey,
+            int fallbackTimeoutSeconds = 5,
+          }) async => null,
+  );
+
+  /// What the relay itself resolves the account's kind 3 to, read over a
+  /// separate socket so nothing in the client's own caches can answer.
+  Future<Event?> readRelayContactList() async {
+    final channel = WebSocketChannel.connect(Uri.parse(relayUrl));
+    await channel.ready;
+    const subId = 'freshness-probe';
+    Event? newest;
+    channel.sink.add(
+      jsonEncode([
+        'REQ',
+        subId,
+        {
+          'kinds': [EventKind.contactList],
+          'authors': [owner],
+        },
+      ]),
+    );
+    await for (final message in channel.stream.timeout(
+      const Duration(seconds: 15),
+    )) {
+      final frame = jsonDecode(message as String) as List<dynamic>;
+      if (frame[0] == 'EVENT' && frame[1] == subId) {
+        final event = Event.fromJson(frame[2] as Map<String, dynamic>);
+        if (newest == null || event.createdAt > newest.createdAt) {
+          newest = event;
+        }
+      } else if (frame[0] == 'EOSE' && frame[1] == subId) {
+        break;
+      }
+    }
+    channel.sink.add(jsonEncode(['CLOSE', subId]));
+    await channel.sink.close();
+    return newest;
+  }
+
+  List<String> followsOf(Event event) => [
+    for (final tag in event.tags)
+      if (tag.length > 1 && tag[0] == 'p') tag[1],
+  ];
+
+  /// Polls the relay until its kind 3 resolves to [expected].
+  ///
+  /// `sendContactList` returns once the frame is handed to the pool, and
+  /// funnelcake commits through ClickHouse, so a read taken straight after a
+  /// publish can still serve the previous version. That is a property of the
+  /// real stack — the in-process relay in the sibling suite answers
+  /// immediately and hides it.
+  Future<void> awaitRelayFollows(
+    List<String> expected, {
+    required String reason,
+  }) async {
+    final deadline = DateTime.now().add(const Duration(seconds: 30));
+    List<String>? last;
+    while (DateTime.now().isBefore(deadline)) {
+      final event = await readRelayContactList();
+      last = event == null ? null : followsOf(event);
+      if (last != null &&
+          last.length == expected.length &&
+          last.toSet().containsAll(expected)) {
+        return;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+    }
+    fail('$reason\nrelay still serves: $last\nexpected: $expected');
+  }
+
+  group('#8266 against the local_stack funnelcake relay', () {
+    testWidgets(
+      'a cross-device unfollow is not undone or republished',
+      (
+        tester,
+      ) async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        await CacheSync.init(dao: _MemoryCacheDao());
+
+        final personalEventCache = <Event>[];
+
+        // ── Device A: follow three accounts ──────────────────────────────
+        final deviceA = await buildRepository(personalEventCache);
+        await deviceA.initialize();
+        for (final target in [alice, bob, carol]) {
+          await deviceA.follow(target);
+          // Distinct created_at per cached event; PersonalEventCache orders on
+          // that field alone.
+          await Future<void>.delayed(const Duration(milliseconds: 1100));
+        }
+        expect(
+          deviceA.followingPubkeys,
+          unorderedEquals([alice, bob, carol]),
+          reason: 'positive control: three follows must reach device A',
+        );
+
+        await awaitRelayFollows(
+          [alice, bob, carol],
+          reason: 'positive control: the relay must hold all three follows',
+        );
+
+        // ── Device B: unfollow two ───────────────────────────────────────
+        await Future<void>.delayed(const Duration(seconds: 2));
+        final deviceB = await buildClient();
+        final remaining = ContactList()..add(Contact(publicKey: alice));
+        expect(
+          await deviceB.sendContactList(remaining, ''),
+          isNotNull,
+          reason: 'positive control: device B must reach the relay',
+        );
+
+        await awaitRelayFollows(
+          [alice],
+          reason: 'positive control: the relay must replace the kind 3',
+        );
+
+        // Let device A's live subscription apply it.
+        final deadline = DateTime.now().add(const Duration(seconds: 15));
+        while (deviceA.followingPubkeys.length != 1 &&
+            DateTime.now().isBefore(deadline)) {
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+        }
+        expect(
+          deviceA.followingPubkeys,
+          [alice],
+          reason:
+              'positive control: device A must see the cross-device '
+              'unfollow before the cold start is staged',
+        );
+        await deviceA.dispose();
+
+        // ── Cold start, with the startup relay read unanswered ───────────
+        final reopened = await buildRepository(
+          personalEventCache,
+          startupRelayReadAnswers: false,
+        );
+        addTearDown(reopened.dispose);
+        await reopened.initialize();
+
+        expect(
+          reopened.followingPubkeys,
+          [alice],
+          reason:
+              'the cached event is older and has more p tags; preferring it '
+              'undoes a legitimate unfollow (#8266)',
+        );
+
+        // ── The next follow must not resurrect them ──────────────────────
+        await reopened.follow(dave);
+
+        await awaitRelayFollows(
+          [alice, dave],
+          reason:
+              'bob and carol were unfollowed on device B; a follow must '
+              'not put them back on the relay',
+        );
+      },
+      timeout: const Timeout(Duration(minutes: 3)),
+    );
+  });
+}

--- a/mobile/integration_test/e2e/contact_list_freshness_test.dart
+++ b/mobile/integration_test/e2e/contact_list_freshness_test.dart
@@ -1,0 +1,292 @@
+// ABOUTME: #8266 — a cross-device unfollow must survive a cold start and must
+// ABOUTME: not be republished by the next follow. Drives the real
+// ABOUTME: FollowRepository + NostrClient over real sockets.
+// ABOUTME: Requires: NO Docker stack — the relay runs in-process.
+
+@Tags(['service'])
+library;
+
+import 'package:cache_sync/cache_sync.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/nip02/contact.dart';
+import 'package:nostr_sdk/nip02/contact_list.dart';
+import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay_base.dart';
+import 'package:nostr_sdk/relay/relay_status.dart';
+import 'package:nostr_sdk/relay/web_socket_connection_manager.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../helpers/fake_relay.dart';
+
+/// Sends every socket to the in-process relay, whatever host was asked for.
+class _LoopbackFactory implements WebSocketChannelFactory {
+  _LoopbackFactory(this.port);
+
+  final int port;
+
+  @override
+  WebSocketChannel create(Uri uri) =>
+      WebSocketChannel.connect(Uri.parse('ws://127.0.0.1:$port${uri.path}'));
+}
+
+class _MemoryCacheDao implements CacheDao {
+  final Map<String, String> _entries = {};
+
+  @override
+  Future<String?> read(String key) async => _entries[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String payload,
+    Duration? ttl,
+  }) async => _entries[key] = payload;
+
+  @override
+  Future<void> delete(String key) async => _entries.remove(key);
+
+  @override
+  Future<void> deletePrefix(String prefix) async =>
+      _entries.removeWhere((key, _) => key.startsWith(prefix));
+
+  @override
+  Future<int> totalPayloadBytes() async =>
+      _entries.values.fold<int>(0, (sum, v) => sum + v.length);
+
+  @override
+  Future<void> evictOldest(int bytesToFree) async {
+    // Intentional no-op: a per-test map has no size limit to enforce.
+  }
+}
+
+extension on FakeRelay {
+  List<Event> get publishedEvents => [
+    for (final frame in receivedFrames)
+      if (frame.isNotEmpty && frame[0] == 'EVENT' && frame.length >= 2)
+        Event.fromJson(frame[1] as Map<String, dynamic>),
+  ];
+
+  /// The `p` tags of the newest kind 3 the relay was handed — kind 3 is
+  /// replaceable, so this is what an external viewer resolves to.
+  List<String>? get publicFollows {
+    final contactLists = publishedEvents.where((e) => e.kind == 3).toList();
+    if (contactLists.isEmpty) return null;
+    contactLists.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    return [
+      for (final tag in contactLists.last.tags)
+        if (tag.length > 1 && tag[0] == 'p') tag[1],
+    ];
+  }
+
+  Future<void> awaitPublished(int kind, {int count = 1}) async {
+    final deadline = DateTime.now().add(const Duration(seconds: 10));
+    while (publishedEvents.where((e) => e.kind == kind).length < count) {
+      if (DateTime.now().isAfter(deadline)) {
+        throw StateError(
+          'relay never received $count event(s) of kind $kind; saw '
+          '${publishedEvents.map((e) => e.kind).toList()}',
+        );
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+    }
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const ownerKey =
+      '06478cf31821ae2643888988c5ce3f31731079dbe6c544f5b4451f3c7ce8979c';
+  const aliceKey =
+      '50dc4b2e01ef449822e422e8c625ddf7d95dc069c414f06d2450556bf5ba7179';
+  final alice = getPublicKey(aliceKey);
+  const bobKey =
+      '2f1a5c39b9e04d8f7c6b3a2e1d0f9876543210fedcba9876543210fedcba9871';
+  final bob = getPublicKey(bobKey);
+  const carolKey =
+      '3e2b6d4ac8f15e907d5c4b3f2e1a8765432109fedcba8765432109fedcba9872';
+  final carol = getPublicKey(carolKey);
+  const daveKey =
+      '4d3c7e5bd7e26fa16e4d5c2a3f0b9654321098fedcba7654321098fedcba9873';
+  final dave = getPublicKey(daveKey);
+
+  /// The real stack — Nostr -> RelayPool -> RelayManager -> NostrClient.
+  ///
+  /// Every socket lands on [relay]. [personalEventCache] stands in for the
+  /// Hive-backed PersonalEventCache: the repository appends its own published
+  /// kind 3 to it, exactly as the app wires `cacheUserEvent`, and reads it
+  /// back newest-first on the next launch.
+  Future<NostrClient> buildClient(FakeRelay relay) async {
+    final factory = _LoopbackFactory(relay.port);
+    RelayBase gen(String url) =>
+        RelayBase(url, RelayStatus(url), channelFactory: factory);
+    final nostr = Nostr(
+      LocalNostrSigner(ownerKey),
+      [],
+      gen,
+      channelFactory: factory,
+    );
+    final relayManager = RelayManager(
+      config: RelayManagerConfig(
+        defaultRelayUrl: relay.url,
+        storage: InMemoryRelayStorage(),
+        autoReconnect: false,
+      ),
+      relayPool: nostr.relayPool,
+    );
+    final client = NostrClient.forTesting(
+      nostr: nostr,
+      relayManager: relayManager,
+    );
+    addTearDown(nostr.relayPool.removeAll);
+    await client.initialize();
+    return client;
+  }
+
+  Future<FollowRepository> buildRepository(
+    FakeRelay relay,
+    List<Event> personalEventCache,
+  ) async => FollowRepository(
+    nostrClient: await buildClient(relay),
+    indexerRelayUrls: const [],
+    isCacheInitialized: () => true,
+    getCachedEventsByKind: (kind) => kind == EventKind.contactList
+        ? (personalEventCache.toList()
+            ..sort((a, b) => b.createdAt.compareTo(a.createdAt)))
+        : const [],
+    cacheUserEvent: personalEventCache.add,
+  );
+
+  /// A second device publishing a kind 3 for the same account.
+  Future<void> publishFromOtherDevice(
+    FakeRelay relay,
+    List<String> follows,
+  ) async {
+    final client = await buildClient(relay);
+    final list = ContactList();
+    for (final follow in follows) {
+      list.add(Contact(publicKey: follow));
+    }
+    final event = await client.sendContactList(list, '');
+    expect(event, isNotNull, reason: 'the other device must reach the relay');
+  }
+
+  group('#8266 contact-list freshness across devices', () {
+    /// Drives both devices until the divergent on-disk state exists, and
+    /// returns the PersonalEventCache contents a cold start would read.
+    ///
+    /// Device A follows three accounts, so its own three-follow kind 3 is the
+    /// newest thing in PersonalEventCache. Device B then unfollows two; that
+    /// event arrives over device A's live subscription, which writes
+    /// LocalStorage and never touches PersonalEventCache. So the cache is
+    /// older and longer than LocalStorage — the exact shape in which counting
+    /// `p` tags picks the wrong one.
+    Future<List<Event>> stageCrossDeviceUnfollow(FakeRelay relay) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      await CacheSync.init(dao: _MemoryCacheDao());
+
+      final personalEventCache = <Event>[];
+      final deviceA = await buildRepository(relay, personalEventCache);
+      await deviceA.initialize();
+
+      // A second apart each, so every cached kind 3 has a distinct
+      // `created_at`. PersonalEventCache orders purely by that field, so
+      // events sharing a second come back in an arbitrary order and the
+      // staging would be non-deterministic.
+      for (final target in [alice, bob, carol]) {
+        await deviceA.follow(target);
+        await Future<void>.delayed(const Duration(milliseconds: 1100));
+      }
+      await relay.awaitPublished(EventKind.contactList, count: 3);
+      expect(
+        deviceA.followingPubkeys,
+        unorderedEquals([alice, bob, carol]),
+        reason: 'positive control: device A must reach three follows first',
+      );
+      expect(
+        personalEventCache.where((e) => e.kind == EventKind.contactList),
+        isNotEmpty,
+        reason: 'positive control: device A caches its own kind 3',
+      );
+
+      // A second later so the cross-device event is unambiguously newer.
+      await Future<void>.delayed(const Duration(seconds: 2));
+      await publishFromOtherDevice(relay, [alice]);
+
+      final deadline = DateTime.now().add(const Duration(seconds: 10));
+      while (deviceA.followingPubkeys.length != 1) {
+        if (DateTime.now().isAfter(deadline)) break;
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+      }
+      expect(
+        deviceA.followingPubkeys,
+        [alice],
+        reason:
+            'positive control: the live subscription must apply the '
+            'cross-device unfollow before the cold start is staged',
+      );
+
+      await deviceA.dispose();
+      return personalEventCache;
+    }
+
+    testWidgets('the cross-device unfollow survives a cold start', (
+      tester,
+    ) async {
+      final relay = await FakeRelay.start(broadcast: true);
+      addTearDown(relay.stop);
+
+      final personalEventCache = await stageCrossDeviceUnfollow(relay);
+
+      // Cold start: same SharedPreferences, same PersonalEventCache.
+      final reopened = await buildRepository(relay, personalEventCache);
+      addTearDown(reopened.dispose);
+      await reopened.initialize();
+
+      expect(
+        reopened.followingPubkeys,
+        [alice],
+        reason:
+            'the cached event is older and has more p tags; preferring it '
+            'undoes a legitimate unfollow (#8266)',
+      );
+    });
+
+    testWidgets('the next follow does not republish the unfollowed accounts', (
+      tester,
+    ) async {
+      final relay = await FakeRelay.start(broadcast: true);
+      addTearDown(relay.stop);
+
+      final personalEventCache = await stageCrossDeviceUnfollow(relay);
+      final publishedBefore = relay.publishedEvents
+          .where((e) => e.kind == EventKind.contactList)
+          .length;
+
+      final reopened = await buildRepository(relay, personalEventCache);
+      addTearDown(reopened.dispose);
+      await reopened.initialize();
+      await reopened.follow(dave);
+      await relay.awaitPublished(
+        EventKind.contactList,
+        count: publishedBefore + 1,
+      );
+
+      expect(
+        relay.publicFollows,
+        unorderedEquals([alice, dave]),
+        reason:
+            'bob and carol were unfollowed on the other device; a follow '
+            'must not put them back on the relay',
+      );
+    });
+  });
+}

--- a/mobile/integration_test/e2e/contact_list_freshness_test.dart
+++ b/mobile/integration_test/e2e/contact_list_freshness_test.dart
@@ -238,55 +238,63 @@ void main() {
       return personalEventCache;
     }
 
-    testWidgets('the cross-device unfollow survives a cold start', (
-      tester,
-    ) async {
-      final relay = await FakeRelay.start(broadcast: true);
-      addTearDown(relay.stop);
+    testWidgets(
+      'the cross-device unfollow survives a cold start',
+      (
+        tester,
+      ) async {
+        final relay = await FakeRelay.start(broadcast: true);
+        addTearDown(relay.stop);
 
-      final personalEventCache = await stageCrossDeviceUnfollow(relay);
+        final personalEventCache = await stageCrossDeviceUnfollow(relay);
 
-      // Cold start: same SharedPreferences, same PersonalEventCache.
-      final reopened = await buildRepository(relay, personalEventCache);
-      addTearDown(reopened.dispose);
-      await reopened.initialize();
+        // Cold start: same SharedPreferences, same PersonalEventCache.
+        final reopened = await buildRepository(relay, personalEventCache);
+        addTearDown(reopened.dispose);
+        await reopened.initialize();
 
-      expect(
-        reopened.followingPubkeys,
-        [alice],
-        reason:
-            'the cached event is older and has more p tags; preferring it '
-            'undoes a legitimate unfollow (#8266)',
-      );
-    });
+        expect(
+          reopened.followingPubkeys,
+          [alice],
+          reason:
+              'the cached event is older and has more p tags; preferring it '
+              'undoes a legitimate unfollow (#8266)',
+        );
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
 
-    testWidgets('the next follow does not republish the unfollowed accounts', (
-      tester,
-    ) async {
-      final relay = await FakeRelay.start(broadcast: true);
-      addTearDown(relay.stop);
+    testWidgets(
+      'the next follow does not republish the unfollowed accounts',
+      (
+        tester,
+      ) async {
+        final relay = await FakeRelay.start(broadcast: true);
+        addTearDown(relay.stop);
 
-      final personalEventCache = await stageCrossDeviceUnfollow(relay);
-      final publishedBefore = relay.publishedEvents
-          .where((e) => e.kind == EventKind.contactList)
-          .length;
+        final personalEventCache = await stageCrossDeviceUnfollow(relay);
+        final publishedBefore = relay.publishedEvents
+            .where((e) => e.kind == EventKind.contactList)
+            .length;
 
-      final reopened = await buildRepository(relay, personalEventCache);
-      addTearDown(reopened.dispose);
-      await reopened.initialize();
-      await reopened.follow(dave);
-      await relay.awaitPublished(
-        EventKind.contactList,
-        count: publishedBefore + 1,
-      );
+        final reopened = await buildRepository(relay, personalEventCache);
+        addTearDown(reopened.dispose);
+        await reopened.initialize();
+        await reopened.follow(dave);
+        await relay.awaitPublished(
+          EventKind.contactList,
+          count: publishedBefore + 1,
+        );
 
-      expect(
-        relay.publicFollows,
-        unorderedEquals([alice, dave]),
-        reason:
-            'bob and carol were unfollowed on the other device; a follow '
-            'must not put them back on the relay',
-      );
-    });
+        expect(
+          relay.publicFollows,
+          unorderedEquals([alice, dave]),
+          reason:
+              'bob and carol were unfollowed on the other device; a follow '
+              'must not put them back on the relay',
+        );
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
   });
 }

--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -3,10 +3,10 @@
 // ABOUTME: account deletion, Zendesk and analytics identity sync (eager)
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:follow_repository/follow_repository.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
@@ -158,8 +158,11 @@ AuthService authService(Ref ref) {
           limit: 5000,
         );
         if (result.pubkeys.isNotEmpty) {
-          final key = 'following_list_$pubkeyHex';
-          await prefs.setString(key, jsonEncode(result.pubkeys));
+          final key = FollowingCacheRecord.storageKey(pubkeyHex);
+          await prefs.setString(
+            key,
+            FollowingCacheRecord(pubkeys: result.pubkeys).encode(),
+          );
           Log.info(
             'Pre-fetched ${result.pubkeys.length} following for '
             'router redirect cache',

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -376,7 +376,7 @@ final class AuthServiceProvider
   }
 }
 
-String _$authServiceHash() => r'0394ec667a3508db7c3bc2e57d4c83ba78dd0d6e';
+String _$authServiceHash() => r'055b50bbbde673a4ad007d5f538cadcddfd8260c';
 
 /// Provider that returns current auth state and rebuilds when it changes.
 /// Widgets should watch this instead of authService.authState directly

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -3,8 +3,6 @@
 // ABOUTME: bookmark, mute, dm, comments — plus CuratedListsState notifier
 
 import 'dart:async';
-import 'dart:convert';
-
 import 'package:badge_repository/badge_repository.dart';
 import 'package:bookmarks_repository/bookmarks_repository.dart';
 import 'package:categories_repository/categories_repository.dart';
@@ -69,10 +67,7 @@ final badgeRepositoryProvider = Provider<BadgeRepository>((ref) {
 
 final FutureProviderFamily<List<ProfileBadgeViewData>, String>
 profileAcceptedBadgesProvider = FutureProvider.autoDispose
-    .family<List<ProfileBadgeViewData>, String>((
-      ref,
-      pubkey,
-    ) {
+    .family<List<ProfileBadgeViewData>, String>((ref, pubkey) {
       if (pubkey.isEmpty) return const [];
       return ref
           .watch(badgeRepositoryProvider)
@@ -91,13 +86,12 @@ List<String> cachedFollowingList(Ref ref) {
   if (pubkey == null || pubkey.isEmpty) return const [];
 
   final prefs = ref.watch(sharedPreferencesProvider);
-  final key = 'following_list_$pubkey';
+  final key = FollowingCacheRecord.storageKey(pubkey);
   final cached = prefs.getString(key);
   if (cached == null) return const [];
 
   try {
-    final decoded = jsonDecode(cached) as List<dynamic>;
-    return decoded.cast<String>();
+    return FollowingCacheRecord.decode(cached).pubkeys;
   } catch (e) {
     return const [];
   }
@@ -305,9 +299,7 @@ HashtagRepository hashtagRepository(Ref ref) {
 
       addMatches(hashtagService.searchHashtags(query));
       if (results.length < limit) {
-        addMatches(
-          topHashtags.searchHashtags(query, limit: limit),
-        );
+        addMatches(topHashtags.searchHashtags(query, limit: limit));
       }
 
       return results;

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -65,7 +65,7 @@ final class CachedFollowingListProvider
 }
 
 String _$cachedFollowingListHash() =>
-    r'9aae18333a2883db193f61b69a4d12a5e58899ac';
+    r'45bc25e8c158362536dd5373b4f70bbbfae54a83';
 
 /// Provider for FollowRepository instance
 ///

--- a/mobile/lib/router/providers/redirect_provider.dart
+++ b/mobile/lib/router/providers/redirect_provider.dart
@@ -1,10 +1,9 @@
 // ABOUTME: Riverpod providers for route redirect guards
 // ABOUTME: Checks following cache for redirect logic
 
-import 'dart:convert';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
+import 'package:follow_repository/follow_repository.dart';
 import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/route_paths.dart';
@@ -34,7 +33,7 @@ final hasFollowingInCacheProvider = Provider<bool>((ref) {
     return false;
   }
 
-  final key = 'following_list_$currentUserPubkey';
+  final key = FollowingCacheRecord.storageKey(currentUserPubkey);
   final value = prefs.getString(key);
 
   if (value == null || value.isEmpty) {
@@ -47,13 +46,13 @@ final hasFollowingInCacheProvider = Provider<bool>((ref) {
   }
 
   try {
-    final decoded = jsonDecode(value) as List<dynamic>;
+    final record = FollowingCacheRecord.decode(value);
     Log.debug(
-      'Current user following list has ${decoded.length} entries',
+      'Current user following list has ${record.pubkeys.length} entries',
       name: 'RedirectGuards',
       category: LogCategory.ui,
     );
-    return decoded.isNotEmpty;
+    return record.pubkeys.isNotEmpty;
   } catch (e) {
     Log.debug(
       'Current user following list has invalid JSON: $e',

--- a/mobile/packages/follow_repository/lib/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/follow_repository.dart
@@ -12,4 +12,5 @@ export 'src/follow_repository.dart';
 export 'src/follow_sort_order.dart';
 export 'src/follower_stats.dart';
 export 'src/followers_snapshot.dart';
+export 'src/following_cache_record.dart';
 export 'src/following_snapshot.dart';

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -2812,11 +2812,10 @@ class FollowRepository {
   /// That is a publish-boundary property, not a durable one. The filtered
   /// event is what relays hold from then on, so the next [initialize] reads
   /// it back and [_processContactListEvent] replaces the local list with it
-  /// — a filtered list is a strict subset, so the catastrophic-reduction
-  /// guard correctly declines to merge. In practice the follow survives
-  /// locally for the rest of the session that blocked, and is gone after
-  /// the next launch. Whether it should be restorable at all is open with
-  /// T&S (#6903).
+  /// — the newest event is adopted wholesale, so the filtered list stands.
+  /// In practice the follow survives locally for the rest of the session
+  /// that blocked, and is gone after the next launch. Whether it should be
+  /// restorable at all is open with T&S (#6903).
   List<String> _publishableFollows() {
     final blocked = _blockedPubkeys?.call(_nostrClient.publicKey);
     if (blocked == null || blocked.isEmpty) return _followingPubkeys;

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -314,6 +314,20 @@ class FollowRepository {
     return eventId.compareTo(incumbentId) < 0;
   }
 
+  /// Remember [event] when it is the newest kind 3 seen so far.
+  ///
+  /// Deliberately independent of whether its *list* was adopted. Those are
+  /// two questions: which copy is authoritative, and where `content` comes
+  /// from. When a source already names the event the relay returns there is
+  /// no list to adopt, but `content` must still come from it — NIP-02 puts
+  /// the user's relay list there, and publishing `''` over it is #8265.
+  void _rememberContactListEvent(Event event) {
+    _currentUserContactListEvent = _pickBestContactList(
+      _currentUserContactListEvent,
+      event,
+    );
+  }
+
   /// Extract the `p`-tagged pubkeys of a kind 3 event.
   List<String> _followsOf(Event event, {required String source}) =>
       _sanitizePubkeys(
@@ -2386,16 +2400,13 @@ class FollowRepository {
           .fold<Event?>(null, _pickBestContactList);
       if (latestContactList == null) return;
 
-      final adopted = _adoptContactList(
+      _rememberContactListEvent(latestContactList);
+      _adoptContactList(
         _followsOf(latestContactList, source: 'PersonalEventCache'),
         createdAt: latestContactList.createdAt,
         eventId: latestContactList.id,
         source: 'PersonalEventCache',
       );
-
-      if (adopted) {
-        _currentUserContactListEvent = latestContactList;
-      }
     } catch (e) {
       Log.error(
         'Failed to load from PersonalEventCache: $e',
@@ -2868,6 +2879,8 @@ class FollowRepository {
     }
 
     if (newest != null) {
+      _rememberContactListEvent(newest);
+
       // Adopt what the relay holds as the base to publish from, then put the
       // pending local change back on top. Reading the authoritative event and
       // using it only for `content` is what let a stale hydration republish
@@ -2880,7 +2893,6 @@ class FollowRepository {
         eventId: newest.id,
         source: 'pre-publish read',
       )) {
-        _currentUserContactListEvent = newest;
         _applyPendingLocalChange(pending);
       }
     }
@@ -3031,9 +3043,9 @@ class FollowRepository {
       eventId: event.id,
       source: 'network Kind 3 event ${event.id}',
     );
+    _rememberContactListEvent(event);
     if (!adopted) return;
 
-    _currentUserContactListEvent = event;
     unawaited(_saveToLocalStorage());
     unawaited(_invalidateMyFollowingCache());
   }

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -230,6 +230,100 @@ class FollowRepository {
   List<String> _followingPubkeys = [];
   Event? _currentUserContactListEvent;
 
+  // ── Contact-list freshness (NIP-01) ──────────────────────────────────
+  //
+  // Kind 3 is replaceable, so NIP-01 already fixes which of two copies is
+  // authoritative: the higher `created_at`, and on an exact tie the lower
+  // event id. Nothing about the number of `p` tags enters that rule, and it
+  // cannot: a shorter list is what a legitimate unfollow produces, so
+  // "whichever has more follows wins" resurrects every removal made on
+  // another device (#8266).
+  //
+  // Two of this repository's five sources cannot state a `created_at` at all
+  // — the legacy bare-array cache written before this record existed, and the
+  // funnelcake REST index, which is derived and lags. Their freshness is
+  // unknowable rather than old, so they seed an empty state and lose to any
+  // source that can name a timestamp.
+
+  /// Where the list currently in [_followingPubkeys] came from, for ordering.
+  ///
+  /// `null` means nothing has been adopted yet. A non-null record with a
+  /// `createdAt` of `null` means the source carried no timestamp.
+  ({int? createdAt, String? id})? _followingProvenance;
+
+  /// The list exactly as adopted, before any local follow/unfollow was
+  /// applied on top. [_broadcastContactList] diffs [_followingPubkeys]
+  /// against this to know what the pending local change actually is.
+  List<String> _adoptedFollows = const [];
+
+  /// Adopt [pubkeys] when [createdAt] makes its source the newest one seen.
+  ///
+  /// Returns whether the list was adopted. [createdAt] `null` means the source
+  /// carries no timestamp; such a source can seed an empty state but never
+  /// displace one that has a timestamp.
+  bool _adoptContactList(
+    List<String> pubkeys, {
+    required int? createdAt,
+    required String source,
+    String? eventId,
+  }) {
+    final incumbent = _followingProvenance;
+
+    if (incumbent != null && !_isNewer(createdAt, eventId, incumbent)) {
+      Log.debug(
+        'Keeping the contact list already loaded '
+        '(created_at ${incumbent.createdAt ?? 'unknown'}) over $source '
+        '(created_at ${createdAt ?? 'unknown'})',
+        name: 'FollowRepository',
+        category: LogCategory.system,
+      );
+      return false;
+    }
+
+    _followingPubkeys = pubkeys;
+    _adoptedFollows = List<String>.from(pubkeys);
+    _followingProvenance = (createdAt: createdAt, id: eventId);
+    _emitFollowingList();
+
+    Log.info(
+      'Adopted contact list from $source: ${pubkeys.length} following '
+      '(created_at ${createdAt ?? 'unknown'})',
+      name: 'FollowRepository',
+      category: LogCategory.system,
+    );
+    return true;
+  }
+
+  /// NIP-01's ordering for replaceable events, with "no timestamp" ranked
+  /// below every real one.
+  static bool _isNewer(
+    int? createdAt,
+    String? eventId,
+    ({int? createdAt, String? id}) incumbent,
+  ) {
+    if (createdAt == null) return false;
+    final incumbentCreatedAt = incumbent.createdAt;
+    if (incumbentCreatedAt == null) return true;
+    if (createdAt != incumbentCreatedAt) return createdAt > incumbentCreatedAt;
+
+    // Same second. NIP-01: "the event with the lowest id (first in lexical
+    // order) should be retained". Only decidable when both ids are known;
+    // otherwise the incumbent stands.
+    final incumbentId = incumbent.id;
+    if (eventId == null || incumbentId == null) return false;
+    return eventId.compareTo(incumbentId) < 0;
+  }
+
+  /// Extract the `p`-tagged pubkeys of a kind 3 event.
+  List<String> _followsOf(Event event, {required String source}) =>
+      _sanitizePubkeys(
+        event.tags
+            .where((tag) => tag.length > 1 && tag[0] == 'p')
+            .map((tag) => tag[1])
+            .toList(),
+        source: source,
+      );
+
   // A contact-list broadcast withheld because the read that precedes it came
   // back inconclusive. Flushed by [retryPendingContactListBroadcast] and by
   // the next follow or unfollow, which rebroadcasts the whole list anyway.
@@ -2009,9 +2103,6 @@ class FollowRepository {
       category: LogCategory.system,
     );
 
-    // Store previous state for rollback
-    final previousFollowList = List<String>.from(_followingPubkeys);
-
     // 1. Update in-memory cache immediately
     _followingPubkeys = [..._followingPubkeys, pubkey];
     _emitFollowingList();
@@ -2046,8 +2137,10 @@ class FollowRepository {
         category: LogCategory.system,
       );
     } catch (e) {
-      // Rollback on failure
-      _followingPubkeys = previousFollowList;
+      // Roll back this follow only. Restoring a whole pre-follow snapshot
+      // would also throw away a newer contact list the pre-publish read
+      // adopted, putting the stale list back (#8266).
+      _followingPubkeys = _followingPubkeys.where((p) => p != pubkey).toList();
       _emitFollowingList();
 
       Log.error(
@@ -2124,9 +2217,6 @@ class FollowRepository {
       category: LogCategory.system,
     );
 
-    // Store previous state for rollback
-    final previousFollowList = List<String>.from(_followingPubkeys);
-
     // 1. Update in-memory cache immediately
     _followingPubkeys = _followingPubkeys.where((p) => p != pubkey).toList();
     _emitFollowingList();
@@ -2161,8 +2251,10 @@ class FollowRepository {
         category: LogCategory.system,
       );
     } catch (e) {
-      // Rollback on failure
-      _followingPubkeys = previousFollowList;
+      // Roll back this unfollow only, for the same reason as [follow].
+      if (!_followingPubkeys.contains(pubkey)) {
+        _followingPubkeys = [..._followingPubkeys, pubkey];
+      }
       _emitFollowingList();
 
       Log.error(
@@ -2203,67 +2295,69 @@ class FollowRepository {
     );
   }
 
-  /// Merge follows from another contact list event (union merge for conflict resolution).
+  /// Schema version of the persisted contact-list record.
   ///
-  /// Used when syncing offline actions - combines local follows with
-  /// any follows that were added on other devices while offline.
-  Future<void> mergeFollows(List<String> additionalPubkeys) async {
-    // Remove self if accidentally included
-    final merged = <String>{
-      ..._followingPubkeys,
-      ..._sanitizePubkeys(additionalPubkeys, source: 'merged follows'),
-    }..remove(_nostrClient.publicKey);
+  /// v1 was a bare JSON array of pubkeys with no timestamp, so a cache written
+  /// by it cannot be ordered against a real event. v2 carries the `created_at`
+  /// and id of the kind 3 the list came from, which is what NIP-01 orders by.
+  static const _followingRecordVersion = 2;
 
-    if (merged.length != _followingPubkeys.length ||
-        !merged.every(_followingPubkeys.contains)) {
-      _followingPubkeys = merged.toList();
-      _emitFollowingList();
-      await _invalidateMyFollowingCache();
+  String _followingStorageKey(String pubkey) => 'following_list_$pubkey';
 
-      // Broadcast the merged list
-      await _broadcastContactList();
-      await _saveToLocalStorage();
-
-      Log.info(
-        'Merged contact lists: now following '
-        '${_followingPubkeys.length} users',
-        name: 'FollowRepository',
-        category: LogCategory.system,
-      );
-    }
-  }
-
-  /// Load following list from local storage (SharedPreferences)
+  /// Load following list from local storage (SharedPreferences).
+  ///
+  /// Reads both schema versions: a bare JSON array is the pre-#8266 v1 record
+  /// and yields no timestamp, so it seeds the list but loses to the first
+  /// source that can name one.
   Future<void> _loadFromLocalStorage() async {
     try {
       final prefs = await SharedPreferences.getInstance();
       final currentUserPubkey = _nostrClient.publicKey;
+      if (currentUserPubkey.isEmpty) return;
 
-      if (currentUserPubkey.isNotEmpty) {
-        final key = 'following_list_$currentUserPubkey';
-        final cached = prefs.getString(key);
+      final cached = prefs.getString(_followingStorageKey(currentUserPubkey));
+      if (cached == null) return;
 
-        if (cached != null) {
-          final decoded = jsonDecode(cached) as List<dynamic>;
-          final cachedPubkeys = decoded.cast<String>();
-          final sanitizedPubkeys = _sanitizePubkeys(
-            cachedPubkeys,
-            source: 'LocalStorage',
-          );
-          _followingPubkeys = sanitizedPubkeys;
-          _emitFollowingList();
+      final decoded = jsonDecode(cached);
 
-          if (sanitizedPubkeys.length != cachedPubkeys.length) {
-            await _saveToLocalStorage();
-          }
+      final List<dynamic> rawPubkeys;
+      int? createdAt;
+      String? eventId;
+      var isLegacyRecord = false;
 
-          Log.info(
-            'Loaded cached following list: '
-            '${_followingPubkeys.length} users',
-            name: 'FollowRepository',
-            category: LogCategory.system,
-          );
-        }
+      if (decoded is List) {
+        rawPubkeys = decoded;
+        isLegacyRecord = true;
+      } else if (decoded is Map<String, dynamic>) {
+        rawPubkeys = (decoded['pubkeys'] as List<dynamic>?) ?? const [];
+        createdAt = decoded['created_at'] as int?;
+        eventId = decoded['id'] as String?;
+      } else {
+        Log.warning(
+          'Ignoring unreadable cached following list',
+          name: 'FollowRepository',
+          category: LogCategory.system,
+        );
+        return;
+      }
+
+      final cachedPubkeys = rawPubkeys.cast<String>();
+      final sanitizedPubkeys = _sanitizePubkeys(
+        cachedPubkeys,
+        source: 'LocalStorage',
+      );
+
+      _adoptContactList(
+        sanitizedPubkeys,
+        createdAt: createdAt,
+        eventId: eventId,
+        source: isLegacyRecord ? 'LocalStorage (v1)' : 'LocalStorage',
+      );
+
+      // Rewrite when entries were dropped, and to migrate a v1 record onto the
+      // versioned envelope so the next launch can order it.
+      if (isLegacyRecord || sanitizedPubkeys.length != cachedPubkeys.length) {
+        await _saveToLocalStorage();
       }
     } catch (e) {
       Log.error(
@@ -2282,53 +2376,25 @@ class FollowRepository {
 
     try {
       final cachedContactLists = _getCachedEventsByKind!(EventKind.contactList);
+      if (cachedContactLists.isEmpty) return;
 
-      if (cachedContactLists.isNotEmpty) {
-        // Use the most recent contact list event
-        final latestContactList = cachedContactLists.first;
+      // PersonalEventCache orders by `created_at` alone, so two kind 3s
+      // written in the same second come back in an arbitrary order. Apply
+      // NIP-01's full rule here rather than trusting `.first`.
+      final latestContactList = cachedContactLists
+          .where((event) => event.kind == EventKind.contactList)
+          .fold<Event?>(null, _pickBestContactList);
+      if (latestContactList == null) return;
 
-        final pTags = latestContactList.tags.where(
-          (tag) => tag.isNotEmpty && tag[0] == 'p',
-        );
+      final adopted = _adoptContactList(
+        _followsOf(latestContactList, source: 'PersonalEventCache'),
+        createdAt: latestContactList.createdAt,
+        eventId: latestContactList.id,
+        source: 'PersonalEventCache',
+      );
 
-        final pubkeys = _sanitizePubkeys(
-          pTags
-              .map((tag) => tag.length > 1 ? tag[1] : '')
-              .where((pubkey) => pubkey.isNotEmpty)
-              .cast<String>()
-              .toList(),
-          source: 'PersonalEventCache',
-        );
-
-        if (pubkeys.isNotEmpty) {
-          // Guard: only accept the cached event when it is at least as
-          // large as the list already loaded from LocalStorage. A stale
-          // PersonalEventCache entry with fewer pubkeys should not
-          // overwrite a fresher LocalStorage value — the network steps
-          // will fetch the authoritative event later.
-          if (pubkeys.length < _followingPubkeys.length) {
-            Log.debug(
-              'PersonalEventCache has fewer follows '
-              '(${pubkeys.length}) than LocalStorage '
-              '(${_followingPubkeys.length}), skipping',
-              name: 'FollowRepository',
-              category: LogCategory.system,
-            );
-            return;
-          }
-
-          _followingPubkeys = pubkeys;
-          _currentUserContactListEvent = latestContactList;
-          _emitFollowingList();
-
-          Log.debug(
-            'Loaded following from '
-            'PersonalEventCache: '
-            '${pubkeys.length} users',
-            name: 'FollowRepository',
-            category: LogCategory.system,
-          );
-        }
+      if (adopted) {
+        _currentUserContactListEvent = latestContactList;
       }
     } catch (e) {
       Log.error(
@@ -2387,18 +2453,17 @@ class FollowRepository {
       final pubkeys = _sanitizePubkeys(collected, source: 'REST API');
 
       if (pubkeys.isNotEmpty) {
-        _followingPubkeys = pubkeys;
-        _emitFollowingList();
-
-        // Persist to SharedPreferences so redirect logic can use it
-        await _saveToLocalStorage();
-
-        Log.info(
-          'Loaded following from REST API: '
-          '${pubkeys.length} users',
-          name: 'FollowRepository',
-          category: LogCategory.system,
-        );
+        // The REST index is derived from the kind 3 and carries no
+        // `created_at` of its own, so it seeds an empty state and loses to
+        // any real event (#8266).
+        if (_adoptContactList(
+          pubkeys,
+          createdAt: null,
+          source: 'REST API',
+        )) {
+          // Persist to SharedPreferences so redirect logic can use it
+          await _saveToLocalStorage();
+        }
       } else {
         Log.debug(
           'REST API returned empty following list',
@@ -2423,12 +2488,21 @@ class FollowRepository {
       final currentUserPubkey = _nostrClient.publicKey;
 
       if (currentUserPubkey.isNotEmpty) {
-        final key = 'following_list_$currentUserPubkey';
-        await prefs.setString(key, jsonEncode(_followingPubkeys));
+        final provenance = _followingProvenance;
+        await prefs.setString(
+          _followingStorageKey(currentUserPubkey),
+          jsonEncode({
+            'v': _followingRecordVersion,
+            'created_at': provenance?.createdAt,
+            'id': provenance?.id,
+            'pubkeys': _followingPubkeys,
+          }),
+        );
 
         Log.debug(
           'Saved following list to cache: '
-          '${_followingPubkeys.length} users',
+          '${_followingPubkeys.length} users '
+          '(created_at ${provenance?.createdAt ?? 'unknown'})',
           name: 'FollowRepository',
           category: LogCategory.system,
         );
@@ -2469,7 +2543,7 @@ class FollowRepository {
         _loadContactListFromIndexer(currentUserPubkey),
       ]);
 
-      // Use whichever returned a result (prefer the one with more p-tags)
+      // Use whichever returned a result, newest first (NIP-01).
       final connectedResult = results[0];
       final indexerResult = results[1];
 
@@ -2640,13 +2714,14 @@ class FollowRepository {
     }
   }
 
-  /// Pick the best contact list from two sources.
-  /// Prefers the newest event by createdAt since kind 3 is replaceable
-  /// (NIP-02) — a user may intentionally unfollow people, reducing p-tags.
+  /// Pick the authoritative contact list of two, per NIP-01's rule for
+  /// replaceable events: newest `created_at`, lowest event id on a tie.
   Event? _pickBestContactList(Event? a, Event? b) {
     if (a == null) return b;
     if (b == null) return a;
-    return b.createdAt > a.createdAt ? b : a;
+    return _isNewer(b.createdAt, b.id, (createdAt: a.createdAt, id: a.id))
+        ? b
+        : a;
   }
 
   /// Subscribe to contact list for real-time sync and cross-device updates.
@@ -2785,17 +2860,72 @@ class FollowRepository {
       timeout: _contactListReadTimeout,
     );
 
-    var newest = _currentUserContactListEvent;
+    Event? newest;
     for (final event in result.events) {
       if (event.pubkey != pubkey) continue;
       if (event.kind != EventKind.contactList) continue;
-      final current = newest;
-      if (current != null && event.createdAt <= current.createdAt) continue;
-      newest = event;
+      newest = _pickBestContactList(newest, event);
     }
-    _currentUserContactListEvent = newest;
+
+    if (newest != null) {
+      // Adopt what the relay holds as the base to publish from, then put the
+      // pending local change back on top. Reading the authoritative event and
+      // using it only for `content` is what let a stale hydration republish
+      // follows the newest event had already dropped (#8266): the `p` tags
+      // come from [_publishableFollows], not from this event.
+      final pending = _pendingLocalChange();
+      if (_adoptContactList(
+        _followsOf(newest, source: 'pre-publish read'),
+        createdAt: newest.createdAt,
+        eventId: newest.id,
+        source: 'pre-publish read',
+      )) {
+        _currentUserContactListEvent = newest;
+        _applyPendingLocalChange(pending);
+      }
+    }
 
     return !result.timedOut && !result.noRelays;
+  }
+
+  /// The local follow/unfollow not yet reflected in the adopted base.
+  ({List<String> added, Set<String> removed}) _pendingLocalChange() {
+    final adopted = _adoptedFollows.toSet();
+    final current = _followingPubkeys.toSet();
+    return (
+      added: _followingPubkeys.where((p) => !adopted.contains(p)).toList(),
+      removed: adopted.where((p) => !current.contains(p)).toSet(),
+    );
+  }
+
+  /// Re-apply [pending] on top of a freshly adopted base.
+  ///
+  /// New follows go on the end, which is where NIP-02 asks clients to append
+  /// them so the list stays in chronological order.
+  void _applyPendingLocalChange(
+    ({List<String> added, Set<String> removed}) pending,
+  ) {
+    if (pending.added.isEmpty && pending.removed.isEmpty) return;
+
+    final rebased = [
+      ..._followingPubkeys.where((p) => !pending.removed.contains(p)),
+      ...pending.added.where((p) => !_followingPubkeys.contains(p)),
+    ];
+    if (rebased.length == _followingPubkeys.length &&
+        rebased.indexed.every((e) => e.$2 == _followingPubkeys[e.$1])) {
+      return;
+    }
+
+    _followingPubkeys = rebased;
+    _emitFollowingList();
+
+    Log.info(
+      'Re-applied the pending local change over the newest contact list: '
+      '${pending.added.length} added, ${pending.removed.length} removed, '
+      'now ${rebased.length} following',
+      name: 'FollowRepository',
+      category: LogCategory.system,
+    );
   }
 
   /// Rebroadcast a contact list whose publish was withheld by an inconclusive
@@ -2872,6 +3002,10 @@ class FollowRepository {
     _cacheUserEvent?.call(event);
 
     _currentUserContactListEvent = event;
+    // The event we just published is now the newest one we know of, and its
+    // tags are the new base for the next pending-change diff.
+    _followingProvenance = (createdAt: event.createdAt, id: event.id);
+    _adoptedFollows = List<String>.from(_followingPubkeys);
     _contactListBroadcastPending = false;
 
     Log.debug(
@@ -2881,130 +3015,26 @@ class FollowRepository {
     );
   }
 
-  // ── Catastrophic-reduction merge guard ──────────────────────────────
-  //
-  // Protects against buggy external Nostr clients that publish a Kind 3
-  // event without first fetching the existing contact list, effectively
-  // overwriting hundreds of follows with a single entry.
-  //
-  // The guard uses a two-condition AND gate:
-  //   1. Drastic reduction — the remote list lost more than
-  //      [_mergeMaxLossFraction] (50 %) of the local list.
-  //   2. New-pubkey fingerprint — the remote list contains at least one
-  //      pubkey absent from the local list (the hallmark of a "follow one
-  //      user, replace the whole list" bug).
-  //
-  // When BOTH conditions are true the lists are union-merged and the
-  // corrected list is re-broadcast so relays converge on the right state.
-  //
-  // A legitimate mass-unfollow produces a strict *subset* of the local
-  // list, so condition 2 filters it out and the replacement is accepted.
-  //
-  // The guard is only active when the local list has at least
-  // [_mergeMinFollows] entries. With only 1 follow the list can only
-  // drop to zero, which is either a legitimate unfollow or a fresh
-  // account state — no merge is needed.
-  //
-  // Edge cases:
-  //   • Exactly 50 % loss (equals the ceil threshold) → accepted, not
-  //     merged, because the loss is within tolerance.
-  //   • Remote list is entirely new pubkeys but same size → accepted,
-  //     because condition 1 fails (no size reduction).
-  //   • Re-broadcast failure after merge → local list is already
-  //     correct; relays will converge on the next publish.
-  // ───────────────────────────────────────────────────────────────────
-
-  /// Minimum local-list size for the merge guard to activate. A user with
-  /// only 1 follow cannot trigger a "catastrophic reduction" — the list
-  /// can only go to zero.
-  static const _mergeMinFollows = 2;
-
-  /// Maximum fraction of the local list that may be removed before the
-  /// reduction is treated as suspicious. 0.5 → more than half lost
-  /// triggers a merge instead of a replace.
-  static const _mergeMaxLossFraction = 0.5;
-
-  /// Process a NIP-02 contact list event (Kind 3)
+  /// Process a NIP-02 contact list event (Kind 3).
+  ///
+  /// Kind 3 is replaceable, so the newest event is the whole truth: whatever
+  /// it omits, the user removed. There is deliberately no size check here.
+  /// The union-merge that used to guard against a "drastically smaller" remote
+  /// list could not tell a buggy client apart from a real cross-device edit —
+  /// unfollowing several people and following one produces exactly the
+  /// fingerprint it looked for — and it re-broadcast the union, publishing the
+  /// resurrected follows back to the relay (#8266).
   void _processContactListEvent(Event event) {
-    // Only update if this is newer than our current contact list event
-    if (_currentUserContactListEvent == null ||
-        event.createdAt > _currentUserContactListEvent!.createdAt) {
-      _currentUserContactListEvent = event;
+    final adopted = _adoptContactList(
+      _followsOf(event, source: 'network Kind 3 event ${event.id}'),
+      createdAt: event.createdAt,
+      eventId: event.id,
+      source: 'network Kind 3 event ${event.id}',
+    );
+    if (!adopted) return;
 
-      // Extract followed pubkeys from 'p' tags
-      final taggedPubkeys = <String>[];
-      for (final tag in event.tags) {
-        if (tag.isNotEmpty && tag[0] == 'p' && tag.length > 1) {
-          taggedPubkeys.add(tag[1]);
-        }
-      }
-      final followedPubkeys = _sanitizePubkeys(
-        taggedPubkeys,
-        source: 'network Kind 3 event ${event.id}',
-      );
-
-      // Guard: detect catastrophic list reduction from buggy external clients.
-      // A common Nostr footgun is publishing a Kind 3 event without first
-      // fetching the existing contact list, which overwrites the full list
-      // with only the newly followed user. We detect this by checking for
-      // two conditions simultaneously:
-      //   1. The remote list is drastically smaller than the local list.
-      //   2. The remote list contains pubkeys NOT already in the local list
-      //      (the "only-new-follow" fingerprint of buggy clients).
-      // A legitimate mass-unfollow produces a strict subset of the local
-      // list, so condition 2 filters it out.
-      final localSet = _followingPubkeys.toSet();
-      final isDrasticReduction =
-          _followingPubkeys.length >= _mergeMinFollows &&
-          followedPubkeys.length <
-              (_followingPubkeys.length * _mergeMaxLossFraction).ceil();
-      final hasNewPubkeys = followedPubkeys.any((pk) => !localSet.contains(pk));
-
-      if (isDrasticReduction && hasNewPubkeys) {
-        final merged = <String>{..._followingPubkeys, ...followedPubkeys};
-
-        Log.warning(
-          'Catastrophic contact list reduction '
-          'detected '
-          '(${_followingPubkeys.length} → '
-          '${followedPubkeys.length}). '
-          'Merging to ${merged.length} follows '
-          'instead of replacing.',
-          name: 'FollowRepository',
-          category: LogCategory.system,
-        );
-
-        _followingPubkeys = merged.toList();
-        _emitFollowingList();
-        unawaited(_saveToLocalStorage());
-        unawaited(_invalidateMyFollowingCache());
-
-        // Re-broadcast the merged list so relays have the correct state.
-        unawaited(
-          _broadcastContactList().catchError((Object e) {
-            Log.error(
-              'Failed to broadcast merged '
-              'contact list: $e',
-              name: 'FollowRepository',
-              category: LogCategory.system,
-            );
-          }),
-        );
-        return;
-      }
-
-      _followingPubkeys = followedPubkeys;
-      _emitFollowingList();
-
-      Log.info(
-        'Updated follow list from network: '
-        '${_followingPubkeys.length} following',
-        name: 'FollowRepository',
-        category: LogCategory.system,
-      );
-
-      unawaited(_saveToLocalStorage());
-      unawaited(_invalidateMyFollowingCache());
-    }
+    _currentUserContactListEvent = event;
+    unawaited(_saveToLocalStorage());
+    unawaited(_invalidateMyFollowingCache());
   }
 }

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:math';
 
 import 'package:cache_sync/cache_sync.dart';
@@ -8,6 +7,7 @@ import 'package:follow_repository/src/follow_list_kind.dart';
 import 'package:follow_repository/src/follow_relationship.dart';
 import 'package:follow_repository/src/follower_stats.dart';
 import 'package:follow_repository/src/followers_snapshot.dart';
+import 'package:follow_repository/src/following_cache_record.dart';
 import 'package:follow_repository/src/following_snapshot.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:meta/meta.dart';
@@ -31,10 +31,7 @@ typedef _FollowerSourceResult = ({
   StackTrace? stackTrace,
 });
 
-typedef _CachedFollowerStats = ({
-  FollowerStats stats,
-  DateTime cachedAt,
-});
+typedef _CachedFollowerStats = ({FollowerStats stats, DateTime cachedAt});
 
 typedef _FollowerCountObservation = ({
   int count,
@@ -128,10 +125,7 @@ class FollowRepository {
   /// Maximum time for connect, response collection, and cleanup combined.
   final Duration _indexerOperationTimeout;
 
-  Duration _remainingIndexerTime(
-    DateTime deadline, {
-    Duration? cap,
-  }) {
+  Duration _remainingIndexerTime(DateTime deadline, {Duration? cap}) {
     final remaining = deadline.difference(DateTime.now());
     if (remaining <= Duration.zero) return Duration.zero;
     if (cap != null && cap < remaining) return cap;
@@ -1211,9 +1205,7 @@ class FollowRepository {
       bool followingAuthoritative,
     })
   >
-  _fetchFollowerStats(
-    String pubkey,
-  ) async {
+  _fetchFollowerStats(String pubkey) async {
     final restResult = await _fetchFollowerStatsViaRest(pubkey);
     // Authority is per field. The two counts come from independent inputs, so
     // a positive value in one is no evidence that zero in the other means
@@ -1681,11 +1673,8 @@ class FollowRepository {
     Future<List<_FollowerRef>> source,
   ) => source.then<_FollowerSourceResult>(
     (refs) => (refs: refs, error: null, stackTrace: null),
-    onError: (Object error, StackTrace stackTrace) => (
-      refs: const <_FollowerRef>[],
-      error: error,
-      stackTrace: stackTrace,
-    ),
+    onError: (Object error, StackTrace stackTrace) =>
+        (refs: const <_FollowerRef>[], error: error, stackTrace: stackTrace),
   );
 
   /// Streams the current user's followers as each source resolves.
@@ -2309,15 +2298,6 @@ class FollowRepository {
     );
   }
 
-  /// Schema version of the persisted contact-list record.
-  ///
-  /// v1 was a bare JSON array of pubkeys with no timestamp, so a cache written
-  /// by it cannot be ordered against a real event. v2 carries the `created_at`
-  /// and id of the kind 3 the list came from, which is what NIP-01 orders by.
-  static const _followingRecordVersion = 2;
-
-  String _followingStorageKey(String pubkey) => 'following_list_$pubkey';
-
   /// Load following list from local storage (SharedPreferences).
   ///
   /// Reads both schema versions: a bare JSON array is the pre-#8266 v1 record
@@ -2329,33 +2309,13 @@ class FollowRepository {
       final currentUserPubkey = _nostrClient.publicKey;
       if (currentUserPubkey.isEmpty) return;
 
-      final cached = prefs.getString(_followingStorageKey(currentUserPubkey));
+      final cached = prefs.getString(
+        FollowingCacheRecord.storageKey(currentUserPubkey),
+      );
       if (cached == null) return;
 
-      final decoded = jsonDecode(cached);
-
-      final List<dynamic> rawPubkeys;
-      int? createdAt;
-      String? eventId;
-      var isLegacyRecord = false;
-
-      if (decoded is List) {
-        rawPubkeys = decoded;
-        isLegacyRecord = true;
-      } else if (decoded is Map<String, dynamic>) {
-        rawPubkeys = (decoded['pubkeys'] as List<dynamic>?) ?? const [];
-        createdAt = decoded['created_at'] as int?;
-        eventId = decoded['id'] as String?;
-      } else {
-        Log.warning(
-          'Ignoring unreadable cached following list',
-          name: 'FollowRepository',
-          category: LogCategory.system,
-        );
-        return;
-      }
-
-      final cachedPubkeys = rawPubkeys.cast<String>();
+      final record = FollowingCacheRecord.decode(cached);
+      final cachedPubkeys = record.pubkeys;
       final sanitizedPubkeys = _sanitizePubkeys(
         cachedPubkeys,
         source: 'LocalStorage',
@@ -2363,14 +2323,17 @@ class FollowRepository {
 
       _adoptContactList(
         sanitizedPubkeys,
-        createdAt: createdAt,
-        eventId: eventId,
-        source: isLegacyRecord ? 'LocalStorage (v1)' : 'LocalStorage',
+        createdAt: record.createdAt,
+        eventId: record.eventId,
+        source: record.needsMigration
+            ? 'LocalStorage (legacy)'
+            : 'LocalStorage',
       );
 
       // Rewrite when entries were dropped, and to migrate a v1 record onto the
       // versioned envelope so the next launch can order it.
-      if (isLegacyRecord || sanitizedPubkeys.length != cachedPubkeys.length) {
+      if (record.needsMigration ||
+          sanitizedPubkeys.length != cachedPubkeys.length) {
         await _saveToLocalStorage();
       }
     } catch (e) {
@@ -2467,11 +2430,7 @@ class FollowRepository {
         // The REST index is derived from the kind 3 and carries no
         // `created_at` of its own, so it seeds an empty state and loses to
         // any real event (#8266).
-        if (_adoptContactList(
-          pubkeys,
-          createdAt: null,
-          source: 'REST API',
-        )) {
+        if (_adoptContactList(pubkeys, createdAt: null, source: 'REST API')) {
           // Persist to SharedPreferences so redirect logic can use it
           await _saveToLocalStorage();
         }
@@ -2501,13 +2460,12 @@ class FollowRepository {
       if (currentUserPubkey.isNotEmpty) {
         final provenance = _followingProvenance;
         await prefs.setString(
-          _followingStorageKey(currentUserPubkey),
-          jsonEncode({
-            'v': _followingRecordVersion,
-            'created_at': provenance?.createdAt,
-            'id': provenance?.id,
-            'pubkeys': _followingPubkeys,
-          }),
+          FollowingCacheRecord.storageKey(currentUserPubkey),
+          FollowingCacheRecord(
+            pubkeys: _followingPubkeys,
+            createdAt: provenance?.createdAt,
+            eventId: provenance?.id,
+          ).encode(),
         );
 
         Log.debug(
@@ -2533,7 +2491,8 @@ class FollowRepository {
   ///
   /// Uses [_queryContactList] callback (same proven approach as
   /// SocialService) to do a one-shot query with proper EOSE handling.
-  /// Called when local cache and REST API are both empty.
+  /// Called on every authenticated initialization so the relay's
+  /// authoritative event can supersede stale derived caches.
   Future<void> _loadFromRelay() async {
     try {
       final currentUserPubkey = _nostrClient.publicKey;

--- a/mobile/packages/follow_repository/lib/src/following_cache_record.dart
+++ b/mobile/packages/follow_repository/lib/src/following_cache_record.dart
@@ -1,0 +1,62 @@
+// ABOUTME: Versioned codec for the following-list SharedPreferences cache.
+// ABOUTME: Keeps repository and app bootstrap readers on one storage contract.
+
+import 'dart:convert';
+
+/// The SharedPreferences record used to bootstrap the signed-in user's
+/// following list before the repository is available.
+final class FollowingCacheRecord {
+  FollowingCacheRecord({
+    required List<String> pubkeys,
+    this.createdAt,
+    this.eventId,
+    this.needsMigration = false,
+  }) : pubkeys = List.unmodifiable(pubkeys);
+
+  /// Decode both the legacy bare-array format and the current envelope.
+  factory FollowingCacheRecord.decode(String encoded) {
+    final decoded = jsonDecode(encoded);
+    if (decoded is List) {
+      return FollowingCacheRecord(
+        pubkeys: decoded.cast<String>(),
+        needsMigration: true,
+      );
+    }
+    if (decoded is! Map<String, dynamic>) {
+      throw const FormatException('Following cache must be a list or object');
+    }
+
+    final rawPubkeys = decoded['pubkeys'];
+    if (rawPubkeys is! List) {
+      throw const FormatException('Following cache is missing pubkeys');
+    }
+
+    return FollowingCacheRecord(
+      pubkeys: rawPubkeys.cast<String>(),
+      createdAt: decoded['created_at'] as int?,
+      eventId: decoded['id'] as String?,
+      needsMigration: decoded['v'] != currentVersion,
+    );
+  }
+
+  /// Schema version written by current clients.
+  static const currentVersion = 2;
+
+  /// SharedPreferences key for [pubkey].
+  static String storageKey(String pubkey) => 'following_list_$pubkey';
+
+  final List<String> pubkeys;
+  final int? createdAt;
+  final String? eventId;
+
+  /// Whether reading this record should rewrite it in the current format.
+  final bool needsMigration;
+
+  /// Encode the current versioned envelope.
+  String encode() => jsonEncode({
+    'v': currentVersion,
+    'created_at': createdAt,
+    'id': eventId,
+    'pubkeys': pubkeys,
+  });
+}

--- a/mobile/packages/follow_repository/test/src/follow_repository_contact_list_freshness_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_contact_list_freshness_test.dart
@@ -374,5 +374,37 @@ void main() {
             'empty string over it is the #8265 wipe',
       );
     });
+
+    // An offline follow persists the list *plus* the provenance of the base it
+    // was applied to, so the record names an event whose tags it no longer
+    // matches. That is deliberate: the record means "at least as fresh as this
+    // event", which is what ordering needs. The queued follow must therefore
+    // survive a restart rather than being overwritten by the very event it was
+    // built on.
+    test(
+      'an offline follow survives a restart against its own base event',
+      () async {
+        final base = contactList(createdAt: 2000, follows: [alice]);
+        SharedPreferences.setMockInitialValues({
+          'following_list_$owner':
+              '{"v":2,"created_at":2000,'
+              '"id":"${base.id}","pubkeys":["$alice","$bob"]}',
+        });
+        getCachedEventsByKind = (kind) =>
+            kind == EventKind.contactList ? [base] : [];
+
+        final repository = buildRepository();
+        addTearDown(repository.dispose);
+        await repository.initialize();
+
+        expect(
+          repository.followingPubkeys,
+          [alice, bob],
+          reason:
+              'the cached event ties on created_at and id, so it must not '
+              'displace the list that already carries the queued follow',
+        );
+      },
+    );
   });
 }

--- a/mobile/packages/follow_repository/test/src/follow_repository_contact_list_freshness_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_contact_list_freshness_test.dart
@@ -311,5 +311,68 @@ void main() {
       expect(repository.followingPubkeys, [alice, bob]);
       expect(published.single, [alice, bob]);
     });
+
+    // The pre-publish read has two jobs: decide whose list wins, and supply
+    // `content` for the event about to be published. They are different
+    // questions. When LocalStorage already names the very event the relay
+    // returns, the list is not adopted — correctly, it is the same list — but
+    // `content` must still come from that event, or the publish sends `''`
+    // over the user's NIP-02 relay list. That is #8265's data loss, through a
+    // different door.
+    test('content survives when the read returns the event LocalStorage '
+        'already names', () async {
+      final existing = Event(
+        owner,
+        EventKind.contactList,
+        [
+          ['p', alice],
+        ],
+        '{"wss://relay.example":{"read":true,"write":true}}',
+        createdAt: 2000,
+      );
+
+      SharedPreferences.setMockInitialValues({
+        'following_list_$owner':
+            '{"v":2,"created_at":2000,'
+            '"id":"${existing.id}","pubkeys":["$alice"]}',
+      });
+
+      when(
+        () => mockNostrClient.queryEventsDetailed(
+          any(),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async =>
+            (events: <Event>[existing], timedOut: false, noRelays: false),
+      );
+
+      final publishedContent = <String>[];
+      when(
+        () => mockNostrClient.sendContactList(
+          any(),
+          any(),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        publishedContent.add(invocation.positionalArguments[1] as String);
+        return contactList(createdAt: 3000, follows: [alice, bob]);
+      });
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      await repository.initialize();
+      await repository.follow(bob);
+
+      expect(
+        publishedContent.single,
+        existing.content,
+        reason:
+            'NIP-02 kind 3 content carries the relay list; publishing an '
+            'empty string over it is the #8265 wipe',
+      );
+    });
   });
 }

--- a/mobile/packages/follow_repository/test/src/follow_repository_contact_list_freshness_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_contact_list_freshness_test.dart
@@ -1,0 +1,315 @@
+// ABOUTME: Reproduction for #8266 — contact-list selection must follow NIP-01
+// ABOUTME: (newest created_at wins), not "whichever list has more p tags".
+
+import 'package:cache_sync/cache_sync.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../cache_sync/test/fake_cache_dao.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {
+  _MockNostrClient() {
+    registerFallbackValue(Duration.zero);
+    when(
+      () => queryEventsDetailed(
+        any(),
+        requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        timeout: any(named: 'timeout'),
+      ),
+    ).thenAnswer(
+      (_) async => (events: <Event>[], timedOut: false, noRelays: false),
+    );
+  }
+}
+
+class _MockEvent extends Mock implements Event {}
+
+class _FakeContactList extends Fake implements ContactList {}
+
+void main() {
+  group('FollowRepository contact-list freshness (#8266)', () {
+    late _MockNostrClient mockNostrClient;
+    late FakeCacheDao cacheDao;
+    late List<Event> Function(int kind) getCachedEventsByKind;
+
+    const owner =
+        'a1b2c3d4e5f6789012345678901234567890abcdef1234567890123456789012';
+    const alice =
+        'b2c3d4e5f6789012345678901234567890abcdef1234567890123456789012a1';
+    const bob =
+        'c3d4e5f6789012345678901234567890abcdef1234567890123456789012ab12';
+    const carol =
+        'd4e5f6789012345678901234567890abcdef1234567890123456789012ab12c3';
+    const dave =
+        'e5f6789012345678901234567890abcdef1234567890123456789012ab12c3d4';
+
+    Event contactList({
+      required int createdAt,
+      required List<String> follows,
+      String content = '',
+    }) => Event(
+      owner,
+      EventKind.contactList,
+      follows.map((p) => ['p', p]).toList(),
+      content,
+      createdAt: createdAt,
+    );
+
+    FollowRepository buildRepository() => FollowRepository(
+      nostrClient: mockNostrClient,
+      isCacheInitialized: () => true,
+      getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+      cacheUserEvent: (_) {},
+      indexerRelayUrls: const [],
+    );
+
+    setUpAll(() {
+      registerFallbackValue(_MockEvent());
+      registerFallbackValue(<Filter>[]);
+      registerFallbackValue(_FakeContactList());
+    });
+
+    setUp(() async {
+      cacheDao = FakeCacheDao();
+      await CacheSync.init(dao: cacheDao);
+
+      mockNostrClient = _MockNostrClient();
+      getCachedEventsByKind = (_) => [];
+
+      when(() => mockNostrClient.hasKeys).thenReturn(true);
+      when(() => mockNostrClient.publicKey).thenReturn(owner);
+      when(
+        () => mockNostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+          relayTypes: any(named: 'relayTypes'),
+          sendAfterAuth: any(named: 'sendAfterAuth'),
+          onEose: any(named: 'onEose'),
+        ),
+      ).thenAnswer((_) => const Stream<Event>.empty());
+      when(() => mockNostrClient.unsubscribe(any())).thenAnswer((_) async {});
+    });
+
+    // The live shape. `cacheUserEvent` is called only from
+    // `_broadcastContactList`, so PersonalEventCache holds the last event THIS
+    // device published. A cross-device unfollow arrives over the subscription,
+    // which writes LocalStorage only. So on the next cold start PEC is
+    // older-and-longer while LocalStorage is newer-and-shorter, and a p-tag
+    // count comparison picks the wrong one.
+    test('a newer, shorter LocalStorage list survives an older, longer '
+        'PersonalEventCache event', () async {
+      SharedPreferences.setMockInitialValues({
+        'following_list_$owner':
+            '{"v":2,"created_at":2000,'
+            '"id":"${'b' * 64}","pubkeys":["$alice"]}',
+      });
+      // Older event this device published before the unfollow happened.
+      getCachedEventsByKind = (kind) => kind == EventKind.contactList
+          ? [
+              contactList(createdAt: 1000, follows: [alice, bob, carol]),
+            ]
+          : [];
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      await repository.initialize();
+
+      expect(
+        repository.followingPubkeys,
+        [alice],
+        reason: 'created_at 2000 beats created_at 1000, regardless of length',
+      );
+    });
+
+    // The direction the issue describes.
+    test('a newer, shorter PersonalEventCache event replaces an older '
+        'LocalStorage list', () async {
+      SharedPreferences.setMockInitialValues({
+        'following_list_$owner':
+            '{"v":2,"created_at":1000,'
+            '"id":"${'a' * 64}","pubkeys":["$alice","$bob","$carol"]}',
+      });
+      getCachedEventsByKind = (kind) => kind == EventKind.contactList
+          ? [
+              contactList(createdAt: 2000, follows: [alice]),
+            ]
+          : [];
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      await repository.initialize();
+
+      expect(
+        repository.followingPubkeys,
+        [alice],
+        reason: 'a legitimate unfollow must not be undone by p-tag counting',
+      );
+    });
+
+    // Chardot: "include backward-compatible migration from the existing bare
+    // pubkey-array cache". A v1 record carries no timestamp, so its freshness
+    // is unknowable and any timestamped event outranks it.
+    test('a legacy bare-array cache loses to any timestamped event', () async {
+      SharedPreferences.setMockInitialValues({
+        'following_list_$owner': '["$alice","$bob","$carol"]',
+      });
+      getCachedEventsByKind = (kind) => kind == EventKind.contactList
+          ? [
+              contactList(createdAt: 1000, follows: [alice]),
+            ]
+          : [];
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      await repository.initialize();
+
+      expect(repository.followingPubkeys, [alice]);
+    });
+
+    // The chain that turns a wrong hydration base into published data loss.
+    // #8267 made `_broadcastContactList` read the authoritative kind 3 before
+    // publishing, but that read only fills `_currentUserContactListEvent`
+    // (which supplies `content`). The `p` tags still come from
+    // `_publishableFollows()` -> `_followingPubkeys`. So a stale-but-longer
+    // hydration is what gets republished, and the unfollows come back.
+    test('a follow does not republish follows the newest known event '
+        'had already dropped', () async {
+      SharedPreferences.setMockInitialValues({
+        'following_list_$owner':
+            '{"v":2,"created_at":2000,'
+            '"id":"${'b' * 64}","pubkeys":["$alice"]}',
+      });
+      getCachedEventsByKind = (kind) => kind == EventKind.contactList
+          ? [
+              contactList(createdAt: 1000, follows: [alice, bob, carol]),
+            ]
+          : [];
+
+      // The relay holds the authoritative post-unfollow list.
+      final authoritative = contactList(createdAt: 2000, follows: [alice]);
+      when(
+        () => mockNostrClient.queryEventsDetailed(
+          any(),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async => (
+          events: <Event>[authoritative],
+          timedOut: false,
+          noRelays: false,
+        ),
+      );
+
+      final published = <List<String>>[];
+      when(
+        () => mockNostrClient.sendContactList(
+          any(),
+          any(),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        final list = invocation.positionalArguments[0] as ContactList;
+        published.add(
+          list
+              .toJson()
+              .where((t) => t.isNotEmpty && t[0] == 'p')
+              .map((t) => t[1])
+              .toList(),
+        );
+        return contactList(
+          createdAt: 3000,
+          follows: published.last,
+        );
+      });
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      await repository.initialize();
+      await repository.follow(dave);
+
+      expect(published, hasLength(1));
+      expect(
+        published.single..sort(),
+        [alice, dave]..sort(),
+        reason:
+            'bob and carol were unfollowed on another device; a follow '
+            'must not resurrect them on the relay',
+      );
+    });
+
+    test('an unreadable cached record is ignored rather than parsed', () async {
+      SharedPreferences.setMockInitialValues({
+        'following_list_$owner': '42',
+      });
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      await repository.initialize();
+
+      expect(repository.followingPubkeys, isEmpty);
+    });
+
+    // The other device made the same follow first. Re-applying the pending
+    // change must not double-add it, and must not claim in the log that it
+    // changed anything.
+    test('a pending follow the newest event already has is a no-op', () async {
+      SharedPreferences.setMockInitialValues({
+        'following_list_$owner':
+            '{"v":2,"created_at":1000,'
+            '"id":"${'a' * 64}","pubkeys":["$alice"]}',
+      });
+
+      when(
+        () => mockNostrClient.queryEventsDetailed(
+          any(),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async => (
+          events: <Event>[
+            contactList(createdAt: 2000, follows: [alice, bob]),
+          ],
+          timedOut: false,
+          noRelays: false,
+        ),
+      );
+
+      final published = <List<String>>[];
+      when(
+        () => mockNostrClient.sendContactList(
+          any(),
+          any(),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        final list = invocation.positionalArguments[0] as ContactList;
+        published.add(
+          list
+              .toJson()
+              .where((t) => t.isNotEmpty && t[0] == 'p')
+              .map((t) => t[1])
+              .toList(),
+        );
+        return contactList(createdAt: 3000, follows: published.last);
+      });
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      await repository.initialize();
+      await repository.follow(bob);
+
+      expect(repository.followingPubkeys, [alice, bob]);
+      expect(published.single, [alice, bob]);
+    });
+  });
+}

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -2981,9 +2981,9 @@ void main() {
           await repository.initialize();
           expect(repository.followingCount, 12);
 
-          // Remote event keeps only 3 of the original 12 — drastic but all
-          // entries are a subset of the local list (no new pubkeys), so this
-          // is a legitimate mass unfollow on another client.
+          // Remote event keeps only 3 of the original 12 — a mass unfollow
+          // on another client. Nothing about the size of the drop matters;
+          // the newer event is authoritative.
           final remoteEvent = Event(
             testCurrentUserPubkey,
             3,
@@ -2995,7 +2995,7 @@ void main() {
           realTimeStreamController.add(remoteEvent);
           await Future<void>.delayed(const Duration(milliseconds: 50));
 
-          // Should accept as-is (not merge) because no new pubkeys
+          // Adopted as-is: the newer event replaces the local list.
           expect(repository.followingCount, 3);
         },
       );
@@ -3110,7 +3110,7 @@ void main() {
           await repository.initialize();
           expect(repository.followingCount, 1);
 
-          // Remote event with only 1 follow — drastic but below threshold
+          // A one-entry list replaced by a different one-entry list.
           final remoteEvent = Event(
             testCurrentUserPubkey,
             3,
@@ -3124,7 +3124,7 @@ void main() {
           realTimeStreamController.add(remoteEvent);
           await Future<void>.delayed(const Duration(milliseconds: 50));
 
-          // Should replace (not merge) because local list is below threshold
+          // Replaced outright: the newer event is authoritative.
           expect(repository.followingCount, 1);
           expect(repository.followingPubkeys, equals([testTargetPubkey]));
         },

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Tests follow/unfollow operations, caching, and network sync
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:cache_sync/cache_sync.dart';
 import 'package:db_client/db_client.dart' hide Filter;
@@ -44,7 +45,19 @@ class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
 
 class _MockProfileStatsDao extends Mock implements ProfileStatsDao {}
 
-class _MockEvent extends Mock implements Event {}
+class _MockEvent extends Mock implements Event {
+  _MockEvent() {
+    // A real `sendContactList` returns a signed event, so `createdAt` and `id`
+    // are always populated. The repository reads both to record which kind 3
+    // its list came from (#8266), so a mock that leaves them null is not a
+    // stand-in for anything production can produce. Tests that care about a
+    // specific value still override these.
+    when(() => createdAt).thenReturn(
+      DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    );
+    when(() => id).thenReturn('e' * 64);
+  }
+}
 
 /// A fake relay that fires [fakeResponses] via [onMessage] during connect.
 ///
@@ -974,10 +987,15 @@ void main() {
         await repository.initialize();
 
         final prefs = await SharedPreferences.getInstance();
-        expect(
-          prefs.getString('following_list_$testCurrentUserPubkey'),
-          '["$testTargetPubkey"]',
-        );
+        final stored =
+            jsonDecode(
+                  prefs.getString('following_list_$testCurrentUserPubkey')!,
+                )
+                as Map<String, dynamic>;
+        expect(stored['pubkeys'], [testTargetPubkey]);
+        // A v1 record carries no timestamp, so the rewrite records none —
+        // which is what makes it lose to any real event (#8266).
+        expect(stored['created_at'], isNull);
       });
 
       test('follow succeeds and publishes a clean list when the cached '
@@ -1241,12 +1259,11 @@ void main() {
 
       // The filter is a publish-boundary property, and this is where it
       // stops being one. Relays hold the filtered event from the publish
-      // onwards, so the next initialize() reads it back and replaces the
-      // local list with it — the entry is a strict subset, so the
-      // catastrophic-reduction guard correctly declines to merge. Pinned so
-      // that "unblocking restores the follow" is never read as durable: it
-      // holds for the session that blocked, not past the next launch.
-      // Whether it should be restorable at all is open with T&S (#6903).
+      // onwards, so the next initialize() reads it back and, being the newest
+      // kind 3, it replaces the local list. Pinned so that "unblocking
+      // restores the follow" is never read as durable: it holds for the
+      // session that blocked, not past the next launch. Whether it should be
+      // restorable at all is open with T&S (#6903).
       test('the filtered kind 3 read back replaces the local list', () async {
         blocked.add(testTargetPubkey);
         var relayContactList = Event(
@@ -2764,71 +2781,6 @@ void main() {
         await realTimeStreamController.close();
       });
 
-      // #6903 filters at the publish boundary only. The inbound path must
-      // stay unfiltered: `hasNewPubkeys` is computed from the incoming list,
-      // so dropping blocked entries before the catastrophic-reduction guard
-      // can flip it false, skip the guard, and let a truncated remote list
-      // replace the local one wholesale — the #6109 class of follow loss.
-      test('does not filter an incoming contact list before the merge '
-          'guard', () async {
-        final seededPubkeys = List.generate(
-          12,
-          (i) => i.toRadixString(16).padLeft(64, '0'),
-        );
-        SharedPreferences.setMockInitialValues({
-          'following_list_$testCurrentUserPubkey':
-              '[${seededPubkeys.map((p) => '"$p"').join(',')}]',
-        });
-        const blockedNewPubkey =
-            'ff00000000000000000000000000000000000000000000000000000000000002';
-
-        when(() => mockNostrClient.sendContactList(any(), any())).thenAnswer(
-          (_) async => Event(
-            testCurrentUserPubkey,
-            EventKind.contactList,
-            [],
-            '',
-            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 200,
-          ),
-        );
-
-        repository = FollowRepository(
-          nostrClient: mockNostrClient,
-          isCacheInitialized: () => cacheIsInitialized,
-          getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
-          cacheUserEvent: cachedUserEvents.add,
-          indexerRelayUrls: const [],
-          blockedPubkeys: (_) => const {blockedNewPubkey},
-        );
-        await repository.initialize();
-        expect(repository.followingCount, 12);
-
-        // The sole incoming pubkey is one we blocked. Filtering it on the way
-        // in would leave an empty list, which is a strict subset — the guard
-        // would accept it and 12 follows would be gone.
-        realTimeStreamController.add(
-          Event(
-            testCurrentUserPubkey,
-            EventKind.contactList,
-            [
-              ['p', blockedNewPubkey],
-            ],
-            '',
-            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 100,
-          ),
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-
-        expect(
-          repository.followingCount,
-          13,
-          reason: 'the guard must merge, not replace',
-        );
-        for (final pubkey in seededPubkeys) {
-          expect(repository.followingPubkeys, contains(pubkey));
-        }
-      });
-
       test('updates following list when newer Kind 3 event arrives', () async {
         await repository.initialize();
 
@@ -3003,10 +2955,12 @@ void main() {
         await subscription.cancel();
       });
 
+      // A cross-device mass unfollow. Nothing about the size of the drop
+      // matters: the newer event is authoritative, so the removals stand.
       test(
-        'merges lists when remote event has drastically fewer follows',
+        'a newer event that drops most of the list is adopted whole',
         () async {
-          // Generate 12 pubkeys to seed the local cache (above _mergeMinFollows)
+          // Seed with 12 follows
           final seededPubkeys = List.generate(
             12,
             (i) => i.toRadixString(16).padLeft(64, '0'),
@@ -3016,7 +2970,6 @@ void main() {
                 '[${seededPubkeys.map((p) => '"$p"').join(',')}]',
           });
 
-          // Need fresh repository to pick up cached data
           repository = FollowRepository(
             nostrClient: mockNostrClient,
             isCacheInitialized: () => cacheIsInitialized,
@@ -3025,29 +2978,16 @@ void main() {
             indexerRelayUrls: const [],
           );
 
-          // Mock sendContactList for the merge broadcast
-          when(() => mockNostrClient.sendContactList(any(), any())).thenAnswer(
-            (_) async => Event(
-              testCurrentUserPubkey,
-              3,
-              [],
-              '',
-              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 200,
-            ),
-          );
-
           await repository.initialize();
           expect(repository.followingCount, 12);
 
-          // Remote event with only 1 follow — catastrophic reduction
-          const newPubkey =
-              'ff00000000000000000000000000000000000000000000000000000000000001';
+          // Remote event keeps only 3 of the original 12 — drastic but all
+          // entries are a subset of the local list (no new pubkeys), so this
+          // is a legitimate mass unfollow on another client.
           final remoteEvent = Event(
             testCurrentUserPubkey,
             3,
-            [
-              ['p', newPubkey],
-            ],
+            seededPubkeys.take(3).map((p) => ['p', p]).toList(),
             '',
             createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 100,
           );
@@ -3055,58 +2995,10 @@ void main() {
           realTimeStreamController.add(remoteEvent);
           await Future<void>.delayed(const Duration(milliseconds: 50));
 
-          // Should have merged: all 12 original + 1 new = 13
-          expect(repository.followingCount, 13);
-          expect(repository.followingPubkeys, contains(newPubkey));
-          for (final pk in seededPubkeys) {
-            expect(repository.followingPubkeys, contains(pk));
-          }
-
-          // Verify broadcast was triggered to fix relay state
-          verify(() => mockNostrClient.sendContactList(any(), any())).called(1);
+          // Should accept as-is (not merge) because no new pubkeys
+          expect(repository.followingCount, 3);
         },
       );
-
-      test('accepts drastic reduction when remote is a subset (legitimate mass '
-          'unfollow)', () async {
-        // Seed with 12 follows
-        final seededPubkeys = List.generate(
-          12,
-          (i) => i.toRadixString(16).padLeft(64, '0'),
-        );
-        SharedPreferences.setMockInitialValues({
-          'following_list_$testCurrentUserPubkey':
-              '[${seededPubkeys.map((p) => '"$p"').join(',')}]',
-        });
-
-        repository = FollowRepository(
-          nostrClient: mockNostrClient,
-          isCacheInitialized: () => cacheIsInitialized,
-          getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
-          cacheUserEvent: cachedUserEvents.add,
-          indexerRelayUrls: const [],
-        );
-
-        await repository.initialize();
-        expect(repository.followingCount, 12);
-
-        // Remote event keeps only 3 of the original 12 — drastic but all
-        // entries are a subset of the local list (no new pubkeys), so this
-        // is a legitimate mass unfollow on another client.
-        final remoteEvent = Event(
-          testCurrentUserPubkey,
-          3,
-          seededPubkeys.take(3).map((p) => ['p', p]).toList(),
-          '',
-          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 100,
-        );
-
-        realTimeStreamController.add(remoteEvent);
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-
-        // Should accept as-is (not merge) because no new pubkeys
-        expect(repository.followingCount, 3);
-      });
 
       test(
         'accepts remote event with slightly fewer follows (legitimate unfollow)',
@@ -3192,10 +3084,12 @@ void main() {
         expect(repository.followingCount, 10);
       });
 
+      // Same rule at the small end: one follow replaced by a different one
+      // is still just the newer event winning.
       test(
-        'skips merge protection when local list is below threshold',
+        'a newer event replaces a single-entry list',
         () async {
-          // Seed with 1 follow (below _mergeMinFollows of 2)
+          // Seed with 1 follow
           final seededPubkeys = List.generate(
             1,
             (i) => i.toRadixString(16).padLeft(64, '0'),
@@ -4153,31 +4047,36 @@ void main() {
         expect(repository.followingCount, 0);
       });
 
+      // Both directions of the #8266 contract. The count is deliberately the
+      // opposite of the answer each time, so a re-introduced "more p tags
+      // wins" heuristic fails here rather than passing by coincidence.
       test(
-        'skips PersonalEventCache when it has fewer follows than '
-        'LocalStorage',
+        'a newer PersonalEventCache event wins even with fewer follows',
         () async {
-          // Seed LocalStorage with 10 follows
           final localPubkeys = List.generate(
             10,
             (i) => i.toRadixString(16).padLeft(64, '0'),
           );
+          final cachePubkeys = localPubkeys.take(3).toList();
           SharedPreferences.setMockInitialValues({
-            'following_list_$testCurrentUserPubkey':
-                '[${localPubkeys.map((p) => '"$p"').join(',')}]',
+            'following_list_$testCurrentUserPubkey': jsonEncode({
+              'v': 2,
+              'created_at': 1000,
+              'id': 'a' * 64,
+              'pubkeys': localPubkeys,
+            }),
           });
 
-          // PersonalEventCache returns a stale event with only 3 pubkeys
-          final stalePubkeys = localPubkeys.take(3).toList();
-          final staleEvent = Event(
-            testCurrentUserPubkey,
-            EventKind.contactList,
-            stalePubkeys.map((p) => ['p', p]).toList(),
-            '',
-            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 - 100,
-          );
           cacheIsInitialized = true;
-          getCachedEventsByKind = (_) => [staleEvent];
+          getCachedEventsByKind = (_) => [
+            Event(
+              testCurrentUserPubkey,
+              EventKind.contactList,
+              cachePubkeys.map((p) => ['p', p]).toList(),
+              '',
+              createdAt: 2000,
+            ),
+          ];
 
           repository = FollowRepository(
             nostrClient: mockNostrClient,
@@ -4189,42 +4088,37 @@ void main() {
 
           await repository.initialize();
 
-          // Should keep the 10 from LocalStorage, not the 3 from cache
-          expect(repository.followingCount, 10);
-          for (final pk in localPubkeys) {
-            expect(repository.followingPubkeys, contains(pk));
-          }
+          expect(repository.followingPubkeys, cachePubkeys);
         },
       );
 
       test(
-        'accepts PersonalEventCache when it has more follows than '
-        'LocalStorage',
+        'a newer LocalStorage record wins even with fewer follows',
         () async {
-          // Seed LocalStorage with 3 follows
-          final localPubkeys = List.generate(
-            3,
+          final cachePubkeys = List.generate(
+            10,
             (i) => i.toRadixString(16).padLeft(64, '0'),
           );
+          final localPubkeys = cachePubkeys.take(3).toList();
           SharedPreferences.setMockInitialValues({
-            'following_list_$testCurrentUserPubkey':
-                '[${localPubkeys.map((p) => '"$p"').join(',')}]',
+            'following_list_$testCurrentUserPubkey': jsonEncode({
+              'v': 2,
+              'created_at': 2000,
+              'id': 'a' * 64,
+              'pubkeys': localPubkeys,
+            }),
           });
 
-          // PersonalEventCache returns a newer event with 5 pubkeys
-          final cachePubkeys = List.generate(
-            5,
-            (i) => (i + 10).toRadixString(16).padLeft(64, '0'),
-          );
-          final cacheEvent = Event(
-            testCurrentUserPubkey,
-            EventKind.contactList,
-            cachePubkeys.map((p) => ['p', p]).toList(),
-            '',
-            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 100,
-          );
           cacheIsInitialized = true;
-          getCachedEventsByKind = (_) => [cacheEvent];
+          getCachedEventsByKind = (_) => [
+            Event(
+              testCurrentUserPubkey,
+              EventKind.contactList,
+              cachePubkeys.map((p) => ['p', p]).toList(),
+              '',
+              createdAt: 1000,
+            ),
+          ];
 
           repository = FollowRepository(
             nostrClient: mockNostrClient,
@@ -4236,11 +4130,7 @@ void main() {
 
           await repository.initialize();
 
-          // Should use the 5 from PersonalEventCache
-          expect(repository.followingCount, 5);
-          for (final pk in cachePubkeys) {
-            expect(repository.followingPubkeys, contains(pk));
-          }
+          expect(repository.followingPubkeys, localPubkeys);
         },
       );
     });
@@ -5239,64 +5129,6 @@ void main() {
           expect(repository.isInitialized, isTrue);
         },
       );
-    });
-
-    group('mergeFollows', () {
-      test('removes self from merged list', () async {
-        final mockEvent = _MockEvent();
-        when(() => mockEvent.id).thenReturn(testCurrentUserPubkey);
-        when(() => mockEvent.content).thenReturn('');
-        when(
-          () => mockNostrClient.sendContactList(
-            any(),
-            any(),
-            tempRelays: any(named: 'tempRelays'),
-            targetRelays: any(named: 'targetRelays'),
-          ),
-        ).thenAnswer((_) async => mockEvent);
-
-        await repository.initialize();
-
-        // Merge a list that includes self
-        await repository.mergeFollows([
-          testTargetPubkey,
-          testCurrentUserPubkey,
-        ]);
-
-        expect(repository.isFollowing(testTargetPubkey), isTrue);
-        expect(
-          repository.isFollowing(testCurrentUserPubkey),
-          isFalse,
-        );
-      });
-
-      test('does not broadcast when no change', () async {
-        SharedPreferences.setMockInitialValues({
-          'following_list_$testCurrentUserPubkey': '["$testTargetPubkey"]',
-        });
-
-        repository = FollowRepository(
-          nostrClient: mockNostrClient,
-          isCacheInitialized: () => cacheIsInitialized,
-          getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
-          cacheUserEvent: cachedUserEvents.add,
-          indexerRelayUrls: const [],
-        );
-
-        await repository.initialize();
-
-        // Merge the same list — no change
-        await repository.mergeFollows([testTargetPubkey]);
-
-        verifyNever(
-          () => mockNostrClient.sendContactList(
-            any(),
-            any(),
-            tempRelays: any(named: 'tempRelays'),
-            targetRelays: any(named: 'targetRelays'),
-          ),
-        );
-      });
     });
 
     group('getFollowerCount', () {
@@ -7708,79 +7540,6 @@ void main() {
 
           // Should not crash — returns whatever was collected
           expect(followers, isA<List<String>>());
-        },
-      );
-
-      test(
-        'broadcastContactList catchError during catastrophic merge',
-        () async {
-          final seededPubkeys = List.generate(
-            12,
-            (i) => i.toRadixString(16).padLeft(64, '0'),
-          );
-          SharedPreferences.setMockInitialValues({
-            'following_list_$testCurrentUserPubkey':
-                '[${seededPubkeys.map((p) => '"$p"').join(',')}]',
-          });
-
-          final controller = StreamController<Event>.broadcast();
-          when(
-            () => mockNostrClient.subscribe(
-              any(),
-              subscriptionId: any(named: 'subscriptionId'),
-              tempRelays: any(named: 'tempRelays'),
-              targetRelays: any(named: 'targetRelays'),
-              relayTypes: any(named: 'relayTypes'),
-              sendAfterAuth: any(named: 'sendAfterAuth'),
-              onEose: any(named: 'onEose'),
-            ),
-          ).thenAnswer((_) => controller.stream);
-
-          // Make broadcast fail
-          when(
-            () => mockNostrClient.sendContactList(
-              any(),
-              any(),
-              tempRelays: any(named: 'tempRelays'),
-              targetRelays: any(named: 'targetRelays'),
-            ),
-          ).thenAnswer((_) async => null);
-
-          repository = FollowRepository(
-            nostrClient: mockNostrClient,
-            isCacheInitialized: () => cacheIsInitialized,
-            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
-            cacheUserEvent: cachedUserEvents.add,
-            indexerRelayUrls: const [],
-          );
-
-          await repository.initialize();
-          expect(repository.followingCount, 12);
-
-          // Catastrophic reduction with new pubkey → triggers merge
-          // + broadcastContactList which fails
-          const newPk =
-              'ff00000000000000000000000000000000000000000000000000000000000001';
-          controller.add(
-            Event(
-              testCurrentUserPubkey,
-              3,
-              [
-                ['p', newPk],
-              ],
-              '',
-              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 100,
-            ),
-          );
-          await Future<void>.delayed(
-            const Duration(milliseconds: 100),
-          );
-
-          // Merge happened, broadcast failed but didn't crash
-          expect(repository.followingCount, 13);
-
-          await repository.dispose();
-          await controller.close();
         },
       );
 

--- a/mobile/packages/follow_repository/test/src/following_cache_record_test.dart
+++ b/mobile/packages/follow_repository/test/src/following_cache_record_test.dart
@@ -1,0 +1,39 @@
+// ABOUTME: Tests legacy and current following-list cache record decoding.
+// ABOUTME: Pins the shared persistence contract used by app bootstrap code.
+
+import 'package:follow_repository/follow_repository.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FollowingCacheRecord', () {
+    test('reads the legacy bare-array format', () {
+      final record = FollowingCacheRecord.decode('["alice","bob"]');
+
+      expect(record.pubkeys, ['alice', 'bob']);
+      expect(record.createdAt, isNull);
+      expect(record.eventId, isNull);
+      expect(record.needsMigration, isTrue);
+    });
+
+    test('round-trips the versioned format', () {
+      final encoded = FollowingCacheRecord(
+        pubkeys: const ['alice', 'bob'],
+        createdAt: 1234,
+        eventId: 'event-id',
+      ).encode();
+
+      final record = FollowingCacheRecord.decode(encoded);
+      expect(record.pubkeys, ['alice', 'bob']);
+      expect(record.createdAt, 1234);
+      expect(record.eventId, 'event-id');
+      expect(record.needsMigration, isFalse);
+    });
+
+    test('rejects an object without pubkeys', () {
+      expect(
+        () => FollowingCacheRecord.decode('{"v":2}'),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/mobile/test/router/empty_contacts_redirect_test.dart
+++ b/mobile/test/router/empty_contacts_redirect_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
@@ -101,6 +102,25 @@ void main() {
           expect(hasFollowing, isTrue);
         },
       );
+
+      test('returns true for the versioned repository cache record', () async {
+        SharedPreferences.setMockInitialValues({
+          'current_user_pubkey_hex': testUserPubkey,
+          FollowingCacheRecord.storageKey(testUserPubkey): FollowingCacheRecord(
+            pubkeys: const ['pubkey1'],
+            createdAt: 1234,
+            eventId: 'a' * 64,
+          ).encode(),
+        });
+
+        final prefs = await SharedPreferences.getInstance();
+        final container = ProviderContainer(
+          overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+        );
+        addTearDown(container.dispose);
+
+        expect(container.read(hasFollowingInCacheProvider), isTrue);
+      });
 
       test(
         'ignores other users following_list - only checks current user',


### PR DESCRIPTION
## Summary

`FollowRepository` decided which kind 3 contact list to trust by counting `p` tags. A shorter list is exactly what a legitimate unfollow produces, so the heuristic cannot tell "this copy is stale" from "the user removed someone" — and it resurrected every cross-device removal, then republished it.

Replaced with NIP-01's own rule for replaceable events: highest `created_at`, and on an exact tie the lowest event id.

## What the reproduction found

Reproduced end to end on the iOS simulator against an in-process relay before writing any fix.

**The live failure runs the opposite direction from the issue's framing, and is worse.** `cacheUserEvent` is called only from `_broadcastContactList`, so PersonalEventCache holds the last event *this* device published. A cross-device unfollow arrives over the subscription, which writes LocalStorage only. On the next cold start the cache is **older and longer**, so `pubkeys.length < _followingPubkeys.length` is false and the guard adopts the stale event:

```
[SYSTEM] Updated follow list from network: 1 following      ← the unfollow applied
[SYSTEM] Loaded cached following list: 1 users              ← LocalStorage is correct
[SYSTEM] Loaded following from PersonalEventCache: 3 users  ← the older event wins
```

**That reaches a published wipe even after #8267.** `_refreshCurrentUserContactList` reads the authoritative kind 3, but assigns only `_currentUserContactListEvent`, which supplies `content`. The `p` tags still come from `_publishableFollows()` → `_followingPubkeys`. So the next follow republished the resurrected accounts to the relay.

**One of the two sites in the issue was already fixed.** `_pickBestContactList` has used `createdAt` since `48007f39b9` (2026-02-20), six months before the issue was filed. What the issue cited at that line was the *caller's* comment, which still said "prefer the one with more p-tags". Corrected.

**A third size heuristic existed that the issue did not mention** — the catastrophic-reduction merge guard. Removed; see below.

**PersonalEventCache orders by `created_at` alone**, so two kind 3s written in the same second come back in an arbitrary order. The first simulator run hit exactly that. Selection now applies the full NIP-01 rule rather than trusting `.first`.

## Changes

**Selection.** One `_adoptContactList` path shared by all five sources. Ordering is `created_at`, then lowest event id on a tie — applied only where both ids are known, otherwise the incumbent stands.

**Freshness that cannot be stated is not old.** The legacy bare-array cache and the funnelcake REST index carry no `created_at`. They seed an empty state and lose to any source that can name one.

**Persistence.** `following_list_<pubkey>` becomes a versioned envelope carrying `created_at` and `id` alongside the pubkeys, under the same key. A bare array is read as v1 and migrated on load, so an upgrade loses nothing.

**Publish base.** The pre-publish read now adopts what the relay holds and re-applies the pending local change on top. Rollback is scoped to the single follow/unfollow rather than a whole snapshot, which would have put the stale list back.

**Merge guard removed.** Its two-condition gate could not tell a buggy client from a real cross-device edit — unfollowing several people and following one produces precisely the fingerprint it looked for — and it re-broadcast the union, publishing the resurrected follows back to the relay. Newest-wins covers the case it was written for. `mergeFollows` went with it: same union-then-broadcast shape, zero callers.

**Skill corrected.** `nostr-replaceable-event-mutation-overwrite` prescribed the same defect as guidance ("use whichever has MORE data"). Its verification section only covered the cold-start overwrite, which a tag-count heuristic passes; added the cross-device removal steps, which it does not. Mirrored to `.agents/skills`. Part of #8258.

## Not in this PR

The product decision on #8266 also asks that follow-derived surfaces stay in a **loading state** until freshness is established, rather than presenting stale data as current. That spans ~35 files across blocs, screens and providers, so it is filed as a follow-up rather than ridden along with a data-loss fix. This PR makes the repository the single source of truth those surfaces will read from.

## Verification

- `flutter test` in `mobile/packages/follow_repository` — **323 passing**
- `flutter test --coverage` — **100.00% (931/931 lines)**, no new `coverage:ignore`
- `flutter analyze lib test integration_test` — clean
- E2E on the iOS simulator (iPhone 17, iOS 26.5) against an in-process relay — **fails on `main`, passes here**
- All 15 CI-only ratchets pass locally
- `.codex/scripts/test-config.sh` passes

### Regression coverage

Both directions asked for, plus the chain through to the publish:

| Test | Pins |
|---|---|
| newer, shorter LocalStorage vs older, longer PersonalEventCache | the live failure |
| newer, shorter PersonalEventCache vs older LocalStorage | the issue's direction |
| legacy bare-array cache vs any timestamped event | the migration |
| a follow does not republish what the newest event dropped | the published wipe |
| an unreadable cached record is ignored | corrupt-record path |
| a pending follow the newest event already has is a no-op | rebase idempotence |
| E2E: cross-device unfollow survives a cold start | the whole chain on device |
| E2E: the next follow does not republish the unfollowed accounts | the whole chain on device |

The count is deliberately the opposite of the answer in each direction, so a re-introduced "more p tags wins" fails rather than passing by coincidence.

Fixes #8266

---

## Second pass: real Docker stack, and three defects found in this PR

Re-validated against `local_stack`'s **real funnelcake relay** rather than only the in-process one, and adversarially reviewed this branch's own diff. Three things came out of it, each fixed here.

### 1. This PR reintroduced #8265's `content` wipe

The pre-publish read answers two different questions — which copy is authoritative, and where `content` comes from — and the first commit conflated them: `_currentUserContactListEvent` was assigned **only when the read's list was adopted**.

So the one case where the answers differ produced a wipe. When LocalStorage already names the very event the relay returns, the list is correctly not adopted (it is the same list), but `content` was then never taken from that event either, and the publish sent `''` over it. That is #8265's data loss on the exact path #8267 closed.

Caught by a test before it shipped, and it is not a corner case — the real relay hits it on an ordinary follow:

```
Keeping the contact list already loaded (created_at 1788411033) over pre-publish read (created_at 1788411033)
```

Fixed by splitting the two concerns: `_rememberContactListEvent` always advances to the newest kind 3 seen, independently of adoption.

### 2. The E2E suite this PR added was never run by CI

The services job runs an **explicit list** of files, deliberately not a glob. A new file under `integration_test/e2e/` trips the workflow's path filter and then runs nothing. Registered it; also gave both tests an explicit timeout, since they carry ~11s of real sleeps on top of relay waits and the default is 30s.

### 3. On a healthy network the defect self-heals — the damaging window is narrower than first stated

Against the real relay the stale cache **is** still adopted:

```
Loaded cached following list: 1 users
Loaded following from PersonalEventCache: 3 users
```

…but the startup relay query then corrects it. The in-process relay answered `EOSE`-only, so it never did, which made the fault look unconditional.

The damaging window is when that startup query **does not answer** — a condition `_loadFromRelay` cannot distinguish from "the user follows nobody", logging both as *No kind 3 contact list found on relay*. A transient network at launch puts a session there, and the next follow then republishes the resurrected accounts, because the publish-time read succeeds where the startup one did not. The new real-relay suite models exactly that through the existing `queryContactList` seam and leaves everything else on the relay.

This does not change the fix; it makes the severity claim accurate.

### Also verified

- **Account switching cannot leak provenance.** A switch builds a new `NostrClient`, so `followRepositoryProvider` rebuilds and the repository is replaced. No cross-account carry-over.
- **Blocked-pubkey filtering (#6903) is unaffected.** After our own publish the relay returns our own event, which ties on `created_at` and id and is therefore not adopted, so a locally-followed-but-blocked entry survives. It is dropped only when another device published something newer — which is correct.
- **funnelcake replacement is not immediately readable.** `sendContactList` returns when the frame is handed to the pool and funnelcake commits through ClickHouse, so a read straight after a publish can still serve the previous version. Every relay assertion polls to a deadline. The first real-stack run failed on this, not on the defect.

### Verification (second pass)

- `flutter test` in `mobile/packages/follow_repository` — **324 passing**
- `flutter test --coverage` — **100.00% (934/934 lines)**, no new `coverage:ignore`
- `flutter analyze lib test integration_test` — clean
- In-process E2E, iOS simulator — fails on `main`, passes here
- **Real-relay E2E against local_stack** — fails on `main`, passes here
- All 16 CI-only ratchets pass locally; `.codex/scripts/test-config.sh` passes

**Not verified on a physical iPhone.** The device is paired but `tunnelState: unavailable` and it is not on the Mac's LAN, so Xcode reports no matching build destination and the device cannot reach the host Docker stack. Everything above ran on the iOS simulator and against the real relay.
