### PR TITLE
fix(playback): play new uploads while renditions are processing

### DIFF
--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -166,9 +166,8 @@ extension VideoEventAppExtensions on VideoEvent {
   ///   manifest overhead) — it is 3-8x smaller than the raw blob. This covers
   ///   raw-only uploads too: their `imeta` lists only the raw blob because it
   ///   is a publish-time snapshot taken before the derivatives transcode, but
-  ///   by playback time the 720p.mp4 almost always exists. Until
-  ///   divine-blossom#198 is fixed, playback waits for transcoding if neither
-  ///   MP4 nor HLS is ready because the broken bare fallback is withheld.
+  ///   by playback time the 720p.mp4 almost always exists. The playback ladder
+  ///   falls back through HLS to the bare blob while renditions catch up.
   ///
   /// Non-Divine videos always use original (no transcoded variants exist).
   String? getOptimalVideoUrlForPlatform() {
@@ -180,11 +179,9 @@ extension VideoEventAppExtensions on VideoEvent {
 
     // Developer format override takes priority over every heuristic below so
     // A/B testing can force a specific server format on any Divine video,
-    // including classic Vine originals and raw-only uploads. Forcing `raw`
-    // intentionally exposes the bare blob path, which currently fails for
-    // range-requesting players until divine-blossom#198 is fixed. If any other
-    // forced variant does not exist yet the runtime fallback chain recovers,
-    // and seeing that is the point of the test switch.
+    // including classic Vine originals and raw-only uploads. If a forced
+    // derivative does not exist yet the runtime fallback chain recovers, and
+    // seeing that is the point of the test switch.
     final override = videoFormatPreference.format;
     if (override != null) {
       return switch (override) {
@@ -203,17 +200,12 @@ extension VideoEventAppExtensions on VideoEvent {
 
     // Production default: progressive MP4 720p (faststart). Fastest startup
     // (1 request, moov at front), correct colors on all platforms, and 3-8x
-    // smaller than the raw blob. Raw-only uploads take this path too. Until
-    // divine-blossom#198 is fixed, playback waits for transcoding if neither
-    // MP4 nor HLS is ready because the broken bare fallback is withheld.
+    // smaller than the raw blob. Raw-only uploads take this path too, with the
+    // bare blob retained as the final playback fallback.
     //
-    // Classic Vine originals take this path as well. They must never be sent
-    // to the bare blob: every Range request to `/{hash}` comes back as a
-    // cached `NoSuchKey` XML body dressed up as a 206, so AVFoundation - which
-    // always range-requests - fails with -11829 "Cannot Open" and the video
-    // never plays (divine-blossom#198). The transcoder caps at the source
-    // resolution, so the "720p" variant of a 480x480 Vine is still 480x480 -
-    // smaller than the raw blob, not an upscale.
+    // Classic Vine originals take this path as well. The transcoder caps at
+    // the source resolution, so the "720p" variant of a 480x480 Vine is still
+    // 480x480 — smaller than the raw blob, not an upscale.
     return '$_divineMediaBase/$hash/720p.mp4';
   }
 
@@ -222,11 +214,9 @@ extension VideoEventAppExtensions on VideoEvent {
   /// Older desktop Chrome (< 150) and Firefox lack native HLS, so an HLS
   /// `.m3u8` won't play there. Resolve HLS to the progressive variant — the
   /// same [getOptimalVideoUrlForPlatform] selection the feed already uses on
-  /// every platform. Resolve bare Divine blobs too: every Range request to
-  /// `/{hash}` comes back as a cached `NoSuchKey` body dressed up as a 206
-  /// (divine-blossom#198), and a range-requesting player gets that instead of
-  /// video. Progressive URLs pass through unchanged, so the common case (and
-  /// its transcode readiness) is never touched.
+  /// every platform. Resolve bare Divine blobs too so previews prefer the
+  /// smaller progressive derivative. Progressive URLs pass through unchanged,
+  /// so the common case and its transcode readiness are never touched.
   String? get inlinePlayerVideoUrl {
     final url = videoUrl;
     if (url == null) return null;
@@ -248,11 +238,9 @@ extension VideoEventAppExtensions on VideoEvent {
   /// first.
   ///
   /// This is the feed's ladder, not a second one: [resolvePlaybackSources]
-  /// expands the platform pick into its canonical alternatives and withholds
-  /// the bare Divine blob, which answers a Range request with a cached
-  /// `NoSuchKey` body dressed up as a 206 (divine-blossom#198). Hand the result
-  /// to [setSourceWithFallbacks] — the HLS entry is a master playlist the
-  /// native player takes directly.
+  /// expands the platform pick into its canonical alternatives and keeps the
+  /// bare Divine blob last. Hand the result to [setSourceWithFallbacks] — the
+  /// HLS entry is a master playlist the native player takes directly.
   List<String> get previewPlaybackSources => resolvePlaybackSources(
     this,
     urlResolver: (video) => video.getOptimalVideoUrlForPlatform(),

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/VideoCache.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/VideoCache.kt
@@ -9,6 +9,7 @@ import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.TransferListener
 import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
@@ -80,8 +81,13 @@ internal object VideoCache {
     }
 
     private fun upstreamFactory(context: Context): DataSource.Factory {
-        val httpDataSourceFactory = DefaultHttpDataSource.Factory()
+        val defaultHttpDataSourceFactory = DefaultHttpDataSource.Factory()
             .setAllowCrossProtocolRedirects(true)
+        val httpDataSourceFactory = DataSource.Factory {
+            ProcessingResponseDataSource(
+                defaultHttpDataSourceFactory.createDataSource(),
+            )
+        }
         return DefaultDataSource.Factory(context, httpDataSourceFactory)
     }
 
@@ -91,6 +97,47 @@ internal object VideoCache {
         cache?.release()
         cache = null
         cacheDataSourceFactory = null
+    }
+}
+
+/**
+ * Converts an accepted HTTP 202 into a typed HTTP failure before Media3 tries
+ * to parse the processing response body as video or a manifest.
+ */
+internal class ProcessingResponseDataSource(
+    private val delegate: HttpDataSource,
+) : DataSource {
+
+    override fun addTransferListener(transferListener: TransferListener) {
+        delegate.addTransferListener(transferListener)
+    }
+
+    override fun open(dataSpec: DataSpec): Long {
+        val length = delegate.open(dataSpec)
+        if (delegate.responseCode != 202) return length
+
+        val responseHeaders = delegate.responseHeaders
+        delegate.close()
+        throw HttpDataSource.InvalidResponseCodeException(
+            202,
+            "Media is still processing",
+            null,
+            responseHeaders,
+            dataSpec,
+            ByteArray(0),
+        )
+    }
+
+    override fun read(buffer: ByteArray, offset: Int, length: Int): Int =
+        delegate.read(buffer, offset, length)
+
+    override fun getUri(): Uri? = delegate.uri
+
+    override fun getResponseHeaders(): Map<String, List<String>> =
+        delegate.responseHeaders
+
+    override fun close() {
+        delegate.close()
     }
 }
 

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/VideoCacheTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/VideoCacheTest.kt
@@ -4,11 +4,13 @@ import android.net.Uri
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.HttpDataSource
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -83,5 +85,24 @@ class VideoCacheTest {
         verify(exactly = 1) { cachedFactory.createDataSource() }
         verify(exactly = 0) { uncachedFactory.createDataSource() }
         assertTrue(openedSpec.captured.httpRequestHeaders.isEmpty())
+    }
+
+    @Test
+    fun `processing response rejects accepted HTTP 202 and closes delegate`() {
+        val delegate = mockk<HttpDataSource>(relaxed = true) {
+            every { open(any()) } returns 42L
+            every { responseCode } returns 202
+            every { responseHeaders } returns mapOf(
+                "Retry-After" to listOf("3"),
+            )
+        }
+        val source = ProcessingResponseDataSource(delegate)
+
+        val error = assertThrows(HttpDataSource.InvalidResponseCodeException::class.java) {
+            source.open(dataSpec())
+        }
+
+        assertEquals(202, error.responseCode)
+        verify(exactly = 1) { delegate.close() }
     }
 }

--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
@@ -11,12 +11,8 @@ import 'package:models/models.dart';
 /// [VideoEvent.videoUrl]. For Divine blob URLs the list is expanded with
 /// canonical alternatives so the runtime can fail over between them.
 ///
-/// For derivative-resolved Divine blobs, avoid falling back to the bare blob.
-/// Until divine-blossom#198 fixes Range support on bare blob URLs, range-
-/// requesting players can receive a cached XML NoSuchKey response as HTTP 206,
-/// so derivatives should recover through other renditions and HLS instead.
-/// Keep the raw URL only when it is the resolved source, where dropping it
-/// would leave raw/classic-Vine playback with no progressive option.
+/// Derivative-resolved Divine blobs use the bare blob as their final fallback,
+/// after quality-specific and HLS sources have been attempted.
 List<String> resolvePlaybackSources(
   VideoEvent video, {
   String? Function(VideoEvent video)? urlResolver,
@@ -32,13 +28,14 @@ List<String> resolvePlaybackSources(
   final hash = extractCanonicalDivineBlobHash(resolvedSource);
   if (hash != null) {
     final hlsUrl = canonicalDivineBlobHlsUrl(hash);
+    final rawUrl = canonicalDivineBlobRawUrl(hash);
     final isAlreadyHls = resolvedSource.contains('/hls/');
     if (isAlreadyHls) {
       final originalFallback =
           originalUrl != null && isDivineBlobRawUrl(originalUrl)
           ? null
           : originalUrl;
-      return orderedUniqueSources([resolvedSource, originalFallback]);
+      return orderedUniqueSources([resolvedSource, originalFallback, rawUrl]);
     }
 
     final isRawBlob = isDivineBlobRawUrl(resolvedSource);
@@ -46,17 +43,25 @@ List<String> resolvePlaybackSources(
       return orderedUniqueSources([resolvedSource, hlsUrl, originalUrl]);
     }
 
-    // TODO(liz): Restore the bare blob fallback after divine-blossom#198
-    // fixes Range support on bare blob URLs (#7184).
     final originalFallback =
         originalUrl != null && isDivineBlobRawUrl(originalUrl)
         ? null
         : originalUrl;
     if (derivativeFailureCache?.hasFreshFailureForHash(hash) ?? false) {
-      return orderedUniqueSources([hlsUrl, resolvedSource, originalFallback]);
+      return orderedUniqueSources([
+        hlsUrl,
+        resolvedSource,
+        originalFallback,
+        rawUrl,
+      ]);
     }
 
-    return orderedUniqueSources([resolvedSource, hlsUrl, originalFallback]);
+    return orderedUniqueSources([
+      resolvedSource,
+      hlsUrl,
+      originalFallback,
+      rawUrl,
+    ]);
   }
 
   return orderedUniqueSources([resolvedSource, originalUrl]);
@@ -109,6 +114,10 @@ VideoErrorType classifyVideoError({
 /// HTTP 422 while the raw blob is already available. Playback should treat both
 /// as transient source failures instead of terminal missing-media evidence.
 bool isMediaProcessingError(Object? error, {String? errorMessage}) {
+  if (nativePlayerErrorCodeFromError(error) ==
+      NativePlayerErrorCode.mediaProcessing) {
+    return true;
+  }
   final lower = '${errorMessage ?? ''} ${error ?? ''}'.toLowerCase();
   return _mentionsHttpStatus(lower, 202) || _mentionsHttpStatus(lower, 422);
 }

--- a/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
@@ -65,19 +65,19 @@ void main() {
     });
 
     group('when URL is a canonical HLS URL', () {
-      test('does not add the raw blob as a fallback', () {
+      test('adds the raw blob as the final fallback', () {
         final video = _makeVideo(videoUrl: _hlsUrl);
-        expect(resolvePlaybackSources(video), equals([_hlsUrl]));
+        expect(resolvePlaybackSources(video), equals([_hlsUrl, _rawUrl]));
       });
 
-      test('drops a raw original when the resolver selects HLS', () {
+      test('canonicalizes a raw original when the resolver selects HLS', () {
         final video = _makeVideo(videoUrl: _queryRawUrl);
         final result = resolvePlaybackSources(
           video,
           urlResolver: (_) => _hlsUrl,
         );
 
-        expect(result, equals([_hlsUrl]));
+        expect(result, equals([_hlsUrl, _rawUrl]));
       });
     });
 
@@ -108,25 +108,25 @@ void main() {
     group('when URL is a quality-specific Divine variant', () {
       const variantUrl = 'https://media.divine.video/$_hash/720p.mp4';
 
-      test(
-        'returns [variantUrl, hlsUrl, originalUrl] without raw fallback',
-        () {
-          final video = _makeVideo(videoUrl: variantUrl);
-          expect(resolvePlaybackSources(video), equals([variantUrl, _hlsUrl]));
-        },
-      );
+      test('returns variant, HLS, then raw blob fallback', () {
+        final video = _makeVideo(videoUrl: variantUrl);
+        expect(
+          resolvePlaybackSources(video),
+          equals([variantUrl, _hlsUrl, _rawUrl]),
+        );
+      });
 
-      test('drops a raw original when the resolver selects a variant', () {
+      test('uses canonical raw fallback when resolver selects a variant', () {
         final video = _makeVideo(videoUrl: _cdnRawUrl);
         final result = resolvePlaybackSources(
           video,
           urlResolver: (_) => variantUrl,
         );
 
-        expect(result, equals([variantUrl, _hlsUrl]));
+        expect(result, equals([variantUrl, _hlsUrl, _rawUrl]));
       });
 
-      test('drops an alternate-host raw original after a fresh failure', () {
+      test('keeps canonical raw last after an alternate-host failure', () {
         final video = _makeVideo(videoUrl: _cdnRawUrl);
         final cache = DerivativeFailureCache()
           ..recordFailureForSource(variantUrl);
@@ -137,17 +137,17 @@ void main() {
           derivativeFailureCache: cache,
         );
 
-        expect(result, equals([_hlsUrl, variantUrl]));
+        expect(result, equals([_hlsUrl, variantUrl, _rawUrl]));
       });
 
-      test('leads with HLS without raw fallback after a fresh failure', () {
+      test('leads with HLS and keeps raw last after a fresh failure', () {
         final video = _makeVideo(videoUrl: variantUrl);
         final cache = DerivativeFailureCache()
           ..recordFailureForSource(variantUrl);
 
         expect(
           resolvePlaybackSources(video, derivativeFailureCache: cache),
-          equals([_hlsUrl, variantUrl]),
+          equals([_hlsUrl, variantUrl, _rawUrl]),
         );
       });
 
@@ -163,7 +163,7 @@ void main() {
 
         expect(
           resolvePlaybackSources(video, derivativeFailureCache: cache),
-          equals([variantUrl, _hlsUrl]),
+          equals([variantUrl, _hlsUrl, _rawUrl]),
         );
       });
     });

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -209,9 +209,7 @@ void main() {
         failures: [
           PlatformException(
             code: 'PLAYER_ERROR',
-            details: const <String, Object?>{
-              'errorCode': 'media_processing',
-            },
+            details: const <String, Object?>{'errorCode': 'media_processing'},
           ),
         ],
       );
@@ -236,6 +234,34 @@ void main() {
       expect(delays, isEmpty);
       expect(logs.where((line) => line.contains('Source processing')), isEmpty);
       expect(logs.any((line) => line.contains('retrySource=rawUrl')), isTrue);
+    });
+
+    test('retries typed media-processing error on the last source', () async {
+      final clips = <VideoClip>[];
+      final controller = _RecordingControllerWithFailures(
+        clips.add,
+        failures: [
+          PlatformException(
+            code: 'PLAYER_ERROR',
+            details: const <String, Object?>{'errorCode': 'media_processing'},
+          ),
+        ],
+      );
+      addTearDown(controller.dispose);
+
+      final delays = <Duration>[];
+      final result = await setSourceWithFallbacks(
+        index: 2,
+        controller: controller,
+        sources: ['processingUrl'],
+        log: logs.add,
+        delay: (duration) async => delays.add(duration),
+      );
+
+      expect(result, equals(('processingUrl', 0)));
+      expect(clips.map((clip) => clip.uri), ['processingUrl', 'processingUrl']);
+      expect(delays, [const Duration(seconds: 1)]);
+      expect(logs.single, contains('Source processing'));
     });
 
     test('records media-processing source failure before failover', () async {

--- a/mobile/test/extensions/video_event_divine_server_test.dart
+++ b/mobile/test/extensions/video_event_divine_server_test.dart
@@ -303,10 +303,8 @@ void main() {
       );
     });
 
-    // Regression test for classic Vines being unplayable on iOS. Every Range
-    // request to the bare blob (`/{hash}`) returns a cached `NoSuchKey` XML
-    // body as a 206, and AVFoundation always range-requests, so it never gets
-    // video back (divine-blossom#198).
+    // Prefer the smaller faststart derivative for classic Vine originals too;
+    // the playback ladder retains the bare blob only as its final fallback.
     test('uses MP4 720p for classic Vine originals', () {
       final video = _createVideoWithUrl(
         'https://media.divine.video/$hash',
@@ -349,17 +347,15 @@ void main() {
     const hash =
         '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
-    test('withholds the bare blob for extensionless Divine URLs', () {
+    test('keeps the bare blob last for extensionless Divine URLs', () {
       final video = _createVideoWithUrl('https://media.divine.video/$hash');
 
-      // The regression in #7550: the preview used to be handed the bare blob,
-      // which answers a Range request with a cached NoSuchKey body dressed up
-      // as a 206 (divine-blossom#198).
       expect(
         video.previewPlaybackSources,
         equals([
           'https://media.divine.video/$hash/720p.mp4',
           'https://media.divine.video/$hash/hls/master.m3u8',
+          'https://media.divine.video/$hash',
         ]),
       );
     });
@@ -386,7 +382,10 @@ void main() {
       // A media playlist (stream_720p.m3u8) carries no #EXT-X-STREAM-INF, so
       // anything that parses variants out of it resolves to nothing. The
       // master is the rung the feed uses and the one the native player takes.
-      expect(video.previewPlaybackSources.last, endsWith('/hls/master.m3u8'));
+      expect(
+        video.previewPlaybackSources[1],
+        endsWith('/hls/master.m3u8'),
+      );
     });
 
     test('leaves non-Divine videos with their single original source', () {

--- a/mobile/test/screens/subtitle_editor/subtitle_editor_screen_test.dart
+++ b/mobile/test/screens/subtitle_editor/subtitle_editor_screen_test.dart
@@ -467,9 +467,8 @@ void main() {
       );
 
       // The editor must not carry its own ladder: #7550 is what happens when it
-      // does. The bare blob answers a Range request with a cached NoSuchKey body
-      // dressed up as a 206 (divine-blossom#198), so it is absent here, and the
-      // HLS rung is the master playlist the native player takes directly.
+      // does. The shared ladder tries renditions first and preserves the bare
+      // blob as its last-resort fallback.
       expect(
         stage.playbackUrls,
         equals(
@@ -484,6 +483,7 @@ void main() {
         equals([
           'https://media.divine.video/$hash/720p.mp4',
           'https://media.divine.video/$hash/hls/master.m3u8',
+          'https://media.divine.video/$hash',
         ]),
       );
     });


### PR DESCRIPTION
## Problem

Freshly uploaded videos could fail playback on Android while their optimized renditions were still processing. Media3 accepts HTTP 202 as a successful response, then reports the processing body as an unsupported video or malformed manifest. The feed exhausted both derivative sources without ever trying the playable original blob.

## Fix

- convert Android HTTP 202 responses into the existing typed media-processing error before Media3 parses the body
- recognize typed media-processing errors in Dart so the existing bounded retry path runs
- keep the original Divine blob as the final fallback after MP4 and HLS, including when derivative failures reorder the ladder
- remove stale comments that described the original blob fallback as unsafe

The Apple native error path is unchanged because it already identifies HTTP 202 responses. Retry timing and the derivative failure cache are also unchanged.

## Verification

- full infinite_video_feed package test suite
- full divine_video_player Dart test suite
- affected app extension tests
- full Flutter analysis
- Android transport regression test added; native compilation and execution are covered by CI because this workstation has no JDK

Closes #8553
Closes #7184