### PR TITLE
fix(db): keep rollback journals with their databases

### DIFF
--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -1089,12 +1089,7 @@ void _backupDestinationDatabase(String dbPath) {
   );
 
   File(dbPath).renameSync(backupPath);
-  for (final suffix in databaseSidecarSuffixes) {
-    final sidecar = File('$dbPath$suffix');
-    if (sidecar.existsSync()) {
-      sidecar.renameSync('$backupPath$suffix');
-    }
-  }
+  _moveSidecars(fromPath: dbPath, toPath: backupPath);
 }
 
 void _backupLegacyConflictDatabase({

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -800,7 +800,7 @@ bool _encryptPlaintextMigrationArtifact({
 }
 
 /// Promotes the verified encrypted migration artifact into the canonical DB
-/// path, carrying WAL/SHM sidecars with it.
+/// path, carrying its rollback-journal, WAL, and SHM sidecars with it.
 @visibleForTesting
 void promoteEncryptedMigrationArtifact({
   required String encryptedPath,
@@ -864,10 +864,11 @@ int _userVersion(Database db) =>
 /// When the platform keystore is cleared (OS reset / restore without keychain
 /// migration) the cipher key is gone and the encrypted database is
 /// cryptographically unrecoverable, so it must be replaced. It is renamed to a
-/// timestamped backup (with its `-wal`/`-shm` sidecars) rather than deleted, so
-/// a misclassification or a future recovery path is never catastrophic. A fresh
-/// encrypted database is created under the new key on first open; DMs resync
-/// from relays. See `mobile/docs/sqlcipher_at_rest_plan.md`.
+/// timestamped backup (with its rollback-journal, WAL, and SHM sidecars)
+/// rather than deleted, so a misclassification or a future recovery path is
+/// never catastrophic. A fresh encrypted database is created under the new
+/// key on first open; DMs resync from relays. See
+/// `mobile/docs/sqlcipher_at_rest_plan.md`.
 Future<void> backUpAndRemoveSharedDatabase() async {
   final dbPath = await getSharedDatabasePath();
   if (!File(dbPath).existsSync()) return;

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -1139,7 +1139,7 @@ void _moveSidecars({
 
 @visibleForTesting
 void deleteDatabaseAndSidecars(String dbPath) {
-  for (final suffix in ['', ...databaseSidecarSuffixes]) {
+  for (final suffix in const ['', ...databaseSidecarSuffixes]) {
     final file = File('$dbPath$suffix');
     if (file.existsSync()) file.deleteSync();
   }

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -3,6 +3,7 @@
 
 import 'dart:io';
 import 'package:collection/collection.dart';
+import 'package:db_client/src/database/connection/database_sidecars.dart';
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:meta/meta.dart';
@@ -921,7 +922,7 @@ bool _isPreCipherMigrationBackupName(String name, String backupPrefix) {
     return true;
   }
 
-  for (final suffix in const ['-wal', '-shm']) {
+  for (final suffix in databaseSidecarSuffixes) {
     if (!name.endsWith(suffix) || name.length <= suffix.length) continue;
     final baseName = name.substring(0, name.length - suffix.length);
     if (baseName == backupPrefix || indexedBackupPattern.hasMatch(baseName)) {
@@ -1037,8 +1038,8 @@ void applyDbCacheVersionReset(String dbPath) {
 ///    data, delete the orphaned legacy file. Otherwise preserve both;
 ///    replacing a populated destination can discard local-only data.
 ///
-/// Also migrates the SQLite `-wal` and `-shm` sidecar files if present, so
-/// any unsynced writes in the write-ahead log are preserved.
+/// Also migrates SQLite rollback-journal, WAL, and SHM sidecar files if
+/// present, so recovery data and unsynced writes stay with the database.
 @visibleForTesting
 Future<void> migrateLegacyDatabase({
   required String legacyPath,
@@ -1087,7 +1088,7 @@ void _backupDestinationDatabase(String dbPath) {
   );
 
   File(dbPath).renameSync(backupPath);
-  for (final suffix in const ['-wal', '-shm']) {
+  for (final suffix in databaseSidecarSuffixes) {
     final sidecar = File('$dbPath$suffix');
     if (sidecar.existsSync()) {
       sidecar.renameSync('$backupPath$suffix');
@@ -1116,7 +1117,7 @@ void _backupLegacyConflictDatabase({
 
 Map<String, List<int>> _readDatabaseSidecars(String dbPath) {
   final sidecars = <String, List<int>>{};
-  for (final suffix in const ['-wal', '-shm']) {
+  for (final suffix in databaseSidecarSuffixes) {
     final sidecar = File('$dbPath$suffix');
     if (sidecar.existsSync()) {
       sidecars[suffix] = sidecar.readAsBytesSync();
@@ -1130,7 +1131,7 @@ void _moveSidecars({
   required String toPath,
   Map<String, List<int>>? preservedSidecars,
 }) {
-  for (final suffix in const ['-wal', '-shm']) {
+  for (final suffix in databaseSidecarSuffixes) {
     final sidecar = File('$fromPath$suffix');
     if (sidecar.existsSync()) {
       sidecar.renameSync('$toPath$suffix');
@@ -1142,7 +1143,7 @@ void _moveSidecars({
 
 @visibleForTesting
 void deleteDatabaseAndSidecars(String dbPath) {
-  for (final suffix in const ['', '-wal', '-shm']) {
+  for (final suffix in ['', ...databaseSidecarSuffixes]) {
     final file = File('$dbPath$suffix');
     if (file.existsSync()) file.deleteSync();
   }
@@ -1152,8 +1153,9 @@ String _nextDatabaseBackupPath(String dbPath, {required String suffix}) {
   var candidate = '$dbPath$suffix';
   var index = 1;
   while (File(candidate).existsSync() ||
-      File('$candidate-wal').existsSync() ||
-      File('$candidate-shm').existsSync()) {
+      databaseSidecarSuffixes.any(
+        (sidecarSuffix) => File('$candidate$sidecarSuffix').existsSync(),
+      )) {
     candidate = '$dbPath$suffix.$index';
     index += 1;
   }

--- a/mobile/packages/db_client/lib/src/database/connection/database_sidecars.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/database_sidecars.dart
@@ -1,0 +1,5 @@
+/// SQLite files whose lifecycle is coupled to the main database file.
+///
+/// A rollback journal is recovery data. It must move with its database and
+/// must only be deleted when the corresponding database is deleted too.
+const databaseSidecarSuffixes = ['-journal', '-wal', '-shm'];

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -84,15 +84,17 @@ void main() {
     test('preserves existing DB and sidecars when stored version is stale', () {
       Directory(dbDir).createSync(recursive: true);
       File(dbPath).writeAsBytesSync(const [1]);
-      File('$dbPath-wal').writeAsBytesSync(const [2]);
-      File('$dbPath-shm').writeAsBytesSync(const [3]);
+      File('$dbPath-journal').writeAsBytesSync(const [2]);
+      File('$dbPath-wal').writeAsBytesSync(const [3]);
+      File('$dbPath-shm').writeAsBytesSync(const [4]);
       writeDbCacheVersion(dbDir, 1);
 
       applyDbCacheVersionReset(dbPath);
 
       expect(File(dbPath).readAsBytesSync(), equals(const [1]));
-      expect(File('$dbPath-wal').readAsBytesSync(), equals(const [2]));
-      expect(File('$dbPath-shm').readAsBytesSync(), equals(const [3]));
+      expect(File('$dbPath-journal').readAsBytesSync(), equals(const [2]));
+      expect(File('$dbPath-wal').readAsBytesSync(), equals(const [3]));
+      expect(File('$dbPath-shm').readAsBytesSync(), equals(const [4]));
       expect(readDbCacheVersion(dbDir), equals(dbCacheVersion));
     });
 
@@ -302,6 +304,21 @@ void main() {
       },
     );
 
+    test('does not reuse a backup name owned by a rollback journal', () async {
+      _createSqliteDatabase(legacyPath, draftCount: 1);
+      _createSqliteDatabase(newPath);
+      final occupiedBackupPath = _destinationBackupPath(newPath);
+      File('$occupiedBackupPath-journal').writeAsBytesSync(const [9]);
+
+      await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
+
+      expect(
+        File('$occupiedBackupPath-journal').readAsBytesSync(),
+        equals([9]),
+      );
+      expect(File('$occupiedBackupPath.1').existsSync(), isTrue);
+    });
+
     test(
       'preserves destination when queue rows still require action',
       () async {
@@ -383,18 +400,21 @@ void main() {
       expect(Directory(p.dirname(newPath)).existsSync(), isFalse);
     });
 
-    test('migrates WAL and SHM sidecar files alongside the database', () async {
+    test('migrates every sidecar file alongside the database', () async {
       final legacyFile = File(legacyPath);
       legacyFile.parent.createSync(recursive: true);
       legacyFile.writeAsBytesSync(const [1]);
-      File('$legacyPath-wal').writeAsBytesSync(const [2]);
-      File('$legacyPath-shm').writeAsBytesSync(const [3]);
+      File('$legacyPath-journal').writeAsBytesSync(const [2]);
+      File('$legacyPath-wal').writeAsBytesSync(const [3]);
+      File('$legacyPath-shm').writeAsBytesSync(const [4]);
 
       await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
 
       expect(File(newPath).readAsBytesSync(), equals(const [1]));
-      expect(File('$newPath-wal').readAsBytesSync(), equals(const [2]));
-      expect(File('$newPath-shm').readAsBytesSync(), equals(const [3]));
+      expect(File('$newPath-journal').readAsBytesSync(), equals(const [2]));
+      expect(File('$newPath-wal').readAsBytesSync(), equals(const [3]));
+      expect(File('$newPath-shm').readAsBytesSync(), equals(const [4]));
+      expect(File('$legacyPath-journal').existsSync(), isFalse);
       expect(File('$legacyPath-wal').existsSync(), isFalse);
       expect(File('$legacyPath-shm').existsSync(), isFalse);
     });
@@ -1423,10 +1443,11 @@ void main() {
       }
     });
 
-    test('moves the encrypted artifact and WAL/SHM sidecars into place', () {
+    test('moves the encrypted artifact and every sidecar into place', () {
       File(encryptedPath).writeAsBytesSync(const [1]);
-      File('$encryptedPath-wal').writeAsBytesSync(const [2]);
-      File('$encryptedPath-shm').writeAsBytesSync(const [3]);
+      File('$encryptedPath-journal').writeAsBytesSync(const [2]);
+      File('$encryptedPath-wal').writeAsBytesSync(const [3]);
+      File('$encryptedPath-shm').writeAsBytesSync(const [4]);
 
       promoteEncryptedMigrationArtifact(
         encryptedPath: encryptedPath,
@@ -1434,9 +1455,11 @@ void main() {
       );
 
       expect(File(dbPath).readAsBytesSync(), equals(const [1]));
-      expect(File('$dbPath-wal').readAsBytesSync(), equals(const [2]));
-      expect(File('$dbPath-shm').readAsBytesSync(), equals(const [3]));
+      expect(File('$dbPath-journal').readAsBytesSync(), equals(const [2]));
+      expect(File('$dbPath-wal').readAsBytesSync(), equals(const [3]));
+      expect(File('$dbPath-shm').readAsBytesSync(), equals(const [4]));
       expect(File(encryptedPath).existsSync(), isFalse);
+      expect(File('$encryptedPath-journal').existsSync(), isFalse);
       expect(File('$encryptedPath-wal').existsSync(), isFalse);
       expect(File('$encryptedPath-shm').existsSync(), isFalse);
     });
@@ -1467,22 +1490,25 @@ void main() {
         final indexedBackupPath = '$dbPath.pre_cipher_migration_backup.1';
         final keyLossBackupPath = '$dbPath.pre_key_loss_wipe_backup';
         File(backupPath).writeAsBytesSync(const [1]);
-        File('$backupPath-wal').writeAsBytesSync(const [2]);
-        File('$backupPath-shm').writeAsBytesSync(const [3]);
-        File(indexedBackupPath).writeAsBytesSync(const [4]);
-        File('$indexedBackupPath-wal').writeAsBytesSync(const [5]);
-        File(keyLossBackupPath).writeAsBytesSync(const [6]);
+        File('$backupPath-journal').writeAsBytesSync(const [2]);
+        File('$backupPath-wal').writeAsBytesSync(const [3]);
+        File('$backupPath-shm').writeAsBytesSync(const [4]);
+        File(indexedBackupPath).writeAsBytesSync(const [5]);
+        File('$indexedBackupPath-journal').writeAsBytesSync(const [6]);
+        File(keyLossBackupPath).writeAsBytesSync(const [7]);
         File(
           '$dbPath.pre_cipher_migration_backup_notes',
-        ).writeAsBytesSync(const [7]);
+        ).writeAsBytesSync(const [8]);
 
         cleanUpPreCipherMigrationBackups(dbPath);
 
         expect(File(dbPath).existsSync(), isTrue);
         expect(File(backupPath).existsSync(), isFalse);
+        expect(File('$backupPath-journal').existsSync(), isFalse);
         expect(File('$backupPath-wal').existsSync(), isFalse);
         expect(File('$backupPath-shm').existsSync(), isFalse);
         expect(File(indexedBackupPath).existsSync(), isFalse);
+        expect(File('$indexedBackupPath-journal').existsSync(), isFalse);
         expect(File('$indexedBackupPath-wal').existsSync(), isFalse);
         expect(File(keyLossBackupPath).existsSync(), isTrue);
         expect(
@@ -1503,9 +1529,10 @@ void main() {
       );
       dbPath = p.join(tempRoot.path, 'divine_db.db');
       File(dbPath).writeAsBytesSync(const [1]);
-      File('$dbPath-wal').writeAsBytesSync(const [2]);
-      File('$dbPath-shm').writeAsBytesSync(const [3]);
-      File('$dbPath.pre_key_loss_wipe_backup').writeAsBytesSync(const [4]);
+      File('$dbPath-journal').writeAsBytesSync(const [2]);
+      File('$dbPath-wal').writeAsBytesSync(const [3]);
+      File('$dbPath-shm').writeAsBytesSync(const [4]);
+      File('$dbPath.pre_key_loss_wipe_backup').writeAsBytesSync(const [5]);
     });
 
     tearDown(() {
@@ -1520,6 +1547,7 @@ void main() {
         deleteDatabaseAndSidecars(dbPath);
 
         expect(File(dbPath).existsSync(), isFalse);
+        expect(File('$dbPath-journal').existsSync(), isFalse);
         expect(File('$dbPath-wal').existsSync(), isFalse);
         expect(File('$dbPath-shm').existsSync(), isFalse);
         expect(


### PR DESCRIPTION
Database moves and backups could leave SQLite rollback journals behind, separating a database from the recovery data needed to undo incomplete writes. This was especially risky during interrupted legacy migration and encrypted-artifact promotion.

This centralizes SQLite sidecar ownership and applies the same `-journal`, `-wal`, and `-shm` set to moves, backups, preserved-sidecar reads, cleanup, paired deletion, and backup-name collision checks. Rollback journals are never deleted independently; they are removed only when the corresponding database is intentionally removed.

This does not add startup journal replay; that independent recovery path remains in #8564.

Verification:
- `flutter test packages/db_client/test/src/database/connection/connection_native_test.dart`
- `flutter analyze packages/db_client`

Closes #8566