### PR TITLE
fix(video-metadata): keep lower options reachable while typing

### DIFF
--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_stack.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_stack.dart
@@ -18,6 +18,7 @@ class VideoMetadataCaptureStack extends StatelessWidget {
         children: [
           Expanded(
             child: SingleChildScrollView(
+              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
               child: Column(
                 mainAxisSize: .min,
                 crossAxisAlignment: .stretch,

--- a/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_stack.dart
+++ b/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_stack.dart
@@ -18,6 +18,7 @@ class VideoMetadataClassicStack extends StatelessWidget {
         children: [
           Expanded(
             child: SingleChildScrollView(
+              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
               padding: .only(top: 12),
               child: Column(
                 mainAxisSize: .min,

--- a/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
+++ b/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
@@ -150,6 +150,7 @@ class _VideoMetadataEditStackContentState
         children: [
           Expanded(
             child: SingleChildScrollView(
+              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_stack_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_stack_test.dart
@@ -113,7 +113,7 @@ void main() {
       );
     });
 
-    testWidgets('dragging a long description scrolls toward metadata options', (
+    testWidgets('a drag notification from the description dismisses keyboard', (
       tester,
     ) async {
       await tester.binding.setSurfaceSize(const Size(402, 874));
@@ -131,27 +131,44 @@ void main() {
         (widget) =>
             widget is DivineTextField && widget.labelText == 'Description',
       );
-      await tester.enterText(description, List.filled(260, 'a').join());
-      await tester.pump();
-
-      final bottomBar = find.byType(VideoMetadataCaptureBottomBar);
-      final descriptionRect = tester.getRect(description);
-      final dragStart = Offset(
-        descriptionRect.center.dx,
-        tester.getTopLeft(bottomBar).dy - 1,
+      await tester.enterText(
+        description,
+        List.generate(40, (index) => 'description line $index').join('\n'),
       );
-      expect(descriptionRect.contains(dragStart), isTrue);
+      await tester.pump(const Duration(seconds: 1));
 
+      final descriptionField = tester.widget<DivineTextField>(description);
+      expect(descriptionField.focusNode?.hasFocus, isTrue);
+
+      final editable = find.descendant(
+        of: description,
+        matching: find.byType(EditableText),
+      );
       final outerScrollable = tester.state<ScrollableState>(
         find.byType(Scrollable).first,
       );
       final initialOffset = outerScrollable.position.pixels;
 
-      await tester.dragFrom(dragStart, const Offset(0, -300));
+      final editableContext = tester.element(editable);
+      final descriptionScrollable = tester.state<ScrollableState>(
+        find.descendant(of: description, matching: find.byType(Scrollable)),
+      );
+      ScrollUpdateNotification(
+        metrics: descriptionScrollable.position,
+        context: editableContext,
+        scrollDelta: 10,
+        dragDetails: DragUpdateDetails(
+          globalPosition: Offset.zero,
+          delta: const Offset(0, -10),
+        ),
+      ).dispatch(editableContext);
       await tester.pump();
-      await tester.pump(const Duration(seconds: 1));
 
-      expect(outerScrollable.position.pixels, greaterThan(initialOffset));
+      // The description consumes this drag to scroll its own text. Dismissing
+      // the keyboard is intentional: it restores the viewport so the next
+      // page drag can reach Tags and the remaining metadata controls.
+      expect(outerScrollable.position.pixels, initialOffset);
+      expect(descriptionField.focusNode?.hasFocus, isFalse);
     });
   });
 }

--- a/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_stack_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_stack_test.dart
@@ -32,7 +32,10 @@ void main() {
       );
     });
 
-    Widget buildWidget() {
+    Widget buildWidget({
+      TextScaler textScaler = TextScaler.noScaling,
+      EdgeInsets viewInsets = EdgeInsets.zero,
+    }) {
       return ProviderScope(
         overrides: [
           clipManagerProvider.overrideWith(
@@ -42,10 +45,21 @@ void main() {
             () => _MockVideoEditorNotifier(VideoEditorProviderState()),
           ),
         ],
-        child: const MaterialApp(
+        child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: VideoMetadataCaptureStack(),
+          theme: ThemeData(platform: TargetPlatform.iOS),
+          builder: (context, child) {
+            final mediaQuery = MediaQuery.of(context);
+            return MediaQuery(
+              data: mediaQuery.copyWith(
+                textScaler: textScaler,
+                viewInsets: viewInsets,
+              ),
+              child: child!,
+            );
+          },
+          home: const VideoMetadataCaptureStack(),
         ),
       );
     }
@@ -87,10 +101,57 @@ void main() {
       expect(scaffold.backgroundColor, equals(VineTheme.surfaceContainerHigh));
     });
 
-    testWidgets('body is scrollable', (tester) async {
+    testWidgets('body scroll dismisses the keyboard', (tester) async {
       await tester.pumpWidget(buildWidget());
 
-      expect(find.byType(SingleChildScrollView), findsOneWidget);
+      final scrollView = tester.widget<SingleChildScrollView>(
+        find.byType(SingleChildScrollView),
+      );
+      expect(
+        scrollView.keyboardDismissBehavior,
+        ScrollViewKeyboardDismissBehavior.onDrag,
+      );
+    });
+
+    testWidgets('dragging a long description scrolls toward metadata options', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(402, 874));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.pumpWidget(
+        buildWidget(
+          textScaler: const TextScaler.linear(1.35),
+          viewInsets: const EdgeInsets.only(bottom: 336),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      final description = find.byWidgetPredicate(
+        (widget) =>
+            widget is DivineTextField && widget.labelText == 'Description',
+      );
+      await tester.enterText(description, List.filled(260, 'a').join());
+      await tester.pump();
+
+      final bottomBar = find.byType(VideoMetadataCaptureBottomBar);
+      final descriptionRect = tester.getRect(description);
+      final dragStart = Offset(
+        descriptionRect.center.dx,
+        tester.getTopLeft(bottomBar).dy - 1,
+      );
+      expect(descriptionRect.contains(dragStart), isTrue);
+
+      final outerScrollable = tester.state<ScrollableState>(
+        find.byType(Scrollable).first,
+      );
+      final initialOffset = outerScrollable.position.pixels;
+
+      await tester.dragFrom(dragStart, const Offset(0, -300));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(outerScrollable.position.pixels, greaterThan(initialOffset));
     });
   });
 }

--- a/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_stack_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_stack_test.dart
@@ -103,10 +103,18 @@ void main() {
       expect(scaffold.backgroundColor, equals(VineTheme.surfaceContainerHigh));
     });
 
-    testWidgetsWithSurfaceSize('body is scrollable', (tester) async {
+    testWidgetsWithSurfaceSize('body scroll dismisses the keyboard', (
+      tester,
+    ) async {
       await tester.pumpWidget(buildWidget());
 
-      expect(find.byType(SingleChildScrollView), findsOneWidget);
+      final scrollView = tester.widget<SingleChildScrollView>(
+        find.byType(SingleChildScrollView),
+      );
+      expect(
+        scrollView.keyboardDismissBehavior,
+        ScrollViewKeyboardDismissBehavior.onDrag,
+      );
     });
 
     testWidgetsWithSurfaceSize(

--- a/mobile/test/widgets/video_metadata/modes/edit/video_metadata_edit_stack_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/edit/video_metadata_edit_stack_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group(VideoMetadataEditStack, () {
+    testWidgets('body scroll dismisses the keyboard', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final preferences = await SharedPreferences.getInstance();
+
+      await tester.pumpWidget(_buildSubject(preferences));
+      await tester.pump();
+
+      final scrollView = tester.widget<SingleChildScrollView>(
+        find.byType(SingleChildScrollView),
+      );
+      expect(
+        scrollView.keyboardDismissBehavior,
+        ScrollViewKeyboardDismissBehavior.onDrag,
+      );
+    });
+  });
+}
+
+Widget _buildSubject(SharedPreferences preferences) {
+  return ProviderScope(
+    overrides: [sharedPreferencesProvider.overrideWithValue(preferences)],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: VideoMetadataEditStack(
+        video: VideoEvent(
+          id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          pubkey:
+              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          createdAt: 1757385263,
+          content: 'Description',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
+          title: 'Title',
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## Problem
With the software keyboard open, the video metadata form stays compressed while the user tries to reach Tags, Collaborators, and the options below a long description. This is especially restrictive with larger accessibility text and affects both initial posting and post-publish editing.

## Why this fix
The long description can become its own scrollable area, while the surrounding page is also scrollable. A drag may therefore scroll either the description or the page. Previously neither path dismissed the keyboard, so the form could remain trapped in the compressed viewport.

The capture, classic import, and post-publish edit forms now dismiss the keyboard when either scrollable receives a user drag. Dismissing on a description scroll is intentional: it restores the vertical space needed for a following page drag to reach the lower controls.

The title and description limits, stored metadata, publishing behavior, and pinned action bars are unchanged.

## Verification
- Reproduced the constrained layout at 402 x 874, iOS scroll behavior, 1.35 text scale, a 336-point keyboard inset, and a long focused description.
- Added red-green coverage proving a drag notification from the internally scrolling description clears focus while leaving the page offset unchanged.
- Added coverage for the capture, classic import, and post-publish edit stacks.
- `flutter test test/widgets/video_metadata/video_metadata_form_fields_test.dart test/widgets/video_metadata/modes/capture/video_metadata_capture_stack_test.dart test/widgets/video_metadata/modes/classic/video_metadata_classic_stack_test.dart test/widgets/video_metadata/modes/edit/video_metadata_edit_stack_test.dart`
- `flutter analyze`
- Pre-push changed-file analysis and tests

Closes #8575
