### PR TITLE
fix(search): put exact account matches first

### DIFF
--- a/mobile/docs/PEOPLE_SEARCH.md
+++ b/mobile/docs/PEOPLE_SEARCH.md
@@ -27,13 +27,14 @@ UserSearchBloc                              mobile/lib/blocs/user_search/
 ProfileRepository.searchUsersProgressive    mobile/packages/profile_repository/
   Phase 1 (offset==0): UserProfilesDao.searchProfilesByIdentity
                        bounded SQLite identity query (name, display name,
-                       nip05, pubkey prefix; bio excluded), npub decoded to hex
+                       nip05, whole pubkey; bio excluded), npub decoded to hex
   Phase 2:             funnelcake.searchProfiles REST, no explicit timeout
   Phase 3 (offset==0): nostrClient.queryUsers    NIP-50 WS, 4.5s relay budget + 5s guard
   Each phase records a SearchSourceStatus in the result envelope.
   Final yield: _enrichFromCache + _applyFilter (exact > prefix > word >
                substring relevance, followers/videos as tie-breaker, block
-               filter, boost); envelope carries nextRestOffset/restHasMore
+               filter, follow boost behind exact matches); envelope carries
+               nextRestOffset/restHasMore
         ↓
 NostrClient.queryUsers                      mobile/packages/nostr_client/
   • tempRelays = [relay.nostr.band, search.nos.today, nostr.wine]

--- a/mobile/docs/PEOPLE_SEARCH.md
+++ b/mobile/docs/PEOPLE_SEARCH.md
@@ -25,11 +25,15 @@ UserSearchBloc                              mobile/lib/blocs/user_search/
     FeedPerformanceTracker.trackSearchSource
         ↓
 ProfileRepository.searchUsersProgressive    mobile/packages/profile_repository/
-  Phase 1 (offset==0): searchUsersLocally        SQLite cache, no timeout
+  Phase 1 (offset==0): UserProfilesDao.searchProfilesByIdentity
+                       bounded SQLite identity query (name, display name,
+                       nip05, pubkey prefix; bio excluded), npub decoded to hex
   Phase 2:             funnelcake.searchProfiles REST, no explicit timeout
   Phase 3 (offset==0): nostrClient.queryUsers    NIP-50 WS, 4.5s relay budget + 5s guard
   Each phase records a SearchSourceStatus in the result envelope.
-  Final yield: _enrichFromCache + _applyFilter (block filter + boost)
+  Final yield: _enrichFromCache + _applyFilter (exact > prefix > word >
+               substring relevance, followers/videos as tie-breaker, block
+               filter, boost); envelope carries nextRestOffset/restHasMore
         ↓
 NostrClient.queryUsers                      mobile/packages/nostr_client/
   • tempRelays = [relay.nostr.band, search.nos.today, nostr.wine]

--- a/mobile/lib/blocs/user_search/user_search_bloc.dart
+++ b/mobile/lib/blocs/user_search/user_search_bloc.dart
@@ -126,7 +126,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
     var trackedFirst = false;
     var latestUnfilteredCount = 0;
     int? nextRestOffset;
-    bool? restHasMore;
+    var restHasMore = false;
     var latestSourceOutcomes = _pendingSourceOutcomes();
     // Snapshot of sources whose terminal status has already been
     // forwarded to feedTracker — prevents duplicate events when a
@@ -217,7 +217,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
         state.copyWith(
           status: UserSearchStatus.success,
           offset: nextRestOffset ?? latestUnfilteredCount,
-          hasMore: restHasMore ?? latestUnfilteredCount == _pageSize,
+          hasMore: restHasMore,
           isLoadingMore: false,
         ),
       );
@@ -314,7 +314,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
         state.copyWith(
           results: allResults,
           offset: result.nextRestOffset ?? state.offset + unfilteredPageCount,
-          hasMore: result.restHasMore ?? unfilteredPageCount == _pageSize,
+          hasMore: result.restHasMore,
           isLoadingMore: false,
         ),
       );

--- a/mobile/lib/blocs/user_search/user_search_bloc.dart
+++ b/mobile/lib/blocs/user_search/user_search_bloc.dart
@@ -125,6 +125,8 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
     _feedTracker?.startFeedLoad('user_search');
     var trackedFirst = false;
     var latestUnfilteredCount = 0;
+    int? nextRestOffset;
+    bool? restHasMore;
     var latestSourceOutcomes = _pendingSourceOutcomes();
     // Snapshot of sources whose terminal status has already been
     // forwarded to feedTracker — prevents duplicate events when a
@@ -179,6 +181,8 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
             : searchStream.timeout(searchTimeout!),
         onData: (result) {
           latestUnfilteredCount = result.profiles.length;
+          nextRestOffset = result.nextRestOffset;
+          restHasMore = result.restHasMore;
           final visibleProfiles = _visibleProfiles(result.profiles);
           if (!trackedFirst && visibleProfiles.isNotEmpty) {
             trackedFirst = true;
@@ -212,8 +216,8 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
       emit(
         state.copyWith(
           status: UserSearchStatus.success,
-          offset: latestUnfilteredCount,
-          hasMore: latestUnfilteredCount == _pageSize,
+          offset: nextRestOffset ?? latestUnfilteredCount,
+          hasMore: restHasMore ?? latestUnfilteredCount == _pageSize,
           isLoadingMore: false,
         ),
       );
@@ -309,8 +313,8 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
       emit(
         state.copyWith(
           results: allResults,
-          offset: state.offset + unfilteredPageCount,
-          hasMore: unfilteredPageCount == _pageSize,
+          offset: result.nextRestOffset ?? state.offset + unfilteredPageCount,
+          hasMore: result.restHasMore ?? unfilteredPageCount == _pageSize,
           isLoadingMore: false,
         ),
       );

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -432,6 +432,8 @@ ProfileRepository _buildProfileRepository(Ref ref, {required bool warmCache}) {
     keycastNip05Url: ref.watch(oauthConfigProvider).nip05Url,
     profileSearchFilter: (query, profiles) =>
         SearchUtils.searchProfiles(query, profiles, limit: 50),
+    localProfileSearch: (query, limit) =>
+        userProfilesDao.searchProfilesByIdentity(query, limit: limit),
     blockFilter: blockFilter,
   );
 

--- a/mobile/packages/db_client/lib/src/database/daos/user_profiles_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/user_profiles_dao.dart
@@ -152,11 +152,10 @@ class UserProfilesDao extends DatabaseAccessor<AppDatabase>
   /// Biography text is deliberately excluded: people discovery should not
   /// turn a short query into an unbounded scan of incidental prose.
   ///
-  /// Public keys match by prefix only. A hex substring is not something a
-  /// person types, and a two-character hex query would otherwise sweep a
-  /// share of every cached pubkey into the bounded candidate set ahead of
-  /// real name matches. Prefix hits rank after name prefixes and before
-  /// name substrings.
+  /// Public keys match only when the whole key is given. A hex prefix or
+  /// substring is not something a person types, and a two-character hex
+  /// query would otherwise sweep a share of every cached pubkey into the
+  /// bounded candidate set ahead of real name matches.
   Future<List<UserProfile>> searchProfilesByIdentity(
     String query, {
     required int limit,
@@ -169,7 +168,7 @@ class UserProfilesDao extends DatabaseAccessor<AppDatabase>
         WHERE instr(lower(coalesce(name, '')), ?) > 0
            OR instr(lower(coalesce(display_name, '')), ?) > 0
            OR instr(lower(coalesce(nip05, '')), ?) > 0
-           OR instr(lower(pubkey), ?) = 1
+           OR lower(pubkey) = ?
         ORDER BY
           CASE
             WHEN lower(coalesce(name, '')) = ? THEN 0
@@ -178,14 +177,13 @@ class UserProfilesDao extends DatabaseAccessor<AppDatabase>
             WHEN lower(pubkey) = ? THEN 0
             WHEN instr(lower(coalesce(name, '')), ?) = 1 THEN 1
             WHEN instr(lower(coalesce(display_name, '')), ?) = 1 THEN 1
-            WHEN instr(lower(pubkey), ?) = 1 THEN 2
-            ELSE 3
+            ELSE 2
           END,
           created_at DESC
         LIMIT ?
       ''',
       variables: [
-        for (var i = 0; i < 11; i++) Variable.withString(normalized),
+        for (var i = 0; i < 10; i++) Variable.withString(normalized),
         Variable.withInt(limit),
       ],
       readsFrom: {userProfiles},

--- a/mobile/packages/db_client/lib/src/database/daos/user_profiles_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/user_profiles_dao.dart
@@ -151,6 +151,12 @@ class UserProfilesDao extends DatabaseAccessor<AppDatabase>
   ///
   /// Biography text is deliberately excluded: people discovery should not
   /// turn a short query into an unbounded scan of incidental prose.
+  ///
+  /// Public keys match by prefix only. A hex substring is not something a
+  /// person types, and a two-character hex query would otherwise sweep a
+  /// share of every cached pubkey into the bounded candidate set ahead of
+  /// real name matches. Prefix hits rank after name prefixes and before
+  /// name substrings.
   Future<List<UserProfile>> searchProfilesByIdentity(
     String query, {
     required int limit,
@@ -163,7 +169,7 @@ class UserProfilesDao extends DatabaseAccessor<AppDatabase>
         WHERE instr(lower(coalesce(name, '')), ?) > 0
            OR instr(lower(coalesce(display_name, '')), ?) > 0
            OR instr(lower(coalesce(nip05, '')), ?) > 0
-           OR instr(lower(pubkey), ?) > 0
+           OR instr(lower(pubkey), ?) = 1
         ORDER BY
           CASE
             WHEN lower(coalesce(name, '')) = ? THEN 0
@@ -172,15 +178,14 @@ class UserProfilesDao extends DatabaseAccessor<AppDatabase>
             WHEN lower(pubkey) = ? THEN 0
             WHEN instr(lower(coalesce(name, '')), ?) = 1 THEN 1
             WHEN instr(lower(coalesce(display_name, '')), ?) = 1 THEN 1
-            ELSE 2
+            WHEN instr(lower(pubkey), ?) = 1 THEN 2
+            ELSE 3
           END,
           created_at DESC
         LIMIT ?
       ''',
       variables: [
-        for (var i = 0; i < 8; i++) Variable.withString(normalized),
-        Variable.withString(normalized),
-        Variable.withString(normalized),
+        for (var i = 0; i < 11; i++) Variable.withString(normalized),
         Variable.withInt(limit),
       ],
       readsFrom: {userProfiles},

--- a/mobile/packages/db_client/lib/src/database/daos/user_profiles_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/user_profiles_dao.dart
@@ -147,6 +147,49 @@ class UserProfilesDao extends DatabaseAccessor<AppDatabase>
     return rows.map(_rowToUserProfile).toList();
   }
 
+  /// Finds a bounded set of cached profiles by identity fields only.
+  ///
+  /// Biography text is deliberately excluded: people discovery should not
+  /// turn a short query into an unbounded scan of incidental prose.
+  Future<List<UserProfile>> searchProfilesByIdentity(
+    String query, {
+    required int limit,
+  }) async {
+    final normalized = query.trim().toLowerCase();
+    if (normalized.isEmpty || limit <= 0) return [];
+    final rows = await customSelect(
+      '''
+        SELECT * FROM user_profiles
+        WHERE instr(lower(coalesce(name, '')), ?) > 0
+           OR instr(lower(coalesce(display_name, '')), ?) > 0
+           OR instr(lower(coalesce(nip05, '')), ?) > 0
+           OR instr(lower(pubkey), ?) > 0
+        ORDER BY
+          CASE
+            WHEN lower(coalesce(name, '')) = ? THEN 0
+            WHEN lower(coalesce(display_name, '')) = ? THEN 0
+            WHEN lower(coalesce(nip05, '')) = ? THEN 0
+            WHEN lower(pubkey) = ? THEN 0
+            WHEN instr(lower(coalesce(name, '')), ?) = 1 THEN 1
+            WHEN instr(lower(coalesce(display_name, '')), ?) = 1 THEN 1
+            ELSE 2
+          END,
+          created_at DESC
+        LIMIT ?
+      ''',
+      variables: [
+        for (var i = 0; i < 8; i++) Variable.withString(normalized),
+        Variable.withString(normalized),
+        Variable.withString(normalized),
+        Variable.withInt(limit),
+      ],
+      readsFrom: {userProfiles},
+    ).get();
+    return rows
+        .map((row) => _rowToUserProfile(userProfiles.map(row.data)))
+        .toList();
+  }
+
   /// Delete a profile by pubkey.
   ///
   /// Returns the number of rows deleted (0 or 1).

--- a/mobile/packages/db_client/test/src/database/daos/user_profiles_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/user_profiles_dao_test.dart
@@ -488,6 +488,44 @@ void main() {
         },
       );
 
+      test(
+        'matches a public key by prefix, ranked after name prefixes',
+        () async {
+          await dao.upsertProfiles([
+            createProfile(name: 'unfed'),
+            createProfile(
+              pubkey: testPubkey2,
+              eventId: 'event2',
+              name: 'unrelated',
+            ),
+            createProfile(pubkey: 'a' * 64, eventId: 'event3', name: 'fedora'),
+          ]);
+
+          final results = await dao.searchProfilesByIdentity('fed', limit: 10);
+
+          expect(results.map((profile) => profile.pubkey), [
+            'a' * 64,
+            testPubkey2,
+            testPubkey,
+          ]);
+        },
+      );
+
+      test('does not match a hex substring inside a public key', () async {
+        await dao.upsertProfiles([
+          createProfile(name: 'someone'),
+          createProfile(
+            pubkey: testPubkey2,
+            eventId: 'event2',
+            name: 'other',
+          ),
+        ]);
+
+        final results = await dao.searchProfilesByIdentity('3210', limit: 10);
+
+        expect(results, isEmpty);
+      });
+
       test('honors the requested bound', () async {
         await dao.upsertProfiles([
           createProfile(name: 'match-one'),

--- a/mobile/packages/db_client/test/src/database/daos/user_profiles_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/user_profiles_dao_test.dart
@@ -488,28 +488,25 @@ void main() {
         },
       );
 
-      test(
-        'matches a public key by prefix, ranked after name prefixes',
-        () async {
-          await dao.upsertProfiles([
-            createProfile(name: 'unfed'),
-            createProfile(
-              pubkey: testPubkey2,
-              eventId: 'event2',
-              name: 'unrelated',
-            ),
-            createProfile(pubkey: 'a' * 64, eventId: 'event3', name: 'fedora'),
-          ]);
+      test('matches a public key only when the whole key is given', () async {
+        await dao.upsertProfiles([
+          createProfile(name: 'someone'),
+          createProfile(
+            pubkey: testPubkey2,
+            eventId: 'event2',
+            name: 'other',
+          ),
+        ]);
 
-          final results = await dao.searchProfilesByIdentity('fed', limit: 10);
+        final whole = await dao.searchProfilesByIdentity(
+          testPubkey2.toUpperCase(),
+          limit: 10,
+        );
+        final prefix = await dao.searchProfilesByIdentity('fedc', limit: 10);
 
-          expect(results.map((profile) => profile.pubkey), [
-            'a' * 64,
-            testPubkey2,
-            testPubkey,
-          ]);
-        },
-      );
+        expect(whole.map((profile) => profile.pubkey), [testPubkey2]);
+        expect(prefix, isEmpty);
+      });
 
       test('does not match a hex substring inside a public key', () async {
         await dao.upsertProfiles([

--- a/mobile/packages/db_client/test/src/database/daos/user_profiles_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/user_profiles_dao_test.dart
@@ -469,12 +469,22 @@ void main() {
             ),
           ]);
 
-          final results = await dao.searchProfilesByIdentity('ALICE', limit: 2);
+          // A generous bound so the biography-only row is excluded by the
+          // WHERE clause, not merely truncated past the limit.
+          final results = await dao.searchProfilesByIdentity(
+            'ALICE',
+            limit: 10,
+          );
 
           expect(results.map((profile) => profile.displayName), [
             'Exact',
             'Prefix',
           ]);
+          expect(
+            results.any((profile) => profile.name == 'other'),
+            isFalse,
+            reason: 'a biography-only match must not be returned',
+          );
         },
       );
 

--- a/mobile/packages/db_client/test/src/database/daos/user_profiles_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/user_profiles_dao_test.dart
@@ -445,6 +445,55 @@ void main() {
       });
     });
 
+    group('searchProfilesByIdentity', () {
+      test(
+        'ranks exact identity matches first and excludes biography text',
+        () async {
+          await dao.upsertProfiles([
+            createProfile(
+              name: 'alice',
+              displayName: 'Exact',
+              about: 'unrelated',
+            ),
+            createProfile(
+              pubkey: testPubkey2,
+              eventId: 'event2',
+              name: 'alice-fan',
+              displayName: 'Prefix',
+            ),
+            createProfile(
+              pubkey: 'a' * 64,
+              eventId: 'event3',
+              name: 'other',
+              about: 'alice appears only here',
+            ),
+          ]);
+
+          final results = await dao.searchProfilesByIdentity('ALICE', limit: 2);
+
+          expect(results.map((profile) => profile.displayName), [
+            'Exact',
+            'Prefix',
+          ]);
+        },
+      );
+
+      test('honors the requested bound', () async {
+        await dao.upsertProfiles([
+          createProfile(name: 'match-one'),
+          createProfile(
+            pubkey: testPubkey2,
+            eventId: 'event2',
+            name: 'match-two',
+          ),
+        ]);
+
+        final results = await dao.searchProfilesByIdentity('match', limit: 1);
+
+        expect(results, hasLength(1));
+      });
+    });
+
     group('upsertProfiles', () {
       test('does nothing for empty list', () async {
         await dao.upsertProfiles([]);

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -13,7 +13,7 @@ import 'package:http/http.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
-import 'package:nostr_sdk/nostr_sdk.dart' show Event, Filter;
+import 'package:nostr_sdk/nostr_sdk.dart' show Event, Filter, Nip19;
 import 'package:profile_repository/profile_repository.dart';
 import 'package:profile_repository/src/identity_event_selection.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -66,6 +66,10 @@ typedef ProfileSearchFilter =
 
 bool _isSearchCancelled(SearchCancellationToken? token) =>
     token?.isCancelled ?? false;
+
+/// Bounded local identity lookup used by interactive people discovery.
+typedef LocalProfileSearch =
+    Future<List<UserProfile>> Function(String query, int limit);
 
 /// Default indexer relays for kind 0 profile lookups.
 ///
@@ -130,6 +134,7 @@ class ProfileRepository implements ProfileReader {
     ProfileStatsDao? profileStatsDao,
     FunnelcakeApiClient? funnelcakeApiClient,
     ProfileSearchFilter? profileSearchFilter,
+    LocalProfileSearch? localProfileSearch,
     BlockedProfileFilter? blockFilter,
     PendingProfileSavesDao? pendingProfileSavesDao,
     IdentityEventsDao? identityEventsDao,
@@ -145,6 +150,7 @@ class ProfileRepository implements ProfileReader {
        _profileStatsDao = profileStatsDao,
        _funnelcakeApiClient = funnelcakeApiClient,
        _profileSearchFilter = profileSearchFilter,
+       _localProfileSearch = localProfileSearch,
        _blockFilter = blockFilter,
        _pendingProfileSavesDao = pendingProfileSavesDao,
        _identityEventsDao = identityEventsDao,
@@ -162,6 +168,7 @@ class ProfileRepository implements ProfileReader {
   final ProfileStatsDao? _profileStatsDao;
   final FunnelcakeApiClient? _funnelcakeApiClient;
   final ProfileSearchFilter? _profileSearchFilter;
+  final LocalProfileSearch? _localProfileSearch;
   final BlockedProfileFilter? _blockFilter;
 
   /// Durable single-row-per-user slot for a save whose kind-0 publish is not
@@ -275,6 +282,23 @@ class ProfileRepository implements ProfileReader {
   Future<int> countUsersLocally({required String query}) async {
     final matches = await searchUsersLocally(query: query);
     return matches.length;
+  }
+
+  Future<List<UserProfile>> _searchUsersForDiscovery({
+    required String query,
+    required int limit,
+  }) async {
+    final localSearch = _localProfileSearch;
+    if (localSearch == null) {
+      return searchUsersLocally(query: query, limit: limit);
+    }
+    final candidates = await localSearch(query, limit);
+    final filtered =
+        _profileSearchFilter?.call(query, candidates) ?? candidates;
+    final blockFilter = _blockFilter;
+    return blockFilter == null
+        ? filtered
+        : filtered.where((profile) => !blockFilter(profile.pubkey)).toList();
   }
 
   /// Whether the given pubkey is known to have no Kind 0 profile.
@@ -2160,6 +2184,8 @@ class ProfileRepository implements ProfileReader {
         source: const SearchSourcePending(),
     };
     final useServerSort = sortBy != null;
+    int? nextRestOffset;
+    var restHasMore = false;
 
     ProgressiveSearchResult snapshot({
       required bool isComplete,
@@ -2178,6 +2204,8 @@ class ProfileRepository implements ProfileReader {
         profiles: profiles,
         sources: Map.unmodifiable(sources),
         isComplete: isComplete,
+        nextRestOffset: nextRestOffset,
+        restHasMore: restHasMore,
       );
     }
 
@@ -2186,7 +2214,10 @@ class ProfileRepository implements ProfileReader {
       final phase1Watch = Stopwatch()..start();
       final preCount = resultMap.length;
       try {
-        final local = await searchUsersLocally(query: trimmed);
+        final local = await _searchUsersForDiscovery(
+          query: trimmed,
+          limit: limit,
+        );
         if (_isSearchCancelled(cancellationToken)) return;
         for (final profile in local) {
           resultMap[profile.pubkey] = profile;
@@ -2228,6 +2259,8 @@ class ProfileRepository implements ProfileReader {
           hasVideos: hasVideos,
         );
         if (_isSearchCancelled(cancellationToken)) return;
+        nextRestOffset = offset + restResults.length;
+        restHasMore = restResults.length == limit;
         for (final result in restResults) {
           resultMap[result.pubkey] = result.toUserProfile();
         }
@@ -2377,7 +2410,7 @@ class ProfileRepository implements ProfileReader {
   }) {
     List<UserProfile> filtered;
     if (useServerSort) {
-      filtered = _rankServerSortedPage(profiles, sortBy);
+      filtered = _rankSearchResults(query, profiles, sortBy);
     } else if (_profileSearchFilter != null) {
       filtered = _profileSearchFilter(query, profiles);
     } else {
@@ -2393,6 +2426,79 @@ class ProfileRepository implements ProfileReader {
     }
 
     return _boostProfiles(filtered, boostPubkeys);
+  }
+
+  /// Orders people search by textual relevance before popularity.
+  ///
+  /// Funnelcake's follower sort remains a useful tie-breaker, but an exact
+  /// account match must never be buried beneath popular substring matches.
+  static List<UserProfile> _rankSearchResults(
+    String query,
+    List<UserProfile> profiles,
+    String? sortBy,
+  ) {
+    final popularityRanked = _rankServerSortedPage(profiles, sortBy);
+    final popularityIndex = {
+      for (final (index, profile) in popularityRanked.indexed)
+        profile.pubkey: index,
+    };
+    final relevanceByPubkey = {
+      for (final profile in profiles)
+        profile.pubkey: _searchRelevance(profile, query),
+    };
+    return [...profiles]..sort((a, b) {
+      final relevance = relevanceByPubkey[b.pubkey]!.compareTo(
+        relevanceByPubkey[a.pubkey]!,
+      );
+      if (relevance != 0) return relevance;
+      return popularityIndex[a.pubkey]!.compareTo(popularityIndex[b.pubkey]!);
+    });
+  }
+
+  static int _searchRelevance(UserProfile profile, String query) {
+    final normalizedQuery = query.trim().toLowerCase();
+    final name = profile.name?.trim().toLowerCase() ?? '';
+    final displayName = profile.displayName?.trim().toLowerCase() ?? '';
+    final nip05 = profile.nip05?.trim().toLowerCase() ?? '';
+    final nip05Name = nip05.split('@').first;
+    final npub = _npub(profile.pubkey);
+
+    if ({
+      profile.pubkey.toLowerCase(),
+      npub,
+      name,
+      displayName,
+      nip05,
+      nip05Name,
+    }.contains(normalizedQuery)) {
+      return 4;
+    }
+    if (name.startsWith(normalizedQuery) ||
+        displayName.startsWith(normalizedQuery) ||
+        nip05Name.startsWith(normalizedQuery)) {
+      return 3;
+    }
+    if (_hasWordPrefix(name, normalizedQuery) ||
+        _hasWordPrefix(displayName, normalizedQuery)) {
+      return 2;
+    }
+    if (name.contains(normalizedQuery) ||
+        displayName.contains(normalizedQuery) ||
+        nip05.contains(normalizedQuery)) {
+      return 1;
+    }
+    return 0;
+  }
+
+  static bool _hasWordPrefix(String value, String query) =>
+      value.split(RegExp(r'\s+')).any((word) => word.startsWith(query));
+
+  static String _npub(String pubkey) {
+    try {
+      return Nip19.encodePubKey(pubkey).toLowerCase();
+    } on Object {
+      return '';
+    }
   }
 
   /// Orders a server-sorted result page by the signals the REST payload

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -71,9 +71,6 @@ bool _isSearchCancelled(SearchCancellationToken? token) =>
 typedef LocalProfileSearch =
     Future<List<UserProfile>> Function(String query, int limit);
 
-/// Length of a bech32 `npub` string (`npub1` prefix + 58 data chars).
-const int _npubStringLength = 63;
-
 /// Default indexer relays for kind 0 profile lookups.
 ///
 /// Production wiring overrides this via
@@ -311,15 +308,8 @@ class ProfileRepository implements ProfileReader {
   /// `npub` query would otherwise return no local candidates even when the
   /// account is cached. A partial `npub` prefix cannot be decoded and is
   /// left for the raw-query path.
-  static String _localSearchTerm(String query) {
-    final trimmed = query.trim();
-    if (trimmed.length != _npubStringLength ||
-        !trimmed.toLowerCase().startsWith('npub1')) {
-      return query;
-    }
-    final hex = Nip19.decode(trimmed);
-    return hex.isEmpty ? query : hex;
-  }
+  static String _localSearchTerm(String query) =>
+      _npubQueryToHex(query) ?? query;
 
   /// Whether the given pubkey is known to have no Kind 0 profile.
   ///
@@ -2462,9 +2452,11 @@ class ProfileRepository implements ProfileReader {
       for (final (index, profile) in popularityRanked.indexed)
         profile.pubkey: index,
     };
+    final normalizedQuery = query.trim().toLowerCase();
+    final queryHex = _npubQueryToHex(normalizedQuery);
     final relevanceByPubkey = {
       for (final profile in profiles)
-        profile.pubkey: _searchRelevance(profile, query),
+        profile.pubkey: _searchRelevance(profile, normalizedQuery, queryHex),
     };
     return [...profiles]..sort((a, b) {
       final relevance = relevanceByPubkey[b.pubkey]!.compareTo(
@@ -2475,22 +2467,25 @@ class ProfileRepository implements ProfileReader {
     });
   }
 
-  static int _searchRelevance(UserProfile profile, String query) {
-    final normalizedQuery = query.trim().toLowerCase();
+  /// Relevance tier of [profile] for an already lowercased, trimmed
+  /// [normalizedQuery]. [queryHex] is the decoded form when the query is an
+  /// npub, so an exact account match never depends on encoding every
+  /// candidate's pubkey.
+  static int _searchRelevance(
+    UserProfile profile,
+    String normalizedQuery,
+    String? queryHex,
+  ) {
+    final pubkey = profile.pubkey.toLowerCase();
     final name = profile.name?.trim().toLowerCase() ?? '';
     final displayName = profile.displayName?.trim().toLowerCase() ?? '';
     final nip05 = profile.nip05?.trim().toLowerCase() ?? '';
     final nip05Name = nip05.split('@').first;
-    final npub = _npub(profile.pubkey);
 
-    if ({
-      profile.pubkey.toLowerCase(),
-      npub,
-      name,
-      displayName,
-      nip05,
-      nip05Name,
-    }.contains(normalizedQuery)) {
+    if (pubkey == queryHex ||
+        {pubkey, name, displayName, nip05, nip05Name}.contains(
+          normalizedQuery,
+        )) {
       return 4;
     }
     if (name.startsWith(normalizedQuery) ||
@@ -2513,13 +2508,23 @@ class ProfileRepository implements ProfileReader {
   static bool _hasWordPrefix(String value, String query) =>
       value.split(RegExp(r'\s+')).any((word) => word.startsWith(query));
 
-  static String _npub(String pubkey) {
-    try {
-      return Nip19.encodePubKey(pubkey).toLowerCase();
-    } on Object {
-      return '';
+  /// Hex pubkey for a complete `npub1…` [query], `null` for anything else.
+  ///
+  /// The cache and the REST payload carry hex, so a pasted npub has to be
+  /// decoded before it can match an account. Partial npubs cannot decode and
+  /// are left to the textual tiers.
+  static String? _npubQueryToHex(String query) {
+    final normalized = query.trim().toLowerCase();
+    if (!Nip19.isPubkey(normalized) || normalized.length != _npubLength) {
+      return null;
     }
+    final hex = Nip19.decode(normalized);
+    return hex.isEmpty ? null : hex;
   }
+
+  /// Length of a bech32 `npub1…` string: the prefix plus 52 data characters
+  /// and a 6-character checksum.
+  static const _npubLength = 63;
 
   /// Orders a server-sorted result page by the signals the REST payload
   /// actually carries.

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -293,12 +293,7 @@ class ProfileRepository implements ProfileReader {
       return searchUsersLocally(query: query, limit: limit);
     }
     final candidates = await localSearch(_localSearchTerm(query), limit);
-    final filtered =
-        _profileSearchFilter?.call(query, candidates) ?? candidates;
-    final blockFilter = _blockFilter;
-    return blockFilter == null
-        ? filtered
-        : filtered.where((profile) => !blockFilter(profile.pubkey)).toList();
+    return _profileSearchFilter?.call(query, candidates) ?? candidates;
   }
 
   /// Translates a full `npub` query into the hex form the bounded local

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -2435,7 +2435,31 @@ class ProfileRepository implements ProfileReader {
       filtered = filtered.where((p) => !blockFilter(p.pubkey)).toList();
     }
 
-    return _boostProfiles(filtered, boostPubkeys);
+    if (!useServerSort) return _boostProfiles(filtered, boostPubkeys);
+    return _boostBehindExactMatches(query, filtered, boostPubkeys);
+  }
+
+  /// Applies the follow-graph boost without letting it bury an exact account
+  /// match. Exact matches stay first, followed ones ahead of unfollowed, and
+  /// the boost then orders everything else; otherwise three followed partial
+  /// matches would push the exact account out of the three-row preview.
+  List<UserProfile> _boostBehindExactMatches(
+    String query,
+    List<UserProfile> profiles,
+    Set<String>? boostPubkeys,
+  ) {
+    final normalizedQuery = query.trim().toLowerCase();
+    final queryHex = _npubQueryToHex(normalizedQuery);
+    final exact = <UserProfile>[];
+    final rest = <UserProfile>[];
+    for (final profile in profiles) {
+      final relevance = _searchRelevance(profile, normalizedQuery, queryHex);
+      (relevance == _exactMatchRelevance ? exact : rest).add(profile);
+    }
+    return [
+      ..._boostProfiles(exact, boostPubkeys),
+      ..._boostProfiles(rest, boostPubkeys),
+    ];
   }
 
   /// Orders people search by textual relevance before popularity.
@@ -2486,7 +2510,7 @@ class ProfileRepository implements ProfileReader {
         {pubkey, name, displayName, nip05, nip05Name}.contains(
           normalizedQuery,
         )) {
-      return 4;
+      return _exactMatchRelevance;
     }
     if (name.startsWith(normalizedQuery) ||
         displayName.startsWith(normalizedQuery) ||
@@ -2504,6 +2528,10 @@ class ProfileRepository implements ProfileReader {
     }
     return 0;
   }
+
+  /// Relevance tier returned by [_searchRelevance] for an exact identifier,
+  /// username, display name, or NIP-05 match.
+  static const _exactMatchRelevance = 4;
 
   static bool _hasWordPrefix(String value, String query) =>
       value.split(RegExp(r'\s+')).any((word) => word.startsWith(query));

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -71,6 +71,9 @@ bool _isSearchCancelled(SearchCancellationToken? token) =>
 typedef LocalProfileSearch =
     Future<List<UserProfile>> Function(String query, int limit);
 
+/// Length of a bech32 `npub` string (`npub1` prefix + 58 data chars).
+const int _npubStringLength = 63;
+
 /// Default indexer relays for kind 0 profile lookups.
 ///
 /// Production wiring overrides this via
@@ -292,13 +295,30 @@ class ProfileRepository implements ProfileReader {
     if (localSearch == null) {
       return searchUsersLocally(query: query, limit: limit);
     }
-    final candidates = await localSearch(query, limit);
+    final candidates = await localSearch(_localSearchTerm(query), limit);
     final filtered =
         _profileSearchFilter?.call(query, candidates) ?? candidates;
     final blockFilter = _blockFilter;
     return blockFilter == null
         ? filtered
         : filtered.where((profile) => !blockFilter(profile.pubkey)).toList();
+  }
+
+  /// Translates a full `npub` query into the hex form the bounded local
+  /// identity search matches on.
+  ///
+  /// The DAO search matches the stored `pubkey` column on hex only, so an
+  /// `npub` query would otherwise return no local candidates even when the
+  /// account is cached. A partial `npub` prefix cannot be decoded and is
+  /// left for the raw-query path.
+  static String _localSearchTerm(String query) {
+    final trimmed = query.trim();
+    if (trimmed.length != _npubStringLength ||
+        !trimmed.toLowerCase().startsWith('npub1')) {
+      return query;
+    }
+    final hex = Nip19.decode(trimmed);
+    return hex.isEmpty ? query : hex;
   }
 
   /// Whether the given pubkey is known to have no Kind 0 profile.

--- a/mobile/packages/profile_repository/lib/src/progressive_search_result.dart
+++ b/mobile/packages/profile_repository/lib/src/progressive_search_result.dart
@@ -110,7 +110,7 @@ class ProgressiveSearchResult {
     required this.sources,
     required this.isComplete,
     this.nextRestOffset,
-    this.restHasMore,
+    this.restHasMore = false,
   });
 
   /// Accumulated, deduplicated, filter+boost-applied profile list.
@@ -129,5 +129,5 @@ class ProgressiveSearchResult {
   final int? nextRestOffset;
 
   /// Whether Funnelcake may have another page.
-  final bool? restHasMore;
+  final bool restHasMore;
 }

--- a/mobile/packages/profile_repository/lib/src/progressive_search_result.dart
+++ b/mobile/packages/profile_repository/lib/src/progressive_search_result.dart
@@ -109,6 +109,8 @@ class ProgressiveSearchResult {
     required this.profiles,
     required this.sources,
     required this.isComplete,
+    this.nextRestOffset,
+    this.restHasMore,
   });
 
   /// Accumulated, deduplicated, filter+boost-applied profile list.
@@ -121,4 +123,11 @@ class ProgressiveSearchResult {
 
   /// `true` when no further yields will arrive for this query.
   final bool isComplete;
+
+  /// Offset for the next Funnelcake REST page, independent of profiles
+  /// contributed by the local cache or NIP-50 relay.
+  final int? nextRestOffset;
+
+  /// Whether Funnelcake may have another page.
+  final bool? restHasMore;
 }

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -4582,7 +4582,7 @@ void main() {
       });
 
       test(
-        'applies search and block filters to bounded local candidates',
+        'applies search and block filters once to bounded local candidates',
         () async {
           final included = UserProfile(
             pubkey: testPubkey,

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -4262,6 +4262,65 @@ void main() {
         expect(pubkeys, [pk18Videos, pk4Videos, pk1Video]);
       });
 
+      test(
+        'searchUsersProgressive puts an exact name ahead of popularity',
+        () async {
+          stubRestResults([
+            ProfileSearchResult(
+              pubkey: pk18Videos,
+              displayName: 'Alice Archive',
+              createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+              followerCount: 10000,
+              videoCount: 18,
+            ),
+            ProfileSearchResult(
+              pubkey: pk1Video,
+              name: 'alice',
+              displayName: 'Exact Account',
+              createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+              followerCount: 1,
+              videoCount: 1,
+            ),
+          ]);
+
+          final result = await repoWithFunnelcake
+              .searchUsersProgressive(query: 'alice', sortBy: 'followers')
+              .last;
+
+          expect(result.profiles.first.pubkey, pk1Video);
+        },
+      );
+
+      test(
+        'reports REST pagination independently of merged profile count',
+        () async {
+          stubRestResults(resultsInServerOrder());
+          when(() => mockUserProfilesDao.getAllProfiles()).thenAnswer(
+            (_) async => [
+              UserProfile(
+                pubkey: pkCachedVine,
+                displayName: 'Lauren Cached',
+                createdAt: DateTime(2026),
+                eventId: 'cached',
+                rawData: const {},
+              ),
+            ],
+          );
+
+          final result = await repoWithFunnelcake
+              .searchUsersProgressive(
+                query: 'lauren',
+                limit: 3,
+                offset: 10,
+                sortBy: 'followers',
+              )
+              .last;
+
+          expect(result.nextRestOffset, 13);
+          expect(result.restHasMore, isTrue);
+        },
+      );
+
       test('searchUsersProgressive breaks a real follower-count tie by '
           'video count', () async {
         stubRestResults(resultsInServerOrder(followerCount: 100));
@@ -4445,6 +4504,44 @@ void main() {
 
         expect(results, isEmpty);
       });
+
+      test(
+        'applies search and block filters to bounded local candidates',
+        () async {
+          final included = UserProfile(
+            pubkey: testPubkey,
+            displayName: 'Included',
+            rawData: const {},
+            createdAt: DateTime(2026),
+            eventId: testEventId,
+          );
+          final blocked = UserProfile(
+            pubkey: otherPubkey,
+            displayName: 'Blocked',
+            rawData: const {},
+            createdAt: DateTime(2026),
+            eventId: 'e' * 64,
+          );
+          final repository = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: mockUserProfilesDao,
+            httpClient: mockHttpClient,
+            localProfileSearch: (query, limit) async {
+              expect(query, 'test');
+              expect(limit, 200);
+              return [included, blocked];
+            },
+            profileSearchFilter: (_, profiles) => profiles,
+            blockFilter: (pubkey) => pubkey == otherPubkey,
+          );
+
+          final emissions = await repository
+              .searchUsersProgressive(query: 'test')
+              .toList();
+
+          expect(emissions.first.profiles, [included]);
+        },
+      );
 
       test('yields local results first then remote results', () async {
         // Arrange - local cache has a profile

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -4292,6 +4292,39 @@ void main() {
       );
 
       test(
+        'searchUsersProgressive puts the account whose npub was pasted first',
+        () async {
+          const pkPasted =
+              'b01b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b';
+          stubRestResults([
+            ProfileSearchResult(
+              pubkey: pk18Videos,
+              displayName: 'Popular Account',
+              createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+              followerCount: 10000,
+              videoCount: 18,
+            ),
+            ProfileSearchResult(
+              pubkey: pkPasted,
+              displayName: 'Pasted Account',
+              createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+              followerCount: 1,
+              videoCount: 1,
+            ),
+          ]);
+
+          final result = await repoWithFunnelcake
+              .searchUsersProgressive(
+                query: Nip19.encodePubKey(pkPasted).toUpperCase(),
+                sortBy: 'followers',
+              )
+              .last;
+
+          expect(result.profiles.first.pubkey, pkPasted);
+        },
+      );
+
+      test(
         'reports REST pagination independently of merged profile count',
         () async {
           stubRestResults(resultsInServerOrder());
@@ -4584,6 +4617,26 @@ void main() {
           await repository.searchUsersProgressive(query: invalid).toList();
 
           expect(receivedTerm, invalid);
+        },
+      );
+
+      test(
+        'passes a non-npub query to the local identity lookup unchanged',
+        () async {
+          String? receivedQuery;
+          final repository = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: mockUserProfilesDao,
+            httpClient: mockHttpClient,
+            localProfileSearch: (query, limit) async {
+              receivedQuery = query;
+              return [];
+            },
+          );
+
+          await repository.searchUsersProgressive(query: 'npub1short').toList();
+
+          expect(receivedQuery, 'npub1short');
         },
       );
 

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -4543,6 +4543,50 @@ void main() {
         },
       );
 
+      test(
+        'decodes a full npub query to hex for the bounded local search',
+        () async {
+          final npub = Nip19.encodePubKey(testPubkey);
+          String? receivedTerm;
+          final repository = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: mockUserProfilesDao,
+            httpClient: mockHttpClient,
+            localProfileSearch: (query, limit) async {
+              receivedTerm = query;
+              return [];
+            },
+          );
+
+          await repository.searchUsersProgressive(query: npub).toList();
+
+          expect(receivedTerm, testPubkey);
+        },
+      );
+
+      test(
+        'leaves an undecodable npub-length query untouched for local search',
+        () async {
+          // 63 chars, starts with npub1, but 'o' is outside the bech32
+          // charset so it cannot decode.
+          final invalid = 'npub1${'o' * 58}';
+          String? receivedTerm;
+          final repository = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: mockUserProfilesDao,
+            httpClient: mockHttpClient,
+            localProfileSearch: (query, limit) async {
+              receivedTerm = query;
+              return [];
+            },
+          );
+
+          await repository.searchUsersProgressive(query: invalid).toList();
+
+          expect(receivedTerm, invalid);
+        },
+      );
+
       test('yields local results first then remote results', () async {
         // Arrange - local cache has a profile
         final cachedProfile = UserProfile(

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -4292,10 +4292,53 @@ void main() {
       );
 
       test(
+        'searchUsersProgressive keeps an exact match ahead of followed '
+        'partial matches',
+        () async {
+          ProfileSearchResult followed(String pubkey, String name) =>
+              ProfileSearchResult(
+                pubkey: pubkey,
+                name: name,
+                createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+                followerCount: 500,
+                videoCount: 5,
+              );
+          stubRestResults([
+            followed(pk18Videos, 'alice_b'),
+            followed(pk4Videos, 'alice_c'),
+            followed(pkCachedVine, 'alice_d'),
+            ProfileSearchResult(
+              pubkey: pk1Video,
+              name: 'alice',
+              createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+              followerCount: 1,
+              videoCount: 1,
+            ),
+          ]);
+
+          final result = await repoWithFunnelcake
+              .searchUsersProgressive(
+                query: 'alice',
+                sortBy: 'followers',
+                boostPubkeys: {pk18Videos, pk4Videos, pkCachedVine},
+              )
+              .last;
+
+          expect(result.profiles.map((profile) => profile.pubkey), [
+            pk1Video,
+            pk18Videos,
+            pk4Videos,
+            pkCachedVine,
+          ]);
+        },
+      );
+
+      test(
         'searchUsersProgressive puts the account whose npub was pasted first',
         () async {
           const pkPasted =
-              'b01b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b';
+              'b01b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b'
+              '2c3d4e5f6a1b2c3d4e5f6a1b';
           stubRestResults([
             ProfileSearchResult(
               pubkey: pk18Videos,

--- a/mobile/test/blocs/user_search/user_search_bloc_test.dart
+++ b/mobile/test/blocs/user_search/user_search_bloc_test.dart
@@ -91,12 +91,14 @@ void main() {
       List<UserProfile> profiles, {
       Map<SearchSource, SearchSourceStatus>? sources,
       bool isComplete = true,
+      bool restHasMore = false,
     }) {
       return Stream.value(
         ProgressiveSearchResult(
           profiles: profiles,
           sources: sources ?? const {},
           isComplete: isComplete,
+          restHasMore: restHasMore,
         ),
       );
     }
@@ -234,7 +236,9 @@ void main() {
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
             ),
-          ).thenAnswer((_) => progressive(createTestProfiles(50)));
+          ).thenAnswer(
+            (_) => progressive(createTestProfiles(50), restHasMore: true),
+          );
         },
         build: createBloc,
         act: (bloc) => bloc.add(const UserSearchQueryChanged('test')),
@@ -752,7 +756,9 @@ void main() {
               offset: 50,
               sortBy: 'followers',
             ),
-          ).thenAnswer((_) => progressive(createTestProfiles(50)));
+          ).thenAnswer(
+            (_) => progressive(createTestProfiles(50), restHasMore: true),
+          );
         },
         build: createBloc,
         seed: () => UserSearchState(

--- a/mobile/test/blocs/user_search/user_search_bloc_test.dart
+++ b/mobile/test/blocs/user_search/user_search_bloc_test.dart
@@ -777,6 +777,49 @@ void main() {
       );
 
       blocTest<UserSearchBloc, UserSearchState>(
+        'uses REST metadata instead of the merged result count',
+        setUp: () {
+          when(
+            () => mockProfileRepository.searchUsersProgressive(
+              query: 'alice',
+              limit: 50,
+              offset: 50,
+              sortBy: 'followers',
+            ),
+          ).thenAnswer(
+            (_) => Stream.value(
+              ProgressiveSearchResult(
+                profiles: createTestProfiles(10),
+                sources: const {},
+                isComplete: true,
+                nextRestOffset: 100,
+                restHasMore: true,
+              ),
+            ),
+          );
+        },
+        build: createBloc,
+        seed: () => UserSearchState(
+          status: UserSearchStatus.success,
+          query: 'alice',
+          results: createTestProfiles(50),
+          offset: 50,
+          hasMore: true,
+        ),
+        act: (bloc) => bloc.add(const UserSearchLoadMore()),
+        expect: () => [
+          isA<UserSearchState>().having(
+            (state) => state.isLoadingMore,
+            'isLoadingMore',
+            true,
+          ),
+          isA<UserSearchState>()
+              .having((state) => state.offset, 'offset', 100)
+              .having((state) => state.hasMore, 'hasMore', true),
+        ],
+      );
+
+      blocTest<UserSearchBloc, UserSearchState>(
         'does nothing when hasMore is false',
         build: createBloc,
         seed: () => UserSearchState(


### PR DESCRIPTION
People searching for an exact account name could see three more-popular partial matches instead, and merged local/REST/relay results could make pagination stop early or skip records.

The search path now ranks exact public identifiers, usernames, display names, and NIP-05 identities ahead of prefixes and substrings, using follower and video counts only as tie-breakers. Local discovery uses a bounded SQLite identity-field query that excludes biography-only noise, and the repository carries REST-specific next-offset/has-more state so the BLoC no longer guesses from the merged visible count.

This does not change non-discovery callers of the existing local profile search API, relay source ordering, or blocked-account filtering. The three-row All-page preview still shows three rows, but which accounts reach it changes: an exact match now ranks ahead of the follow-graph boost, which is what puts an exact low-popularity match in the preview.

Verification:
- `flutter test packages/db_client/test/src/database/daos/user_profiles_dao_test.dart packages/profile_repository/test/src/profile_repository_test.dart test/blocs/user_search/user_search_bloc_test.dart --reporter compact` (335 passed)
- `flutter analyze` (no issues)
- `../.codex/scripts/test-config.sh`

Closes #8569

