### PR TITLE
fix(search): cancel superseded query work

### DIFF
--- a/mobile/lib/blocs/user_search/user_search_bloc.dart
+++ b/mobile/lib/blocs/user_search/user_search_bloc.dart
@@ -12,12 +12,24 @@ import 'package:nostr_sdk/nip19/pubkeys_equal.dart';
 import 'package:openvine/constants/search_constants.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:profile_repository/profile_repository.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 part 'user_search_event.dart';
 part 'user_search_state.dart';
 
 /// Number of results per page
 const _pageSize = 50;
+int _nextSearchCorrelationId = 0;
+
+typedef UserSearchRunner =
+    Stream<ProgressiveSearchResult> Function({
+      required String query,
+      required int limit,
+      required String sortBy,
+      required bool hasVideos,
+      required Set<String>? boostPubkeys,
+      required SearchCancellationToken cancellationToken,
+    });
 
 Map<SearchSource, SearchSourceStatus> _pendingSourceOutcomes() {
   return {
@@ -35,9 +47,12 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
     this.searchTimeout = userSearchOuterTimeout,
     this.excludedPubkey,
     FeedPerformanceTracker? feedTracker,
+    UserSearchRunner? searchRunner,
+    this.enableCancellation = false,
   }) : _profileRepository = profileRepository,
        _followRepository = followRepository,
        _feedTracker = feedTracker,
+       _searchRunner = searchRunner,
        super(const UserSearchState()) {
     on<UserSearchQueryChanged>(
       _onQueryChanged,
@@ -54,6 +69,9 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
   final FollowRepository? _followRepository;
 
   final FeedPerformanceTracker? _feedTracker;
+  final UserSearchRunner? _searchRunner;
+
+  final bool enableCancellation;
 
   /// Whether to filter results to users who have uploaded videos.
   final bool hasVideos;
@@ -118,15 +136,42 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
     // repository (see ProfileRepository.searchUsersProgressive), keeping
     // ranking logic out of the BLoC.
     final followedPubkeys = _followRepository?.followingPubkeys.toSet();
+    final cancellationToken = SearchCancellationToken(
+      'user-search-${++_nextSearchCorrelationId}',
+    );
+    var reachedTerminalState = false;
+    Log.debug(
+      '${cancellationToken.correlationId} started; queryLength=${query.length}',
+      name: 'UserSearchBloc',
+      category: LogCategory.api,
+    );
 
     try {
-      final searchStream = _profileRepository.searchUsersProgressive(
-        query: query,
-        limit: _pageSize,
-        sortBy: profileSearchSortFollowers,
-        hasVideos: hasVideos,
-        boostPubkeys: followedPubkeys,
-      );
+      final searchStream =
+          _searchRunner?.call(
+            query: query,
+            limit: _pageSize,
+            sortBy: profileSearchSortFollowers,
+            hasVideos: hasVideos,
+            boostPubkeys: followedPubkeys,
+            cancellationToken: cancellationToken,
+          ) ??
+          (enableCancellation
+              ? _profileRepository.searchUsersProgressive(
+                  query: query,
+                  limit: _pageSize,
+                  sortBy: profileSearchSortFollowers,
+                  hasVideos: hasVideos,
+                  boostPubkeys: followedPubkeys,
+                  cancellationToken: cancellationToken,
+                )
+              : _profileRepository.searchUsersProgressive(
+                  query: query,
+                  limit: _pageSize,
+                  sortBy: profileSearchSortFollowers,
+                  hasVideos: hasVideos,
+                  boostPubkeys: followedPubkeys,
+                ));
 
       await emit.forEach<ProgressiveSearchResult>(
         searchTimeout == null
@@ -146,6 +191,12 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
             if (entry.value is! SearchSourcePending &&
                 trackedSources.add(entry.key)) {
               _feedTracker?.trackSearchSource(entry.key, entry.value);
+              Log.debug(
+                '${cancellationToken.correlationId} source=${entry.key.name} '
+                'outcome=${entry.value.runtimeType}',
+                name: 'UserSearchBloc',
+                category: LogCategory.api,
+              );
             }
           }
           latestSourceOutcomes = result.sources;
@@ -168,6 +219,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
       );
 
       _feedTracker?.markFeedDisplayed('user_search', state.results.length);
+      reachedTerminalState = true;
     } on TimeoutException {
       // Outer stream timed out. Promote every source still in pending
       // (or absent from the latest snapshot) to failed(timeout) so the
@@ -201,6 +253,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
           sourceOutcomes: updatedOutcomes,
         ),
       );
+      reachedTerminalState = true;
     } on Exception catch (e, stackTrace) {
       _feedTracker?.trackFeedError(
         'user_search',
@@ -213,6 +266,16 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
       // — those land in the TimeoutException branch above.
       addError(Reportable(e, context: '_onQueryChanged'), stackTrace);
       emit(state.copyWith(status: UserSearchStatus.failure));
+      reachedTerminalState = true;
+    } finally {
+      cancellationToken.cancel();
+      Log.debug(
+        '${cancellationToken.correlationId} '
+        '${reachedTerminalState ? "completed" : "cancelled"}; '
+        'resultCount=${state.results.length}',
+        name: 'UserSearchBloc',
+        category: LogCategory.api,
+      );
     }
   }
 

--- a/mobile/lib/screens/search_results/view/search_results_page.dart
+++ b/mobile/lib/screens/search_results/view/search_results_page.dart
@@ -73,7 +73,10 @@ class SearchResultsPage extends ConsumerWidget {
           ),
         ),
         BlocProvider(
-          create: (_) => UserSearchBloc(profileRepository: profileRepository),
+          create: (_) => UserSearchBloc(
+            profileRepository: profileRepository,
+            enableCancellation: true,
+          ),
         ),
         BlocProvider(create: (_) => SearchResultsFilterCubit()),
         BlocProvider(

--- a/mobile/lib/widgets/find_people_sheet.dart
+++ b/mobile/lib/widgets/find_people_sheet.dart
@@ -88,6 +88,7 @@ class _FindPeopleSheetState extends ConsumerState<FindPeopleSheet> {
     if (profileRepo != null) {
       _searchBloc = UserSearchBloc(
         profileRepository: profileRepo,
+        enableCancellation: true,
         searchTimeout: widget.searchTimeout,
         excludedPubkey: widget.currentUserPubkey,
       );

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -179,6 +179,7 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
     }
     _searchBloc = UserSearchBloc(
       profileRepository: profileRepo,
+      enableCancellation: true,
       followRepository: ref.read(followRepositoryProvider),
     );
 

--- a/mobile/packages/profile_repository/lib/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/profile_repository.dart
@@ -11,6 +11,7 @@ export 'src/pending_profile_save.dart';
 export 'src/profile_reader.dart';
 export 'src/profile_repository.dart';
 export 'src/progressive_search_result.dart';
+export 'src/search_cancellation_token.dart';
 export 'src/username_availability_result.dart';
 export 'src/username_claim_result.dart';
 export 'src/username_release_result.dart';

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -64,6 +64,9 @@ const String profileSearchSortFollowers =
 typedef ProfileSearchFilter =
     List<UserProfile> Function(String query, List<UserProfile> profiles);
 
+bool _isSearchCancelled(SearchCancellationToken? token) =>
+    token?.isCancelled ?? false;
+
 /// Default indexer relays for kind 0 profile lookups.
 ///
 /// Production wiring overrides this via
@@ -872,10 +875,7 @@ class ProfileRepository implements ProfileReader {
       if (delay > Duration.zero) {
         await Future<void>.delayed(delay);
       }
-      final retry = await _doFetchFreshProfile(
-        pubkey,
-        requireRawKind0: true,
-      );
+      final retry = await _doFetchFreshProfile(pubkey, requireRawKind0: true);
       if (retry != null) return retry;
     }
 
@@ -2148,9 +2148,11 @@ class ProfileRepository implements ProfileReader {
     String? sortBy,
     bool hasVideos = false,
     Set<String>? boostPubkeys,
+    SearchCancellationToken? cancellationToken,
   }) async* {
     final trimmed = query.trim();
     if (trimmed.isEmpty) return;
+    if (_isSearchCancelled(cancellationToken)) return;
 
     final resultMap = <String, UserProfile>{};
     final sources = <SearchSource, SearchSourceStatus>{
@@ -2185,6 +2187,7 @@ class ProfileRepository implements ProfileReader {
       final preCount = resultMap.length;
       try {
         final local = await searchUsersLocally(query: trimmed);
+        if (_isSearchCancelled(cancellationToken)) return;
         for (final profile in local) {
           resultMap[profile.pubkey] = profile;
         }
@@ -2211,6 +2214,7 @@ class ProfileRepository implements ProfileReader {
     }
 
     // Phase 2: Funnelcake REST API (fast)
+    if (_isSearchCancelled(cancellationToken)) return;
     final prevCount = resultMap.length;
     if (_funnelcakeApiClient?.isAvailable ?? false) {
       final phase2Watch = Stopwatch()..start();
@@ -2223,6 +2227,7 @@ class ProfileRepository implements ProfileReader {
           sortBy: sortBy,
           hasVideos: hasVideos,
         );
+        if (_isSearchCancelled(cancellationToken)) return;
         for (final result in restResults) {
           resultMap[result.pubkey] = result.toUserProfile();
         }
@@ -2253,6 +2258,7 @@ class ProfileRepository implements ProfileReader {
     }
 
     // Phase 3: NIP-50 WebSocket (first page only)
+    if (_isSearchCancelled(cancellationToken)) return;
     if (offset == 0) {
       final preWsCount = resultMap.length;
       final phase3Watch = Stopwatch()..start();
@@ -2260,6 +2266,7 @@ class ProfileRepository implements ProfileReader {
         final events = await _nostrClient
             .queryUsers(trimmed, limit: limit, timeout: _nip50RelayQueryTimeout)
             .timeout(_nip50SearchTimeout);
+        if (_isSearchCancelled(cancellationToken)) return;
         for (final event in events) {
           final profile = UserProfile.fromNostrEvent(event);
           resultMap.putIfAbsent(profile.pubkey, () => profile);
@@ -2293,7 +2300,11 @@ class ProfileRepository implements ProfileReader {
       }
 
       if (resultMap.length > preWsCount) {
-        final enriched = await _enrichFromCache(resultMap.values.toList());
+        final enriched = await _enrichFromCache(
+          resultMap.values.toList(),
+          cancellationToken: cancellationToken,
+        );
+        if (_isSearchCancelled(cancellationToken)) return;
         final result = snapshot(
           isComplete: true,
           enriched: _applyFilter(
@@ -2314,7 +2325,12 @@ class ProfileRepository implements ProfileReader {
 
     // Final yield: enriched + filtered (when WS didn't add anything or
     // was skipped due to offset > 0)
-    final enriched = await _enrichFromCache(resultMap.values.toList());
+    if (_isSearchCancelled(cancellationToken)) return;
+    final enriched = await _enrichFromCache(
+      resultMap.values.toList(),
+      cancellationToken: cancellationToken,
+    );
+    if (_isSearchCancelled(cancellationToken)) return;
     final result = snapshot(
       isComplete: true,
       enriched: _applyFilter(
@@ -2582,19 +2598,16 @@ class ProfileRepository implements ProfileReader {
       // Connected relay fetches (one per pubkey, in parallel)
       final relayFuture = Future.wait(
         remainingList.map(
-          (
-            pubkey,
-          ) => Future.sync(() => _nostrClient.fetchProfile(pubkey)).catchError((
-            Object e,
-          ) {
-            Log.warning(
-              'Batch connected relay fetch failed for '
-              '${pubkeyForLogs(pubkey)}: $e',
-              name: 'ProfileRepository.fetchBatchProfiles',
-              category: LogCategory.relay,
-            );
-            return null;
-          }, test: (_) => true),
+          (pubkey) => Future.sync(() => _nostrClient.fetchProfile(pubkey))
+              .catchError((Object e) {
+                Log.warning(
+                  'Batch connected relay fetch failed for '
+                  '${pubkeyForLogs(pubkey)}: $e',
+                  name: 'ProfileRepository.fetchBatchProfiles',
+                  category: LogCategory.relay,
+                );
+                return null;
+              }, test: (_) => true),
         ),
       );
 
@@ -2694,12 +2707,17 @@ class ProfileRepository implements ProfileReader {
   ///
   /// For each profile, fills in null fields (picture, about, etc.) from
   /// the cached version without overwriting data from search results.
-  Future<List<UserProfile>> _enrichFromCache(List<UserProfile> profiles) async {
+  Future<List<UserProfile>> _enrichFromCache(
+    List<UserProfile> profiles, {
+    SearchCancellationToken? cancellationToken,
+  }) async {
     final enriched = <UserProfile>[];
     var cacheHits = 0;
     var pictureEnriched = 0;
     for (final profile in profiles) {
+      if (_isSearchCancelled(cancellationToken)) break;
       final cached = await _userProfilesDao.getProfile(profile.pubkey);
+      if (_isSearchCancelled(cancellationToken)) break;
       if (cached == null) {
         enriched.add(profile);
         continue;

--- a/mobile/packages/profile_repository/lib/src/search_cancellation_token.dart
+++ b/mobile/packages/profile_repository/lib/src/search_cancellation_token.dart
@@ -1,0 +1,19 @@
+// ABOUTME: Cooperative cancellation token for progressive profile searches.
+// ABOUTME: Lets superseded UI searches stop before starting later work.
+
+/// A lightweight cooperative cancellation signal for one search lifecycle.
+class SearchCancellationToken {
+  /// Creates a token with a privacy-safe correlation identifier.
+  SearchCancellationToken(this.correlationId);
+
+  /// Session-local identifier that never contains query text or identities.
+  final String correlationId;
+
+  bool _isCancelled = false;
+
+  /// Whether the owner has superseded or disposed this search.
+  bool get isCancelled => _isCancelled;
+
+  /// Requests cancellation. Safe to call more than once.
+  void cancel() => _isCancelled = true;
+}

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -4567,6 +4567,46 @@ void main() {
           mockFunnelcakeClient = MockFunnelcakeApiClient();
         });
 
+        test('cancellation after delayed REST prevents relay work', () async {
+          final rest = Completer<List<ProfileSearchResult>>();
+          final token = SearchCancellationToken('test-search');
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.searchProfiles(
+              query: any(named: 'query'),
+              limit: any(named: 'limit'),
+              offset: any(named: 'offset'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer((_) => rest.future);
+          final repository = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: mockUserProfilesDao,
+            httpClient: mockHttpClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final resultFuture = repository
+              .searchUsersProgressive(
+                query: 'test',
+                cancellationToken: token,
+              )
+              .toList();
+          await Future<void>.delayed(Duration.zero);
+          token.cancel();
+          rest.complete([]);
+
+          expect(await resultFuture, isEmpty);
+          verifyNever(
+            () => mockNostrClient.queryUsers(
+              any(),
+              limit: any(named: 'limit'),
+              timeout: any(named: 'timeout'),
+            ),
+          );
+        });
+
         test('yields progressively: local, then API+relay merged', () async {
           // Arrange - local cache
           final cachedProfile = UserProfile(

--- a/mobile/test/blocs/user_search/user_search_bloc_test.dart
+++ b/mobile/test/blocs/user_search/user_search_bloc_test.dart
@@ -38,6 +38,21 @@ void main() {
       ).thenAnswer((_) async => 0);
     });
 
+    Stream<ProgressiveSearchResult> mockSearchRunner({
+      required String query,
+      required int limit,
+      required String sortBy,
+      required bool hasVideos,
+      required Set<String>? boostPubkeys,
+      required SearchCancellationToken cancellationToken,
+    }) => mockProfileRepository.searchUsersProgressive(
+      query: query,
+      limit: limit,
+      sortBy: sortBy,
+      hasVideos: hasVideos,
+      boostPubkeys: boostPubkeys,
+    );
+
     UserSearchBloc createBloc({
       Duration? searchTimeout = const Duration(seconds: 20),
       String? excludedPubkey,
@@ -45,6 +60,7 @@ void main() {
       profileRepository: mockProfileRepository,
       searchTimeout: searchTimeout,
       excludedPubkey: excludedPubkey,
+      searchRunner: mockSearchRunner,
     );
 
     UserProfile createTestProfile(String pubkey, String displayName) {
@@ -97,6 +113,42 @@ void main() {
       expect(bloc.state.hasMore, isFalse);
       expect(bloc.state.isLoadingMore, isFalse);
       bloc.close();
+    });
+
+    test('superseding a running query cancels its repository token', () async {
+      final tokens = <SearchCancellationToken>[];
+      final controllers = <StreamController<ProgressiveSearchResult>>[];
+      final bloc = UserSearchBloc(
+        profileRepository: mockProfileRepository,
+        searchRunner:
+            ({
+              required query,
+              required limit,
+              required sortBy,
+              required hasVideos,
+              required boostPubkeys,
+              required cancellationToken,
+            }) {
+              tokens.add(cancellationToken);
+              final controller = StreamController<ProgressiveSearchResult>();
+              controllers.add(controller);
+              return controller.stream;
+            },
+      );
+
+      bloc.add(const UserSearchQueryChanged('first'));
+      await Future<void>.delayed(const Duration(milliseconds: 450));
+      bloc.add(const UserSearchQueryChanged('second'));
+      await Future<void>.delayed(const Duration(milliseconds: 450));
+
+      expect(tokens, hasLength(2));
+      expect(tokens.first.isCancelled, isTrue);
+      expect(tokens.last.isCancelled, isFalse);
+      await bloc.close();
+      expect(tokens.last.isCancelled, isTrue);
+      for (final controller in controllers) {
+        await controller.close();
+      }
     });
 
     blocTest<UserSearchBloc, UserSearchState>(
@@ -827,6 +879,7 @@ void main() {
           UserSearchBloc(
             profileRepository: mockProfileRepository,
             followRepository: followRepository,
+            searchRunner: mockSearchRunner,
           );
 
       blocTest<UserSearchBloc, UserSearchState>(
@@ -999,6 +1052,7 @@ void main() {
         build: () => UserSearchBloc(
           profileRepository: mockProfileRepository,
           hasVideos: true,
+          searchRunner: mockSearchRunner,
         ),
         act: (bloc) => bloc.add(const UserSearchQueryChanged('test')),
         wait: debounceDuration,
@@ -1244,7 +1298,10 @@ void main() {
             (_) => progressive([createTestProfile('a' * 64, 'Alice')]),
           );
         },
-        build: () => UserSearchBloc(profileRepository: mockProfileRepository),
+        build: () => UserSearchBloc(
+          profileRepository: mockProfileRepository,
+          searchRunner: mockSearchRunner,
+        ),
         act: (bloc) => bloc.add(const UserSearchQueryChanged('alice')),
         wait: debounceDuration,
         expect: () => [
@@ -1340,8 +1397,25 @@ void main() {
         mockTracker = _MockFeedPerformanceTracker();
       });
 
-      UserSearchBloc createBlocWithTracker() =>
-          UserSearchBloc(profileRepository: mockRepo, feedTracker: mockTracker);
+      UserSearchBloc createBlocWithTracker() => UserSearchBloc(
+        profileRepository: mockRepo,
+        feedTracker: mockTracker,
+        searchRunner:
+            ({
+              required query,
+              required limit,
+              required sortBy,
+              required hasVideos,
+              required boostPubkeys,
+              required cancellationToken,
+            }) => mockRepo.searchUsersProgressive(
+              query: query,
+              limit: limit,
+              sortBy: sortBy,
+              hasVideos: hasVideos,
+              boostPubkeys: boostPubkeys,
+            ),
+      );
 
       blocTest<UserSearchBloc, UserSearchState>(
         'calls startFeedLoad, markFirstVideosReceived, and '

--- a/mobile/test/screens/search_results/view/search_results_page_test.dart
+++ b/mobile/test/screens/search_results/view/search_results_page_test.dart
@@ -27,6 +27,7 @@ class _MockPeopleListsRepository extends Mock
 void main() {
   setUpAll(() {
     registerFallbackValue(defaultVideoSearchSort);
+    registerFallbackValue(SearchCancellationToken('test-search'));
   });
 
   group(SearchResultsPage, () {
@@ -78,6 +79,7 @@ void main() {
           sortBy: any(named: 'sortBy'),
           hasVideos: any(named: 'hasVideos'),
           boostPubkeys: any(named: 'boostPubkeys'),
+          cancellationToken: any(named: 'cancellationToken'),
         ),
       ).thenAnswer((_) => const Stream<ProgressiveSearchResult>.empty());
       when(

--- a/mobile/test/widgets/find_people_sheet_test.dart
+++ b/mobile/test/widgets/find_people_sheet_test.dart
@@ -22,6 +22,10 @@ import '../helpers/test_provider_overrides.dart';
 class _MockProfileRepository extends Mock implements ProfileRepository {}
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(SearchCancellationToken('test-search'));
+  });
+
   group(FindPeopleSheet, () {
     const currentUserPubkey =
         'facade00facade00facade00facade00facade00facade00facade00facade00';
@@ -29,6 +33,23 @@ void main() {
 
     setUp(() {
       mockProfileRepo = _MockProfileRepository();
+      when(
+        () => mockProfileRepo.searchUsersProgressive(
+          query: any(named: 'query'),
+          limit: any(named: 'limit'),
+          sortBy: any(named: 'sortBy'),
+          hasVideos: any(named: 'hasVideos'),
+          boostPubkeys: any(named: 'boostPubkeys'),
+          cancellationToken: any(named: 'cancellationToken'),
+        ),
+      ).thenAnswer((invocation) {
+        return mockProfileRepo.searchUsersProgressive(
+          query: invocation.namedArguments[#query] as String,
+          limit: invocation.namedArguments[#limit] as int,
+          sortBy: invocation.namedArguments[#sortBy] as String?,
+          hasVideos: invocation.namedArguments[#hasVideos] as bool,
+        );
+      });
     });
 
     Widget createTestWidget({

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -57,6 +57,7 @@ _MockProfileRepository _createMockProfileRepository({
       sortBy: any(named: 'sortBy'),
       hasVideos: any(named: 'hasVideos'),
       boostPubkeys: any(named: 'boostPubkeys'),
+      cancellationToken: any(named: 'cancellationToken'),
     ),
   ).thenAnswer(
     (_) => Stream.value(
@@ -127,6 +128,10 @@ Override _vanishedProfiles(Set<String> pubkeys) =>
     vanishedProfilePubkeysProvider.overrideWith((ref) => Stream.value(pubkeys));
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(SearchCancellationToken('test-search'));
+  });
+
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group(UserPickerSheet, () {
@@ -1207,6 +1212,7 @@ void main() {
             sortBy: any(named: 'sortBy'),
             hasVideos: any(named: 'hasVideos'),
             boostPubkeys: any(named: 'boostPubkeys'),
+            cancellationToken: any(named: 'cancellationToken'),
           ),
         ).thenAnswer((_) => streamController.stream);
 
@@ -1290,6 +1296,7 @@ void main() {
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
               boostPubkeys: any(named: 'boostPubkeys'),
+              cancellationToken: any(named: 'cancellationToken'),
             ),
           ).thenAnswer((invocation) {
             final boost =
@@ -1433,6 +1440,7 @@ void main() {
             sortBy: any(named: 'sortBy'),
             hasVideos: any(named: 'hasVideos'),
             boostPubkeys: any(named: 'boostPubkeys'),
+            cancellationToken: any(named: 'cancellationToken'),
           ),
         ).thenAnswer(
           (_) => Stream.value(
@@ -1451,6 +1459,7 @@ void main() {
             sortBy: any(named: 'sortBy'),
             hasVideos: any(named: 'hasVideos'),
             boostPubkeys: any(named: 'boostPubkeys'),
+            cancellationToken: any(named: 'cancellationToken'),
           ),
         ).thenAnswer((_) => bobController.stream);
 


### PR DESCRIPTION
## Problem

Superseding a people-search query stopped stale BLoC emissions but did not signal the repository pipeline to stop avoidable later work.

## Fix

- add a per-search cooperative cancellation token and pass it from `UserSearchBloc`
- stop after non-cancellable awaits before starting later sources or cache enrichment
- stop enrichment between individual profile reads
- cancel on query replacement, timeout, failure, completion, and BLoC disposal
- add privacy-safe lifecycle/source telemetry using session-local correlation IDs, query length, outcomes, and counts only

## Verification

- `flutter test packages/profile_repository/test/src/profile_repository_test.dart test/blocs/user_search/user_search_bloc_test.dart --reporter compact`
- `very_good test --coverage --test-randomize-ordering-seed random` (profile_repository; 100% coverage)
- `flutter analyze`
- `../.codex/scripts/test-config.sh`

Closes #8570
