### PR TITLE
fix(search): keep avatar failures private

### DIFF
--- a/mobile/lib/config/bug_report_config.dart
+++ b/mobile/lib/config/bug_report_config.dart
@@ -228,9 +228,9 @@ class BugReportConfig {
       r'\b[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\.[A-Z]{2,24}\b',
       caseSensitive: false,
     ),
-    // Malformed or partially redacted NIP-05 values can lose their local
-    // part and appear as a bare `@domain`. They remain identity-linked data
-    // and must not escape into a support artifact beside the reporter pubkey.
+    // Root NIP-05 identifiers (`_@domain`) are displayed as a bare domain.
+    // That display form remains identity-linked data and must not escape into
+    // a support artifact beside the reporter pubkey.
     RegExp(
       r'(?<![A-Z0-9._%+-])@[A-Z0-9.-]{1,255}\.[A-Z]{2,24}\b',
       caseSensitive: false,

--- a/mobile/lib/config/bug_report_config.dart
+++ b/mobile/lib/config/bug_report_config.dart
@@ -228,6 +228,13 @@ class BugReportConfig {
       r'\b[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\.[A-Z]{2,24}\b',
       caseSensitive: false,
     ),
+    // Malformed or partially redacted NIP-05 values can lose their local
+    // part and appear as a bare `@domain`. They remain identity-linked data
+    // and must not escape into a support artifact beside the reporter pubkey.
+    RegExp(
+      r'(?<![A-Z0-9._%+-])@[A-Z0-9.-]{1,255}\.[A-Z]{2,24}\b',
+      caseSensitive: false,
+    ),
     // Filesystem paths rooted at a user or app-sandbox directory. See
     // [_filesystemPathRoot]. Quote-specific rules run first so a quoted path
     // with a spaced basename is redacted whole before the unquoted rule can

--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -10,7 +10,6 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
-import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
 import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/models/known_account.dart';
@@ -430,8 +429,7 @@ Future<void> _setZendeskIdentity(
     }
 
     Log.info(
-      'Zendesk identity set for user: '
-      '${profile?.bestDisplayName ?? pubkeyForLogs(npub)}',
+      'Zendesk identity set for authenticated user',
       name: 'ZendeskIdentitySync',
       category: LogCategory.system,
     );

--- a/mobile/lib/repositories/avatar_svg_repository.dart
+++ b/mobile/lib/repositories/avatar_svg_repository.dart
@@ -79,7 +79,7 @@ class HttpAvatarSvgRepository implements AvatarSvgRepository {
       return bytes;
     } on Object catch (error) {
       UnifiedLogger.warning(
-        'Avatar SVG validation failed for URL: $url - Error: $error',
+        'Avatar SVG validation failed (${error.runtimeType})',
         name: 'AvatarSvgRepository',
       );
       _writeCache(url, null, AvatarSvgRepositoryConfig.negativeTtl);
@@ -263,7 +263,7 @@ class HttpAvatarSvgRepository implements AvatarSvgRepository {
 
   void _logRejected(Uri uri, String? contentType, String reason) {
     UnifiedLogger.warning(
-      'Avatar SVG rejected: url=$uri contentType=${contentType ?? '<none>'} reason=$reason',
+      'Avatar SVG rejected: contentType=${contentType ?? '<none>'} reason=$reason',
       name: 'AvatarSvgRepository',
     );
   }

--- a/mobile/lib/screens/profile_setup/widgets/profile_avatar_section.dart
+++ b/mobile/lib/screens/profile_setup/widgets/profile_avatar_section.dart
@@ -153,7 +153,7 @@ class _ProfileAvatarSectionState extends ConsumerState<ProfileAvatarSection> {
     final pending = editorState.pendingPictureUrl;
     if (pending != null &&
         pending.isNotEmpty &&
-        !isKnownDeadImageHost(pending)) {
+        isUsableNetworkImageUrl(pending)) {
       return NetworkImage(pending);
     }
 
@@ -164,7 +164,7 @@ class _ProfileAvatarSectionState extends ConsumerState<ProfileAvatarSection> {
     final persisted = editorState.persistedPictureUrl;
     if (persisted != null &&
         persisted.isNotEmpty &&
-        !isKnownDeadImageHost(persisted)) {
+        isUsableNetworkImageUrl(persisted)) {
       return NetworkImage(persisted);
     }
 

--- a/mobile/lib/screens/safety_settings_screen.dart
+++ b/mobile/lib/screens/safety_settings_screen.dart
@@ -16,6 +16,7 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/route_paths.dart';
 import 'package:openvine/screens/content_filters_screen.dart';
 import 'package:openvine/screens/settings/account_content_labels_tile.dart';
+import 'package:openvine/utils/dead_image_hosts.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
@@ -492,7 +493,9 @@ class _BlockedUserTile extends ConsumerWidget {
         ),
         child: ClipRRect(
           borderRadius: BorderRadius.circular(11),
-          child: profile?.picture != null && profile!.picture!.isNotEmpty
+          child:
+              profile?.picture != null &&
+                  isUsableNetworkImageUrl(profile!.picture!)
               ? VineCachedImage(
                   imageUrl: profile.picture!,
                   width: 38,

--- a/mobile/lib/utils/dead_image_hosts.dart
+++ b/mobile/lib/utils/dead_image_hosts.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Hosts whose image content is verified-dead at the origin and must
-// ABOUTME: never be requested — the placeholder is the correct render.
+// ABOUTME: Central policy for profile/media image URLs requested by the app.
+// ABOUTME: Requires HTTPS and excludes origins verified dead at the source.
 
 /// Whether [url] points at a host whose content is known to be permanently
 /// unavailable, so no request should ever be attempted.
@@ -12,4 +12,17 @@
 bool isKnownDeadImageHost(String url) {
   final host = Uri.tryParse(url)?.host.toLowerCase();
   return host == 'v.cdn.vine.co';
+}
+
+/// Whether [url] is eligible for a direct image request from the app.
+///
+/// Profile metadata is untrusted. Only HTTPS URLs with an authority are
+/// fetched, and origins known to be permanently unavailable are rejected
+/// before an image provider or cache operation is created.
+bool isUsableNetworkImageUrl(String url) {
+  final uri = Uri.tryParse(url);
+  return uri != null &&
+      uri.scheme.toLowerCase() == 'https' &&
+      uri.hasAuthority &&
+      !isKnownDeadImageHost(url);
 }

--- a/mobile/lib/widgets/user_avatar.dart
+++ b/mobile/lib/widgets/user_avatar.dart
@@ -132,8 +132,7 @@ class UserAvatar extends StatelessWidget {
   bool get _hasNetworkImage =>
       imageUrl != null &&
       imageUrl!.isNotEmpty &&
-      Uri.tryParse(imageUrl!)?.scheme == 'https' &&
-      !isKnownDeadImageHost(imageUrl!);
+      isUsableNetworkImageUrl(imageUrl!);
 
   bool get _isSvgImageUrl => isSvgImageUrl(imageUrl);
 

--- a/mobile/lib/widgets/user_avatar.dart
+++ b/mobile/lib/widgets/user_avatar.dart
@@ -132,6 +132,7 @@ class UserAvatar extends StatelessWidget {
   bool get _hasNetworkImage =>
       imageUrl != null &&
       imageUrl!.isNotEmpty &&
+      Uri.tryParse(imageUrl!)?.scheme == 'https' &&
       !isKnownDeadImageHost(imageUrl!);
 
   bool get _isSvgImageUrl => isSvgImageUrl(imageUrl);
@@ -210,12 +211,12 @@ class UserAvatar extends StatelessWidget {
 
           if (failureKind == AvatarFailureKind.deterministic) {
             UnifiedLogger.warning(
-              '🖼️ Invalid image data for avatar URL: $url - Error: $error',
+              'Avatar image data was invalid; showing placeholder',
               name: 'UserAvatar',
             );
           } else {
             UnifiedLogger.debug(
-              'Avatar image failed to load URL: $url - Error: $error',
+              'Avatar image request failed; showing placeholder',
               name: 'UserAvatar',
             );
           }
@@ -257,7 +258,7 @@ class _AvatarSvgContent extends StatelessWidget {
             fit: BoxFit.cover,
             errorBuilder: (context, error, stackTrace) {
               UnifiedLogger.debug(
-                'Avatar SVG failed to render URL: $imageUrl - Error: $error',
+                'Avatar SVG failed to render; showing placeholder',
                 name: 'UserAvatar',
               );
               AvatarFailureCache.instance.recordFailureForError(

--- a/mobile/lib/widgets/vine_bottom_nav.dart
+++ b/mobile/lib/widgets/vine_bottom_nav.dart
@@ -25,6 +25,7 @@ import 'package:openvine/screens/inbox/inbox_page.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/utils/camera_permission_check.dart';
+import 'package:openvine/utils/dead_image_hosts.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/notification_badge.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
@@ -641,7 +642,7 @@ class _ProfileTabButton extends ConsumerWidget {
         ? null
         : ref.watch(userProfileReactiveProvider(pubkey)).value;
     final imageUrl = profile?.picture;
-    final hasAvatar = imageUrl != null && imageUrl.isNotEmpty;
+    final hasAvatar = imageUrl != null && isUsableNetworkImageUrl(imageUrl);
 
     final iconBox = SizedBox.square(
       dimension: kMinInteractiveDimension,

--- a/mobile/lib/widgets/vine_cached_image.dart
+++ b/mobile/lib/widgets/vine_cached_image.dart
@@ -103,7 +103,7 @@ class _VineCachedImageState extends State<VineCachedImage> {
   }
 
   void _resolveImageStream() {
-    if (isKnownDeadImageHost(widget.imageUrl)) {
+    if (!isUsableNetworkImageUrl(widget.imageUrl)) {
       _removeImageListener();
       _error = null;
       _hasImage = false;
@@ -167,11 +167,10 @@ class _VineCachedImageState extends State<VineCachedImage> {
 
   @override
   Widget build(BuildContext context) {
-    // A known-dead host must never be resolved: the origin is gone, so the
-    // request would only burn a failure before landing here anyway.
-    if (isKnownDeadImageHost(widget.imageUrl)) {
+    // Invalid, insecure, and known-dead origins must never be resolved.
+    if (!isUsableNetworkImageUrl(widget.imageUrl)) {
       return _ErrorWidget(
-        error: StateError('known-dead image host: ${widget.imageUrl}'),
+        error: StateError('image URL is not eligible for a network request'),
         imageUrl: widget.imageUrl,
         width: widget.width,
         height: widget.height,

--- a/mobile/packages/media_cache/lib/src/cancellable_downloader.dart
+++ b/mobile/packages/media_cache/lib/src/cancellable_downloader.dart
@@ -180,7 +180,7 @@ class _HttpDownload implements CancellableDownload {
       final uri = Uri.parse(_url);
       if (uri.scheme.toLowerCase() != 'https') {
         Log.warning(
-          'CancellableDownload: rejecting non-https url $_url',
+          'CancellableDownload: rejected non-https URL',
           name: 'MediaCache',
           category: LogCategory.video,
         );
@@ -210,7 +210,7 @@ class _HttpDownload implements CancellableDownload {
       }
       if (response.statusCode != HttpStatus.ok) {
         Log.warning(
-          'CancellableDownload: $_url returned HTTP ${response.statusCode}',
+          'CancellableDownload: request returned HTTP ${response.statusCode}',
           name: 'MediaCache',
           category: LogCategory.video,
         );
@@ -260,7 +260,8 @@ class _HttpDownload implements CancellableDownload {
           // teardown, not a download failure — only warn for real errors.
           if (!_isCancelled) {
             Log.warning(
-              'CancellableDownload: stream error for $_url: $error',
+              'CancellableDownload: response stream failed '
+              '(${error.runtimeType})',
               name: 'MediaCache',
               category: LogCategory.video,
             );
@@ -313,7 +314,7 @@ class _HttpDownload implements CancellableDownload {
       // failure, and must not pollute bug-report logs with false warnings.
       if (!_isCancelled) {
         Log.warning(
-          'CancellableDownload: request failed for $_url: $error',
+          'CancellableDownload: request failed (${error.runtimeType})',
           name: 'MediaCache',
           category: LogCategory.video,
         );
@@ -335,7 +336,7 @@ class _HttpDownload implements CancellableDownload {
     _sink = null;
     if (!alreadyFailed && !_isCancelled) {
       Log.warning(
-        'CancellableDownload: write failed for $_url: $error',
+        'CancellableDownload: cache write failed (${error.runtimeType})',
         name: 'MediaCache',
         category: LogCategory.video,
       );

--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -943,7 +943,7 @@ class MediaCacheManager extends CacheManager {
         if (!completer.isCompleted) completer.complete(downloadResult);
       } on Object catch (error) {
         Log.warning(
-          'MediaCacheManager: download setup failed for $url: $error',
+          'MediaCacheManager: download setup failed (${error.runtimeType})',
           name: 'MediaCache',
           category: LogCategory.video,
         );

--- a/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
+++ b/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
@@ -499,13 +499,13 @@ void main() {
     // surface a captured warning. If the capture path is ever gated or
     // refactored away, this fails loudly instead of letting the
     // "does not log a warning" test quietly go vacuous.
-    test('a genuine non-2xx failure logs a captured warning', () async {
+    test('a rate-limited response logs status without the URL', () async {
       await LogCaptureService().clearAllLogs();
 
       final client = _CallbackClient(
         (_) async => http.StreamedResponse(
           Stream<List<int>>.value(utf8.encode('not found')),
-          404,
+          429,
         ),
       );
       final downloader = HttpCancellableDownloader(client);
@@ -522,7 +522,34 @@ void main() {
           .where((entry) => entry.message.contains('CancellableDownload'))
           .toList();
       expect(downloaderWarnings, isNotEmpty);
-      expect(downloaderWarnings.first.message, contains('returned HTTP 404'));
+      expect(downloaderWarnings.first.message, contains('returned HTTP 429'));
+      expect(
+        downloaderWarnings.first.message,
+        isNot(contains('https://example.com/missing.mp4')),
+      );
+    });
+
+    test('non-https rejection does not log the URL', () async {
+      await LogCaptureService().clearAllLogs();
+      final downloader = HttpCancellableDownloader(
+        _CallbackClient((_) async {
+          throw StateError('request must not start');
+        }),
+      );
+
+      final file = await downloader
+          .download(
+            url: 'http://private.example/avatar.jpg?identity=alice',
+            targetFile: File('${tempDir.path}/insecure.jpg'),
+          )
+          .file;
+
+      expect(file, isNull);
+      final warning = LogCaptureService().getRecentLogs().singleWhere(
+        (entry) => entry.message.contains('non-https'),
+      );
+      expect(warning.message, isNot(contains('private.example')));
+      expect(warning.message, isNot(contains('alice')));
     });
 
     test('close waits for active response stream cancellation', () async {

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -2685,14 +2685,6 @@ class ProfileRepository implements ProfileReader {
       final cachedHasPicture = cached.picture != null;
       final willEnrichPicture = !hadPicture && cachedHasPicture;
       if (willEnrichPicture) pictureEnriched++;
-      Log.debug(
-        'Cache hit for ${profile.bestDisplayName}: '
-        'search picture=${profile.picture ?? "null"}, '
-        'cached picture=${cached.picture ?? "null"}, '
-        'will enrich=$willEnrichPicture',
-        name: 'ProfileRepository._enrichFromCache',
-        category: LogCategory.storage,
-      );
       enriched.add(
         profile.copyWith(
           name: profile.name ?? cached.name,

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -1097,7 +1097,7 @@ class ProfileRepository implements ProfileReader {
       if (event != null) {
         final profile = UserProfile.fromNostrEvent(event);
         Log.debug(
-          'Fetched from relay: ${profile.bestDisplayName}',
+          'Fetched profile from connected relay',
           name: 'ProfileRepository.fetchFreshProfile',
           category: LogCategory.relay,
         );
@@ -1135,7 +1135,7 @@ class ProfileRepository implements ProfileReader {
         );
         final profile = UserProfile.fromNostrEvent(newest);
         Log.debug(
-          'Fetched from indexer relay: ${profile.bestDisplayName}',
+          'Fetched profile from indexer relay',
           name: 'ProfileRepository.fetchFreshProfile',
           category: LogCategory.relay,
         );
@@ -2198,7 +2198,7 @@ class ProfileRepository implements ProfileReader {
           latencyMs: phase1Watch.elapsedMilliseconds,
         );
         Log.warning(
-          'Local cache search failed: $e',
+          'Local cache search failed (${e.runtimeType})',
           name: 'ProfileRepository.searchUsersProgressive',
           category: LogCategory.api,
         );
@@ -2236,7 +2236,7 @@ class ProfileRepository implements ProfileReader {
           latencyMs: phase2Watch.elapsedMilliseconds,
         );
         Log.warning(
-          'REST search failed: $e',
+          'REST search failed (${e.runtimeType})',
           name: 'ProfileRepository.searchUsersProgressive',
           category: LogCategory.api,
         );
@@ -2286,7 +2286,7 @@ class ProfileRepository implements ProfileReader {
           latencyMs: phase3Watch.elapsedMilliseconds,
         );
         Log.warning(
-          'NIP-50 search failed: $e',
+          'NIP-50 search failed (${e.runtimeType})',
           name: 'ProfileRepository.searchUsersProgressive',
           category: LogCategory.relay,
         );
@@ -2294,7 +2294,7 @@ class ProfileRepository implements ProfileReader {
 
       if (resultMap.length > preWsCount) {
         final enriched = await _enrichFromCache(resultMap.values.toList());
-        yield snapshot(
+        final result = snapshot(
           isComplete: true,
           enriched: _applyFilter(
             trimmed,
@@ -2304,6 +2304,8 @@ class ProfileRepository implements ProfileReader {
             sortBy: sortBy,
           ),
         );
+        _logSearchSummary(result);
+        yield result;
         return;
       }
     } else {
@@ -2313,7 +2315,7 @@ class ProfileRepository implements ProfileReader {
     // Final yield: enriched + filtered (when WS didn't add anything or
     // was skipped due to offset > 0)
     final enriched = await _enrichFromCache(resultMap.values.toList());
-    yield snapshot(
+    final result = snapshot(
       isComplete: true,
       enriched: _applyFilter(
         trimmed,
@@ -2322,6 +2324,28 @@ class ProfileRepository implements ProfileReader {
         boostPubkeys,
         sortBy: sortBy,
       ),
+    );
+    _logSearchSummary(result);
+    yield result;
+  }
+
+  void _logSearchSummary(ProgressiveSearchResult result) {
+    String describe(SearchSourceStatus status) => switch (status) {
+      SearchSourcePending() => 'pending',
+      SearchSourceSkipped() => 'skipped',
+      SearchSourceSuccess(:final resultCount, :final latencyMs) =>
+        'success(count=$resultCount,latencyMs=$latencyMs)',
+      SearchSourceFailed(:final reason, :final latencyMs) =>
+        'failed(reason=${reason.name},latencyMs=$latencyMs)',
+    };
+
+    Log.info(
+      'Search summary: total=${result.profiles.length}, '
+      'local=${describe(result.sources[SearchSource.localCache]!)}, '
+      'api=${describe(result.sources[SearchSource.funnelcakeApi]!)}, '
+      'relay=${describe(result.sources[SearchSource.nip50Relay]!)}',
+      name: 'ProfileRepository.searchUsersProgressive',
+      category: LogCategory.api,
     );
   }
 

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -12,6 +12,7 @@ import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:profile_repository/profile_repository.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class MockNostrClient extends Mock implements NostrClient {}
 
@@ -4384,6 +4385,51 @@ void main() {
     });
 
     group('searchUsersProgressive', () {
+      test('logs privacy-safe terminal source diagnostics', () async {
+        await LogCaptureService().clearAllLogs();
+        const privateName = 'Private Search Identity';
+        const privatePicture = 'https://identity.example/avatar.jpg';
+        final cachedProfile = UserProfile(
+          pubkey: testPubkey,
+          displayName: privateName,
+          picture: privatePicture,
+          rawData: const {
+            'display_name': privateName,
+            'picture': privatePicture,
+          },
+          createdAt: DateTime(2026),
+          eventId: testEventId,
+        );
+        when(
+          () => mockUserProfilesDao.getAllProfiles(),
+        ).thenAnswer((_) async => [cachedProfile]);
+        when(
+          () => mockNostrClient.queryUsers(
+            privateName,
+            limit: 200,
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async => []);
+
+        await profileRepository
+            .searchUsersProgressive(query: privateName)
+            .toList();
+
+        final messages = LogCaptureService()
+            .getRecentLogs()
+            .map((entry) => entry.message)
+            .toList();
+        final summary = messages.singleWhere(
+          (message) => message.startsWith('Search summary:'),
+        );
+        expect(summary, contains('total=1'));
+        expect(summary, contains('local=success(count=1,latencyMs='));
+        expect(summary, contains('api=skipped'));
+        expect(summary, contains('relay=success(count=0,latencyMs='));
+        expect(messages.join('\n'), isNot(contains(privateName)));
+        expect(messages.join('\n'), isNot(contains(privatePicture)));
+      });
+
       test('returns empty stream for empty query', () async {
         final results = await profileRepository
             .searchUsersProgressive(query: '')

--- a/mobile/test/config/bug_report_config_test.dart
+++ b/mobile/test/config/bug_report_config_test.dart
@@ -29,6 +29,11 @@ const _deepLinkLogLine =
 
 void main() {
   group('sanitizeDiagnosticText', () {
+    test('redacts a bare NIP-05 domain fragment', () {
+      const input = 'profile nip05: @example.test';
+
+      expect(sanitizeDiagnosticText(input), 'profile nip05: [REDACTED]');
+    });
     group('redacts the whole credential value', () {
       // Serialized shapes are how credentials actually reach the log buffer,
       // so a quote between the key and the separator must not defeat the rule,

--- a/mobile/test/screens/profile_setup/profile_avatar_section_test.dart
+++ b/mobile/test/screens/profile_setup/profile_avatar_section_test.dart
@@ -158,6 +158,24 @@ void main() {
       );
     });
 
+    testWidgets('skips insecure pending avatar URLs in the preview', (
+      tester,
+    ) async {
+      when(() => bloc.state).thenReturn(
+        const ProfileEditorState(
+          pendingAvatarStatus: PendingAvatarStatus.staged,
+          pendingPictureUrl: 'http://images.example/staged.jpg',
+        ),
+      );
+
+      await pump(tester);
+
+      expect(
+        tester.widget<UserAvatar>(find.byType(UserAvatar)).imageProvider,
+        isNull,
+      );
+    });
+
     testWidgets('skips dead persisted avatar URLs in the preview', (
       tester,
     ) async {

--- a/mobile/test/utils/dead_image_hosts_test.dart
+++ b/mobile/test/utils/dead_image_hosts_test.dart
@@ -41,4 +41,29 @@ void main() {
       expect(isKnownDeadImageHost(''), isFalse);
     });
   });
+
+  group(isUsableNetworkImageUrl, () {
+    test('accepts HTTPS URLs with an authority', () {
+      expect(
+        isUsableNetworkImageUrl('https://images.example/avatar.jpg'),
+        isTrue,
+      );
+      expect(
+        isUsableNetworkImageUrl('HTTPS://images.example/avatar.jpg'),
+        isTrue,
+      );
+    });
+
+    test('rejects insecure, malformed, and known-dead URLs', () {
+      expect(
+        isUsableNetworkImageUrl('http://images.example/avatar.jpg'),
+        isFalse,
+      );
+      expect(isUsableNetworkImageUrl('not a url'), isFalse);
+      expect(
+        isUsableNetworkImageUrl('https://v.cdn.vine.co/avatar.jpg'),
+        isFalse,
+      );
+    });
+  });
 }

--- a/mobile/test/widgets/comprehensive_user_avatar_test.dart
+++ b/mobile/test/widgets/comprehensive_user_avatar_test.dart
@@ -207,9 +207,9 @@ void main() {
       });
 
       testWidgets(
-        'renders the placeholder without requesting a dead http vine.co URL',
+        'renders the placeholder without requesting an insecure URL',
         (tester) async {
-          const deadUrl = 'http://v.cdn.vine.co/v/avatars/dead.jpg';
+          const deadUrl = 'http://images.example/avatar.jpg';
 
           await tester.pumpWidget(
             const MaterialApp(
@@ -219,9 +219,8 @@ void main() {
             ),
           );
 
-          // The origin is verified dead (403 on cleartext, expired cert on
-          // 443), so the request must never be attempted — the placeholder
-          // is the correct render.
+          // Profile metadata is untrusted, so cleartext image requests are
+          // rejected before constructing the cached-image widget.
           expect(find.byType(VineCachedImage), findsNothing);
           expect(_gradientFinder(), findsWidgets);
         },

--- a/mobile/test/widgets/comprehensive_user_avatar_test.dart
+++ b/mobile/test/widgets/comprehensive_user_avatar_test.dart
@@ -163,6 +163,26 @@ void main() {
     });
 
     group('Image Loading States', () {
+      testWidgets('uses placeholder for an insecure archive avatar URL', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: UserAvatar(
+                imageUrl: 'http://web.archive.org/avatar.jpg',
+                placeholderSeed: 'stable-user',
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(VineCachedImage), findsNothing);
+        expect(_gradientFinder(), findsWidgets);
+      });
+
       testWidgets('shows VineCachedImage when imageUrl is provided', (
         tester,
       ) async {


### PR DESCRIPTION
## Problem

Unusable avatar URLs left search identities hard to distinguish, while avatar, media-cache, identity, and cache-enrichment logs exposed names, complete media URLs, raw failures, and NIP-05 fragments in support exports. Search also lacked privacy-safe source diagnostics.

## Fix

- centralize direct image-request eligibility: HTTPS URLs with an authority only, excluding known-dead origins
- apply that policy to search/profile avatars, edit-profile previews, bottom navigation, blocked-user rows, and the shared cached-image boundary
- keep stable generated placeholders for insecure, dead, rate-limited, invalid, and failed images
- remove URLs, names, and raw errors from avatar, SVG, media-cache, profile-fetch, enrichment, and Zendesk identity diagnostics
- log one terminal search summary containing only per-source outcome, count, and latency plus the final result count
- redact root NIP-05 display fragments in support payloads

The client does not rewrite or retry arbitrary third-party URLs. Historical insecure URLs are rejected before a provider or cache request is created; controlled HTTPS URLs remain the responsibility of the source/ingestion boundary.

## Verification

- `flutter test test/utils/dead_image_hosts_test.dart test/widgets/comprehensive_user_avatar_test.dart test/widgets/vine_cached_image_test.dart test/screens/profile_setup/profile_avatar_section_test.dart test/repositories/avatar_svg_repository_test.dart test/config/bug_report_config_test.dart packages/media_cache/test/src/cancellable_downloader_test.dart packages/profile_repository/test/src/profile_repository_test.dart --reporter compact`
- pre-push affected suite: 568 tests passed
- `flutter analyze`
- Nostr identifier, pubkey encoding, and design-system ceiling checks

Part of #8571
