### PR TITLE
fix(dm): keep loading old messages fast after a brief signer hiccup

### DIFF
--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -431,7 +431,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
         logHttpErrors: false,
       );
     } on RpcException catch (error) {
-      if (_isUnsupportedSignCanonical(error)) {
+      if (_isUnsupportedMethod(error)) {
         _signCanonicalUnsupported = true;
         Log.info(
           '[Keycast RPC] sign_canonical unsupported by backend; '
@@ -460,18 +460,21 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     }
   }
 
-  /// Whether [error] is the backend signalling that `sign_canonical` is not
-  /// implemented, as opposed to a transient or auth failure that must stay
-  /// retryable.
+  /// Whether [error] is the backend signalling that a verb is not implemented,
+  /// as opposed to a transient or auth failure that must stay retryable.
   ///
   /// Matched against the exact wordings the login backend returns today: the
-  /// HTTP `Unsupported method: sign_canonical` body and the JSON-RPC
-  /// `method_not_found` error field. The match is deliberately narrow — a
-  /// broader signal (e.g. caching on any 4xx) would risk permanently disabling
-  /// a supported capability after a transient blip. If the backend ever rewords
-  /// this, update the substrings here, otherwise canonical binding silently
-  /// re-requests on every publish.
-  bool _isUnsupportedSignCanonical(RpcException error) {
+  /// HTTP `Unsupported method: <verb>` body and the JSON-RPC `method_not_found`
+  /// error field. The match is deliberately narrow — a broader signal (e.g.
+  /// latching on any 4xx) would risk permanently disabling a supported
+  /// capability after a transient blip. If the backend ever rewords this,
+  /// update the substrings here, otherwise every caller silently re-probes.
+  ///
+  /// Shared by the three capability probes ([signCanonicalPayload],
+  /// [nip17WrapBatch] and [nip17UnwrapBatch]) so they cannot drift apart: two
+  /// byte-identical copies of this predicate had already accumulated, and the
+  /// third caller had none at all, which is #7323.
+  bool _isUnsupportedMethod(RpcException error) {
     final lower = error.message.toLowerCase();
     return lower.contains('unsupported method') ||
         lower.contains('method_not_found') ||
@@ -487,10 +490,12 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
   /// wrap (gift wrap → seal, seal → rumor) with a single round trip per chunk;
   /// the server verifies both signatures and decrypts both layers.
   ///
-  /// Returns `null` (rather than throwing) when the backend does not expose the
-  /// verb yet — method-not-found surfaces as an [RpcException] — so callers fall
-  /// back to the per-wrap decrypt path. A local [TimeoutException] is
-  /// deliberately allowed to propagate so a slow page is retried by the caller
+  /// Returns `null` ONLY when the backend does not expose the verb yet, so
+  /// callers fall back to the per-wrap decrypt path for the rest of the
+  /// session. Everything else throws — a transient 5xx, an expired token or a
+  /// rejected request — because the caller latches on `null` and a single blip
+  /// is not evidence the verb is gone (#7323). A local [TimeoutException] is
+  /// likewise allowed to propagate so a slow page is retried by the caller
   /// rather than being mistaken for an empty result.
   @override
   Future<List<GiftWrapUnwrapSlot>?> nip17UnwrapBatch(
@@ -510,10 +515,20 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
         timeout: batchRequestTimeout,
         classifyLocalTimeout: false,
       );
-    } on RpcException {
-      // Older keycast without the verb, or a server-level error: degrade so the
-      // caller uses the per-wrap fallback. Note: no `catch (_)` here — a
-      // TimeoutException must propagate, not be swallowed into a null result.
+    } on RpcException catch (error) {
+      // Only an absent verb may latch the caller off. A transient 5xx, an
+      // expired token or a rejected request must stay retryable: the caller
+      // caches `null` for the whole session, so swallowing a blip here costs
+      // two decrypt round trips per wrap until the signer is replaced (#7323).
+      // Note: no `catch (_)` — a TimeoutException must propagate too, not be
+      // swallowed into a null result.
+      if (!_isUnsupportedMethod(error)) rethrow;
+      Log.info(
+        '[Keycast RPC] nip17_unwrap_batch unsupported by backend; '
+        'DM history drain will use the per-wrap decrypt path for this session',
+        name: 'KeycastRpc',
+        category: LogCategory.auth,
+      );
       return null;
     }
   }
@@ -538,12 +553,11 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
   /// caller can stop asking for the rest of the session.
   ///
   /// Everything else throws — a transient 5xx, an expired token, a rejected
-  /// request, or a transient [RpcTimeoutException]. This is a deliberate
-  /// divergence from
-  /// [nip17UnwrapBatch], which collapses every [RpcException] into `null`:
-  /// there, a caller that latches off pays two decrypt RPCs per wrap; here it
-  /// would pay four signing round trips per DM for the rest of the session, and
-  /// a single blip is not evidence the verb is gone.
+  /// request, or a transient [RpcTimeoutException] — because a caller that
+  /// latches off would pay four signing round trips per DM for the rest of the
+  /// session, and a single blip is not evidence the verb is gone.
+  /// [nip17UnwrapBatch] follows the same rule since #7323; before that it
+  /// collapsed every [RpcException] into `null`.
   Future<List<GiftWrapSlot>?> nip17WrapBatch(
     Map<String, dynamic> rumor,
     List<String> recipientPubkeys,
@@ -565,7 +579,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
         timeout: batchRequestTimeout,
       );
     } on RpcException catch (error) {
-      if (!_isUnsupportedWrapBatch(error)) rethrow;
+      if (!_isUnsupportedMethod(error)) rethrow;
       Log.info(
         '[Keycast RPC] nip17_wrap_batch unsupported by backend; '
         'DM sends will use the per-wrap signing path for this session',
@@ -574,14 +588,6 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
       );
       return null;
     }
-  }
-
-  /// Distinguishes an absent batch verb from ordinary HTTP 400 rejections.
-  bool _isUnsupportedWrapBatch(RpcException error) {
-    final lower = error.message.toLowerCase();
-    return lower.contains('unsupported method') ||
-        lower.contains('method_not_found') ||
-        lower.contains('method not found');
   }
 
   static GiftWrapSlot _parseWrapSlot(Map<String, dynamic> slot) {

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -1035,9 +1035,69 @@ void main() {
         expect(await rpc.nip17UnwrapBatch([giftWrap('1')]), isNull);
       });
 
-      test('returns null on an HTTP error response', () async {
+      test('throws rather than returning null on a request-level rejection '
+          'that shares the unsupported-method status code', () async {
+        // Same HTTP 400 as an absent verb, different body. Collapsing this to
+        // null would latch the caller onto the per-wrap decrypt path for the
+        // whole session because of one bad request (#7323).
         mockClient = MockClient((request) async {
           return http.Response('boom', 400);
+        });
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: mockClient,
+        );
+        await expectLater(
+          rpc.nip17UnwrapBatch([giftWrap('1')]),
+          throwsA(isA<RpcException>()),
+        );
+      });
+
+      test('throws on a transient server error', () async {
+        // A 503 under pool saturation is not evidence the verb is missing.
+        // Before #7323 this latched the drain onto two decrypt round trips per
+        // wrap for the rest of the session.
+        mockClient = MockClient((request) async {
+          return http.Response('Database temporarily unavailable', 503);
+        });
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: mockClient,
+        );
+        await expectLater(
+          rpc.nip17UnwrapBatch([giftWrap('1')]),
+          throwsA(isA<RpcException>()),
+        );
+      });
+
+      test('throws on an expired token rather than latching the verb '
+          'off', () async {
+        // A 401 that survives refresh is an auth problem, not a capability
+        // one — the verb is still there once the session recovers.
+        mockClient = MockClient((request) async {
+          return http.Response('Unauthorized', 401);
+        });
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: mockClient,
+        );
+        await expectLater(
+          rpc.nip17UnwrapBatch([giftWrap('1')]),
+          throwsA(isA<RpcException>()),
+        );
+      });
+
+      test('returns null on the plain-text unsupported-method body, not '
+          'only the JSON one', () async {
+        // keycast answers HTTP 400 with a bare body for an unknown method
+        // (`format!("Unsupported method: {}", method)`), so the body — not the
+        // status — identifies an older backend. The sibling nip17WrapBatch
+        // suite pins the same shape.
+        mockClient = MockClient((request) async {
+          return http.Response('Unsupported method: nip17_unwrap_batch', 400);
         });
         final rpc = KeycastRpc(
           nostrApi: 'https://login.divine.video/api/nostr',

--- a/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_batch_unwrap.dart
+++ b/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_batch_unwrap.dart
@@ -46,10 +46,11 @@ abstract interface class GiftWrapBatchUnwrapper {
   /// Unwraps [giftWraps] — a list of kind:1059 gift-wrap events as JSON — into
   /// ordered, index-aligned [GiftWrapUnwrapSlot]s.
   ///
-  /// Returns `null` when the server does not support the verb (e.g. an older
-  /// backend), so the caller can fall back to the per-wrap path. May throw
-  /// [TimeoutException] when the request times out — callers should treat that
-  /// as a transient failure to retry, never as "no messages".
+  /// Returns `null` only when the server does not support the verb (e.g. an
+  /// older backend), so the caller can fall back to the per-wrap path. Request
+  /// failures, including [TimeoutException], are thrown instead; callers should
+  /// treat them as transient batch failures rather than evidence that the
+  /// capability is unavailable.
   Future<List<GiftWrapUnwrapSlot>?> nip17UnwrapBatch(
     List<Map<String, dynamic>> giftWraps,
   );


### PR DESCRIPTION
## Description

When you sign in with a Keycast account, Divine loads your past direct messages by asking the signer to decrypt them in batches — one request per 100 messages. There is also a slower path that asks per message, used for older signers that cannot do batches.

The client decided which path to use by a single signal: if the batch request came back empty-handed, it concluded the signer does not support batches and stopped asking **for the rest of the session**. But it drew that conclusion from *any* failure. One momentary server error, an expired token, or a single rejected request in the middle of loading was enough to permanently switch you to the slow path — two decrypt round trips per message instead of one per hundred — until the app rebuilt the signer. Loading your history took minutes instead of seconds, and nothing recovered on its own.

Now only an actual "I don't support that" answer switches paths. Every other failure is reported normally and the next batch tries again.

**Related Issue:** Closes #7323

### Why this shape

The code that calls this already does the right thing with a reported failure: it sends that one batch down the slow path and keeps trying batches for everything after it. So the fix is entirely in how the failure is classified, and no calling code changed.

The check needed to tell "unsupported" apart from "something went wrong" already existed in this file — twice, byte for byte, for the two other capabilities that probe the signer the same way. Rather than adding a third copy, the three now share one. The neighbouring method's documentation described the old behaviour as a deliberate difference between the two, so that has been corrected too.

## Out of Scope

- No change to the batch size, the retry budget, or when the slow path is used on a genuinely older signer.
- A supported signer behaves identically to before; nothing user-visible changes when everything is working.

## Verification

- `flutter analyze packages/keycast_flutter` — no issues.
- `flutter test packages/keycast_flutter/test/rpc_client_test.dart` — 55 passing.
- `flutter test packages/dm_repository/.../dm_repository_test.dart --plain-name "remote-signer batch unwrap"` — passing, confirming the calling side is unaffected.
- **Mutation-checked.** One existing test asserted the behaviour being removed (a plain HTTP 400 returning "unsupported") and now asserts the error is reported instead. Three cases were added: a momentary server error, an expired token, and the plain-text unsupported-method response the sibling capability already pins. Reverting the one-line guard fails exactly those three and nothing else.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
