### PR TITLE
fix(dm): stop reporting group DM delivery to a recipient whose inbox we could not read

### DIFF
--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -89,6 +89,7 @@ jobs:
             integration_test/e2e/dm_group_delete_for_everyone_test.dart \
             integration_test/e2e/dm_reaction_unreadable_inbox_test.dart \
             integration_test/e2e/dm_deletion_unreadable_inbox_test.dart \
+            integration_test/e2e/dm_group_send_unreadable_inbox_test.dart \
             integration_test/e2e/dm_oneway_latch_unlatch_test.dart \
             integration_test/e2e/dm_history_drain_idle_pool_test.dart; do
             echo "── $suite"

--- a/mobile/integration_test/e2e/dm_group_send_unreadable_inbox_test.dart
+++ b/mobile/integration_test/e2e/dm_group_send_unreadable_inbox_test.dart
@@ -1,0 +1,301 @@
+// ABOUTME: E2E regression for #8434 — a group DM fans one rumor out as one gift
+// ABOUTME: wrap per recipient, so a recipient whose kind-10050 inbox is
+// ABOUTME: UNREADABLE must not have that recipient's fallback-pool OK scored as
+// ABOUTME: delivery while a readable sibling in the same send still is.
+// ABOUTME: Drives a real DmRepository + NostrClient over real sockets.
+// ABOUTME: Requires: NO Docker stack — every dependency here is local.
+
+@Tags(['service'])
+library;
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay_base.dart';
+import 'package:nostr_sdk/relay/relay_status.dart';
+import 'package:nostr_sdk/relay/web_socket_connection_manager.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../helpers/fake_relay.dart';
+
+/// Redirects the public hostnames a relay list advertises onto the in-process
+/// relay. A `ws://127.0.0.1` host can never *be* an admitted target
+/// (`isRemoteSuppliedRelayUrlAllowed` refuses loopback by design), so an
+/// advertised inbox has to be reached through a redirect like this one.
+class _RedirectFactory implements WebSocketChannelFactory {
+  _RedirectFactory(this.port);
+
+  final int port;
+
+  @override
+  WebSocketChannel create(Uri uri) => WebSocketChannel.connect(
+    Uri.parse('ws://127.0.0.1:$port${uri.path}'),
+  );
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const senderKey =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+  // "Readable" — the relay serves this one's kind-10050.
+  const readableKey =
+      '2222222222222222222222222222222222222222222222222222222222222222';
+  // "Unreadable" — the relay swallows every REQ naming this author.
+  const unreadableKey =
+      '3333333333333333333333333333333333333333333333333333333333333333';
+  final senderPubkey = getPublicKey(senderKey);
+  final readablePubkey = getPublicKey(readableKey);
+  final unreadablePubkey = getPublicKey(unreadableKey);
+
+  final groupConversationId = DmRepository.computeConversationId([
+    senderPubkey,
+    readablePubkey,
+    unreadablePubkey,
+  ]);
+
+  /// A kind-10050 the readable recipient signs, advertising one admissible
+  /// public host. `_RedirectFactory` lands the dial on the in-process relay.
+  Map<String, dynamic> readableInbox() {
+    final event = Event(
+      readablePubkey,
+      EventKind.dmRelaysList,
+      [
+        ['relay', 'wss://inbox-1.example'],
+      ],
+      '',
+      createdAt: 1700000000,
+    )..sign(readableKey);
+    return event.toJson();
+  }
+
+  /// Builds the real stack the way `repository_providers.dart` does.
+  ///
+  /// `outgoingDmsDao` is wired deliberately: production never builds this
+  /// repository without the queue, and the whole subject here is what happens
+  /// to the durable row.
+  Future<({DmRepository repository, AppDatabase db})> buildStack(
+    FakeRelay relay,
+  ) async {
+    final factory = _RedirectFactory(relay.port);
+    final signer = LocalNostrSigner(senderKey);
+
+    RelayBase gen(String url) =>
+        RelayBase(url, RelayStatus(url), channelFactory: factory);
+    final nostr = Nostr(signer, [], gen, channelFactory: factory);
+
+    final relayManager = RelayManager(
+      config: RelayManagerConfig(
+        defaultRelayUrl: relay.url,
+        storage: InMemoryRelayStorage(),
+        autoReconnect: false,
+      ),
+      relayPool: nostr.relayPool,
+    );
+    final client = NostrClient.forTesting(
+      nostr: nostr,
+      relayManager: relayManager,
+    );
+
+    final db = AppDatabase.test(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final messageService = NIP17MessageService(
+      signer: signer,
+      senderPublicKey: senderPubkey,
+      nostrService: client,
+    );
+
+    final repository = DmRepository(
+      nostrClient: client,
+      directMessagesDao: db.directMessagesDao,
+      conversationsDao: db.conversationsDao,
+      outgoingDmsDao: db.outgoingDmsDao,
+      userPubkey: senderPubkey,
+      signer: signer,
+      messageService: messageService,
+    );
+    addTearDown(repository.stopListening);
+    addTearDown(nostr.relayPool.removeAll);
+    await client.initialize();
+
+    return (repository: repository, db: db);
+  }
+
+  /// The surviving queue row for [recipient], or null once it was consumed.
+  Future<OutgoingDm?> queueRowFor(AppDatabase db, String recipient) async {
+    final rows = await db.outgoingDmsDao.getForConversation(
+      conversationId: groupConversationId,
+      ownerPubkey: senderPubkey,
+    );
+    for (final row in rows) {
+      if (row.recipientPubkey == recipient) return row;
+    }
+    return null;
+  }
+
+  setUp(() {
+    DmRepository.inboxResolutionBudget = DmSendBudget.inboxResolution;
+  });
+  tearDown(() {
+    DmRepository.inboxResolutionBudget = DmSendBudget.inboxResolution;
+  });
+
+  group('#8434 group DM send on a partially unreadable fan-out', () {
+    testWidgets(
+      'ARM A: the recipient whose inbox could not be read is held pending '
+      'with its row kept, while the readable sibling in the SAME send is '
+      'still delivered and consumed',
+      (tester) async {
+        // The relay serves the readable recipient's kind-10050 and swallows
+        // every REQ naming the unreadable one — neither EVENT nor EOSE, which
+        // is the only shape that makes `queryEventsDetailed` report
+        // `timedOut`. An EOSE would be a conclusive "nothing here", i.e.
+        // `absent`, which is a fact about the recipient and correctly still
+        // routes to the pool.
+        final relay = await FakeRelay.start(
+          reply: readableInbox(),
+          replyForKinds: const {EventKind.dmRelaysList},
+          stallReqForAuthors: {unreadablePubkey},
+        );
+        addTearDown(relay.stop);
+        final stack = await buildStack(relay);
+
+        expect(
+          (await stack.repository.resolveDmInboxRelaysDetailed(
+            readablePubkey,
+          )).state,
+          DmInboxResolution.found,
+          reason: 'precondition: this recipient must be READABLE',
+        );
+        expect(
+          (await stack.repository.resolveDmInboxRelaysDetailed(
+            unreadablePubkey,
+          )).state,
+          DmInboxResolution.unreadable,
+          reason: 'precondition: this recipient must be UNREADABLE, not absent',
+        );
+
+        final results = await stack.repository.sendGroupMessage(
+          recipientPubkeys: [readablePubkey, unreadablePubkey],
+          content: 'group message with one unreadable recipient',
+        );
+
+        expect(results, hasLength(2));
+
+        // The readable sibling is untouched by this fix: its wrap went to the
+        // inbox it advertises, so the OK is real delivery.
+        expect(
+          results[0].success,
+          isTrue,
+          reason: 'the readable recipient must still be delivered',
+        );
+        expect(
+          await queueRowFor(stack.db, readablePubkey),
+          isNull,
+          reason: 'a delivered sibling consumes its durable row',
+        );
+
+        // Before #8434 this sibling ALSO reported success and its row was
+        // deleted, so the batch read `delivered` for a recipient whose wrap
+        // was written only to the fallback pool — and the handle that could
+        // have re-resolved and republished was destroyed.
+        expect(
+          results[1].success,
+          isFalse,
+          reason:
+              'a fallback-pool OK is not delivery when the inbox was '
+              'unreadable',
+        );
+        expect(results[1].retryablePending, isTrue);
+        final held = await queueRowFor(stack.db, unreadablePubkey);
+        expect(
+          held,
+          isNotNull,
+          reason: 'the sweep needs this row to re-resolve and re-drive',
+        );
+        expect(held!.recipientWrapStatus, OutgoingWrapStatus.pending);
+        expect(
+          results[1].queuedRumorId,
+          held.id,
+          reason: 'the caller needs the durable handle to re-drive this row',
+        );
+      },
+    );
+
+    testWidgets(
+      'ARM B: control — when every recipient is readable the fan-out is '
+      'delivered and every row is consumed',
+      (tester) async {
+        // Same relay, no stall: this arm exists so ARM A cannot pass merely
+        // because the send is broken for everyone.
+        final relay = await FakeRelay.start(
+          reply: readableInbox(),
+          replyForKinds: const {EventKind.dmRelaysList},
+        );
+        addTearDown(relay.stop);
+        final stack = await buildStack(relay);
+
+        final results = await stack.repository.sendGroupMessage(
+          recipientPubkeys: [readablePubkey, unreadablePubkey],
+          content: 'group message with every inbox readable',
+        );
+
+        expect(results.every((r) => r.success), isTrue);
+        expect(await queueRowFor(stack.db, readablePubkey), isNull);
+        expect(await queueRowFor(stack.db, unreadablePubkey), isNull);
+      },
+    );
+
+    testWidgets(
+      'ARM C: a wholly unreadable fan-out holds every row, and the retry '
+      'sweep does not consume what the send preserved',
+      (tester) async {
+        // Stalling the kind rather than the authors makes every recipient
+        // unreadable at once. The second half is the failure #7317's review
+        // round caught on the 1:1 path: a send-path fix the sweep then undoes
+        // is worth one sweep interval and nothing else.
+        final relay = await FakeRelay.start(
+          stallReqForKinds: const {EventKind.dmRelaysList},
+        );
+        addTearDown(relay.stop);
+        final stack = await buildStack(relay);
+
+        final results = await stack.repository.sendGroupMessage(
+          recipientPubkeys: [readablePubkey, unreadablePubkey],
+          content: 'group message with no readable inbox',
+        );
+
+        expect(results, hasLength(2));
+        expect(results.every((r) => r.retryablePending), isTrue);
+        final rows = [
+          await queueRowFor(stack.db, readablePubkey),
+          await queueRowFor(stack.db, unreadablePubkey),
+        ];
+        expect(rows.every((r) => r != null), isTrue);
+
+        final replayed = await stack.repository.recoverFullSend(
+          rumorId: rows[0]!.id,
+        );
+        expect(
+          replayed.success,
+          isFalse,
+          reason: 'the sweep re-resolves the same unreadable inbox',
+        );
+        expect(
+          await queueRowFor(stack.db, readablePubkey),
+          isNotNull,
+          reason: 'the re-drive must not consume the row the send preserved',
+        );
+      },
+    );
+  });
+}

--- a/mobile/integration_test/e2e/dm_inbox_relay_admission_test.dart
+++ b/mobile/integration_test/e2e/dm_inbox_relay_admission_test.dart
@@ -168,9 +168,9 @@ void main() {
       addTearDown(relay.stop);
       final stack = await buildStack(relay);
 
-      final resolved = await stack.repository.resolveDmInboxRelays(
+      final resolved = (await stack.repository.resolveDmInboxRelaysDetailed(
         recipientPubkey,
-      );
+      )).relays;
 
       expect(resolved, hasLength(RelayListCaps.dmInbox));
       // First-N in tag order: the two admitted hosts, then surplus.
@@ -232,7 +232,9 @@ void main() {
       final stack = await buildStack(relay);
 
       expect(
-        await stack.repository.resolveDmInboxRelays(recipientPubkey),
+        (await stack.repository.resolveDmInboxRelaysDetailed(
+          recipientPubkey,
+        )).relays,
         isNull,
       );
 

--- a/mobile/integration_test/e2e/dm_self_wrap_inbox_relays_test.dart
+++ b/mobile/integration_test/e2e/dm_self_wrap_inbox_relays_test.dart
@@ -155,7 +155,9 @@ void main() {
       // admitted inbox, so their wrap goes to the plain pool and cannot be
       // what reaches _senderOnlyInbox.
       expect(
-        await stack.repository.resolveDmInboxRelays(recipientPubkey),
+        (await stack.repository.resolveDmInboxRelaysDetailed(
+          recipientPubkey,
+        )).relays,
         isNull,
         reason:
             'the served kind-10050 is authored by the sender, so it must be '

--- a/mobile/integration_test/helpers/fake_relay.dart
+++ b/mobile/integration_test/helpers/fake_relay.dart
@@ -27,6 +27,7 @@ class FakeRelay {
     this.okConfirms,
     this.broadcast,
     this.stallReqForKinds,
+    this.stallReqForAuthors,
   );
 
   /// Starts a relay on a loopback port — ephemeral unless [port] is given.
@@ -44,6 +45,12 @@ class FakeRelay {
   /// `queryEventsDetailed` report `timedOut` — an `EOSE` is a conclusive
   /// "nothing here", so a relay answering EOSE cannot stand in for one that
   /// could not be read.
+  /// [stallReqForAuthors] does the same, but keyed on the `authors` a `REQ`
+  /// names rather than its kinds. A group fan-out resolves each recipient's
+  /// kind-10050 in its own `REQ`, so this is what lets ONE recipient's inbox
+  /// read as `found` while another's is `unreadable` in the same send — the
+  /// partially-unreadable fan-out #8434 is about. A kind-keyed stall cannot
+  /// express that: it stalls every recipient at once.
   /// Pass a stopped relay's [FakeRelay.port] as [port] to bring "the same
   /// relay" back, which is what a client that remembers the URL sees when a
   /// relay recovers.
@@ -53,6 +60,7 @@ class FakeRelay {
     bool okConfirms = true,
     bool broadcast = false,
     Set<int> stallReqForKinds = const <int>{},
+    Set<String> stallReqForAuthors = const <String>{},
     int port = 0,
   }) async {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
@@ -63,6 +71,7 @@ class FakeRelay {
       okConfirms,
       broadcast,
       stallReqForKinds,
+      stallReqForAuthors,
     );
     server.listen(relay._handle, onError: (_) {});
     return relay;
@@ -90,6 +99,13 @@ class FakeRelay {
   /// `EOSE`, so the read never settles and the client reports it as timed out
   /// rather than empty. Other subscriptions on the same socket are unaffected.
   final Set<int> stallReqForKinds;
+
+  /// Authors whose `REQ` is swallowed rather than answered.
+  ///
+  /// Same shape as [stallReqForKinds] — neither `EVENT` nor `EOSE`, so the
+  /// read times out instead of settling empty — but selective per pubkey, so a
+  /// fan-out can have a readable recipient and an unreadable one at once.
+  final Set<String> stallReqForAuthors;
 
   /// Whether a published `EVENT` is forwarded to other open subscriptions.
   ///
@@ -194,9 +210,12 @@ class FakeRelay {
     );
   }
 
-  /// Whether this `REQ` frame names a kind in [stallReqForKinds].
+  /// Whether this `REQ` frame names a kind in [stallReqForKinds] or an author
+  /// in [stallReqForAuthors].
   bool _isStalled(List<dynamic> frame) =>
-      stallReqForKinds.isNotEmpty && _namesAnyKind(frame, stallReqForKinds);
+      (stallReqForKinds.isNotEmpty && _namesAnyKind(frame, stallReqForKinds)) ||
+      (stallReqForAuthors.isNotEmpty &&
+          _namesAnyAuthor(frame, stallReqForAuthors));
 
   /// Whether [reply] is owed to this `REQ` frame; see [replyForKinds].
   bool _wantsReply(List<dynamic> frame) =>
@@ -209,6 +228,18 @@ class FakeRelay {
       if (kinds is! List) continue;
       for (final kind in kinds) {
         if (kind is int && wanted.contains(kind)) return true;
+      }
+    }
+    return false;
+  }
+
+  bool _namesAnyAuthor(List<dynamic> frame, Set<String> wanted) {
+    for (final filter in frame.skip(2)) {
+      if (filter is! Map) continue;
+      final authors = filter['authors'];
+      if (authors is! List) continue;
+      for (final author in authors) {
+        if (author is String && wanted.contains(author)) return true;
       }
     }
     return false;

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -113,9 +113,9 @@ class DmReactionRetryTarget {
 /// The state travels with the relays because `null` relays mean two different
 /// things: [DmInboxResolution.absent] (the recipient reads the default pool,
 /// so a pool `OK` is delivery) and [DmInboxResolution.unreadable] (we never
-/// read their inbox, so a pool `OK` proves nothing). The narrower
-/// `DmRepository.resolveDmInboxRelays` flattens both to `null` and must not be
-/// wired here — that flattening is #8443.
+/// read their inbox, so a pool `OK` proves nothing). A resolver that returns
+/// only the relay list would flatten both to `null` and must not be wired here
+/// — that flattening is #8443.
 ///
 /// Contract: **must not throw**. `DmRepository.resolveDmInboxRelaysDetailed`
 /// satisfies this — its whole body is wrapped in `on Object catch`. A resolver

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -274,8 +274,11 @@ typedef DmInboxLookup = ({List<String>? relays, DmInboxResolution state});
 /// be sitting on relays the recipient never queries, so it is reported
 /// soft-unconfirmed and the durable row is kept for the sweep to re-resolve
 /// (#7317). Shared by every gift-wrap publisher that also reports delivery —
-/// the 1:1 send, its retry, and the reaction fan-out (#8443) — so no sweep can
-/// undo what the send path preserved.
+/// the 1:1 send, its retry, the reaction fan-out (#8443), the deletion
+/// fan-out (#8515), and the group send (#8434) — so no sweep can undo what a
+/// send path preserved. A fan-out applies it per recipient: NIP-17 states the
+/// rule against "the recipient's kind 10050 event" (17.md:77), so a readable
+/// member is delivered even when a sibling in the same batch is not.
 ///
 /// Logs the hold. The message service has already logged `Successfully
 /// published` for this wrap — the relay did confirm it — so without this line
@@ -3554,8 +3557,10 @@ class DmRepository {
   /// Routing only needs the relays, so this signature stays. A caller that
   /// also REPORTS delivery must use [resolveDmInboxRelaysDetailed] instead:
   /// scoring a fallback-pool `OK` as delivered on an unreadable inbox is
-  /// #7317. `sendGroupMessage` (#8434) still resolves through here and
-  /// inherits that collapse.
+  /// #7317. Every publisher that reports delivery now resolves through the
+  /// detailed reader — the 1:1 send and its retry, the reaction fan-out, the
+  /// deletion fan-out, and the group send (#8434) — so this remains as the
+  /// routing-only contract for callers that never score an `OK`.
   Future<List<String>?> resolveDmInboxRelays(String pubkey) async {
     return (await resolveDmInboxRelaysDetailed(pubkey)).relays;
   }
@@ -5804,10 +5809,20 @@ class DmRepository {
     // keeps N sequential ~5s inbox queries from stacking and delaying the
     // visible group bubble. Resolution never throws (it degrades to null →
     // default pool), so a failed lookup just falls back.
-    final inboxByRecipient = <String, List<String>?>{};
+    //
+    // Resolved through the DETAILED reader: routing only needs the relays, but
+    // this fan-out also REPORTS delivery, and `absent` and `unreadable` both
+    // route to the pool while meaning opposite things (#8434). Kept per
+    // recipient rather than collapsed to one batch verdict because NIP-17
+    // states the rule per recipient — "the relays listed in the recipient's
+    // kind 10050 event" (17.md:77) — and the queue already holds one row per
+    // member, so a readable sibling stays genuinely delivered.
+    final inboxByRecipient = <String, DmInboxLookup>{};
     await Future.wait([
       for (final pubkey in recipientPubkeys)
-        resolveDmInboxRelays(pubkey).then((r) => inboxByRecipient[pubkey] = r),
+        resolveDmInboxRelaysDetailed(
+          pubkey,
+        ).then((inbox) => inboxByRecipient[pubkey] = inbox),
     ]);
 
     // One destination for every self-copy in the batch — it is addressed to
@@ -6013,17 +6028,38 @@ class DmRepository {
       // failure so one bad join cannot abort the rest of the batch —
       // _sendRumorWithTimeout itself classifies instead of throwing.
       NIP17SendResult result;
+      final inbox = inboxByRecipient[pubkey];
       try {
-        result = await _joinOrStartRecovery(
-          'full:${queueIds[i]}',
-          () => _sendRumorWithTimeout(
+        result = await _joinOrStartRecovery('full:${queueIds[i]}', () async {
+          final published = await _sendRumorWithTimeout(
             rumor: groupRumor,
             recipientPubkey: pubkey,
-            targetRelays: inboxByRecipient[pubkey],
+            targetRelays: inbox?.relays,
             selfWrapTargetRelays: selfWrapRelays,
             awaitRecipientOk: true,
-          ),
-        );
+          );
+          // An `OK` from the DEFAULT POOL is not delivery for a recipient
+          // whose inbox we never read: their wrap may sit on relays they never
+          // query, and finalizing this sibling deletes the one handle that
+          // could re-resolve and republish it (#8434). Per recipient, because
+          // the batch holds one queue row per member — a sibling we DID reach
+          // on its advertised inbox is still genuinely delivered.
+          //
+          // Applied INSIDE the closure, not around the join. A second entrant
+          // does not run this attempt; it awaits an in-flight recovery that
+          // resolved its own inbox and already applied this same rule. Judging
+          // that outcome out here would re-judge it against this send's older
+          // snapshot, and could hold a wrap that did reach the advertised
+          // inbox.
+          //
+          // Only when the queue is wired, mirroring `sendMessage`: with no row
+          // to preserve there is nothing to gain, and downgrading every
+          // sibling would leave `results.any(success)` false, skipping the
+          // local persist that puts the message in the sender's own thread.
+          return outgoingDao == null || inbox == null
+              ? published
+              : downgradeFallbackPoolDelivery(published, inbox.state);
+        });
       } on Object catch (e) {
         result = NIP17SendResult.failure(
           'joined in-flight recovery failed: $e',

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3532,16 +3532,14 @@ class DmRepository {
   // Send - Text (Kind 14)
   // -------------------------------------------------------------------------
 
-  /// Resolves [pubkey]'s NIP-17 DM inbox relays from their kind-10050
-  /// "DM relays list" event.
+  /// Resolves [pubkey]'s NIP-17 DM inbox relays and reports whether the lookup
+  /// found an inbox, conclusively found none, or could not be completed.
   ///
-  /// Returns the relay URLs the recipient prefers to receive gift-wrapped
-  /// DMs on, or `null` when no kind-10050 event is found (NIP-17: such a
-  /// user "is not ready to receive messages"). Callers route the gift
-  /// wrap to these relays; a `null` result lets the caller fall back to
-  /// the default relay pool so reachability is preserved for recipients
-  /// who have not advertised a DM inbox. Resolution failures degrade to
-  /// `null` rather than throwing, so a relay hiccup never blocks a send.
+  /// The returned relays are the recipient's preferred gift-wrap targets, or
+  /// `null` when the caller must fall back to the default relay pool. The state
+  /// preserves whether that fallback means the recipient advertised no inbox
+  /// or the lookup was unreadable, because those cases route identically but
+  /// carry different delivery evidence (#7317).
   ///
   /// The list is admitted on remote-supplied terms and capped at
   /// [RelayListCaps.dmInbox]: each entry becomes an outbound connection from
@@ -3553,19 +3551,6 @@ class DmRepository {
   /// degrades to the default pool whether the list is absent or unreadable,
   /// and overwrites nothing — so it keeps the cache and the first answer it
   /// gets rather than waiting for full relay settlement (#8212).
-  ///
-  /// Routing only needs the relays, so this signature stays. A caller that
-  /// also REPORTS delivery must use [resolveDmInboxRelaysDetailed] instead:
-  /// scoring a fallback-pool `OK` as delivered on an unreadable inbox is
-  /// #7317. Every publisher that reports delivery now resolves through the
-  /// detailed reader — the 1:1 send and its retry, the reaction fan-out, the
-  /// deletion fan-out, and the group send (#8434) — so this remains as the
-  /// routing-only contract for callers that never score an `OK`.
-  Future<List<String>?> resolveDmInboxRelays(String pubkey) async {
-    return (await resolveDmInboxRelaysDetailed(pubkey)).relays;
-  }
-
-  /// [resolveDmInboxRelays], plus why it returned what it did.
   ///
   /// Callers that route a gift wrap need the relays; callers that also report
   /// delivery need the reason. A `null` list from [DmInboxResolution.absent]
@@ -3659,10 +3644,8 @@ class DmRepository {
   /// Queries [pubkey]'s kind-10050 DM inbox relay list and reports a
   /// found / absent / failed outcome (#4974).
   ///
-  /// Collapsing absent and failed to `null` (as the public
-  /// [resolveDmInboxRelays] does) is safe for anything that only ROUTES —
-  /// both fall back to the default pool either way. Anything that reports
-  /// delivery, or replaces the list it read, must tell them apart: see
+  /// Absent and failed both route through the default pool, but anything that
+  /// reports delivery or replaces the list it read must tell them apart: see
   /// [resolveDmInboxRelaysDetailed] (#7317) and [ensureDmRelayListPublished]
   /// (#8212) respectively.
   ///
@@ -3774,7 +3757,8 @@ class DmRepository {
       // ANOTHER client, and some clients write `r` tags; within a
       // kind-10050 event both unambiguously denote DM inbox relays. Matches
       // divine-web's resolveDmReadRelays. Shared with the send path via
-      // resolveDmInboxRelays, so it also widens recipient resolution there.
+      // resolveDmInboxRelaysDetailed, so it also widens recipient resolution
+      // there.
       final relays = _admitDmRelays(
         [
           for (final tag in matchingEvents.first.tags)
@@ -3794,9 +3778,7 @@ class DmRepository {
       // means the user "is not ready to receive messages"; a read we abandoned
       // says nothing about them. Collapsing the two is #7317, and routing a
       // new timeout into `absent` would make that defect more reachable.
-      // `resolveDmInboxRelays` still flattens both to null, so behaviour here
-      // is unchanged — the distinction is preserved for the caller that needs
-      // it rather than acted on now.
+      // The detailed result preserves that distinction for every caller.
       Log.warning(
         'DM inbox resolution for ${pubkeyForLogs(pubkey)} exceeded '
         '${inboxResolutionBudget.inMilliseconds}ms; treating as unread',

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -4482,7 +4482,10 @@ void main() {
       );
     });
 
-    group('resolveDmInboxRelays', () {
+    group('resolveDmInboxRelaysDetailed routing', () {
+      Future<List<String>?> resolveRelays(DmRepository repository) async =>
+          (await repository.resolveDmInboxRelaysDetailed(_validPubkeyB)).relays;
+
       Event kind10050Event(
         List<String> relays, {
         int createdAt = 1700000000,
@@ -4548,7 +4551,7 @@ void main() {
           final repository = createRepository();
 
           expect(
-            await repository.resolveDmInboxRelays(_validPubkeyB),
+            await resolveRelays(repository),
             isNull,
             reason: 'an unread inbox degrades to the default pool, as today',
           );
@@ -4561,7 +4564,7 @@ void main() {
         ]);
         final repository = createRepository();
         expect(
-          await repository.resolveDmInboxRelays(_validPubkeyB),
+          await resolveRelays(repository),
           ['wss://inbox.example', 'wss://inbox2.example'],
         );
       });
@@ -4569,13 +4572,13 @@ void main() {
       test('returns null when no kind-10050 event exists', () async {
         // setUp already stubs queryEventsDetailed -> [].
         final repository = createRepository();
-        expect(await repository.resolveDmInboxRelays(_validPubkeyB), isNull);
+        expect(await resolveRelays(repository), isNull);
       });
 
       test('returns null when the event has no relay tags', () async {
         stubQuery([kind10050Event(const [])]);
         final repository = createRepository();
-        expect(await repository.resolveDmInboxRelays(_validPubkeyB), isNull);
+        expect(await resolveRelays(repository), isNull);
       });
 
       test(
@@ -4593,7 +4596,7 @@ void main() {
             ),
           ]);
           final repository = createRepository();
-          expect(await repository.resolveDmInboxRelays(_validPubkeyB), isNull);
+          expect(await resolveRelays(repository), isNull);
         },
       );
 
@@ -4603,7 +4606,7 @@ void main() {
         ]);
         final repository = createRepository();
         expect(
-          await repository.resolveDmInboxRelays(_validPubkeyB),
+          await resolveRelays(repository),
           ['wss://a.example'],
         );
       });
@@ -4620,7 +4623,7 @@ void main() {
           ]),
         ]);
         final repository = createRepository();
-        expect(await repository.resolveDmInboxRelays(_validPubkeyB), [
+        expect(await resolveRelays(repository), [
           'wss://valid.example',
         ]);
       });
@@ -4648,7 +4651,7 @@ void main() {
           ]),
         ]);
         final repository = createRepository();
-        expect(await repository.resolveDmInboxRelays(_validPubkeyB), [
+        expect(await resolveRelays(repository), [
           'wss://valid.example',
         ]);
       });
@@ -4660,7 +4663,7 @@ void main() {
           ]),
         ]);
         final repository = createRepository();
-        final resolved = await repository.resolveDmInboxRelays(_validPubkeyB);
+        final resolved = await resolveRelays(repository);
 
         expect(resolved, hasLength(RelayListCaps.dmInbox));
         // Deterministic: first-N in tag order, not an arbitrary subset.
@@ -4683,7 +4686,7 @@ void main() {
             ]),
           ]);
           final repository = createRepository();
-          expect(await repository.resolveDmInboxRelays(_validPubkeyB), isNull);
+          expect(await resolveRelays(repository), isNull);
         },
       );
 
@@ -4694,7 +4697,7 @@ void main() {
         ]);
         final repository = createRepository();
         expect(
-          await repository.resolveDmInboxRelays(_validPubkeyB),
+          await resolveRelays(repository),
           ['wss://new.example'],
         );
       });
@@ -4702,7 +4705,7 @@ void main() {
       test('queries kind-10050 for the requested author', () async {
         stubQuery(const []);
         final repository = createRepository();
-        await repository.resolveDmInboxRelays(_validPubkeyB);
+        await resolveRelays(repository);
         final captured =
             verify(
                   () => mockNostrClient.queryEventsDetailed(
@@ -4741,7 +4744,7 @@ void main() {
         );
         expect(resolved.relays, isNull);
         expect(resolved.state, DmInboxResolution.unreadable);
-        expect(await repository.resolveDmInboxRelays(_validPubkeyB), isNull);
+        expect(await resolveRelays(repository), isNull);
       });
 
       test('accepts both `relay` and `r` tags (#4974 cross-client)', () async {
@@ -4772,7 +4775,7 @@ void main() {
         );
         final repository = createRepository();
         expect(
-          await repository.resolveDmInboxRelays(_validPubkeyB),
+          await resolveRelays(repository),
           ['wss://relay-tag.example', 'wss://r-tag.example'],
         );
       });
@@ -5932,7 +5935,7 @@ void main() {
             stubOwnInbox(answeredList(const <Event>[]));
 
             final repository = createRepository(syncState: _FakeDmSyncState());
-            await repository.resolveDmInboxRelays(_validPubkeyB);
+            await repository.resolveDmInboxRelaysDetailed(_validPubkeyB);
 
             final captured = verify(
               () => mockNostrClient.queryEventsDetailed(

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -23105,6 +23105,164 @@ void main() {
           );
         },
       );
+
+      test(
+        'an unreadable recipient inbox is NOT delivery for that sibling, '
+        'while a readable sibling in the SAME fan-out still is (#8434)',
+        () async {
+          // B advertises an inbox we can read; nothing ever answers for C.
+          // Both wraps are OK-confirmed - but C's OK came from the default
+          // pool, which is exactly the false positive.
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((invocation) async {
+            final filters = invocation.positionalArguments.first as List;
+            final authors =
+                (filters.first as nostr_filter.Filter).authors ?? const [];
+            if (authors.contains(_validPubkeyC)) {
+              return unansweredList(noRelays: true);
+            }
+            return answeredList([
+              Event(
+                _validPubkeyB,
+                EventKind.dmRelaysList,
+                [
+                  ['relay', 'wss://inbox.example'],
+                ],
+                '',
+                createdAt: 1700000000,
+              ),
+            ]);
+          });
+          stubSendRumor(
+            (rumorEvent, recipientPubkey) async => NIP17SendResult.success(
+              rumorEventId: rumorEvent.id,
+              messageEventId: 'wrap-$recipientPubkey',
+              recipientPubkey: recipientPubkey,
+            ),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final results = await repository.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'one readable recipient, one unreadable',
+          );
+
+          final captured = verify(
+            () => mockOutgoingDmsDao.enqueue(captureAny()),
+          ).captured;
+          final enqueuedB = captured.first as OutgoingDm;
+          final enqueuedC = captured.last as OutgoingDm;
+
+          expect(results, hasLength(2));
+          expect(
+            results.first.success,
+            isTrue,
+            reason:
+                "the wrap went to the inbox B advertises, so B's OK is "
+                'real delivery and must not be held by a sibling',
+          );
+          expect(results.last.success, isFalse);
+          expect(results.last.retryablePending, isTrue);
+          expect(
+            results.last.queuedRumorId,
+            equals(enqueuedC.id),
+            reason: 'the caller needs the durable handle to re-drive this row',
+          );
+
+          // B's handle is consumed; C's SURVIVES. Without it no sweep can
+          // ever re-resolve C's inbox and republish.
+          verify(() => mockOutgoingDmsDao.deleteById(enqueuedB.id)).called(1);
+          verifyNever(() => mockOutgoingDmsDao.deleteById(enqueuedC.id));
+          verify(
+            () => mockOutgoingDmsDao.incrementRetry(enqueuedC.id),
+          ).called(1);
+        },
+      );
+
+      test(
+        'a recipient who genuinely advertises no inbox is still delivered - '
+        'the pool is where they read, so #8434 must not regress it',
+        () async {
+          // The shared setUp answers every lookup with answeredList([]): the
+          // relays replied and there is no kind-10050. Conclusive absence is
+          // a fact about the recipient, not about our read.
+          stubSendRumor(
+            (rumorEvent, recipientPubkey) async => NIP17SendResult.success(
+              rumorEventId: rumorEvent.id,
+              messageEventId: 'wrap-$recipientPubkey',
+              recipientPubkey: recipientPubkey,
+            ),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final results = await repository.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'nobody advertises an inbox',
+          );
+
+          expect(results.every((r) => r.success), isTrue);
+          final captured = verify(
+            () => mockOutgoingDmsDao.enqueue(captureAny()),
+          ).captured;
+          for (final row in captured.cast<OutgoingDm>()) {
+            verify(() => mockOutgoingDmsDao.deleteById(row.id)).called(1);
+          }
+        },
+      );
+
+      test(
+        'with NO durable queue an unreadable inbox stays delivered - there is '
+        'no row to preserve, and holding every sibling would drop the '
+        'message from the sender own thread',
+        () async {
+          // The contrast case for this group: `sendMessage` guards the
+          // downgrade on the queue being wired, and the fan-out mirrors it.
+          // Without the guard `results.any(success)` is false, the local
+          // persist is skipped, and no queue row exists to project a bubble
+          // from - so the message vanishes for the sender.
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => unansweredList(timedOut: true));
+          stubSendRumor(
+            (rumorEvent, recipientPubkey) async => NIP17SendResult.success(
+              rumorEventId: rumorEvent.id,
+              messageEventId: 'wrap-$recipientPubkey',
+              recipientPubkey: recipientPubkey,
+            ),
+          );
+
+          final repository = createRepository();
+
+          final results = await repository.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'no queue wired',
+          );
+
+          expect(results, hasLength(2));
+          expect(results.every((r) => r.success), isTrue);
+        },
+      );
     });
 
     group('getOutgoing', () {


### PR DESCRIPTION
Fixes #8434

## The problem

Send a message to a group and one member never gets it — while your bubble
says it was delivered, and nothing in the app will ever retry it.

A group send fans one rumor out as one gift wrap per recipient. It resolved
every recipient's DM inbox through `resolveDmInboxRelays`, which returns
`null` for two different facts:

- **this recipient advertises no DM inbox** — the default relay pool is
  where they read, so a pool `OK` really is delivery; and
- **we could not read the inbox they do advertise** — no relay took the
  `REQ`, or nothing settled inside the budget.

Both fall back to Divine's default pool. A single `OK true` from Divine's own
relay is `PublishOutcome.confirmed`, so that sibling's `outgoing_dms` row is
deleted. The wrap is sitting on relays the recipient never queries, the sender
is told it arrived, and the durable handle that could have re-resolved and
republished it is gone.

The repository already knew better and said so in the same log window:

```
17:40:42.680  Recipient kind-10050 lookup ... was inconclusive (not every relay
              settled) — routing to the default pool, and NOT scoring the
              publish as delivered (#7317)
17:40:42.948  Successfully published NIP-17 message (selfWrapPublished=true)
```

The second line is `sendGroupMessage` scoring it delivered anyway, 268 ms later.

## Why this fix

`sendGroupMessage` was the last publisher that reports delivery and still
resolved through the collapsing helper. The 1:1 send and its retry (#8436),
the reaction fan-out (#8443) and the deletion fan-out (#8515) already route
through `resolveDmInboxRelaysDetailed` and the shared
`downgradeFallbackPoolDelivery`. This applies the same rule here, so the
change adds no new concept and no new API.

**Per recipient, not per batch.** The issue asked whether one unreadable
member should hold the whole fan-out. It should not, for two reasons that
agree: NIP-17 states the rule against *"the relays listed in the recipient's
kind 10050 event"* (`17.md:77`) — singular, evaluated once per recipient — and
the queue already holds one row per member, so per-recipient is the only thing
the storage can express. A member we did reach on their advertised inbox stays
genuinely delivered; only the unreadable one is held.

**The downgrade sits inside the `_joinOrStartRecovery` closure.** A second
entrant does not run this attempt — it awaits an in-flight recovery that
resolved its own inbox and already applied this rule. Judging that outcome
outside the join would re-judge it against this send's older snapshot and
could hold a wrap that did reach the advertised inbox.

**It is gated on the durable queue being wired**, mirroring `sendMessage`.
Without that gate, an unwired-queue send would return every sibling
`retryablePending`, leaving `results.any(success)` false — which skips the
local persist and, with no queue rows to project a bubble from, drops the
message from the sender's own thread.

## Deliberately unchanged

- **Routing.** The wrap still falls back to the default pool. That is the
  NIP-17 MUST, and honouring it is a product decision tracked by #7317 — so
  this is `Refs`, not `Fixes`, for that issue.
- **Conclusive `absent`.** A recipient who genuinely advertises nothing is
  still delivered and still consumes its row; #570's reachability intent is
  preserved, with a regression test pinning it.
- **No visible change.** `DmDeliveryStatus.pending` and `.delivered` render
  identically, and `statusFor` already aggregates a batch worst-first over
  surviving rows. This buys durability — the row survives so the sweep can
  re-resolve — not a new indicator. There is no UI diff to look for.
- **Terminal state for a held row.** Unchanged: `_finalizeAfterRecipientUnconfirmed`
  charges `incrementRetry`, and an exhausted budget turns the row `failed`
  (the existing red "Not delivered" bubble). The reaction sibling's age-based
  expiry was deliberately removed by a maintainer on the grounds that age is
  not proof of non-delivery; nothing like it is added here.

## Verification

Reproduced first, on an iPhone 17 simulator, driving the real `DmRepository`
and `NostrClient` over real sockets — then re-run unchanged after the fix.

| arm | before | after |
|---|---|---|
| mixed fan-out: one readable, one unreadable recipient | **fail** — the unreadable recipient reported `success`, row deleted | pass — held `retryablePending`, row kept |
| control: every recipient readable | pass | pass |
| wholly unreadable, then `recoverFullSend` | **fail** — reported `success` | pass — held, and the sweep does not consume it |

The control arm exists so the mixed arm cannot pass merely because sends are
broken for everyone.

`FakeRelay` could only stall a `REQ` by kind, which stalls every recipient at
once and cannot express a partially unreadable fan-out. `stallReqForAuthors`
adds the same swallow-the-`REQ` behaviour keyed on the authors a filter names;
it defaults to empty, so no existing suite changes behaviour.

Mutation-tested at the production boundary — each guard is covered by exactly
one test:

- neutering the fan-out downgrade turns the mixed-fan-out test red, and leaves
  the two boundary tests green;
- removing the `outgoingDao == null` guard turns the no-queue test red.

```
flutter test (packages/dm_repository)      886 passed
coverage                                   94.69%  (gate 93%)
flutter test (app dm blocs)                150 passed
flutter analyze lib test integration_test  no issues
e2e on iPhone 17 simulator                 3/3 passed
```

Ratchets green: ungrouped tests, skip ceiling, placeholder tests, shared-setup
stubs, test/unit structure, nostr-id truncation, pubkey log encoding, l10n
delegates, post-close emit, uncancellable timer wait, layer direction, the four
design-system ceilings, dependency provenance, service god-file ceiling,
untested-services floor, orphaned ARB keys.

The app was also built and run on the simulator against the local Docker stack
with this change: it boots clean with no Dart runtime errors. That run is a
smoke test only — it signs in as `AuthenticationSource.none`, so the DM stack
does not initialise, and the local environment configures a single relay, which
cannot express one readable and one unreadable recipient at the same time. The
simulator e2e above is the DM evidence.

## Note for the reviewer

`sendGroupMessage` was the last production caller of the narrow
`resolveDmInboxRelays`. Review removed that now-unused public contract and
migrated its routing assertions to `resolveDmInboxRelaysDetailed(...).relays`,
so a future delivery-scoring caller cannot accidentally reintroduce the
absent/unreadable collapse.

