### PR TITLE
fix(dm): close four ways a direct message is lost silently

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/processed_gift_wraps_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/processed_gift_wraps_dao.dart
@@ -25,6 +25,40 @@ class ProcessedGiftWrapsDao extends DatabaseAccessor<AppDatabase>
     return (await query.get()).isNotEmpty;
   }
 
+  /// Has [giftWrapId] been terminally processed *by [ownerPubkey]*?
+  ///
+  /// [hasGiftWrap] answers "has any local account handled this", which is the
+  /// right question for deciding whether to pay a decrypt again. This answers
+  /// "did THIS account handle it", which is the right question for deciding
+  /// whether the account may move its own sync boundary past the event.
+  ///
+  /// The global form rests on a gift-wrap id being unique to one recipient,
+  /// which holds for kind 1059 because NIP-59 mints a fresh ephemeral key and
+  /// a separate wrap per recipient. It does not hold for an unwrapped kind 4,
+  /// whose single event id is shared by sender and recipient — so when both
+  /// are accounts on this device the ledger genuinely holds one id for two
+  /// accounts. See #8209 for why moving a boundary for a message this account
+  /// never stored is permanent damage.
+  ///
+  /// Rows with no owner are treated as this account's, matching
+  /// [clearForAccountSwitch] and `DirectMessagesDao`'s legacy handling, so an
+  /// upgrade does not reclassify an account's own history as somebody else's.
+  Future<bool> hasGiftWrapForOwner({
+    required String giftWrapId,
+    required String ownerPubkey,
+  }) async {
+    final query = selectOnly(processedGiftWraps)
+      ..addColumns([processedGiftWraps.giftWrapId])
+      ..where(
+        processedGiftWraps.giftWrapId.equals(giftWrapId) &
+            (processedGiftWraps.ownerPubkey.equals(ownerPubkey) |
+                processedGiftWraps.ownerPubkey.isNull() |
+                processedGiftWraps.ownerPubkey.equals('')),
+      )
+      ..limit(1);
+    return (await query.get()).isNotEmpty;
+  }
+
   /// Which of [giftWrapIds] are already recorded in the ledger. Batched
   /// counterpart to [hasGiftWrap]: one `IN` query instead of N single-id
   /// lookups, used by the history-drain dedup probe to avoid a per-wrap DB

--- a/mobile/packages/db_client/test/src/database/daos/processed_gift_wraps_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/processed_gift_wraps_dao_test.dart
@@ -51,7 +51,7 @@ void main() {
         );
       });
 
-      test('sees this account\'s own row', () async {
+      test("sees this account's own row", () async {
         await dao.record(giftWrapId: wrap1, ownerPubkey: ownerA);
 
         expect(

--- a/mobile/packages/db_client/test/src/database/daos/processed_gift_wraps_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/processed_gift_wraps_dao_test.dart
@@ -35,6 +35,55 @@ void main() {
   });
 
   group(ProcessedGiftWrapsDao, () {
+    group('hasGiftWrapForOwner', () {
+      test("does not see another account's row", () async {
+        await dao.record(giftWrapId: wrap1, ownerPubkey: ownerA);
+
+        // An unwrapped kind 4 carries one event id shared by both ends, so
+        // this is how the ledger looks when the other party is also a local
+        // account. B never stored it and must not act as though it had.
+        expect(
+          await dao.hasGiftWrapForOwner(
+            giftWrapId: wrap1,
+            ownerPubkey: ownerB,
+          ),
+          isFalse,
+        );
+      });
+
+      test('sees this account\'s own row', () async {
+        await dao.record(giftWrapId: wrap1, ownerPubkey: ownerA);
+
+        expect(
+          await dao.hasGiftWrapForOwner(
+            giftWrapId: wrap1,
+            ownerPubkey: ownerA,
+          ),
+          isTrue,
+        );
+      });
+
+      test('leaves the global probe answering for every account', () async {
+        await dao.record(giftWrapId: wrap1, ownerPubkey: ownerA);
+
+        // The cost decision stays global: the event is terminally handled on
+        // this device, so nobody pays to decrypt it again.
+        expect(await dao.hasGiftWrap(wrap1), isTrue);
+      });
+
+      test('is false for an id nobody recorded', () async {
+        await dao.record(giftWrapId: wrap1, ownerPubkey: ownerA);
+
+        expect(
+          await dao.hasGiftWrapForOwner(
+            giftWrapId: wrap2,
+            ownerPubkey: ownerA,
+          ),
+          isFalse,
+        );
+      });
+    });
+
     test('hasGiftWrap is false before any record', () async {
       expect(await dao.hasGiftWrap(wrap1), isFalse);
     });

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3961,13 +3961,23 @@ class DmRepository {
       // relay that settled before another relay timed out.
       final _OwnDmInboxState absentOrFailed;
       String? inconclusiveReason;
-      // NOT gated on [requireAuthoritative]: `noRelays` and `timedOut` are
-      // computed identically in both read modes (`Nostr.queryEventsDetailed`),
-      // so the send path can tell an unreadable inbox from an absent one at no
-      // cost — no extra round trip, no settle wait, so #8220's decision to keep
-      // the strict read off the send path is untouched (#7317). What
-      // `requireAllRelaysSettled` still buys the authoritative caller is the
-      // CLOSED-refusal case, which completes early and remains `absent` here.
+      // NOT gated on [requireAuthoritative], so the send path can tell an
+      // unreadable inbox from an absent one at no extra round trip and no
+      // settle wait — #8220's decision to keep the strict read off the send
+      // path is untouched (#7317).
+      //
+      // But the two modes do NOT produce the same flags, and treating a fast
+      // read's `absent` as conclusive is a real defect rather than a
+      // conservative approximation. `Nostr.queryEventsDetailed` composes
+      // `timedOut` with `requireAllRelaysSettled` in the expression itself,
+      // and more importantly the two modes complete at different moments: a
+      // relay that stays connected and never sends a terminal frame is skipped
+      // after the settle window for a fast caller, which still reports
+      // `timedOut: false`. So a silent relay reaches here as an ordinary empty
+      // answer and is classified `absent`. Only a full-settlement caller sees
+      // that as `failed`. Callers that merely route to the default pool can
+      // live with the guess; callers that latch something permanent must make
+      // their own strict read — see [_drainOwnInboxRelays].
       if (result.noRelays || result.timedOut) {
         absentOrFailed = _OwnDmInboxState.failed;
         // `noRelays` first: an offline device sets both flags, and reporting

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2124,10 +2124,7 @@ class DmRepository {
     try {
       for (final tag in deletionEvent.tags) {
         if (tag.length < 2 || tag[0] != 'e') continue;
-        await _applyMessageDeletion(
-          rumorId: tag[1],
-          deletion: deletionEvent,
-        );
+        await _applyMessageDeletion(rumorId: tag[1], deletion: deletionEvent);
       }
     } on Object catch (e, stackTrace) {
       Log.error(
@@ -2454,379 +2451,444 @@ class DmRepository {
         );
         return;
       }
-      // Decrypt succeeded — drop any prior failed-decrypt record so the
-      // retry queue stops reprocessing this wrap. See #5202.
-      await _pendingGiftWrapsDao?.deletePending(
-        giftWrapId: giftWrapEvent.id,
-        ownerPubkey: ownerPubkey,
-      );
+      // The pending row is dropped in the `finally` below, AFTER the
+      // writes commit — deliberately not here. Deleting it first is what
+      // made a persist failure unrecoverable: the transaction rolls back,
+      // no ledger row is written, and the queue row that would have
+      // replayed this wrap is already gone, so it survives in no table at
+      // all. It also erased the attempt count, so a wrap that kept failing
+      // re-inserted at 1 on every pass and [DmHistoryDrainConfig
+      // .maxDecryptRetries] could never be reached. See #5202 for the
+      // queue itself.
+      var persistFailed = false;
+      try {
+        // Bind to a final local so the non-null type promotes inside the
+        // runInTransaction closure below (a nullable parameter would not).
+        final rumor = rumorEvent;
 
-      // Bind to a final local so the non-null type promotes inside the
-      // runInTransaction closure below (a nullable parameter would not).
-      final rumor = rumorEvent;
-
-      // A NIP-59 rumor is unsigned, so `created_at` is chosen freely by the
-      // sender. Keep the message, but clamp the timestamp used for local
-      // ordering/cursors so a bad clock cannot blackhole future subscriptions
-      // or pin the thread above honest messages forever.
-      final clock = DmClock.now();
-      final persistedCreatedAt = clock.atMostNow(rumor.createdAt);
-      if (rumor.createdAt >
-          clock.nowSeconds + DmSyncState.maxFutureSkewSeconds) {
-        Log.warning(
-          'Clamped DM (kind ${rumor.kind}) from '
-          '${pubkeyForLogs(rumor.pubkey)}: rumor '
-          'created_at ${rumor.createdAt} is beyond the expected skew of '
-          '${DmSyncState.maxFutureSkewSeconds}s (now ${clock.nowSeconds})',
-          category: LogCategory.system,
-        );
-      }
-
-      // NIP-17 spec line 14 explicitly permits kind 7 reactions inside
-      // the gift-wrap envelope. Reaction deletions are also wrapped by
-      // this feature so the remove path preserves DM privacy. Route both
-      // before the DM-only kinds gate below. #4633.
-      if (rumor.kind == EventKind.reaction) {
-        final outcome = await _reactionsRepository?.persistIncoming(
-          rumorEvent: rumor,
-          giftWrapId: giftWrapEvent.id,
-        );
-        // Record only terminal outcomes: a reaction whose target message has
-        // not synced is left out so it re-decrypts and lands later. #5452.
-        if (outcome == DmWrapOutcome.processed) {
-          await _recordProcessedWrap(
-            giftWrapEvent.id,
-            ownerPubkey: ownerPubkey,
+        // A NIP-59 rumor is unsigned, so `created_at` is chosen freely by the
+        // sender. Keep the message, but clamp the timestamp used for local
+        // ordering/cursors so a bad clock cannot blackhole future subscriptions
+        // or pin the thread above honest messages forever.
+        final clock = DmClock.now();
+        final persistedCreatedAt = clock.atMostNow(rumor.createdAt);
+        if (rumor.createdAt >
+            clock.nowSeconds + DmSyncState.maxFutureSkewSeconds) {
+          Log.warning(
+            'Clamped DM (kind ${rumor.kind}) from '
+            '${pubkeyForLogs(rumor.pubkey)}: rumor '
+            'created_at ${rumor.createdAt} is beyond the expected skew of '
+            '${DmSyncState.maxFutureSkewSeconds}s (now ${clock.nowSeconds})',
+            category: LogCategory.system,
           );
         }
-        return;
-      }
-      if (rumor.kind == EventKind.eventDeletion) {
-        final outcome = await _routeWrappedDeletion(
-          rumor: rumor,
-          giftWrapId: giftWrapEvent.id,
-        );
-        if (outcome == DmWrapOutcome.processed) {
-          await _recordProcessedWrap(
-            giftWrapEvent.id,
-            ownerPubkey: ownerPubkey,
+
+        // NIP-17 spec line 14 explicitly permits kind 7 reactions inside
+        // the gift-wrap envelope. Reaction deletions are also wrapped by
+        // this feature so the remove path preserves DM privacy. Route both
+        // before the DM-only kinds gate below. #4633.
+        if (rumor.kind == EventKind.reaction) {
+          final outcome = await _reactionsRepository?.persistIncoming(
+            rumorEvent: rumor,
+            giftWrapId: giftWrapEvent.id,
           );
-        }
-        return;
-      }
-
-      // Cross-device DM read-state marker (#4977). Route only Divine's read
-      // marker d-tag to the reconciler before the DM-only kinds gate so it is
-      // never rendered as a message, then record it terminally so it is not
-      // re-decrypted every launch. Other app-specific self-wraps must remain
-      // unrecorded so future/foreign kind-30078 handlers can still process
-      // them instead of losing them to the processed-wrap ledger.
-      if (rumor.kind == EventKind.appSpecificData) {
-        if (_hasReadMarkerDTag(rumor)) {
-          await _reconcileReadMarker(rumor);
-          await _recordProcessedWrap(
-            giftWrapEvent.id,
-            ownerPubkey: ownerPubkey,
-          );
-        }
-        return;
-      }
-
-      // Accept kind 14 (text) and kind 15 (file). Any other kind is terminally
-      // unsupported — record it so it is not re-decrypted on every launch.
-      // Note: the ledger survives upgrades, so a future version that adds
-      // support for a new kind will not reprocess wraps already recorded here;
-      // such a kind would need a one-off backfill. Acceptable vs. re-decrypting
-      // every unknown wrap on every launch today. #5452.
-      if (!_supportedDmKinds.contains(rumor.kind)) {
-        await _recordProcessedWrap(giftWrapEvent.id, ownerPubkey: ownerPubkey);
-        return;
-      }
-
-      // Extract conversation participants from pubkey + p tags, then
-      // resolve against existing conversations to prevent duplicates
-      // from non-compliant clients that add extra p-tags.
-      final rawParticipants = _extractParticipants(rumor);
-      if (rawParticipants.length < 2) {
-        await _recordProcessedWrap(giftWrapEvent.id, ownerPubkey: ownerPubkey);
-        return;
-      }
-
-      final participants = await _resolveConversationParticipants(
-        rawParticipants,
-        rumor.pubkey,
-      );
-
-      // Reject self-conversations (all participants are the same pubkey).
-      // Defense-in-depth: should not happen after the self-wrap fix above,
-      // but guards against any future code path producing degenerate lists.
-      if (participants.toSet().length < 2) {
-        await _recordProcessedWrap(giftWrapEvent.id, ownerPubkey: ownerPubkey);
-        return;
-      }
-
-      final conversationId = computeConversationId(participants);
-
-      // Extract common tags
-      String? replyToId;
-      String? subject;
-      String? sendBatchId;
-      for (final tag in rumor.tags) {
-        if (tag.length >= 2) {
-          if (tag[0] == 'e') replyToId = tag[1];
-          if (tag[0] == 'subject') subject = tag[1];
-          // Stamp the batch id from the sender's OWN self-wrap echo so a
-          // group send's local persist / recovery dedups (both owner-scoped
-          // via hasMessageWithSendBatchId) against this pre-persisted row
-          // instead of inserting a duplicate bubble. Honour the tag only on
-          // a self-authored rumor: hasMessageWithSendBatchId is owner-scoped,
-          // so accepting a peer-authored 'batch' tag would let a sender
-          // suppress the local user's own in-flight group persist. The
-          // well-formed-hex check keeps this keyspace disjoint from the
-          // legacy (content, createdAt) dedup tuple.
-          if (tag[0] == _sendBatchTagKey &&
-              rumor.pubkey == ownerPubkey &&
-              _isValidSendBatchId(tag[1])) {
-            sendBatchId = tag[1];
-          }
-        }
-      }
-
-      // Extract file metadata for kind 15
-      final fileMetadata = rumor.kind == EventKind.fileMessage
-          ? _extractFileMetadata(rumor)
-          : null;
-
-      // Cross-protocol dedup: if a NIP-04 copy of this message was
-      // processed first (network reordering), skip the duplicate. Record the
-      // wrap so the skipped NIP-17 copy is not re-decrypted every launch.
-      // #5452.
-      //
-      // Only a NIP-04 copy may suppress a peer's rumor: a row that also
-      // arrived over NIP-17 is a genuine earlier message (#7324).
-      //
-      // Our own self-wrap echo is the exception. A group send persists one row
-      // but publishes one self-wrap per recipient for the shared rumor. Every
-      // echo dedups on the batch token, or the unfiltered window when the send
-      // predates it (#6046).
-      final isSentByMe = rumor.pubkey == ownerPubkey;
-      final isGroup = participants.length > 2;
-      final bool isDuplicate;
-      if (isSentByMe && sendBatchId != null) {
-        isDuplicate = await _directMessagesDao.hasMessageWithSendBatchId(
-          batchId: sendBatchId,
-          ownerPubkey: ownerPubkey,
-        );
-      } else if (isSentByMe && isGroup) {
-        isDuplicate = await _directMessagesDao.hasMatchingMessage(
-          conversationId: conversationId,
-          senderPubkey: rumor.pubkey,
-          content: rumor.content,
-          createdAt: persistedCreatedAt,
-          ownerPubkey: ownerPubkey,
-          counterpart: DmDedupCounterpart.unconstrained,
-        );
-      } else {
-        // A peer's rumor may only be collapsed onto the ONE NIP-04 twin of
-        // this same message, which the claim consumes so a second same-text
-        // rumor in the window cannot be collapsed onto it too (#8211).
-        isDuplicate = await _directMessagesDao.claimCrossProtocolTwin(
-          conversationId: conversationId,
-          senderPubkey: rumor.pubkey,
-          content: rumor.content,
-          createdAt: persistedCreatedAt,
-          ownerPubkey: ownerPubkey,
-          counterpart: DmDedupCounterpart.nip04Copy,
-        );
-      }
-      if (isDuplicate) {
-        // A twin from the PEER is proof they speak NIP-17, and it is the only
-        // place that proof ever appears: the rumor is about to be dropped as a
-        // duplicate, so without this the evidence is discarded and the thread
-        // stays latched to 'nip04' forever. That latch is what makes the
-        // legacy dual-send the steady state rather than an edge case — every
-        // later pair hits this same early return, so the decision the first
-        // arrival race made is never revisited (#8499).
-        //
-        // `!isSentByMe` is load-bearing on this duplicate branch. The `else`
-        // above is reached by a peer's rumor AND by a self-authored 1:1 rumor
-        // with no send batch token; clearing here on our own self-wrap would
-        // invert *this* path into "clear when *I* speak NIP-17". It does not
-        // cover a unique self-authored NIP-17, which is not a twin and still
-        // hits the persist upsert's `dmProtocol: 'nip17'` below.
-        // Ledger first, unlatch second, and the unlatch can never throw out of
-        // here. It is an opportunistic upgrade on evidence we happen to be
-        // holding; the dedup bookkeeping below it is what stops this wrap
-        // being decrypted again on every redelivery. Ordering them the other
-        // way round made a failed unlatch abort `_recordProcessedWrap`, so a
-        // transient DB error would have cost a signer round trip per replay,
-        // forever. A dropped unlatch costs nothing — the next message from the
-        // peer presents the same evidence again.
-        await _recordProcessedWrap(giftWrapEvent.id, ownerPubkey: ownerPubkey);
-        if (!isSentByMe) {
-          try {
-            final cleared = await _conversationsDao.clearNip04ProtocolLatch(
-              conversationId,
+          // Record only terminal outcomes: a reaction whose target message has
+          // not synced is left out so it re-decrypts and lands later. #5452.
+          if (outcome == DmWrapOutcome.processed) {
+            await _recordProcessedWrap(
+              giftWrapEvent.id,
               ownerPubkey: ownerPubkey,
             );
-            if (cleared) {
-              Log.info(
-                'Cleared the nip04 protocol latch on conversation '
-                '$conversationId: ${pubkeyForLogs(rumor.pubkey)} sent NIP-17, '
-                'so the legacy kind-4 copy is no longer published to them',
+          }
+          return;
+        }
+        if (rumor.kind == EventKind.eventDeletion) {
+          final outcome = await _routeWrappedDeletion(
+            rumor: rumor,
+            giftWrapId: giftWrapEvent.id,
+          );
+          if (outcome == DmWrapOutcome.processed) {
+            await _recordProcessedWrap(
+              giftWrapEvent.id,
+              ownerPubkey: ownerPubkey,
+            );
+          }
+          return;
+        }
+
+        // Cross-device DM read-state marker (#4977). Route only Divine's read
+        // marker d-tag to the reconciler before the DM-only kinds gate so it is
+        // never rendered as a message, then record it terminally so it is not
+        // re-decrypted every launch. Other app-specific self-wraps must remain
+        // unrecorded so future/foreign kind-30078 handlers can still process
+        // them instead of losing them to the processed-wrap ledger.
+        if (rumor.kind == EventKind.appSpecificData) {
+          if (_hasReadMarkerDTag(rumor)) {
+            await _reconcileReadMarker(rumor);
+            await _recordProcessedWrap(
+              giftWrapEvent.id,
+              ownerPubkey: ownerPubkey,
+            );
+          }
+          return;
+        }
+
+        // Accept kind 14 (text) and kind 15 (file). Any other kind is terminally
+        // unsupported — record it so it is not re-decrypted on every launch.
+        // Note: the ledger survives upgrades, so a future version that adds
+        // support for a new kind will not reprocess wraps already recorded here;
+        // such a kind would need a one-off backfill. Acceptable vs. re-decrypting
+        // every unknown wrap on every launch today. #5452.
+        if (!_supportedDmKinds.contains(rumor.kind)) {
+          await _recordProcessedWrap(
+            giftWrapEvent.id,
+            ownerPubkey: ownerPubkey,
+          );
+          return;
+        }
+
+        // Extract conversation participants from pubkey + p tags, then
+        // resolve against existing conversations to prevent duplicates
+        // from non-compliant clients that add extra p-tags.
+        final rawParticipants = _extractParticipants(rumor);
+        if (rawParticipants.length < 2) {
+          await _recordProcessedWrap(
+            giftWrapEvent.id,
+            ownerPubkey: ownerPubkey,
+          );
+          return;
+        }
+
+        final participants = await _resolveConversationParticipants(
+          rawParticipants,
+          rumor.pubkey,
+        );
+
+        // Reject self-conversations (all participants are the same pubkey).
+        // Defense-in-depth: should not happen after the self-wrap fix above,
+        // but guards against any future code path producing degenerate lists.
+        if (participants.toSet().length < 2) {
+          await _recordProcessedWrap(
+            giftWrapEvent.id,
+            ownerPubkey: ownerPubkey,
+          );
+          return;
+        }
+
+        final conversationId = computeConversationId(participants);
+
+        // Extract common tags
+        String? replyToId;
+        String? subject;
+        String? sendBatchId;
+        for (final tag in rumor.tags) {
+          if (tag.length >= 2) {
+            if (tag[0] == 'e') replyToId = tag[1];
+            if (tag[0] == 'subject') subject = tag[1];
+            // Stamp the batch id from the sender's OWN self-wrap echo so a
+            // group send's local persist / recovery dedups (both owner-scoped
+            // via hasMessageWithSendBatchId) against this pre-persisted row
+            // instead of inserting a duplicate bubble. Honour the tag only on
+            // a self-authored rumor: hasMessageWithSendBatchId is owner-scoped,
+            // so accepting a peer-authored 'batch' tag would let a sender
+            // suppress the local user's own in-flight group persist. The
+            // well-formed-hex check keeps this keyspace disjoint from the
+            // legacy (content, createdAt) dedup tuple.
+            if (tag[0] == _sendBatchTagKey &&
+                rumor.pubkey == ownerPubkey &&
+                _isValidSendBatchId(tag[1])) {
+              sendBatchId = tag[1];
+            }
+          }
+        }
+
+        // Extract file metadata for kind 15
+        final fileMetadata = rumor.kind == EventKind.fileMessage
+            ? _extractFileMetadata(rumor)
+            : null;
+
+        // Cross-protocol dedup: if a NIP-04 copy of this message was
+        // processed first (network reordering), skip the duplicate. Record the
+        // wrap so the skipped NIP-17 copy is not re-decrypted every launch.
+        // #5452.
+        //
+        // Only a NIP-04 copy may suppress a peer's rumor: a row that also
+        // arrived over NIP-17 is a genuine earlier message (#7324).
+        //
+        // Our own self-wrap echo is the exception. A group send persists one row
+        // but publishes one self-wrap per recipient for the shared rumor. Every
+        // echo dedups on the batch token, or the unfiltered window when the send
+        // predates it (#6046).
+        final isSentByMe = rumor.pubkey == ownerPubkey;
+        final isGroup = participants.length > 2;
+        final bool isDuplicate;
+        if (isSentByMe && sendBatchId != null) {
+          isDuplicate = await _directMessagesDao.hasMessageWithSendBatchId(
+            batchId: sendBatchId,
+            ownerPubkey: ownerPubkey,
+          );
+        } else if (isSentByMe && isGroup) {
+          isDuplicate = await _directMessagesDao.hasMatchingMessage(
+            conversationId: conversationId,
+            senderPubkey: rumor.pubkey,
+            content: rumor.content,
+            createdAt: persistedCreatedAt,
+            ownerPubkey: ownerPubkey,
+            counterpart: DmDedupCounterpart.unconstrained,
+          );
+        } else {
+          // A peer's rumor may only be collapsed onto the ONE NIP-04 twin of
+          // this same message, which the claim consumes so a second same-text
+          // rumor in the window cannot be collapsed onto it too (#8211).
+          isDuplicate = await _directMessagesDao.claimCrossProtocolTwin(
+            conversationId: conversationId,
+            senderPubkey: rumor.pubkey,
+            content: rumor.content,
+            createdAt: persistedCreatedAt,
+            ownerPubkey: ownerPubkey,
+            counterpart: DmDedupCounterpart.nip04Copy,
+          );
+        }
+        if (isDuplicate) {
+          // A twin from the PEER is proof they speak NIP-17, and it is the only
+          // place that proof ever appears: the rumor is about to be dropped as a
+          // duplicate, so without this the evidence is discarded and the thread
+          // stays latched to 'nip04' forever. That latch is what makes the
+          // legacy dual-send the steady state rather than an edge case — every
+          // later pair hits this same early return, so the decision the first
+          // arrival race made is never revisited (#8499).
+          //
+          // `!isSentByMe` is load-bearing on this duplicate branch. The `else`
+          // above is reached by a peer's rumor AND by a self-authored 1:1 rumor
+          // with no send batch token; clearing here on our own self-wrap would
+          // invert *this* path into "clear when *I* speak NIP-17". It does not
+          // cover a unique self-authored NIP-17, which is not a twin and still
+          // hits the persist upsert's `dmProtocol: 'nip17'` below.
+          // Ledger first, unlatch second, and the unlatch can never throw out of
+          // here. It is an opportunistic upgrade on evidence we happen to be
+          // holding; the dedup bookkeeping below it is what stops this wrap
+          // being decrypted again on every redelivery. Ordering them the other
+          // way round made a failed unlatch abort `_recordProcessedWrap`, so a
+          // transient DB error would have cost a signer round trip per replay,
+          // forever. A dropped unlatch costs nothing — the next message from the
+          // peer presents the same evidence again.
+          await _recordProcessedWrap(
+            giftWrapEvent.id,
+            ownerPubkey: ownerPubkey,
+          );
+          if (!isSentByMe) {
+            try {
+              final cleared = await _conversationsDao.clearNip04ProtocolLatch(
+                conversationId,
+                ownerPubkey: ownerPubkey,
+              );
+              if (cleared) {
+                Log.info(
+                  'Cleared the nip04 protocol latch on conversation '
+                  '$conversationId: ${pubkeyForLogs(rumor.pubkey)} sent NIP-17, '
+                  'so the legacy kind-4 copy is no longer published to them',
+                  category: LogCategory.system,
+                );
+              }
+            } on Object catch (e) {
+              Log.warning(
+                'Could not clear the nip04 protocol latch on conversation '
+                '$conversationId: $e — the thread keeps dual-sending until the '
+                'next NIP-17 message from the peer',
                 category: LogCategory.system,
               );
             }
-          } on Object catch (e) {
-            Log.warning(
-              'Could not clear the nip04 protocol latch on conversation '
-              '$conversationId: $e — the thread keeps dual-sending until the '
-              'next NIP-17 message from the peer',
-              category: LogCategory.system,
-            );
           }
-        }
-        Log.debug(
-          'Skipping duplicate NIP-17 DM ${rumor.id} in conversation '
-          '$conversationId from ${pubkeyForLogs(rumor.pubkey)}: matching '
-          'message already '
-          'stored',
-          category: LogCategory.system,
-        );
-        return;
-      }
-
-      // Persist message + conversation atomically inside a transaction.
-      // The inner hasGiftWrap re-check guards against TOCTOU races where
-      // a poll and subscription event both pass the outer fast-path check.
-      final previewContent = rumor.kind == EventKind.fileMessage
-          ? _filePreviewText(fileMetadata?.fileType)
-          : rumor.content;
-
-      var inserted = false;
-      var skippedByTransactionalGiftWrapDedup = false;
-      var suppressedByRemovedConversation = false;
-      int? removedAt;
-      await _conversationsDao.runInTransaction(() async {
-        // Re-check dedup inside transaction (TOCTOU protection). The skip is
-        // logged after the transaction below; logging here too would emit one
-        // line per skip twice.
-        if (await _directMessagesDao.hasGiftWrap(giftWrapEvent.id)) {
-          skippedByTransactionalGiftWrapDedup = true;
+          Log.debug(
+            'Skipping duplicate NIP-17 DM ${rumor.id} in conversation '
+            '$conversationId from ${pubkeyForLogs(rumor.pubkey)}: matching '
+            'message already '
+            'stored',
+            category: LogCategory.system,
+          );
           return;
         }
 
-        removedAt = await _removedConversationsDao?.removedAtFor(
-          conversationId: conversationId,
-          ownerPubkey: ownerPubkey,
-        );
-        if (removedAt != null && persistedCreatedAt <= removedAt!) {
-          suppressedByRemovedConversation = true;
+        // Persist message + conversation atomically inside a transaction.
+        // The inner hasGiftWrap re-check guards against TOCTOU races where
+        // a poll and subscription event both pass the outer fast-path check.
+        final previewContent = rumor.kind == EventKind.fileMessage
+            ? _filePreviewText(fileMetadata?.fileType)
+            : rumor.content;
+
+        var inserted = false;
+        var skippedByTransactionalGiftWrapDedup = false;
+        var suppressedByRemovedConversation = false;
+        int? removedAt;
+        await _conversationsDao.runInTransaction(() async {
+          // Re-check dedup inside transaction (TOCTOU protection). The skip is
+          // logged after the transaction below; logging here too would emit one
+          // line per skip twice.
+          if (await _directMessagesDao.hasGiftWrap(giftWrapEvent.id)) {
+            skippedByTransactionalGiftWrapDedup = true;
+            return;
+          }
+
+          removedAt = await _removedConversationsDao?.removedAtFor(
+            conversationId: conversationId,
+            ownerPubkey: ownerPubkey,
+          );
+          if (removedAt != null && persistedCreatedAt <= removedAt!) {
+            suppressedByRemovedConversation = true;
+            return;
+          }
+
+          inserted = await _directMessagesDao.insertMessage(
+            id: rumor.id,
+            conversationId: conversationId,
+            senderPubkey: rumor.pubkey,
+            content: rumor.content,
+            createdAt: persistedCreatedAt,
+            giftWrapId: giftWrapEvent.id,
+            messageKind: rumor.kind,
+            replyToId: replyToId,
+            subject: subject,
+            tagsJson: jsonEncode(rumor.tags),
+            fileType: fileMetadata?.fileType,
+            encryptionAlgorithm: fileMetadata?.encryptionAlgorithm,
+            decryptionKey: fileMetadata?.decryptionKey,
+            decryptionNonce: fileMetadata?.decryptionNonce,
+            fileHash: fileMetadata?.fileHash,
+            originalFileHash: fileMetadata?.originalFileHash,
+            fileSize: fileMetadata?.fileSize,
+            dimensions: fileMetadata?.dimensions,
+            blurhash: fileMetadata?.blurhash,
+            thumbnailUrl: fileMetadata?.thumbnailUrl,
+            ownerPubkey: ownerPubkey,
+            sendBatchId: sendBatchId,
+          );
+          if (!inserted) return;
+
+          final existing = await _conversationsDao.getConversation(
+            conversationId,
+            ownerPubkey: ownerPubkey,
+          );
+
+          await _conversationsDao.upsertConversation(
+            id: conversationId,
+            participantPubkeys: jsonEncode(participants),
+            isGroup: isGroup,
+            createdAt: existing?.createdAt ?? persistedCreatedAt,
+            lastMessageContent: previewContent,
+            lastMessageTimestamp: persistedCreatedAt,
+            lastMessageSenderPubkey: rumor.pubkey,
+            subject: subject,
+            isRead: isSentByMe,
+            currentUserHasSent:
+                isSentByMe || (existing?.currentUserHasSent ?? false),
+            ownerPubkey: ownerPubkey,
+            dmProtocol: 'nip17',
+          );
+          // A newer message reopens a removed conversation: the row is
+          // recreated above, while the tombstone is deliberately kept so
+          // replayed history stamped at or before the removal stays
+          // suppressed. #7804.
+        });
+
+        if (skippedByTransactionalGiftWrapDedup) {
+          Log.debug(
+            'Skipping NIP-17 gift wrap ${giftWrapEvent.id}: already persisted '
+            'during transaction',
+            category: LogCategory.system,
+          );
+          return;
+        }
+        if (suppressedByRemovedConversation) {
+          // Terminal: record the wrap so replays skip it before decryption.
+          // The tombstone is authoritative for the account's lifetime, so the
+          // ledger is not racing a reopening that clears it.
+          await _recordProcessedWrap(
+            giftWrapEvent.id,
+            ownerPubkey: ownerPubkey,
+          );
+          Log.debug(
+            'Suppressed NIP-17 DM ${rumor.id} in removed conversation '
+            '$conversationId: createdAt $persistedCreatedAt is at or before '
+            'removal at $removedAt',
+            category: LogCategory.system,
+          );
+          return;
+        }
+        if (!inserted) {
+          await _recordProcessedWrap(
+            giftWrapEvent.id,
+            ownerPubkey: ownerPubkey,
+          );
+          Log.debug(
+            'Skipped duplicate NIP-17 DM ${rumor.id} in conversation '
+            '$conversationId: insert was ignored by local dedup constraints',
+            category: LogCategory.system,
+          );
           return;
         }
 
-        inserted = await _directMessagesDao.insertMessage(
-          id: rumor.id,
-          conversationId: conversationId,
-          senderPubkey: rumor.pubkey,
-          content: rumor.content,
+        // Advance sync boundaries in BOTH clocks, because they answer two
+        // different questions. The rumor timestamp is the honest send time the
+        // UI orders by, and its randomized outer wrap must not be used for
+        // that. But the relay indexes and filters the outer stamp, so the live
+        // subscription's `since:` has to be derived from that one instead —
+        // recording only the rumor clock is what made a backdated wrap fall
+        // outside the window and never be requested again. See #8209.
+        await _syncState?.recordSeen(
+          ownerPubkey,
           createdAt: persistedCreatedAt,
+        );
+        await _syncState?.recordWireSeen(
+          ownerPubkey,
+          createdAt: giftWrapEvent.createdAt,
+        );
+
+        Log.debug(
+          'Persisted NIP-17 DM ${rumor.id} (kind ${rumor.kind}) in conversation '
+          '$conversationId from ${pubkeyForLogs(rumor.pubkey)} '
+          'createdAt=$persistedCreatedAt',
+          category: LogCategory.system,
+        );
+      } on Object catch (e, stackTrace) {
+        persistFailed = true;
+        // The wrap decrypted but did not persist, so it is in no table:
+        // the transaction rolled back and nothing was ledgered. Put it
+        // back on the retry queue rather than dropping it — this is the
+        // same durable path a failed decrypt takes, under the same attempt
+        // budget. Without this the wrap is lost the moment the live
+        // window moves past its outer stamp, with one log line to show
+        // for it.
+        //
+        // NIP-04 deliberately has no equivalent: `_handleNip04Event` has
+        // no queue to re-enter, because [PendingGiftWraps] stores raw
+        // kind-1059 JSON for `Event.fromJson` + `_decryptRumor` and a
+        // kind 4 needs a different replay path. Out of scope here.
+        Log.error(
+          'Persisting decrypted gift wrap ${giftWrapEvent.id} failed after '
+          'the decrypt succeeded; re-queued for retry: $e',
+          category: LogCategory.system,
+          error: e,
+          stackTrace: stackTrace,
+        );
+        await _pendingGiftWrapsDao?.recordFailedDecrypt(
           giftWrapId: giftWrapEvent.id,
-          messageKind: rumor.kind,
-          replyToId: replyToId,
-          subject: subject,
-          tagsJson: jsonEncode(rumor.tags),
-          fileType: fileMetadata?.fileType,
-          encryptionAlgorithm: fileMetadata?.encryptionAlgorithm,
-          decryptionKey: fileMetadata?.decryptionKey,
-          decryptionNonce: fileMetadata?.decryptionNonce,
-          fileHash: fileMetadata?.fileHash,
-          originalFileHash: fileMetadata?.originalFileHash,
-          fileSize: fileMetadata?.fileSize,
-          dimensions: fileMetadata?.dimensions,
-          blurhash: fileMetadata?.blurhash,
-          thumbnailUrl: fileMetadata?.thumbnailUrl,
           ownerPubkey: ownerPubkey,
-          sendBatchId: sendBatchId,
+          rawJson: jsonEncode(giftWrapEvent.toJson()),
+          createdAt: giftWrapEvent.createdAt,
         );
-        if (!inserted) return;
-
-        final existing = await _conversationsDao.getConversation(
-          conversationId,
-          ownerPubkey: ownerPubkey,
-        );
-
-        await _conversationsDao.upsertConversation(
-          id: conversationId,
-          participantPubkeys: jsonEncode(participants),
-          isGroup: isGroup,
-          createdAt: existing?.createdAt ?? persistedCreatedAt,
-          lastMessageContent: previewContent,
-          lastMessageTimestamp: persistedCreatedAt,
-          lastMessageSenderPubkey: rumor.pubkey,
-          subject: subject,
-          isRead: isSentByMe,
-          currentUserHasSent:
-              isSentByMe || (existing?.currentUserHasSent ?? false),
-          ownerPubkey: ownerPubkey,
-          dmProtocol: 'nip17',
-        );
-        // A newer message reopens a removed conversation: the row is
-        // recreated above, while the tombstone is deliberately kept so
-        // replayed history stamped at or before the removal stays
-        // suppressed. #7804.
-      });
-
-      if (skippedByTransactionalGiftWrapDedup) {
-        Log.debug(
-          'Skipping NIP-17 gift wrap ${giftWrapEvent.id}: already persisted '
-          'during transaction',
-          category: LogCategory.system,
-        );
-        return;
+      } finally {
+        // Every exit that got here without throwing has handled the wrap
+        // terminally — persisted, deduped, or recorded in the ledger — so
+        // the queue row is stale and goes. A `return` inside the `try`
+        // runs this first, which is what keeps parity with the twelve
+        // early returns above that relied on the delete happening up top.
+        if (!persistFailed) {
+          await _pendingGiftWrapsDao?.deletePending(
+            giftWrapId: giftWrapEvent.id,
+            ownerPubkey: ownerPubkey,
+          );
+        }
       }
-      if (suppressedByRemovedConversation) {
-        // Terminal: record the wrap so replays skip it before decryption.
-        // The tombstone is authoritative for the account's lifetime, so the
-        // ledger is not racing a reopening that clears it.
-        await _recordProcessedWrap(giftWrapEvent.id, ownerPubkey: ownerPubkey);
-        Log.debug(
-          'Suppressed NIP-17 DM ${rumor.id} in removed conversation '
-          '$conversationId: createdAt $persistedCreatedAt is at or before '
-          'removal at $removedAt',
-          category: LogCategory.system,
-        );
-        return;
-      }
-      if (!inserted) {
-        await _recordProcessedWrap(giftWrapEvent.id, ownerPubkey: ownerPubkey);
-        Log.debug(
-          'Skipped duplicate NIP-17 DM ${rumor.id} in conversation '
-          '$conversationId: insert was ignored by local dedup constraints',
-          category: LogCategory.system,
-        );
-        return;
-      }
-
-      // Advance sync boundaries in BOTH clocks, because they answer two
-      // different questions. The rumor timestamp is the honest send time the
-      // UI orders by, and its randomized outer wrap must not be used for
-      // that. But the relay indexes and filters the outer stamp, so the live
-      // subscription's `since:` has to be derived from that one instead —
-      // recording only the rumor clock is what made a backdated wrap fall
-      // outside the window and never be requested again. See #8209.
-      await _syncState?.recordSeen(ownerPubkey, createdAt: persistedCreatedAt);
-      await _syncState?.recordWireSeen(
-        ownerPubkey,
-        createdAt: giftWrapEvent.createdAt,
-      );
-
-      Log.debug(
-        'Persisted NIP-17 DM ${rumor.id} (kind ${rumor.kind}) in conversation '
-        '$conversationId from ${pubkeyForLogs(rumor.pubkey)} '
-        'createdAt=$persistedCreatedAt',
-        category: LogCategory.system,
-      );
     } on Object catch (e, stackTrace) {
       Log.error(
         'Failed to process gift wrap event: $e',

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1194,6 +1194,68 @@ class DmRepository {
     return res.state == _OwnDmInboxState.found ? res.relays : null;
   }
 
+  /// The user's own kind-10050 inbox relays for the history drain, together
+  /// with whether the answer can be trusted.
+  ///
+  /// [_ownInboxRelays] is the wrong reader here. It collapses "the user
+  /// advertises nothing" and "we could not read what the user advertises" into
+  /// the same `null`, which is free for a caller that merely routes to the
+  /// default pool and wrong for one that latches a permanent flag off the
+  /// result.
+  ///
+  /// The two are easy to confuse because the fast read cannot tell them apart:
+  /// a relay that stays connected and never answers is skipped after the
+  /// settle window and the query still reports success, so a silent relay
+  /// arrives as an ordinary empty list. `absent` then swallows it — and unlike
+  /// `failed`, `absent` is memoized for the rest of the session.
+  ///
+  /// That matters because the advertised inbox is usually NOT in the default
+  /// pool: the relays published in every kind-10050 join the pool only when
+  /// relay discovery came back empty. So a drain that guesses `absent` pages
+  /// the one relay set least likely to hold the missing history, and then
+  /// records that history as fully recovered.
+  ///
+  /// The live subscription cannot afford a conclusive read — it is awaited on
+  /// every login and reconnect (#8212). The drain can: it is unawaited
+  /// background work that already runs fully-settled page queries, and it pays
+  /// this at most once per run, and not at all when the fast read already
+  /// returned a list.
+  Future<({List<String>? relays, bool conclusive})> _drainOwnInboxRelays(
+    String pubkey,
+    int generation,
+  ) async {
+    final memoFuture = _resolveOwnDmInbox();
+    final memo = await memoFuture;
+    if (memo.state == _OwnDmInboxState.found) {
+      return (relays: memo.relays, conclusive: true);
+    }
+    if (_ingestSessionEnded(pubkey, generation)) {
+      return (relays: null, conclusive: true);
+    }
+    final strict = await _queryOwnDmInbox(
+      pubkey,
+      requireAuthoritative: true,
+      source: _DmRelayListSource.selfAuthored,
+    );
+    if (_ingestSessionEnded(pubkey, generation)) {
+      return (relays: null, conclusive: true);
+    }
+    // Repair the session memo with the better answer, so the live
+    // subscription's next re-subscribe stops routing by a silence we have
+    // since resolved. Guarded like the `failed` self-clear so a concurrent
+    // reset wins.
+    if (_ownInboxFuture == null || identical(_ownInboxFuture, memoFuture)) {
+      _ownInboxFuture = strict.state == _OwnDmInboxState.failed
+          ? null
+          : Future.value(strict);
+    }
+    return switch (strict.state) {
+      _OwnDmInboxState.found => (relays: strict.relays, conclusive: true),
+      _OwnDmInboxState.absent => (relays: null, conclusive: true),
+      _OwnDmInboxState.failed => (relays: null, conclusive: false),
+    };
+  }
+
   /// Where the sender's own gift-wrap copy of an outgoing DM should land: the
   /// configured pool UNION the user's advertised kind-10050 DM inbox.
   ///
@@ -1660,6 +1722,32 @@ class DmRepository {
     // the stale flag once so recovery runs again. No-op once at the current
     // version, so it does not loop on every inbox open. See #5202.
     await syncState.upgradeDrainVersionIfNeeded(pubkey);
+    if (syncState.historyDrainComplete(pubkey) &&
+        !syncState.drainCoveredOwnInbox(pubkey)) {
+      // Completed before the drain recorded whether it knew the user's
+      // advertised inbox relays — so it may have declared history complete
+      // having never asked them. Fixing that forward helps nobody already
+      // latched, and there is no user-facing resync, so spend one conclusive
+      // read to find out.
+      final recovery = await _drainOwnInboxRelays(pubkey, gen);
+      if (_ingestSessionEnded(pubkey, gen)) return;
+      if (recovery.conclusive) {
+        // Either answer settles it. A list means the earlier run may have
+        // missed whole relays, so re-arm once. No list means the pool was
+        // always the whole story and the completion was honest. Recording it
+        // either way is what stops this costing a read on every inbox open.
+        await syncState.setDrainCoveredOwnInbox(pubkey);
+        if (recovery.relays != null) {
+          await syncState.rearmDrainForOwnInbox(pubkey);
+          Log.info(
+            'DM history drain re-armed for ${pubkeyForLogs(pubkey)}: the '
+            'completed run never read the account\'s own DM inbox relays, '
+            'which are now known',
+            category: LogCategory.system,
+          );
+        }
+      }
+    }
     if (syncState.historyDrainComplete(pubkey)) {
       Log.info(
         'DM history drain skipped for ${pubkeyForLogs(pubkey)}: already '
@@ -1731,19 +1819,41 @@ class DmRepository {
           DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
       // Resolve the user's OWN kind-10050 inbox relays once for the whole
-      // drain (memoized, shared with the live subscription) and dial every
-      // page at them as well as the pool, so the backfill reads gift wraps
-      // delivered outside the default pool. `null` keeps default-pool-only
-      // behavior. See #4974.
-      final ownInbox = await _ownInboxRelays();
+      // drain and dial every page at them as well as the pool, so the backfill
+      // reads gift wraps delivered outside the default pool. `null` keeps
+      // default-pool-only behavior. See #4974.
+      final inbox = await _drainOwnInboxRelays(pubkey, gen);
       if (_ingestSessionEnded(pubkey, gen)) return;
+      final ownInbox = inbox.relays;
 
       var reachedEnd = false;
       // Set by any page not every relay settled — empty or not. Freezes the
       // durable cursor and blocks completion for the rest of this run, so a
       // window one relay never answered is re-requested rather than skipped
       // past. See the partial-page guard below. #8209.
-      var sawUnansweredPage = false;
+      //
+      // Seeded true when the inbox itself could not be read: that is the same
+      // defect one level up — the fan-out is missing whole relays rather than
+      // one relay in it staying silent — and it must not latch completion
+      // either.
+      var sawUnansweredPage = !inbox.conclusive;
+      var partialViewReason = 'an earlier page was not fully settled';
+      if (sawUnansweredPage) {
+        partialViewReason =
+            "the account's own DM inbox relays could not be read, so this run "
+            'paged the default pool only';
+        // Pin the resume point before paging, for the same reason the in-loop
+        // pins exist: this run persists messages, which drags oldestSyncedAt
+        // down, and an unpinned next run would seed below the windows the
+        // inbox relays still have to be asked for.
+        await syncState.setHistoryDrainCursor(pubkey, cursor);
+        Log.warning(
+          'DM history drain for ${pubkeyForLogs(pubkey)} could not read the '
+          "account's own DM inbox relays; holding the resume cursor at "
+          '$cursor and deferring completion to the next inbox open.',
+          category: LogCategory.system,
+        );
+      }
       var pagesRun = 0;
       var totalEvents = 0;
       for (var page = 0; page < DmHistoryDrainConfig.maxPages; page++) {
@@ -1868,6 +1978,10 @@ class DmRepository {
         // resumes on the next inbox open instead.
         final nip04Recovered = await _recoverOutgoingNip04(pubkey, gen);
         if (nip04Recovered) {
+          // This run reached a conclusive answer about the account's own
+          // inbox relays — completion is only reachable when it did — so a
+          // later session never has to spend a read finding that out.
+          await syncState.setDrainCoveredOwnInbox(pubkey);
           await syncState.markHistoryDrainComplete(pubkey);
           // Restore read state now that the full conversation set is present:
           // last-sent floor + any read markers stashed during the drain. #4977.
@@ -1894,7 +2008,7 @@ class DmRepository {
         // that window; the next inbox open re-requests it. #8209.
         Log.warning(
           'DM history drain reached the end for ${pubkeyForLogs(pubkey)} but '
-          'an earlier page was not fully settled; deferring completion to the '
+          '$partialViewReason; deferring completion to the '
           'next inbox open.',
           category: LogCategory.system,
         );

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1741,7 +1741,7 @@ class DmRepository {
           await syncState.rearmDrainForOwnInbox(pubkey);
           Log.info(
             'DM history drain re-armed for ${pubkeyForLogs(pubkey)}: the '
-            'completed run never read the account\'s own DM inbox relays, '
+            "completed run never read the account's own DM inbox relays, "
             'which are now known',
             category: LogCategory.system,
           );
@@ -2705,11 +2705,14 @@ class DmRepository {
           return;
         }
 
-        // Accept kind 14 (text) and kind 15 (file). Any other kind is terminally
+        // Accept kind 14 (text) and kind 15 (file). Any other kind is
+        // terminally
         // unsupported — record it so it is not re-decrypted on every launch.
         // Note: the ledger survives upgrades, so a future version that adds
-        // support for a new kind will not reprocess wraps already recorded here;
-        // such a kind would need a one-off backfill. Acceptable vs. re-decrypting
+        // support for a new kind will not reprocess wraps already recorded
+        // here;
+        // such a kind would need a one-off backfill. Acceptable vs.
+        // re-decrypting
         // every unknown wrap on every launch today. #5452.
         if (!_supportedDmKinds.contains(rumor.kind)) {
           await _recordProcessedWrap(
@@ -2787,9 +2790,11 @@ class DmRepository {
         // Only a NIP-04 copy may suppress a peer's rumor: a row that also
         // arrived over NIP-17 is a genuine earlier message (#7324).
         //
-        // Our own self-wrap echo is the exception. A group send persists one row
+        // Our own self-wrap echo is the exception. A group send persists
+        // one row
         // but publishes one self-wrap per recipient for the shared rumor. Every
-        // echo dedups on the batch token, or the unfiltered window when the send
+        // echo dedups on the batch token, or the unfiltered window when
+        // the send
         // predates it (#6046).
         final isSentByMe = rumor.pubkey == ownerPubkey;
         final isGroup = participants.length > 2;
@@ -2823,7 +2828,8 @@ class DmRepository {
         }
         if (isDuplicate) {
           // A twin from the PEER is proof they speak NIP-17, and it is the only
-          // place that proof ever appears: the rumor is about to be dropped as a
+          // place that proof ever appears: the rumor is about to be
+          // dropped as a
           // duplicate, so without this the evidence is discarded and the thread
           // stays latched to 'nip04' forever. That latch is what makes the
           // legacy dual-send the steady state rather than an edge case — every
@@ -2836,13 +2842,15 @@ class DmRepository {
           // invert *this* path into "clear when *I* speak NIP-17". It does not
           // cover a unique self-authored NIP-17, which is not a twin and still
           // hits the persist upsert's `dmProtocol: 'nip17'` below.
-          // Ledger first, unlatch second, and the unlatch can never throw out of
+          // Ledger first, unlatch second, and the unlatch can never throw
+          // out of
           // here. It is an opportunistic upgrade on evidence we happen to be
           // holding; the dedup bookkeeping below it is what stops this wrap
           // being decrypted again on every redelivery. Ordering them the other
           // way round made a failed unlatch abort `_recordProcessedWrap`, so a
           // transient DB error would have cost a signer round trip per replay,
-          // forever. A dropped unlatch costs nothing — the next message from the
+          // forever. A dropped unlatch costs nothing — the next message
+          // from the
           // peer presents the same evidence again.
           await _recordProcessedWrap(
             giftWrapEvent.id,
@@ -2857,7 +2865,8 @@ class DmRepository {
               if (cleared) {
                 Log.info(
                   'Cleared the nip04 protocol latch on conversation '
-                  '$conversationId: ${pubkeyForLogs(rumor.pubkey)} sent NIP-17, '
+                  '$conversationId: ${pubkeyForLogs(rumor.pubkey)} sent '
+                  'NIP-17, '
                   'so the legacy kind-4 copy is no longer published to them',
                   category: LogCategory.system,
                 );
@@ -3016,7 +3025,8 @@ class DmRepository {
         );
 
         Log.debug(
-          'Persisted NIP-17 DM ${rumor.id} (kind ${rumor.kind}) in conversation '
+          'Persisted NIP-17 DM ${rumor.id} (kind ${rumor.kind}) in '
+          'conversation '
           '$conversationId from ${pubkeyForLogs(rumor.pubkey)} '
           'createdAt=$persistedCreatedAt',
           category: LogCategory.system,

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -223,6 +223,21 @@ const Duration _messagePublishTimeout = DmBatchSendBudget.messagePublishTimeout;
 /// don't conflate them: the live subscription / drain fall back to the
 /// default pool on either, but RC3 must only publish-when-`absent` and never
 /// overwrite a real list when the lookup merely `failed`.
+/// Which local account terminally handled an already-processed event.
+///
+/// Only meaningful for NIP-04. A kind-1059 wrap id belongs to exactly one
+/// recipient, so "processed" and "processed by us" are the same fact there.
+enum _Nip04DedupHit {
+  /// Not processed by anyone on this device.
+  none,
+
+  /// Processed by the account that is receiving it now.
+  thisAccount,
+
+  /// Processed by a different local account, so this one never stored it.
+  otherAccount,
+}
+
 enum _OwnDmInboxState {
   /// The user advertises a kind-10050 with at least one allowed relay.
   found,
@@ -2287,6 +2302,49 @@ class DmRepository {
     return ledger.hasGiftWrap(giftWrapId);
   }
 
+  /// Attributes an already-processed kind-4 to a local account.
+  ///
+  /// [_alreadyProcessed] is global on the documented reasoning that a
+  /// gift-wrap event id is globally unique. That holds for kind 1059, where
+  /// NIP-59 mints a fresh ephemeral key and a separate wrap per recipient, so
+  /// one id can only ever belong to one local account. A kind 4 has no
+  /// envelope — one signed event, one author, one `p` recipient — so when both
+  /// ends are accounts on this device they genuinely share an id, and
+  /// `_recoverOutgoingNip04` makes that concrete by paging the whole outgoing
+  /// history of one account into tables the other one reads.
+  ///
+  /// The global probe still runs first and still decides whether to pay for a
+  /// decrypt: the event is terminally handled on this device either way. What
+  /// this adds is who handled it, which is what decides whether this account
+  /// may move its own sync boundary past it.
+  Future<_Nip04DedupHit> _nip04DedupHit(
+    String eventId, {
+    required String ownerPubkey,
+  }) async {
+    if (!await _alreadyProcessed(eventId)) return _Nip04DedupHit.none;
+    if (ownerPubkey.isEmpty) return _Nip04DedupHit.thisAccount;
+    // The kind-4 insert writes the same id into both `id` and `giftWrapId`,
+    // so an owner-scoped lookup by id is the exact counterpart of the global
+    // `hasGiftWrap` probe on this path — and it already applies the legacy
+    // unowned-row allowance.
+    if (await _directMessagesDao.getMessageById(
+          eventId,
+          ownerPubkey: ownerPubkey,
+        ) !=
+        null) {
+      return _Nip04DedupHit.thisAccount;
+    }
+    final ledger = _processedGiftWrapsDao;
+    if (ledger != null &&
+        await ledger.hasGiftWrapForOwner(
+          giftWrapId: eventId,
+          ownerPubkey: ownerPubkey,
+        )) {
+      return _Nip04DedupHit.thisAccount;
+    }
+    return _Nip04DedupHit.otherAccount;
+  }
+
   /// Batched form of [_alreadyProcessed] for the history-drain dedup probe.
   /// Resolves which of [giftWrapIds] are already persisted or in the dedup
   /// ledger with TWO `IN` queries instead of 2×N sequential single-id lookups,
@@ -3321,14 +3379,33 @@ class DmRepository {
       // processed-wraps ledger also carries NIP-04 event ids that were
       // suppressed by a removed-conversation tombstone, so replays skip
       // decryption entirely — matching the terminal NIP-17 behavior. #7804.
-      if (await _alreadyProcessed(nip04Event.id)) {
-        // Advance the wire boundary for the same reason the gift-wrap dedup
-        // path does. A kind 4 is its own envelope, so the stamp the relay
-        // filtered to deliver this replay is the event's own `created_at`.
-        await _syncState?.recordWireSeen(
-          ownerPubkey,
-          createdAt: nip04Event.createdAt,
-        );
+      final dedupHit = await _nip04DedupHit(
+        nip04Event.id,
+        ownerPubkey: ownerPubkey,
+      );
+      if (dedupHit != _Nip04DedupHit.none) {
+        if (dedupHit == _Nip04DedupHit.thisAccount) {
+          // Advance the wire boundary for the same reason the gift-wrap dedup
+          // path does. A kind 4 is its own envelope, so the stamp the relay
+          // filtered to deliver this replay is the event's own `created_at`.
+          await _syncState?.recordWireSeen(
+            ownerPubkey,
+            createdAt: nip04Event.createdAt,
+          );
+        } else {
+          // A different local account processed this kind 4 — its id is shared
+          // by both ends, unlike a gift wrap's. This account never stored the
+          // message, so moving its boundary past the event would raise the
+          // floor of every future window over a message it does not have, and
+          // the boundary only ever rises. See #8209.
+          Log.warning(
+            'Skipping kind-4 ${nip04Event.id} for '
+            '${pubkeyForLogs(ownerPubkey)}: another local account processed '
+            'it, so this account is not advancing its sync boundary past a '
+            'message it never stored',
+            category: LogCategory.system,
+          );
+        }
         if (_historyDrain == null) {
           Log.debug(
             'Skipping already-processed NIP-04 event ${nip04Event.id}',

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1230,7 +1230,7 @@ class DmRepository {
       return (relays: memo.relays, conclusive: true);
     }
     if (_ingestSessionEnded(pubkey, generation)) {
-      return (relays: null, conclusive: true);
+      return (relays: null, conclusive: false);
     }
     final strict = await _queryOwnDmInbox(
       pubkey,
@@ -1238,7 +1238,7 @@ class DmRepository {
       source: _DmRelayListSource.selfAuthored,
     );
     if (_ingestSessionEnded(pubkey, generation)) {
-      return (relays: null, conclusive: true);
+      return (relays: null, conclusive: false);
     }
     // Repair the session memo with the better answer, so the live
     // subscription's next re-subscribe stops routing by a silence we have
@@ -3522,13 +3522,18 @@ class DmRepository {
           // message, so moving its boundary past the event would raise the
           // floor of every future window over a message it does not have, and
           // the boundary only ever rises. See #8209.
-          Log.warning(
-            'Skipping kind-4 ${nip04Event.id} for '
-            '${pubkeyForLogs(ownerPubkey)}: another local account processed '
-            'it, so this account is not advancing its sync boundary past a '
-            'message it never stored',
-            category: LogCategory.system,
-          );
+          // A drain deliberately re-requests this event while its cursor stays
+          // above it. Logging every replay would fill the capture ring and
+          // evict the persist diagnostics the warning is meant to support.
+          if (_historyDrain == null) {
+            Log.warning(
+              'Skipping kind-4 ${nip04Event.id} for '
+              '${pubkeyForLogs(ownerPubkey)}: another local account processed '
+              'it, so this account is not advancing its sync boundary past a '
+              'message it never stored',
+              category: LogCategory.system,
+            );
+          }
         }
         if (_historyDrain == null) {
           Log.debug(

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -30,6 +30,7 @@ class DmSyncState {
   static const _drainVersionPrefix = 'dm.historyDrainVersion.';
   static const _dmRelayListPublishedPrefix = 'dm.dmRelayListPublished.';
   static const _groupRecoveryVersionPrefix = 'dm.groupRecoveryVersion.';
+  static const _drainInboxCoveredPrefix = 'dm.drainCoveredOwnInbox.';
 
   /// Current history-drain logic version. Installs whose persisted
   /// [drainVersion] is below this re-run the drain once, even if
@@ -340,6 +341,43 @@ class DmSyncState {
     await _prefs.setBool('$_dmRelayListPublishedPrefix$pubkey', true);
   }
 
+  /// Whether the completed history drain for [pubkey] actually knew which
+  /// relays the user advertises for DMs.
+  ///
+  /// A drain that could not read the user's own kind-10050 paged the default
+  /// pool alone. For a user whose advertised inbox is not in that pool — the
+  /// normal case once NIP-65 discovery has found real relays — that means the
+  /// drain declared history complete having never asked the relays most likely
+  /// to hold it, and `historyDrainComplete` is permanent.
+  ///
+  /// Reads `false` for every install that completed before this was recorded,
+  /// which is exactly the stranded population. It is set once the drain
+  /// completes against a conclusive answer — a list it read, or an
+  /// authoritative "there is no list" — so a healthy install pays the recovery
+  /// check at most once and never again.
+  bool drainCoveredOwnInbox(String pubkey) =>
+      _prefs.getBool('$_drainInboxCoveredPrefix$pubkey') ?? false;
+
+  /// Records that the drain for [pubkey] reached a conclusive answer about the
+  /// user's own DM inbox relays. See [drainCoveredOwnInbox].
+  Future<void> setDrainCoveredOwnInbox(String pubkey) async {
+    await _prefs.setBool('$_drainInboxCoveredPrefix$pubkey', true);
+  }
+
+  /// Clears the completion latch for [pubkey] and re-arms the drain from now,
+  /// so a run that completed without ever asking the user's advertised inbox
+  /// relays gets one pass that does ask them.
+  ///
+  /// Seeds the cursor at now for the same reason [upgradeDrainVersionIfNeeded]
+  /// does: removing it would seed from `oldestSyncedAt` and re-read only
+  /// history the install already has.
+  Future<void> rearmDrainForOwnInbox(String pubkey) async {
+    await _armRedrainFromNow(
+      pubkey,
+      DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    );
+  }
+
   /// The group-conversation recovery logic version last run for [pubkey], or
   /// `0` if it has never run (#8407).
   int groupRecoveryVersion(String pubkey) =>
@@ -360,6 +398,7 @@ class DmSyncState {
     await _prefs.remove('$_drainVersionPrefix$pubkey');
     await _prefs.remove('$_dmRelayListPublishedPrefix$pubkey');
     await _prefs.remove('$_groupRecoveryVersionPrefix$pubkey');
+    await _prefs.remove('$_drainInboxCoveredPrefix$pubkey');
   }
 
   /// Removes all DM sync state entries for every pubkey.
@@ -378,7 +417,8 @@ class DmSyncState {
               key.startsWith(_drainCursorPrefix) ||
               key.startsWith(_drainVersionPrefix) ||
               key.startsWith(_dmRelayListPublishedPrefix) ||
-              key.startsWith(_groupRecoveryVersionPrefix),
+              key.startsWith(_groupRecoveryVersionPrefix) ||
+              key.startsWith(_drainInboxCoveredPrefix),
         )
         .toList();
     for (final key in keysToRemove) {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -7190,7 +7190,7 @@ void main() {
       // from "a relay stayed silent": a connected relay that never answers is
       // skipped after the settle window and the read still reports success.
       // The drain used to act on that guess and latch completion permanently.
-      group('the account\'s own inbox relays gate completion', () {
+      group("the account's own inbox relays gate completion", () {
         // Answers the kind-10050 lookup differently depending on whether the
         // caller demanded full settlement, which is the whole distinction.
         void stubSilentInboxRelay({required bool conclusive}) {
@@ -7248,7 +7248,8 @@ void main() {
               syncState: syncState,
             ).backfillHistoryIfNeeded();
 
-            // Without the pin the next run seeds from oldestSyncedAt, which this
+            // Without the pin the next run seeds from oldestSyncedAt,
+            // which this
             // run's own persisted messages drag below the windows still owed.
             expect(syncState.persistedDrainCursors, contains(100));
           },
@@ -12734,8 +12735,8 @@ void main() {
         });
       });
 
-      test("a duplicate this account itself stored still advances its wire "
-          'boundary', () async {
+      test('a duplicate this account itself stored still advances its '
+          'wire boundary', () async {
         final nip04Event = createNip04Event();
 
         when(
@@ -12750,7 +12751,7 @@ void main() {
             ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).thenAnswer(
-          (_) async => DirectMessageRow(
+          (_) async => const DirectMessageRow(
             id: _rumorEventId,
             conversationId: 'own-duplicate',
             senderPubkey: _validPubkeyB,
@@ -12835,7 +12836,7 @@ void main() {
               ownerPubkey: any(named: 'ownerPubkey'),
             ),
           ).thenAnswer(
-            (_) async => DirectMessageRow(
+            (_) async => const DirectMessageRow(
               id: _rumorEventId,
               conversationId: 'own-duplicate',
               senderPubkey: _validPubkeyB,

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -12479,12 +12479,110 @@ void main() {
         await repository.stopListening();
       });
 
-      test('duplicate NIP-04 events still advance the wire boundary', () async {
+      // A kind-1059 id belongs to one recipient, so "some account processed
+      // this" and "we processed this" are the same fact. A kind 4 has no
+      // envelope: sender and recipient share one event id, so when both are
+      // accounts on this device the dedup tables hold one id for two accounts.
+      group('a kind-4 another local account processed', () {
+        late _MockProcessedGiftWrapsDao ledger;
+
+        setUp(() {
+          ledger = _MockProcessedGiftWrapsDao();
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(_rumorEventId),
+          ).thenAnswer((_) async => true);
+          when(
+            () => mockDirectMessagesDao.getMessageById(
+              _rumorEventId,
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => null);
+        });
+
+        Future<_FakeDmSyncState> deliverDuplicate() async {
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+          final syncState = _FakeDmSyncState();
+          final repository = createRepository(
+            nip04Decryptor: (_, _) async => 'should not reach',
+            syncState: syncState,
+            processedGiftWrapsDao: ledger,
+          );
+          await repository.startListening();
+          controller.add(createNip04Event());
+          await Future<void>.delayed(Duration.zero);
+          await controller.close();
+          await repository.stopListening();
+          return syncState;
+        }
+
+        test("does not advance this account's wire boundary", () async {
+          when(
+            () => ledger.hasGiftWrapForOwner(
+              giftWrapId: any(named: 'giftWrapId'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => false);
+
+          final syncState = await deliverDuplicate();
+
+          // The boundary only ever rises, so raising it over a message this
+          // account never stored puts every future window above it.
+          expect(syncState.recordedWire, isEmpty);
+        });
+
+        test('still advances it when this account ledgered the event '
+            'itself', () async {
+          when(
+            () => ledger.hasGiftWrapForOwner(
+              giftWrapId: any(named: 'giftWrapId'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => true);
+
+          final syncState = await deliverDuplicate();
+
+          // Mutation guard: "never advance on a dedup hit" would regress the
+          // account's own suppressed history, which the 2-day overlap
+          // re-delivers on every launch.
+          expect(syncState.recordedWire, hasLength(1));
+          expect(syncState.recordedWire.single.pubkey, _validPubkeyA);
+        });
+      });
+
+      test("a duplicate this account itself stored still advances its wire "
+          'boundary', () async {
         final nip04Event = createNip04Event();
 
         when(
           () => mockDirectMessagesDao.hasGiftWrap(_rumorEventId),
         ).thenAnswer((_) async => true);
+
+        // This account's OWN duplicate: the row is in direct_messages under
+        // this owner, which is what entitles it to move its boundary.
+        when(
+          () => mockDirectMessagesDao.getMessageById(
+            _rumorEventId,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer(
+          (_) async => DirectMessageRow(
+            id: _rumorEventId,
+            conversationId: 'own-duplicate',
+            senderPubkey: _validPubkeyB,
+            content: 'duplicate',
+            createdAt: 1700000000,
+            giftWrapId: _rumorEventId,
+            messageKind: 4,
+            isDeleted: false,
+            twinCollapsed: false,
+          ),
+        );
 
         final controller = StreamController<Event>();
         when(
@@ -12552,6 +12650,24 @@ void main() {
             dedupStarted.complete();
             return dedupResult.future;
           });
+          when(
+            () => mockDirectMessagesDao.getMessageById(
+              _rumorEventId,
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer(
+            (_) async => DirectMessageRow(
+              id: _rumorEventId,
+              conversationId: 'own-duplicate',
+              senderPubkey: _validPubkeyB,
+              content: 'duplicate',
+              createdAt: 1700000000,
+              giftWrapId: _rumorEventId,
+              messageKind: 4,
+              isDeleted: false,
+              twinCollapsed: false,
+            ),
+          );
 
           final controller = StreamController<Event>();
           when(

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -456,6 +456,9 @@ class _FakeDmSyncState implements DmSyncState {
       <({String pubkey, int createdAt})>[];
   final List<({String pubkey, int createdAt})> recordedWire =
       <({String pubkey, int createdAt})>[];
+  bool drainCoveredOwnInboxOverride = false;
+  final List<String> inboxCoveredPubkeys = <String>[];
+  final List<String> rearmedForInboxPubkeys = <String>[];
 
   @override
   int? newestSyncedAt(String pubkey) => newestOverride;
@@ -474,6 +477,22 @@ class _FakeDmSyncState implements DmSyncState {
     markedCompletePubkeys.add(pubkey);
     drainCompleteOverride = true;
     drainCursorOverride = null;
+  }
+
+  @override
+  bool drainCoveredOwnInbox(String pubkey) => drainCoveredOwnInboxOverride;
+
+  @override
+  Future<void> setDrainCoveredOwnInbox(String pubkey) async {
+    inboxCoveredPubkeys.add(pubkey);
+    drainCoveredOwnInboxOverride = true;
+  }
+
+  @override
+  Future<void> rearmDrainForOwnInbox(String pubkey) async {
+    rearmedForInboxPubkeys.add(pubkey);
+    drainCompleteOverride = false;
+    drainCursorOverride = DateTime.now().millisecondsSinceEpoch ~/ 1000;
   }
 
   @override
@@ -7167,9 +7186,169 @@ void main() {
         },
       );
 
+      // The fast kind-10050 read cannot tell "the account advertises nothing"
+      // from "a relay stayed silent": a connected relay that never answers is
+      // skipped after the settle window and the read still reports success.
+      // The drain used to act on that guess and latch completion permanently.
+      group('the account\'s own inbox relays gate completion', () {
+        // Answers the kind-10050 lookup differently depending on whether the
+        // caller demanded full settlement, which is the whole distinction.
+        void stubSilentInboxRelay({required bool conclusive}) {
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((invocation) async {
+            final filters =
+                invocation.positionalArguments.first
+                    as List<nostr_filter.Filter>;
+            final isInboxLookup =
+                filters.first.kinds?.contains(EventKind.dmRelaysList) ?? false;
+            if (!isInboxLookup) return answeredPage(const <Event>[]);
+            final strict =
+                invocation.namedArguments[#requireAllRelaysSettled] as bool? ??
+                false;
+            if (!strict) return answeredList(const <Event>[]);
+            return conclusive
+                ? answeredList(const <Event>[])
+                : unansweredList(timedOut: true);
+          });
+        }
+
+        test('defers completion when they could not be read', () async {
+          stubSilentInboxRelay(conclusive: false);
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+
+          await createRepository(
+            syncState: syncState,
+          ).backfillHistoryIfNeeded();
+
+          // Latching here is permanent, and the relays that were never asked
+          // are the ones most likely to hold the missing history.
+          expect(syncState.markedCompletePubkeys, isEmpty);
+          expect(syncState.drainCompleteOverride, isFalse);
+        });
+
+        test(
+          'pins the resume cursor so the next run re-reads the window',
+          () async {
+            stubSilentInboxRelay(conclusive: false);
+            final syncState = _FakeDmSyncState()
+              ..oldestOverride = 100
+              ..drainVersionOverride = DmSyncState.currentDrainVersion;
+
+            await createRepository(
+              syncState: syncState,
+            ).backfillHistoryIfNeeded();
+
+            // Without the pin the next run seeds from oldestSyncedAt, which this
+            // run's own persisted messages drag below the windows still owed.
+            expect(syncState.persistedDrainCursors, contains(100));
+          },
+        );
+
+        test('still completes when they conclusively do not exist', () async {
+          stubSilentInboxRelay(conclusive: true);
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+
+          await createRepository(
+            syncState: syncState,
+          ).backfillHistoryIfNeeded();
+
+          // Mutation guard against "defer whenever the fast read is not
+          // found": an account that advertises nothing must still finish.
+          expect(syncState.markedCompletePubkeys, contains(_validPubkeyA));
+        });
+      });
+
+      // A run that completed before the drain recorded whether it knew the
+      // account's advertised inbox relays may have declared history complete
+      // having never asked them. Fixing that forward strands every install
+      // already in that state, and there is no user-facing resync.
+      test(
+        'a completed drain that never read the inbox is re-armed once the '
+        'relays are known',
+        () async {
+          final syncState = _FakeDmSyncState()
+            ..drainCompleteOverride = true
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => answeredList([
+              Event(
+                _validPubkeyA,
+                EventKind.dmRelaysList,
+                const [
+                  ['relay', 'wss://own.example'],
+                ],
+                '',
+                createdAt: 1700000000,
+              ),
+            ]),
+          );
+
+          await createRepository(
+            syncState: syncState,
+          ).backfillHistoryIfNeeded();
+
+          expect(syncState.rearmedForInboxPubkeys, contains(_validPubkeyA));
+          expect(syncState.inboxCoveredPubkeys, contains(_validPubkeyA));
+        },
+      );
+
+      test(
+        'a completed drain is left alone when the account genuinely '
+        'advertises no inbox',
+        () async {
+          final syncState = _FakeDmSyncState()
+            ..drainCompleteOverride = true
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => answeredList(const <Event>[]));
+
+          await createRepository(
+            syncState: syncState,
+          ).backfillHistoryIfNeeded();
+
+          // Conclusively nothing to dial, so the completion was honest. The
+          // bit is still recorded, which is what stops this costing a read on
+          // every inbox open forever.
+          expect(syncState.rearmedForInboxPubkeys, isEmpty);
+          expect(syncState.inboxCoveredPubkeys, contains(_validPubkeyA));
+        },
+      );
+
       test('is a no-op when the drain already completed', () async {
         final syncState = _FakeDmSyncState()
           ..drainCompleteOverride = true
+          // Already knows which relays the account advertises, so there is
+          // nothing left for the recovery pass to find out.
+          ..drainCoveredOwnInboxOverride = true
           ..drainVersionOverride = DmSyncState.currentDrainVersion;
         final repository = createRepository(syncState: syncState);
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -3651,6 +3651,142 @@ void main() {
         },
       );
 
+      // A wrap that DECRYPTS and then fails to persist used to end up in no
+      // table at all: the transaction rolls back, no ledger row is written,
+      // and the pending row that would have replayed it had already been
+      // deleted on the way in. The tests above cover a failed DECRYPT, which
+      // has always been queued; this group covers the persist half.
+      group('a decrypted wrap that fails to persist', () {
+        late _MockPendingGiftWrapsDao pendingDao;
+
+        setUp(() {
+          pendingDao = _MockPendingGiftWrapsDao();
+          when(
+            () => pendingDao.recordFailedDecrypt(
+              giftWrapId: any(named: 'giftWrapId'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              rawJson: any(named: 'rawJson'),
+              createdAt: any(named: 'createdAt'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => pendingDao.deletePending(
+              giftWrapId: any(named: 'giftWrapId'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(_giftWrapEventId),
+          ).thenAnswer((_) async => false);
+        });
+
+        Future<DmRepository> deliver() async {
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+          final repository = createRepository(
+            rumorDecryptor: (_, _) async => createRumorEvent(),
+            pendingGiftWrapsDao: pendingDao,
+          );
+          await repository.startListening();
+          controller.add(createGiftWrapEvent());
+          await Future<void>.delayed(Duration.zero);
+          await controller.close();
+          return repository;
+        }
+
+        void throwOnConversationUpsert() {
+          when(
+            () => mockConversationsDao.upsertConversation(
+              id: any(named: 'id'),
+              participantPubkeys: any(named: 'participantPubkeys'),
+              isGroup: any(named: 'isGroup'),
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: any(named: 'lastMessageContent'),
+              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+              lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+              subject: any(named: 'subject'),
+              isRead: any(named: 'isRead'),
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          ).thenThrow(Exception('drift busy'));
+        }
+
+        test('re-queues the wrap so a later pass can replay it', () async {
+          stubDaoInserts();
+          throwOnConversationUpsert();
+
+          final repository = await deliver();
+
+          verify(
+            () => pendingDao.recordFailedDecrypt(
+              giftWrapId: _giftWrapEventId,
+              ownerPubkey: _validPubkeyA,
+              rawJson: any(named: 'rawJson'),
+              createdAt: 1700000000,
+            ),
+          ).called(1);
+
+          await repository.stopListening();
+        });
+
+        test(
+          'keeps the pending row rather than clearing it on the way in',
+          () async {
+            stubDaoInserts();
+            throwOnConversationUpsert();
+
+            final repository = await deliver();
+
+            // Deleting up front is what made this unrecoverable, and it also
+            // erased the attempt count so the retry budget could never be
+            // reached. The row must survive a failed persist.
+            verifyNever(
+              () => pendingDao.deletePending(
+                giftWrapId: any(named: 'giftWrapId'),
+                ownerPubkey: any(named: 'ownerPubkey'),
+              ),
+            );
+
+            await repository.stopListening();
+          },
+        );
+
+        test(
+          'still clears the pending row when the persist succeeds',
+          () async {
+            stubDaoInserts();
+
+            final repository = await deliver();
+
+            // Mutation guard for the `finally`: a successful persist must still
+            // drop the queue row, or every recovered wrap is replayed forever.
+            verify(
+              () => pendingDao.deletePending(
+                giftWrapId: _giftWrapEventId,
+                ownerPubkey: _validPubkeyA,
+              ),
+            ).called(1);
+            verifyNever(
+              () => pendingDao.recordFailedDecrypt(
+                giftWrapId: any(named: 'giftWrapId'),
+                ownerPubkey: any(named: 'ownerPubkey'),
+                rawJson: any(named: 'rawJson'),
+                createdAt: any(named: 'createdAt'),
+              ),
+            );
+
+            await repository.stopListening();
+          },
+        );
+      });
+
       test('skips events with wrong kind', () async {
         final giftWrap = createGiftWrapEvent();
         // kind 1 instead of kind 14

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -969,6 +969,12 @@ class RelayPool {
   /// Set [afterFanoutReachedNoRelay] when the REQ fan-out ended with no relay
   /// having taken the query.
   ///
+  /// A fourth fact takes no flag because it is read from the relays
+  /// themselves: whether any relay still holds this query while being unable
+  /// to answer it. That one is recomputed on every call rather than recorded,
+  /// because it can both appear without a status change and disappear again on
+  /// a reconnect.
+  ///
   /// Every set this records into is written *after* the `callback == null`
   /// return, so a query the caller already abandoned cannot re-enter the
   /// bookkeeping that [_completeQuery] and [unsubscribe] have swept.
@@ -990,15 +996,37 @@ class RelayPool {
       ..._tempRelaysSnapshot(),
       ..._cacheRelaysSnapshot(),
     ];
+    // Split what the old single condition collapsed. A relay that owes nothing
+    // and a relay that took the REQ and can no longer answer it are very
+    // different facts, and only the first means "settled".
+    //
+    // The second is the hole: a dropped socket, a zombie repair mid-cycle, or
+    // a NIP-42 gate the relay has shown is shut. Such a relay is deliberately
+    // not waited on — that is what [_canStillSettleQuery] exists to stop — but
+    // it leaves exactly the gap a silent relay leaves, and a caller that
+    // demanded full settlement must not read the relays that did answer as
+    // "every relay says there is nothing".
+    //
+    // Derived here rather than recorded when the relay goes dark, for two
+    // reasons. A silent-relay repair marks the relay unable to settle *before*
+    // it fires any status change, so a recorded flag would still be empty in
+    // that window. And the state is not permanent: a reconnect re-issues the
+    // saved REQ under the same subscription id and its events reach the
+    // original caller, so a relay that comes back and answers must stop
+    // counting — a sticky flag would report a repaired flap as an inconclusive
+    // read and roll back a write that had in fact succeeded.
+    var strandedOnBlockedRelay = false;
     for (final r in list) {
+      if (!r.checkQuery(subId)) continue;
       // Some relay still owes us a terminal frame for this query.
-      if (r.checkQuery(subId) && _canStillSettleQuery(r)) {
+      if (_canStillSettleQuery(r)) {
         if (_queryAnswered.contains(subId) &&
             !_queriesRequiringFullSettlement.contains(subId)) {
           _armQuerySettleWindow(subId);
         }
         return;
       }
+      strandedOnBlockedRelay = true;
     }
 
     // Nothing is pending — but for a full-settlement caller that only means
@@ -1012,10 +1040,14 @@ class RelayPool {
     // — see [_queryReachedNoRelay] — and `sentTo` already tells the caller the
     // answer is not authoritative, so it completes now instead of costing the
     // caller its whole deadline.
+    // [strandedOnBlockedRelay] joins the two existing reasons to keep waiting.
+    // It cannot coincide with [_queryReachedNoRelay]: a fan-out no relay took
+    // leaves no relay holding the query, so nothing can be stranded on one.
     if (_queriesRequiringFullSettlement.contains(subId) &&
         !_queryReachedNoRelay.contains(subId) &&
         (!_queryAnswered.contains(subId) ||
-            _queryClosedWithoutAnswer.contains(subId))) {
+            _queryClosedWithoutAnswer.contains(subId) ||
+            strandedOnBlockedRelay)) {
       return;
     }
 

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
@@ -1165,6 +1165,130 @@ void main() {
           reason: 'full settlement is reached, so nothing has to be waited out',
         );
       });
+
+      // A relay that TOOK the REQ and then went dark records none of the three
+      // facts the settlement guard consults, so the peers' answers alone used
+      // to complete the query and report it as conclusive. For a caller about
+      // to republish a replaceable event, that is an empty box read as "every
+      // relay says there is nothing".
+      test('reports a relay that dropped its socket as a timeout, not an empty '
+          'answer', () async {
+        final nostr = _newNostr();
+        final answering = _SilentRelay('wss://answers.example');
+        final dropping = _SilentRelay('wss://drops.example');
+        expect(await nostr.relayPool.add(answering), isTrue);
+        expect(await nostr.relayPool.add(dropping), isTrue);
+
+        final pending = nostr.queryEventsDetailed(
+          [
+            {
+              'kinds': [10003],
+            },
+          ],
+          timeout: timeout,
+          requireAllRelaysSettled: true,
+        );
+
+        final subId = await answering.awaitPendingQuery();
+        await dropping.awaitPendingQuery();
+        dropping.onError('socket closed', reconnect: true);
+        await answering.deliver(['EOSE', subId]);
+
+        final result = await pending;
+
+        expect(result.events, isEmpty);
+        expect(
+          result.timedOut,
+          isTrue,
+          reason:
+              'the relay that went dark may be the only one holding the '
+              'list, and it never got to say so',
+        );
+        expect(
+          result.noRelaysParticipated,
+          isFalse,
+          reason: 'both relays took the REQ — one of them then died',
+        );
+      });
+
+      // The same hole reached through the other entry point: the drop arrives
+      // after the peer has already answered, so the release runs through the
+      // path that records nothing at all.
+      test('a socket that drops after its peer answered still holds the query '
+          'open', () async {
+        final nostr = _newNostr();
+        final answering = _SilentRelay('wss://answers.example');
+        final dropping = _SilentRelay('wss://drops.example');
+        expect(await nostr.relayPool.add(answering), isTrue);
+        expect(await nostr.relayPool.add(dropping), isTrue);
+
+        final pending = nostr.queryEventsDetailed(
+          [
+            {
+              'kinds': [10003],
+            },
+          ],
+          timeout: timeout,
+          requireAllRelaysSettled: true,
+        );
+
+        final subId = await answering.awaitPendingQuery();
+        await dropping.awaitPendingQuery();
+        await answering.deliver(['EOSE', subId]);
+        dropping.onError('socket closed', reconnect: true);
+
+        final result = await pending;
+
+        expect(result.timedOut, isTrue);
+        expect(result.noRelaysParticipated, isFalse);
+      });
+
+      // Not a driver for the fix — a guard against over-applying it. A relay
+      // that comes back and answers inside the caller's budget has settled,
+      // and reporting that as inconclusive would roll back writes that
+      // succeeded. This is what a recorded flag would get wrong.
+      test('a relay that reconnects and answers still settles the query '
+          'conclusively', () async {
+        final nostr = _newNostr();
+        final answering = _SilentRelay('wss://answers.example');
+        final flapping = _SilentRelay('wss://flaps.example');
+        expect(await nostr.relayPool.add(answering), isTrue);
+        expect(await nostr.relayPool.add(flapping), isTrue);
+
+        final stopwatch = Stopwatch()..start();
+        final pending = nostr.queryEventsDetailed(
+          [
+            {
+              'kinds': [10003],
+            },
+          ],
+          timeout: timeout,
+          requireAllRelaysSettled: true,
+        );
+
+        final subId = await answering.awaitPendingQuery();
+        await flapping.awaitPendingQuery();
+        flapping.onError('socket closed', reconnect: true);
+        await answering.deliver(['EOSE', subId]);
+        expect(await flapping.connect(), isTrue);
+        await flapping.deliver(['EOSE', subId]);
+
+        final result = await pending;
+        stopwatch.stop();
+
+        expect(
+          result.timedOut,
+          isFalse,
+          reason:
+              'the reconnect re-issued the REQ under the same id and the '
+              'relay answered it, so full settlement was reached',
+        );
+        expect(
+          stopwatch.elapsed,
+          lessThan(timeout),
+          reason: 'a settled query must not be held to the deadline',
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
## The problem

Four separate ways a direct message could be lost permanently and silently. Each was found while validating #8439 and each is independent of it — they all survive a fixed #8439, and none of them needs #8439's mechanism to fire.

None of them tells the user anything. The sender sees the message delivered; the recipient sees a conversation with a message missing from it, or a conversation that never appears at all.

| | What is lost | Issue |
|---|---|---|
| 1 | A message that decrypts and then fails to save is dropped entirely — no row, no ledger entry, no retry | #8595 |
| 2 | One signed-in account's legacy history suppresses another account's copy of the same message, and narrows its sync window permanently | #8596 |
| 3 | A relay that accepts a request and then goes away is counted as having answered nothing, so callers republish truncated lists | #8594 |
| 4 | History restore reports success having never contacted the relays the account advertises for messages | #8593 |

## Why these fixes

Each commit is one finding, so any can be reverted alone.

**A message that fails to save is kept (#8595).** The retry-queue row was deleted before the write was attempted rather than after it committed. That opened the loss window, and it also erased the attempt count, so a wrap that kept failing re-inserted at one attempt forever and the retry budget could never be reached. The delete now runs only when the write did not throw, and a failed write re-queues onto the queue a failed decrypt already uses.

**A vanished relay no longer counts as an answer (#8594).** The settlement check now distinguishes a relay that owes nothing from one that owes a reply it can no longer send, and waits on the latter for callers that asked for full settlement. This is derived from the relays on each evaluation rather than recorded when one goes dark, and both halves matter: one of the causes appears before any status change fires, and a relay that reconnects re-issues its request under the same id and *has* genuinely answered — a sticky flag would report a repaired flap as inconclusive and roll back a write that succeeded. A test covers that second case specifically.

**A duplicate is attributed before it moves a boundary (#8596).** The duplicate check still runs globally and still decides the decrypt cost. What is new is asking *which* account handled the event, so only that account advances its own sync boundary past it.

**History restore asks before it finishes (#8593).** The restore makes its own thorough lookup, and only when the fast one did not already return a list. It can afford to: it runs in the background, nothing waits on it, and it already makes thorough requests per page. A definite "there are none" completes as before; an inconclusive answer defers and holds its resume point. A restore that already finished without knowing gets one lookup on the next open and is re-armed once if relays turn up — a forward-only fix would strand every account already in that state, which is the mistake that made #8362 necessary.

## What this deliberately leaves alone

- **#8439's own remedy.** That issue holds itself open pending a measurement and this does not pre-empt it.
- **The legacy half of #8595.** There is no retry queue for unwrapped messages to re-enter; adding one is a storage-semantics decision, not a bug fix.
- **The storage half of #8596.** The receiving account still cannot store its own copy: the uniqueness index and the ledger key are both on the event id alone, so its insert is ignored regardless. Making those composite needs a migration that would conflict with #8586, and it refutes that PR's stated reason for leaving them global — raised there rather than done here.
- **The version that forces a re-run of history restore.** #8586 already raises it; raising it twice would cost every account two full passes.

## Expected user-visible and operational cost

Every caller that requests full relay settlement now waits for its own deadline when a relay accepts the request and then becomes unable to answer. This affects account deletion, moderation-label reads, corrupted-video repair, content-blocklist reads, follow/contact-list reads, people-list reads, bookmark reads, and the authoritative DM inbox lookup.

For mutating list flows, the resulting timeout is intentional: a visible retryable failure with rollback is safer than silently replacing a list from a partial relay answer. The existing network-oriented snackbar copy already covers both an unreachable pool and a timed-out relay.

If the authoritative kind-10050 inbox lookup remains inconclusive, history restore keeps its durable cursor pinned and retries that same range on a later inbox open. Depending on what the default pool returns, a retry may stop at an authoritative empty page or may process up to the page cap again. This repeats until the lookup is conclusive by design: imposing a retry ceiling without a separate user-triggered recovery path would turn a transient network problem back into permanent missing history.

## Sequencing

**#8593's fix should land before or with #8586.** That PR forces every account to re-run history restore; if this is not in first, the forced re-run repeats the same blindness and finishes just as blind, spending the one-shot recovery pass for nothing.

## Verified

- `flutter analyze` clean across `dm_repository`, `nostr_sdk` and `db_client`.
- 893 + 1057 + 517 tests green in those three packages.
- **Every new test mutation-proven**: each fix reverted in isolation, confirming only its own tests go red. Three tests are deliberate guards that pass both before and after — they exist to catch an over-broad fix, and they are labelled as such rather than passed off as failing-first.
- CI-only ratchets run locally: shared-setup stubs, ungrouped tests, skip ceiling, placeholder tests, pubkey log encoding, Nostr id truncation, post-close emit, uncancellable timer waits.
- Takeover verification: the changed-package pre-push gate passed analysis, generated-file verification, and all 515 selected tests.

The underlying #8439 mechanism was reproduced end to end on a simulator against a real relay first — a wrap five seconds below the window never delivered while a control two hours above it was, both arriving by the same path on the same relay, with the conversation then rendering "5 messages" against six published.

Closes #8593
Closes #8594
Closes #8595
Closes #8596
