### PR TITLE
fix(bug-report): attach the app locale to bug reports

### DIFF
--- a/mobile/docs/LOCALIZATION_STYLE_GUIDE.md
+++ b/mobile/docs/LOCALIZATION_STYLE_GUIDE.md
@@ -485,11 +485,12 @@ screen and a language is a Tier 3 finding with a source behind it — the thing
 this repo otherwise cannot generate. Treat it as an ordinary bug, fix the key,
 and if it overturns a decision in this file, change the file too.
 
-The report carries platform, device model, OS and app version
-(`bug_report_service.dart`) but **not the app's locale**, so a copy report
-arrives without the one field that would route it — tracked in
-[#7939](https://github.com/divinevideo/divine-mobile/issues/7939). Until that
-lands, ask which language they were reading.
+The report carries platform, device model, OS and app version, and the
+**resolved app UI locale** — the language the app was actually rendering —
+plus the device locale when it differs (`bug_report_service.dart`, #7939). So a
+copy report already names the language to route it by; a resolved locale that is
+English while the device asked for another language is itself a signal (a
+missing translation forcing the fallback), not a bad string in that language.
 
 ### Who signs off
 

--- a/mobile/docs/LOCALIZATION_STYLE_GUIDE.md
+++ b/mobile/docs/LOCALIZATION_STYLE_GUIDE.md
@@ -490,8 +490,9 @@ The report carries platform, device model, OS and app version, and the
 so a copy report already names the language to route it by
 (`bug_report_service.dart`, #7939).
 
-A second field, `deviceLocale`, appears only when the phone asks for a language
-this app does not ship. That one is its own finding: the reader was pushed onto
+A second field, `deviceLocale`, appears only when no language in the phone's
+preference list is supported and no supported language was chosen in Settings.
+It records the phone's first preference. The reader was pushed onto
 the English fallback by a missing translation, which is a different bug from a
 bad string in a language we do ship. A language chosen in Settings is a choice
 rather than a fallback, so it never adds that line.

--- a/mobile/docs/LOCALIZATION_STYLE_GUIDE.md
+++ b/mobile/docs/LOCALIZATION_STYLE_GUIDE.md
@@ -487,10 +487,14 @@ and if it overturns a decision in this file, change the file too.
 
 The report carries platform, device model, OS and app version, and the
 **resolved app UI locale** — the language the app was actually rendering —
-plus the device locale when it differs (`bug_report_service.dart`, #7939). So a
-copy report already names the language to route it by; a resolved locale that is
-English while the device asked for another language is itself a signal (a
-missing translation forcing the fallback), not a bad string in that language.
+so a copy report already names the language to route it by
+(`bug_report_service.dart`, #7939).
+
+A second field, `deviceLocale`, appears only when the phone asks for a language
+this app does not ship. That one is its own finding: the reader was pushed onto
+the English fallback by a missing translation, which is a different bug from a
+bad string in a language we do ship. A language chosen in Settings is a choice
+rather than a fallback, so it never adds that line.
 
 ### Who signs off
 

--- a/mobile/docs/LOCALIZATION_STYLE_GUIDE.md
+++ b/mobile/docs/LOCALIZATION_STYLE_GUIDE.md
@@ -491,7 +491,7 @@ so a copy report already names the language to route it by
 (`bug_report_service.dart`, #7939).
 
 A second field, `deviceLocale`, appears only when no language in the phone's
-preference list is supported and no supported language was chosen in Settings.
+preference list is supported and Settings follows the device language.
 It records the phone's first preference. The reader was pushed onto
 the English fallback by a missing translation, which is a different bug from a
 bad string in a language we do ship. A language chosen in Settings is a choice

--- a/mobile/lib/l10n/current_app_l10n.dart
+++ b/mobile/lib/l10n/current_app_l10n.dart
@@ -16,16 +16,26 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// without requiring a [BuildContext]. Use this from services that are
 /// constructed inside Riverpod factories or other context-less call sites
 /// — e.g. `CollaboratorInviteService` built by `VideoPublishService`.
-AppLocalizations currentAppL10n(SharedPreferences prefs) {
+AppLocalizations currentAppL10n(SharedPreferences prefs) =>
+    lookupAppLocalizations(currentAppUiLocale(prefs));
+
+/// Returns the [Locale] the app UI is currently rendering in, without a
+/// [BuildContext].
+///
+/// Mirrors what `MaterialApp.router` resolves at runtime: the user's saved
+/// preference (`LocaleCubit`) when set and supported, otherwise the device
+/// locales resolved through [resolveAppUiLocale] (which can fall back to
+/// English). This is the resolved value, not the raw device language — a
+/// device set to a locale with no translation is reading the fallback.
+Locale currentAppUiLocale(SharedPreferences prefs) {
   final saved = prefs.getString(LocalePreferenceService.prefsKey);
   const supported = AppLocalizations.supportedLocales;
   final isSupported =
       saved != null && supported.any((locale) => locale.languageCode == saved);
-  final locale = isSupported
+  return isSupported
       ? Locale(saved)
       : resolveAppUiLocale(
           PlatformDispatcher.instance.locales,
           supported,
         );
-  return lookupAppLocalizations(locale);
 }

--- a/mobile/lib/l10n/current_app_l10n.dart
+++ b/mobile/lib/l10n/current_app_l10n.dart
@@ -25,17 +25,22 @@ AppLocalizations currentAppL10n(SharedPreferences prefs) =>
 /// Mirrors what `MaterialApp.router` resolves at runtime: the user's saved
 /// preference (`LocaleCubit`) when set and supported, otherwise the device
 /// locales resolved through [resolveAppUiLocale] (which can fall back to
-/// English). This is the resolved value, not the raw device language — a
-/// device set to a locale with no translation is reading the fallback.
+/// English). This is the resolved value, not the raw device language.
 Locale currentAppUiLocale(SharedPreferences prefs) {
+  return appUiLocaleOverride(prefs) ??
+      resolveAppUiLocale(
+        PlatformDispatcher.instance.locales,
+        AppLocalizations.supportedLocales,
+      );
+}
+
+/// The Settings language, or null when absent or no longer supported.
+Locale? appUiLocaleOverride(SharedPreferences prefs) {
   final saved = prefs.getString(LocalePreferenceService.prefsKey);
-  const supported = AppLocalizations.supportedLocales;
   final isSupported =
-      saved != null && supported.any((locale) => locale.languageCode == saved);
-  return isSupported
-      ? Locale(saved)
-      : resolveAppUiLocale(
-          PlatformDispatcher.instance.locales,
-          supported,
-        );
+      saved != null &&
+      AppLocalizations.supportedLocales.any(
+        (locale) => locale.languageCode == saved,
+      );
+  return isSupported ? Locale(saved) : null;
 }

--- a/mobile/lib/l10n/current_app_l10n.dart
+++ b/mobile/lib/l10n/current_app_l10n.dart
@@ -23,24 +23,19 @@ AppLocalizations currentAppL10n(SharedPreferences prefs) =>
 /// [BuildContext].
 ///
 /// Mirrors what `MaterialApp.router` resolves at runtime: the user's saved
-/// preference (`LocaleCubit`) when set and supported, otherwise the device
-/// locales resolved through [resolveAppUiLocale] (which can fall back to
+/// preference (`LocaleCubit`) when set, otherwise the device locales,
+/// resolved through [resolveAppUiLocale] (which can fall back to
 /// English). This is the resolved value, not the raw device language.
 Locale currentAppUiLocale(SharedPreferences prefs) {
-  return appUiLocaleOverride(prefs) ??
-      resolveAppUiLocale(
-        PlatformDispatcher.instance.locales,
-        AppLocalizations.supportedLocales,
-      );
+  final override = appUiLocaleOverride(prefs);
+  return resolveAppUiLocale(
+    override == null ? PlatformDispatcher.instance.locales : [override],
+    AppLocalizations.supportedLocales,
+  );
 }
 
-/// The Settings language, or null when absent or no longer supported.
+/// The saved Settings language, or null when following the device.
 Locale? appUiLocaleOverride(SharedPreferences prefs) {
   final saved = prefs.getString(LocalePreferenceService.prefsKey);
-  final isSupported =
-      saved != null &&
-      AppLocalizations.supportedLocales.any(
-        (locale) => locale.languageCode == saved,
-      );
-  return isSupported ? Locale(saved) : null;
+  return saved == null ? null : Locale(saved);
 }

--- a/mobile/lib/providers/bug_report_providers.dart
+++ b/mobile/lib/providers/bug_report_providers.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Lives outside social_providers so it can watch the storage service
 // ABOUTME: without creating an import cycle with storage_providers.
 
+import 'package:openvine/l10n/current_app_l10n.dart';
 import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/documents_path_provider.dart';
@@ -25,6 +26,9 @@ BugReportService bugReportService(Ref ref) {
   return BugReportService(
     errorTracker: ref.watch(errorAnalyticsTrackerProvider),
     storageManagementService: ref.watch(storageManagementServiceProvider),
+    // Preference-aware so a language chosen in Settings is reflected, not just
+    // the device locales.
+    resolvedUiLocaleLoader: () => currentAppUiLocale(preferences),
     supportDiagnosticsLoader: () async {
       final recovery = DatabaseRecoveryStore(preferences: preferences).read();
       final localContent = await LocalContentDiagnosticsService(

--- a/mobile/lib/providers/bug_report_providers.dart
+++ b/mobile/lib/providers/bug_report_providers.dart
@@ -29,6 +29,7 @@ BugReportService bugReportService(Ref ref) {
     // Preference-aware so a language chosen in Settings is reflected, not just
     // the device locales.
     resolvedUiLocaleLoader: () => currentAppUiLocale(preferences),
+    hasLocaleOverrideLoader: () => appUiLocaleOverride(preferences) != null,
     supportDiagnosticsLoader: () async {
       final recovery = DatabaseRecoveryStore(preferences: preferences).read();
       final localContent = await LocalContentDiagnosticsService(

--- a/mobile/lib/providers/bug_report_providers.g.dart
+++ b/mobile/lib/providers/bug_report_providers.g.dart
@@ -57,4 +57,4 @@ final class BugReportServiceProvider
   }
 }
 
-String _$bugReportServiceHash() => r'a9c35af1e20f19977fc9facd11c9338d48af4ac6';
+String _$bugReportServiceHash() => r'a0bf40845646283ff64c10948ccc1f4495bbf9d8';

--- a/mobile/lib/providers/bug_report_providers.g.dart
+++ b/mobile/lib/providers/bug_report_providers.g.dart
@@ -57,4 +57,4 @@ final class BugReportServiceProvider
   }
 }
 
-String _$bugReportServiceHash() => r'a0bf40845646283ff64c10948ccc1f4495bbf9d8';
+String _$bugReportServiceHash() => r'2dcf9498c309f0ed4161369bc911e703e4780499';

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -200,17 +200,21 @@ class BugReportService {
       // there is no native reviewer, so the user's report is the only signal,
       // and without the language it can't be routed without asking (#7939). The
       // resolved UI locale is what the user was reading; the device locale is
-      // added only when it differs, since a device set to a language with no
-      // translation is reading the English fallback - a distinct bug from a bad
-      // string in that language. Best-effort: a probe failure must not block the
-      // report.
+      // added (as its full tag) only when its language differs from the resolved
+      // one, since a device set to a language with no translation is reading the
+      // English fallback - a distinct bug from a bad string in that language.
+      // Every supported locale is language-only, so the resolved locale never
+      // carries a region; comparing on language keeps a region-only difference
+      // (e.g. an en-US device reading en) from masquerading as a fallback.
+      // Best-effort: a probe failure must not block the report.
       try {
-        final resolvedLocale = _resolvedUiLocaleLoader().toLanguageTag();
-        final deviceLocale = _deviceLocaleLoader().toLanguageTag();
+        final resolvedLocale = _resolvedUiLocaleLoader();
+        final deviceLocale = _deviceLocaleLoader();
         deviceInfo = {
           ...deviceInfo,
-          'locale': resolvedLocale,
-          if (deviceLocale != resolvedLocale) 'deviceLocale': deviceLocale,
+          'locale': resolvedLocale.toLanguageTag(),
+          if (deviceLocale.languageCode != resolvedLocale.languageCode)
+            'deviceLocale': deviceLocale.toLanguageTag(),
         };
       } on Object catch (e) {
         Log.warning(

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -13,6 +13,8 @@ import 'package:flutter/foundation.dart';
 import 'package:models/models.dart' show BugReportData, LogEntry;
 import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
 import 'package:openvine/config/bug_report_config.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/l10n/resolve_app_ui_locale.dart';
 import 'package:openvine/services/storage_management_service.dart';
 import 'package:openvine/utils/app_uptime.dart';
 import 'package:openvine/utils/browser_file_download.dart';
@@ -70,10 +72,23 @@ class BugReportService {
     StorageManagementService? storageManagementService,
     Future<PackageInfo> Function()? packageInfoLoader,
     Future<Map<String, dynamic>> Function()? supportDiagnosticsLoader,
+    ui.Locale Function()? resolvedUiLocaleLoader,
+    ui.Locale Function()? deviceLocaleLoader,
   }) : _errorTracker = errorTracker ?? ErrorAnalyticsTracker(),
        _storageManagementService = storageManagementService,
        _supportDiagnosticsLoader = supportDiagnosticsLoader,
-       _packageInfoLoader = packageInfoLoader ?? PackageInfo.fromPlatform;
+       _packageInfoLoader = packageInfoLoader ?? PackageInfo.fromPlatform,
+       // Default resolves from the device locales alone. The provider injects a
+       // preference-aware resolver (`currentAppUiLocale`) so a user who picked
+       // a language in Settings is reflected too.
+       _resolvedUiLocaleLoader =
+           resolvedUiLocaleLoader ??
+           (() => resolveAppUiLocale(
+             ui.PlatformDispatcher.instance.locales,
+             AppLocalizations.supportedLocales,
+           )),
+       _deviceLocaleLoader =
+           deviceLocaleLoader ?? (() => ui.PlatformDispatcher.instance.locale);
 
   static const _uuid = Uuid();
 
@@ -90,6 +105,8 @@ class BugReportService {
   final StorageManagementService? _storageManagementService;
   final Future<PackageInfo> Function() _packageInfoLoader;
   final Future<Map<String, dynamic>> Function()? _supportDiagnosticsLoader;
+  final ui.Locale Function() _resolvedUiLocaleLoader;
+  final ui.Locale Function() _deviceLocaleLoader;
 
   /// Collect comprehensive diagnostics for bug report
   Future<BugReportData> collectDiagnostics({
@@ -176,6 +193,30 @@ class BugReportService {
           'version': 'unknown',
           'error': 'Failed to get device info',
         };
+      }
+
+      // Record the locale the UI was rendering in. For copy/localization
+      // reports this is the field that routes them: for most of the 21+ locales
+      // there is no native reviewer, so the user's report is the only signal,
+      // and without the language it can't be routed without asking (#7939). The
+      // resolved UI locale is what the user was reading; the device locale is
+      // added only when it differs, since a device set to a language with no
+      // translation is reading the English fallback - a distinct bug from a bad
+      // string in that language. Best-effort: a probe failure must not block the
+      // report.
+      try {
+        final resolvedLocale = _resolvedUiLocaleLoader().toLanguageTag();
+        final deviceLocale = _deviceLocaleLoader().toLanguageTag();
+        deviceInfo = {
+          ...deviceInfo,
+          'locale': resolvedLocale,
+          if (deviceLocale != resolvedLocale) 'deviceLocale': deviceLocale,
+        };
+      } on Object catch (e) {
+        Log.warning(
+          'Failed to resolve locale for bug report: $e',
+          category: LogCategory.system,
+        );
       }
 
       // Get recent logs from LogCaptureService

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -205,8 +205,8 @@ class BugReportService {
         };
       }
 
-      // Flag a missing-translation fallback only when neither Settings nor
-      // any device preference selects a shipped language. Best-effort: a
+      // Flag a missing device translation only when Settings follows the
+      // device and no device preference matches a shipped language. A
       // probe failure must not block the report.
       try {
         final resolvedLocale = _resolvedUiLocaleLoader();

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -108,6 +108,12 @@ class BugReportService {
   final ui.Locale Function() _resolvedUiLocaleLoader;
   final ui.Locale Function() _deviceLocaleLoader;
 
+  /// Language codes the app ships a translation for. A device language outside
+  /// this set is what makes the rendered locale a fallback rather than a choice.
+  static final Set<String> _supportedLanguageCodes = {
+    for (final locale in AppLocalizations.supportedLocales) locale.languageCode,
+  };
+
   /// Collect comprehensive diagnostics for bug report
   Future<BugReportData> collectDiagnostics({
     required String userDescription,
@@ -195,25 +201,23 @@ class BugReportService {
         };
       }
 
-      // Record the locale the UI was rendering in. For copy/localization
-      // reports this is the field that routes them: for most of the 21+ locales
-      // there is no native reviewer, so the user's report is the only signal,
-      // and without the language it can't be routed without asking (#7939). The
-      // resolved UI locale is what the user was reading; the device locale is
-      // added (as its full tag) only when its language differs from the resolved
-      // one, since a device set to a language with no translation is reading the
-      // English fallback - a distinct bug from a bad string in that language.
-      // Every supported locale is language-only, so the resolved locale never
-      // carries a region; comparing on language keeps a region-only difference
-      // (e.g. an en-US device reading en) from masquerading as a fallback.
-      // Best-effort: a probe failure must not block the report.
+      // The locale the UI was rendering in is what routes a copy report: for
+      // most of the 21+ locales there is no native reviewer, so the report is
+      // the only signal (#7939). `deviceLocale` is added only when the app
+      // ships no translation for the device's language, because that is the
+      // fallback worth flagging — a language the user picked in Settings is a
+      // choice, not a fallback, and would otherwise read as a missing
+      // translation. Best-effort: a probe failure must not block the report.
       try {
         final resolvedLocale = _resolvedUiLocaleLoader();
         final deviceLocale = _deviceLocaleLoader();
+        final deviceLanguageIsTranslated = _supportedLanguageCodes.contains(
+          deviceLocale.languageCode,
+        );
         deviceInfo = {
           ...deviceInfo,
           'locale': resolvedLocale.toLanguageTag(),
-          if (deviceLocale.languageCode != resolvedLocale.languageCode)
+          if (!deviceLanguageIsTranslated)
             'deviceLocale': deviceLocale.toLanguageTag(),
         };
       } on Object catch (e) {

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -73,7 +73,8 @@ class BugReportService {
     Future<PackageInfo> Function()? packageInfoLoader,
     Future<Map<String, dynamic>> Function()? supportDiagnosticsLoader,
     ui.Locale Function()? resolvedUiLocaleLoader,
-    ui.Locale Function()? deviceLocaleLoader,
+    List<ui.Locale> Function()? deviceLocalesLoader,
+    bool Function()? hasLocaleOverrideLoader,
   }) : _errorTracker = errorTracker ?? ErrorAnalyticsTracker(),
        _storageManagementService = storageManagementService,
        _supportDiagnosticsLoader = supportDiagnosticsLoader,
@@ -87,8 +88,10 @@ class BugReportService {
              ui.PlatformDispatcher.instance.locales,
              AppLocalizations.supportedLocales,
            )),
-       _deviceLocaleLoader =
-           deviceLocaleLoader ?? (() => ui.PlatformDispatcher.instance.locale);
+       _deviceLocalesLoader =
+           deviceLocalesLoader ??
+           (() => ui.PlatformDispatcher.instance.locales),
+       _hasLocaleOverrideLoader = hasLocaleOverrideLoader ?? (() => false);
 
   static const _uuid = Uuid();
 
@@ -106,10 +109,11 @@ class BugReportService {
   final Future<PackageInfo> Function() _packageInfoLoader;
   final Future<Map<String, dynamic>> Function()? _supportDiagnosticsLoader;
   final ui.Locale Function() _resolvedUiLocaleLoader;
-  final ui.Locale Function() _deviceLocaleLoader;
+  final List<ui.Locale> Function() _deviceLocalesLoader;
+  final bool Function() _hasLocaleOverrideLoader;
 
   /// Language codes the app ships a translation for. A device language outside
-  /// this set is what makes the rendered locale a fallback rather than a choice.
+  /// this set cannot be matched during device locale resolution.
   static final Set<String> _supportedLanguageCodes = {
     for (final locale in AppLocalizations.supportedLocales) locale.languageCode,
   };
@@ -201,24 +205,22 @@ class BugReportService {
         };
       }
 
-      // The locale the UI was rendering in is what routes a copy report: for
-      // most of the 21+ locales there is no native reviewer, so the report is
-      // the only signal (#7939). `deviceLocale` is added only when the app
-      // ships no translation for the device's language, because that is the
-      // fallback worth flagging — a language the user picked in Settings is a
-      // choice, not a fallback, and would otherwise read as a missing
-      // translation. Best-effort: a probe failure must not block the report.
+      // Flag a missing-translation fallback only when neither Settings nor
+      // any device preference selects a shipped language. Best-effort: a
+      // probe failure must not block the report.
       try {
         final resolvedLocale = _resolvedUiLocaleLoader();
-        final deviceLocale = _deviceLocaleLoader();
-        final deviceLanguageIsTranslated = _supportedLanguageCodes.contains(
-          deviceLocale.languageCode,
-        );
+        final deviceLocales = _deviceLocalesLoader();
+        final usesFallback =
+            !_hasLocaleOverrideLoader() &&
+            !deviceLocales.any(
+              (locale) => _supportedLanguageCodes.contains(locale.languageCode),
+            );
         deviceInfo = {
           ...deviceInfo,
           'locale': resolvedLocale.toLanguageTag(),
-          if (!deviceLanguageIsTranslated)
-            'deviceLocale': deviceLocale.toLanguageTag(),
+          if (usesFallback && deviceLocales.isNotEmpty)
+            'deviceLocale': deviceLocales.first.toLanguageTag(),
         };
       } on Object catch (e) {
         Log.warning(

--- a/mobile/test/l10n/current_app_l10n_test.dart
+++ b/mobile/test/l10n/current_app_l10n_test.dart
@@ -22,6 +22,7 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
 
       expect(currentAppUiLocale(prefs).languageCode, 'de');
+      expect(appUiLocaleOverride(prefs)?.languageCode, 'de');
     });
 
     test('ignores a saved language the app no longer ships', () async {
@@ -36,10 +37,18 @@ void main() {
       final resolved = currentAppUiLocale(prefs);
 
       expect(resolved.languageCode, isNot('cs'));
+      expect(appUiLocaleOverride(prefs), isNull);
       expect(
         AppLocalizations.supportedLocales.map((l) => l.languageCode),
         contains(resolved.languageCode),
       );
+    });
+
+    test('has no override when Settings follows the device', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+
+      expect(appUiLocaleOverride(prefs), isNull);
     });
   });
 }

--- a/mobile/test/l10n/current_app_l10n_test.dart
+++ b/mobile/test/l10n/current_app_l10n_test.dart
@@ -25,10 +25,9 @@ void main() {
       expect(appUiLocaleOverride(prefs)?.languageCode, 'de');
     });
 
-    test('ignores a saved language the app no longer ships', () async {
-      // Dropping a locale from the shipped set leaves the old preference on
-      // disk. Honouring it would hand `lookupAppLocalizations` a locale it has
-      // no translation for, so resolution has to fall back to the device.
+    test('resolves a stale Settings language like MaterialApp', () async {
+      // LocaleCubit still supplies the saved locale to MaterialApp. Resolve
+      // that preference, rather than selecting a different device language.
       SharedPreferences.setMockInitialValues({
         LocalePreferenceService.prefsKey: 'cs',
       });
@@ -36,8 +35,9 @@ void main() {
 
       final resolved = currentAppUiLocale(prefs);
 
-      expect(resolved.languageCode, isNot('cs'));
-      expect(appUiLocaleOverride(prefs), isNull);
+      expect(resolved.languageCode, 'en');
+      expect(currentAppL10n(prefs).localeName, 'en');
+      expect(appUiLocaleOverride(prefs)?.languageCode, 'cs');
       expect(
         AppLocalizations.supportedLocales.map((l) => l.languageCode),
         contains(resolved.languageCode),

--- a/mobile/test/l10n/current_app_l10n_test.dart
+++ b/mobile/test/l10n/current_app_l10n_test.dart
@@ -1,0 +1,45 @@
+// ABOUTME: Tests currentAppUiLocale, the context-less mirror of the UI locale
+// ABOUTME: Covers the Settings preference winning over device resolution
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/current_app_l10n.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/services/locale_preference_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('currentAppUiLocale', () {
+    setUp(TestWidgetsFlutterBinding.ensureInitialized);
+    tearDown(SharedPreferences.resetStatic);
+
+    test('uses the language the user picked in Settings', () async {
+      // The bug report's `locale` field is only worth routing by if it names
+      // the language the user was actually reading, which for a Settings
+      // choice is the saved preference rather than the device language.
+      SharedPreferences.setMockInitialValues({
+        LocalePreferenceService.prefsKey: 'de',
+      });
+      final prefs = await SharedPreferences.getInstance();
+
+      expect(currentAppUiLocale(prefs).languageCode, 'de');
+    });
+
+    test('ignores a saved language the app no longer ships', () async {
+      // Dropping a locale from the shipped set leaves the old preference on
+      // disk. Honouring it would hand `lookupAppLocalizations` a locale it has
+      // no translation for, so resolution has to fall back to the device.
+      SharedPreferences.setMockInitialValues({
+        LocalePreferenceService.prefsKey: 'cs',
+      });
+      final prefs = await SharedPreferences.getInstance();
+
+      final resolved = currentAppUiLocale(prefs);
+
+      expect(resolved.languageCode, isNot('cs'));
+      expect(
+        AppLocalizations.supportedLocales.map((l) => l.languageCode),
+        contains(resolved.languageCode),
+      );
+    });
+  });
+}

--- a/mobile/test/providers/bug_report_providers_test.dart
+++ b/mobile/test/providers/bug_report_providers_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/storage_providers.dart';
 import 'package:openvine/services/clip_library_service.dart';
+import 'package:openvine/services/locale_preference_service.dart';
 import 'package:openvine/services/storage_management_service.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -97,6 +98,23 @@ void main() {
           'missingSourceMediaFiles': 0,
         },
       });
+    });
+
+    test('reports the language chosen in Settings, not the device', () async {
+      // The whole point of #7939 is that a copy report names the language the
+      // user was reading. That is the Settings choice when there is one, and
+      // the provider is the only place that resolution is wired in — read
+      // lazily, so a language picked after the service was built still counts.
+      final service = container.read(bugReportServiceProvider);
+      await container
+          .read(sharedPreferencesProvider)
+          .setString(LocalePreferenceService.prefsKey, 'de');
+
+      final report = await service.collectDiagnostics(
+        userDescription: 'This screen is showing bad copy',
+      );
+
+      expect(report.deviceInfo['locale'], 'de');
     });
   });
 }

--- a/mobile/test/services/bug_report_service_test.dart
+++ b/mobile/test/services/bug_report_service_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Tests data gathering, sensitive data removal, and report packaging
 
 import 'dart:io' show Platform;
+import 'dart:ui' show Locale;
 
 import 'package:analytics/analytics.dart';
 import 'package:flutter/services.dart';
@@ -451,6 +452,46 @@ void main() {
           ? 'Only runs on iOS/Android'
           : null,
     );
+
+    group('locale diagnostics', () {
+      // For most of the 21+ supported locales there is no native reviewer, so
+      // a copy report is the only signal - and it can only be routed if it says
+      // which language the app was rendering. The resolved UI locale is that
+      // language; the device locale is recorded only when it differs, because
+      // a device set to Amharic that is showing the English fallback is a
+      // different bug from a bad Amharic string (#7939).
+      test('records the resolved UI locale in deviceInfo', () async {
+        final service = BugReportService(
+          resolvedUiLocaleLoader: () => const Locale('am'),
+          deviceLocaleLoader: () => const Locale('am'),
+        );
+
+        final data = await service.collectDiagnostics(
+          userDescription: 'This screen is showing bad copy',
+        );
+
+        expect(data.deviceInfo['locale'], 'am');
+        // Same language shown as requested, so no device-locale line to add.
+        expect(data.deviceInfo.containsKey('deviceLocale'), isFalse);
+      });
+
+      test(
+        'records the device locale when it differs from the resolved locale',
+        () async {
+          final service = BugReportService(
+            resolvedUiLocaleLoader: () => const Locale('en'),
+            deviceLocaleLoader: () => const Locale('am', 'ET'),
+          );
+
+          final data = await service.collectDiagnostics(
+            userDescription: 'App is in English but my phone is Amharic',
+          );
+
+          expect(data.deviceInfo['locale'], 'en');
+          expect(data.deviceInfo['deviceLocale'], 'am-ET');
+        },
+      );
+    });
 
     group('clearCapturedLogs', () {
       test('empties the in-memory capture buffer', () async {

--- a/mobile/test/services/bug_report_service_test.dart
+++ b/mobile/test/services/bug_report_service_test.dart
@@ -491,6 +491,44 @@ void main() {
           expect(data.deviceInfo['deviceLocale'], 'am-ET');
         },
       );
+
+      test(
+        'omits the device locale when only the region differs',
+        () async {
+          // Every supported locale is language-only, so the resolved locale
+          // never carries a region. An en-US device reading `en` is reading the
+          // exact language it asked for - there is no fallback to flag, so the
+          // region-only difference must not emit a deviceLocale (#7939).
+          final service = BugReportService(
+            resolvedUiLocaleLoader: () => const Locale('en'),
+            deviceLocaleLoader: () => const Locale('en', 'US'),
+          );
+
+          final data = await service.collectDiagnostics(
+            userDescription: 'This screen is showing bad copy',
+          );
+
+          expect(data.deviceInfo['locale'], 'en');
+          expect(data.deviceInfo.containsKey('deviceLocale'), isFalse);
+        },
+      );
+
+      test('a locale probe failure does not block the report', () async {
+        final service = BugReportService(
+          resolvedUiLocaleLoader: () => throw StateError('locale unavailable'),
+          deviceLocaleLoader: () => const Locale('en'),
+        );
+
+        final data = await service.collectDiagnostics(
+          userDescription: 'This screen is showing bad copy',
+        );
+
+        // Best-effort contract: the report still succeeds, just without the
+        // locale fields.
+        expect(data.userDescription, 'This screen is showing bad copy');
+        expect(data.deviceInfo.containsKey('locale'), isFalse);
+        expect(data.deviceInfo.containsKey('deviceLocale'), isFalse);
+      });
     });
 
     group('clearCapturedLogs', () {

--- a/mobile/test/services/bug_report_service_test.dart
+++ b/mobile/test/services/bug_report_service_test.dart
@@ -457,9 +457,10 @@ void main() {
       // For most of the 21+ supported locales there is no native reviewer, so
       // a copy report is the only signal - and it can only be routed if it says
       // which language the app was rendering. The resolved UI locale is that
-      // language; the device locale is recorded only when it differs, because
-      // a device set to Amharic that is showing the English fallback is a
-      // different bug from a bad Amharic string (#7939).
+      // language; the device locale is recorded only when the app ships no
+      // translation for it, because a phone set to a language we do not ship
+      // is reading a fallback - a different bug from a bad string in a
+      // language we do ship (#7939).
       test('records the resolved UI locale in deviceInfo', () async {
         final service = BugReportService(
           resolvedUiLocaleLoader: () => const Locale('am'),
@@ -476,32 +477,34 @@ void main() {
       });
 
       test(
-        'records the device locale when it differs from the resolved locale',
+        'records the device locale when the app has no translation for it',
         () async {
+          // Czech is not in AppLocalizations.supportedLocales, so this reader
+          // is on the English fallback rather than reading a bad string.
           final service = BugReportService(
             resolvedUiLocaleLoader: () => const Locale('en'),
-            deviceLocaleLoader: () => const Locale('am', 'ET'),
+            deviceLocaleLoader: () => const Locale('cs', 'CZ'),
           );
 
           final data = await service.collectDiagnostics(
-            userDescription: 'App is in English but my phone is Amharic',
+            userDescription: 'App is in English but my phone is Czech',
           );
 
           expect(data.deviceInfo['locale'], 'en');
-          expect(data.deviceInfo['deviceLocale'], 'am-ET');
+          expect(data.deviceInfo['deviceLocale'], 'cs-CZ');
         },
       );
 
       test(
-        'omits the device locale when only the region differs',
+        'omits the device locale when the user picked another shipped language',
         () async {
-          // Every supported locale is language-only, so the resolved locale
-          // never carries a region. An en-US device reading `en` is reading the
-          // exact language it asked for - there is no fallback to flag, so the
-          // region-only difference must not emit a deviceLocale (#7939).
+          // German is shipped, so an en-reading German phone is a Settings
+          // choice, not a missing translation. Emitting deviceLocale here
+          // would send triage looking for a German translation gap that does
+          // not exist (#7939).
           final service = BugReportService(
             resolvedUiLocaleLoader: () => const Locale('en'),
-            deviceLocaleLoader: () => const Locale('en', 'US'),
+            deviceLocaleLoader: () => const Locale('de', 'DE'),
           );
 
           final data = await service.collectDiagnostics(
@@ -512,6 +515,24 @@ void main() {
           expect(data.deviceInfo.containsKey('deviceLocale'), isFalse);
         },
       );
+
+      test('omits the device locale when only the region differs', () async {
+        // Every supported locale is language-only, so the resolved locale
+        // never carries a region. An en-US device reading `en` is reading the
+        // exact language it asked for - there is no fallback to flag, so the
+        // region-only difference must not emit a deviceLocale (#7939).
+        final service = BugReportService(
+          resolvedUiLocaleLoader: () => const Locale('en'),
+          deviceLocaleLoader: () => const Locale('en', 'US'),
+        );
+
+        final data = await service.collectDiagnostics(
+          userDescription: 'This screen is showing bad copy',
+        );
+
+        expect(data.deviceInfo['locale'], 'en');
+        expect(data.deviceInfo.containsKey('deviceLocale'), isFalse);
+      });
 
       test('a locale probe failure does not block the report', () async {
         final service = BugReportService(

--- a/mobile/test/services/bug_report_service_test.dart
+++ b/mobile/test/services/bug_report_service_test.dart
@@ -454,17 +454,59 @@ void main() {
     );
 
     group('locale diagnostics', () {
-      // For most of the 21+ supported locales there is no native reviewer, so
-      // a copy report is the only signal - and it can only be routed if it says
-      // which language the app was rendering. The resolved UI locale is that
-      // language; the device locale is recorded only when the app ships no
-      // translation for it, because a phone set to a language we do not ship
-      // is reading a fallback - a different bug from a bad string in a
-      // language we do ship (#7939).
+      test('omits fallback metadata for an explicit English choice', () async {
+        final service = BugReportService(
+          resolvedUiLocaleLoader: () => const Locale('en'),
+          deviceLocalesLoader: () => const [Locale('cs', 'CZ')],
+          hasLocaleOverrideLoader: () => true,
+        );
+
+        final data = await service.collectDiagnostics(
+          userDescription: 'English was selected in Settings',
+        );
+
+        expect(data.deviceInfo['locale'], 'en');
+        expect(data.deviceInfo, isNot(contains('deviceLocale')));
+      });
+
+      test(
+        'omits fallback metadata for a supported secondary locale',
+        () async {
+          final service = BugReportService(
+            resolvedUiLocaleLoader: () => const Locale('de'),
+            deviceLocalesLoader: () => const [
+              Locale('cs', 'CZ'),
+              Locale('de', 'DE'),
+            ],
+          );
+
+          final data = await service.collectDiagnostics(
+            userDescription: 'Copy report',
+          );
+
+          expect(data.deviceInfo['locale'], 'de');
+          expect(data.deviceInfo, isNot(contains('deviceLocale')));
+        },
+      );
+
+      test('omits device locale when device preferences are empty', () async {
+        final service = BugReportService(
+          resolvedUiLocaleLoader: () => const Locale('en'),
+          deviceLocalesLoader: () => const [],
+        );
+
+        final data = await service.collectDiagnostics(
+          userDescription: 'Copy report',
+        );
+
+        expect(data.deviceInfo['locale'], 'en');
+        expect(data.deviceInfo, isNot(contains('deviceLocale')));
+      });
+
       test('records the resolved UI locale in deviceInfo', () async {
         final service = BugReportService(
           resolvedUiLocaleLoader: () => const Locale('am'),
-          deviceLocaleLoader: () => const Locale('am'),
+          deviceLocalesLoader: () => const [Locale('am')],
         );
 
         final data = await service.collectDiagnostics(
@@ -483,7 +525,7 @@ void main() {
           // is on the English fallback rather than reading a bad string.
           final service = BugReportService(
             resolvedUiLocaleLoader: () => const Locale('en'),
-            deviceLocaleLoader: () => const Locale('cs', 'CZ'),
+            deviceLocalesLoader: () => const [Locale('cs', 'CZ')],
           );
 
           final data = await service.collectDiagnostics(
@@ -504,7 +546,7 @@ void main() {
           // not exist (#7939).
           final service = BugReportService(
             resolvedUiLocaleLoader: () => const Locale('en'),
-            deviceLocaleLoader: () => const Locale('de', 'DE'),
+            deviceLocalesLoader: () => const [Locale('de', 'DE')],
           );
 
           final data = await service.collectDiagnostics(
@@ -523,7 +565,7 @@ void main() {
         // region-only difference must not emit a deviceLocale (#7939).
         final service = BugReportService(
           resolvedUiLocaleLoader: () => const Locale('en'),
-          deviceLocaleLoader: () => const Locale('en', 'US'),
+          deviceLocalesLoader: () => const [Locale('en', 'US')],
         );
 
         final data = await service.collectDiagnostics(
@@ -537,7 +579,7 @@ void main() {
       test('a locale probe failure does not block the report', () async {
         final service = BugReportService(
           resolvedUiLocaleLoader: () => throw StateError('locale unavailable'),
-          deviceLocaleLoader: () => const Locale('en'),
+          deviceLocalesLoader: () => const [Locale('en')],
         );
 
         final data = await service.collectDiagnostics(


### PR DESCRIPTION
## Description

Someone reports that a piece of copy in the app is wrong, and we cannot act on it, because the report never says which language they were reading it in. For most of the 21+ languages Divine ships there is no native speaker on the team, so a user's report is the only signal we get — and support has to write back and ask "what language is your app in?" before it can be routed to anyone. That round trip usually ends the conversation.

The bug report already carried platform, device model, OS and app version. This adds the language: `locale` is the language the app was actually rendering, which is the field a copy report gets routed by.

Getting that value right is the whole of the change. It is not the phone's language setting: a supported Settings choice takes precedence, and device resolution can select a supported secondary preference before falling back to English. The report resolves the saved preference, or otherwise the device's preference list, through the existing `resolveAppUiLocale`, just as the app does at runtime. The resolution logic was already there for `MaterialApp`; this pulls the locale half of it out into `currentAppUiLocale` so a service with no `BuildContext` can ask the same question, and the provider injects it.

A second field, `deviceLocale`, appears **only** when Settings follows the device and none of the phone's preferred languages has a shipped translation. It records the phone's first preference, identifying the English fallback rather than a bad string in a supported language. An explicit Settings choice or a supported secondary device preference adds no line. Saved Settings values that are no longer supported resolve to English, just as the running app does, instead of making the report name a different device language.

Collecting the locale is best-effort: if the probe throws, the report is still filed without those fields rather than failing.

**Related Issue:** Closes #7939

## Out of Scope

- Nothing surfaces the locale in the Zendesk ticket **form fields**; it lands in the ticket's Device Information body alongside the other diagnostics, which is where support already reads model and OS version.
- No change to runtime UI locale selection or translated copy. Context-less localized messages also follow the existing UI fallback when a saved Settings language is no longer supported.
- The localization style guide is updated to drop the "ask them which language they were reading" workaround it recommended while #7939 was open.

## Verification

- `flutter analyze lib test integration_test tools` and the declared formatter check passed.
- `flutter test test/services/bug_report_service_test.dart test/providers/bug_report_providers_test.dart test/l10n/current_app_l10n_test.dart test/l10n/resolve_app_ui_locale_test.dart`: 48 passed, 2 existing native-platform skips.
- Unit coverage for each case the field has to distinguish: the language rendered is recorded; a device language we do not ship emits `deviceLocale`; a language picked in Settings does not; a region-only difference (`en-US` reading `en`) does not; and a failed probe still produces a report.
- Not exercised end-to-end on a device, because submitting a bug report from the app files a real support ticket.
- Local coverage limits: the full unsharded suite timed out; reusable workflows and CI-only orchestration were not run locally. Twelve applicable ratchets and the configuration tests passed. Three stale-base ratchets reject baseline entries removed by newer `main`; a synthetic merge-tree comparison confirms those removals are preserved.
- All 19 GitHub checks passed on the final head, including four test shards, goldens, and generated files.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation
