### PR TITLE
refactor(search): keep people-search cancellation always active

### DIFF
--- a/mobile/lib/blocs/user_search/user_search_bloc.dart
+++ b/mobile/lib/blocs/user_search/user_search_bloc.dart
@@ -48,7 +48,6 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
     this.excludedPubkey,
     FeedPerformanceTracker? feedTracker,
     UserSearchRunner? searchRunner,
-    this.enableCancellation = false,
   }) : _profileRepository = profileRepository,
        _followRepository = followRepository,
        _feedTracker = feedTracker,
@@ -70,8 +69,6 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
 
   final FeedPerformanceTracker? _feedTracker;
   final UserSearchRunner? _searchRunner;
-
-  final bool enableCancellation;
 
   /// Whether to filter results to users who have uploaded videos.
   final bool hasVideos;
@@ -158,22 +155,14 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
             boostPubkeys: followedPubkeys,
             cancellationToken: cancellationToken,
           ) ??
-          (enableCancellation
-              ? _profileRepository.searchUsersProgressive(
-                  query: query,
-                  limit: _pageSize,
-                  sortBy: profileSearchSortFollowers,
-                  hasVideos: hasVideos,
-                  boostPubkeys: followedPubkeys,
-                  cancellationToken: cancellationToken,
-                )
-              : _profileRepository.searchUsersProgressive(
-                  query: query,
-                  limit: _pageSize,
-                  sortBy: profileSearchSortFollowers,
-                  hasVideos: hasVideos,
-                  boostPubkeys: followedPubkeys,
-                ));
+          _profileRepository.searchUsersProgressive(
+            query: query,
+            limit: _pageSize,
+            sortBy: profileSearchSortFollowers,
+            hasVideos: hasVideos,
+            boostPubkeys: followedPubkeys,
+            cancellationToken: cancellationToken,
+          );
 
       await emit.forEach<ProgressiveSearchResult>(
         searchTimeout == null

--- a/mobile/lib/screens/search_results/view/search_results_page.dart
+++ b/mobile/lib/screens/search_results/view/search_results_page.dart
@@ -73,10 +73,7 @@ class SearchResultsPage extends ConsumerWidget {
           ),
         ),
         BlocProvider(
-          create: (_) => UserSearchBloc(
-            profileRepository: profileRepository,
-            enableCancellation: true,
-          ),
+          create: (_) => UserSearchBloc(profileRepository: profileRepository),
         ),
         BlocProvider(create: (_) => SearchResultsFilterCubit()),
         BlocProvider(

--- a/mobile/lib/widgets/find_people_sheet.dart
+++ b/mobile/lib/widgets/find_people_sheet.dart
@@ -88,7 +88,6 @@ class _FindPeopleSheetState extends ConsumerState<FindPeopleSheet> {
     if (profileRepo != null) {
       _searchBloc = UserSearchBloc(
         profileRepository: profileRepo,
-        enableCancellation: true,
         searchTimeout: widget.searchTimeout,
         excludedPubkey: widget.currentUserPubkey,
       );

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -179,7 +179,6 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
     }
     _searchBloc = UserSearchBloc(
       profileRepository: profileRepo,
-      enableCancellation: true,
       followRepository: ref.read(followRepositoryProvider),
     );
 
@@ -1104,9 +1103,7 @@ class _SelectedChipsRow extends ConsumerWidget {
               key: ValueKey(profile.pubkey),
               label: vanishedAccountName(
                 context,
-                isVanished: ref.watch(
-                  profileVanishedProvider(profile.pubkey),
-                ),
+                isVanished: ref.watch(profileVanishedProvider(profile.pubkey)),
                 fallbackName: profile.bestDisplayName,
               ),
               onRemove: () => onRemove(profile),

--- a/mobile/test/blocs/user_search/user_search_bloc_test.dart
+++ b/mobile/test/blocs/user_search/user_search_bloc_test.dart
@@ -25,6 +25,7 @@ void main() {
     // matcher for the `SearchSourceStatus` parameter of `trackSearchSource`.
     registerFallbackValue(const SearchSourcePending());
     registerFallbackValue(SearchSource.localCache);
+    registerFallbackValue(SearchCancellationToken('test-search'));
   });
 
   group('UserSearchBloc', () {
@@ -152,6 +153,39 @@ void main() {
         await controller.close();
       }
     });
+
+    blocTest<UserSearchBloc, UserSearchState>(
+      'passes a cancellation token to the repository by default',
+      setUp: () {
+        when(
+          () => mockProfileRepository.searchUsersProgressive(
+            query: 'alice',
+            limit: 50,
+            sortBy: profileSearchSortFollowers,
+            cancellationToken: any(named: 'cancellationToken'),
+          ),
+        ).thenAnswer((_) => progressive([]));
+      },
+      build: () => UserSearchBloc(
+        profileRepository: mockProfileRepository,
+        searchTimeout: null,
+      ),
+      act: (bloc) => bloc.add(const UserSearchQueryChanged('alice')),
+      wait: debounceDuration,
+      verify: (_) {
+        final token =
+            verify(
+                  () => mockProfileRepository.searchUsersProgressive(
+                    query: 'alice',
+                    limit: 50,
+                    sortBy: profileSearchSortFollowers,
+                    cancellationToken: captureAny(named: 'cancellationToken'),
+                  ),
+                ).captured.single
+                as SearchCancellationToken;
+        expect(token.isCancelled, isTrue);
+      },
+    );
 
     blocTest<UserSearchBloc, UserSearchState>(
       'omits the excluded pubkey case-insensitively',

--- a/mobile/test/widgets/find_people_sheet_test.dart
+++ b/mobile/test/widgets/find_people_sheet_test.dart
@@ -33,23 +33,6 @@ void main() {
 
     setUp(() {
       mockProfileRepo = _MockProfileRepository();
-      when(
-        () => mockProfileRepo.searchUsersProgressive(
-          query: any(named: 'query'),
-          limit: any(named: 'limit'),
-          sortBy: any(named: 'sortBy'),
-          hasVideos: any(named: 'hasVideos'),
-          boostPubkeys: any(named: 'boostPubkeys'),
-          cancellationToken: any(named: 'cancellationToken'),
-        ),
-      ).thenAnswer((invocation) {
-        return mockProfileRepo.searchUsersProgressive(
-          query: invocation.namedArguments[#query] as String,
-          limit: invocation.namedArguments[#limit] as int,
-          sortBy: invocation.namedArguments[#sortBy] as String?,
-          hasVideos: invocation.namedArguments[#hasVideos] as bool,
-        );
-      });
     });
 
     Widget createTestWidget({
@@ -190,6 +173,7 @@ void main() {
             limit: any(named: 'limit'),
             sortBy: any(named: 'sortBy'),
             hasVideos: any(named: 'hasVideos'),
+            cancellationToken: any(named: 'cancellationToken'),
           ),
         ).thenAnswer((_) => controller.stream);
 
@@ -224,6 +208,7 @@ void main() {
             limit: any(named: 'limit'),
             sortBy: any(named: 'sortBy'),
             hasVideos: any(named: 'hasVideos'),
+            cancellationToken: any(named: 'cancellationToken'),
           ),
         ).thenAnswer(
           (_) => Stream.value(
@@ -262,6 +247,7 @@ void main() {
             limit: any(named: 'limit'),
             sortBy: any(named: 'sortBy'),
             hasVideos: any(named: 'hasVideos'),
+            cancellationToken: any(named: 'cancellationToken'),
           ),
         ).thenAnswer(
           (_) => Stream.value(
@@ -307,6 +293,7 @@ void main() {
             limit: any(named: 'limit'),
             sortBy: any(named: 'sortBy'),
             hasVideos: any(named: 'hasVideos'),
+            cancellationToken: any(named: 'cancellationToken'),
           ),
         ).thenAnswer(
           (_) => Stream.value(
@@ -347,6 +334,7 @@ void main() {
             limit: any(named: 'limit'),
             sortBy: any(named: 'sortBy'),
             hasVideos: any(named: 'hasVideos'),
+            cancellationToken: any(named: 'cancellationToken'),
           ),
         ).thenAnswer(
           (_) => Stream.value(
@@ -385,6 +373,7 @@ void main() {
               limit: any(named: 'limit'),
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
+              cancellationToken: any(named: 'cancellationToken'),
             ),
           ).thenAnswer(
             (_) => Stream.value(
@@ -413,6 +402,7 @@ void main() {
             limit: any(named: 'limit'),
             sortBy: any(named: 'sortBy'),
             hasVideos: any(named: 'hasVideos'),
+            cancellationToken: any(named: 'cancellationToken'),
           ),
         ).thenAnswer(
           (_) =>
@@ -437,6 +427,7 @@ void main() {
             limit: any(named: 'limit'),
             sortBy: any(named: 'sortBy'),
             hasVideos: any(named: 'hasVideos'),
+            cancellationToken: any(named: 'cancellationToken'),
           ),
         ).thenAnswer(
           (_) => Stream.value(
@@ -580,6 +571,7 @@ void main() {
               query: any(named: 'query'),
               limit: any(named: 'limit'),
               sortBy: any(named: 'sortBy'),
+              cancellationToken: any(named: 'cancellationToken'),
             ),
           ).thenAnswer(
             (_) => Stream.value(
@@ -605,6 +597,7 @@ void main() {
               query: 'test',
               limit: 50,
               sortBy: 'followers',
+              cancellationToken: any(named: 'cancellationToken'),
             ),
           ).called(1);
         },
@@ -654,24 +647,21 @@ void main() {
         expect(find.text('Aeontropy'), findsNothing);
       });
 
-      testWidgets(
-        "hides a vanished peer's handle, which identifies them too",
-        (
+      testWidgets("hides a vanished peer's handle, which identifies them too", (
+        tester,
+      ) async {
+        await openWith(
           tester,
-        ) async {
-          await openWith(
-            tester,
-            contact: const ShareableUser(
-              pubkey: vanishedPubkey,
-              displayName: 'Aeontropy',
-              handle: '@aeontropy',
-            ),
-            isVanished: true,
-          );
+          contact: const ShareableUser(
+            pubkey: vanishedPubkey,
+            displayName: 'Aeontropy',
+            handle: '@aeontropy',
+          ),
+          isVanished: true,
+        );
 
-          expect(find.text('@aeontropy'), findsNothing);
-        },
-      );
+        expect(find.text('@aeontropy'), findsNothing);
+      });
 
       testWidgets('gives the moderation account its bundled wordmark and '
           'shared name', (tester) async {


### PR DESCRIPTION
## Problem

People-search cancellation is enabled by every production screen, but `UserSearchBloc` still carries an on/off flag and a duplicate token-less repository path left over from the rollout. Tests also retain a compatibility shim that hides the real token-bearing call shape.

## Why this fix

This removes the unused flag and always forwards the query cancellation token through the default repository path. The three production callers become simpler, and tests now match the production signature directly. A focused BLoC assertion verifies that the default repository path receives and completes the token.

## Deliberately unchanged

Pagination remains unchanged because load-more requests are not superseded query requests. There are no localization, generated-code, protocol, or repository API changes.

## Verification

- `flutter analyze lib test integration_test`
- `flutter test test/blocs/user_search/user_search_bloc_test.dart test/widgets/find_people_sheet_test.dart test/widgets/user_picker_sheet_test.dart test/screens/search_results`
- `flutter test` in `mobile/packages/profile_repository`
- pre-push analyzer and changed-file tests

Closes #8591