### PR TITLE
fix(perf): make Android image allocation failures measurable

### DIFF
--- a/mobile/lib/app/divine_app.dart
+++ b/mobile/lib/app/divine_app.dart
@@ -125,6 +125,7 @@ class _DivineAppState extends ConsumerState<DivineApp>
   late final StartupSplashReleaseController _splashReleaseController;
   late final MemoryPressureHandler _memoryPressureHandler;
   late final MemoryTelemetryService _memoryTelemetry;
+  int _memoryPressureEvents = 0;
 
   @override
   void initState() {
@@ -139,6 +140,12 @@ class _DivineAppState extends ConsumerState<DivineApp>
       openVineImageCache.cancelInFlightDownloads();
     }
     _memoryPressureHandler = MemoryPressureHandler(
+      onPressureObserved: (eventCount) {
+        _memoryPressureEvents = eventCount;
+        // Capture the cache occupancy that triggered the signal before the
+        // handler clears both keep-alive and live images below.
+        _memoryTelemetry.sampleOnce();
+      },
       clearImageCache: () {
         PaintingBinding.instance.imageCache
           ..clear()
@@ -155,6 +162,10 @@ class _DivineAppState extends ConsumerState<DivineApp>
           DivineVideoPlayerController.liveControllerCount,
       queueDepth: () =>
           ref.read(videoEventServiceProvider).eventRouter?.queuedLength ?? 0,
+      imageCacheBytes: () =>
+          PaintingBinding.instance.imageCache.currentSizeBytes,
+      imageCacheLiveCount: () =>
+          PaintingBinding.instance.imageCache.liveImageCount,
       emit: _emitMemorySnapshot,
     );
     // Subscribe before deferred startup settles auth; routerDelegate reliably
@@ -199,7 +210,9 @@ class _DivineAppState extends ConsumerState<DivineApp>
         _initializeDeepLinkServices();
         _initializeQuickActions();
         _initializeBackgroundServices();
-        _memoryTelemetry.start();
+        _memoryTelemetry
+          ..sampleOnce()
+          ..start();
       }
     });
   }
@@ -281,16 +294,33 @@ class _DivineAppState extends ConsumerState<DivineApp>
   void _emitMemorySnapshot(MemorySnapshot snapshot) {
     final rssMb = _rssMb(snapshot.rssBytes);
     final peakMb = _rssMb(snapshot.peakRssBytes);
+    final imageCacheMb = _rssMb(snapshot.imageCacheBytes);
     Log.info(
       'Memory: rss $rssMb MB (peak $peakMb MB), '
       'vc_native=${snapshot.nativeControllers}, '
-      'ingest_queue_depth=${snapshot.queueDepth}',
+      'ingest_queue_depth=${snapshot.queueDepth}, '
+      'img_cache_mb=$imageCacheMb, '
+      'img_cache_live=${snapshot.imageCacheLiveCount}, '
+      'mem_pressure_events=$_memoryPressureEvents',
       name: 'MemoryTelemetry',
       category: LogCategory.system,
     );
     final crashReporting = CrashReportingService.instance;
     unawaited(crashReporting.setCustomKey('mem_rss_mb', rssMb));
     unawaited(crashReporting.setCustomKey('mem_peak_mb', peakMb));
+    unawaited(crashReporting.setCustomKey('img_cache_mb', imageCacheMb));
+    unawaited(
+      crashReporting.setCustomKey(
+        'img_cache_live',
+        snapshot.imageCacheLiveCount,
+      ),
+    );
+    unawaited(
+      crashReporting.setCustomKey(
+        'mem_pressure_events',
+        _memoryPressureEvents,
+      ),
+    );
     unawaited(
       crashReporting.setCustomKey('vc_native', snapshot.nativeControllers),
     );

--- a/mobile/lib/app/divine_app.dart
+++ b/mobile/lib/app/divine_app.dart
@@ -93,6 +93,31 @@ class DivineApp extends ConsumerStatefulWidget {
   ConsumerState<DivineApp> createState() => _DivineAppState();
 }
 
+/// Builds the app's sampler with Flutter's decoded-image cache gauges.
+///
+/// Kept as a test seam so a widget test can dispatch a real framework memory
+/// pressure message and verify the production cache wiring survives Flutter's
+/// automatic keep-alive cache clear.
+@visibleForTesting
+MemoryTelemetryService createAppMemoryTelemetryService({
+  required int Function() readRssBytes,
+  required int Function() readPeakRssBytes,
+  required int Function() nativeControllerCount,
+  required int Function() queueDepth,
+  required void Function(MemorySnapshot) emit,
+}) {
+  return MemoryTelemetryService(
+    readRssBytes: readRssBytes,
+    readPeakRssBytes: readPeakRssBytes,
+    nativeControllerCount: nativeControllerCount,
+    queueDepth: queueDepth,
+    imageCacheBytes: () => PaintingBinding.instance.imageCache.currentSizeBytes,
+    imageCacheLiveCount: () =>
+        PaintingBinding.instance.imageCache.liveImageCount,
+    emit: emit,
+  );
+}
+
 /// Whether a launch that observes [state] as its first lifecycle reading must
 /// start with media downloads suspended.
 ///
@@ -142,8 +167,10 @@ class _DivineAppState extends ConsumerState<DivineApp>
     _memoryPressureHandler = MemoryPressureHandler(
       onPressureObserved: (eventCount) {
         _memoryPressureEvents = eventCount;
-        // Capture the cache occupancy that triggered the signal before the
-        // handler clears both keep-alive and live images below.
+        // Flutter has already cleared keep-alive images before notifying its
+        // observers. Sampling here preserves the process high-water mark,
+        // captures the still-live image count, and updates the event count
+        // before our handler clears live images and sheds ingestion below.
         _memoryTelemetry.sampleOnce();
       },
       clearImageCache: () {
@@ -155,17 +182,13 @@ class _DivineAppState extends ConsumerState<DivineApp>
         ref.read(videoEventServiceProvider).eventRouter?.shedLowPriority();
       },
     );
-    _memoryTelemetry = MemoryTelemetryService(
+    _memoryTelemetry = createAppMemoryTelemetryService(
       readRssBytes: _currentRssBytes,
       readPeakRssBytes: _peakRssBytes,
       nativeControllerCount: () =>
           DivineVideoPlayerController.liveControllerCount,
       queueDepth: () =>
           ref.read(videoEventServiceProvider).eventRouter?.queuedLength ?? 0,
-      imageCacheBytes: () =>
-          PaintingBinding.instance.imageCache.currentSizeBytes,
-      imageCacheLiveCount: () =>
-          PaintingBinding.instance.imageCache.liveImageCount,
       emit: _emitMemorySnapshot,
     );
     // Subscribe before deferred startup settles auth; routerDelegate reliably
@@ -294,12 +317,14 @@ class _DivineAppState extends ConsumerState<DivineApp>
   void _emitMemorySnapshot(MemorySnapshot snapshot) {
     final rssMb = _rssMb(snapshot.rssBytes);
     final peakMb = _rssMb(snapshot.peakRssBytes);
-    final imageCacheMb = _rssMb(snapshot.imageCacheBytes);
+    final imageCacheMb = _memoryGaugeMb(snapshot.imageCacheBytes);
+    final peakImageCacheMb = _memoryGaugeMb(snapshot.peakImageCacheBytes);
     Log.info(
       'Memory: rss $rssMb MB (peak $peakMb MB), '
       'vc_native=${snapshot.nativeControllers}, '
       'ingest_queue_depth=${snapshot.queueDepth}, '
       'img_cache_mb=$imageCacheMb, '
+      'img_cache_peak_mb=$peakImageCacheMb, '
       'img_cache_live=${snapshot.imageCacheLiveCount}, '
       'mem_pressure_events=$_memoryPressureEvents',
       name: 'MemoryTelemetry',
@@ -308,7 +333,9 @@ class _DivineAppState extends ConsumerState<DivineApp>
     final crashReporting = CrashReportingService.instance;
     unawaited(crashReporting.setCustomKey('mem_rss_mb', rssMb));
     unawaited(crashReporting.setCustomKey('mem_peak_mb', peakMb));
-    unawaited(crashReporting.setCustomKey('img_cache_mb', imageCacheMb));
+    unawaited(
+      crashReporting.setCustomKey('img_cache_peak_mb', peakImageCacheMb),
+    );
     unawaited(
       crashReporting.setCustomKey(
         'img_cache_live',
@@ -328,6 +355,9 @@ class _DivineAppState extends ConsumerState<DivineApp>
       crashReporting.setCustomKey('ingest_queue_depth', snapshot.queueDepth),
     );
   }
+
+  static String _memoryGaugeMb(int bytes) =>
+      bytes == MemorySnapshot.unavailableGauge ? 'unavailable' : _rssMb(bytes);
 
   void _initializeDeepLinkServices() {
     Log.info(

--- a/mobile/lib/services/memory_pressure_handler.dart
+++ b/mobile/lib/services/memory_pressure_handler.dart
@@ -1,25 +1,37 @@
-// ABOUTME: Fans a memory-pressure signal out to load-shedding actions
+// ABOUTME: Observes memory pressure before fanning it out to shedding actions
 // ABOUTME: Clears the image cache and sheds low-priority ingestion backlog
 
 /// Coordinates the app's response to an OS memory-pressure signal.
 ///
-/// Both actions are injected so the handler stays free of Flutter and service
-/// dependencies and is trivially testable. Production wiring supplies an image
-/// cache clear and an [EventRouter]-backed ingestion shed.
+/// Every signal is observed before either shedding action runs, preserving the
+/// pre-shed gauges for diagnostics. All callbacks are injected so the handler
+/// stays free of Flutter and service dependencies and is trivially testable.
 class MemoryPressureHandler {
   MemoryPressureHandler({
     required void Function() clearImageCache,
     required void Function() shedIngestion,
+    required void Function(int eventCount) onPressureObserved,
   }) : _clearImageCache = clearImageCache,
+       _onPressureObserved = onPressureObserved,
        _shedIngestion = shedIngestion;
 
   final void Function() _clearImageCache;
+  final void Function(int eventCount) _onPressureObserved;
   final void Function() _shedIngestion;
+  int _eventCount = 0;
 
-  /// Sheds load in response to memory pressure by clearing the image cache
-  /// and dropping low-priority ingestion backlog.
+  /// Records the signal, then clears the image cache and drops low-priority
+  /// ingestion backlog.
   void onMemoryPressure() {
-    _clearImageCache();
-    _shedIngestion();
+    _eventCount += 1;
+    try {
+      _onPressureObserved(_eventCount);
+    } finally {
+      try {
+        _clearImageCache();
+      } finally {
+        _shedIngestion();
+      }
+    }
   }
 }

--- a/mobile/lib/services/memory_telemetry_service.dart
+++ b/mobile/lib/services/memory_telemetry_service.dart
@@ -12,8 +12,12 @@ class MemorySnapshot {
     required this.nativeControllers,
     required this.queueDepth,
     required this.imageCacheBytes,
+    required this.peakImageCacheBytes,
     required this.imageCacheLiveCount,
   });
+
+  /// Sentinel used when a gauge could not be read.
+  static const int unavailableGauge = -1;
 
   /// Resident set size at sample time, in bytes.
   final int rssBytes;
@@ -32,12 +36,23 @@ class MemorySnapshot {
   final int queueDepth;
 
   /// Decoded image bytes retained by Flutter's keep-alive image cache.
+  ///
+  /// This is [unavailableGauge] when the cache could not be read.
   final int imageCacheBytes;
+
+  /// Highest decoded-image cache occupancy observed during this process.
+  ///
+  /// Flutter clears [imageCacheBytes] before notifying memory-pressure
+  /// observers. This high-water mark preserves the last meaningful occupancy
+  /// across that framework clear. It is [unavailableGauge] until the first
+  /// successful reading.
+  final int peakImageCacheBytes;
 
   /// Decoded images with at least one live listener.
   ///
   /// Live images are tracked separately from [imageCacheBytes], so this is a
-  /// count rather than an estimate of their memory footprint.
+  /// count rather than an estimate of their memory footprint. This is
+  /// [unavailableGauge] when the cache could not be read.
   final int imageCacheLiveCount;
 
   @override
@@ -45,6 +60,7 @@ class MemorySnapshot {
       'MemorySnapshot(rssBytes: $rssBytes, peakRssBytes: $peakRssBytes, '
       'nativeControllers: $nativeControllers, queueDepth: $queueDepth, '
       'imageCacheBytes: $imageCacheBytes, '
+      'peakImageCacheBytes: $peakImageCacheBytes, '
       'imageCacheLiveCount: $imageCacheLiveCount)';
 }
 
@@ -91,6 +107,7 @@ class MemoryTelemetryService {
 
   Timer? _timer;
   int _peakRssBytes = 0;
+  int _peakImageCacheBytes = MemorySnapshot.unavailableGauge;
 
   /// Reads every gauge once, updates the running peak, and emits a snapshot.
   ///
@@ -98,6 +115,16 @@ class MemoryTelemetryService {
   /// so a platform without an OS gauge still reports something monotonic.
   void sampleOnce() {
     final rss = _readGauge(_readRssBytes);
+    final imageCacheBytes = _readGauge(
+      _imageCacheBytes,
+      unavailable: MemorySnapshot.unavailableGauge,
+    );
+    if (imageCacheBytes != MemorySnapshot.unavailableGauge) {
+      _peakImageCacheBytes = math.max(
+        _peakImageCacheBytes,
+        imageCacheBytes,
+      );
+    }
     _peakRssBytes = math.max(
       math.max(_peakRssBytes, rss),
       _readGauge(_readPeakRssBytes),
@@ -108,18 +135,26 @@ class MemoryTelemetryService {
         peakRssBytes: _peakRssBytes,
         nativeControllers: _readGauge(_nativeControllerCount),
         queueDepth: _readGauge(_queueDepth),
-        imageCacheBytes: _readGauge(_imageCacheBytes),
-        imageCacheLiveCount: _readGauge(_imageCacheLiveCount),
+        imageCacheBytes: imageCacheBytes,
+        peakImageCacheBytes: _peakImageCacheBytes,
+        imageCacheLiveCount: _readGauge(
+          _imageCacheLiveCount,
+          unavailable: MemorySnapshot.unavailableGauge,
+        ),
       ),
     );
   }
 
-  static int _readGauge(int Function() read) {
+  /// Isolates gauge failures so telemetry cannot prevent memory shedding.
+  ///
+  /// Some platforms do not implement every gauge, and cache access must stay
+  /// distinguishable from a genuinely empty cache.
+  static int _readGauge(int Function() read, {int unavailable = 0}) {
     try {
       final value = read();
-      return value < 0 ? 0 : value;
+      return value < 0 ? unavailable : value;
     } on Object catch (_) {
-      return 0;
+      return unavailable;
     }
   }
 

--- a/mobile/lib/services/memory_telemetry_service.dart
+++ b/mobile/lib/services/memory_telemetry_service.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Always-on memory gauge sampler (RSS + peak) for OOM instrumentation
+// ABOUTME: Always-on memory gauge sampler for OOM instrumentation
 // ABOUTME: Reads injected gauges on an interval and emits a MemorySnapshot
 
 import 'dart:async';
@@ -11,6 +11,8 @@ class MemorySnapshot {
     required this.peakRssBytes,
     required this.nativeControllers,
     required this.queueDepth,
+    required this.imageCacheBytes,
+    required this.imageCacheLiveCount,
   });
 
   /// Resident set size at sample time, in bytes.
@@ -29,10 +31,21 @@ class MemorySnapshot {
   /// Events queued for ingestion across all priorities.
   final int queueDepth;
 
+  /// Decoded image bytes retained by Flutter's keep-alive image cache.
+  final int imageCacheBytes;
+
+  /// Decoded images with at least one live listener.
+  ///
+  /// Live images are tracked separately from [imageCacheBytes], so this is a
+  /// count rather than an estimate of their memory footprint.
+  final int imageCacheLiveCount;
+
   @override
   String toString() =>
       'MemorySnapshot(rssBytes: $rssBytes, peakRssBytes: $peakRssBytes, '
-      'nativeControllers: $nativeControllers, queueDepth: $queueDepth)';
+      'nativeControllers: $nativeControllers, queueDepth: $queueDepth, '
+      'imageCacheBytes: $imageCacheBytes, '
+      'imageCacheLiveCount: $imageCacheLiveCount)';
 }
 
 /// Samples memory-relevant gauges and emits a [MemorySnapshot].
@@ -53,18 +66,24 @@ class MemoryTelemetryService {
     required int Function() readPeakRssBytes,
     required int Function() nativeControllerCount,
     required int Function() queueDepth,
+    required int Function() imageCacheBytes,
+    required int Function() imageCacheLiveCount,
     required void Function(MemorySnapshot) emit,
     this.interval = const Duration(seconds: 30),
   }) : _readRssBytes = readRssBytes,
        _readPeakRssBytes = readPeakRssBytes,
        _nativeControllerCount = nativeControllerCount,
        _queueDepth = queueDepth,
+       _imageCacheBytes = imageCacheBytes,
+       _imageCacheLiveCount = imageCacheLiveCount,
        _emit = emit;
 
   final int Function() _readRssBytes;
   final int Function() _readPeakRssBytes;
   final int Function() _nativeControllerCount;
   final int Function() _queueDepth;
+  final int Function() _imageCacheBytes;
+  final int Function() _imageCacheLiveCount;
   final void Function(MemorySnapshot) _emit;
 
   /// How often [start] samples the gauges.
@@ -78,19 +97,30 @@ class MemoryTelemetryService {
   /// The peak is the OS high-water mark, floored by the highest sampled RSS
   /// so a platform without an OS gauge still reports something monotonic.
   void sampleOnce() {
-    final rss = _readRssBytes();
+    final rss = _readGauge(_readRssBytes);
     _peakRssBytes = math.max(
       math.max(_peakRssBytes, rss),
-      _readPeakRssBytes(),
+      _readGauge(_readPeakRssBytes),
     );
     _emit(
       MemorySnapshot(
         rssBytes: rss,
         peakRssBytes: _peakRssBytes,
-        nativeControllers: _nativeControllerCount(),
-        queueDepth: _queueDepth(),
+        nativeControllers: _readGauge(_nativeControllerCount),
+        queueDepth: _readGauge(_queueDepth),
+        imageCacheBytes: _readGauge(_imageCacheBytes),
+        imageCacheLiveCount: _readGauge(_imageCacheLiveCount),
       ),
     );
+  }
+
+  static int _readGauge(int Function() read) {
+    try {
+      final value = read();
+      return value < 0 ? 0 : value;
+    } on Object catch (_) {
+      return 0;
+    }
   }
 
   /// Begins periodic sampling on [interval]. Safe to call after [stop].

--- a/mobile/test/services/memory_pressure_handler_test.dart
+++ b/mobile/test/services/memory_pressure_handler_test.dart
@@ -1,24 +1,46 @@
-// ABOUTME: Tests MemoryPressureHandler fans out to both load-shedding callbacks
-// ABOUTME: Injects spies and asserts image-cache clear + ingestion shed both fire
+// ABOUTME: Tests MemoryPressureHandler observation and load-shedding order
+// ABOUTME: Verifies telemetry failures cannot prevent either shedding action
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/memory_pressure_handler.dart';
 
 void main() {
   group(MemoryPressureHandler, () {
-    test('onMemoryPressure invokes both shedding callbacks once', () {
-      var clearImageCacheCalls = 0;
-      var shedIngestionCalls = 0;
+    test('observes each event before shedding memory', () {
+      final calls = <String>[];
 
       final handler = MemoryPressureHandler(
-        clearImageCache: () => clearImageCacheCalls++,
-        shedIngestion: () => shedIngestionCalls++,
+        onPressureObserved: (count) => calls.add('observe:$count'),
+        clearImageCache: () => calls.add('clear'),
+        shedIngestion: () => calls.add('shed'),
       );
 
-      handler.onMemoryPressure();
+      handler
+        ..onMemoryPressure()
+        ..onMemoryPressure();
 
-      expect(clearImageCacheCalls, equals(1));
-      expect(shedIngestionCalls, equals(1));
+      expect(calls, [
+        'observe:1',
+        'clear',
+        'shed',
+        'observe:2',
+        'clear',
+        'shed',
+      ]);
+    });
+
+    test('still sheds memory when observation fails', () {
+      var clearedImageCache = false;
+      var shedIngestion = false;
+      final handler = MemoryPressureHandler(
+        onPressureObserved: (_) => throw StateError('telemetry unavailable'),
+        clearImageCache: () => clearedImageCache = true,
+        shedIngestion: () => shedIngestion = true,
+      );
+
+      expect(handler.onMemoryPressure, throwsStateError);
+      expect(clearedImageCache, isTrue);
+      expect(shedIngestion, isTrue);
     });
   });
 }

--- a/mobile/test/services/memory_telemetry_service_test.dart
+++ b/mobile/test/services/memory_telemetry_service_test.dart
@@ -18,6 +18,8 @@ void main() {
       int Function() readPeakRssBytes = _zero,
       int Function() nativeControllerCount = _zero,
       int Function() queueDepth = _zero,
+      int Function() imageCacheBytes = _zero,
+      int Function() imageCacheLiveCount = _zero,
       Duration interval = const Duration(seconds: 30),
     }) {
       return MemoryTelemetryService(
@@ -25,6 +27,8 @@ void main() {
         readPeakRssBytes: readPeakRssBytes,
         nativeControllerCount: nativeControllerCount,
         queueDepth: queueDepth,
+        imageCacheBytes: imageCacheBytes,
+        imageCacheLiveCount: imageCacheLiveCount,
         emit: emitted.add,
         interval: interval,
       );
@@ -101,11 +105,13 @@ void main() {
       expect(emitted.map((s) => s.peakRssBytes), equals([100, 900, 900]));
     });
 
-    test('snapshot carries the injected controller and queue gauges', () {
+    test('snapshot carries every injected memory gauge', () {
       final service = build(
         readRssBytes: () => 4242,
         nativeControllerCount: () => 3,
         queueDepth: () => 7,
+        imageCacheBytes: () => 8,
+        imageCacheLiveCount: () => 9,
       );
 
       service.sampleOnce();
@@ -116,6 +122,32 @@ void main() {
       expect(snapshot.peakRssBytes, equals(4242));
       expect(snapshot.nativeControllers, equals(3));
       expect(snapshot.queueDepth, equals(7));
+      expect(snapshot.imageCacheBytes, equals(8));
+      expect(snapshot.imageCacheLiveCount, equals(9));
+    });
+
+    test('failed or negative gauges are reported as zero', () {
+      final service = build(
+        readRssBytes: () => throw StateError('rss unavailable'),
+        readPeakRssBytes: () => -1,
+        nativeControllerCount: () => -2,
+        queueDepth: () => throw StateError('queue unavailable'),
+        imageCacheBytes: () => throw StateError('cache unavailable'),
+        imageCacheLiveCount: () => -3,
+      );
+
+      service
+        ..sampleOnce()
+        ..sampleOnce();
+
+      expect(emitted, hasLength(2));
+      final snapshot = emitted.last;
+      expect(snapshot.rssBytes, isZero);
+      expect(snapshot.peakRssBytes, isZero);
+      expect(snapshot.nativeControllers, isZero);
+      expect(snapshot.queueDepth, isZero);
+      expect(snapshot.imageCacheBytes, isZero);
+      expect(snapshot.imageCacheLiveCount, isZero);
     });
 
     test('start samples periodically on the interval', () {

--- a/mobile/test/services/memory_telemetry_service_test.dart
+++ b/mobile/test/services/memory_telemetry_service_test.dart
@@ -1,8 +1,13 @@
 // ABOUTME: Tests MemoryTelemetryService RSS/peak sampling and snapshot assembly
 // ABOUTME: Drives sampleOnce() with injected gauges and asserts the emitted data
 
+import 'dart:ui' as ui;
+
 import 'package:fake_async/fake_async.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/app/divine_app.dart';
 import 'package:openvine/services/memory_telemetry_service.dart';
 
 void main() {
@@ -126,7 +131,7 @@ void main() {
       expect(snapshot.imageCacheLiveCount, equals(9));
     });
 
-    test('failed or negative gauges are reported as zero', () {
+    test('failed cache gauges stay distinguishable from an empty cache', () {
       final service = build(
         readRssBytes: () => throw StateError('rss unavailable'),
         readPeakRssBytes: () => -1,
@@ -146,8 +151,55 @@ void main() {
       expect(snapshot.peakRssBytes, isZero);
       expect(snapshot.nativeControllers, isZero);
       expect(snapshot.queueDepth, isZero);
-      expect(snapshot.imageCacheBytes, isZero);
-      expect(snapshot.imageCacheLiveCount, isZero);
+      expect(snapshot.imageCacheBytes, MemorySnapshot.unavailableGauge);
+      expect(snapshot.peakImageCacheBytes, MemorySnapshot.unavailableGauge);
+      expect(snapshot.imageCacheLiveCount, MemorySnapshot.unavailableGauge);
+    });
+
+    testWidgets('image cache peak survives Flutter memory-pressure clearing', (
+      tester,
+    ) async {
+      final cache = PaintingBinding.instance.imageCache;
+      addTearDown(() {
+        cache
+          ..clear()
+          ..clearLiveImages();
+      });
+      final recorder = ui.PictureRecorder();
+      final canvas = ui.Canvas(recorder);
+      canvas.drawPaint(ui.Paint()..color = const ui.Color(0xFFFFFFFF));
+      final image = await recorder.endRecording().toImage(4, 4);
+      cache.putIfAbsent(
+        'memory-telemetry-test',
+        () => OneFrameImageStreamCompleter(
+          Future<ImageInfo>.value(ImageInfo(image: image)),
+        ),
+      );
+      await tester.idle();
+      final populatedBytes = cache.currentSizeBytes;
+      expect(populatedBytes, greaterThan(0));
+
+      final service = createAppMemoryTelemetryService(
+        readRssBytes: _zero,
+        readPeakRssBytes: _zero,
+        nativeControllerCount: _zero,
+        queueDepth: _zero,
+        emit: emitted.add,
+      )..sampleOnce();
+      final message = const JSONMessageCodec().encodeMessage(
+        <String, dynamic>{'type': 'memoryPressure'},
+      );
+      await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+        SystemChannels.system.name,
+        message,
+        (_) {},
+      );
+      expect(cache.currentSizeBytes, isZero);
+
+      service.sampleOnce();
+
+      expect(emitted.last.imageCacheBytes, isZero);
+      expect(emitted.last.peakImageCacheBytes, populatedBytes);
     });
 
     test('start samples periodically on the interval', () {


### PR DESCRIPTION
## Description

Android bitmap allocation failures remain visible as non-fatals, but those reports cannot show whether Flutter's decoded-image cache had been heavily occupied or whether Android had already signaled memory pressure. This adds current cache occupancy to periodic logs, a process-lifetime sampled cache high-water mark to logs and Crashlytics, live-image count, and a pressure-event counter.

Flutter clears keep-alive images before notifying application observers, so the pressure callback cannot honestly capture instantaneous pre-signal occupancy. The high-water mark preserves the last meaningful maximum across that framework clear. Cache gauge failures are isolated from load shedding and reported as unavailable rather than being conflated with an empty cache.

**Related Issue:** Relates to #8484

## Out of Scope

This does not change the 256 MB image-cache budget, Android device-tier classification, image decode sizing, or the issue's done criteria. #8484 stays open for field correlation, low-memory-device profiling, and the eventual budget decision.

## Verification

- `flutter test test/services/memory_telemetry_service_test.dart test/services/memory_pressure_handler_test.dart`
- `flutter analyze lib/app/divine_app.dart lib/services/memory_pressure_handler.dart lib/services/memory_telemetry_service.dart test/services/memory_pressure_handler_test.dart test/services/memory_telemetry_service_test.dart`
- Widget regression test primes the production Flutter image-cache wiring, dispatches a real `flutter/system` memory-pressure message, observes Flutter clear the instantaneous cache, and verifies the sampled peak survives
- `bash scripts/check_raw_logging.sh`
- `bash scripts/check_empty_catch_ceiling.sh`
- `bash scripts/check_service_sentinel_ceiling.sh`
- `bash scripts/check_nostr_id_log_truncation.sh`
- `bash scripts/check_pubkey_log_encoding.sh`
- pre-push changed-file analysis and tests

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
