### PR TITLE
fix(dm): hide player replies in closed and blocked conversations

### DIFF
--- a/mobile/integration_test/e2e/reel_reply_retry_double_send_test.dart
+++ b/mobile/integration_test/e2e/reel_reply_retry_double_send_test.dart
@@ -28,9 +28,11 @@ import 'package:nostr_sdk/signer/local_nostr_signer.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/screens/feed/dm_reply_context.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/widgets/video_feed_item/reel_dm_reply_bar.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../helpers/fake_relay.dart';
@@ -128,7 +130,7 @@ void main() {
     return (repository: repository, db: db, nostr: nostr);
   }
 
-  Widget wrap(DmRepository repository) {
+  Widget wrap(DmRepository repository, SharedPreferences preferences) {
     final reactionsRepo = _MockDmReactionsRepository();
     final auth = _MockAuthService();
     final analytics = _MockScreenAnalyticsService();
@@ -151,6 +153,7 @@ void main() {
         dmReactionsRepositoryProvider.overrideWithValue(reactionsRepo),
         authServiceProvider.overrideWithValue(auth),
         screenAnalyticsServiceProvider.overrideWithValue(analytics),
+        sharedPreferencesProvider.overrideWithValue(preferences),
       ],
       child: MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -177,8 +180,10 @@ void main() {
         final relay = await FakeRelay.start(okConfirms: false);
         addTearDown(relay.stop);
         final stack = await buildStack(relay);
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        final preferences = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(wrap(stack.repository));
+        await tester.pumpWidget(wrap(stack.repository, preferences));
         await tester.pump();
 
         final l10n = lookupAppLocalizations(const Locale('en'));

--- a/mobile/lib/blocs/dm/dm_thread_writability.dart
+++ b/mobile/lib/blocs/dm/dm_thread_writability.dart
@@ -1,0 +1,28 @@
+// ABOUTME: Shared policy for whether a DM thread may expose write affordances.
+// ABOUTME: Keeps conversation and detached player surfaces on the same gate.
+
+import 'package:openvine/config/official_accounts.dart';
+
+/// Why a DM thread is writable or read-only for the current account.
+enum DmThreadWritability { writable, closedRetired, blockedByUs }
+
+/// Resolves the write state shared by every DM surface.
+///
+/// Retired moderation threads are one-to-one today, but checking every peer
+/// keeps a rotated key read-only if an old route reconstructs it as a group.
+/// Blocking deliberately follows the conversation's existing rule: the route
+/// identifies its target with the first participant. Changing group semantics
+/// is a separate product decision.
+DmThreadWritability resolveDmThreadWritability({
+  required List<String> participantPubkeys,
+  required bool Function(String pubkey) isBlockedByUs,
+}) {
+  if (participantPubkeys.any(isRetiredModerationAccount)) {
+    return DmThreadWritability.closedRetired;
+  }
+  if (participantPubkeys.isNotEmpty &&
+      isBlockedByUs(participantPubkeys.first)) {
+    return DmThreadWritability.blockedByUs;
+  }
+  return DmThreadWritability.writable;
+}

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -13,6 +13,7 @@ import 'package:follow_repository/follow_repository.dart'
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
+import 'package:openvine/blocs/dm/dm_thread_writability.dart';
 import 'package:openvine/blocs/dm/reactions/conversation_reactions_cubit.dart';
 import 'package:openvine/blocs/dm/restore_status/dm_restore_status_cubit.dart';
 import 'package:openvine/blocs/dm/shared_video_save/shared_video_save_cubit.dart';
@@ -233,11 +234,15 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
     // would undo the block the viewer deliberately set. Rebuilds off the
     // `blocklistVersionProvider` watch above, so unblocking from the kebab
     // brings the composer straight back.
-    final isBlockedByUs = blocklistRepository.isBlocked(_otherPubkey);
-
     // Resolve other participant's profile for the app bar + empty state
     final otherPubkey = _otherPubkey;
-    final isRetiredModerationThread = isRetiredModerationAccount(otherPubkey);
+    final threadWritability = resolveDmThreadWritability(
+      participantPubkeys: widget.participantPubkeys,
+      isBlockedByUs: blocklistRepository.isBlocked,
+    );
+    final isBlockedByUs = threadWritability == DmThreadWritability.blockedByUs;
+    final isRetiredModerationThread =
+        threadWritability == DmThreadWritability.closedRetired;
     final profileAsync = ref.watch(fetchUserProfileProvider(otherPubkey));
     final profile = profileAsync.asData?.value;
     final isResolving = ref.watch(

--- a/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
@@ -13,6 +13,8 @@ import 'package:flutter/semantics.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:models/models.dart' show DmReactionPublishStatus;
+import 'package:openvine/blocs/dm/dm_thread_writability.dart';
 import 'package:openvine/blocs/dm/inline_reel_reply/inline_reel_reply_cubit.dart';
 import 'package:openvine/blocs/dm/reactions/conversation_reactions_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
@@ -48,6 +50,16 @@ class ReelDmReplyBarHost extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(blocklistVersionProvider);
+    final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
+    final writability = resolveDmThreadWritability(
+      participantPubkeys: dmReplyContext.participantPubkeys,
+      isBlockedByUs: blocklistRepository.isBlocked,
+    );
+    if (writability != DmThreadWritability.writable) {
+      return const SizedBox.shrink();
+    }
+
     final dmRepository = ref.watch(dmRepositoryProvider);
     final reactionsRepository = ref.watch(dmReactionsRepositoryProvider);
     final ownerPubkey =
@@ -269,15 +281,18 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
     );
     final localStatus = state.pending[key];
     final persisted = state.reactionsByMessageId[_ctx.sharedReelMessageId]
-        ?.firstWhereOrNull((r) => r.reactorPubkey == widget.ownerPubkey)
-        ?.emoji;
+        ?.firstWhereOrNull((r) => r.reactorPubkey == widget.ownerPubkey);
 
     if (localStatus == ReactionPublishLocalStatus.failed) {
+      _announce(context.l10n.dmReelReplyFailed);
       setState(() {
         _optimisticEmoji = null;
         _lastDispatchedEmoji = null;
       });
-    } else if (persisted != null) {
+    } else if (persisted?.emoji == emoji &&
+        (persisted?.publishStatus == DmReactionPublishStatus.sent ||
+            persisted?.publishStatus == DmReactionPublishStatus.received)) {
+      _announce(context.l10n.dmReelReactionSentAnnouncement(emoji));
       setState(() => _optimisticEmoji = null);
     }
   }
@@ -307,11 +322,6 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
     if (!MediaQuery.of(context).disableAnimations) {
       widget.onReaction?.call(emoji);
     }
-    SemanticsService.sendAnnouncement(
-      View.of(context),
-      context.l10n.dmReelReactionSentAnnouncement(emoji),
-      Directionality.of(context),
-    );
     widget.screenAnalytics.trackInteraction(
       ReelReplyConstants.analyticsScreen,
       'dm_reel_emoji_sent',

--- a/mobile/test/blocs/dm/dm_thread_writability_test.dart
+++ b/mobile/test/blocs/dm/dm_thread_writability_test.dart
@@ -16,25 +16,27 @@ void main() {
         isBlockedByUs: (pubkey) => pubkey == blockedPeer,
       );
 
-  test('ordinary thread is writable', () {
-    expect(resolve([ordinaryPeer]), DmThreadWritability.writable);
-  });
+  group('resolveDmThreadWritability', () {
+    test('ordinary thread is writable', () {
+      expect(resolve([ordinaryPeer]), DmThreadWritability.writable);
+    });
 
-  test('thread containing a retired moderation peer is closed', () {
-    expect(
-      resolve([ordinaryPeer, kLegacyModerationPubkeys.first]),
-      DmThreadWritability.closedRetired,
-    );
-  });
+    test('thread containing a retired moderation peer is closed', () {
+      expect(
+        resolve([ordinaryPeer, kLegacyModerationPubkeys.first]),
+        DmThreadWritability.closedRetired,
+      );
+    });
 
-  test('blocked first participant makes the thread read-only', () {
-    expect(resolve([blockedPeer]), DmThreadWritability.blockedByUs);
-  });
+    test('blocked first participant makes the thread read-only', () {
+      expect(resolve([blockedPeer]), DmThreadWritability.blockedByUs);
+    });
 
-  test('group block behavior follows the first route participant', () {
-    expect(
-      resolve([ordinaryPeer, blockedPeer]),
-      DmThreadWritability.writable,
-    );
+    test('group block behavior follows the first route participant', () {
+      expect(
+        resolve([ordinaryPeer, blockedPeer]),
+        DmThreadWritability.writable,
+      );
+    });
   });
 }

--- a/mobile/test/blocs/dm/dm_thread_writability_test.dart
+++ b/mobile/test/blocs/dm/dm_thread_writability_test.dart
@@ -1,0 +1,40 @@
+// ABOUTME: Tests the shared write gate used by DM conversation/player UI.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/dm/dm_thread_writability.dart';
+import 'package:openvine/config/official_accounts.dart';
+
+void main() {
+  const ordinaryPeer =
+      '2222222222222222222222222222222222222222222222222222222222222222';
+  const blockedPeer =
+      '3333333333333333333333333333333333333333333333333333333333333333';
+
+  DmThreadWritability resolve(List<String> participants) =>
+      resolveDmThreadWritability(
+        participantPubkeys: participants,
+        isBlockedByUs: (pubkey) => pubkey == blockedPeer,
+      );
+
+  test('ordinary thread is writable', () {
+    expect(resolve([ordinaryPeer]), DmThreadWritability.writable);
+  });
+
+  test('thread containing a retired moderation peer is closed', () {
+    expect(
+      resolve([ordinaryPeer, kLegacyModerationPubkeys.first]),
+      DmThreadWritability.closedRetired,
+    );
+  });
+
+  test('blocked first participant makes the thread read-only', () {
+    expect(resolve([blockedPeer]), DmThreadWritability.blockedByUs);
+  });
+
+  test('group block behavior follows the first route participant', () {
+    expect(
+      resolve([ordinaryPeer, blockedPeer]),
+      DmThreadWritability.writable,
+    );
+  });
+}

--- a/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
@@ -2,13 +2,16 @@
 
 import 'dart:async';
 
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/dm_reply_context.dart';
@@ -22,6 +25,9 @@ class _MockDmReactionsRepository extends Mock
     implements DmReactionsRepository {}
 
 class _MockAuthService extends Mock implements AuthService {}
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
 
 const _owner =
     '1111111111111111111111111111111111111111111111111111111111111111';
@@ -41,19 +47,44 @@ DmReplyContext context({bool isOwn = false, String hintName = 'Alice'}) =>
       isOwnMessage: isOwn,
     );
 
+List<String> captureAnnouncements(WidgetTester tester) {
+  final announcements = <String>[];
+  tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(
+    SystemChannels.accessibility,
+    (message) async {
+      if (message is Map && message['type'] == 'announce') {
+        final data = message['data'];
+        if (data is Map) announcements.add('${data['message']}');
+      }
+      return null;
+    },
+  );
+  addTearDown(
+    () => tester.binding.defaultBinaryMessenger
+        .setMockDecodedMessageHandler<Object?>(
+          SystemChannels.accessibility,
+          null,
+        ),
+  );
+  return announcements;
+}
+
 void main() {
   late _MockDmRepository dmRepo;
   late _MockDmReactionsRepository reactionsRepo;
   late _MockAuthService auth;
+  late _MockContentBlocklistRepository blocklist;
   late StreamController<List<DmReaction>> reactionStream;
 
   setUp(() {
     dmRepo = _MockDmRepository();
     reactionsRepo = _MockDmReactionsRepository();
     auth = _MockAuthService();
+    blocklist = _MockContentBlocklistRepository();
     reactionStream = StreamController<List<DmReaction>>.broadcast();
 
     when(() => auth.currentPublicKeyHex).thenReturn(_owner);
+    when(() => blocklist.isBlocked(any())).thenReturn(false);
     when(
       () => reactionsRepo.watchForConversation(any()),
     ).thenAnswer((_) => reactionStream.stream);
@@ -76,6 +107,7 @@ void main() {
       dmRepositoryProvider.overrideWithValue(dmRepo),
       dmReactionsRepositoryProvider.overrideWithValue(reactionsRepo),
       authServiceProvider.overrideWithValue(auth),
+      contentBlocklistRepositoryProvider.overrideWithValue(blocklist),
     ],
     child: MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -105,6 +137,7 @@ void main() {
           dmRepositoryProvider.overrideWithValue(dmRepo),
           dmReactionsRepositoryProvider.overrideWithValue(reactionsRepo),
           authServiceProvider.overrideWithValue(auth),
+          contentBlocklistRepositoryProvider.overrideWithValue(blocklist),
         ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -126,6 +159,55 @@ void main() {
       );
 
   group('renders', () {
+    testWidgets('does not render for a retired moderation thread', (
+      tester,
+    ) async {
+      final retiredContext = DmReplyContext(
+        conversationId: 'retired-convo',
+        participantPubkeys: [kLegacyModerationPubkeys.first],
+        isGroup: false,
+        sharedReelMessageId: _reelId,
+        messageAuthorPubkey: kLegacyModerationPubkeys.first,
+        hintName: 'Divine Moderation',
+        isOwnMessage: false,
+      );
+
+      await tester.pumpWidget(wrap(retiredContext));
+      await tester.pump();
+
+      expect(find.byType(TextField), findsNothing);
+      expect(find.text('❤️'), findsNothing);
+    });
+
+    testWidgets('does not render for a blocked thread', (tester) async {
+      when(() => blocklist.isBlocked(_peer)).thenReturn(true);
+
+      await tester.pumpWidget(wrap(context()));
+      await tester.pump();
+
+      expect(find.byType(TextField), findsNothing);
+      expect(find.text('❤️'), findsNothing);
+    });
+
+    testWidgets('returns when the peer is unblocked while the player is open', (
+      tester,
+    ) async {
+      when(() => blocklist.isBlocked(_peer)).thenReturn(true);
+      await tester.pumpWidget(wrap(context()));
+      await tester.pump();
+      expect(find.byType(TextField), findsNothing);
+
+      when(() => blocklist.isBlocked(_peer)).thenReturn(false);
+      final providerContainer = ProviderScope.containerOf(
+        tester.element(find.byType(Scaffold)),
+      );
+      providerContainer.read(blocklistVersionProvider.notifier).increment();
+      await tester.pump();
+
+      expect(find.byType(TextField), findsOneWidget);
+      expect(find.text('❤️'), findsOneWidget);
+    });
+
     testWidgets('renders composer + the 6 quick emojis + picker button', (
       tester,
     ) async {
@@ -173,6 +255,93 @@ void main() {
   });
 
   group('interactions', () {
+    testWidgets('announces a reaction only after it persists', (tester) async {
+      final announcements = captureAnnouncements(tester);
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await tester.pumpWidget(wrap(context()));
+      await tester.pump();
+
+      await tester.tap(find.text('❤️'));
+      await tester.pump();
+
+      expect(
+        announcements,
+        isNot(contains(l10n.dmReelReactionSentAnnouncement('❤️'))),
+      );
+
+      reactionStream.add([
+        const DmReaction(
+          id: 'pending-reaction',
+          conversationId: 'convo-id',
+          targetMessageId: _reelId,
+          targetMessageAuthor: _peer,
+          reactorPubkey: _owner,
+          emoji: '❤️',
+          createdAt: 1700000000,
+          ownerPubkey: _owner,
+          publishStatus: DmReactionPublishStatus.pending,
+        ),
+      ]);
+      await tester.pump();
+
+      expect(
+        announcements,
+        isNot(contains(l10n.dmReelReactionSentAnnouncement('❤️'))),
+      );
+
+      reactionStream.add([
+        const DmReaction(
+          id: 'persisted-reaction',
+          conversationId: 'convo-id',
+          targetMessageId: _reelId,
+          targetMessageAuthor: _peer,
+          reactorPubkey: _owner,
+          emoji: '❤️',
+          createdAt: 1700000000,
+          ownerPubkey: _owner,
+          publishStatus: DmReactionPublishStatus.sent,
+        ),
+      ]);
+      await tester.pump();
+
+      expect(
+        announcements,
+        contains(l10n.dmReelReactionSentAnnouncement('❤️')),
+      );
+    });
+
+    testWidgets('announces a failed reaction without claiming success', (
+      tester,
+    ) async {
+      when(
+        () => reactionsRepo.publish(
+          conversationId: any(named: 'conversationId'),
+          targetMessageId: any(named: 'targetMessageId'),
+          targetMessageAuthor: any(named: 'targetMessageAuthor'),
+          emoji: any(named: 'emoji'),
+        ),
+      ).thenAnswer(
+        (_) async => const DmReactionPublishResult(
+          success: false,
+          rumorId: 'failed-rumor',
+        ),
+      );
+      final announcements = captureAnnouncements(tester);
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await tester.pumpWidget(wrap(context()));
+      await tester.pump();
+
+      await tester.tap(find.text('❤️'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(announcements, contains(l10n.dmReelReplyFailed));
+      expect(
+        announcements,
+        isNot(contains(l10n.dmReelReactionSentAnnouncement('❤️'))),
+      );
+    });
+
     testWidgets('tapping a quick emoji publishes a reaction on the reel', (
       tester,
     ) async {
@@ -204,6 +373,7 @@ void main() {
             dmRepositoryProvider.overrideWithValue(dmRepo),
             dmReactionsRepositoryProvider.overrideWithValue(reactionsRepo),
             authServiceProvider.overrideWithValue(auth),
+            contentBlocklistRepositoryProvider.overrideWithValue(blocklist),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -417,6 +587,7 @@ void main() {
             dmRepositoryProvider.overrideWithValue(dmRepo),
             dmReactionsRepositoryProvider.overrideWithValue(reactionsRepo),
             authServiceProvider.overrideWithValue(auth),
+            contentBlocklistRepositoryProvider.overrideWithValue(blocklist),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -454,6 +625,7 @@ void main() {
             dmRepositoryProvider.overrideWithValue(dmRepo),
             dmReactionsRepositoryProvider.overrideWithValue(reactionsRepo),
             authServiceProvider.overrideWithValue(auth),
+            contentBlocklistRepositoryProvider.overrideWithValue(blocklist),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -915,6 +1087,7 @@ void main() {
             dmRepositoryProvider.overrideWithValue(dmRepo),
             dmReactionsRepositoryProvider.overrideWithValue(reactionsRepo),
             authServiceProvider.overrideWithValue(auth),
+            contentBlocklistRepositoryProvider.overrideWithValue(blocklist),
           ],
           child: MaterialApp.router(
             localizationsDelegates: AppLocalizations.localizationsDelegates,


### PR DESCRIPTION
## Problem

Opening a shared reel from a retired moderation conversation or a conversation the viewer blocked still mounted the in-player reply composer. Retired-thread sends were refused downstream, blocked-thread reactions could still publish, and the reaction accessibility announcement claimed success as soon as the send was dispatched.

## Why this fix

- Centralizes DM thread writability in one pure helper used by both the conversation screen and the player reply host.
- Re-evaluates the player gate whenever the blocklist version changes, so unblocking while the player is open restores the composer.
- Treats any retired moderation participant as closed while deliberately preserving the conversation screen's existing first-participant block semantics.
- Announces reaction success only after the matching local reaction reaches `sent` or `received`, and announces the existing localized failure copy when publication fails.
- Adds regression coverage for retired, blocked, live-unblock, pending, success, and failure states.

## Deliberately unchanged

This does not widen `DmSendPolicy` or add repository-level blocklist enforcement. That policy also governs wrapped kind-5 retractions, which must remain publishable to a blocked recipient, so changing its contract needs separate product and architectural scope. Group-thread blocking also continues to follow the conversation screen's existing first-participant behavior rather than changing that behavior inside this fix.

## Verification

- Red/green regression check: blocked composer and premature success-announcement tests fail when the old behavior is restored, then pass with this fix.
- `flutter test test/blocs/dm/dm_thread_writability_test.dart test/widgets/video_feed_item/reel_dm_reply_bar_test.dart test/screens/inbox/conversation/conversation_view_test.dart test/l10n/arb_consistency_test.dart` — 124 passed after rebasing onto current `main`.
- `flutter analyze` — no issues after rebasing onto current `main`.

Fixes #8518
