### PR TITLE
fix(testing): stop conversation-list tests failing on slow runners

### DIFF
--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -529,24 +529,25 @@ void main() {
           )..add(const ConversationListStarted());
           addTearDown(bloc.close);
 
-          final states = <ConversationListState>[];
-          final sub = bloc.stream.listen(states.add);
-          addTearDown(sub.cancel);
-
+          final visible = bloc.stream.firstWhere(
+            (state) => state.status == ConversationListStatus.loaded,
+          );
           acceptedController.add([conv]);
-          await Future<void>.delayed(const Duration(milliseconds: 50));
+          final visibleState = await visible;
           expect(
-            states.last.conversations.map((c) => c.id).toList(),
+            visibleState.conversations.map((c) => c.id).toList(),
             ['c'],
             reason: 'approved counterparty is visible before revocation',
           );
 
           // A revocation fires the gate's changes stream; the list must re-filter
           // and drop the now-unapproved counterparty without any new DAO write.
+          final revoked = bloc.stream.firstWhere(
+            (state) => state.conversations.isEmpty,
+          );
           gate.revoke(_testPubkey2);
-          await Future<void>.delayed(const Duration(milliseconds: 50));
           expect(
-            states.last.conversations,
+            (await revoked).conversations,
             isEmpty,
             reason: 'a verdict flip re-filters the list without a DAO write',
           );
@@ -3307,6 +3308,9 @@ void main() {
         bloc.add(const ConversationListSearchQueryChanged('alice'));
         await bloc.stream.firstWhere((s) => s.searchQuery == 'alice');
 
+        final pendingQueryApplied = bloc.stream.firstWhere(
+          (state) => state.searchQuery == 'alice w',
+        );
         bloc.add(const ConversationListSearchQueryChanged('alice w'));
         acceptedController.add([
           _createConversation(id: 'pizza', lastMessageContent: 'pizza friday?'),
@@ -3317,7 +3321,7 @@ void main() {
           ),
         ]);
 
-        await Future<void>.delayed(const Duration(milliseconds: 350));
+        await pendingQueryApplied;
 
         expect(
           bloc.state.searchQuery,
@@ -3379,6 +3383,9 @@ void main() {
         await bloc.stream.firstWhere((s) => s.searchQuery == 'alice');
 
         // ...then types one more character; still inside the 300ms debounce.
+        final pendingQueryApplied = bloc.stream.firstWhere(
+          (state) => state.searchQuery == 'alice w',
+        );
         bloc.add(const ConversationListSearchQueryChanged('alice w'));
 
         // Nostr becomes ready and the provider hands over the repository.
@@ -3386,7 +3393,7 @@ void main() {
           ConversationListProfileRepositoryChanged(mockProfileRepository),
         );
 
-        await Future<void>.delayed(const Duration(milliseconds: 350));
+        await pendingQueryApplied;
 
         expect(
           bloc.state.searchQuery,


### PR DESCRIPTION
## Problem

Conversation-list tests could fail on slower CI runners depending on randomized test order. The affected assertions slept for a fixed amount of wall-clock time, so a cold BLoC pipeline could still be loading when the test inspected its latest state.

## Fix

Wait for the specific loaded, revoked, or updated-query state before asserting. Each state future is registered before its triggering event so broadcast emissions cannot be missed. This also removes two adjacent fixed waits around positive search-query transitions.

The single-character debounce test remains time-based because elapsed time is the behavior that negative assertion verifies. This is test-only and does not change application behavior.

## Verification

- `flutter test test/blocs/dm/conversation_list/conversation_list_bloc_test.dart --test-randomize-ordering-seed=725195427`
- `flutter test test/blocs/dm/conversation_list/conversation_list_bloc_test.dart --test-randomize-ordering-seed=1`
- Additional full-file runs with seeds 2 and 3 and two unseeded runs
- `flutter analyze test/blocs/dm/conversation_list/conversation_list_bloc_test.dart`

Closes #8486
