### PR TITLE
fix(testing): stop font loading order from changing layout tests

### DIFF
--- a/mobile/test/flutter_test_config.dart
+++ b/mobile/test/flutter_test_config.dart
@@ -8,6 +8,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:golden_toolkit/golden_toolkit.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:openvine/widgets/avatar_failure_cache.dart';
 
 import 'helpers/background_activity_reset.dart';
@@ -40,6 +41,16 @@ Future<void> testExecutable(FutureOr<void> Function() testMain) async {
     // determine page transitions for every later test in the merged isolate.
     final _ = VineTheme.theme;
     final _ = VineTheme.lightTheme;
+
+    // google_fonts registers bundled faces asynchronously. Preload every
+    // variant used by VineTheme before testMain so the first test selected by
+    // a shard ordering seed measures the same glyphs as later tests (#8485).
+    VineTheme.bodyLargeFont();
+    VineTheme.labelSmallFont();
+    VineTheme.headlineMediumFont();
+    VineTheme.titleLargeFont();
+    VineTheme.codeFont();
+    await GoogleFonts.pendingFonts();
   }
 
   // Under `very_good test --optimization` the whole unit suite runs in one

--- a/mobile/test/flutter_test_config_font_preload_test.dart
+++ b/mobile/test/flutter_test_config_font_preload_test.dart
@@ -1,0 +1,58 @@
+// ABOUTME: Guards the bundled-font preload in flutter_test_config.dart.
+// ABOUTME: Without it, layout assertions silently measure fallback glyphs.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// No asset provides this family, so it measures as the engine fallback —
+/// which is exactly what an un-preloaded bundled face also measures as.
+const _unregisteredFamily = 'DivineNoSuchFontFamily';
+
+const _sample = 'Divine typography metrics 0123456789';
+
+double _widthOf(String? fontFamily) {
+  final painter = TextPainter(
+    text: TextSpan(
+      text: _sample,
+      style: TextStyle(fontSize: 14, fontFamily: fontFamily),
+    ),
+    textDirection: TextDirection.ltr,
+  )..layout();
+  final width = painter.width;
+  painter.dispose();
+  return width;
+}
+
+void main() {
+  group('bundled font preload', () {
+    // google_fonts registers faces asynchronously, so before #8485 whichever
+    // test a shard's ordering seed ran first measured fallback glyphs while
+    // later tests measured the real face. Any face that still measures as the
+    // fallback here means testExecutable stopped awaiting its load.
+    testWidgets('every VineTheme face is registered before the first test', (
+      tester,
+    ) async {
+      final fallbackWidth = _widthOf(_unregisteredFamily);
+
+      final faces = <String, String?>{
+        'Inter w400': VineTheme.bodyMediumFont().fontFamily,
+        'Inter w600': VineTheme.labelLargeFont().fontFamily,
+        'BricolageGrotesque w700': VineTheme.headlineMediumFont().fontFamily,
+        'BricolageGrotesque w800': VineTheme.titleLargeFont().fontFamily,
+        'ChivoMono w300': VineTheme.codeFont().fontFamily,
+      };
+
+      for (final MapEntry(key: face, value: family) in faces.entries) {
+        expect(
+          _widthOf(family),
+          isNot(fallbackWidth),
+          reason:
+              '$face ($family) measured as the fallback font, so the '
+              'preload in flutter_test_config.dart did not await it.',
+        );
+      }
+    }, skip: kIsWeb);
+  });
+}

--- a/mobile/test/screens/auth/email_verification_screen_test.dart
+++ b/mobile/test/screens/auth/email_verification_screen_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:invite_api_client/invite_api_client.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
@@ -41,14 +40,6 @@ class _MockInviteApiClient extends Mock implements InviteApiClient {}
 
 Finder _divineIcon(DivineIconName name) =>
     find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
-
-Future<void> _loadEmailVerificationLayoutFonts(WidgetTester tester) async {
-  // Construct the exact styles before draining them: google_fonts only queues
-  // bundled font I/O when a style is first requested.
-  VineTheme.bodyMediumFont();
-  VineTheme.labelLargeFont();
-  await tester.runAsync(GoogleFonts.pendingFonts);
-}
 
 void main() {
   late _MockEmailVerificationCubit mockCubit;
@@ -1666,7 +1657,6 @@ void main() {
       tester.view.viewInsets = const FakeViewPadding(bottom: keyboardExtent);
       addTearDown(tester.view.reset);
 
-      await _loadEmailVerificationLayoutFonts(tester);
       await tester.pumpWidget(
         createTestWidget(
           deviceCode: 'test-device-code',
@@ -1710,7 +1700,6 @@ void main() {
       tester.view.physicalSize = const Size(360, 560);
       addTearDown(tester.view.reset);
 
-      await _loadEmailVerificationLayoutFonts(tester);
       await tester.pumpWidget(
         MediaQuery(
           data: const MediaQueryData(textScaler: TextScaler.linear(1.6)),
@@ -1744,7 +1733,6 @@ void main() {
       tester.view.physicalSize = const Size(320, 480);
       addTearDown(tester.view.reset);
 
-      await _loadEmailVerificationLayoutFonts(tester);
       await tester.pumpWidget(
         MediaQuery(
           data: const MediaQueryData(textScaler: TextScaler.linear(1.6)),


### PR DESCRIPTION
## Problem

Text-layout tests could pass or fail depending on which test a randomized shard ran first. VineTheme requests its bundled fonts through `google_fonts`, which registers each face asynchronously, so the first layout could measure fallback glyphs while later layouts measured the intended fonts. This caused an unrelated pull request to fail the badge helper-text assertion.

## Fix

Preload and await all five bundled font variants used by VineTheme before any non-web test begins. This gives every test in an optimized merged isolate the same font metrics regardless of ordering. The now-redundant email-verification-specific font drain is removed.

The golden gallery keeps its local drain because individual golden widgets can request variants beyond the five design-system weights. The welcome-screen surface-size safeguard is deliberately unchanged. This is test-only and does not change app behavior.

## Verification

- `very_good test --optimization --concurrency=4 --exclude-tags integration --dart-define=DIVINE_STRICT_CHANNELS=true --dart-define=DIVINE_STRICT_GLOBALS=true --test-randomize-ordering-seed 728049587 test/screens/badges/badge_editor_screen_test.dart test/screens/inbox/widgets/inbox_segmented_toggle_test.dart test/screens/auth/email_verification_screen_test.dart test/screens/welcome_screen_test.dart` (101 passed)
- `flutter analyze lib test integration_test`
- Repository pre-commit and pre-push checks

Closes #8485