### PR TITLE
fix(dm): restrict only confirmed Greenlight accounts

### DIFF
--- a/mobile/lib/config/official_accounts.dart
+++ b/mobile/lib/config/official_accounts.dart
@@ -45,7 +45,7 @@ const OfficialAccount kHqAccount = OfficialAccount(
   pubkeyHex: kHqPubkeyHex,
   nip05: '_@divinehq.divine.video',
   role: OfficialAccountRole.hq,
-  minorContactable: true,
+  minorContactable: false,
 );
 
 /// The current Divine moderation pubkey — the report target, the pinned support

--- a/mobile/lib/providers/official_accounts_providers.dart
+++ b/mobile/lib/providers/official_accounts_providers.dart
@@ -40,14 +40,15 @@ final officialAccountsServiceProvider = Provider<OfficialAccountsService>((
 /// these threads by [ConversationPage]'s route guard, since retired keys are
 /// absent from [kPinnedOfficialAccounts].
 ///
-/// Otherwise, keys off [isDmRestrictedProvider], the fail-closed seam: only a
-/// positive not-protected verdict (trusted live or persisted) is unrestricted;
-/// a restricted user may only send to an account currently approved by
-/// [OfficialAccountsService] (pin ∩ live NIP-05). Reads state at call time
-/// (send-time) so the decision is fresh: a mid-session approval/revocation
-/// takes effect on the next send without rebuilding. An unknown/loading
-/// protected-minor status still denies the send, but marks the denial temporary
-/// so a durable queue row is retained until Keycast provides a trusted verdict.
+/// Otherwise, keys off [isDmRestrictedProvider]: an account is restricted
+/// only when it is confirmed as a protected minor, by a trusted live
+/// protected verdict or the persisted last-known protected value. An account
+/// with no confirmed protected status is not restricted, including while the
+/// status is unknown or loading. A restricted user may only send to an
+/// account currently approved by [OfficialAccountsService] (pin ∩ live
+/// NIP-05). Reads state at call time (send-time) so the decision is fresh: a
+/// mid-session approval or revocation takes effect on the next send without
+/// rebuilding. A send to any other recipient is blocked.
 final dmSendPolicyProvider = Provider<DmSendPolicy>((ref) {
   return (String recipientPubkey) async {
     if (isRetiredModerationAccount(recipientPubkey)) {

--- a/mobile/lib/providers/protected_minor_providers.dart
+++ b/mobile/lib/providers/protected_minor_providers.dart
@@ -146,10 +146,10 @@ final isProtectedMinorProvider = Provider<bool>((ref) {
 /// account. Returns `true` only for OAuth-authenticated accounts and for
 /// accounts that have previously been marked as Keycast-custodial.
 ///
-/// The #176 DM restriction uses this to distinguish accounts that may have
-/// an unknown verdict from Keycast (and must fail closed) from pure
-/// self-custody accounts that Keycast can never produce a verdict for (and
-/// must not be permanently restricted by an unanswerable check).
+/// The #182 key-management restriction uses this to distinguish accounts that
+/// may have an unknown verdict from Keycast (and must fail closed) from pure
+/// self-custody accounts that Keycast can never produce a verdict for (and must
+/// not be permanently restricted by an unanswerable check).
 final keycastSignalApplicableProvider = Provider<bool>((ref) {
   // AuthService mutates its pubkey and auth-source fields in place, so watch
   // the auth state so applicability recomputes across the current account-swap
@@ -161,20 +161,21 @@ final keycastSignalApplicableProvider = Provider<bool>((ref) {
   final authSource = authService.authenticationSource;
   final store = ref.watch(protectedMinorStickyStoreProvider);
 
-  // OAuth accounts can receive a Keycast verdict; fail closed on unknown.
+  // OAuth accounts can receive a Keycast verdict, so key management fails
+  // closed on unknown.
   if (authSource == AuthenticationSource.divineOAuth) {
     return true;
   }
 
-  // Self-custody accounts that were previously seen by Keycast must stay
-  // fail-closed, since a pubkey can flip between auth sources on the same
-  // device.
+  // Key management stays fail-closed for self-custody accounts that were
+  // previously seen by Keycast, since a pubkey can flip between auth sources
+  // on the same device.
   if (pubkey != null && store.wasKeycastAccountFor(pubkey)) {
     return true;
   }
 
   // Keep this exhaustive so every new auth source requires an explicit
-  // fail-direction decision at this child-safety boundary.
+  // key-management fail-direction decision at this child-safety boundary.
   return switch (authSource) {
     AuthenticationSource.divineOAuth => true,
     AuthenticationSource.none ||

--- a/mobile/lib/providers/protected_minor_providers.dart
+++ b/mobile/lib/providers/protected_minor_providers.dart
@@ -186,25 +186,35 @@ final keycastSignalApplicableProvider = Provider<bool>((ref) {
   };
 });
 
-/// The #176 DM-restriction seam — fail CLOSED conditionally, a deliberate
-/// divergence from
-/// [isProtectedMinorProvider] (which #175's content lock consumes fail-open):
-/// the restricted party can trivially suppress the input that produces an
-/// absent answer (airplane mode, cleared storage, blocked keycast domain,
-/// expired token), so "no answer" must restrict rather than lift.
+/// Whether the current account has an affirmative protected-minor designation
+/// and must use the restricted DM experience (#176, #8561).
 ///
-/// Keycast-backed accounts are restricted unless a positive not-protected
-/// verdict exists:
-/// - trusted live `notProtected` -> unrestricted (persisted for cold start);
-/// - persisted last-known `notProtected` -> unrestricted, so adults don't eat
-///   a lockout on every network blip;
-/// - everything else (protected, unknown, loading, missing token, never
-///   resolved, unauthenticated, auth source not yet restored) -> restricted.
+/// Divine treats accounts as 16+ for messaging unless Greenlight has marked
+/// them as protected minors. An unavailable or unresolved Keycast check must
+/// therefore not restrict an account with no prior protected verdict. The
+/// sticky behavior in [isProtectedMinorProvider] still keeps a previously
+/// confirmed protected minor restricted through startup, refreshes, and
+/// outages until a trusted not-protected verdict clears the designation.
+final isDmRestrictedProvider = Provider<bool>(
+  (ref) => ref.watch(isProtectedMinorProvider),
+);
+
+/// Whether the current DM restriction comes from a confirmed protected-minor
+/// verdict. DM restrictions now require that affirmative verdict, so this
+/// named seam remains for policy consumers while sharing the same answer.
+final hasConfirmedDmRestrictionProvider = Provider<bool>(
+  (ref) => ref.watch(isDmRestrictedProvider),
+);
+
+/// The #182 key-management seam — gates nsec export ("copy private key") and
+/// key import/change (swapping the account to a self-held key) for protected
+/// minors.
 ///
-/// Pure self-custody accounts that have never been associated with Keycast
-/// are never restricted — they are outside Keycast's verified-minor signal and
-/// must not be permanently blocked by a check Keycast can never produce.
-final isDmRestrictedProvider = Provider<bool>((ref) {
+/// Key management intentionally retains its fail-closed posture independently
+/// of the DM policy: a protected minor — or any Keycast-backed account whose
+/// status cannot be positively cleared — cannot export or replace its key.
+/// Pure self-custody accounts that Keycast has never known remain unrestricted.
+final isKeyManagementRestrictedProvider = Provider<bool>((ref) {
   final authState = ref.watch(currentAuthStateProvider);
   final authService = ref.watch(authServiceProvider);
   final pubkey = authService.currentPublicKeyHex;
@@ -245,39 +255,3 @@ final isDmRestrictedProvider = Provider<bool>((ref) {
   // Fail closed only when Keycast signals are applicable to this account.
   return keycastApplicable;
 });
-
-/// Whether the current DM restriction comes from a confirmed protected-minor
-/// verdict rather than the fail-closed unknown/loading fallback.
-final hasConfirmedDmRestrictionProvider = Provider<bool>((ref) {
-  final authState = ref.watch(currentAuthStateProvider);
-  final pubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
-  final store = ref.watch(protectedMinorStickyStoreProvider);
-  final live = ref.watch(protectedMinorStatusProvider);
-  final trusted = trustedProtectedMinorStatus(
-    authenticated: authState == AuthState.authenticated,
-    live: live,
-  );
-  if (trusted?.kind == ProtectedMinorStatusKind.protected) return true;
-  if (trusted?.kind == ProtectedMinorStatusKind.notProtected) return false;
-  return store.lastKnownFor(pubkey) == true;
-});
-
-/// The #182 key-management seam — gates nsec export ("copy private key") and
-/// key import/change (swapping the account to a self-held key) for protected
-/// minors.
-///
-/// Deliberately the SAME fail-closed verdict as the #176 DM restriction
-/// ([isDmRestrictedProvider]): a protected minor — or any account whose
-/// protected-minor status can't be positively cleared (unknown, cold start,
-/// suppressed check, missing token) — is restricted. A named passthrough (not
-/// a direct reuse) so the call site documents intent, and the two conditions
-/// can diverge later without touching the screen.
-///
-/// Uses the same signal-applicability boundary as the DM seam: Keycast-backed
-/// accounts fail closed on an absent answer, while pure self-custody accounts
-/// are not restricted by a Keycast verdict that cannot exist for them. This is
-/// why it does NOT reuse the fail-OPEN [isProtectedMinorProvider] that #175's
-/// content lock consumes.
-final isKeyManagementRestrictedProvider = Provider<bool>(
-  (ref) => ref.watch(isDmRestrictedProvider),
-);

--- a/mobile/test/providers/dm_send_policy_test.dart
+++ b/mobile/test/providers/dm_send_policy_test.dart
@@ -23,8 +23,6 @@ class _MockOfficials extends Mock implements OfficialAccountsService {}
 class _MockAuthService extends Mock implements AuthService {}
 
 void main() {
-  const hqHex =
-      'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e';
   const strangerHex =
       'deadbeef00000000000000000000000000000000000000000000000000000000';
 
@@ -123,12 +121,15 @@ void main() {
 
   test('a restricted user may send to an approved official', () async {
     when(
-      () => officials.isApprovedMinorDmRecipient(hqHex),
+      () => officials.isApprovedMinorDmRecipient(kModerationPubkeyHex),
     ).thenAnswer((_) async => true);
     final container = containerWith(isRestricted: true);
     final policy = container.read(dmSendPolicyProvider);
 
-    expect(await policy(hqHex), DmSendPolicyDecision.allowed);
+    expect(
+      await policy(kModerationPubkeyHex),
+      DmSendPolicyDecision.allowed,
+    );
   });
 
   test('a restricted user may not send to a non-approved recipient', () async {
@@ -142,13 +143,8 @@ void main() {
   });
 
   test(
-    'fail-closed: unresolved status with no persisted verdict denies a '
-    'stranger (never unrestricted before a trusted not-protected answer)',
+    'an unresolved status without a Greenlight designation allows DMs',
     () async {
-      // The exact hole from review: while Keycast is loading / unknown /
-      // token-missing AND the sticky store has never seen this account, the
-      // policy must restrict — not fall through to unrestricted. Spec
-      // "Fail-safe posture": only a positive not-protected signal lifts.
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
       final authService = _MockAuthService();
@@ -156,20 +152,12 @@ void main() {
       when(
         () => authService.authenticationSource,
       ).thenReturn(AuthenticationSource.divineOAuth);
-      when(
-        () => officials.isApprovedMinorDmRecipient(strangerHex),
-      ).thenAnswer((_) async => false);
-      when(
-        () => officials.isApprovedMinorDmRecipient(hqHex),
-      ).thenAnswer((_) async => true);
-
       final container = ProviderContainer(
         overrides: [
           currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
           sharedPreferencesProvider.overrideWithValue(prefs),
           authServiceProvider.overrideWithValue(authService),
-          // Keycast never answers (outage / suppressed by the restricted party).
-          // Keycast accounts must not wait on this to fail closed.
+          // Keycast never answers (startup, outage, or missing token).
           protectedMinorStatusProvider.overrideWith(
             (ref) => Completer<ProtectedMinorStatus>().future,
           ),
@@ -181,19 +169,15 @@ void main() {
 
       expect(
         await policy(strangerHex),
-        DmSendPolicyDecision.temporarilyBlocked,
-        reason: 'unresolved + never-seen must restrict (fail closed)',
-      );
-      expect(
-        await policy(hqHex),
         DmSendPolicyDecision.allowed,
-        reason: 'a pinned approved official stays reachable while restricted',
+        reason: 'no affirmative Greenlight designation exists',
       );
+      verifyNever(() => officials.isApprovedMinorDmRecipient(any()));
     },
   );
 
   test(
-    'unresolved fail-closed denial is temporary, not a terminal policy block',
+    'unknown status does not manufacture a temporary policy block',
     () async {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
@@ -202,10 +186,6 @@ void main() {
       when(
         () => authService.authenticationSource,
       ).thenReturn(AuthenticationSource.divineOAuth);
-      when(
-        () => officials.isApprovedMinorDmRecipient(strangerHex),
-      ).thenAnswer((_) async => false);
-
       final container = ProviderContainer(
         overrides: [
           currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
@@ -221,7 +201,8 @@ void main() {
 
       final decision = await container.read(dmSendPolicyProvider)(strangerHex);
 
-      expect(decision, DmSendPolicyDecision.temporarilyBlocked);
+      expect(decision, DmSendPolicyDecision.allowed);
+      verifyNever(() => officials.isApprovedMinorDmRecipient(any()));
     },
   );
 }

--- a/mobile/test/providers/is_dm_restricted_provider_test.dart
+++ b/mobile/test/providers/is_dm_restricted_provider_test.dart
@@ -1,6 +1,5 @@
-// ABOUTME: Tests isDmRestrictedProvider (#176) — the fail-CLOSED DM-restriction
-// ABOUTME: seam: only a positive not-protected verdict (trusted live or
-// ABOUTME: persisted) lifts the restriction; every absent answer restricts.
+// ABOUTME: Tests isDmRestrictedProvider (#176, #8561) — only an affirmative
+// ABOUTME: Greenlight designation restricts DMs, and that designation is sticky.
 
 import 'dart:async';
 
@@ -55,10 +54,10 @@ void main() {
   }
 
   group('unresolved with no verdict', () {
-    test('unauthenticated with no verdict persisted is restricted', () {
+    test('unauthenticated with no verdict persisted is unrestricted', () {
       final container = containerWith(authState: AuthState.unauthenticated);
 
-      expect(container.read(isDmRestrictedProvider), isTrue);
+      expect(container.read(isDmRestrictedProvider), isFalse);
     });
   });
 
@@ -135,59 +134,40 @@ void main() {
       expect(container.read(isDmRestrictedProvider), isFalse);
     });
 
-    test('an unknown resolution never creates a relaxing verdict', () async {
-      final container = containerWith(
-        authState: AuthState.authenticated,
-        status: () async => ProtectedMinorStatus.unknown(),
-      );
-      await container.read(protectedMinorStatusProvider.future);
+    test(
+      'an unknown resolution leaves an undesignated account unrestricted',
+      () async {
+        final container = containerWith(
+          authState: AuthState.authenticated,
+          status: () async => ProtectedMinorStatus.unknown(),
+        );
+        await container.read(protectedMinorStatusProvider.future);
 
-      expect(container.read(isDmRestrictedProvider), isTrue);
-      final store = ProtectedMinorStickyStore(prefs: prefs);
-      expect(store.lastKnownFor(pubkey), isNull);
-    });
+        expect(container.read(isDmRestrictedProvider), isFalse);
+        final store = ProtectedMinorStickyStore(prefs: prefs);
+        expect(store.lastKnownFor(pubkey), isNull);
+      },
+    );
   });
 
-  // The fail direction per auth source with no verdict anywhere (live status
-  // unresolved, nothing persisted). Keycast-backed or not-yet-known sources
-  // fail closed; pure self-custody sources Keycast can never answer for are
-  // unrestricted. Pinning every source stops a refactor from silently moving
-  // one in either direction. An absent OAuth verdict can be suppressed by the
-  // restricted party, while an absent self-custody verdict is structurally
-  // inapplicable.
+  // Authentication source does not confer protected-minor status. With no
+  // affirmative live or persisted designation, every account is unrestricted.
   group('per-auth-source fail direction with an absent verdict', () {
     for (final source in AuthenticationSource.values) {
-      final expectRestricted = switch (source) {
-        // `none` is the initial value while the source restores after the
-        // pubkey on cold start: not yet known whether Keycast applies.
-        AuthenticationSource.none => true,
-        AuthenticationSource.divineOAuth => true,
-        AuthenticationSource.automatic ||
-        AuthenticationSource.importedKeys ||
-        AuthenticationSource.bunker ||
-        AuthenticationSource.amber ||
-        AuthenticationSource.nip07 => false,
-      };
+      test('$source -> unrestricted', () {
+        final container = containerWith(
+          authState: AuthState.authenticated,
+          authSource: source,
+          status: () => Completer<ProtectedMinorStatus>().future,
+        );
 
-      test(
-        '$source -> ${expectRestricted ? 'restricted' : 'unrestricted'}',
-        () {
-          final container = containerWith(
-            authState: AuthState.authenticated,
-            authSource: source,
-            status: () => Completer<ProtectedMinorStatus>().future,
-          );
-
-          expect(container.read(isDmRestrictedProvider), expectRestricted);
-        },
-      );
+        expect(container.read(isDmRestrictedProvider), isFalse);
+      });
     }
   });
 
-  // A pubkey previously seen by Keycast stays fail-closed under any
-  // self-custody source, since the same pubkey can flip auth sources on one
-  // device and Keycast may hold a verdict for it.
-  group('ever-Keycast pubkey stays restricted under self-custody sources', () {
+  // Merely having used Keycast is not an affirmative Greenlight designation.
+  group('ever-Keycast pubkey remains unrestricted without a verdict', () {
     for (final source in [
       AuthenticationSource.automatic,
       AuthenticationSource.importedKeys,
@@ -195,7 +175,7 @@ void main() {
       AuthenticationSource.amber,
       AuthenticationSource.nip07,
     ]) {
-      test('$source with Keycast marker -> restricted', () async {
+      test('$source with Keycast marker -> unrestricted', () async {
         final store = ProtectedMinorStickyStore(prefs: prefs);
         await store.markKeycastAccount(pubkey);
 
@@ -205,14 +185,14 @@ void main() {
           status: () => Completer<ProtectedMinorStatus>().future,
         );
 
-        expect(container.read(isDmRestrictedProvider), isTrue);
+        expect(container.read(isDmRestrictedProvider), isFalse);
       });
     }
   });
 
   group('auth transitions', () {
     test(
-      'a live provider restricts a Keycast account after a self-custody session',
+      'a live provider does not infer Greenlight status after an account switch',
       () async {
         // Regression test for the provider-cache staleness in
         // keycastSignalApplicableProvider: AuthService mutates its pubkey and
@@ -274,18 +254,17 @@ void main() {
         key = '';
         authStateController.add(AuthState.unauthenticated);
         await pumpEventQueue();
-        expect(container.read(isDmRestrictedProvider), isTrue);
+        expect(container.read(isDmRestrictedProvider), isFalse);
 
-        // Sign in as account B: divineOAuth, protected minor, Keycast
-        // unreachable, nothing persisted for B. Must fail closed — a stale
-        // `applicable=false` from A's session would leave B unrestricted.
+        // Sign in as account B: divineOAuth, Keycast unreachable, and no
+        // persisted Greenlight designation. It remains unrestricted.
         state = AuthState.authenticated;
         source = AuthenticationSource.divineOAuth;
         key = pubkeyB;
         authStateController.add(AuthState.authenticated);
         await pumpEventQueue();
 
-        expect(container.read(isDmRestrictedProvider), isTrue);
+        expect(container.read(isDmRestrictedProvider), isFalse);
       },
     );
   });

--- a/mobile/test/providers/is_key_management_restricted_provider_test.dart
+++ b/mobile/test/providers/is_key_management_restricted_provider_test.dart
@@ -1,6 +1,5 @@
 // ABOUTME: Tests isKeyManagementRestrictedProvider (#182) — the fail-CLOSED gate
-// ABOUTME: for nsec export + key import/change. Delegates to the #176 DM seam, so
-// ABOUTME: unresolved / suppressed Keycast checks must restrict.
+// ABOUTME: for nsec export + key import/change, independently of the DM gate.
 
 import 'dart:async';
 

--- a/mobile/test/services/official_accounts_service_test.dart
+++ b/mobile/test/services/official_accounts_service_test.dart
@@ -11,8 +11,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 class _MockResolver extends Mock implements Nip05Resolver {}
 
 void main() {
-  const hqHex =
-      'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e';
   const modHex =
       '8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e';
   const strangerHex =
@@ -39,7 +37,7 @@ void main() {
         accounts: accounts,
       );
 
-  const hqNip05 = '_@divinehq.divine.video';
+  const modNip05 = 'moderation@divine.video';
 
   group('isApprovedMinorDmRecipient', () {
     test('unpinned pubkey is never an approved recipient', () async {
@@ -56,64 +54,72 @@ void main() {
         final svc = build(
           accounts: const [
             OfficialAccount(
-              pubkeyHex: hqHex,
-              nip05: hqNip05,
-              role: 'hq',
+              pubkeyHex: modHex,
+              nip05: modNip05,
+              role: 'moderation',
               minorContactable: false,
             ),
           ],
         );
-        expect(svc.isPinnedMinorContactable(hqHex), isFalse);
-        expect(await svc.isApprovedMinorDmRecipient(hqHex), isFalse);
+        expect(svc.isPinnedMinorContactable(modHex), isFalse);
+        expect(await svc.isApprovedMinorDmRecipient(modHex), isFalse);
         verifyNever(() => resolver.resolve(any(), any()));
       },
     );
 
+    test('Divine HQ is not an approved minor DM recipient', () async {
+      final svc = build();
+
+      expect(svc.isPinnedMinorContactable(kHqPubkeyHex), isFalse);
+      expect(await svc.isApprovedMinorDmRecipient(kHqPubkeyHex), isFalse);
+      verifyNever(() => resolver.resolve(any(), any()));
+    });
+
     test('pinned + NIP-05 matches -> approved', () async {
       when(
-        () => resolver.resolve(hqNip05, hqHex),
-      ).thenAnswer((_) async => const Nip05Resolution.matched(hqHex));
+        () => resolver.resolve(modNip05, modHex),
+      ).thenAnswer((_) async => const Nip05Resolution.matched(modHex));
 
       final svc = build();
-      expect(await svc.isApprovedMinorDmRecipient(hqHex), isTrue);
+      expect(await svc.isApprovedMinorDmRecipient(modHex), isTrue);
     });
 
     test(
       'pinned but NIP-05 resolves to a DIFFERENT key -> dropped immediately and persisted',
       () async {
-        when(() => resolver.resolve(hqNip05, hqHex)).thenAnswer(
+        when(() => resolver.resolve(modNip05, modHex)).thenAnswer(
           (_) async => const Nip05Resolution.differentKey(attackerHex),
         );
 
         final svc = build();
-        expect(await svc.isApprovedMinorDmRecipient(hqHex), isFalse);
+        expect(await svc.isApprovedMinorDmRecipient(modHex), isFalse);
         // persisted revoked: the sync hot path now rejects without re-resolving
-        expect(svc.isApprovedMinorDmRecipientSync(hqHex), isFalse);
+        expect(svc.isApprovedMinorDmRecipientSync(modHex), isFalse);
       },
     );
 
     test('a single absence never drops (keeps last-known approved)', () async {
       when(
-        () => resolver.resolve(hqNip05, hqHex),
+        () => resolver.resolve(modNip05, modHex),
       ).thenAnswer((_) async => const Nip05Resolution.absent());
 
       final svc = build();
-      expect(await svc.isApprovedMinorDmRecipient(hqHex), isTrue);
-      expect(svc.isApprovedMinorDmRecipientSync(hqHex), isTrue);
+      expect(await svc.isApprovedMinorDmRecipient(modHex), isTrue);
+      expect(svc.isApprovedMinorDmRecipientSync(modHex), isTrue);
     });
 
     test(
       'absence within the recheck window does not re-resolve or drop',
       () async {
         when(
-          () => resolver.resolve(hqNip05, hqHex),
+          () => resolver.resolve(modNip05, modHex),
         ).thenAnswer((_) async => const Nip05Resolution.absent());
 
         final svc = build();
-        expect(await svc.isApprovedMinorDmRecipient(hqHex), isTrue);
+        expect(await svc.isApprovedMinorDmRecipient(modHex), isTrue);
         clock = clock.add(const Duration(minutes: 2));
-        expect(await svc.isApprovedMinorDmRecipient(hqHex), isTrue);
-        verify(() => resolver.resolve(hqNip05, hqHex)).called(1);
+        expect(await svc.isApprovedMinorDmRecipient(modHex), isTrue);
+        verify(() => resolver.resolve(modNip05, modHex)).called(1);
       },
     );
 
@@ -121,32 +127,32 @@ void main() {
       'a confirming absence after the recheck window drops and persists',
       () async {
         when(
-          () => resolver.resolve(hqNip05, hqHex),
+          () => resolver.resolve(modNip05, modHex),
         ).thenAnswer((_) async => const Nip05Resolution.absent());
 
         final svc = build();
-        expect(await svc.isApprovedMinorDmRecipient(hqHex), isTrue);
+        expect(await svc.isApprovedMinorDmRecipient(modHex), isTrue);
         clock = clock.add(const Duration(minutes: 6));
-        expect(await svc.isApprovedMinorDmRecipient(hqHex), isFalse);
-        expect(svc.isApprovedMinorDmRecipientSync(hqHex), isFalse);
+        expect(await svc.isApprovedMinorDmRecipient(modHex), isFalse);
+        expect(svc.isApprovedMinorDmRecipientSync(modHex), isFalse);
       },
     );
 
     test('absence recovers if a later resolution matches again', () async {
       final answers = <Nip05Resolution>[
         const Nip05Resolution.absent(),
-        const Nip05Resolution.matched(hqHex),
+        const Nip05Resolution.matched(modHex),
       ];
       var i = 0;
       when(
-        () => resolver.resolve(hqNip05, hqHex),
+        () => resolver.resolve(modNip05, modHex),
       ).thenAnswer((_) async => answers[i++]);
 
       final svc = build();
-      expect(await svc.isApprovedMinorDmRecipient(hqHex), isTrue);
+      expect(await svc.isApprovedMinorDmRecipient(modHex), isTrue);
       clock = clock.add(const Duration(minutes: 6));
-      expect(await svc.isApprovedMinorDmRecipient(hqHex), isTrue);
-      expect(svc.isApprovedMinorDmRecipientSync(hqHex), isTrue);
+      expect(await svc.isApprovedMinorDmRecipient(modHex), isTrue);
+      expect(svc.isApprovedMinorDmRecipientSync(modHex), isTrue);
     });
 
     test('networkError keeps a previously revoked verdict', () async {
@@ -156,59 +162,59 @@ void main() {
       ];
       var i = 0;
       when(
-        () => resolver.resolve(hqNip05, hqHex),
+        () => resolver.resolve(modNip05, modHex),
       ).thenAnswer((_) async => answers[i++]);
 
       final svc = build();
-      expect(await svc.isApprovedMinorDmRecipient(hqHex), isFalse);
+      expect(await svc.isApprovedMinorDmRecipient(modHex), isFalse);
       clock = clock.add(const Duration(hours: 2));
-      expect(await svc.isApprovedMinorDmRecipient(hqHex), isFalse);
+      expect(await svc.isApprovedMinorDmRecipient(modHex), isFalse);
     });
 
     test(
       'networkError with no record defaults to pin-trusted and retries',
       () async {
         when(
-          () => resolver.resolve(hqNip05, hqHex),
+          () => resolver.resolve(modNip05, modHex),
         ).thenAnswer((_) async => const Nip05Resolution.networkError());
 
         final svc = build();
-        expect(await svc.isApprovedMinorDmRecipient(hqHex), isTrue);
+        expect(await svc.isApprovedMinorDmRecipient(modHex), isTrue);
         // nothing cached -> the next call resolves again rather than trusting a non-answer
-        expect(await svc.isApprovedMinorDmRecipient(hqHex), isTrue);
-        verify(() => resolver.resolve(hqNip05, hqHex)).called(2);
+        expect(await svc.isApprovedMinorDmRecipient(modHex), isTrue);
+        verify(() => resolver.resolve(modNip05, modHex)).called(2);
       },
     );
 
     test('a fresh verdict is reused without re-resolving (TTL)', () async {
       when(
-        () => resolver.resolve(hqNip05, hqHex),
-      ).thenAnswer((_) async => const Nip05Resolution.matched(hqHex));
+        () => resolver.resolve(modNip05, modHex),
+      ).thenAnswer((_) async => const Nip05Resolution.matched(modHex));
 
       final svc = build();
-      expect(await svc.isApprovedMinorDmRecipient(hqHex), isTrue);
+      expect(await svc.isApprovedMinorDmRecipient(modHex), isTrue);
       clock = clock.add(const Duration(minutes: 30));
-      expect(await svc.isApprovedMinorDmRecipient(hqHex), isTrue);
-      verify(() => resolver.resolve(hqNip05, hqHex)).called(1);
+      expect(await svc.isApprovedMinorDmRecipient(modHex), isTrue);
+      verify(() => resolver.resolve(modNip05, modHex)).called(1);
     });
 
     test(
       'a stale verdict triggers a fresh resolution (send-time freshness)',
       () async {
         when(
-          () => resolver.resolve(hqNip05, hqHex),
-        ).thenAnswer((_) async => const Nip05Resolution.matched(hqHex));
+          () => resolver.resolve(modNip05, modHex),
+        ).thenAnswer((_) async => const Nip05Resolution.matched(modHex));
 
         final svc = build();
-        expect(await svc.isApprovedMinorDmRecipient(hqHex), isTrue);
+        expect(await svc.isApprovedMinorDmRecipient(modHex), isTrue);
         clock = clock.add(const Duration(hours: 2));
-        expect(await svc.isApprovedMinorDmRecipient(hqHex), isTrue);
-        verify(() => resolver.resolve(hqNip05, hqHex)).called(2);
+        expect(await svc.isApprovedMinorDmRecipient(modHex), isTrue);
+        verify(() => resolver.resolve(modNip05, modHex)).called(2);
       },
     );
 
     test(
-      'moderation account is independently approved (both pins live)',
+      'moderation account is approved by the shipped policy',
       () async {
         when(
           () => resolver.resolve('moderation@divine.video', modHex),
@@ -224,11 +230,11 @@ void main() {
       'caller hex is normalized (mixed-case + surrounding whitespace)',
       () async {
         when(
-          () => resolver.resolve(hqNip05, hqHex),
-        ).thenAnswer((_) async => const Nip05Resolution.matched(hqHex));
+          () => resolver.resolve(modNip05, modHex),
+        ).thenAnswer((_) async => const Nip05Resolution.matched(modHex));
 
         final svc = build();
-        final messy = '  ${hqHex.toUpperCase()}\n';
+        final messy = '  ${modHex.toUpperCase()}\n';
         expect(svc.isPinnedMinorContactable(messy), isTrue);
         expect(await svc.isApprovedMinorDmRecipient(messy), isTrue);
       },
@@ -249,18 +255,18 @@ void main() {
       () async {
         final answers = <Nip05Resolution>[
           const Nip05Resolution.differentKey(attackerHex),
-          const Nip05Resolution.matched(hqHex),
+          const Nip05Resolution.matched(modHex),
         ];
         var i = 0;
         when(
-          () => resolver.resolve(hqNip05, hqHex),
+          () => resolver.resolve(modNip05, modHex),
         ).thenAnswer((_) async => answers[i++]);
 
         final svc = build();
-        expect(await svc.isApprovedMinorDmRecipient(hqHex), isFalse);
+        expect(await svc.isApprovedMinorDmRecipient(modHex), isFalse);
         clock = clock.add(const Duration(hours: 2));
-        expect(await svc.isApprovedMinorDmRecipient(hqHex), isTrue);
-        expect(svc.isApprovedMinorDmRecipientSync(hqHex), isTrue);
+        expect(await svc.isApprovedMinorDmRecipient(modHex), isTrue);
+        expect(svc.isApprovedMinorDmRecipientSync(modHex), isTrue);
       },
     );
 
@@ -274,29 +280,29 @@ void main() {
         ];
         var i = 0;
         when(
-          () => resolver.resolve(hqNip05, hqHex),
+          () => resolver.resolve(modNip05, modHex),
         ).thenAnswer((_) async => answers[i++]);
 
         final svc = build();
         expect(
-          await svc.isApprovedMinorDmRecipient(hqHex),
+          await svc.isApprovedMinorDmRecipient(modHex),
           isTrue,
         ); // absence #1
         clock = clock.add(const Duration(minutes: 6));
         expect(
-          await svc.isApprovedMinorDmRecipient(hqHex),
+          await svc.isApprovedMinorDmRecipient(modHex),
           isTrue,
         ); // networkError
         clock = clock.add(const Duration(minutes: 1));
         // firstAbsentAt preserved from #1, so this confirming absence (>5m later) drops
-        expect(await svc.isApprovedMinorDmRecipient(hqHex), isFalse);
+        expect(await svc.isApprovedMinorDmRecipient(modHex), isFalse);
       },
     );
   });
 
   group('onVerdictChanged', () {
     test('onVerdictChanged fires when a verdict flips to revoked', () async {
-      when(() => resolver.resolve(hqNip05, hqHex)).thenAnswer(
+      when(() => resolver.resolve(modNip05, modHex)).thenAnswer(
         (_) async => const Nip05Resolution.differentKey(attackerHex),
       );
       final svc = build();
@@ -305,7 +311,7 @@ void main() {
       final sub = svc.onVerdictChanged.listen(fired.add);
       addTearDown(sub.cancel);
 
-      await svc.isApprovedMinorDmRecipient(hqHex);
+      await svc.isApprovedMinorDmRecipient(modHex);
       await Future<void>.delayed(Duration.zero);
 
       expect(fired, hasLength(1));
@@ -315,8 +321,8 @@ void main() {
       'onVerdictChanged does not fire when a resolution confirms the verdict',
       () async {
         when(
-          () => resolver.resolve(hqNip05, hqHex),
-        ).thenAnswer((_) async => const Nip05Resolution.matched(hqHex));
+          () => resolver.resolve(modNip05, modHex),
+        ).thenAnswer((_) async => const Nip05Resolution.matched(modHex));
         final svc = build();
         addTearDown(svc.dispose);
         final fired = <void>[];
@@ -324,7 +330,7 @@ void main() {
         addTearDown(sub.cancel);
 
         // matched == the pin-trusted default (approved), so no observable flip.
-        await svc.isApprovedMinorDmRecipient(hqHex);
+        await svc.isApprovedMinorDmRecipient(modHex);
         await Future<void>.delayed(Duration.zero);
 
         expect(fired, isEmpty);


### PR DESCRIPTION
## Problem

Some ordinary accounts temporarily lost access to direct messaging whenever the Greenlight status check was loading or unavailable. Divine treats an account as 16+ for messaging unless it has been affirmatively designated as a Greenlight user aged 13–15. The existing mobile gate instead treated the absence of an answer as a possible protected-minor state.

The existing protected-minor exception also allowed contact with both Divine HQ and Divine Moderation, while policy permits contact only with the current Moderation identity.

## Why this fix

The DM gate now consumes the existing sticky affirmative protected-minor state. Accounts with no Greenlight designation remain unrestricted when the service is unavailable, while a previously confirmed Greenlight user remains restricted across startup, refreshes, and outages until a trusted non-protected result clears that state.

Divine HQ remains an official account but is no longer marked minor-contactable. The Moderation identity retains the existing pinned-key and live NIP-05 revocation protections.

## Deliberately unchanged

- The existing outbound, inbox, unread-count, route, profile, request, and delivery enforcement remains in place.
- Retired moderation identities remain blocked for everyone.
- Private-key export and account-key changes retain their separate fail-closed restriction.
- Featured-tab visibility continues to use the independent 18+ adult-content verification gate.

## Verification

- 92 focused tests passed across Greenlight state, DM sending, inbox filtering, route/profile/request gates, official-account verification, and key management.
- Targeted `flutter analyze` passed for all six changed files.
- Full-repo analysis also ran; it reports two existing missing `ownerPubkey` arguments in `packages/dm_repository/test/src/dm_repository_test.dart`, outside this diff. Current `main` Mobile CI is green at `b81f1009ef`.

Closes #8561