### PR TITLE
fix(observability): keep shared log exports within device limits

### DIFF
--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -782,6 +782,8 @@ class BugReportService {
     required String Function(String) sanitize,
     required int maxBytes,
   }) {
+    // Reserve against the widest possible counts so the header budget can
+    // only over-estimate: the real header is never larger than this probe.
     final provisionalHeader = buildHeader(
       exportedCount: lines.length,
       omittedCount: lines.length,

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -24,9 +24,46 @@ import 'package:unified_logger/unified_logger.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:uuid/uuid.dart';
 
+typedef LogExportHeaderBuilder =
+    String Function({
+      required int exportedCount,
+      required int omittedCount,
+    });
+
+@immutable
+class LogExportBody {
+  const LogExportBody({
+    required this.lines,
+    required this.body,
+    required this.exportedCount,
+    required this.omittedCount,
+  });
+
+  final List<String> lines;
+  final String body;
+  final int exportedCount;
+  final int omittedCount;
+}
+
+@immutable
+class LogExportContent {
+  const LogExportContent({
+    required this.content,
+    required this.exportedCount,
+    required this.omittedCount,
+  });
+
+  final String content;
+  final int exportedCount;
+  final int omittedCount;
+}
+
 /// Service for creating and managing bug reports
 class BugReportService {
   static const _logExportShareSubject = 'Divine Full Logs';
+
+  /// Maximum UTF-8 size of a log export, including its diagnostic header.
+  static const int maxLogExportBytes = 2 * 1024 * 1024;
 
   BugReportService({
     ErrorAnalyticsTracker? errorTracker,
@@ -283,14 +320,7 @@ class BugReportService {
         category: LogCategory.system,
       );
 
-      // Get comprehensive statistics about logs
-      final stats = await LogCaptureService().getLogStatistics();
-      Log.info(
-        'Log stats: ${stats['totalLogLines']} lines, ${stats['totalSizeMB']} MB across ${stats['fileCount']} files',
-        category: LogCategory.system,
-      );
-
-      // Get ALL logs from persistent storage (hundreds of thousands of entries)
+      // Take one formatted snapshot so statistics and exported records agree.
       final allLogLines = await LogCaptureService().getAllLogsAsText();
 
       if (allLogLines.isEmpty) {
@@ -301,37 +331,41 @@ class BugReportService {
         return const LogExportResult.noLogs();
       }
 
+      final stats = await LogCaptureService().getLogStatistics(
+        logLines: allLogLines,
+      );
+      Log.info(
+        'Log stats: ${stats['totalLogLines']} lines, ${stats['totalSizeMB']} MB across ${stats['fileCount']} files',
+        category: LogCategory.system,
+      );
+
       final exportTime = DateTime.now().toUtc();
-      final buffer = StringBuffer()
-        ..write(
-          await _buildLogHeader(
-            stats: stats,
-            lineCount: allLogLines.length,
-            exportTime: exportTime,
-            currentScreen: currentScreen,
-            userPubkey: userPubkey,
-          ),
-        );
-
-      // Add all log lines (already formatted by LogCaptureService)
-      for (final line in allLogLines) {
-        // Sanitize each line for sensitive data
-        buffer.writeln(_sanitizeString(line));
-      }
-
-      final content = buffer.toString();
+      final headerBuilder = await _createLogHeaderBuilder(
+        stats: stats,
+        lineCount: allLogLines.length,
+        exportTime: exportTime,
+        currentScreen: currentScreen,
+        userPubkey: userPubkey,
+      );
+      final export = buildBoundedLogContent(
+        allLogLines,
+        buildHeader: headerBuilder,
+        sanitize: _sanitizeString,
+        maxBytes: maxLogExportBytes,
+      );
+      final content = export.content;
       final fileName = buildLogExportFileName(exportTime);
 
       if (kIsWeb) {
-        return _exportLogsWeb(content, fileName, allLogLines.length);
+        return _exportLogsWeb(content, fileName, export.exportedCount);
       }
       if (_isDesktop) {
-        return _exportLogsDesktop(content, fileName, allLogLines.length);
+        return _exportLogsDesktop(content, fileName, export.exportedCount);
       }
       return _exportLogsNative(
         content,
         fileName,
-        allLogLines.length,
+        export.exportedCount,
         sharePositionOrigin: sharePositionOrigin,
       );
     } catch (e, stackTrace) {
@@ -640,9 +674,8 @@ class BugReportService {
     }
   }
 
-  /// The diagnostic preamble the exported log file starts with,
-  /// terminated by a blank line.
-  Future<String> _buildLogHeader({
+  /// Loads diagnostics once and returns a pure header builder.
+  Future<LogExportHeaderBuilder> _createLogHeaderBuilder({
     required Map<String, dynamic> stats,
     required int lineCount,
     required DateTime exportTime,
@@ -650,33 +683,136 @@ class BugReportService {
     String? userPubkey,
   }) async {
     final packageInfo = await _packageInfoLoader();
-    final buffer = StringBuffer()
-      ..writeln('OpenVine Comprehensive Log Export')
-      ..writeln('═' * 80)
-      ..writeln('Export Time: ${formatLogExportTimestamp(exportTime)}')
-      ..writeln(
-        'App Version: ${packageInfo.version}+${packageInfo.buildNumber}',
-      )
-      ..writeln('Total Log Lines: $lineCount')
-      ..writeln('Log Files: ${stats['fileCount']}')
-      ..writeln('Total Size: ${stats['totalSizeMB']} MB');
     final deviceDescription = await buildDeviceDescription();
-    if (deviceDescription != null) {
-      buffer.writeln('Device: $deviceDescription');
+    final runtimeDiagnostics = buildRuntimeDiagnostics();
+    final environmentDiagnostics = await buildEnvironmentDiagnostics();
+    final formattedPubkey = userPubkey == null
+        ? null
+        : pubkeyForLogs(userPubkey);
+
+    return ({required int exportedCount, required int omittedCount}) {
+      final buffer = StringBuffer()
+        ..writeln('OpenVine Comprehensive Log Export')
+        ..writeln('═' * 80)
+        ..writeln('Export Time: ${formatLogExportTimestamp(exportTime)}')
+        ..writeln(
+          'App Version: ${packageInfo.version}+${packageInfo.buildNumber}',
+        )
+        ..writeln('Total Log Lines: $lineCount')
+        ..writeln('Log Files: ${stats['fileCount']}')
+        ..writeln('Captured Log Size: ${stats['totalSizeMB']} MB')
+        ..write(
+          buildLogExportRecordSummary(
+            totalCount: lineCount,
+            exportedCount: exportedCount,
+            omittedCount: omittedCount,
+          ),
+        );
+      if (deviceDescription != null) {
+        buffer.writeln('Device: $deviceDescription');
+      }
+      buffer
+        ..write(runtimeDiagnostics)
+        ..write(environmentDiagnostics);
+      if (currentScreen != null) {
+        buffer.writeln('Current Screen: $currentScreen');
+      }
+      if (formattedPubkey != null) {
+        buffer.writeln('User Pubkey: $formattedPubkey');
+      }
+      return (buffer
+            ..writeln('═' * 80)
+            ..writeln())
+          .toString();
+    };
+  }
+
+  @visibleForTesting
+  static String buildLogExportRecordSummary({
+    required int totalCount,
+    required int exportedCount,
+    required int omittedCount,
+  }) {
+    final limitMegabytes = (maxLogExportBytes / (1024 * 1024)).toStringAsFixed(
+      1,
+    );
+    return 'Records Exported: $exportedCount of $totalCount\n'
+        'Omitted Records: $omittedCount '
+        '(oldest first, export size limit $limitMegabytes MB)\n';
+  }
+
+  /// Builds a newest-first bounded selection in chronological order.
+  @visibleForTesting
+  static LogExportBody buildBoundedLogBody(
+    List<String> lines, {
+    required String Function(String) sanitize,
+    required int maxBytes,
+  }) {
+    if (maxBytes < 0) {
+      throw ArgumentError.value(maxBytes, 'maxBytes', 'must not be negative');
     }
-    buffer
-      ..write(buildRuntimeDiagnostics())
-      ..write(await buildEnvironmentDiagnostics());
-    if (currentScreen != null) {
-      buffer.writeln('Current Screen: $currentScreen');
+
+    final retainedLines = <String>[];
+    var retainedBytes = 0;
+    for (var index = lines.length - 1; index >= 0; index--) {
+      final sanitizedLine = sanitize(lines[index]);
+      final lineBytes = utf8.encode(sanitizedLine).length + 1;
+      if (retainedBytes + lineBytes > maxBytes) break;
+      retainedLines.add(sanitizedLine);
+      retainedBytes += lineBytes;
     }
-    if (userPubkey != null) {
-      buffer.writeln('User Pubkey: ${pubkeyForLogs(userPubkey)}');
+
+    final chronologicalLines = retainedLines.reversed.toList(growable: false);
+    final body = chronologicalLines.isEmpty
+        ? ''
+        : '${chronologicalLines.join('\n')}\n';
+    return LogExportBody(
+      lines: chronologicalLines,
+      body: body,
+      exportedCount: chronologicalLines.length,
+      omittedCount: lines.length - chronologicalLines.length,
+    );
+  }
+
+  /// Builds a complete export whose UTF-8 encoding fits within [maxBytes].
+  @visibleForTesting
+  static LogExportContent buildBoundedLogContent(
+    List<String> lines, {
+    required LogExportHeaderBuilder buildHeader,
+    required String Function(String) sanitize,
+    required int maxBytes,
+  }) {
+    final provisionalHeader = buildHeader(
+      exportedCount: lines.length,
+      omittedCount: lines.length,
+    );
+    final provisionalHeaderBytes = utf8.encode(provisionalHeader).length;
+    if (provisionalHeaderBytes > maxBytes) {
+      throw ArgumentError.value(
+        maxBytes,
+        'maxBytes',
+        'is smaller than the export header',
+      );
     }
-    return (buffer
-          ..writeln('═' * 80)
-          ..writeln())
-        .toString();
+
+    final body = buildBoundedLogBody(
+      lines,
+      sanitize: sanitize,
+      maxBytes: maxBytes - provisionalHeaderBytes,
+    );
+    final header = buildHeader(
+      exportedCount: body.exportedCount,
+      omittedCount: body.omittedCount,
+    );
+    final content = '$header${body.body}';
+    if (utf8.encode(content).length > maxBytes) {
+      throw StateError('The final log export exceeded its byte ceiling');
+    }
+    return LogExportContent(
+      content: content,
+      exportedCount: body.exportedCount,
+      omittedCount: body.omittedCount,
+    );
   }
 
   /// Export logs on mobile platforms using the system share sheet.

--- a/mobile/packages/unified_logger/lib/src/log_capture_service.dart
+++ b/mobile/packages/unified_logger/lib/src/log_capture_service.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Maintains a ring buffer of recent logs without file I/O overhead
 
 import 'dart:collection';
+import 'dart:convert';
+
 import 'package:models/models.dart' show LogEntry, LogLevel;
 
 /// Service for capturing and storing log entries in memory for bug reports
@@ -92,18 +94,20 @@ class LogCaptureService {
   }
 
   /// Get statistics about log storage
-  Future<Map<String, dynamic>> getLogStatistics() async {
-    final allLogLines = await getAllLogsAsText();
-    final totalSize = allLogLines.fold<int>(
+  Future<Map<String, dynamic>> getLogStatistics({
+    List<String>? logLines,
+  }) async {
+    final lines = logLines ?? await getAllLogsAsText();
+    final totalSize = lines.fold<int>(
       0,
-      (sum, line) => sum + line.length,
+      (sum, line) => sum + utf8.encode(line).length,
     );
 
     return {
       'fileCount': 0, // No file storage
       'totalSizeBytes': totalSize,
       'totalSizeMB': (totalSize / (1024 * 1024)).toStringAsFixed(2),
-      'totalLogLines': allLogLines.length,
+      'totalLogLines': lines.length,
       'memoryBufferSize': _memoryBuffer.length,
       'totalEntriesWritten': _totalEntriesWritten,
     };

--- a/mobile/packages/unified_logger/test/src/log_capture_service_test.dart
+++ b/mobile/packages/unified_logger/test/src/log_capture_service_test.dart
@@ -241,5 +241,14 @@ void main() {
       expect(logs, isEmpty);
       expect(logs, isA<List<LogEntry>>());
     });
+
+    test('reports formatted log size in UTF-8 bytes', () async {
+      const lines = ['ASCII', '🪩'];
+
+      final stats = await service.getLogStatistics(logLines: lines);
+
+      expect(stats['totalSizeBytes'], 9);
+      expect(stats['totalLogLines'], 2);
+    });
   });
 }

--- a/mobile/test/services/bug_report_log_export_test.dart
+++ b/mobile/test/services/bug_report_log_export_test.dart
@@ -1,7 +1,7 @@
-// ABOUTME: Tests for BugReportService log export result value type and surface.
-// ABOUTME: The full export flow is exercised via manual testing because it
-// ABOUTME: depends on the device's Downloads directory and LogCaptureService
-// ABOUTME: file IO that is awkward to mock in pure unit tests.
+// ABOUTME: Tests BugReportService export sizing, headers, and result values.
+// ABOUTME: Covers deterministic UTF-8 bounds without platform file or share IO.
+
+import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -89,6 +89,158 @@ void main() {
       expect(
         BugReportService.buildLogExportFileName(localTime),
         'openvine_full_logs_2026-09-02T08-00-00.000Z.txt',
+      );
+    });
+  });
+
+  group('buildBoundedLogBody', () {
+    const passthrough = _passthrough;
+
+    test('retains every record under the limit', () {
+      final result = BugReportService.buildBoundedLogBody(
+        const ['oldest', 'newest'],
+        sanitize: passthrough,
+        maxBytes: 100,
+      );
+
+      expect(result.lines, ['oldest', 'newest']);
+      expect(result.exportedCount, 2);
+      expect(result.omittedCount, 0);
+      expect(result.body, 'oldest\nnewest\n');
+    });
+
+    test('retains every record exactly at the limit', () {
+      final result = BugReportService.buildBoundedLogBody(
+        const ['abc', 'de'],
+        sanitize: passthrough,
+        maxBytes: utf8.encode('abc\nde\n').length,
+      );
+
+      expect(result.lines, ['abc', 'de']);
+      expect(utf8.encode(result.body).length, 7);
+      expect(result.omittedCount, 0);
+    });
+
+    test('drops the oldest record when one byte over the limit', () {
+      final result = BugReportService.buildBoundedLogBody(
+        const ['a', 'new'],
+        sanitize: passthrough,
+        maxBytes: utf8.encode('a\nnew\n').length - 1,
+      );
+
+      expect(result.lines, ['new']);
+      expect(result.exportedCount, 1);
+      expect(result.omittedCount, 1);
+    });
+
+    test('retains a newest contiguous suffix in original order', () {
+      final result = BugReportService.buildBoundedLogBody(
+        const ['first', 'second', 'third'],
+        sanitize: passthrough,
+        maxBytes: utf8.encode('second\nthird\n').length,
+      );
+
+      expect(result.lines, ['second', 'third']);
+      expect(result.omittedCount, 1);
+    });
+
+    test('counts multibyte records as UTF-8 without splitting them', () {
+      final result = BugReportService.buildBoundedLogBody(
+        const ['🪩', '🌿'],
+        sanitize: passthrough,
+        maxBytes: utf8.encode('🌿\n').length,
+      );
+
+      expect(result.lines, ['🌿']);
+      expect(utf8.decode(utf8.encode(result.body)), '🌿\n');
+      expect(result.body, isNot(contains('�')));
+    });
+
+    test('measures records after sanitization', () {
+      final result = BugReportService.buildBoundedLogBody(
+        const ['secret', 'safe'],
+        sanitize: (line) => line == 'secret' ? '[REDACTED]' : line,
+        maxBytes: utf8.encode('[REDACTED]\nsafe\n').length - 1,
+      );
+
+      expect(result.lines, ['safe']);
+      expect(result.omittedCount, 1);
+    });
+
+    test('sanitizes retained records plus at most one rejected probe', () {
+      var calls = 0;
+      final result = BugReportService.buildBoundedLogBody(
+        const ['first', 'second', 'third'],
+        sanitize: (line) {
+          calls++;
+          return line;
+        },
+        maxBytes: utf8.encode('third\n').length,
+      );
+
+      expect(result.lines, ['third']);
+      expect(calls, result.exportedCount + 1);
+    });
+  });
+
+  group('buildBoundedLogContent', () {
+    String header({required int exportedCount, required int omittedCount}) =>
+        'Records Exported: $exportedCount of 3\n'
+        'Omitted Records: $omittedCount\n\n';
+
+    test('includes header bytes in the export ceiling', () {
+      final maxBytes =
+          utf8.encode(header(exportedCount: 3, omittedCount: 3)).length +
+          utf8.encode('three\n').length;
+      final result = BugReportService.buildBoundedLogContent(
+        const ['one', 'two', 'three'],
+        buildHeader: header,
+        sanitize: _passthrough,
+        maxBytes: maxBytes,
+      );
+
+      expect(utf8.encode(result.content).length, lessThanOrEqualTo(maxBytes));
+      expect(result.content, contains('Records Exported: 1 of 3'));
+      expect(result.content, contains('Omitted Records: 2'));
+      expect(result.content, endsWith('three\n'));
+    });
+
+    test('rejects a header that alone exceeds the ceiling', () {
+      expect(
+        () => BugReportService.buildBoundedLogContent(
+          const ['line'],
+          buildHeader: ({required exportedCount, required omittedCount}) =>
+              'Current Screen: ${'x' * 100}',
+          sanitize: _passthrough,
+          maxBytes: 20,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('buildLogExportRecordSummary', () {
+    test('reports full retention', () {
+      expect(
+        BugReportService.buildLogExportRecordSummary(
+          totalCount: 3,
+          exportedCount: 3,
+          omittedCount: 0,
+        ),
+        'Records Exported: 3 of 3\n'
+        'Omitted Records: 0 '
+        '(oldest first, export size limit 2.0 MB)\n',
+      );
+    });
+
+    test('reports oldest records omitted by the ceiling', () {
+      expect(
+        BugReportService.buildLogExportRecordSummary(
+          totalCount: 50000,
+          exportedCount: 17342,
+          omittedCount: 32658,
+        ),
+        contains('Omitted Records: 32658 (oldest first'),
       );
     });
   });
@@ -341,3 +493,5 @@ void main() {
     });
   });
 }
+
+String _passthrough(String value) => value;

--- a/mobile/test/services/bug_report_log_export_test.dart
+++ b/mobile/test/services/bug_report_log_export_test.dart
@@ -148,7 +148,7 @@ void main() {
       final result = BugReportService.buildBoundedLogBody(
         const ['🪩', '🌿'],
         sanitize: passthrough,
-        maxBytes: utf8.encode('🌿\n').length,
+        maxBytes: utf8.encode('🌿\n').length + 1,
       );
 
       expect(result.lines, ['🌿']);

--- a/mobile/test/services/bug_report_log_export_test.dart
+++ b/mobile/test/services/bug_report_log_export_test.dart
@@ -167,6 +167,18 @@ void main() {
       expect(result.omittedCount, 1);
     });
 
+    test('exports retained records in their sanitized form', () {
+      final result = BugReportService.buildBoundedLogBody(
+        const ['keep nsec1secret'],
+        sanitize: (line) => line.replaceAll('nsec1secret', '[REDACTED]'),
+        maxBytes: 100,
+      );
+
+      expect(result.lines, ['keep [REDACTED]']);
+      expect(result.body, contains('[REDACTED]'));
+      expect(result.body, isNot(contains('nsec1secret')));
+    });
+
     test('sanitizes retained records plus at most one rejected probe', () {
       var calls = 0;
       final result = BugReportService.buildBoundedLogBody(


### PR DESCRIPTION
## Description

Exporting a full capture buffer could create a multi-megabyte file that failed when a mobile share provider copied it into a nearly full device cache. This caps every platform’s UTF-8 export at 2 MiB, preserves the newest complete sanitized records, and tells support exactly how many older records were omitted.

The export now takes one formatted snapshot for both statistics and content, reports captured size in actual UTF-8 bytes, and avoids sanitizing records that cannot fit.

**Related Issue:** Closes #8500

## Out of Scope

This does not change the capture buffer’s entry-count memory bound or remove the existing `Log Files: 0` diagnostic line.

## Verification

- `flutter test test/services/bug_report_log_export_test.dart packages/unified_logger/test`
- `flutter analyze lib test integration_test`
- Repository pre-push hook: analyzer and 60 selected tests passed

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore