### PR TITLE
fix(dm): keep failed appeals visible after moderation rotation

### DIFF
--- a/mobile/docs/RETIRED_MODERATION_KEYS.md
+++ b/mobile/docs/RETIRED_MODERATION_KEYS.md
@@ -92,7 +92,7 @@ role uses the shared support identity.
 | Composer closed; banner routes replies to the current support key | `conversation_view.dart`, via `isRetiredModerationAccount` and `kModerationPubkeyHex` |
 | Pinned support row, unread partition, and retired predicates wired into list state | `inbox_page.dart`, `message_requests_page.dart`, `app_shell_badge_scope.dart`, and `ConversationListBloc` |
 | Destructive request action withheld for moderation threads | `request_preview_view.dart`, via `isModerationAccount` |
-| Outbound sends refused at the lowest repository send primitive | `dmSendPolicyProvider` → `DmSendPolicyDecision.terminallyBlocked` |
+| Outbound sends refused and retained as non-retryable evidence | `dmSendPolicyProvider` → `DmSendPolicyDecision.terminallyBlockedRetain` |
 | Pre-rotation threads excluded from pinned-support adoption | `DmRepository.extractPinnedSupport` |
 | Labeler subscription migrated to the current key | `ModerationLabelService._migrateLegacyPubkey` |
 

--- a/mobile/lib/blocs/dm/conversation/conversation_state.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_state.dart
@@ -54,8 +54,9 @@ enum SendStatus {
 ///
 /// Bubbles flow through this enum: [pending] → [delivered] on full
 /// success, [pending] → [deliveredSelfFailed] on a partial delivery,
-/// [pending] → [failed] on a recipient-side publish failure. Persisted
-/// rows with no queue row remaining are always [delivered].
+/// [pending] → [failed] on a retryable recipient-side publish failure, or
+/// [pending] → [blocked] on a terminal refusal whose local record is retained.
+/// Persisted rows with no queue row remaining are always [delivered].
 enum DmDeliveryStatus {
   /// Neither wrap has landed yet. Renders as a plain sent bubble — sends are
   /// optimistic, so there is no in-flight indicator (only [failed] is shown).
@@ -72,10 +73,14 @@ enum DmDeliveryStatus {
   /// self-wrap recovery runs silently); no distinct indicator.
   deliveredSelfFailed,
 
-  /// Recipient gift wrap failed. The only status with a visible indicator:
-  /// the bubble shows the red "Not delivered" row and is tappable to
-  /// resend/cancel, and the retry service replays it on reconnect.
+  /// Recipient gift wrap failed. The bubble shows the red "Not delivered" row
+  /// and is tappable to resend/cancel; the retry service replays it on
+  /// reconnect.
   failed,
+
+  /// Recipient delivery is permanently blocked. The bubble stays visible as
+  /// the sender's record, shows closed-thread copy, and cannot be retried.
+  blocked,
 }
 
 /// Snapshot of the rumor ids whose recipient publish landed but whose
@@ -248,8 +253,9 @@ class ConversationState extends Equatable {
   /// queue-row deletion with persisted-row insertion).
   ///
   /// Group bubbles aggregate their whole fan-out batch, worst first:
-  /// any sibling hard-failed → [DmDeliveryStatus.failed]; else any still
-  /// pending → [DmDeliveryStatus.pending]; else any self-wrap failure →
+  /// any sibling blocked → [DmDeliveryStatus.blocked]; else any sibling
+  /// hard-failed → [DmDeliveryStatus.failed]; else any still pending →
+  /// [DmDeliveryStatus.pending]; else any self-wrap failure →
   /// [DmDeliveryStatus.deliveredSelfFailed]. This also lets the PERSISTED
   /// group bubble (inserted when the first recipient confirmed) surface a
   /// remaining sibling's failure as the red tap-to-resend affordance.
@@ -263,6 +269,9 @@ class ConversationState extends Equatable {
     var anyPending = false;
     var anySelfFailed = false;
     for (final q in rows) {
+      if (q.recipientWrapStatus == OutgoingWrapStatus.blocked) {
+        return DmDeliveryStatus.blocked;
+      }
       if (q.recipientWrapStatus == OutgoingWrapStatus.failed) {
         return DmDeliveryStatus.failed;
       }

--- a/mobile/lib/providers/official_accounts_providers.dart
+++ b/mobile/lib/providers/official_accounts_providers.dart
@@ -34,8 +34,8 @@ final officialAccountsServiceProvider = Provider<OfficialAccountsService>((
 /// keys, so a send there is accepted by the relay and reported as delivered
 /// while reaching nobody — worst on an enforcement thread whose own copy
 /// invites a reply. Terminal rather than temporary: a retired recipient can
-/// never become deliverable, so the cold-start drain is right to drop a queued
-/// row instead of retrying forever. Checked ahead of the restriction branch
+/// never become deliverable, so the cold-start drain retains the sender's row
+/// in a non-retryable state. Checked ahead of the restriction branch
 /// because it applies to adults too — a protected minor is already bounced off
 /// these threads by [ConversationPage]'s route guard, since retired keys are
 /// absent from [kPinnedOfficialAccounts].
@@ -51,7 +51,7 @@ final officialAccountsServiceProvider = Provider<OfficialAccountsService>((
 final dmSendPolicyProvider = Provider<DmSendPolicy>((ref) {
   return (String recipientPubkey) async {
     if (isRetiredModerationAccount(recipientPubkey)) {
-      return DmSendPolicyDecision.terminallyBlocked;
+      return DmSendPolicyDecision.terminallyBlockedRetain;
     }
     if (!ref.read(isDmRestrictedProvider)) {
       return DmSendPolicyDecision.allowed;
@@ -61,7 +61,7 @@ final dmSendPolicyProvider = Provider<DmSendPolicy>((ref) {
         .isApprovedMinorDmRecipient(recipientPubkey);
     if (approved) return DmSendPolicyDecision.allowed;
     return ref.read(hasConfirmedDmRestrictionProvider)
-        ? DmSendPolicyDecision.terminallyBlocked
+        ? DmSendPolicyDecision.terminallyBlockedDiscard
         : DmSendPolicyDecision.temporarilyBlocked;
   };
 });

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -611,9 +611,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
   void _showErrorToastAndAnnounce(BuildContext context, String message) {
     ScaffoldMessenger.of(context)
       ..hideCurrentSnackBar()
-      ..showSnackBar(
-        DivineSnackbarContainer.snackBar(message, error: true),
-      );
+      ..showSnackBar(DivineSnackbarContainer.snackBar(message, error: true));
     SemanticsService.sendAnnouncement(
       View.of(context),
       message,
@@ -983,10 +981,8 @@ class _MessageList extends StatelessWidget {
   /// This flag removes the affordance only — the bubble itself stays rendered,
   /// so the evidence is intact and nothing is force-deleted here. On a blocked
   /// thread that holds end to end, and unblocking restores the sheet along with
-  /// the composer. On a retired thread it does not: the first retry sweep after
-  /// the rotation deletes the queue row outright, so the bubble disappears on
-  /// its own. That is a separate defect in the terminal-blocked queue
-  /// transition, tracked in #8492, not something this flag can reach.
+  /// the composer. On a retired thread a terminal queue state preserves the
+  /// bubble without exposing a retry action.
   ///
   /// This closes the user-initiated path only. TODO(#7047): Decide whether a
   /// block cancels queued outgoing sends; the reconnect sweep still re-drives
@@ -1000,6 +996,7 @@ class _MessageList extends StatelessWidget {
     bool isSent,
     DmDeliveryStatus deliveryStatus,
     DmRetractionStatus retractionStatus,
+    bool isPersisted,
   ) async {
     final videoTarget = resolveDmVideoTarget(
       content: StringUtils.sanitizeUtf16(message.content),
@@ -1013,14 +1010,18 @@ class _MessageList extends StatelessWidget {
     final showPicker =
         reactionsEnabled &&
         retractionStatus == DmRetractionStatus.none &&
-        !(isSent && deliveryStatus == DmDeliveryStatus.failed);
+        !(isSent &&
+            (deliveryStatus == DmDeliveryStatus.failed ||
+                deliveryStatus == DmDeliveryStatus.blocked));
     final result = await ReactionPickerOverlay.show(
       context: context,
       isSent: isSent,
       isVideoShare: videoTarget != null,
       showPicker: showPicker,
       showDelete:
-          retractionsEnabled && retractionStatus == DmRetractionStatus.none,
+          (retractionsEnabled || !isPersisted) &&
+          retractionStatus == DmRetractionStatus.none,
+      deleteForEveryone: isPersisted,
     );
     if (result == null) return;
     if (!context.mounted) return;
@@ -1261,6 +1262,9 @@ class _MessageList extends StatelessWidget {
               isSent,
               status,
               message.retractionStatus,
+              context.read<ConversationBloc>().state.messages.any(
+                (persisted) => persisted.id == message.id,
+              ),
             ),
             // A single tap on a failed own bubble opens the resend/stop-trying
             // recovery bottom sheet; every other bubble keeps its default tap.
@@ -1286,7 +1290,9 @@ class _MessageList extends StatelessWidget {
             onDoubleTap:
                 !reactionsEnabled ||
                     message.retractionStatus != DmRetractionStatus.none ||
-                    (isSent && status == DmDeliveryStatus.failed)
+                    (isSent &&
+                        (status == DmDeliveryStatus.failed ||
+                            status == DmDeliveryStatus.blocked))
                 ? null
                 : () => _likeOnDoubleTap(context, message),
             deliveryStatus: status,

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -249,6 +249,8 @@ class MessageBubble extends StatelessWidget {
     // win the gesture arena over the card's dominant surface and swallow that
     // sole resend affordance, so their taps are disabled on a failed own send.
     final isFailedOwnSend = isSent && deliveryStatus == DmDeliveryStatus.failed;
+    final isBlockedOwnSend =
+        isSent && deliveryStatus == DmDeliveryStatus.blocked;
     final hasUnconfirmedRetraction =
         isSent && retractionStatus != DmRetractionStatus.none;
 
@@ -347,9 +349,7 @@ class MessageBubble extends StatelessWidget {
                             // Video messages need a bigger breath between the
                             // date header and the thumbnail; text messages
                             // keep the tighter 4 px rhythm.
-                            padding: EdgeInsets.only(
-                              bottom: hasVideo ? 12 : 4,
-                            ),
+                            padding: EdgeInsets.only(bottom: hasVideo ? 12 : 4),
                             child: Text(
                               timestamp,
                               style: VineTheme.labelSmallFont(
@@ -415,6 +415,11 @@ class MessageBubble extends StatelessWidget {
                           const Padding(
                             padding: EdgeInsets.only(top: 4),
                             child: _NotDeliveredIndicator(),
+                          ),
+                        if (isBlockedOwnSend)
+                          const Padding(
+                            padding: EdgeInsets.only(top: 4),
+                            child: _BlockedDeliveryIndicator(),
                           ),
                       ],
                     ),
@@ -1279,9 +1284,10 @@ class _VideoCard extends ConsumerWidget {
 /// Small trailing icon at the bottom of a sent bubble that surfaces
 /// The in-bubble "Not delivered" affordance for a hard-failed own send.
 ///
-/// Sends are optimistic, so this is the ONLY delivery state ever shown on a
-/// bubble — pending, delivered, and self-wrap-failed all render as a plain
-/// sent message. The enclosing bubble is tappable to resend or delete.
+/// Sends are optimistic, so ordinary pending, delivered, and self-wrap-failed
+/// states render as a plain sent message. The enclosing failed bubble is
+/// tappable to resend or delete; a terminal blocked bubble uses the distinct
+/// [_BlockedDeliveryIndicator].
 class _NotDeliveredIndicator extends StatelessWidget {
   const _NotDeliveredIndicator();
 
@@ -1300,6 +1306,36 @@ class _NotDeliveredIndicator extends StatelessWidget {
             color: VineTheme.error,
           ),
           Text(label, style: VineTheme.labelSmallFont(color: VineTheme.error)),
+        ],
+      ),
+    );
+  }
+}
+
+/// The in-bubble terminal status for a send retained on a closed thread.
+class _BlockedDeliveryIndicator extends StatelessWidget {
+  const _BlockedDeliveryIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    final label = context.l10n.dmSendBlockedRetiredMessage;
+    return Semantics(
+      label: label,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 4,
+        children: [
+          const DivineIcon(
+            icon: DivineIconName.warningCircle,
+            size: 14,
+            color: VineTheme.error,
+          ),
+          Flexible(
+            child: Text(
+              label,
+              style: VineTheme.labelSmallFont(color: VineTheme.error),
+            ),
+          ),
         ],
       ),
     );

--- a/mobile/lib/screens/inbox/conversation/widgets/reaction_picker_overlay.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reaction_picker_overlay.dart
@@ -55,6 +55,7 @@ class ReactionPickerOverlay {
     required bool isSent,
     bool showPicker = true,
     bool showDelete = true,
+    bool deleteForEveryone = true,
     bool isVideoShare = false,
     List<String> emojis = kDefaultDmReactionEmojis,
   }) async {
@@ -93,6 +94,7 @@ class ReactionPickerOverlay {
                 _ActionList(
                   isSent: isSent,
                   showDelete: showDelete,
+                  deleteForEveryone: deleteForEveryone,
                   isVideoShare: isVideoShare,
                   onSelected: (action) => sheetContext.popModalIfMounted(
                     ReactionPickerResult(action: action),
@@ -222,6 +224,7 @@ class _ActionList extends StatelessWidget {
   const _ActionList({
     required this.isSent,
     required this.showDelete,
+    required this.deleteForEveryone,
     required this.isVideoShare,
     required this.onSelected,
   });
@@ -232,6 +235,7 @@ class _ActionList extends StatelessWidget {
   /// closed thread, where the kind-5 cannot be published and the tile would
   /// only drop the local copy.
   final bool showDelete;
+  final bool deleteForEveryone;
   final bool isVideoShare;
   final ValueChanged<MessageAction> onSelected;
 
@@ -259,7 +263,9 @@ class _ActionList extends StatelessWidget {
       if (isSent && showDelete)
         _ActionTile(
           icon: DivineIconName.trash,
-          label: l10n.dmMessageActionDeleteForEveryone,
+          label: deleteForEveryone
+              ? l10n.dmMessageActionDeleteForEveryone
+              : l10n.dmMessageActionCancelSend,
           onTap: () => onSelected(MessageAction.delete),
           color: VineTheme.error,
         ),

--- a/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
@@ -40,6 +40,10 @@ enum OutgoingWrapStatus {
   /// service will replay this wrap (only) until `retry_count` reaches
   /// the policy cap.
   failed,
+
+  /// A terminal policy refusal. The row remains visible as the sender's only
+  /// durable copy, but retry queries must never re-drive it.
+  blocked,
 }
 
 /// Thrown when [OutgoingDmsDao] reads a row whose persisted wrap-status
@@ -370,6 +374,27 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
             recipientWrapLastError: lastError != null
                 ? Value(lastError)
                 : const Value.absent(),
+            lastAttemptAt: Value(DateTime.now()),
+          ),
+        );
+    return rows > 0;
+  }
+
+  /// Retain [id] as a terminal, non-retryable policy refusal.
+  ///
+  /// Both wraps must leave `pending`: the pending-row recovery query selects a
+  /// row when either wrap is pending, and a recipient refusal means the
+  /// self-wrap was never attempted.
+  Future<bool> markRecipientBlocked({
+    required String id,
+    required String lastError,
+  }) async {
+    final rows = await (update(outgoingDms)..where((t) => t.id.equals(id)))
+        .write(
+          OutgoingDmsCompanion(
+            recipientWrapStatus: Value(OutgoingWrapStatus.blocked.name),
+            selfWrapStatus: Value(OutgoingWrapStatus.blocked.name),
+            recipientWrapLastError: Value(lastError),
             lastAttemptAt: Value(DateTime.now()),
           ),
         );

--- a/mobile/packages/db_client/test/src/database/daos/outgoing_dms_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/outgoing_dms_dao_test.dart
@@ -383,6 +383,28 @@ void main() {
         },
       );
 
+      test('terminal block leaves neither wrap retryable or pending', () async {
+        await dao.enqueue(makeDm(id: 'aaaa'));
+
+        final ok = await dao.markRecipientBlocked(
+          id: 'aaaa',
+          lastError: 'recipient retired',
+        );
+
+        expect(ok, isTrue);
+        final fetched = await dao.getById('aaaa');
+        expect(fetched!.recipientWrapStatus, OutgoingWrapStatus.blocked);
+        expect(fetched.selfWrapStatus, OutgoingWrapStatus.blocked);
+        expect(fetched.recipientWrapLastError, 'recipient retired');
+        expect(fetched.hasRetryableFailure, isFalse);
+        expect(fetched.isFullyDelivered, isFalse);
+        expect(
+          await dao.getRetryableForOwner(ownerPubkey: ownerA, maxRetries: 5),
+          isEmpty,
+        );
+        expect(await dao.getStillPendingForOwner(ownerA), isEmpty);
+      });
+
       test('returns false when the row does not exist', () async {
         final ok = await dao.markRecipientWrapStatus(
           id: 'missing',
@@ -748,6 +770,14 @@ void main() {
               queuedAt: DateTime.utc(2026, 5, 4),
             ),
           );
+          await dao.enqueue(
+            makeDm(
+              id: 'blocked',
+              recipientStatus: OutgoingWrapStatus.blocked,
+              selfStatus: OutgoingWrapStatus.blocked,
+              queuedAt: DateTime.utc(2026, 5, 4, 12),
+            ),
+          );
           // Failed but past the retry cap: excluded.
           await dao.enqueue(
             makeDm(
@@ -834,6 +864,14 @@ void main() {
               recipientStatus: OutgoingWrapStatus.failed,
               selfStatus: OutgoingWrapStatus.failed,
               queuedAt: DateTime.utc(2026, 5, 4),
+            ),
+          );
+          await dao.enqueue(
+            makeDm(
+              id: 'blocked',
+              recipientStatus: OutgoingWrapStatus.blocked,
+              selfStatus: OutgoingWrapStatus.blocked,
+              queuedAt: DateTime.utc(2026, 5, 5),
             ),
           );
 

--- a/mobile/packages/dm_repository/lib/src/collaborator_invite_recovery.dart
+++ b/mobile/packages/dm_repository/lib/src/collaborator_invite_recovery.dart
@@ -145,7 +145,8 @@ class PendingCollaboratorInvite extends Equatable {
 
   /// Whether the collaborator-directed wrap still needs recovery.
   bool get requiresRecipientRecovery =>
-      recipientWrapStatus != OutgoingWrapStatus.sent;
+      recipientWrapStatus != OutgoingWrapStatus.sent &&
+      recipientWrapStatus != OutgoingWrapStatus.blocked;
 
   @override
   List<Object?> get props => [

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -4741,10 +4741,12 @@ class DmRepository {
         // Local persistence failure is a degraded state, not a send failure.
       }
     } else if (result.blocked && outgoingDao != null) {
-      // A policy block is terminal, not a transient failure: drop the queue
-      // row so the sweep stops re-driving a send the gate refuses every time
-      // (no doomed Resend bubble). Mirrors sendGroupMessage's per-recipient
-      // classification and the drain's blocked arm.
+      // A policy block is terminal, not a transient failure.
+      // _finalizeAfterRecipientBlocked discards or retains the row per the
+      // block's disposition, so the sweep stops re-driving a send the gate
+      // refuses every time (no doomed Resend bubble). Mirrors
+      // sendGroupMessage's per-recipient classification and the drain's
+      // blocked arm.
       await _finalizeAfterRecipientBlocked(
         outgoingDao: outgoingDao,
         rumorId: rumor.id,
@@ -5505,9 +5507,10 @@ class DmRepository {
         // arrives via the receive pipeline.
       }
     } else if (result.blocked) {
-      // A confirmed #176 policy block is terminal, not a transient error:
-      // drop the row so the retry sweep stops re-attempting a send the gate
-      // refuses every time. This attempt delivered nothing.
+      // A confirmed policy block is terminal, not a transient error.
+      // _finalizeAfterRecipientBlocked discards or retains the row per the
+      // block's disposition, so the retry sweep stops re-attempting a send the
+      // gate refuses every time. This attempt delivered nothing.
       await _finalizeAfterRecipientBlocked(
         outgoingDao: dao,
         rumorId: rumorId,
@@ -6469,14 +6472,17 @@ class DmRepository {
     // nothing to atomically tie a queue update to (no message row insert).
     // Classify each the same way the 1:1 path does — soft-unconfirmed stays
     // pending (plain optimistic bubble), a policy block is terminal (row
-    // dropped), and a hard failure marks both wraps failed.
+    // discarded or retained per disposition), and a hard failure marks both
+    // wraps failed.
     //
     // The two surviving-row branches also stamp their sibling's queued rumor
     // id onto the returned result, exactly as [sendMessage] does. Without it
     // a group caller has no handle on the rows this send parked and its only
     // way to "retry" is a fresh fan-out, which mints a whole second set of
     // rumors the receiver cannot collapse (#7316). Cancelled and blocked
-    // siblings are deliberately unstamped: none leaves a row behind.
+    // siblings are deliberately unstamped: a cancelled sibling leaves no row,
+    // and a blocked sibling is terminal (retained or discarded) and must never
+    // be handed back for retry.
     if (outgoingDao != null) {
       for (var i = 0; i < queueIds.length; i++) {
         // A sibling skipped for cancellation has no live row to transition; an

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -4748,6 +4748,7 @@ class DmRepository {
       await _finalizeAfterRecipientBlocked(
         outgoingDao: outgoingDao,
         rumorId: rumor.id,
+        result: result,
       );
     } else if (result.retryablePending && outgoingDao != null) {
       // Soft retry: either the recipient frame was written but no NIP-20 OK
@@ -5507,7 +5508,11 @@ class DmRepository {
       // A confirmed #176 policy block is terminal, not a transient error:
       // drop the row so the retry sweep stops re-attempting a send the gate
       // refuses every time. This attempt delivered nothing.
-      await _finalizeAfterRecipientBlocked(outgoingDao: dao, rumorId: rumorId);
+      await _finalizeAfterRecipientBlocked(
+        outgoingDao: dao,
+        rumorId: rumorId,
+        result: result,
+      );
     } else if (result.retryablePending) {
       // Soft retry: frame written with no OK yet, or a pre-publish wrap build
       // timeout while a human-gated signer approval may still be pending. Keep
@@ -5896,22 +5901,30 @@ class DmRepository {
     }
   }
 
-  /// Apply the terminal queue-row transition for a policy-blocked (#176)
-  /// recipient publish. Unlike [_finalizeAfterRecipientFailure], a block is
-  /// terminal — the send gate refuses every retry — so the row is deleted
-  /// rather than left retryable. Non-rethrowing to match the failure path: the
-  /// caller still returns the blocked result. A failed delete leaves the row in
-  /// place (still `failed` or `pending`, depending on the drain arm), which
-  /// self-heals on a later sweep — the gate re-blocks and re-drops it.
+  /// Apply the terminal queue-row transition for a policy-blocked recipient.
+  ///
+  /// Protected-minor refusals discard the row because the intent must not
+  /// remain visible. A retired moderation recipient retains it in the
+  /// non-retryable `blocked` state because the row is the sender's only copy.
+  /// Non-rethrowing to match the failure path: the caller still receives the
+  /// blocked result when the durable transition fails.
   Future<void> _finalizeAfterRecipientBlocked({
     required OutgoingDmsDao outgoingDao,
     required String rumorId,
+    required NIP17SendResult result,
   }) async {
     try {
-      await outgoingDao.deleteById(rumorId);
+      if (result.blockedDisposition == NIP17BlockedSendDisposition.retain) {
+        await outgoingDao.markRecipientBlocked(
+          id: rumorId,
+          lastError: result.error ?? 'Blocked by send policy',
+        );
+      } else {
+        await outgoingDao.deleteById(rumorId);
+      }
     } on Object catch (e, stackTrace) {
       Log.error(
-        'Failed to delete blocked outgoing_dms row $rumorId: $e',
+        'Failed to terminalize blocked outgoing_dms row $rumorId: $e',
         category: LogCategory.system,
         error: e,
         stackTrace: stackTrace,
@@ -6479,6 +6492,7 @@ class DmRepository {
           await _finalizeAfterRecipientBlocked(
             outgoingDao: outgoingDao,
             rumorId: queueIds[i],
+            result: result,
           );
         } else if (result.retryablePending) {
           await _finalizeAfterRecipientUnconfirmed(

--- a/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
@@ -37,9 +37,8 @@ abstract class DmRepositoryReportableSites {
   static const String finalizeAfterRecipientFailure =
       'finalizeAfterRecipientFailure';
 
-  /// `_finalizeAfterRecipientBlocked`: deleting the terminally-blocked
-  /// queue row threw. Caller already has the blocked result; the row
-  /// stays failed or pending and self-heals on a later sweep.
+  /// `_finalizeAfterRecipientBlocked`: terminalizing the policy-blocked queue
+  /// row threw. Caller already has the blocked result.
   static const String finalizeAfterRecipientBlocked =
       'finalizeAfterRecipientBlocked';
 

--- a/mobile/packages/dm_repository/lib/src/dm_send_policy.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_send_policy.dart
@@ -10,12 +10,17 @@ enum DmSendPolicyDecision {
   /// Fail closed for now, but the missing account-state verdict may resolve.
   temporarilyBlocked,
 
-  /// A confirmed policy blocks this recipient — the send can never succeed.
+  /// A confirmed policy blocks this recipient — the send can never succeed —
+  /// and any existing queue row should be discarded.
   ///
   /// The reason is deliberately not carried here: the app owns the policy and
   /// therefore owns the copy. A caller that needs to explain the refusal
   /// re-derives it from the recipient it already holds.
-  terminallyBlocked,
+  terminallyBlockedDiscard,
+
+  /// A confirmed policy blocks this recipient permanently, but an existing
+  /// queue row is the sender's only durable copy and must be retained.
+  terminallyBlockedRetain,
 }
 
 /// Decides whether the current sender may deliver a DM to [recipientPubkey].

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -11,7 +11,8 @@ import 'package:dm_repository/src/dm_send_budget.dart';
 import 'package:dm_repository/src/dm_send_policy.dart';
 import 'package:dm_repository/src/gift_wrap_build_worker.dart';
 import 'package:meta/meta.dart';
-import 'package:models/models.dart' show NIP17SendResult;
+import 'package:models/models.dart'
+    show NIP17BlockedSendDisposition, NIP17SendResult;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
@@ -622,8 +623,12 @@ class NIP17MessageService {
             'temporarily blocked: protected-minor status unresolved',
           );
         }
-        return const NIP17SendResult.blocked(
+        return NIP17SendResult.blocked(
           'blocked: recipient not permitted by send policy',
+          disposition:
+              policyDecision == DmSendPolicyDecision.terminallyBlockedRetain
+              ? NIP17BlockedSendDisposition.retain
+              : NIP17BlockedSendDisposition.discard,
         );
       }
 

--- a/mobile/packages/dm_repository/test/src/collaborator_invite_recovery_test.dart
+++ b/mobile/packages/dm_repository/test/src/collaborator_invite_recovery_test.dart
@@ -269,6 +269,19 @@ void main() {
       );
       expect(failedInvite.requiresRecipientRecovery, isTrue);
       expect(sentInvite.requiresRecipientRecovery, isFalse);
+      expect(
+        PendingCollaboratorInvite(
+          rumorId: 'blocked-a',
+          collaboratorPubkey: _collaboratorA,
+          creatorPubkey: _ownerPubkey,
+          videoAddress: _videoAddress,
+          recipientWrapStatus: OutgoingWrapStatus.blocked,
+          selfWrapStatus: OutgoingWrapStatus.blocked,
+          retryCount: 2,
+          queuedAt: queuedAt,
+        ).requiresRecipientRecovery,
+        isFalse,
+      );
     });
 
     test('pending invite group exposes collaborators and equality', () {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -25387,6 +25387,45 @@ void main() {
       );
 
       test(
+        'on a retained block: terminalizes the row without deleting the '
+        'sender copy',
+        () async {
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer((_) async => queuedRow());
+          stubSendRumor(
+            (_, _) async => const NIP17SendResult.blocked(
+              'blocked: retired recipient',
+              disposition: NIP17BlockedSendDisposition.retain,
+            ),
+          );
+          when(
+            () => mockOutgoingDmsDao.markRecipientBlocked(
+              id: _rumorEventId,
+              lastError: 'blocked: retired recipient',
+            ),
+          ).thenAnswer((_) async => true);
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverFullSend(
+            rumorId: _rumorEventId,
+          );
+
+          expect(result.blockedDisposition, NIP17BlockedSendDisposition.retain);
+          verify(
+            () => mockOutgoingDmsDao.markRecipientBlocked(
+              id: _rumorEventId,
+              lastError: 'blocked: retired recipient',
+            ),
+          ).called(1);
+          verifyNever(() => mockOutgoingDmsDao.deleteById(any()));
+        },
+      );
+
+      test(
         'on a blocked send: when deleteById throws, swallows the error and '
         'still returns the blocked result (row self-heals on a later sweep)',
         () async {

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -8,7 +8,8 @@ import 'package:dm_repository/dm_repository.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:models/models.dart' show NIP17SendFailure, NIP17SendResult;
+import 'package:models/models.dart'
+    show NIP17BlockedSendDisposition, NIP17SendFailure, NIP17SendResult;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/client_utils/keys.dart';
 import 'package:nostr_sdk/event.dart';
@@ -100,11 +101,15 @@ class _RefusesToSignSigner implements NostrSigner {
 /// Denies every recipient — stands in for a protected minor's policy where the
 /// counterparty is not in the approved official set.
 Future<DmSendPolicyDecision> _denyAllPolicy(String recipientPubkey) async =>
-    DmSendPolicyDecision.terminallyBlocked;
+    DmSendPolicyDecision.terminallyBlockedDiscard;
 
 Future<DmSendPolicyDecision> _temporarilyDenyPolicy(
   String recipientPubkey,
 ) async => DmSendPolicyDecision.temporarilyBlocked;
+
+Future<DmSendPolicyDecision> _retainBlockedPolicy(
+  String recipientPubkey,
+) async => DmSendPolicyDecision.terminallyBlockedRetain;
 
 /// A local-key signer that advertises the isolate-offload capability,
 /// delegating all crypto to a real [LocalNostrSigner]. Used to exercise the
@@ -289,6 +294,10 @@ void main() {
           // conversation view and tells the cold-start drain to drop the row
           // instead of retrying a send that can never succeed.
           expect(result.blocked, isTrue);
+          expect(
+            result.blockedDisposition,
+            NIP17BlockedSendDisposition.discard,
+          );
           verifyNever(() => mockNostrClient.publishEvent(any()));
           verifyNever(
             () => mockNostrClient.publishEvent(
@@ -298,6 +307,31 @@ void main() {
           );
         },
       );
+
+      test('sendRumor carries a retained terminal disposition', () async {
+        final blocked = NIP17MessageService(
+          signer: LocalNostrSigner(_testPrivateKey),
+          senderPublicKey: _testPublicKey,
+          nostrService: mockNostrClient,
+          sendPolicy: _retainBlockedPolicy,
+        );
+        final rumor = blocked.buildRumor(
+          recipientPubkey: _recipientPubkey,
+          content: 'keep my local copy',
+        );
+
+        final result = await blocked.sendRumor(
+          rumorEvent: rumor,
+          recipientPubkey: _recipientPubkey,
+        );
+
+        expect(result.blocked, isTrue);
+        expect(
+          result.blockedDisposition,
+          NIP17BlockedSendDisposition.retain,
+        );
+        verifyNever(() => mockNostrClient.publishEvent(any()));
+      });
 
       test(
         'canSendTo surfaces the policy verdict for pre-enqueue/group checks',

--- a/mobile/packages/models/lib/src/nip17_send_result.dart
+++ b/mobile/packages/models/lib/src/nip17_send_result.dart
@@ -4,6 +4,15 @@
 
 import 'package:meta/meta.dart';
 
+/// Durable treatment for a queue row after a terminal policy refusal.
+enum NIP17BlockedSendDisposition {
+  /// Remove the row because the refused intent must not remain visible.
+  discard,
+
+  /// Keep the row as a visible, non-retryable record of the sender's intent.
+  retain,
+}
+
 /// Result of NIP-17 encrypted message sending.
 ///
 /// NIP-17 send is two independent publishes to relays:
@@ -81,8 +90,10 @@ sealed class NIP17SendResult {
   /// Build a policy-block result (protected-minor DM restriction, #176). Unlike
   /// a transient failure, a blocked send must NOT be retried — retrying only
   /// re-hits the same policy — so the UI surfaces distinct, no-retry copy.
-  const factory NIP17SendResult.blocked(String error) =
-      NIP17SendFailure.blocked;
+  const factory NIP17SendResult.blocked(
+    String error, {
+    NIP17BlockedSendDisposition? disposition,
+  }) = NIP17SendFailure.blocked;
 
   /// Build an oversized-message result (#7331): the rumor serializes to more
   /// than the NIP-44 double encryption can carry, so no wrap could be built.
@@ -101,6 +112,11 @@ sealed class NIP17SendResult {
   /// Whether this failure is a policy block (#176), not a transient/network
   /// error. Blocked sends are not retriable. Always `false` for success.
   bool get blocked => false;
+
+  /// How an existing durable row should be treated for a policy block.
+  ///
+  /// `null` for every result other than [NIP17SendFailure.blocked].
+  NIP17BlockedSendDisposition? get blockedDisposition => null;
 
   /// Whether this failure is an oversized message (#7331), refused before any
   /// wrap was built. Not retriable — the size is a property of the rumor, so
@@ -239,17 +255,21 @@ final class NIP17SendFailure extends NIP17SendResult {
     this.retryablePending = false,
     this.queuedRumorId,
   }) : blocked = false,
+       _blockedDisposition = null,
        tooLong = false;
 
   /// A policy block (#176): same non-delivery as a failure, but not retriable.
   ///
   /// Never carries a [queuedRumorId]: the send gate returns before the
   /// enqueue, so a block leaves no row behind to coalesce onto.
-  const NIP17SendFailure.blocked(this.error)
-    : blocked = true,
-      tooLong = false,
-      retryablePending = false,
-      queuedRumorId = null;
+  const NIP17SendFailure.blocked(
+    this.error, {
+    NIP17BlockedSendDisposition? disposition,
+  }) : blocked = true,
+       _blockedDisposition = disposition,
+       tooLong = false,
+       retryablePending = false,
+       queuedRumorId = null;
 
   /// An oversized message (#7331): refused before any wrap build.
   ///
@@ -259,6 +279,7 @@ final class NIP17SendFailure extends NIP17SendResult {
   /// whole retry budget re-running a crypto chain that cannot succeed.
   const NIP17SendFailure.tooLong(this.error)
     : blocked = false,
+      _blockedDisposition = null,
       tooLong = true,
       retryablePending = false,
       queuedRumorId = null;
@@ -268,6 +289,13 @@ final class NIP17SendFailure extends NIP17SendResult {
 
   @override
   final bool blocked;
+
+  final NIP17BlockedSendDisposition? _blockedDisposition;
+
+  @override
+  NIP17BlockedSendDisposition? get blockedDisposition => blocked
+      ? _blockedDisposition ?? NIP17BlockedSendDisposition.discard
+      : null;
 
   @override
   final bool tooLong;
@@ -299,18 +327,26 @@ final class NIP17SendFailure extends NIP17SendResult {
     return other is NIP17SendFailure &&
         other.error == error &&
         other.blocked == blocked &&
+        other.blockedDisposition == blockedDisposition &&
         other.tooLong == tooLong &&
         other.retryablePending == retryablePending &&
         other.queuedRumorId == queuedRumorId;
   }
 
   @override
-  int get hashCode =>
-      Object.hash(error, blocked, tooLong, retryablePending, queuedRumorId);
+  int get hashCode => Object.hash(
+    error,
+    blocked,
+    blockedDisposition,
+    tooLong,
+    retryablePending,
+    queuedRumorId,
+  );
 
   @override
   String toString() =>
       'NIP17SendFailure(error: $error, blocked: $blocked, '
+      'blockedDisposition: $blockedDisposition, '
       'tooLong: $tooLong, '
       'retryablePending: $retryablePending, '
       'queuedRumorId: $queuedRumorId)';

--- a/mobile/packages/models/test/src/nip17_send_result_test.dart
+++ b/mobile/packages/models/test/src/nip17_send_result_test.dart
@@ -343,6 +343,23 @@ void main() {
         expect(transient.hashCode, isNot(equals(blocked.hashCode)));
       });
 
+      test('blocked disposition defaults to discard and participates in '
+          'value equality', () {
+        const discard = NIP17SendFailure.blocked('policy');
+        const retain = NIP17SendFailure.blocked(
+          'policy',
+          disposition: NIP17BlockedSendDisposition.retain,
+        );
+
+        expect(
+          discard.blockedDisposition,
+          NIP17BlockedSendDisposition.discard,
+        );
+        expect(retain.blockedDisposition, NIP17BlockedSendDisposition.retain);
+        expect(discard, isNot(equals(retain)));
+        expect(discard.hashCode, isNot(equals(retain.hashCode)));
+      });
+
       test('value equality: success and failure are never equal', () {
         final success = NIP17SendSuccess(
           rumorEventId: rumorEventId,

--- a/mobile/test/blocs/dm/conversation/conversation_state_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_state_test.dart
@@ -142,6 +142,22 @@ void main() {
         );
       });
 
+      test('a retained terminal block renders as blocked, not delivered', () {
+        final blocked = _outgoingDm(
+          id: 'blocked-rumor',
+          rumorId: 'blocked-rumor',
+          recipientWrap: OutgoingWrapStatus.blocked,
+        );
+        final state = ConversationState(pendingOutgoing: [blocked]);
+
+        expect(state.displayedMessages.single.id, 'blocked-rumor');
+        expect(
+          state.statusFor('blocked-rumor'),
+          DmDeliveryStatus.blocked,
+        );
+        expect(state.failedSiblingRumorIdsFor('blocked-rumor'), isEmpty);
+      });
+
       test(
         'partial group delivery renders exactly ONE bubble with the '
         'combined status — the persisted winner suppresses the surviving '

--- a/mobile/test/providers/dm_send_policy_test.dart
+++ b/mobile/test/providers/dm_send_policy_test.dart
@@ -70,7 +70,7 @@ void main() {
       for (final retired in kLegacyModerationPubkeys) {
         expect(
           await policy(retired),
-          DmSendPolicyDecision.terminallyBlocked,
+          DmSendPolicyDecision.terminallyBlockedRetain,
           reason: 'retired key $retired must never be a send target',
         );
       }
@@ -104,7 +104,7 @@ void main() {
 
       expect(
         decision,
-        DmSendPolicyDecision.terminallyBlocked,
+        DmSendPolicyDecision.terminallyBlockedRetain,
         reason: 'a stubbed approval must not reopen a retired identity',
       );
     });
@@ -138,7 +138,10 @@ void main() {
     final container = containerWith(isRestricted: true);
     final policy = container.read(dmSendPolicyProvider);
 
-    expect(await policy(strangerHex), DmSendPolicyDecision.terminallyBlocked);
+    expect(
+      await policy(strangerHex),
+      DmSendPolicyDecision.terminallyBlockedDiscard,
+    );
   });
 
   test(

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -647,6 +647,70 @@ void main() {
           ),
         );
       });
+
+      testWidgets(
+        'a retained blocked bubble is visible, non-retryable, and locally '
+        'deletable',
+        (tester) async {
+          final retired = kLegacyModerationPubkeys.first;
+          const ownConversationId =
+              '3434343434343434343434343434343434343434343434343434343434343434';
+          const content = 'my retained appeal';
+          final blockedRow = OutgoingDm(
+            id: 'rumor-blocked-retired',
+            conversationId: ownConversationId,
+            recipientPubkey: retired,
+            content: content,
+            createdAt: DateTime(2026).millisecondsSinceEpoch ~/ 1000,
+            rumorEventJson: '{}',
+            recipientWrapStatus: OutgoingWrapStatus.blocked,
+            selfWrapStatus: OutgoingWrapStatus.blocked,
+            queuedAt: DateTime(2026),
+            ownerPubkey: currentPubkey,
+          );
+
+          await tester.pumpWidget(
+            buildSubject(
+              counterparty: retired,
+              state: ConversationState(
+                status: ConversationStatus.loaded,
+                pendingOutgoing: [blockedRow],
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.text(content), findsOneWidget);
+          expect(find.text(l10n.dmSendBlockedRetiredMessage), findsOneWidget);
+
+          await tester.tap(find.text(content));
+          await tester.pumpAndSettle();
+          expect(find.text(l10n.dmMessageActionRetrySend), findsNothing);
+
+          await tester.longPress(find.text(content));
+          await tester.pumpAndSettle();
+          expect(find.text(l10n.dmMessageActionCancelSend), findsOneWidget);
+          expect(
+            find.text(l10n.dmMessageActionDeleteForEveryone),
+            findsNothing,
+          );
+
+          await tester.tap(find.text(l10n.dmMessageActionCancelSend));
+          await tester.pumpAndSettle();
+          verify(
+            () => mockBloc.add(
+              const ConversationMessageDeleted(
+                rumorId: 'rumor-blocked-retired',
+              ),
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockBloc.add(
+              any(that: isA<ConversationFullSendRecoveryRequested>()),
+            ),
+          );
+        },
+      );
     });
 
     // #6416. Nothing has read a retired moderation key since the rotation, so

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -523,6 +523,32 @@ void main() {
         expect(find.text(strings.dmStatusFailed), findsOneWidget);
       });
 
+      testWidgets('renders closed-thread copy for blocked status', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: MessageBubble(
+                message: 'Retained appeal',
+                timestamp: '2:30 PM',
+                isSent: true,
+                deliveryStatus: DmDeliveryStatus.blocked,
+              ),
+            ),
+          ),
+        );
+
+        expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
+        expect(
+          find.text(strings.dmSendBlockedRetiredMessage),
+          findsOneWidget,
+        );
+        expect(find.text(strings.dmStatusFailed), findsNothing);
+      });
+
       testWidgets(
         'does not render indicator for received messages even when '
         'a non-delivered status is passed',


### PR DESCRIPTION
## Problem

A DM that failed while a moderation key was active remained visible only in the outgoing queue. After that key retired, the next retry classified the recipient as terminally blocked and deleted the queue row, silently erasing the sender copy.

## Why this fix

The send policy now carries an explicit terminal queue disposition. Retired moderation recipients retain their queue row, while confirmed protected-minor refusals preserve their existing discard behavior. Retained rows mark both gift-wrap legs blocked, which keeps them out of pending and failed retry queries without a database migration.

The conversation maps that durable state to a distinct blocked indicator using the existing closed-thread explanation. It cannot be tapped to retry, but a queue-only bubble can still be removed locally through Stop trying even though delete-for-everyone is disabled on retired threads. Collaborator invite recovery also treats blocked as terminal.

## Deliberately unchanged

- Confirmed protected-minor policy refusals still discard queue rows.
- Persisted messages on retired threads still cannot publish delete-for-everyone events.
- Blocked reaction rendering is a separate surface and is not changed here.

## Verification

- flutter analyze
- 907 focused policy, model, DAO, repository, retry-service, state, and widget tests
- repository pre-push analyzer, generated-file verification, and 849 changed-file tests
- .codex/scripts/test-config.sh
- Full app suite: 19,015 tests passed; three local-renderer gallery goldens mismatched and three manual relay tests correctly reported that the local relay stack was not running

Closes #8492