### PR TITLE
fix(settings): resume NIP-05 setup after profile creation

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -397,6 +397,7 @@
     "profileLinkCopied": "የመገለጫ አገናኝ ተቀድቷል።",
     "profileSetupEditProfileTitle": "መገለጫ አርትዕ",
     "nostrSettingsNip05ProfileRequired": "የNIP-05 አድራሻ ከማከልዎ በፊት መገለጫዎን ያዘጋጁ።",
+    "nostrSettingsNip05CreateProfileAction": "መገለጫ ይፍጠሩ",
     "profileSetupBackLabel": "ተመለስ",
     "profileSetupAboutNostr": "ስለ Nostr",
     "profileSetupProfilePublished": "መገለጫ በተሳካ ሁኔታ ታትሟል!",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -334,6 +334,7 @@
     "profileLinkCopied": "تم نسخ رابط الملف الشخصي",
     "profileSetupEditProfileTitle": "تعديل الملف الشخصي",
     "nostrSettingsNip05ProfileRequired": "أعِدّ ملفك الشخصي قبل إضافة عنوان NIP-05.",
+    "nostrSettingsNip05CreateProfileAction": "إنشاء ملف شخصي",
     "profileSetupBackLabel": "رجوع",
     "profileSetupAboutNostr": "عن Nostr",
     "profileSetupProfilePublished": "تم نشر الملف الشخصي بنجاح!",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -372,6 +372,7 @@
     "profileLinkCopied": "Връзката към профила е копирана",
     "profileSetupEditProfileTitle": "Редактиране на профил",
     "nostrSettingsNip05ProfileRequired": "Настрой профила си, преди да добавиш NIP-05 адрес.",
+    "nostrSettingsNip05CreateProfileAction": "Създай профил",
     "profileSetupBackLabel": "Назад",
     "profileSetupAboutNostr": "Относно Nostr",
     "profileSetupProfilePublished": "Профилът е публикуван успешно!",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -334,6 +334,7 @@
     "profileLinkCopied": "Profil-Link kopiert",
     "profileSetupEditProfileTitle": "Profil bearbeiten",
     "nostrSettingsNip05ProfileRequired": "Richte dein Profil ein, bevor du eine NIP-05-Adresse hinzufügst.",
+    "nostrSettingsNip05CreateProfileAction": "Profil erstellen",
     "profileSetupBackLabel": "Zurück",
     "profileSetupAboutNostr": "Über Nostr",
     "profileSetupProfilePublished": "Profil erfolgreich veröffentlicht!",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -582,6 +582,10 @@
   "@nostrSettingsNip05ProfileRequired": {
     "description": "Empty-state message on NIP-05 settings when the account has not published a profile yet."
   },
+  "nostrSettingsNip05CreateProfileAction": "Create profile",
+  "@nostrSettingsNip05CreateProfileAction": {
+    "description": "Button that opens first-profile setup from NIP-05 settings."
+  },
   "profileSetupBackLabel": "Back",
   "profileSetupAboutNostr": "About Nostr",
   "profileSetupProfilePublished": "Profile published successfully!",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -334,6 +334,7 @@
     "profileLinkCopied": "Link del perfil copiado",
     "profileSetupEditProfileTitle": "Editar perfil",
     "nostrSettingsNip05ProfileRequired": "Configura tu perfil antes de añadir una dirección NIP-05.",
+    "nostrSettingsNip05CreateProfileAction": "Crear perfil",
     "profileSetupBackLabel": "Atrás",
     "profileSetupAboutNostr": "Sobre Nostr",
     "profileSetupProfilePublished": "¡Perfil publicado con éxito!",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -202,6 +202,7 @@
     "profileLinkCopied": "Nakopya na ang profile link",
     "profileSetupEditProfileTitle": "I-edit ang Profile",
     "nostrSettingsNip05ProfileRequired": "I-set up ang profile mo bago magdagdag ng NIP-05 address.",
+    "nostrSettingsNip05CreateProfileAction": "Gumawa ng profile",
     "profileSetupBackLabel": "Bumalik",
     "profileSetupAboutNostr": "Tungkol sa Nostr",
     "profileSetupProfilePublished": "Matagumpay na na-publish ang profile!",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -334,6 +334,7 @@
     "profileLinkCopied": "Lien du profil copié",
     "profileSetupEditProfileTitle": "Modifier le profil",
     "nostrSettingsNip05ProfileRequired": "Configure ton profil avant d’ajouter une adresse NIP-05.",
+    "nostrSettingsNip05CreateProfileAction": "Créer un profil",
     "profileSetupBackLabel": "Retour",
     "profileSetupAboutNostr": "À propos de Nostr",
     "profileSetupProfilePublished": "Profil publié avec succès !",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -334,6 +334,7 @@
     "profileLinkCopied": "Tautan profil disalin",
     "profileSetupEditProfileTitle": "Ubah Profil",
     "nostrSettingsNip05ProfileRequired": "Siapkan profilmu sebelum menambahkan alamat NIP-05.",
+    "nostrSettingsNip05CreateProfileAction": "Buat profil",
     "profileSetupBackLabel": "Kembali",
     "profileSetupAboutNostr": "Tentang Nostr",
     "profileSetupProfilePublished": "Profil berhasil dipublikasikan!",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -334,6 +334,7 @@
     "profileLinkCopied": "Link del profilo copiato",
     "profileSetupEditProfileTitle": "Modifica profilo",
     "nostrSettingsNip05ProfileRequired": "Configura il tuo profilo prima di aggiungere un indirizzo NIP-05.",
+    "nostrSettingsNip05CreateProfileAction": "Crea profilo",
     "profileSetupBackLabel": "Indietro",
     "profileSetupAboutNostr": "Info su Nostr",
     "profileSetupProfilePublished": "Profilo pubblicato con successo!",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -334,6 +334,7 @@
     "profileLinkCopied": "プロフィールのリンクをコピーしたよ",
     "profileSetupEditProfileTitle": "プロフィールを編集",
     "nostrSettingsNip05ProfileRequired": "NIP-05アドレスを追加する前にプロフィールを設定してください。",
+    "nostrSettingsNip05CreateProfileAction": "プロフィールを作成",
     "profileSetupBackLabel": "戻る",
     "profileSetupAboutNostr": "Nostr について",
     "profileSetupProfilePublished": "プロフィールを公開したよ！",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -202,6 +202,7 @@
     "profileLinkCopied": "프로필 링크를 복사했어요",
     "profileSetupEditProfileTitle": "프로필 편집",
     "nostrSettingsNip05ProfileRequired": "NIP-05 주소를 추가하기 전에 프로필을 설정하세요.",
+    "nostrSettingsNip05CreateProfileAction": "프로필 만들기",
     "profileSetupBackLabel": "뒤로",
     "profileSetupAboutNostr": "Nostr란?",
     "profileSetupProfilePublished": "프로필을 게시했어요!",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -427,6 +427,7 @@
   "profileLinkCopied": "Pautan profil disalin",
   "profileSetupEditProfileTitle": "Sunting Profil",
   "nostrSettingsNip05ProfileRequired": "Sediakan profil anda sebelum menambah alamat NIP-05.",
+  "nostrSettingsNip05CreateProfileAction": "Cipta profil",
   "profileSetupBackLabel": "Kembali",
   "profileSetupAboutNostr": "Perihal Nostr",
   "profileSetupProfilePublished": "Profil berjaya diterbitkan!",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -334,6 +334,7 @@
     "profileLinkCopied": "Profiellink gekopieerd",
     "profileSetupEditProfileTitle": "Profiel bewerken",
     "nostrSettingsNip05ProfileRequired": "Stel je profiel in voordat je een NIP-05-adres toevoegt.",
+    "nostrSettingsNip05CreateProfileAction": "Profiel maken",
     "profileSetupBackLabel": "Terug",
     "profileSetupAboutNostr": "Over Nostr",
     "profileSetupProfilePublished": "Profiel succesvol gepubliceerd!",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -334,6 +334,7 @@
     "profileLinkCopied": "Link do profilu skopiowany",
     "profileSetupEditProfileTitle": "Edytuj profil",
     "nostrSettingsNip05ProfileRequired": "Skonfiguruj profil, zanim dodasz adres NIP-05.",
+    "nostrSettingsNip05CreateProfileAction": "Utwórz profil",
     "profileSetupBackLabel": "Wstecz",
     "profileSetupAboutNostr": "O Nostr",
     "profileSetupProfilePublished": "Profil opublikowany pomyślnie!",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -334,6 +334,7 @@
     "profileLinkCopied": "Link do perfil copiado",
     "profileSetupEditProfileTitle": "Editar perfil",
     "nostrSettingsNip05ProfileRequired": "Configura o teu perfil antes de adicionares um endereço NIP-05.",
+    "nostrSettingsNip05CreateProfileAction": "Criar perfil",
     "profileSetupBackLabel": "Voltar",
     "profileSetupAboutNostr": "Sobre o Nostr",
     "profileSetupProfilePublished": "Perfil publicado com sucesso!",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -334,6 +334,7 @@
     "profileLinkCopied": "Linkul profilului a fost copiat",
     "profileSetupEditProfileTitle": "Editează profilul",
     "nostrSettingsNip05ProfileRequired": "Configurează-ți profilul înainte de a adăuga o adresă NIP-05.",
+    "nostrSettingsNip05CreateProfileAction": "Creează profil",
     "profileSetupBackLabel": "Înapoi",
     "profileSetupAboutNostr": "Despre Nostr",
     "profileSetupProfilePublished": "Profil publicat cu succes!",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -334,6 +334,7 @@
     "profileLinkCopied": "Profillänk kopierad",
     "profileSetupEditProfileTitle": "Redigera profil",
     "nostrSettingsNip05ProfileRequired": "Konfigurera din profil innan du lägger till en NIP-05-adress.",
+    "nostrSettingsNip05CreateProfileAction": "Skapa profil",
     "profileSetupBackLabel": "Tillbaka",
     "profileSetupAboutNostr": "Om Nostr",
     "profileSetupProfilePublished": "Profilen publicerades!",

--- a/mobile/lib/l10n/app_te.arb
+++ b/mobile/lib/l10n/app_te.arb
@@ -579,6 +579,7 @@
   "profileLinkCopied": "ప్రొఫైల్ లింక్ కాపీ చేయబడింది",
   "profileSetupEditProfileTitle": "ప్రొఫైల్‌ను సవరించండి",
   "nostrSettingsNip05ProfileRequired": "NIP-05 చిరునామాను జోడించే ముందు మీ ప్రొఫైల్‌ను సెటప్ చేయండి.",
+  "nostrSettingsNip05CreateProfileAction": "ప్రొఫైల్‌ను సృష్టించండి",
   "profileSetupBackLabel": "వెనుకకు",
   "profileSetupAboutNostr": "Nostr గురించి",
   "profileSetupProfilePublished": "ప్రొఫైల్ విజయవంతంగా ప్రచురించబడింది!",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -334,6 +334,7 @@
     "profileLinkCopied": "Profil bağlantısı kopyalandı",
     "profileSetupEditProfileTitle": "Profili Düzenle",
     "nostrSettingsNip05ProfileRequired": "NIP-05 adresi eklemeden önce profilini oluştur.",
+    "nostrSettingsNip05CreateProfileAction": "Profil oluştur",
     "profileSetupBackLabel": "Geri",
     "profileSetupAboutNostr": "Nostr Hakkında",
     "profileSetupProfilePublished": "Profil başarıyla yayınlandı!",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -427,6 +427,7 @@
   "profileLinkCopied": "پروفائل لنک کاپی ہو گیا",
   "profileSetupEditProfileTitle": "پروفائل میں ترمیم کریں",
   "nostrSettingsNip05ProfileRequired": "NIP-05 پتہ شامل کرنے سے پہلے اپنا پروفائل ترتیب دیں۔",
+  "nostrSettingsNip05CreateProfileAction": "پروفائل بنائیں",
   "profileSetupBackLabel": "واپس",
   "profileSetupAboutNostr": "Nostr کے بارے میں",
   "profileSetupProfilePublished": "پروفائل کامیابی سے شائع ہو گیا!",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -427,6 +427,7 @@
   "profileLinkCopied": "Đã sao chép liên kết hồ sơ",
   "profileSetupEditProfileTitle": "Chỉnh sửa hồ sơ",
   "nostrSettingsNip05ProfileRequired": "Hãy thiết lập hồ sơ trước khi thêm địa chỉ NIP-05.",
+  "nostrSettingsNip05CreateProfileAction": "Tạo hồ sơ",
   "profileSetupBackLabel": "Quay lại",
   "profileSetupAboutNostr": "Về Nostr",
   "profileSetupProfilePublished": "Đã đăng hồ sơ thành công!",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -427,6 +427,7 @@
   "profileLinkCopied": "主页链接已复制",
   "profileSetupEditProfileTitle": "编辑资料",
   "nostrSettingsNip05ProfileRequired": "添加 NIP-05 地址前，请先设置个人资料。",
+  "nostrSettingsNip05CreateProfileAction": "创建个人资料",
   "profileSetupBackLabel": "返回",
   "profileSetupAboutNostr": "关于 Nostr",
   "profileSetupProfilePublished": "资料发布成功！",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -1484,6 +1484,12 @@ abstract class AppLocalizations {
   /// **'Set up your profile before adding a NIP-05 address.'**
   String get nostrSettingsNip05ProfileRequired;
 
+  /// Button that opens first-profile setup from NIP-05 settings.
+  ///
+  /// In en, this message translates to:
+  /// **'Create profile'**
+  String get nostrSettingsNip05CreateProfileAction;
+
   /// No description provided for @profileSetupBackLabel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -850,6 +850,9 @@ class AppLocalizationsAm extends AppLocalizations {
       'የNIP-05 አድራሻ ከማከልዎ በፊት መገለጫዎን ያዘጋጁ።';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'መገለጫ ይፍጠሩ';
+
+  @override
   String get profileSetupBackLabel => 'ተመለስ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -851,6 +851,9 @@ class AppLocalizationsAr extends AppLocalizations {
       'أعِدّ ملفك الشخصي قبل إضافة عنوان NIP-05.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'إنشاء ملف شخصي';
+
+  @override
   String get profileSetupBackLabel => 'رجوع';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -878,6 +878,9 @@ class AppLocalizationsBg extends AppLocalizations {
       'Настрой профила си, преди да добавиш NIP-05 адрес.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'Създай профил';
+
+  @override
   String get profileSetupBackLabel => 'Назад';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -877,6 +877,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Richte dein Profil ein, bevor du eine NIP-05-Adresse hinzufügst.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'Profil erstellen';
+
+  @override
   String get profileSetupBackLabel => 'Zurück';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -879,6 +879,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Set up your profile before adding a NIP-05 address.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'Create profile';
+
+  @override
   String get profileSetupBackLabel => 'Back';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -877,6 +877,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'Configura tu perfil antes de añadir una dirección NIP-05.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'Crear perfil';
+
+  @override
   String get profileSetupBackLabel => 'Atrás';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -848,6 +848,9 @@ class AppLocalizationsFil extends AppLocalizations {
       'I-set up ang profile mo bago magdagdag ng NIP-05 address.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'Gumawa ng profile';
+
+  @override
   String get profileSetupBackLabel => 'Bumalik';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -886,6 +886,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Configure ton profil avant d’ajouter une adresse NIP-05.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'Créer un profil';
+
+  @override
   String get profileSetupBackLabel => 'Retour';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -811,6 +811,9 @@ class AppLocalizationsId extends AppLocalizations {
       'Siapkan profilmu sebelum menambahkan alamat NIP-05.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'Buat profil';
+
+  @override
   String get profileSetupBackLabel => 'Kembali';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -882,6 +882,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Configura il tuo profilo prima di aggiungere un indirizzo NIP-05.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'Crea profilo';
+
+  @override
   String get profileSetupBackLabel => 'Indietro';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -770,6 +770,9 @@ class AppLocalizationsJa extends AppLocalizations {
       'NIP-05アドレスを追加する前にプロフィールを設定してください。';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'プロフィールを作成';
+
+  @override
   String get profileSetupBackLabel => '戻る';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -772,6 +772,9 @@ class AppLocalizationsKo extends AppLocalizations {
       'NIP-05 주소를 추가하기 전에 프로필을 설정하세요.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => '프로필 만들기';
+
+  @override
   String get profileSetupBackLabel => '뒤로';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -840,6 +840,9 @@ class AppLocalizationsMs extends AppLocalizations {
       'Sediakan profil anda sebelum menambah alamat NIP-05.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'Cipta profil';
+
+  @override
   String get profileSetupBackLabel => 'Kembali';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -872,6 +872,9 @@ class AppLocalizationsNl extends AppLocalizations {
       'Stel je profiel in voordat je een NIP-05-adres toevoegt.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'Profiel maken';
+
+  @override
   String get profileSetupBackLabel => 'Terug';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -893,6 +893,9 @@ class AppLocalizationsPl extends AppLocalizations {
       'Skonfiguruj profil, zanim dodasz adres NIP-05.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'Utwórz profil';
+
+  @override
   String get profileSetupBackLabel => 'Wstecz';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -878,6 +878,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'Configura o teu perfil antes de adicionares um endereço NIP-05.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'Criar perfil';
+
+  @override
   String get profileSetupBackLabel => 'Voltar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -907,6 +907,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'Configurează-ți profilul înainte de a adăuga o adresă NIP-05.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'Creează profil';
+
+  @override
   String get profileSetupBackLabel => 'Înapoi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -853,6 +853,9 @@ class AppLocalizationsSv extends AppLocalizations {
       'Konfigurera din profil innan du lägger till en NIP-05-adress.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'Skapa profil';
+
+  @override
   String get profileSetupBackLabel => 'Tillbaka';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -890,6 +890,9 @@ class AppLocalizationsTe extends AppLocalizations {
       'NIP-05 చిరునామాను జోడించే ముందు మీ ప్రొఫైల్‌ను సెటప్ చేయండి.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'ప్రొఫైల్‌ను సృష్టించండి';
+
+  @override
   String get profileSetupBackLabel => 'వెనుకకు';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -807,6 +807,9 @@ class AppLocalizationsTr extends AppLocalizations {
       'NIP-05 adresi eklemeden önce profilini oluştur.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'Profil oluştur';
+
+  @override
   String get profileSetupBackLabel => 'Geri';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -871,6 +871,9 @@ class AppLocalizationsUr extends AppLocalizations {
       'NIP-05 پتہ شامل کرنے سے پہلے اپنا پروفائل ترتیب دیں۔';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'پروفائل بنائیں';
+
+  @override
   String get profileSetupBackLabel => 'واپس';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -840,6 +840,9 @@ class AppLocalizationsVi extends AppLocalizations {
       'Hãy thiết lập hồ sơ trước khi thêm địa chỉ NIP-05.';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => 'Tạo hồ sơ';
+
+  @override
   String get profileSetupBackLabel => 'Quay lại';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -792,6 +792,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get nostrSettingsNip05ProfileRequired => '添加 NIP-05 地址前，请先设置个人资料。';
 
   @override
+  String get nostrSettingsNip05CreateProfileAction => '创建个人资料';
+
+  @override
   String get profileSetupBackLabel => '返回';
 
   @override

--- a/mobile/lib/screens/settings/nip05_settings_screen.dart
+++ b/mobile/lib/screens/settings/nip05_settings_screen.dart
@@ -490,9 +490,9 @@ class _Nip05SettingsMissingProfile extends StatelessWidget {
             ),
             DivineButton(
               size: DivineButtonSize.small,
-              label: context.l10n.profileSetupEditProfileTitle,
+              label: context.l10n.nostrSettingsNip05CreateProfileAction,
               onPressed: () async {
-                await context.push(ProfileSetupScreen.editPath);
+                await context.push(ProfileSetupScreen.setupPath);
                 if (!context.mounted) return;
                 context.read<MyProfileBloc>().add(
                   const MyProfileLoadRequested(),

--- a/mobile/test/screens/settings/nip05_settings_screen_test.dart
+++ b/mobile/test/screens/settings/nip05_settings_screen_test.dart
@@ -324,14 +324,18 @@ void main() {
     );
 
     testWidgets(
-      'sends a profile-less user to Edit Profile instead of showing Retry',
+      'sends a profile-less user to Profile Setup and reloads on return',
       (tester) async {
         when(
           () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
         ).thenAnswer((_) async => null);
+        var fetchCount = 0;
         when(
           () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
-        ).thenAnswer((_) async => null);
+        ).thenAnswer((_) async {
+          fetchCount++;
+          return fetchCount == 1 ? null : createProfile();
+        });
         when(
           () => mockProfileRepository.isConfirmedMissing(testPubkey),
         ).thenReturn(true);
@@ -362,10 +366,10 @@ void main() {
               ),
             ),
             GoRoute(
-              path: ProfileSetupScreen.editPath,
+              path: ProfileSetupScreen.setupPath,
               builder: (context, state) => TextButton(
                 onPressed: context.pop,
-                child: const Text('edit-profile-route'),
+                child: const Text('create-profile-route'),
               ),
             ),
           ],
@@ -383,23 +387,25 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(
-          find.text(l10n.nostrSettingsNip05ProfileRequired),
+          find.text(l10n.nostrSettingsNip05CreateProfileAction),
           findsOneWidget,
         );
-        expect(find.text(l10n.profileRetryButton), findsNothing);
+        expect(find.text(l10n.profileSetupEditProfileTitle), findsNothing);
 
-        await tester.tap(find.text(l10n.profileSetupEditProfileTitle));
+        await tester.tap(find.text(l10n.nostrSettingsNip05CreateProfileAction));
         await tester.pumpAndSettle();
 
-        expect(find.text('edit-profile-route'), findsOneWidget);
+        expect(find.text('create-profile-route'), findsOneWidget);
 
-        await tester.tap(find.text('edit-profile-route'));
+        await tester.tap(find.text('create-profile-route'));
         await tester.pumpAndSettle();
 
+        expect(find.text(l10n.profileSetupUsernameLabel), findsOneWidget);
         expect(
           find.text(l10n.nostrSettingsNip05ProfileRequired),
-          findsOneWidget,
+          findsNothing,
         );
+        expect(find.text(l10n.profileRetryButton), findsNothing);
         verify(
           () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
         ).called(2);


### PR DESCRIPTION
## Problem

PR #8496 gave profile-less users a way out of the NIP-05 settings dead end, but it sent them into Edit Profile. That flow assumes a profile already exists and makes the ownership boundary unclear.

## Why this fix

Profile Setup now remains the only place that creates a first public profile. The NIP-05 screen labels the action **Create profile**, opens the first-profile setup route, and reloads the profile when the user returns so successful creation resumes the NIP-05 form.

The NIP-05 screen still only edits an existing profile. It does not invent a display name or silently publish a first profile.

## Deliberately unchanged

- Network failures still show Retry.
- Existing-profile NIP-05 editing and validation are unchanged.
- There are no NIP-05 draft values to preserve before a profile exists.

## Verification

- flutter test test/screens/settings/nip05_settings_screen_test.dart test/l10n/arb_consistency_test.dart
- flutter analyze lib/screens/settings/nip05_settings_screen.dart test/screens/settings/nip05_settings_screen_test.dart
- bash scripts/check_orphaned_arb_key_floor.sh
- check-l10n hardcoded-string scan
- pre-push checks

Closes #8497