### PR TITLE
fix(verify): tell people which part of their proof failed instead of always blaming the npub

### DIFF
--- a/mobile/lib/blocs/verify/verify_connect_cubit.dart
+++ b/mobile/lib/blocs/verify/verify_connect_cubit.dart
@@ -3,9 +3,11 @@
 
 import 'dart:async';
 
+import 'package:analytics/analytics.dart';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:openvine/blocs/verify/verify_proof_input.dart';
+import 'package:openvine/blocs/verify/verify_rejection.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -29,7 +31,9 @@ class VerifyConnectCubit extends Cubit<VerifyConnectState> {
     required VerifierPlatform platform,
     required VerifyOAuthLauncher launchOAuth,
     required String oauthReturnUrl,
+    required AnalyticsEventSink analytics,
   }) : _repository = repository,
+       _analytics = analytics,
        _pubkey = pubkey,
        _launchOAuth = launchOAuth,
        _oauthReturnUrl = oauthReturnUrl,
@@ -38,6 +42,7 @@ class VerifyConnectCubit extends Cubit<VerifyConnectState> {
   final IdentityClaimsRepository _repository;
   final String _pubkey;
   final VerifyOAuthLauncher _launchOAuth;
+  final AnalyticsEventSink _analytics;
   final String _oauthReturnUrl;
 
   /// Records the account handle the user is claiming.
@@ -85,16 +90,33 @@ class VerifyConnectCubit extends Cubit<VerifyConnectState> {
     if (isClosed) return;
 
     if (!result.verified) {
-      // The verifier's reason is specific ("author does not match", "npub not
-      // found") but free-form English, so it guides triage rather than the
-      // user. Dropping it entirely leaves a rejection with no way to tell
-      // which of the two happened.
+      // `error` stays free-form English and is only fit for triage, so the log
+      // keeps it. `code` is the stable half, and is what decides which of the
+      // reasons the user is shown — telling someone their npub is missing when
+      // the real problem was their username is what sends them round the loop
+      // of re-posting a message that was already correct.
       Log.warning(
-        'Verifier rejected ${claim.platform}:${claim.identity}: '
+        'Verifier rejected ${claim.platform}:${claim.identity} '
+        '(code: ${result.code ?? 'none'}): '
         '${result.error ?? 'no reason given'}',
         name: 'VerifyConnectCubit',
       );
-      return _fail(VerifyConnectError.proofRejected);
+      // Nothing else counts these. The rejection is an expected domain
+      // outcome, so it is deliberately not a Crashlytics report — see the
+      // reportable-error matrix in .claude/rules/error_handling.md — but with
+      // no signal at all we cannot tell one stuck person from everybody.
+      // `reason` is a fixed vocabulary and `platform` is a platform key, so
+      // neither carries the npub, the handle, the link or the message.
+      unawaited(
+        _analytics.logEvent(
+          name: 'verify_proof_rejected',
+          parameters: {
+            'platform': claim.platform,
+            'reason': result.code ?? 'none',
+          },
+        ),
+      );
+      return _fail(verifyErrorForCode(result.code));
     }
     await _publish(claim);
   }

--- a/mobile/lib/blocs/verify/verify_connect_state.dart
+++ b/mobile/lib/blocs/verify/verify_connect_state.dart
@@ -23,8 +23,27 @@ enum VerifyConnectStatus {
 
 /// Why a link attempt did not land.
 enum VerifyConnectError {
-  /// The verifier could not find the npub in the proof post.
+  /// The verifier refused the proof for a reason this build cannot name.
+  ///
+  /// The fallback for every unmapped or absent code, so its copy has to stay
+  /// true of any rejection.
   proofRejected,
+
+  /// The link points at the channel rather than at a message in it.
+  discordChannelLink,
+
+  /// Discord has no such message, or it has since been deleted.
+  discordMessageNotFound,
+
+  /// The bot cannot see the channel the message was posted in.
+  discordBotNoAccess,
+
+  /// The message exists but somebody else wrote it.
+  discordAuthorMismatch,
+
+  /// The message exists and its text came back empty, which is our own
+  /// misconfiguration rather than anything the user did.
+  discordContentUnavailable,
 
   /// The verifier could not be reached.
   verifierUnreachable,

--- a/mobile/lib/blocs/verify/verify_connect_state.dart
+++ b/mobile/lib/blocs/verify/verify_connect_state.dart
@@ -29,6 +29,12 @@ enum VerifyConnectError {
   /// true of any rejection.
   proofRejected,
 
+  /// The proof post exists and is the right account's, but has no npub in it.
+  ///
+  /// Named for the reason rather than the platform: every verifier looks for
+  /// the npub in the post, so this copy is true on all of them.
+  proofMissingNpub,
+
   /// The link points at a direct message, which no bot can read.
   discordDmLink,
 

--- a/mobile/lib/blocs/verify/verify_connect_state.dart
+++ b/mobile/lib/blocs/verify/verify_connect_state.dart
@@ -29,6 +29,9 @@ enum VerifyConnectError {
   /// true of any rejection.
   proofRejected,
 
+  /// The link points at a direct message, which no bot can read.
+  discordDmLink,
+
   /// The link points at the channel rather than at a message in it.
   discordChannelLink,
 

--- a/mobile/lib/blocs/verify/verify_rejection.dart
+++ b/mobile/lib/blocs/verify/verify_rejection.dart
@@ -20,6 +20,7 @@ import 'package:openvine/blocs/verify/verify_connect_cubit.dart';
 /// explainer, and the rest name a service-side condition the user cannot act
 /// on, so the generic rejection is the honest answer.
 VerifyConnectError verifyErrorForCode(String? code) => switch (code) {
+  'discord_dm_link' => VerifyConnectError.discordDmLink,
   'discord_channel_link' => VerifyConnectError.discordChannelLink,
   'discord_message_not_found' => VerifyConnectError.discordMessageNotFound,
   'discord_bot_no_access' => VerifyConnectError.discordBotNoAccess,

--- a/mobile/lib/blocs/verify/verify_rejection.dart
+++ b/mobile/lib/blocs/verify/verify_rejection.dart
@@ -1,0 +1,30 @@
+// ABOUTME: Turns the verifier's stable rejection code into the error the
+// ABOUTME: connect flow shows, falling back for anything it does not know.
+
+import 'package:openvine/blocs/verify/verify_connect_cubit.dart';
+
+/// Resolves the verifier's [code] to the error the connect flow should show.
+///
+/// Mirrors the codes set in
+/// `divine-identify-verification-service/src/platforms/discord.ts`.
+///
+/// An unknown or absent code falls back to [VerifyConnectError.proofRejected].
+/// That is not defensive padding: the service owns this vocabulary and adds to
+/// it independently of the app, and every deployment older than the codes
+/// answers without one. A build that could not absorb an unfamiliar value
+/// would show the user nothing at all.
+///
+/// Four real codes are deliberately unmapped — `discord_invite_refused`,
+/// `discord_not_configured`, `discord_invalid_proof_format` and
+/// `discord_api_error`. The first is already covered by the form's own
+/// explainer, and the rest name a service-side condition the user cannot act
+/// on, so the generic rejection is the honest answer.
+VerifyConnectError verifyErrorForCode(String? code) => switch (code) {
+  'discord_channel_link' => VerifyConnectError.discordChannelLink,
+  'discord_message_not_found' => VerifyConnectError.discordMessageNotFound,
+  'discord_bot_no_access' => VerifyConnectError.discordBotNoAccess,
+  'discord_author_mismatch' => VerifyConnectError.discordAuthorMismatch,
+  'discord_message_content_unavailable' =>
+    VerifyConnectError.discordContentUnavailable,
+  _ => VerifyConnectError.proofRejected,
+};

--- a/mobile/lib/blocs/verify/verify_rejection.dart
+++ b/mobile/lib/blocs/verify/verify_rejection.dart
@@ -20,6 +20,7 @@ import 'package:openvine/blocs/verify/verify_connect_cubit.dart';
 /// explainer, and the rest name a service-side condition the user cannot act
 /// on, so the generic rejection is the honest answer.
 VerifyConnectError verifyErrorForCode(String? code) => switch (code) {
+  'discord_npub_not_in_message' => VerifyConnectError.proofMissingNpub,
   'discord_dm_link' => VerifyConnectError.discordDmLink,
   'discord_channel_link' => VerifyConnectError.discordChannelLink,
   'discord_message_not_found' => VerifyConnectError.discordMessageNotFound,

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4705,7 +4705,6 @@
   "verifyIdentityLabel": "የመለያ ስም",
   "verifyProofLabel": "የልጥፍህ አገናኝ",
   "verifyConnectProofCta": "መርምር እና አገናኝ",
-  "verifyErrorProofRejected": "በዚያ ልጥፍ ውስጥ npub ህን አላገኘንም።",
   "verifyErrorVerifierUnreachable": "አረጋጋጩ አልተገኘም። ትንሽ ቆይተህ ሞክር።",
   "verifyErrorOauthFailed": "አልተሳካም። እንደገና ሞክር።",
   "verifyErrorHandleRequired": "መጀመሪያ ሃንድልህን አስገባ።",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4573,7 +4573,6 @@
   "verifyIdentityLabel": "اسم الحساب",
   "verifyProofLabel": "رابط منشورك",
   "verifyConnectProofCta": "افحص واربط",
-  "verifyErrorProofRejected": "لم نجد npub الخاص بك في ذلك المنشور.",
   "verifyErrorVerifierUnreachable": "تعذّر الوصول إلى خدمة التوثيق. حاول بعد قليل.",
   "verifyErrorOauthFailed": "لم تنجح العملية. جرّب مرة أخرى.",
   "verifyErrorHandleRequired": "أدخل المُعرّف أولاً.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4711,7 +4711,6 @@
   "verifyIdentityLabel": "Име на профила",
   "verifyProofLabel": "Линк към публикацията ти",
   "verifyConnectProofCta": "Провери и свържи",
-  "verifyErrorProofRejected": "Не намерихме твоя npub в тази публикация.",
   "verifyErrorVerifierUnreachable": "Проверяващият не отговаря. Опитай пак след малко.",
   "verifyErrorOauthFailed": "Не се получи. Пробвай отново.",
   "verifyErrorHandleRequired": "Първо въведи своя handle.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4573,7 +4573,6 @@
   "verifyIdentityLabel": "Kontoname",
   "verifyProofLabel": "Link zu deinem Post",
   "verifyConnectProofCta": "Prüfen und verknüpfen",
-  "verifyErrorProofRejected": "Wir haben deinen npub in dem Post nicht gefunden.",
   "verifyErrorVerifierUnreachable": "Der Verifizierer war nicht erreichbar. Versuch es gleich nochmal.",
   "verifyErrorOauthFailed": "Das hat nicht geklappt. Versuch es nochmal.",
   "verifyErrorHandleRequired": "Gib zuerst dein Handle ein.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -7700,6 +7700,10 @@
   "@verifyErrorProofRejected": {
     "description": "Error shown when the verification service could not find the user's npub in the linked post."
   },
+  "verifyErrorDiscordDmLink": "That's a link to a DM, which our bot can't read. Post your npub in a server channel instead.",
+  "@verifyErrorDiscordDmLink": {
+    "description": "Error shown when the pasted Discord link points at a direct message. No bot can read someone's DMs, so this can never verify."
+  },
   "verifyErrorDiscordChannelLink": "That's a link to the channel, not your message. Long-press your message and pick Copy Message Link.",
   "@verifyErrorDiscordChannelLink": {
     "description": "Error shown when the pasted Discord link points at a channel instead of a specific message."

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -7700,6 +7700,26 @@
   "@verifyErrorProofRejected": {
     "description": "Error shown when the verification service could not find the user's npub in the linked post."
   },
+  "verifyErrorDiscordChannelLink": "That's a link to the channel, not your message. Long-press your message and pick Copy Message Link.",
+  "@verifyErrorDiscordChannelLink": {
+    "description": "Error shown when the pasted Discord link points at a channel instead of a specific message."
+  },
+  "verifyErrorDiscordMessageNotFound": "We couldn't find that message. Check the link, and make sure the message is still up.",
+  "@verifyErrorDiscordMessageNotFound": {
+    "description": "Error shown when Discord has no message at the pasted link, or it was deleted."
+  },
+  "verifyErrorDiscordBotNoAccess": "Our bot can't read that channel. Post your npub somewhere it can see.",
+  "@verifyErrorDiscordBotNoAccess": {
+    "description": "Error shown when Divine's Discord bot cannot see the channel the proof message was posted in."
+  },
+  "verifyErrorDiscordAuthorMismatch": "That message is from a different account. Use your Discord username — the one on your profile, not your display name.",
+  "@verifyErrorDiscordAuthorMismatch": {
+    "description": "Error shown when the Discord message was posted by an account other than the one being claimed. Discord usernames are lowercase and differ from the display name shown in chat."
+  },
+  "verifyErrorDiscordContentUnavailable": "We couldn't read that message's text. That's on us — please tell support.",
+  "@verifyErrorDiscordContentUnavailable": {
+    "description": "Error shown when Discord returns the proof message with empty text, which means Divine's bot is missing a permission. Not the user's mistake."
+  },
   "verifyErrorVerifierUnreachable": "Couldn't reach the verifier. Try again in a moment.",
   "@verifyErrorVerifierUnreachable": {
     "description": "Error shown when the verification service could not be reached."

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -7696,9 +7696,13 @@
   "@verifyConnectProofCta": {
     "description": "Button that verifies the proof post and, if it checks out, publishes the link."
   },
-  "verifyErrorProofRejected": "We couldn't find your npub in that post.",
+  "verifyErrorProofRejected": "That didn't check out. Check the link and the account name, then try again.",
   "@verifyErrorProofRejected": {
-    "description": "Error shown when the verification service could not find the user's npub in the linked post."
+    "description": "Fallback error when the verifier refused a proof for a reason this build cannot name — every platform without rejection codes lands here, so the wording must stay true of any refusal, including a wrong account name or an unreachable post."
+  },
+  "verifyErrorProofMissingNpub": "We couldn't find your npub in that post.",
+  "@verifyErrorProofMissingNpub": {
+    "description": "Error shown when the proof post exists and belongs to the right account, but does not contain the user's npub."
   },
   "verifyErrorDiscordDmLink": "That's a link to a DM, which our bot can't read. Post your npub in a server channel instead.",
   "@verifyErrorDiscordDmLink": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4573,7 +4573,6 @@
   "verifyIdentityLabel": "Nombre de la cuenta",
   "verifyProofLabel": "Enlace a tu publicación",
   "verifyConnectProofCta": "Comprobar y vincular",
-  "verifyErrorProofRejected": "No encontramos tu npub en esa publicación.",
   "verifyErrorVerifierUnreachable": "No pudimos contactar al verificador. Probá de nuevo en un momento.",
   "verifyErrorOauthFailed": "No salió. Probá otra vez.",
   "verifyErrorHandleRequired": "Escribí tu handle primero.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3529,7 +3529,6 @@
   "verifyIdentityLabel": "Pangalan ng account",
   "verifyProofLabel": "Link ng post mo",
   "verifyConnectProofCta": "I-check at i-link",
-  "verifyErrorProofRejected": "Hindi namin nakita ang npub mo sa post na 'yon.",
   "verifyErrorVerifierUnreachable": "Hindi maabot ang verifier. Subukan ulit mamaya.",
   "verifyErrorOauthFailed": "Hindi natuloy. Subukan ulit.",
   "verifyErrorHandleRequired": "Ilagay muna ang handle mo.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4573,7 +4573,6 @@
   "verifyIdentityLabel": "Nom du compte",
   "verifyProofLabel": "Lien vers ton post",
   "verifyConnectProofCta": "Vérifier et lier",
-  "verifyErrorProofRejected": "On n'a pas trouvé ton npub dans ce post.",
   "verifyErrorVerifierUnreachable": "Vérificateur injoignable. Réessaie dans un instant.",
   "verifyErrorOauthFailed": "Ça n'a pas marché. Retente le coup.",
   "verifyErrorHandleRequired": "Saisis d'abord ton identifiant.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4573,7 +4573,6 @@
   "verifyIdentityLabel": "Nama akun",
   "verifyProofLabel": "Tautan ke postinganmu",
   "verifyConnectProofCta": "Cek dan tautkan",
-  "verifyErrorProofRejected": "Kami tidak menemukan npub-mu di postingan itu.",
   "verifyErrorVerifierUnreachable": "Verifier tidak bisa dihubungi. Coba lagi sebentar lagi.",
   "verifyErrorOauthFailed": "Gagal. Coba sekali lagi.",
   "verifyErrorHandleRequired": "Isi handle kamu dulu.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4573,7 +4573,6 @@
   "verifyIdentityLabel": "Nome dell'account",
   "verifyProofLabel": "Link al tuo post",
   "verifyConnectProofCta": "Controlla e collega",
-  "verifyErrorProofRejected": "Non abbiamo trovato il tuo npub in quel post.",
   "verifyErrorVerifierUnreachable": "Verificatore non raggiungibile. Riprova tra poco.",
   "verifyErrorOauthFailed": "Non è andata. Riprova.",
   "verifyErrorHandleRequired": "Inserisci prima il tuo handle.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4573,7 +4573,6 @@
   "verifyIdentityLabel": "アカウント名",
   "verifyProofLabel": "投稿のリンク",
   "verifyConnectProofCta": "確認して連携",
-  "verifyErrorProofRejected": "その投稿に npub が見つからなかった。",
   "verifyErrorVerifierUnreachable": "認証サービスにつながらなかった。少ししてからもう一度。",
   "verifyErrorOauthFailed": "うまくいかなかった。もう一度試してみて。",
   "verifyErrorHandleRequired": "先にハンドルを入力してね。",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -4111,7 +4111,6 @@
   "verifyIdentityLabel": "계정 이름",
   "verifyProofLabel": "게시물 링크",
   "verifyConnectProofCta": "확인하고 연결",
-  "verifyErrorProofRejected": "그 게시물에서 npub을 찾지 못했어.",
   "verifyErrorVerifierUnreachable": "인증 서비스에 연결하지 못했어. 잠시 후 다시 시도해.",
   "verifyErrorOauthFailed": "잘 안 됐어. 한 번 더 해봐.",
   "verifyErrorHandleRequired": "핸들부터 입력해.",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -6358,7 +6358,6 @@
   "verifyIdentityLabel": "Nama akaun",
   "verifyProofLabel": "Pautan ke siaran anda",
   "verifyConnectProofCta": "Semak dan pautkan",
-  "verifyErrorProofRejected": "Kami tidak jumpa npub anda dalam siaran itu.",
   "verifyErrorVerifierUnreachable": "Pengesah tidak dapat dihubungi. Cuba lagi sebentar.",
   "verifyErrorOauthFailed": "Tak menjadi. Cuba sekali lagi.",
   "verifyErrorHandleRequired": "Masukkan handle anda dahulu.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4573,7 +4573,6 @@
   "verifyIdentityLabel": "Accountnaam",
   "verifyProofLabel": "Link naar je post",
   "verifyConnectProofCta": "Controleren en koppelen",
-  "verifyErrorProofRejected": "We konden je npub niet vinden in die post.",
   "verifyErrorVerifierUnreachable": "Verifier niet bereikbaar. Probeer het zo nog eens.",
   "verifyErrorOauthFailed": "Dat ging niet door. Probeer het nog eens.",
   "verifyErrorHandleRequired": "Vul eerst je handle in.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4573,7 +4573,6 @@
   "verifyIdentityLabel": "Nazwa konta",
   "verifyProofLabel": "Link do twojego wpisu",
   "verifyConnectProofCta": "Sprawdź i połącz",
-  "verifyErrorProofRejected": "Nie znaleźliśmy twojego npub w tym wpisie.",
   "verifyErrorVerifierUnreachable": "Weryfikator nieosiągalny. Spróbuj za chwilę.",
   "verifyErrorOauthFailed": "Nie poszło. Spróbuj jeszcze raz.",
   "verifyErrorHandleRequired": "Najpierw podaj swój handle.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4573,7 +4573,6 @@
   "verifyIdentityLabel": "Nome da conta",
   "verifyProofLabel": "Link do seu post",
   "verifyConnectProofCta": "Checar e vincular",
-  "verifyErrorProofRejected": "Não achamos seu npub nesse post.",
   "verifyErrorVerifierUnreachable": "Verificador fora do ar. Tente de novo daqui a pouco.",
   "verifyErrorOauthFailed": "Não rolou. Tenta mais uma vez.",
   "verifyErrorHandleRequired": "Digite seu handle primeiro.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4573,7 +4573,6 @@
   "verifyIdentityLabel": "Numele contului",
   "verifyProofLabel": "Linkul postării tale",
   "verifyConnectProofCta": "Verifică și leagă",
-  "verifyErrorProofRejected": "Nu am găsit npub-ul tău în postarea aia.",
   "verifyErrorVerifierUnreachable": "Verificatorul nu răspunde. Mai încearcă într-o clipă.",
   "verifyErrorOauthFailed": "N-a mers. Mai încearcă o dată.",
   "verifyErrorHandleRequired": "Scrie mai întâi handle-ul tău.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4573,7 +4573,6 @@
   "verifyIdentityLabel": "Kontonamn",
   "verifyProofLabel": "Länk till ditt inlägg",
   "verifyConnectProofCta": "Kolla och länka",
-  "verifyErrorProofRejected": "Vi hittade inte din npub i det inlägget.",
   "verifyErrorVerifierUnreachable": "Nådde inte verifieraren. Försök igen om en stund.",
   "verifyErrorOauthFailed": "Det gick inte igenom. Testa igen.",
   "verifyErrorHandleRequired": "Fyll i ditt handle först.",

--- a/mobile/lib/l10n/app_te.arb
+++ b/mobile/lib/l10n/app_te.arb
@@ -7713,10 +7713,6 @@
   "@verifyConnectProofCta": {
     "description": "Button that verifies the proof post and, if it checks out, publishes the link."
   },
-  "verifyErrorProofRejected": "మేము ఆ పోస్ట్‌లో మీ npubని కనుగొనలేకపోయాము.",
-  "@verifyErrorProofRejected": {
-    "description": "Error shown when the verification service could not find the user's npub in the linked post."
-  },
   "verifyErrorVerifierUnreachable": "వెరిఫైయర్‌ని చేరుకోలేకపోయింది. క్షణంలో మళ్లీ ప్రయత్నించండి.",
   "@verifyErrorVerifierUnreachable": {
     "description": "Error shown when the verification service could not be reached."

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4573,7 +4573,6 @@
   "verifyIdentityLabel": "Hesap adı",
   "verifyProofLabel": "Gönderinin bağlantısı",
   "verifyConnectProofCta": "Kontrol et ve bağla",
-  "verifyErrorProofRejected": "O gönderide npub'ını bulamadık.",
   "verifyErrorVerifierUnreachable": "Doğrulayıcıya ulaşılamadı. Birazdan tekrar dene.",
   "verifyErrorOauthFailed": "Olmadı. Bir daha dene.",
   "verifyErrorHandleRequired": "Önce kullanıcı adını gir.",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -6358,7 +6358,6 @@
   "verifyIdentityLabel": "اکاؤنٹ کا نام",
   "verifyProofLabel": "آپ کی پوسٹ کا لنک",
   "verifyConnectProofCta": "جانچیں اور جوڑیں",
-  "verifyErrorProofRejected": "ہمیں اس پوسٹ میں آپ کا npub نہیں ملا۔",
   "verifyErrorVerifierUnreachable": "تصدیقی سروس تک رسائی نہیں ہوئی۔ تھوڑی دیر بعد کوشش کریں۔",
   "verifyErrorOauthFailed": "بات نہیں بنی۔ ایک بار پھر کوشش کریں۔",
   "verifyErrorHandleRequired": "پہلے اپنا ہینڈل درج کریں۔",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -6358,7 +6358,6 @@
   "verifyIdentityLabel": "Tên tài khoản",
   "verifyProofLabel": "Liên kết tới bài đăng",
   "verifyConnectProofCta": "Kiểm tra và liên kết",
-  "verifyErrorProofRejected": "Chúng tôi không tìm thấy npub của bạn trong bài đăng đó.",
   "verifyErrorVerifierUnreachable": "Không liên hệ được dịch vụ xác minh. Thử lại sau chút.",
   "verifyErrorOauthFailed": "Chưa xong. Thử lại lần nữa nhé.",
   "verifyErrorHandleRequired": "Nhập handle của bạn trước đã.",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -6358,7 +6358,6 @@
   "verifyIdentityLabel": "账号名称",
   "verifyProofLabel": "帖子链接",
   "verifyConnectProofCta": "核查并关联",
-  "verifyErrorProofRejected": "我们在那条帖子里没找到你的 npub。",
   "verifyErrorVerifierUnreachable": "连不上验证服务。过一会儿再试。",
   "verifyErrorOauthFailed": "没成功。再试一次吧。",
   "verifyErrorHandleRequired": "先填你的 handle。",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -19398,6 +19398,12 @@ abstract class AppLocalizations {
   /// **'We couldn\'t find your npub in that post.'**
   String get verifyErrorProofRejected;
 
+  /// Error shown when the pasted Discord link points at a direct message. No bot can read someone's DMs, so this can never verify.
+  ///
+  /// In en, this message translates to:
+  /// **'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.'**
+  String get verifyErrorDiscordDmLink;
+
   /// Error shown when the pasted Discord link points at a channel instead of a specific message.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -19398,6 +19398,36 @@ abstract class AppLocalizations {
   /// **'We couldn\'t find your npub in that post.'**
   String get verifyErrorProofRejected;
 
+  /// Error shown when the pasted Discord link points at a channel instead of a specific message.
+  ///
+  /// In en, this message translates to:
+  /// **'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.'**
+  String get verifyErrorDiscordChannelLink;
+
+  /// Error shown when Discord has no message at the pasted link, or it was deleted.
+  ///
+  /// In en, this message translates to:
+  /// **'We couldn\'t find that message. Check the link, and make sure the message is still up.'**
+  String get verifyErrorDiscordMessageNotFound;
+
+  /// Error shown when Divine's Discord bot cannot see the channel the proof message was posted in.
+  ///
+  /// In en, this message translates to:
+  /// **'Our bot can\'t read that channel. Post your npub somewhere it can see.'**
+  String get verifyErrorDiscordBotNoAccess;
+
+  /// Error shown when the Discord message was posted by an account other than the one being claimed. Discord usernames are lowercase and differ from the display name shown in chat.
+  ///
+  /// In en, this message translates to:
+  /// **'That message is from a different account. Use your Discord username — the one on your profile, not your display name.'**
+  String get verifyErrorDiscordAuthorMismatch;
+
+  /// Error shown when Discord returns the proof message with empty text, which means Divine's bot is missing a permission. Not the user's mistake.
+  ///
+  /// In en, this message translates to:
+  /// **'We couldn\'t read that message\'s text. That\'s on us — please tell support.'**
+  String get verifyErrorDiscordContentUnavailable;
+
   /// Error shown when the verification service could not be reached.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -19392,11 +19392,17 @@ abstract class AppLocalizations {
   /// **'Check and link'**
   String get verifyConnectProofCta;
 
-  /// Error shown when the verification service could not find the user's npub in the linked post.
+  /// Fallback error when the verifier refused a proof for a reason this build cannot name — every platform without rejection codes lands here, so the wording must stay true of any refusal, including a wrong account name or an unreachable post.
+  ///
+  /// In en, this message translates to:
+  /// **'That didn\'t check out. Check the link and the account name, then try again.'**
+  String get verifyErrorProofRejected;
+
+  /// Error shown when the proof post exists and belongs to the right account, but does not contain the user's npub.
   ///
   /// In en, this message translates to:
   /// **'We couldn\'t find your npub in that post.'**
-  String get verifyErrorProofRejected;
+  String get verifyErrorProofMissingNpub;
 
   /// Error shown when the pasted Discord link points at a direct message. No bot can read someone's DMs, so this can never verify.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -11166,7 +11166,8 @@ class AppLocalizationsAm extends AppLocalizations {
   String get verifyConnectProofCta => 'መርምር እና አገናኝ';
 
   @override
-  String get verifyErrorProofRejected => 'በዚያ ልጥፍ ውስጥ npub ህን አላገኘንም።';
+  String get verifyErrorProofRejected =>
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -11169,6 +11169,10 @@ class AppLocalizationsAm extends AppLocalizations {
   String get verifyErrorProofRejected => 'በዚያ ልጥፍ ውስጥ npub ህን አላገኘንም።';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -11169,6 +11169,10 @@ class AppLocalizationsAm extends AppLocalizations {
   String get verifyErrorProofRejected => 'በዚያ ልጥፍ ውስጥ npub ህን አላገኘንም።';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -11169,6 +11169,26 @@ class AppLocalizationsAm extends AppLocalizations {
   String get verifyErrorProofRejected => 'በዚያ ልጥፍ ውስጥ npub ህን አላገኘንም።';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable => 'አረጋጋጩ አልተገኘም። ትንሽ ቆይተህ ሞክር።';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -11394,6 +11394,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get verifyErrorProofRejected => 'لم نجد npub الخاص بك في ذلك المنشور.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -11391,7 +11391,8 @@ class AppLocalizationsAr extends AppLocalizations {
   String get verifyConnectProofCta => 'افحص واربط';
 
   @override
-  String get verifyErrorProofRejected => 'لم نجد npub الخاص بك في ذلك المنشور.';
+  String get verifyErrorProofRejected =>
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -11394,6 +11394,26 @@ class AppLocalizationsAr extends AppLocalizations {
   String get verifyErrorProofRejected => 'لم نجد npub الخاص بك في ذلك المنشور.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'تعذّر الوصول إلى خدمة التوثيق. حاول بعد قليل.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -11394,6 +11394,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get verifyErrorProofRejected => 'لم نجد npub الخاص بك في ذلك المنشور.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -11589,7 +11589,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get verifyErrorProofRejected =>
-      'Не намерихме твоя npub в тази публикация.';
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -11592,6 +11592,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Не намерихме твоя npub в тази публикация.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -11592,6 +11592,26 @@ class AppLocalizationsBg extends AppLocalizations {
       'Не намерихме твоя npub в тази публикация.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'Проверяващият не отговаря. Опитай пак след малко.';
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -11592,6 +11592,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Не намерихме твоя npub в тази публикация.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -11618,6 +11618,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wir haben deinen npub in dem Post nicht gefunden.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -11618,6 +11618,26 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wir haben deinen npub in dem Post nicht gefunden.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'Der Verifizierer war nicht erreichbar. Versuch es gleich nochmal.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -11615,7 +11615,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get verifyErrorProofRejected =>
-      'Wir haben deinen npub in dem Post nicht gefunden.';
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -11618,6 +11618,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wir haben deinen npub in dem Post nicht gefunden.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -11573,6 +11573,26 @@ class AppLocalizationsEn extends AppLocalizations {
       'We couldn\'t find your npub in that post.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'Couldn\'t reach the verifier. Try again in a moment.';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -11570,6 +11570,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get verifyErrorProofRejected =>
+      'That didn\'t check out. Check the link and the account name, then try again.';
+
+  @override
+  String get verifyErrorProofMissingNpub =>
       'We couldn\'t find your npub in that post.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -11573,6 +11573,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'We couldn\'t find your npub in that post.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -11603,6 +11603,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'No encontramos tu npub en esa publicación.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -11603,6 +11603,26 @@ class AppLocalizationsEs extends AppLocalizations {
       'No encontramos tu npub en esa publicación.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'No pudimos contactar al verificador. Probá de nuevo en un momento.';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -11603,6 +11603,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'No encontramos tu npub en esa publicación.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -11600,7 +11600,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get verifyErrorProofRejected =>
-      'No encontramos tu npub en esa publicación.';
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -11583,6 +11583,26 @@ class AppLocalizationsFil extends AppLocalizations {
       'Hindi namin nakita ang npub mo sa post na \'yon.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'Hindi maabot ang verifier. Subukan ulit mamaya.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -11580,7 +11580,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get verifyErrorProofRejected =>
-      'Hindi namin nakita ang npub mo sa post na \'yon.';
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -11583,6 +11583,10 @@ class AppLocalizationsFil extends AppLocalizations {
       'Hindi namin nakita ang npub mo sa post na \'yon.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -11583,6 +11583,10 @@ class AppLocalizationsFil extends AppLocalizations {
       'Hindi namin nakita ang npub mo sa post na \'yon.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -11646,6 +11646,26 @@ class AppLocalizationsFr extends AppLocalizations {
       'On n\'a pas trouvé ton npub dans ce post.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'Vérificateur injoignable. Réessaie dans un instant.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -11646,6 +11646,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'On n\'a pas trouvé ton npub dans ce post.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -11646,6 +11646,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'On n\'a pas trouvé ton npub dans ce post.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -11643,7 +11643,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get verifyErrorProofRejected =>
-      'On n\'a pas trouvé ton npub dans ce post.';
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -11394,6 +11394,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Kami tidak menemukan npub-mu di postingan itu.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -11394,6 +11394,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Kami tidak menemukan npub-mu di postingan itu.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -11391,7 +11391,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get verifyErrorProofRejected =>
-      'Kami tidak menemukan npub-mu di postingan itu.';
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -11394,6 +11394,26 @@ class AppLocalizationsId extends AppLocalizations {
       'Kami tidak menemukan npub-mu di postingan itu.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'Verifier tidak bisa dihubungi. Coba lagi sebentar lagi.';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -11611,7 +11611,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get verifyErrorProofRejected =>
-      'Non abbiamo trovato il tuo npub in quel post.';
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -11614,6 +11614,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Non abbiamo trovato il tuo npub in quel post.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -11614,6 +11614,26 @@ class AppLocalizationsIt extends AppLocalizations {
       'Non abbiamo trovato il tuo npub in quel post.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'Verificatore non raggiungibile. Riprova tra poco.';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -11614,6 +11614,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Non abbiamo trovato il tuo npub in quel post.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -10896,6 +10896,26 @@ class AppLocalizationsJa extends AppLocalizations {
   String get verifyErrorProofRejected => 'その投稿に npub が見つからなかった。';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable => '認証サービスにつながらなかった。少ししてからもう一度。';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -10893,7 +10893,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get verifyConnectProofCta => '確認して連携';
 
   @override
-  String get verifyErrorProofRejected => 'その投稿に npub が見つからなかった。';
+  String get verifyErrorProofRejected =>
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -10896,6 +10896,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get verifyErrorProofRejected => 'その投稿に npub が見つからなかった。';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -10896,6 +10896,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get verifyErrorProofRejected => 'その投稿に npub が見つからなかった。';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -10910,6 +10910,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get verifyErrorProofRejected => '그 게시물에서 npub을 찾지 못했어.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -10907,7 +10907,8 @@ class AppLocalizationsKo extends AppLocalizations {
   String get verifyConnectProofCta => '확인하고 연결';
 
   @override
-  String get verifyErrorProofRejected => '그 게시물에서 npub을 찾지 못했어.';
+  String get verifyErrorProofRejected =>
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -10910,6 +10910,26 @@ class AppLocalizationsKo extends AppLocalizations {
   String get verifyErrorProofRejected => '그 게시물에서 npub을 찾지 못했어.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable => '인증 서비스에 연결하지 못했어. 잠시 후 다시 시도해.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -10910,6 +10910,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get verifyErrorProofRejected => '그 게시물에서 npub을 찾지 못했어.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -11484,6 +11484,26 @@ class AppLocalizationsMs extends AppLocalizations {
       'Kami tidak jumpa npub anda dalam siaran itu.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'Pengesah tidak dapat dihubungi. Cuba lagi sebentar.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -11484,6 +11484,10 @@ class AppLocalizationsMs extends AppLocalizations {
       'Kami tidak jumpa npub anda dalam siaran itu.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -11481,7 +11481,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get verifyErrorProofRejected =>
-      'Kami tidak jumpa npub anda dalam siaran itu.';
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -11484,6 +11484,10 @@ class AppLocalizationsMs extends AppLocalizations {
       'Kami tidak jumpa npub anda dalam siaran itu.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -11537,6 +11537,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'We konden je npub niet vinden in die post.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -11534,7 +11534,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get verifyErrorProofRejected =>
-      'We konden je npub niet vinden in die post.';
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -11537,6 +11537,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'We konden je npub niet vinden in die post.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -11537,6 +11537,26 @@ class AppLocalizationsNl extends AppLocalizations {
       'We konden je npub niet vinden in die post.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'Verifier niet bereikbaar. Probeer het zo nog eens.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -11696,6 +11696,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Nie znaleźliśmy twojego npub w tym wpisie.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -11696,6 +11696,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Nie znaleźliśmy twojego npub w tym wpisie.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -11696,6 +11696,26 @@ class AppLocalizationsPl extends AppLocalizations {
       'Nie znaleźliśmy twojego npub w tym wpisie.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'Weryfikator nieosiągalny. Spróbuj za chwilę.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -11693,7 +11693,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get verifyErrorProofRejected =>
-      'Nie znaleźliśmy twojego npub w tym wpisie.';
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -11564,6 +11564,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get verifyErrorProofRejected => 'Não achamos seu npub nesse post.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -11564,6 +11564,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get verifyErrorProofRejected => 'Não achamos seu npub nesse post.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -11561,7 +11561,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get verifyConnectProofCta => 'Checar e vincular';
 
   @override
-  String get verifyErrorProofRejected => 'Não achamos seu npub nesse post.';
+  String get verifyErrorProofRejected =>
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -11564,6 +11564,26 @@ class AppLocalizationsPt extends AppLocalizations {
   String get verifyErrorProofRejected => 'Não achamos seu npub nesse post.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'Verificador fora do ar. Tente de novo daqui a pouco.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -11725,6 +11725,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Nu am găsit npub-ul tău în postarea aia.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -11725,6 +11725,26 @@ class AppLocalizationsRo extends AppLocalizations {
       'Nu am găsit npub-ul tău în postarea aia.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'Verificatorul nu răspunde. Mai încearcă într-o clipă.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -11725,6 +11725,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Nu am găsit npub-ul tău în postarea aia.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -11722,7 +11722,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get verifyErrorProofRejected =>
-      'Nu am găsit npub-ul tău în postarea aia.';
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -11473,6 +11473,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Vi hittade inte din npub i det inlägget.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -11470,7 +11470,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get verifyErrorProofRejected =>
-      'Vi hittade inte din npub i det inlägget.';
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -11473,6 +11473,26 @@ class AppLocalizationsSv extends AppLocalizations {
       'Vi hittade inte din npub i det inlägget.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'Nådde inte verifieraren. Försök igen om en stund.';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -11473,6 +11473,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Vi hittade inte din npub i det inlägget.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -11811,6 +11811,26 @@ class AppLocalizationsTe extends AppLocalizations {
       'మేము ఆ పోస్ట్‌లో మీ npubని కనుగొనలేకపోయాము.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'వెరిఫైయర్‌ని చేరుకోలేకపోయింది. క్షణంలో మళ్లీ ప్రయత్నించండి.';
 

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -11811,6 +11811,10 @@ class AppLocalizationsTe extends AppLocalizations {
       'మేము ఆ పోస్ట్‌లో మీ npubని కనుగొనలేకపోయాము.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -11808,7 +11808,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get verifyErrorProofRejected =>
-      'మేము ఆ పోస్ట్‌లో మీ npubని కనుగొనలేకపోయాము.';
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -11811,6 +11811,10 @@ class AppLocalizationsTe extends AppLocalizations {
       'మేము ఆ పోస్ట్‌లో మీ npubని కనుగొనలేకపోయాము.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -11401,6 +11401,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get verifyErrorProofRejected => 'O gönderide npub\'ını bulamadık.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -11401,6 +11401,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get verifyErrorProofRejected => 'O gönderide npub\'ını bulamadık.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -11398,7 +11398,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get verifyConnectProofCta => 'Kontrol et ve bağla';
 
   @override
-  String get verifyErrorProofRejected => 'O gönderide npub\'ını bulamadık.';
+  String get verifyErrorProofRejected =>
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -11401,6 +11401,26 @@ class AppLocalizationsTr extends AppLocalizations {
   String get verifyErrorProofRejected => 'O gönderide npub\'ını bulamadık.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'Doğrulayıcıya ulaşılamadı. Birazdan tekrar dene.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -11461,6 +11461,10 @@ class AppLocalizationsUr extends AppLocalizations {
       'ہمیں اس پوسٹ میں آپ کا npub نہیں ملا۔';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -11461,6 +11461,26 @@ class AppLocalizationsUr extends AppLocalizations {
       'ہمیں اس پوسٹ میں آپ کا npub نہیں ملا۔';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'تصدیقی سروس تک رسائی نہیں ہوئی۔ تھوڑی دیر بعد کوشش کریں۔';
 

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -11461,6 +11461,10 @@ class AppLocalizationsUr extends AppLocalizations {
       'ہمیں اس پوسٹ میں آپ کا npub نہیں ملا۔';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -11458,7 +11458,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get verifyErrorProofRejected =>
-      'ہمیں اس پوسٹ میں آپ کا npub نہیں ملا۔';
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -11427,6 +11427,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Chúng tôi không tìm thấy npub của bạn trong bài đăng đó.';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -11424,7 +11424,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get verifyErrorProofRejected =>
-      'Chúng tôi không tìm thấy npub của bạn trong bài đăng đó.';
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -11427,6 +11427,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Chúng tôi không tìm thấy npub của bạn trong bài đăng đó.';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -11427,6 +11427,26 @@ class AppLocalizationsVi extends AppLocalizations {
       'Chúng tôi không tìm thấy npub của bạn trong bài đăng đó.';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable =>
       'Không liên hệ được dịch vụ xác minh. Thử lại sau chút.';
 

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -10775,6 +10775,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get verifyErrorProofRejected => '我们在那条帖子里没找到你的 npub。';
 
   @override
+  String get verifyErrorDiscordDmLink =>
+      'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
+
+  @override
   String get verifyErrorDiscordChannelLink =>
       'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
 

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -10775,6 +10775,26 @@ class AppLocalizationsZh extends AppLocalizations {
   String get verifyErrorProofRejected => '我们在那条帖子里没找到你的 npub。';
 
   @override
+  String get verifyErrorDiscordChannelLink =>
+      'That\'s a link to the channel, not your message. Long-press your message and pick Copy Message Link.';
+
+  @override
+  String get verifyErrorDiscordMessageNotFound =>
+      'We couldn\'t find that message. Check the link, and make sure the message is still up.';
+
+  @override
+  String get verifyErrorDiscordBotNoAccess =>
+      'Our bot can\'t read that channel. Post your npub somewhere it can see.';
+
+  @override
+  String get verifyErrorDiscordAuthorMismatch =>
+      'That message is from a different account. Use your Discord username — the one on your profile, not your display name.';
+
+  @override
+  String get verifyErrorDiscordContentUnavailable =>
+      'We couldn\'t read that message\'s text. That\'s on us — please tell support.';
+
+  @override
   String get verifyErrorVerifierUnreachable => '连不上验证服务。过一会儿再试。';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -10772,7 +10772,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get verifyConnectProofCta => '核查并关联';
 
   @override
-  String get verifyErrorProofRejected => '我们在那条帖子里没找到你的 npub。';
+  String get verifyErrorProofRejected =>
+      'That didn\'t check out. Check the link and the account name, then try again.';
 
   @override
   String get verifyErrorProofMissingNpub =>

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -10775,6 +10775,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get verifyErrorProofRejected => '我们在那条帖子里没找到你的 npub。';
 
   @override
+  String get verifyErrorProofMissingNpub =>
+      'We couldn\'t find your npub in that post.';
+
+  @override
   String get verifyErrorDiscordDmLink =>
       'That\'s a link to a DM, which our bot can\'t read. Post your npub in a server channel instead.';
 

--- a/mobile/lib/screens/verify/verify_connect_screen.dart
+++ b/mobile/lib/screens/verify/verify_connect_screen.dart
@@ -11,6 +11,7 @@ import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/features/oauth/app_oauth_callback.dart';
 import 'package:openvine/features/oauth/app_oauth_support.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/screens/verify/verify_platform_labels.dart';
 import 'package:openvine/utils/clipboard_utils.dart';
@@ -74,6 +75,9 @@ class VerifyConnectPage extends ConsumerWidget {
         platform: platform,
         launchOAuth: launchAppOAuth,
         oauthReturnUrl: appOAuthCallbackUrl,
+        // A plain Provider whose identity never changes, so it is read rather
+        // than watched and stays out of the ValueKey above.
+        analytics: ref.read(analyticsEventSinkProvider),
       ),
       child: VerifyConnectView(
         npub: NostrKeyUtils.encodePubKey(pubkey),
@@ -129,6 +133,16 @@ class VerifyConnectView extends StatelessWidget {
     ScaffoldMessenger.of(context).showSnackBar(
       DivineSnackbarContainer.snackBar(switch (error) {
         VerifyConnectError.proofRejected => l10n.verifyErrorProofRejected,
+        VerifyConnectError.discordChannelLink =>
+          l10n.verifyErrorDiscordChannelLink,
+        VerifyConnectError.discordMessageNotFound =>
+          l10n.verifyErrorDiscordMessageNotFound,
+        VerifyConnectError.discordBotNoAccess =>
+          l10n.verifyErrorDiscordBotNoAccess,
+        VerifyConnectError.discordAuthorMismatch =>
+          l10n.verifyErrorDiscordAuthorMismatch,
+        VerifyConnectError.discordContentUnavailable =>
+          l10n.verifyErrorDiscordContentUnavailable,
         VerifyConnectError.verifierUnreachable =>
           l10n.verifyErrorVerifierUnreachable,
         VerifyConnectError.oauthFailed => l10n.verifyErrorOauthFailed,

--- a/mobile/lib/screens/verify/verify_connect_screen.dart
+++ b/mobile/lib/screens/verify/verify_connect_screen.dart
@@ -133,6 +133,7 @@ class VerifyConnectView extends StatelessWidget {
     ScaffoldMessenger.of(context).showSnackBar(
       DivineSnackbarContainer.snackBar(switch (error) {
         VerifyConnectError.proofRejected => l10n.verifyErrorProofRejected,
+        VerifyConnectError.discordDmLink => l10n.verifyErrorDiscordDmLink,
         VerifyConnectError.discordChannelLink =>
           l10n.verifyErrorDiscordChannelLink,
         VerifyConnectError.discordMessageNotFound =>

--- a/mobile/lib/screens/verify/verify_connect_screen.dart
+++ b/mobile/lib/screens/verify/verify_connect_screen.dart
@@ -133,6 +133,7 @@ class VerifyConnectView extends StatelessWidget {
     ScaffoldMessenger.of(context).showSnackBar(
       DivineSnackbarContainer.snackBar(switch (error) {
         VerifyConnectError.proofRejected => l10n.verifyErrorProofRejected,
+        VerifyConnectError.proofMissingNpub => l10n.verifyErrorProofMissingNpub,
         VerifyConnectError.discordDmLink => l10n.verifyErrorDiscordDmLink,
         VerifyConnectError.discordChannelLink =>
           l10n.verifyErrorDiscordChannelLink,

--- a/mobile/packages/verifier_client/lib/src/models/verification_result.dart
+++ b/mobile/packages/verifier_client/lib/src/models/verification_result.dart
@@ -14,6 +14,7 @@ class VerificationResult extends Equatable {
     required this.checkedAt,
     required this.cached,
     this.error,
+    this.code,
   });
 
   /// Parses a [VerificationResult] from the verifier API JSON shape.
@@ -25,6 +26,7 @@ class VerificationResult extends Equatable {
       checkedAt: json['checked_at'] as int,
       cached: json['cached'] as bool? ?? false,
       error: json['error'] as String?,
+      code: json['code'] as String?,
     );
   }
 
@@ -46,6 +48,14 @@ class VerificationResult extends Equatable {
   /// Free-form error string when [verified] is false. Not a stable key.
   final String? error;
 
+  /// Stable machine-readable rejection reason, when the verifier sends one.
+  ///
+  /// Unlike [error], this is safe to branch on: the service treats these as a
+  /// fixed vocabulary. It is null for platforms that have not adopted codes and
+  /// for any deployment older than them, so a caller must have a fallback —
+  /// and must keep it for values a newer service invents.
+  final String? code;
+
   @override
   List<Object?> get props => [
     platform,
@@ -54,5 +64,6 @@ class VerificationResult extends Equatable {
     checkedAt,
     cached,
     error,
+    code,
   ];
 }

--- a/mobile/packages/verifier_client/test/src/models/verification_result_test.dart
+++ b/mobile/packages/verifier_client/test/src/models/verification_result_test.dart
@@ -46,5 +46,53 @@ void main() {
       final result = VerificationResult.fromJson(json);
       expect(result.cached, isFalse);
     });
+
+    group('code', () {
+      test('parses the verifier rejection code when one is sent', () {
+        final result = VerificationResult.fromJson(const {
+          'platform': 'discord',
+          'identity': 'alice',
+          'verified': false,
+          'checked_at': 1,
+          'cached': false,
+          'error': 'Message not found — check the message link or ID',
+          'code': 'discord_message_not_found',
+        });
+
+        expect(result.code, 'discord_message_not_found');
+      });
+
+      test('is null when the verifier omits it', () {
+        final result = VerificationResult.fromJson(const {
+          'platform': 'discord',
+          'identity': 'alice',
+          'verified': false,
+          'checked_at': 1,
+          'cached': false,
+        });
+
+        expect(result.code, isNull);
+      });
+
+      test('is part of equality, so a changed reason is a changed result', () {
+        VerificationResult withCode(String? code) => VerificationResult(
+          platform: 'discord',
+          identity: 'alice',
+          verified: false,
+          checkedAt: 1,
+          cached: false,
+          code: code,
+        );
+
+        expect(
+          withCode('discord_bot_no_access'),
+          withCode('discord_bot_no_access'),
+        );
+        expect(
+          withCode('discord_bot_no_access'),
+          isNot(withCode('discord_message_not_found')),
+        );
+      });
+    });
   });
 }

--- a/mobile/test/blocs/verify/verify_connect_cubit_test.dart
+++ b/mobile/test/blocs/verify/verify_connect_cubit_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:analytics/analytics.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart' hide VerificationResult;
@@ -11,6 +12,8 @@ import 'package:profile_repository/profile_repository.dart';
 
 class _MockIdentityClaimsRepository extends Mock
     implements IdentityClaimsRepository {}
+
+class _MockAnalyticsEventSink extends Mock implements AnalyticsEventSink {}
 
 const _pubkey =
     '1111111111111111111111111111111111111111111111111111111111111111';
@@ -47,17 +50,20 @@ const _youtube = VerifierPlatform(
   supported: true,
 );
 
-VerificationResult _result({required bool verified}) => VerificationResult(
-  platform: 'github',
-  identity: 'octocat',
-  verified: verified,
-  checkedAt: 1,
-  cached: false,
-);
+VerificationResult _result({required bool verified, String? code}) =>
+    VerificationResult(
+      platform: 'github',
+      identity: 'octocat',
+      verified: verified,
+      checkedAt: 1,
+      cached: false,
+      code: code,
+    );
 
 void main() {
   group(VerifyConnectCubit, () {
     late _MockIdentityClaimsRepository repository;
+    late _MockAnalyticsEventSink analytics;
     late List<Uri> launched;
     late Uri? callback;
 
@@ -74,6 +80,13 @@ void main() {
 
     setUp(() {
       repository = _MockIdentityClaimsRepository();
+      analytics = _MockAnalyticsEventSink();
+      when(
+        () => analytics.logEvent(
+          name: any(named: 'name'),
+          parameters: any(named: 'parameters'),
+        ),
+      ).thenAnswer((_) async {});
       launched = [];
       callback = Uri.parse(
         '$_returnUrl?oauth_verified=true&platform=twitter&identity=jack',
@@ -99,6 +112,7 @@ void main() {
       pubkey: _pubkey,
       platform: platform,
       oauthReturnUrl: _returnUrl,
+      analytics: analytics,
       launchOAuth: (uri) async {
         launched.add(uri);
         return callback;
@@ -106,6 +120,75 @@ void main() {
     );
 
     group('submitProof', () {
+      blocTest<VerifyConnectCubit, VerifyConnectState>(
+        'shows the reason the verifier gave rather than blaming the npub',
+        setUp: () {
+          when(() => repository.verifyClaim(any())).thenAnswer(
+            (_) async =>
+                _result(verified: false, code: 'discord_author_mismatch'),
+          );
+        },
+        build: () => build(_discord),
+        act: (cubit) => cubit
+          ..identityChanged('alice')
+          ..proofChanged('https://discord.com/channels/1/2/3')
+          ..submitProof(),
+        verify: (cubit) {
+          expect(
+            cubit.state.error,
+            VerifyConnectError.discordAuthorMismatch,
+          );
+        },
+      );
+
+      blocTest<VerifyConnectCubit, VerifyConnectState>(
+        'counts the rejection by reason, carrying nothing that identifies anyone',
+        setUp: () {
+          when(() => repository.verifyClaim(any())).thenAnswer(
+            (_) async =>
+                _result(verified: false, code: 'discord_bot_no_access'),
+          );
+        },
+        build: () => build(_discord),
+        act: (cubit) => cubit
+          ..identityChanged('alice')
+          ..proofChanged('https://discord.com/channels/1/2/3')
+          ..submitProof(),
+        verify: (_) {
+          verify(
+            () => analytics.logEvent(
+              name: 'verify_proof_rejected',
+              parameters: {
+                'platform': 'discord',
+                'reason': 'discord_bot_no_access',
+              },
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<VerifyConnectCubit, VerifyConnectState>(
+        'names an absent code rather than dropping the event',
+        setUp: () {
+          when(
+            () => repository.verifyClaim(any()),
+          ).thenAnswer((_) async => _result(verified: false));
+        },
+        build: () => build(_github),
+        act: (cubit) => cubit
+          ..identityChanged('octocat')
+          ..proofChanged('abc')
+          ..submitProof(),
+        verify: (_) {
+          verify(
+            () => analytics.logEvent(
+              name: 'verify_proof_rejected',
+              parameters: {'platform': 'github', 'reason': 'none'},
+            ),
+          ).called(1);
+        },
+      );
+
       blocTest<VerifyConnectCubit, VerifyConnectState>(
         'publishes the claim once the verifier confirms it',
         build: () => build(_github),
@@ -479,6 +562,7 @@ void main() {
           pubkey: _pubkey,
           platform: _twitter,
           oauthReturnUrl: _returnUrl,
+          analytics: analytics,
           launchOAuth: (_) async => throw const FormatException('bad callback'),
         ),
         act: (cubit) => cubit.connectWithOAuth(),
@@ -495,6 +579,7 @@ void main() {
           pubkey: _pubkey,
           platform: _twitter,
           oauthReturnUrl: _returnUrl,
+          analytics: analytics,
           launchOAuth: (uri) {
             launched.add(uri);
             return browser.future;

--- a/mobile/test/blocs/verify/verify_rejection_test.dart
+++ b/mobile/test/blocs/verify/verify_rejection_test.dart
@@ -9,6 +9,10 @@ void main() {
   group('verifyErrorForCode', () {
     test('gives each known Discord reason its own error', () {
       expect(
+        verifyErrorForCode('discord_dm_link'),
+        VerifyConnectError.discordDmLink,
+      );
+      expect(
         verifyErrorForCode('discord_channel_link'),
         VerifyConnectError.discordChannelLink,
       );

--- a/mobile/test/blocs/verify/verify_rejection_test.dart
+++ b/mobile/test/blocs/verify/verify_rejection_test.dart
@@ -32,6 +32,10 @@ void main() {
         verifyErrorForCode('discord_message_content_unavailable'),
         VerifyConnectError.discordContentUnavailable,
       );
+      expect(
+        verifyErrorForCode('discord_npub_not_in_message'),
+        VerifyConnectError.proofMissingNpub,
+      );
     });
 
     test('falls back when the verifier sends no code', () {

--- a/mobile/test/blocs/verify/verify_rejection_test.dart
+++ b/mobile/test/blocs/verify/verify_rejection_test.dart
@@ -1,0 +1,67 @@
+// ABOUTME: Tests that each verifier rejection code maps to its own error, and
+// ABOUTME: that anything unrecognised still lands on the generic rejection.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/verify/verify_connect_cubit.dart';
+import 'package:openvine/blocs/verify/verify_rejection.dart';
+
+void main() {
+  group('verifyErrorForCode', () {
+    test('gives each known Discord reason its own error', () {
+      expect(
+        verifyErrorForCode('discord_channel_link'),
+        VerifyConnectError.discordChannelLink,
+      );
+      expect(
+        verifyErrorForCode('discord_message_not_found'),
+        VerifyConnectError.discordMessageNotFound,
+      );
+      expect(
+        verifyErrorForCode('discord_bot_no_access'),
+        VerifyConnectError.discordBotNoAccess,
+      );
+      expect(
+        verifyErrorForCode('discord_author_mismatch'),
+        VerifyConnectError.discordAuthorMismatch,
+      );
+      expect(
+        verifyErrorForCode('discord_message_content_unavailable'),
+        VerifyConnectError.discordContentUnavailable,
+      );
+    });
+
+    test('falls back when the verifier sends no code', () {
+      // Every deployment older than the codes, and every platform that has not
+      // adopted them, answers without one.
+      expect(verifyErrorForCode(null), VerifyConnectError.proofRejected);
+    });
+
+    test('falls back for a code this build has never heard of', () {
+      // The service owns the vocabulary and can add to it at any time. A build
+      // that met a new value with anything but its generic copy would show the
+      // user nothing at all.
+      expect(
+        verifyErrorForCode('discord_some_future_reason'),
+        VerifyConnectError.proofRejected,
+      );
+    });
+
+    test('falls back for the codes deliberately left unmapped', () {
+      // These are real codes with no copy of their own: the invite refusal is
+      // already covered by the form's own explainer, and the rest describe a
+      // service-side condition the user cannot act on.
+      for (final code in const [
+        'discord_invite_refused',
+        'discord_not_configured',
+        'discord_invalid_proof_format',
+        'discord_api_error',
+      ]) {
+        expect(
+          verifyErrorForCode(code),
+          VerifyConnectError.proofRejected,
+          reason: '$code should fall back',
+        );
+      }
+    });
+  });
+}

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -428,6 +428,17 @@ void main() {
 // Keys intentionally allowed to fall back to English until a translation pass.
 // Keep this list small and reviewable so new translation gaps stay visible.
 const _knownUntranslatedDebt = <String>{
+  // Discord proof-rejection reasons (verifier PR #43). Each names a distinct
+  // way a Discord proof can fail, replacing one message that blamed the npub
+  // for all of them. Deferred to the next human pass rather than
+  // machine-translated: verifyErrorDiscordAuthorMismatch turns on the
+  // username/display-name distinction, which each locale has to render in
+  // whatever words Discord itself uses there.
+  'verifyErrorDiscordChannelLink',
+  'verifyErrorDiscordMessageNotFound',
+  'verifyErrorDiscordBotNoAccess',
+  'verifyErrorDiscordAuthorMismatch',
+  'verifyErrorDiscordContentUnavailable',
   // Retraction-in-flight screen-reader label (#8201). Deferred to the next
   // human translation pass rather than machine-translated: its translated
   // siblings dmDeleteRefusedMessage / dmDeleteRefusedDetails each chose a

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -434,6 +434,7 @@ const _knownUntranslatedDebt = <String>{
   // machine-translated: verifyErrorDiscordAuthorMismatch turns on the
   // username/display-name distinction, which each locale has to render in
   // whatever words Discord itself uses there.
+  'verifyErrorDiscordDmLink',
   'verifyErrorDiscordChannelLink',
   'verifyErrorDiscordMessageNotFound',
   'verifyErrorDiscordBotNoAccess',

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -434,6 +434,7 @@ const _knownUntranslatedDebt = <String>{
   // machine-translated: verifyErrorDiscordAuthorMismatch turns on the
   // username/display-name distinction, which each locale has to render in
   // whatever words Discord itself uses there.
+  'verifyErrorProofMissingNpub',
   'verifyErrorDiscordDmLink',
   'verifyErrorDiscordChannelLink',
   'verifyErrorDiscordMessageNotFound',

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -434,6 +434,7 @@ const _knownUntranslatedDebt = <String>{
   // machine-translated: verifyErrorDiscordAuthorMismatch turns on the
   // username/display-name distinction, which each locale has to render in
   // whatever words Discord itself uses there.
+  'verifyErrorProofRejected',
   'verifyErrorProofMissingNpub',
   'verifyErrorDiscordDmLink',
   'verifyErrorDiscordChannelLink',

--- a/mobile/test/screens/verify/verify_connect_screen_test.dart
+++ b/mobile/test/screens/verify/verify_connect_screen_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Widget tests for the single-platform verify connect form.
 // ABOUTME: Covers the manual account fallback used when a proof link is opaque.
 
+import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -14,6 +15,8 @@ import 'package:profile_repository/profile_repository.dart';
 
 class _MockIdentityClaimsRepository extends Mock
     implements IdentityClaimsRepository {}
+
+class _MockAnalyticsEventSink extends Mock implements AnalyticsEventSink {}
 
 const _pubkey =
     '1111111111111111111111111111111111111111111111111111111111111111';
@@ -33,15 +36,24 @@ const _bluesky = VerifierPlatform(
 void main() {
   group(VerifyConnectView, () {
     late _MockIdentityClaimsRepository repository;
+    late _MockAnalyticsEventSink analytics;
     late VerifyConnectCubit cubit;
 
     setUp(() {
       repository = _MockIdentityClaimsRepository();
+      analytics = _MockAnalyticsEventSink();
+      when(
+        () => analytics.logEvent(
+          name: any(named: 'name'),
+          parameters: any(named: 'parameters'),
+        ),
+      ).thenAnswer((_) async {});
       cubit = VerifyConnectCubit(
         repository: repository,
         pubkey: _pubkey,
         platform: _telegram,
         oauthReturnUrl: _returnUrl,
+        analytics: analytics,
         launchOAuth: (_) async => null,
       );
     });
@@ -125,6 +137,116 @@ void main() {
     });
   });
 
+  group('$VerifyConnectView rejection copy', () {
+    late _MockIdentityClaimsRepository repository;
+    late _MockAnalyticsEventSink analytics;
+    late VerifyConnectCubit cubit;
+
+    const discord = VerifierPlatform(
+      key: 'discord',
+      label: 'Discord',
+      supported: true,
+    );
+
+    setUpAll(() {
+      registerFallbackValue(
+        const IdentityClaim(
+          pubkey: _pubkey,
+          platform: 'discord',
+          identity: 'alice',
+          proof: 'x',
+        ),
+      );
+    });
+
+    setUp(() {
+      repository = _MockIdentityClaimsRepository();
+      analytics = _MockAnalyticsEventSink();
+      when(
+        () => analytics.logEvent(
+          name: any(named: 'name'),
+          parameters: any(named: 'parameters'),
+        ),
+      ).thenAnswer((_) async {});
+      cubit = VerifyConnectCubit(
+        repository: repository,
+        pubkey: _pubkey,
+        platform: discord,
+        oauthReturnUrl: _returnUrl,
+        launchOAuth: (_) async => null,
+        analytics: analytics,
+      );
+    });
+
+    tearDown(() async {
+      await cubit.close();
+    });
+
+    Future<void> submit(WidgetTester tester, {required String? code}) async {
+      when(() => repository.verifyClaim(any())).thenAnswer(
+        (_) async => VerificationResult(
+          platform: 'discord',
+          identity: 'alice',
+          verified: false,
+          checkedAt: 1,
+          cached: false,
+          code: code,
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          home: BlocProvider<VerifyConnectCubit>.value(
+            value: cubit,
+            child: const VerifyConnectView(npub: _npub),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField).first, 'alice');
+      await tester.enterText(
+        find.byType(TextField).last,
+        'https://discord.com/channels/1/2/3',
+      );
+      await tester.pump();
+
+      await tester.tap(
+        find.text(
+          lookupAppLocalizations(const Locale('en')).verifyConnectProofCta,
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+    }
+
+    testWidgets('names the account when the author does not match', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      await submit(tester, code: 'discord_author_mismatch');
+
+      expect(find.text(l10n.verifyErrorDiscordAuthorMismatch), findsOneWidget);
+      // The old behaviour showed this for every rejection, which is what sent
+      // people back to re-post an npub that was already there.
+      expect(find.text(l10n.verifyErrorProofRejected), findsNothing);
+    });
+
+    testWidgets('keeps the generic copy when the verifier sends no code', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      await submit(tester, code: null);
+
+      expect(find.text(l10n.verifyErrorProofRejected), findsOneWidget);
+    });
+  });
+
   group('$VerifyConnectView OAuth support arriving late', () {
     late VerifyConnectCubit cubit;
 
@@ -134,6 +256,8 @@ void main() {
         pubkey: _pubkey,
         platform: _bluesky,
         oauthReturnUrl: _returnUrl,
+        // This group never rejects a proof, so the sink is never reached.
+        analytics: const NoOpAnalyticsEventSink(),
         launchOAuth: (_) async => null,
       );
     });

--- a/mobile/test/screens/verify/verify_connect_screen_test.dart
+++ b/mobile/test/screens/verify/verify_connect_screen_test.dart
@@ -245,6 +245,29 @@ void main() {
 
       expect(find.text(l10n.verifyErrorProofRejected), findsOneWidget);
     });
+
+    testWidgets('the fallback does not blame the npub', (tester) async {
+      // Every platform without rejection codes lands here, including a GitHub
+      // gist-owner mismatch and a Mastodon author mismatch. Naming the npub
+      // there reproduces the original bug for those platforms.
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      await submit(tester, code: null);
+
+      expect(l10n.verifyErrorProofRejected, isNot(contains('npub')));
+      expect(find.text(l10n.verifyErrorProofMissingNpub), findsNothing);
+    });
+
+    testWidgets('says the npub is missing only when that is the reason', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      await submit(tester, code: 'discord_npub_not_in_message');
+
+      expect(find.text(l10n.verifyErrorProofMissingNpub), findsOneWidget);
+      expect(find.text(l10n.verifyErrorProofRejected), findsNothing);
+    });
   });
 
   group('$VerifyConnectView OAuth support arriving late', () {

--- a/mobile/test/screens/verify/verify_connect_screen_test.dart
+++ b/mobile/test/screens/verify/verify_connect_screen_test.dart
@@ -246,7 +246,9 @@ void main() {
       expect(find.text(l10n.verifyErrorProofRejected), findsOneWidget);
     });
 
-    testWidgets('the fallback does not blame the npub', (tester) async {
+    testWidgets('the fallback does not blame the npub in any locale', (
+      tester,
+    ) async {
       // Every platform without rejection codes lands here, including a GitHub
       // gist-owner mismatch and a Mastodon author mismatch. Naming the npub
       // there reproduces the original bug for those platforms.
@@ -254,7 +256,13 @@ void main() {
 
       await submit(tester, code: null);
 
-      expect(l10n.verifyErrorProofRejected, isNot(contains('npub')));
+      for (final locale in AppLocalizations.supportedLocales) {
+        expect(
+          lookupAppLocalizations(locale).verifyErrorProofRejected,
+          isNot(contains('npub')),
+          reason: '$locale must use the generic rejection fallback',
+        );
+      }
       expect(find.text(l10n.verifyErrorProofMissingNpub), findsNothing);
     });
 


### PR DESCRIPTION
Closes #8620

## Problem

Identity verification reduced every rejected proof to the same message: “We could not find your npub in that post.” That blamed the npub when the real cause could be a wrong account name, a channel or direct-message link, a deleted message, missing bot access, or a verifier-side problem. Repeating the wrong remedy could leave someone stuck even when the npub in the post was already correct.

## Why this fix

The verifier service now returns an optional stable code beside its free-form diagnostic error. This PR parses that code and maps each user-actionable Discord rejection to a typed app error and dedicated localized copy. Unknown codes, service-side failures, platforms without codes, and older deployments use a generic fallback that does not claim to know the cause. The npub-specific sentence is reserved for discord_npub_not_in_message.

The error switch remains exhaustive, so adding a new app error requires choosing user-facing copy. Rejected proofs also emit verify_proof_rejected analytics with only fixed platform and reason values; it does not include the npub, handle, proof URL, message text, or diagnostic error.

## Compatibility and scope

The mobile and verifier-service changes can deploy in either order. A service without codes takes the generic fallback path. A newer unknown code also falls back safely.

The new rejection messages and the corrected generic fallback are recorded as known untranslated debt. Until a human translation pass, all 22 non-English locales fall back to the semantically correct English messages instead of retaining translations of the obsolete npub-specific fallback.

This PR does not move code-to-error mapping into verifier_client and does not generalize Discord-specific copy for future platforms.

## Verification

- Verifier client parsing and equality coverage for present and absent codes
- Mapping coverage for all seven actionable codes, absent and future codes, and the four deliberately generic service codes
- Cubit coverage for typed failures and privacy-bounded analytics
- Widget coverage for actionable copy, the generic fallback, and the npub-only reason
- Regression coverage across every supported locale that the generic fallback does not blame the npub
- ARB consistency and generated localization checks
- Flutter analyze and test coverage through Mobile CI

The corresponding verifier-service contract is in divine-identify-verification-service#43.