### PR TITLE
fix(support): explain rejected keyboard image insertions

### DIFF
--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2907,9 +2907,9 @@
   "@reportDetailsImageNotAttached": {
     "description": "Shown in the content report details field the moment the user tries to insert a photo or GIF from the keyboard. Reports carry no attachments, so the image is intentionally dropped; this confirms it was not attached and redirects the reporter to describing the issue in words."
   },
-  "bugReportImageInsertionRejected": "That image wasn’t added. Use Add images below to attach it.",
+  "bugReportImageInsertionRejected": "That image wasn’t added. Use \"Attach images\" below instead.",
   "@bugReportImageInsertionRejected": {
-    "description": "Shown when a keyboard image insertion is rejected from a bug report field. The screen has a separate image picker below."
+    "description": "Shown when a keyboard image insertion is rejected from a bug report field. Names the image picker button below the fields; keep the quoted name identical to the bugReportAttachImages translation in each locale."
   },
   "featureRequestImageInsertionRejected": "That image wasn’t attached. Describe it in words instead.",
   "@featureRequestImageInsertionRejected": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2907,9 +2907,9 @@
   "@reportDetailsImageNotAttached": {
     "description": "Shown in the content report details field the moment the user tries to insert a photo or GIF from the keyboard. Reports carry no attachments, so the image is intentionally dropped; this confirms it was not attached and redirects the reporter to describing the issue in words."
   },
-  "bugReportImageInsertionRejected": "That image wasn’t added. Use \"Attach images\" below instead.",
+  "bugReportImageInsertionRejected": "That image wasn’t added. You can attach up to 3 images below.",
   "@bugReportImageInsertionRejected": {
-    "description": "Shown when a keyboard image insertion is rejected from a bug report field. Names the image picker button below the fields; keep the quoted name identical to the bugReportAttachImages translation in each locale."
+    "description": "Shown when a keyboard image insertion is rejected from a bug report field. Directs the reporter to the attachment area without naming its add button, which is hidden once the three-image limit is reached."
   },
   "featureRequestImageInsertionRejected": "That image wasn’t attached. Describe it in words instead.",
   "@featureRequestImageInsertionRejected": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2907,6 +2907,14 @@
   "@reportDetailsImageNotAttached": {
     "description": "Shown in the content report details field the moment the user tries to insert a photo or GIF from the keyboard. Reports carry no attachments, so the image is intentionally dropped; this confirms it was not attached and redirects the reporter to describing the issue in words."
   },
+  "bugReportImageInsertionRejected": "That image wasn’t added. Use Add images below to attach it.",
+  "@bugReportImageInsertionRejected": {
+    "description": "Shown when a keyboard image insertion is rejected from a bug report field. The screen has a separate image picker below."
+  },
+  "featureRequestImageInsertionRejected": "That image wasn’t attached. Describe it in words instead.",
+  "@featureRequestImageInsertionRejected": {
+    "description": "Shown when a keyboard image insertion is rejected from a text-only feature request field."
+  },
   "reportReasonSpam": "Spam or Unwanted Content",
   "reportReasonSpamSubtitle": "Unwanted or repetitive content",
   "reportReasonHarassment": "Harassment, Bullying, or Threats",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7963,10 +7963,10 @@ abstract class AppLocalizations {
   /// **'That wasn’t attached. Reports are text only, so describe it in words.'**
   String get reportDetailsImageNotAttached;
 
-  /// Shown when a keyboard image insertion is rejected from a bug report field. The screen has a separate image picker below.
+  /// Shown when a keyboard image insertion is rejected from a bug report field. Names the image picker button below the fields; keep the quoted name identical to the bugReportAttachImages translation in each locale.
   ///
   /// In en, this message translates to:
-  /// **'That image wasn’t added. Use Add images below to attach it.'**
+  /// **'That image wasn’t added. Use \"Attach images\" below instead.'**
   String get bugReportImageInsertionRejected;
 
   /// Shown when a keyboard image insertion is rejected from a text-only feature request field.

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7963,10 +7963,10 @@ abstract class AppLocalizations {
   /// **'That wasn’t attached. Reports are text only, so describe it in words.'**
   String get reportDetailsImageNotAttached;
 
-  /// Shown when a keyboard image insertion is rejected from a bug report field. Names the image picker button below the fields; keep the quoted name identical to the bugReportAttachImages translation in each locale.
+  /// Shown when a keyboard image insertion is rejected from a bug report field. Directs the reporter to the attachment area without naming its add button, which is hidden once the three-image limit is reached.
   ///
   /// In en, this message translates to:
-  /// **'That image wasn’t added. Use \"Attach images\" below instead.'**
+  /// **'That image wasn’t added. You can attach up to 3 images below.'**
   String get bugReportImageInsertionRejected;
 
   /// Shown when a keyboard image insertion is rejected from a text-only feature request field.

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7963,6 +7963,18 @@ abstract class AppLocalizations {
   /// **'That wasn’t attached. Reports are text only, so describe it in words.'**
   String get reportDetailsImageNotAttached;
 
+  /// Shown when a keyboard image insertion is rejected from a bug report field. The screen has a separate image picker below.
+  ///
+  /// In en, this message translates to:
+  /// **'That image wasn’t added. Use Add images below to attach it.'**
+  String get bugReportImageInsertionRejected;
+
+  /// Shown when a keyboard image insertion is rejected from a text-only feature request field.
+  ///
+  /// In en, this message translates to:
+  /// **'That image wasn’t attached. Describe it in words instead.'**
+  String get featureRequestImageInsertionRejected;
+
   /// No description provided for @reportReasonSpam.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4537,7 +4537,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4537,7 +4537,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4536,6 +4536,14 @@ class AppLocalizationsAm extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'አይፈለጌ መልእክት ወይም የማይፈለግ ይዘት';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4605,7 +4605,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4604,6 +4604,14 @@ class AppLocalizationsAr extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'محتوى غير مرغوب فيه أو مزعج';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4605,7 +4605,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4696,7 +4696,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4696,7 +4696,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4695,6 +4695,14 @@ class AppLocalizationsBg extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'Спам или нежелано съдържание';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4706,7 +4706,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4706,7 +4706,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4705,6 +4705,14 @@ class AppLocalizationsDe extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'Spam oder unerwünschte Inhalte';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4734,7 +4734,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4734,7 +4734,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4733,6 +4733,14 @@ class AppLocalizationsEn extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'Spam or Unwanted Content';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4695,7 +4695,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4695,7 +4695,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4694,6 +4694,14 @@ class AppLocalizationsEs extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'Spam o contenido no deseado';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4679,7 +4679,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4678,6 +4678,14 @@ class AppLocalizationsFil extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'Spam o Hindi Gustong Content';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4679,7 +4679,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4713,7 +4713,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4713,7 +4713,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4712,6 +4712,14 @@ class AppLocalizationsFr extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'Spam ou contenu indésirable';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4577,6 +4577,14 @@ class AppLocalizationsId extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'Spam atau Konten Tidak Diinginkan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4578,7 +4578,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4578,7 +4578,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4700,7 +4700,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4700,7 +4700,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4699,6 +4699,14 @@ class AppLocalizationsIt extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'Spam o contenuto indesiderato';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4370,7 +4370,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4369,6 +4369,14 @@ class AppLocalizationsJa extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'スパムや迷惑なコンテンツ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4370,7 +4370,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4384,6 +4384,14 @@ class AppLocalizationsKo extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => '스팸 또는 원치 않는 콘텐츠';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4385,7 +4385,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4385,7 +4385,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -4647,7 +4647,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -4647,7 +4647,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -4646,6 +4646,14 @@ class AppLocalizationsMs extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'Spam atau Kandungan Tidak Diingini';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4665,7 +4665,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4665,7 +4665,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4664,6 +4664,14 @@ class AppLocalizationsNl extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'Spam of ongewenste inhoud';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4767,7 +4767,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4766,6 +4766,14 @@ class AppLocalizationsPl extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'Spam lub niechciana treść';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4767,7 +4767,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4678,7 +4678,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4678,7 +4678,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4677,6 +4677,14 @@ class AppLocalizationsPt extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'Spam ou conteúdo indesejado';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4785,7 +4785,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4785,7 +4785,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4784,6 +4784,14 @@ class AppLocalizationsRo extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'Spam sau conținut nedorit';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4644,7 +4644,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4643,6 +4643,14 @@ class AppLocalizationsSv extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'Skräppost eller ovälkommet innehåll';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4644,7 +4644,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -4816,6 +4816,14 @@ class AppLocalizationsTe extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'స్పామ్ లేదా అవాంఛిత కంటెంట్';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -4817,7 +4817,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -4817,7 +4817,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4586,7 +4586,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4585,6 +4585,14 @@ class AppLocalizationsTr extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'Spam veya İstenmeyen İçerik';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4586,7 +4586,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -4654,6 +4654,14 @@ class AppLocalizationsUr extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'اسپیم یا ناپسندیدہ مواد';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -4655,7 +4655,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -4655,7 +4655,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -4613,7 +4613,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -4612,6 +4612,14 @@ class AppLocalizationsVi extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => 'Spam hoặc nội dung không mong muốn';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -4613,7 +4613,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -4348,6 +4348,14 @@ class AppLocalizationsZh extends AppLocalizations {
       'That wasn’t attached. Reports are text only, so describe it in words.';
 
   @override
+  String get bugReportImageInsertionRejected =>
+      'That image wasn’t added. Use Add images below to attach it.';
+
+  @override
+  String get featureRequestImageInsertionRejected =>
+      'That image wasn’t attached. Describe it in words instead.';
+
+  @override
   String get reportReasonSpam => '垃圾或不受欢迎的内容';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -4349,7 +4349,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use \"Attach images\" below instead.';
+      'That image wasn’t added. You can attach up to 3 images below.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -4349,7 +4349,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get bugReportImageInsertionRejected =>
-      'That image wasn’t added. Use Add images below to attach it.';
+      'That image wasn’t added. Use \"Attach images\" below instead.';
 
   @override
   String get featureRequestImageInsertionRejected =>

--- a/mobile/lib/widgets/bug_report_dialog.dart
+++ b/mobile/lib/widgets/bug_report_dialog.dart
@@ -139,6 +139,8 @@ class _BugReportView extends StatelessWidget {
                         labelText: l10n.supportSubjectRequiredLabel,
                         hintText: l10n.bugReportSubjectHint,
                         helperText: l10n.supportRequiredHelper,
+                        imageInsertionNotice:
+                            l10n.bugReportImageInsertionRejected,
                         enabled: !isSubmitting,
                         textInputAction: TextInputAction.next,
                         onSubmitted: (_) =>
@@ -151,6 +153,8 @@ class _BugReportView extends StatelessWidget {
                         labelText: l10n.bugReportDescriptionRequiredLabel,
                         hintText: l10n.bugReportDescriptionHint,
                         helperText: l10n.supportRequiredHelper,
+                        imageInsertionNotice:
+                            l10n.bugReportImageInsertionRejected,
                         enabled: !isSubmitting,
                         minLines: 3,
                         maxLines: 5,
@@ -161,6 +165,8 @@ class _BugReportView extends StatelessWidget {
                         controller: fields.steps,
                         labelText: l10n.bugReportStepsLabel,
                         hintText: l10n.bugReportStepsHint,
+                        imageInsertionNotice:
+                            l10n.bugReportImageInsertionRejected,
                         enabled: !isSubmitting,
                         minLines: 3,
                         maxLines: 5,
@@ -171,6 +177,8 @@ class _BugReportView extends StatelessWidget {
                         controller: fields.expected,
                         labelText: l10n.bugReportExpectedBehaviorLabel,
                         hintText: l10n.bugReportExpectedBehaviorHint,
+                        imageInsertionNotice:
+                            l10n.bugReportImageInsertionRejected,
                         enabled: !isSubmitting,
                         minLines: 2,
                         maxLines: 4,

--- a/mobile/lib/widgets/feature_request_dialog.dart
+++ b/mobile/lib/widgets/feature_request_dialog.dart
@@ -117,6 +117,8 @@ class _FeatureRequestView extends StatelessWidget {
                         labelText: l10n.supportSubjectRequiredLabel,
                         hintText: l10n.featureRequestSubjectHint,
                         helperText: l10n.supportRequiredHelper,
+                        imageInsertionNotice:
+                            l10n.featureRequestImageInsertionRejected,
                         enabled: !isSubmitting,
                         textInputAction: TextInputAction.next,
                         onSubmitted: (_) =>
@@ -129,6 +131,8 @@ class _FeatureRequestView extends StatelessWidget {
                         labelText: l10n.featureRequestDescriptionRequiredLabel,
                         hintText: l10n.featureRequestDescriptionHint,
                         helperText: l10n.supportRequiredHelper,
+                        imageInsertionNotice:
+                            l10n.featureRequestImageInsertionRejected,
                         enabled: !isSubmitting,
                         minLines: 3,
                         maxLines: 5,
@@ -139,6 +143,8 @@ class _FeatureRequestView extends StatelessWidget {
                         controller: fields.usefulness,
                         labelText: l10n.featureRequestUsefulnessLabel,
                         hintText: l10n.featureRequestUsefulnessHint,
+                        imageInsertionNotice:
+                            l10n.featureRequestImageInsertionRejected,
                         enabled: !isSubmitting,
                         minLines: 3,
                         maxLines: 5,
@@ -149,6 +155,8 @@ class _FeatureRequestView extends StatelessWidget {
                         controller: fields.whenToUse,
                         labelText: l10n.featureRequestWhenLabel,
                         hintText: l10n.featureRequestWhenHint,
+                        imageInsertionNotice:
+                            l10n.featureRequestImageInsertionRejected,
                         enabled: !isSubmitting,
                         minLines: 2,
                         maxLines: 4,

--- a/mobile/lib/widgets/support_capped_text_field.dart
+++ b/mobile/lib/widgets/support_capped_text_field.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Support form text field that caps its length and says when it did
-// ABOUTME: Keeps a silently truncated paste from looking like an accepted one
+// ABOUTME: Support form text field that reports rejected text and image input
+// ABOUTME: Keeps dropped keyboard content from looking like accepted evidence
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -42,6 +42,7 @@ class SupportCappedTextField extends StatefulWidget {
     this.keyboardType,
     this.textInputAction,
     this.onSubmitted,
+    this.imageInsertionNotice,
   });
 
   final TextEditingController controller;
@@ -57,12 +58,19 @@ class SupportCappedTextField extends StatefulWidget {
   final TextInputAction? textInputAction;
   final ValueChanged<String>? onSubmitted;
 
+  /// Feedback shown when the keyboard tries to insert unsupported rich media.
+  ///
+  /// Null leaves rich-content insertion disabled without changing existing
+  /// callers.
+  final String? imageInsertionNotice;
+
   @override
   State<SupportCappedTextField> createState() => _SupportCappedTextFieldState();
 }
 
 class _SupportCappedTextFieldState extends State<SupportCappedTextField> {
   bool _truncated = false;
+  bool _imageInsertionRejected = false;
 
   void _onTruncated() {
     if (_truncated || !mounted) return;
@@ -78,19 +86,46 @@ class _SupportCappedTextFieldState extends State<SupportCappedTextField> {
   }
 
   void _onChanged(String value) {
-    // Once the user makes room again, the warning has nothing left to warn
-    // about.
-    if (_truncated && value.characters.length < widget.maxLength) {
-      setState(() => _truncated = false);
+    final clearsTruncation =
+        _truncated && value.characters.length < widget.maxLength;
+    if (!clearsTruncation && !_imageInsertionRejected) return;
+    setState(() {
+      if (clearsTruncation) _truncated = false;
+      _imageInsertionRejected = false;
+    });
+  }
+
+  void _onImageInserted() {
+    final notice = widget.imageInsertionNotice;
+    if (notice == null || !mounted) return;
+    if (!_imageInsertionRejected) {
+      setState(() => _imageInsertionRejected = true);
     }
+    // Each insertion is a separate action, so announce every attempt even
+    // while the visual notice is already present.
+    SemanticsService.sendAnnouncement(
+      View.of(context),
+      notice,
+      Directionality.of(context),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
+    final imageInsertionNotice = widget.imageInsertionNotice;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       spacing: 4,
       children: [
+        if (_imageInsertionRejected && imageInsertionNotice != null)
+          // Keep this above the field: the keyboard's media panel covers the
+          // space below it at the exact moment insertion feedback appears.
+          Text(
+            imageInsertionNotice,
+            style: VineTheme.labelSmallFont(
+              color: context.vineColors.onSurfaceVariant,
+            ),
+          ),
         DivineTextField(
           controller: widget.controller,
           focusNode: widget.focusNode,
@@ -105,6 +140,11 @@ class _SupportCappedTextFieldState extends State<SupportCappedTextField> {
           textInputAction: widget.textInputAction,
           onSubmitted: widget.onSubmitted,
           onChanged: _onChanged,
+          contentInsertionConfiguration: imageInsertionNotice == null
+              ? null
+              : ContentInsertionConfiguration(
+                  onContentInserted: (_) => _onImageInserted(),
+                ),
           inputFormatters: [
             ReportingLengthLimiter(widget.maxLength, _onTruncated),
           ],

--- a/mobile/packages/divine_ui/lib/src/text_field/divine_text_field.dart
+++ b/mobile/packages/divine_ui/lib/src/text_field/divine_text_field.dart
@@ -34,6 +34,7 @@ class DivineTextField extends StatelessWidget {
     this.primaryWhenFilled = false,
     this.autofocus = false,
     this.spellCheckConfiguration,
+    this.contentInsertionConfiguration,
     this.filled = false,
     this.fillColor,
     this.fillBorderRadius = defaultFillBorderRadius,
@@ -157,6 +158,11 @@ class DivineTextField extends StatelessWidget {
   /// technical inputs (search, keys, URLs) where spell check adds noise.
   final SpellCheckConfiguration? spellCheckConfiguration;
 
+  /// Configures rich content inserted through the system keyboard.
+  ///
+  /// Null preserves Flutter's default text-only behavior.
+  final ContentInsertionConfiguration? contentInsertionConfiguration;
+
   /// The spell check configuration used when [spellCheckConfiguration] is not
   /// provided.
   ///
@@ -236,6 +242,7 @@ class DivineTextField extends StatelessWidget {
       autofocus: autofocus,
       spellCheckConfiguration:
           spellCheckConfiguration ?? defaultSpellCheckConfiguration,
+      contentInsertionConfiguration: contentInsertionConfiguration,
       onTap: onTap,
       onEditingComplete: onEditingComplete,
       decoration: InputDecoration(

--- a/mobile/packages/divine_ui/test/src/text_field/divine_text_field_test.dart
+++ b/mobile/packages/divine_ui/test/src/text_field/divine_text_field_test.dart
@@ -149,6 +149,40 @@ void main() {
       expect(textField.textInputAction, TextInputAction.search);
     });
 
+    testWidgets('forwards content insertion configuration', (tester) async {
+      final configuration = ContentInsertionConfiguration(
+        onContentInserted: (_) {},
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: VineTheme.theme,
+          home: Scaffold(
+            body: DivineTextField(
+              contentInsertionConfiguration: configuration,
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        tester
+            .widget<TextField>(find.byType(TextField))
+            .contentInsertionConfiguration,
+        same(configuration),
+      );
+    });
+
+    testWidgets('does not advertise rich content by default', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(
+        tester
+            .widget<TextField>(find.byType(TextField))
+            .contentInsertionConfiguration,
+        isNull,
+      );
+    });
+
     testWidgets('uses focus node when provided', (tester) async {
       final focusNode = FocusNode();
       await tester.pumpWidget(buildTestWidget(focusNode: focusNode));

--- a/mobile/test/helpers/keyboard_content_insertion.dart
+++ b/mobile/test/helpers/keyboard_content_insertion.dart
@@ -1,0 +1,34 @@
+// ABOUTME: Test helper for simulating keyboard rich-content insertion
+// ABOUTME: Sends the same commitContent platform message used by Android IMEs
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Simulates an Android keyboard committing an image into the focused field.
+///
+/// Client id `-1` is Flutter's debug-mode id, which bypasses the active
+/// connection-id check in the same way as the framework's insertion tests.
+Future<void> commitKeyboardImage(
+  WidgetTester tester, {
+  String mimeType = 'image/gif',
+}) {
+  const uri =
+      'content://com.google.android.inputmethod.latin.fileprovider/report.gif';
+  final message = const JSONMessageCodec().encodeMessage(<String, dynamic>{
+    'method': 'TextInputClient.performAction',
+    'args': <dynamic>[
+      -1,
+      'TextInputAction.commitContent',
+      <String, dynamic>{
+        'mimeType': mimeType,
+        'data': <int>[0, 1, 0, 1, 0, 1],
+        'uri': uri,
+      },
+    ],
+  });
+  return tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+    SystemChannels.textInput.name,
+    message,
+    (ByteData? _) {},
+  );
+}

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -440,6 +440,11 @@ const _knownUntranslatedDebt = <String>{
   // than machine-translating moderation copy that has to say exactly what it
   // means.
   'reportDetailsImageNotAttached',
+  // Support-form image-rejection notices (#8602). Deferred to the same human
+  // translation pass as reportDetailsImageNotAttached so attachment guidance
+  // stays accurate in every locale rather than being machine-translated.
+  'bugReportImageInsertionRejected',
+  'featureRequestImageInsertionRejected',
   // Deletion prep-failure copy (feature #6126). Deferred to the l10n
   // translation-debt pass (#7632) rather than machine-translating a
   // safety-critical "nothing was deleted" message. Mirror the translated

--- a/mobile/test/widgets/bug_report_dialog_test.dart
+++ b/mobile/test/widgets/bug_report_dialog_test.dart
@@ -271,6 +271,10 @@ void main() {
       await commitKeyboardImage(tester);
       await tester.pumpAndSettle();
 
+      expect(
+        l10n.bugReportImageInsertionRejected,
+        'That image wasn’t added. You can attach up to 3 images below.',
+      );
       expect(find.text(l10n.bugReportImageInsertionRejected), findsOneWidget);
       expect(
         tester.widget<TextField>(description).controller!.text,

--- a/mobile/test/widgets/bug_report_dialog_test.dart
+++ b/mobile/test/widgets/bug_report_dialog_test.dart
@@ -17,6 +17,8 @@ import 'package:openvine/services/bug_report_service.dart';
 import 'package:openvine/widgets/bug_report_dialog.dart';
 import 'package:openvine/widgets/support_public_submission_notice.dart';
 
+import '../helpers/keyboard_content_insertion.dart';
+
 class _MockBugReportService extends Mock implements BugReportService {}
 
 class _FakeBugReportData extends Fake implements BugReportData {}
@@ -246,6 +248,34 @@ void main() {
 
       final l10n = lookupAppLocalizations(const Locale('en'));
       expect(announcements, contains(l10n.supportFieldLimitReached));
+    });
+
+    testWidgets('gives all fields bug-report image insertion feedback', (
+      tester,
+    ) async {
+      await openFlow(tester);
+
+      final fields = tester.widgetList<TextField>(find.byType(TextField));
+      expect(fields, hasLength(4));
+      expect(
+        fields.every(
+          (field) => field.contentInsertionConfiguration != null,
+        ),
+        isTrue,
+      );
+
+      const reporterWords = 'The app freezes after opening settings.';
+      final description = find.byType(TextField).at(1);
+      await tester.tap(description);
+      await tester.enterText(description, reporterWords);
+      await commitKeyboardImage(tester);
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.bugReportImageInsertionRejected), findsOneWidget);
+      expect(
+        tester.widget<TextField>(description).controller!.text,
+        reporterWords,
+      );
     });
 
     BugReportData testReportData() {

--- a/mobile/test/widgets/feature_request_dialog_test.dart
+++ b/mobile/test/widgets/feature_request_dialog_test.dart
@@ -13,6 +13,8 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/feature_request_dialog.dart';
 import 'package:openvine/widgets/support_public_submission_notice.dart';
 
+import '../helpers/keyboard_content_insertion.dart';
+
 const _pubkeyHex =
     '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
 
@@ -120,6 +122,37 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text(l10n.supportFieldLimitReached), findsOneWidget);
+    });
+
+    testWidgets('gives all fields feature-request image insertion feedback', (
+      tester,
+    ) async {
+      await openFlow(tester);
+
+      final fields = tester.widgetList<TextField>(find.byType(TextField));
+      expect(fields, hasLength(4));
+      expect(
+        fields.every(
+          (field) => field.contentInsertionConfiguration != null,
+        ),
+        isTrue,
+      );
+
+      const requesterWords = 'Let people save favorite search filters.';
+      final description = find.byType(TextField).at(1);
+      await tester.tap(description);
+      await tester.enterText(description, requesterWords);
+      await commitKeyboardImage(tester);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(l10n.featureRequestImageInsertionRejected),
+        findsOneWidget,
+      );
+      expect(
+        tester.widget<TextField>(description).controller!.text,
+        requesterWords,
+      );
     });
 
     DivineButton buttonFor(WidgetTester tester, String label) {

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -24,6 +24,7 @@ import 'package:openvine/services/content_reporting_service.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/widgets/report_content_dialog.dart';
 
+import '../helpers/keyboard_content_insertion.dart';
 import '../helpers/scroll.dart';
 import '../helpers/test_provider_overrides.dart';
 import '../helpers/test_pubkeys.dart';
@@ -2638,37 +2639,6 @@ void main() {
         home: Scaffold(body: ReportContentDialog(video: testVideo)),
       ),
     );
-
-    // Simulates a keyboard committing rich content (a GIF/image) into the
-    // focused field, exactly as Gboard does. Mirrors the framework's own
-    // content-insertion test in editable_text_test.dart: a
-    // `TextInputClient.performAction` / `TextInputAction.commitContent`
-    // platform message. Client id -1 is the debug-mode magic id that bypasses
-    // the connection-id check.
-    Future<void> commitKeyboardImage(
-      WidgetTester tester, {
-      String mimeType = 'image/gif',
-    }) {
-      const uri =
-          'content://com.google.android.inputmethod.latin.fileprovider/report.gif';
-      final message = const JSONMessageCodec().encodeMessage(<String, dynamic>{
-        'method': 'TextInputClient.performAction',
-        'args': <dynamic>[
-          -1,
-          'TextInputAction.commitContent',
-          <String, dynamic>{
-            'mimeType': mimeType,
-            'data': <int>[0, 1, 0, 1, 0, 1],
-            'uri': uri,
-          },
-        ],
-      });
-      return tester.binding.defaultBinaryMessenger.handlePlatformMessage(
-        SystemChannels.textInput.name,
-        message,
-        (ByteData? _) {},
-      );
-    }
 
     Future<void> openDetailsField(
       WidgetTester tester, {

--- a/mobile/test/widgets/support_capped_text_field_test.dart
+++ b/mobile/test/widgets/support_capped_text_field_test.dart
@@ -30,90 +30,89 @@ void main() {
     );
   }
 
-  testWidgets('leaves keyboard image insertion disabled without notice', (
-    tester,
-  ) async {
-    await tester.pumpWidget(buildSubject(imageInsertionNotice: null));
+  group('keyboard image insertion', () {
+    testWidgets('leaves insertion disabled without notice', (tester) async {
+      await tester.pumpWidget(buildSubject(imageInsertionNotice: null));
 
-    expect(
-      tester
-          .widget<TextField>(find.byType(TextField))
-          .contentInsertionConfiguration,
-      isNull,
-    );
-  });
+      expect(
+        tester
+            .widget<TextField>(find.byType(TextField))
+            .contentInsertionConfiguration,
+        isNull,
+      );
+    });
 
-  testWidgets('rejects a keyboard image with visible feedback', (tester) async {
-    await tester.pumpWidget(buildSubject());
-    await tester.tap(find.byType(TextField));
-    await tester.enterText(find.byType(TextField), 'typed report details');
+    testWidgets('shows visible feedback without changing text', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.tap(find.byType(TextField));
+      await tester.enterText(find.byType(TextField), 'typed report details');
 
-    await commitKeyboardImage(tester);
-    await tester.pumpAndSettle();
+      await commitKeyboardImage(tester);
+      await tester.pumpAndSettle();
 
-    expect(find.text(notice), findsOneWidget);
-    expect(
-      tester.widget<TextField>(find.byType(TextField)).controller!.text,
-      'typed report details',
-    );
-  });
+      expect(find.text(notice), findsOneWidget);
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        'typed report details',
+      );
+    });
 
-  testWidgets('announces every rejected keyboard image', (tester) async {
-    final announcements = <String>[];
-    tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(
-      SystemChannels.accessibility,
-      (
-        message,
-      ) async {
-        final data = message! as Map<Object?, Object?>;
-        if (data['type'] == 'announce') {
-          final payload = data['data']! as Map<Object?, Object?>;
-          announcements.add(payload['message']! as String);
-        }
-        return null;
-      },
-    );
-    addTearDown(
-      () => tester.binding.defaultBinaryMessenger
+    testWidgets('announces every rejection', (tester) async {
+      final announcements = <String>[];
+      tester.binding.defaultBinaryMessenger
           .setMockDecodedMessageHandler<Object?>(
             SystemChannels.accessibility,
-            null,
-          ),
-    );
+            (
+              message,
+            ) async {
+              final data = message! as Map<Object?, Object?>;
+              if (data['type'] == 'announce') {
+                final payload = data['data']! as Map<Object?, Object?>;
+                announcements.add(payload['message']! as String);
+              }
+              return null;
+            },
+          );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(
+              SystemChannels.accessibility,
+              null,
+            ),
+      );
 
-    await tester.pumpWidget(buildSubject());
-    await tester.tap(find.byType(TextField));
-    await commitKeyboardImage(tester);
-    await commitKeyboardImage(tester);
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(buildSubject());
+      await tester.tap(find.byType(TextField));
+      await commitKeyboardImage(tester);
+      await commitKeyboardImage(tester);
+      await tester.pumpAndSettle();
 
-    expect(announcements.where((message) => message == notice), hasLength(2));
-  });
+      expect(announcements.where((message) => message == notice), hasLength(2));
+    });
 
-  testWidgets('clears image feedback when the reporter types', (tester) async {
-    await tester.pumpWidget(buildSubject());
-    await tester.tap(find.byType(TextField));
-    await commitKeyboardImage(tester);
-    await tester.pumpAndSettle();
-    expect(find.text(notice), findsOneWidget);
+    testWidgets('clears feedback when the reporter types', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.tap(find.byType(TextField));
+      await commitKeyboardImage(tester);
+      await tester.pumpAndSettle();
+      expect(find.text(notice), findsOneWidget);
 
-    await tester.enterText(find.byType(TextField), 'described in words');
-    await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), 'described in words');
+      await tester.pumpAndSettle();
 
-    expect(find.text(notice), findsNothing);
-  });
+      expect(find.text(notice), findsNothing);
+    });
 
-  testWidgets('renders image feedback above the affected field', (
-    tester,
-  ) async {
-    await tester.pumpWidget(buildSubject());
-    await tester.tap(find.byType(TextField));
-    await commitKeyboardImage(tester);
-    await tester.pumpAndSettle();
+    testWidgets('renders feedback above the affected field', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.tap(find.byType(TextField));
+      await commitKeyboardImage(tester);
+      await tester.pumpAndSettle();
 
-    expect(
-      tester.getRect(find.text(notice)).bottom,
-      lessThanOrEqualTo(tester.getRect(find.byType(TextField)).top),
-    );
+      expect(
+        tester.getRect(find.text(notice)).bottom,
+        lessThanOrEqualTo(tester.getRect(find.byType(TextField)).top),
+      );
+    });
   });
 }

--- a/mobile/test/widgets/support_capped_text_field_test.dart
+++ b/mobile/test/widgets/support_capped_text_field_test.dart
@@ -1,0 +1,119 @@
+// ABOUTME: Widget tests for support form text-field feedback
+// ABOUTME: Covers rejected keyboard images alongside paste truncation notices
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/support_capped_text_field.dart';
+
+import '../helpers/keyboard_content_insertion.dart';
+
+void main() {
+  const notice = 'That image was not added.';
+  late TextEditingController controller;
+
+  setUp(() => controller = TextEditingController());
+  tearDown(() => controller.dispose());
+
+  Widget buildSubject({String? imageInsertionNotice = notice}) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: SupportCappedTextField(
+          controller: controller,
+          maxLength: 100,
+          imageInsertionNotice: imageInsertionNotice,
+        ),
+      ),
+    );
+  }
+
+  testWidgets('leaves keyboard image insertion disabled without notice', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildSubject(imageInsertionNotice: null));
+
+    expect(
+      tester
+          .widget<TextField>(find.byType(TextField))
+          .contentInsertionConfiguration,
+      isNull,
+    );
+  });
+
+  testWidgets('rejects a keyboard image with visible feedback', (tester) async {
+    await tester.pumpWidget(buildSubject());
+    await tester.tap(find.byType(TextField));
+    await tester.enterText(find.byType(TextField), 'typed report details');
+
+    await commitKeyboardImage(tester);
+    await tester.pumpAndSettle();
+
+    expect(find.text(notice), findsOneWidget);
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller!.text,
+      'typed report details',
+    );
+  });
+
+  testWidgets('announces every rejected keyboard image', (tester) async {
+    final announcements = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(
+      SystemChannels.accessibility,
+      (
+        message,
+      ) async {
+        final data = message! as Map<Object?, Object?>;
+        if (data['type'] == 'announce') {
+          final payload = data['data']! as Map<Object?, Object?>;
+          announcements.add(payload['message']! as String);
+        }
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger
+          .setMockDecodedMessageHandler<Object?>(
+            SystemChannels.accessibility,
+            null,
+          ),
+    );
+
+    await tester.pumpWidget(buildSubject());
+    await tester.tap(find.byType(TextField));
+    await commitKeyboardImage(tester);
+    await commitKeyboardImage(tester);
+    await tester.pumpAndSettle();
+
+    expect(announcements.where((message) => message == notice), hasLength(2));
+  });
+
+  testWidgets('clears image feedback when the reporter types', (tester) async {
+    await tester.pumpWidget(buildSubject());
+    await tester.tap(find.byType(TextField));
+    await commitKeyboardImage(tester);
+    await tester.pumpAndSettle();
+    expect(find.text(notice), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'described in words');
+    await tester.pumpAndSettle();
+
+    expect(find.text(notice), findsNothing);
+  });
+
+  testWidgets('renders image feedback above the affected field', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildSubject());
+    await tester.tap(find.byType(TextField));
+    await commitKeyboardImage(tester);
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getRect(find.text(notice)).bottom,
+      lessThanOrEqualTo(tester.getRect(find.byType(TextField)).top),
+    );
+  });
+}


### PR DESCRIPTION
## Problem

Bug-report and feature-request detail fields silently discarded images inserted through Android keyboards because the shared design-system text field exposed no content-insertion configuration. Reporters could therefore believe evidence was attached when it was not.

## Fix

- expose Flutter's content-insertion configuration through `DivineTextField`
- let `SupportCappedTextField` intercept image insertion per focused field, preserve typed text, show above-field feedback, and announce each rejection
- use bug-report-specific copy directing reporters to the three-image attachment area below the fields, and text-only feature-request copy
- extract the shared keyboard `commitContent` test helper instead of duplicating the platform-message fixture

The two new strings intentionally use the existing English fallback/untranslated-debt mechanism until the human localization pass. This does not add keyboard media as an attachment path: bug reports continue to attach up to three images through the picker below the fields, and feature requests remain text-only.

Closes #8602

## Verification

- `flutter analyze lib test integration_test`
- 116 focused app tests after rebase
- 156 changed-file tests in the pre-push hook
- `flutter analyze` in `packages/divine_ui`
- `flutter test --coverage` in `packages/divine_ui` (979 tests)
- ARB consistency, orphan-key floor, and Maestro copy-drift checks
- mutation checks proving the notice tests require the insertion configuration and the accessibility test independently requires the announcement
