### PR TITLE
fix(dm): keep refused reaction removals retryable

### DIFF
--- a/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
+++ b/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
@@ -42,6 +42,10 @@ class ConversationReactionsCubit
       _onRetryRequested,
       transformer: sequential(),
     );
+    on<ConversationReactionRemovalRetryRequested>(
+      _onRemovalRetryRequested,
+      transformer: sequential(),
+    );
     on<_ConversationReactionsSubscriptionTicked>(_onSubscriptionTicked);
   }
 
@@ -364,6 +368,20 @@ class ConversationReactionsCubit
     }
   }
 
+  Future<void> _onRemovalRetryRequested(
+    ConversationReactionRemovalRetryRequested event,
+    Emitter<ConversationReactionsState> emit,
+  ) async {
+    try {
+      await _reactionsRepository.retryDeletion(
+        rumorId: event.rumorId,
+        targetMessageAuthor: event.messageAuthorPubkey,
+      );
+    } on Object catch (error, stackTrace) {
+      addError(error, stackTrace);
+    }
+  }
+
   void _onSubscriptionTicked(
     _ConversationReactionsSubscriptionTicked event,
     Emitter<ConversationReactionsState> emit,
@@ -398,7 +416,15 @@ class ConversationReactionsCubit
       final ownHasEmoji = rows.any((r) => r.isOwn && r.emoji == key.emoji);
       return switch (intent) {
         OptimisticReactionAdded() => ownHasEmoji,
-        OptimisticReactionRemoved() => !ownHasEmoji,
+        OptimisticReactionRemoved() =>
+          !ownHasEmoji ||
+              rows.any(
+                (reaction) =>
+                    reaction.isOwn &&
+                    reaction.emoji == key.emoji &&
+                    reaction.publishStatus ==
+                        DmReactionPublishStatus.removalRefused,
+              ),
       };
     });
     return next;

--- a/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
+++ b/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
@@ -112,6 +112,15 @@ class ConversationReactionsCubit
         );
         return;
       }
+      if (existing.publishStatus == DmReactionPublishStatus.removalRefused) {
+        add(
+          ConversationReactionRemovalRetryRequested(
+            rumorId: existing.id,
+            messageAuthorPubkey: event.messageAuthorPubkey,
+          ),
+        );
+        return;
+      }
       final key = ReactionPublishKey(
         messageId: event.messageId,
         emoji: event.emoji,
@@ -372,13 +381,43 @@ class ConversationReactionsCubit
     ConversationReactionRemovalRetryRequested event,
     Emitter<ConversationReactionsState> emit,
   ) async {
+    emit(
+      state.copyWith(
+        removalRetries: {
+          event.rumorId: ReactionRemovalRetryLocalStatus.retrying,
+        },
+      ),
+    );
     try {
-      await _reactionsRepository.retryDeletion(
+      final outcome = await _reactionsRepository.retryDeletion(
         rumorId: event.rumorId,
         targetMessageAuthor: event.messageAuthorPubkey,
       );
+      emit(
+        state.copyWith(
+          removalRetries: {
+            event.rumorId: switch (outcome) {
+              DmReactionDeletionOutcome.sent =>
+                ReactionRemovalRetryLocalStatus.sent,
+              DmReactionDeletionOutcome.refused =>
+                ReactionRemovalRetryLocalStatus.refused,
+              DmReactionDeletionOutcome.unconfirmed =>
+                ReactionRemovalRetryLocalStatus.unconfirmed,
+              DmReactionDeletionOutcome.unavailable =>
+                ReactionRemovalRetryLocalStatus.unavailable,
+            },
+          },
+        ),
+      );
     } on Object catch (error, stackTrace) {
       addError(error, stackTrace);
+      emit(
+        state.copyWith(
+          removalRetries: {
+            event.rumorId: ReactionRemovalRetryLocalStatus.unavailable,
+          },
+        ),
+      );
     }
   }
 

--- a/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
+++ b/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
@@ -151,7 +151,7 @@ class ConversationReactionsCubit
       return;
     }
 
-    if (_blockWhileRemovalRefused(event.messageId, emit)) return;
+    if (await _blockWhileRemovalOutstanding(event.messageId, emit)) return;
 
     await _publishReaction(
       conversationId: event.conversationId,
@@ -166,7 +166,7 @@ class ConversationReactionsCubit
     ConversationReactionSet event,
     Emitter<ConversationReactionsState> emit,
   ) async {
-    if (_blockWhileRemovalRefused(event.messageId, emit)) return;
+    if (await _blockWhileRemovalOutstanding(event.messageId, emit)) return;
 
     // Set-not-toggle: re-selecting the active emoji is a no-op (keep it);
     // a different emoji supersedes the prior one in the repository. The
@@ -191,11 +191,12 @@ class ConversationReactionsCubit
     );
   }
 
-  /// Blocks new reactions while a refused removal must remain visible.
-  bool _blockWhileRemovalRefused(
+  /// Blocks new reactions while a pending or refused removal must remain
+  /// reachable for delivery or manual retry.
+  Future<bool> _blockWhileRemovalOutstanding(
     String messageId,
     Emitter<ConversationReactionsState> emit,
-  ) {
+  ) async {
     final hasRefusedRemoval = state
         .reactionsFor(messageId)
         .any(
@@ -203,7 +204,12 @@ class ConversationReactionsCubit
               reaction.isOwn &&
               reaction.publishStatus == DmReactionPublishStatus.removalRefused,
         );
-    if (!hasRefusedRemoval) return false;
+    final hasOutstandingRemoval =
+        hasRefusedRemoval ||
+        await _reactionsRepository.hasOutstandingOwnDeletion(
+          targetMessageId: messageId,
+        );
+    if (!hasOutstandingRemoval) return false;
     emit(
       state.copyWith(
         blockedReactionAttempts: state.blockedReactionAttempts + 1,

--- a/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
+++ b/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
@@ -151,16 +151,7 @@ class ConversationReactionsCubit
       return;
     }
 
-    // Preserve the refused row's only retry path; a newer emoji would hide it
-    // in the repository's cap-at-one collapse.
-    final hasRefusedRemoval = state
-        .reactionsFor(event.messageId)
-        .any(
-          (reaction) =>
-              reaction.isOwn &&
-              reaction.publishStatus == DmReactionPublishStatus.removalRefused,
-        );
-    if (hasRefusedRemoval) return;
+    if (_blockWhileRemovalRefused(event.messageId, emit)) return;
 
     await _publishReaction(
       conversationId: event.conversationId,
@@ -175,6 +166,8 @@ class ConversationReactionsCubit
     ConversationReactionSet event,
     Emitter<ConversationReactionsState> emit,
   ) async {
+    if (_blockWhileRemovalRefused(event.messageId, emit)) return;
+
     // Set-not-toggle: re-selecting the active emoji is a no-op (keep it);
     // a different emoji supersedes the prior one in the repository. The
     // optimistic-inclusive check also covers the pre-persist window, so a
@@ -196,6 +189,27 @@ class ConversationReactionsCubit
       emoji: event.emoji,
       emit: emit,
     );
+  }
+
+  /// Blocks new reactions while a refused removal must remain visible.
+  bool _blockWhileRemovalRefused(
+    String messageId,
+    Emitter<ConversationReactionsState> emit,
+  ) {
+    final hasRefusedRemoval = state
+        .reactionsFor(messageId)
+        .any(
+          (reaction) =>
+              reaction.isOwn &&
+              reaction.publishStatus == DmReactionPublishStatus.removalRefused,
+        );
+    if (!hasRefusedRemoval) return false;
+    emit(
+      state.copyWith(
+        blockedReactionAttempts: state.blockedReactionAttempts + 1,
+      ),
+    );
+    return true;
   }
 
   /// The current account's live reaction with [emoji] on [messageId], or null.

--- a/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
+++ b/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
@@ -151,6 +151,17 @@ class ConversationReactionsCubit
       return;
     }
 
+    // Preserve the refused row's only retry path; a newer emoji would hide it
+    // in the repository's cap-at-one collapse.
+    final hasRefusedRemoval = state
+        .reactionsFor(event.messageId)
+        .any(
+          (reaction) =>
+              reaction.isOwn &&
+              reaction.publishStatus == DmReactionPublishStatus.removalRefused,
+        );
+    if (hasRefusedRemoval) return;
+
     await _publishReaction(
       conversationId: event.conversationId,
       messageId: event.messageId,

--- a/mobile/lib/blocs/dm/reactions/conversation_reactions_event.dart
+++ b/mobile/lib/blocs/dm/reactions/conversation_reactions_event.dart
@@ -119,12 +119,26 @@ class ConversationReactionRetryRequested extends ConversationReactionsEvent {
   final String emoji;
 
   @override
-  List<Object?> get props => [
-    rumorId,
-    messageId,
-    messageAuthorPubkey,
-    emoji,
-  ];
+  List<Object?> get props => [rumorId, messageId, messageAuthorPubkey, emoji];
+}
+
+/// Retry the retained kind-5 for a refused own-reaction removal.
+class ConversationReactionRemovalRetryRequested
+    extends ConversationReactionsEvent {
+  /// Construct a removal retry event.
+  const ConversationReactionRemovalRetryRequested({
+    required this.rumorId,
+    required this.messageAuthorPubkey,
+  });
+
+  /// Reaction rumor id targeted by the stored kind-5.
+  final String rumorId;
+
+  /// Target message author used to resolve the wrap recipients.
+  final String messageAuthorPubkey;
+
+  @override
+  List<Object?> get props => [rumorId, messageAuthorPubkey];
 }
 
 /// Internal — projected from the DAO stream subscription.

--- a/mobile/lib/blocs/dm/reactions/conversation_reactions_state.dart
+++ b/mobile/lib/blocs/dm/reactions/conversation_reactions_state.dart
@@ -11,6 +11,15 @@ enum ConversationReactionsStatus { initial, loading, loaded, failure }
 /// Distinct from [DmReactionPublishStatus] which is the on-disk shape.
 enum ReactionPublishLocalStatus { sending, failed }
 
+/// Result of explicitly retrying a refused reaction removal.
+enum ReactionRemovalRetryLocalStatus {
+  retrying,
+  sent,
+  refused,
+  unconfirmed,
+  unavailable,
+}
+
 /// Identity for an outgoing publish, used as the key in [pending] and
 /// [ConversationReactionsState.optimistic].
 @immutable
@@ -73,6 +82,7 @@ class ConversationReactionsState extends Equatable {
     this.reactionsByMessageId = const <String, List<DmReaction>>{},
     this.pending = const <ReactionPublishKey, ReactionPublishLocalStatus>{},
     this.optimistic = const <ReactionPublishKey, OptimisticReactionIntent>{},
+    this.removalRetries = const <String, ReactionRemovalRetryLocalStatus>{},
   });
 
   /// Lifecycle status of the cubit.
@@ -94,6 +104,9 @@ class ConversationReactionsState extends Equatable {
   /// between a tap and the persisted row arriving on the DAO stream (#5389).
   /// Reconciled away by the cubit once the persisted set reflects the intent.
   final Map<ReactionPublishKey, OptimisticReactionIntent> optimistic;
+
+  /// Latest explicit removal-retry status by reaction rumor id.
+  final Map<String, ReactionRemovalRetryLocalStatus> removalRetries;
 
   /// Live reactions for [messageId] as the chips should render them: the
   /// persisted rows with [optimistic] applied. Returns `const []` if none.
@@ -165,12 +178,14 @@ class ConversationReactionsState extends Equatable {
     Map<String, List<DmReaction>>? reactionsByMessageId,
     Map<ReactionPublishKey, ReactionPublishLocalStatus>? pending,
     Map<ReactionPublishKey, OptimisticReactionIntent>? optimistic,
+    Map<String, ReactionRemovalRetryLocalStatus>? removalRetries,
   }) {
     return ConversationReactionsState(
       status: status ?? this.status,
       reactionsByMessageId: reactionsByMessageId ?? this.reactionsByMessageId,
       pending: pending ?? this.pending,
       optimistic: optimistic ?? this.optimistic,
+      removalRetries: removalRetries ?? this.removalRetries,
     );
   }
 
@@ -180,5 +195,6 @@ class ConversationReactionsState extends Equatable {
     reactionsByMessageId,
     pending,
     optimistic,
+    removalRetries,
   ];
 }

--- a/mobile/lib/blocs/dm/reactions/conversation_reactions_state.dart
+++ b/mobile/lib/blocs/dm/reactions/conversation_reactions_state.dart
@@ -83,6 +83,7 @@ class ConversationReactionsState extends Equatable {
     this.pending = const <ReactionPublishKey, ReactionPublishLocalStatus>{},
     this.optimistic = const <ReactionPublishKey, OptimisticReactionIntent>{},
     this.removalRetries = const <String, ReactionRemovalRetryLocalStatus>{},
+    this.blockedReactionAttempts = 0,
   });
 
   /// Lifecycle status of the cubit.
@@ -107,6 +108,10 @@ class ConversationReactionsState extends Equatable {
 
   /// Latest explicit removal-retry status by reaction rumor id.
   final Map<String, ReactionRemovalRetryLocalStatus> removalRetries;
+
+  /// Monotonic signal emitted whenever an outstanding refused removal blocks
+  /// a new reaction. The view listens for increments to explain the no-op.
+  final int blockedReactionAttempts;
 
   /// Live reactions for [messageId] as the chips should render them: the
   /// persisted rows with [optimistic] applied. Returns `const []` if none.
@@ -179,6 +184,7 @@ class ConversationReactionsState extends Equatable {
     Map<ReactionPublishKey, ReactionPublishLocalStatus>? pending,
     Map<ReactionPublishKey, OptimisticReactionIntent>? optimistic,
     Map<String, ReactionRemovalRetryLocalStatus>? removalRetries,
+    int? blockedReactionAttempts,
   }) {
     return ConversationReactionsState(
       status: status ?? this.status,
@@ -186,6 +192,8 @@ class ConversationReactionsState extends Equatable {
       pending: pending ?? this.pending,
       optimistic: optimistic ?? this.optimistic,
       removalRetries: removalRetries ?? this.removalRetries,
+      blockedReactionAttempts:
+          blockedReactionAttempts ?? this.blockedReactionAttempts,
     );
   }
 
@@ -196,5 +204,6 @@ class ConversationReactionsState extends Equatable {
     pending,
     optimistic,
     removalRetries,
+    blockedReactionAttempts,
   ];
 }

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4817,5 +4817,6 @@
     "analyticsWindowAll": "ሁሉም",
     "followUserIndexedSemanticLabel": "ተጠቃሚን ተከታተል {index}",
     "unfollowUserIndexedSemanticLabel": "ተጠቃሚን መከታተል አቁም {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / በወር"
+    "supporterTierMonthlyLabel": "{title} — {price} / በወር",
+    "dmReactionAddBlockedByRemoval": "ሌላ ምላሽ ከማከልዎ በፊት የቀድሞውን ምላሽዎን ማስወገድ ያጠናቅቁ።"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4685,5 +4685,6 @@
     "analyticsWindowAll": "الكل",
     "followUserIndexedSemanticLabel": "متابعة المستخدم {index}",
     "unfollowUserIndexedSemanticLabel": "إلغاء متابعة المستخدم {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / شهريًا"
+    "supporterTierMonthlyLabel": "{title} — {price} / شهريًا",
+    "dmReactionAddBlockedByRemoval": "أكمل إزالة تفاعلك السابق قبل إضافة تفاعل آخر."
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4823,5 +4823,6 @@
     "analyticsWindowAll": "Всички",
     "followUserIndexedSemanticLabel": "Последвай потребителя {index}",
     "unfollowUserIndexedSemanticLabel": "Спри да следваш потребителя {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / месец"
+    "supporterTierMonthlyLabel": "{title} — {price} / месец",
+    "dmReactionAddBlockedByRemoval": "Завършете премахването на предишната си реакция, преди да добавите друга."
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4685,5 +4685,6 @@
     "analyticsWindowAll": "Alle",
     "followUserIndexedSemanticLabel": "Nutzer folgen {index}",
     "unfollowUserIndexedSemanticLabel": "Nutzer nicht mehr folgen {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / Monat"
+    "supporterTierMonthlyLabel": "{title} — {price} / Monat",
+    "dmReactionAddBlockedByRemoval": "Entferne zuerst deine vorherige Reaktion, bevor du eine neue hinzufügst."
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3766,6 +3766,23 @@
   "@dmReactionChipRetryAnnouncement": {
     "description": "Live-region announcement on chip retry."
   },
+  "dmReactionRemovalRefusedA11yLabel": "Couldn't remove your {emoji} reaction. Double tap to try again",
+  "@dmReactionRemovalRefusedA11yLabel": {
+    "description": "Screen-reader label for an own reaction whose removal was refused.",
+    "placeholders": {
+      "emoji": {
+        "type": "String"
+      }
+    }
+  },
+  "dmReactionRemovalRefusedTitle": "Couldn't remove your reaction.",
+  "@dmReactionRemovalRefusedTitle": {
+    "description": "Title of the retry prompt for a refused DM reaction removal."
+  },
+  "dmReactionRemovalRefusedDetails": "Some people may still be able to see this reaction.",
+  "@dmReactionRemovalRefusedDetails": {
+    "description": "Detail text explaining that a refused DM reaction removal may remain visible to recipients."
+  },
   "dmReactionsSheetTitle": "Reactions",
   "@dmReactionsSheetTitle": {
     "description": "Title of the bottom sheet listing everyone who reacted to a DM message."

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3779,6 +3779,10 @@
   "@dmReactionRemovalRefusedTitle": {
     "description": "Title of the retry prompt for a refused DM reaction removal."
   },
+  "dmReactionAddBlockedByRemoval": "Finish removing your previous reaction before adding another.",
+  "@dmReactionAddBlockedByRemoval": {
+    "description": "Snackbar shown when adding a DM reaction is blocked until an earlier removal finishes."
+  },
   "dmReactionRemovalRefusedDetails": "Some people may still be able to see this reaction.",
   "@dmReactionRemovalRefusedDetails": {
     "description": "Detail text explaining that a refused DM reaction removal may remain visible to recipients."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4685,5 +4685,6 @@
     "analyticsWindowAll": "Todo",
     "followUserIndexedSemanticLabel": "Seguir usuario {index}",
     "unfollowUserIndexedSemanticLabel": "Dejar de seguir al usuario {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / mes"
+    "supporterTierMonthlyLabel": "{title} — {price} / mes",
+    "dmReactionAddBlockedByRemoval": "Termina de eliminar tu reacción anterior antes de añadir otra."
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3641,5 +3641,6 @@
     "analyticsWindowAll": "Lahat",
     "followUserIndexedSemanticLabel": "Sundan ang user {index}",
     "unfollowUserIndexedSemanticLabel": "I-unfollow ang user {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / buwan"
+    "supporterTierMonthlyLabel": "{title} — {price} / buwan",
+    "dmReactionAddBlockedByRemoval": "Tapusin munang alisin ang dati mong reaksyon bago magdagdag ng bago."
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4685,5 +4685,6 @@
     "analyticsWindowAll": "Tout",
     "followUserIndexedSemanticLabel": "Suivre l'utilisateur {index}",
     "unfollowUserIndexedSemanticLabel": "Ne plus suivre l'utilisateur {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / mois"
+    "supporterTierMonthlyLabel": "{title} — {price} / mois",
+    "dmReactionAddBlockedByRemoval": "Terminez de supprimer votre réaction précédente avant d’en ajouter une autre."
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4685,5 +4685,6 @@
     "analyticsWindowAll": "Semua",
     "followUserIndexedSemanticLabel": "Ikuti pengguna {index}",
     "unfollowUserIndexedSemanticLabel": "Berhenti mengikuti pengguna {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / bulan"
+    "supporterTierMonthlyLabel": "{title} — {price} / bulan",
+    "dmReactionAddBlockedByRemoval": "Selesaikan penghapusan reaksi sebelumnya sebelum menambahkan reaksi lain."
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4685,5 +4685,6 @@
     "analyticsWindowAll": "Tutto",
     "followUserIndexedSemanticLabel": "Segui utente {index}",
     "unfollowUserIndexedSemanticLabel": "Smetti di seguire l'utente {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / mese"
+    "supporterTierMonthlyLabel": "{title} — {price} / mese",
+    "dmReactionAddBlockedByRemoval": "Completa la rimozione della reazione precedente prima di aggiungerne un'altra."
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4685,5 +4685,6 @@
     "analyticsWindowAll": "すべて",
     "followUserIndexedSemanticLabel": "ユーザーをフォロー {index}",
     "unfollowUserIndexedSemanticLabel": "ユーザーのフォローを解除 {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / 月"
+    "supporterTierMonthlyLabel": "{title} — {price} / 月",
+    "dmReactionAddBlockedByRemoval": "別のリアクションを追加する前に、前のリアクションの削除を完了してください。"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -4223,5 +4223,6 @@
     "analyticsWindowAll": "전체",
     "followUserIndexedSemanticLabel": "사용자 팔로우 {index}",
     "unfollowUserIndexedSemanticLabel": "사용자 팔로우 취소 {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / 월"
+    "supporterTierMonthlyLabel": "{title} — {price} / 월",
+    "dmReactionAddBlockedByRemoval": "다른 반응을 추가하기 전에 이전 반응 삭제를 완료하세요."
 }

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -6470,5 +6470,6 @@
   "analyticsWindowAll": "Semua",
   "followUserIndexedSemanticLabel": "Ikut pengguna {index}",
   "unfollowUserIndexedSemanticLabel": "Nyahikut pengguna {index}",
-  "supporterTierMonthlyLabel": "{title} — {price} / bulan"
+  "supporterTierMonthlyLabel": "{title} — {price} / bulan",
+  "dmReactionAddBlockedByRemoval": "Selesaikan pengalihan keluar reaksi terdahulu sebelum menambah reaksi lain."
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4685,5 +4685,6 @@
     "analyticsWindowAll": "Alles",
     "followUserIndexedSemanticLabel": "Gebruiker volgen {index}",
     "unfollowUserIndexedSemanticLabel": "Gebruiker ontvolgen {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / maand"
+    "supporterTierMonthlyLabel": "{title} — {price} / maand",
+    "dmReactionAddBlockedByRemoval": "Voltooi eerst het verwijderen van je vorige reactie voordat je een andere toevoegt."
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4685,5 +4685,6 @@
     "analyticsWindowAll": "Wszystko",
     "followUserIndexedSemanticLabel": "Obserwuj użytkownika {index}",
     "unfollowUserIndexedSemanticLabel": "Przestań obserwować użytkownika {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / miesiąc"
+    "supporterTierMonthlyLabel": "{title} — {price} / miesiąc",
+    "dmReactionAddBlockedByRemoval": "Dokończ usuwanie poprzedniej reakcji, zanim dodasz kolejną."
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4685,5 +4685,6 @@
     "analyticsWindowAll": "Tudo",
     "followUserIndexedSemanticLabel": "Seguir usuário {index}",
     "unfollowUserIndexedSemanticLabel": "Deixar de seguir usuário {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / mês"
+    "supporterTierMonthlyLabel": "{title} — {price} / mês",
+    "dmReactionAddBlockedByRemoval": "Conclua a remoção da reação anterior antes de adicionar outra."
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4685,5 +4685,6 @@
     "analyticsWindowAll": "Tot",
     "followUserIndexedSemanticLabel": "Urmărește utilizatorul {index}",
     "unfollowUserIndexedSemanticLabel": "Nu mai urmări utilizatorul {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / lună"
+    "supporterTierMonthlyLabel": "{title} — {price} / lună",
+    "dmReactionAddBlockedByRemoval": "Finalizează eliminarea reacției anterioare înainte de a adăuga alta."
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4685,5 +4685,6 @@
     "analyticsWindowAll": "Alla",
     "followUserIndexedSemanticLabel": "Följ användare {index}",
     "unfollowUserIndexedSemanticLabel": "Sluta följa användare {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / månad"
+    "supporterTierMonthlyLabel": "{title} — {price} / månad",
+    "dmReactionAddBlockedByRemoval": "Slutför borttagningen av din tidigare reaktion innan du lägger till en ny."
 }

--- a/mobile/lib/l10n/app_te.arb
+++ b/mobile/lib/l10n/app_te.arb
@@ -8189,6 +8189,7 @@
     }
   },
   "supporterTierMonthlyLabel": "{title} — {price}/ నెల",
+  "dmReactionAddBlockedByRemoval": "మరొక ప్రతిస్పందనను జోడించే ముందు మీ మునుపటి ప్రతిస్పందనను తొలగించడం పూర్తి చేయండి.",
   "@supporterTierMonthlyLabel": {
     "description": "Label on a supporter subscription button: the tier name, its price, and the monthly billing period.",
     "placeholders": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4685,5 +4685,6 @@
     "analyticsWindowAll": "Tümü",
     "followUserIndexedSemanticLabel": "Kullanıcıyı takip et {index}",
     "unfollowUserIndexedSemanticLabel": "Kullanıcıyı takipten çık {index}",
-    "supporterTierMonthlyLabel": "{title} — {price} / ay"
+    "supporterTierMonthlyLabel": "{title} — {price} / ay",
+    "dmReactionAddBlockedByRemoval": "Başka bir tepki eklemeden önce önceki tepkinizi kaldırmayı tamamlayın."
 }

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -6470,5 +6470,6 @@
   "analyticsWindowAll": "سب",
   "followUserIndexedSemanticLabel": "صارف کو فالو کریں {index}",
   "unfollowUserIndexedSemanticLabel": "صارف کو ان فالو کریں {index}",
-  "supporterTierMonthlyLabel": "{title} — {price} / ماہ"
+  "supporterTierMonthlyLabel": "{title} — {price} / ماہ",
+  "dmReactionAddBlockedByRemoval": "کوئی دوسرا ردعمل شامل کرنے سے پہلے پچھلا ردعمل ہٹانے کا عمل مکمل کریں۔"
 }

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -6470,5 +6470,6 @@
   "analyticsWindowAll": "Tất cả",
   "followUserIndexedSemanticLabel": "Theo dõi người dùng {index}",
   "unfollowUserIndexedSemanticLabel": "Bỏ theo dõi người dùng {index}",
-  "supporterTierMonthlyLabel": "{title} — {price} / tháng"
+  "supporterTierMonthlyLabel": "{title} — {price} / tháng",
+  "dmReactionAddBlockedByRemoval": "Hãy hoàn tất việc xóa cảm xúc trước đó trước khi thêm cảm xúc khác."
 }

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -6470,5 +6470,6 @@
   "analyticsWindowAll": "全部",
   "followUserIndexedSemanticLabel": "关注用户 {index}",
   "unfollowUserIndexedSemanticLabel": "取消关注用户 {index}",
-  "supporterTierMonthlyLabel": "{title} — {price} / 月"
+  "supporterTierMonthlyLabel": "{title} — {price} / 月",
+  "dmReactionAddBlockedByRemoval": "请先完成移除之前的回应，再添加其他回应。"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -10171,6 +10171,12 @@ abstract class AppLocalizations {
   /// **'Couldn\'t remove your reaction.'**
   String get dmReactionRemovalRefusedTitle;
 
+  /// Snackbar shown when adding a DM reaction is blocked until an earlier removal finishes.
+  ///
+  /// In en, this message translates to:
+  /// **'Finish removing your previous reaction before adding another.'**
+  String get dmReactionAddBlockedByRemoval;
+
   /// Detail text explaining that a refused DM reaction removal may remain visible to recipients.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -10159,6 +10159,24 @@ abstract class AppLocalizations {
   /// **'Retrying reaction'**
   String get dmReactionChipRetryAnnouncement;
 
+  /// Screen-reader label for an own reaction whose removal was refused.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t remove your {emoji} reaction. Double tap to try again'**
+  String dmReactionRemovalRefusedA11yLabel(String emoji);
+
+  /// Title of the retry prompt for a refused DM reaction removal.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t remove your reaction.'**
+  String get dmReactionRemovalRefusedTitle;
+
+  /// Detail text explaining that a refused DM reaction removal may remain visible to recipients.
+  ///
+  /// In en, this message translates to:
+  /// **'Some people may still be able to see this reaction.'**
+  String get dmReactionRemovalRefusedDetails;
+
   /// Title of the bottom sheet listing everyone who reacted to a DM message.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5760,6 +5760,18 @@ class AppLocalizationsAm extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'ምላሹን እንደገና በመሞከር ላይ';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'ምላሾች';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5768,6 +5768,10 @@ class AppLocalizationsAm extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'ሌላ ምላሽ ከማከልዎ በፊት የቀድሞውን ምላሽዎን ማስወገድ ያጠናቅቁ።';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5852,6 +5852,18 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'جارٍ إعادة محاولة التفاعل';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'التفاعلات';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5860,6 +5860,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'أكمل إزالة تفاعلك السابق قبل إضافة تفاعل آخر.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5955,6 +5955,18 @@ class AppLocalizationsBg extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'Нов опит за реакцията';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'Реакции';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5963,6 +5963,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'Завършете премахването на предишната си реакция, преди да добавите друга.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5986,6 +5986,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'Entferne zuerst deine vorherige Reaktion, bevor du eine neue hinzufügst.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5978,6 +5978,18 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'Reaktion wird wiederholt';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'Reaktionen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5993,6 +5993,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'Retrying reaction';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'Reactions';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -6001,6 +6001,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'Finish removing your previous reaction before adding another.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5951,6 +5951,18 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'Reintentando la reacción';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'Reacciones';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5959,6 +5959,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'Termina de eliminar tu reacción anterior antes de añadir otra.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5947,6 +5947,10 @@ class AppLocalizationsFil extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'Tapusin munang alisin ang dati mong reaksyon bago magdagdag ng bago.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5939,6 +5939,18 @@ class AppLocalizationsFil extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'Sinusubukan ulit ang reaction';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'Mga reaksyon';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5982,6 +5982,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'Terminez de supprimer votre réaction précédente avant d’en ajouter une autre.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5974,6 +5974,18 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'Nouvel essai pour la réaction';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'Réactions';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5838,6 +5838,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'Selesaikan penghapusan reaksi sebelumnya sebelum menambahkan reaksi lain.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5830,6 +5830,18 @@ class AppLocalizationsId extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'Mencoba reaksi lagi';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'Reaksi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5962,6 +5962,18 @@ class AppLocalizationsIt extends AppLocalizations {
       'Nuovo tentativo per la reazione';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'Reazioni';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5970,6 +5970,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'Completa la rimozione della reazione precedente prima di aggiungerne un\'altra.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5583,6 +5583,18 @@ class AppLocalizationsJa extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'リアクションを再試行中';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'リアクション';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5591,6 +5591,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      '別のリアクションを追加する前に、前のリアクションの削除を完了してください。';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5609,6 +5609,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval => '다른 반응을 추가하기 전에 이전 반응 삭제를 완료하세요.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5601,6 +5601,18 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => '반응 다시 시도 중';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => '반응';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -5908,6 +5908,18 @@ class AppLocalizationsMs extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'Mencuba semula tindak balas';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'Tindak balas';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -5916,6 +5916,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'Selesaikan pengalihan keluar reaksi terdahulu sebelum menambah reaksi lain.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5928,6 +5928,18 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'Reactie opnieuw proberen';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'Reacties';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5936,6 +5936,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'Voltooi eerst het verwijderen van je vorige reactie voordat je een andere toevoegt.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6047,6 +6047,18 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'Ponawianie reakcji';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'Reakcje';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6055,6 +6055,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'Dokończ usuwanie poprzedniej reakcji, zanim dodasz kolejną.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5941,6 +5941,18 @@ class AppLocalizationsPt extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'Tentando a reação de novo';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'Reações';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5949,6 +5949,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'Conclua a remoção da reação anterior antes de adicionar outra.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6059,6 +6059,18 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'Se reîncearcă reacția';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'Reacții';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6067,6 +6067,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'Finalizează eliminarea reacției anterioare înainte de a adăuga alta.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5904,6 +5904,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'Slutför borttagningen av din tidigare reaktion innan du lägger till en ny.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5896,6 +5896,18 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'Försöker med reaktionen igen';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'Reaktioner';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -6094,6 +6094,18 @@ class AppLocalizationsTe extends AppLocalizations {
       'ప్రతిచర్యను మళ్లీ ప్రయత్నిస్తోంది';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'ప్రతిచర్యలు';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -6102,6 +6102,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'మరొక ప్రతిస్పందనను జోడించే ముందు మీ మునుపటి ప్రతిస్పందనను తొలగించడం పూర్తి చేయండి.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5840,6 +5840,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'Başka bir tepki eklemeden önce önceki tepkinizi kaldırmayı tamamlayın.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5832,6 +5832,18 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'Tepki yeniden deneniyor';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'Tepkiler';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -5903,6 +5903,18 @@ class AppLocalizationsUr extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'ردعمل دوبارہ کوشش ہو رہی ہے';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'ردعملات';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -5911,6 +5911,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'کوئی دوسرا ردعمل شامل کرنے سے پہلے پچھلا ردعمل ہٹانے کا عمل مکمل کریں۔';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -5874,6 +5874,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval =>
+      'Hãy hoàn tất việc xóa cảm xúc trước đó trước khi thêm cảm xúc khác.';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -5866,6 +5866,18 @@ class AppLocalizationsVi extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => 'Đang thử lại cảm xúc';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => 'Cảm xúc';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -5551,6 +5551,18 @@ class AppLocalizationsZh extends AppLocalizations {
   String get dmReactionChipRetryAnnouncement => '正在重试回应';
 
   @override
+  String dmReactionRemovalRefusedA11yLabel(String emoji) {
+    return 'Couldn\'t remove your $emoji reaction. Double tap to try again';
+  }
+
+  @override
+  String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
+
+  @override
+  String get dmReactionRemovalRefusedDetails =>
+      'Some people may still be able to see this reaction.';
+
+  @override
   String get dmReactionsSheetTitle => '回应';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -5559,6 +5559,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get dmReactionRemovalRefusedTitle => 'Couldn\'t remove your reaction.';
 
   @override
+  String get dmReactionAddBlockedByRemoval => '请先完成移除之前的回应，再添加其他回应。';
+
+  @override
   String get dmReactionRemovalRefusedDetails =>
       'Some people may still be able to see this reaction.';
 

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -364,6 +364,22 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                 },
                 listener: _onRetractionRefused,
               ),
+              BlocListener<
+                ConversationReactionsCubit,
+                ConversationReactionsState
+              >(
+                listenWhen: (previous, current) =>
+                    previous.removalRetries != current.removalRetries &&
+                    current.removalRetries.values.any(
+                      (status) =>
+                          status != ReactionRemovalRetryLocalStatus.retrying &&
+                          status != ReactionRemovalRetryLocalStatus.sent,
+                    ),
+                listener: (_, _) => _showSnackbar(
+                  context.l10n.dmReactionRemovalRefusedTitle,
+                  error: true,
+                ),
+              ),
             ],
             child: Column(
               children: [

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -369,21 +369,28 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                 ConversationReactionsState
               >(
                 listenWhen: (previous, current) {
-                  final retryFailed =
-                      previous.removalRetries != current.removalRetries &&
+                  return previous.removalRetries != current.removalRetries &&
                       current.removalRetries.values.any(
                         (status) =>
                             status !=
                                 ReactionRemovalRetryLocalStatus.retrying &&
                             status != ReactionRemovalRetryLocalStatus.sent,
                       );
-                  final reactionBlocked =
-                      previous.blockedReactionAttempts !=
-                      current.blockedReactionAttempts;
-                  return retryFailed || reactionBlocked;
                 },
                 listener: (_, _) => _showSnackbar(
                   context.l10n.dmReactionRemovalRefusedTitle,
+                  error: true,
+                ),
+              ),
+              BlocListener<
+                ConversationReactionsCubit,
+                ConversationReactionsState
+              >(
+                listenWhen: (previous, current) =>
+                    previous.blockedReactionAttempts !=
+                    current.blockedReactionAttempts,
+                listener: (_, _) => _showSnackbar(
+                  context.l10n.dmReactionAddBlockedByRemoval,
                   error: true,
                 ),
               ),

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -368,13 +368,20 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                 ConversationReactionsCubit,
                 ConversationReactionsState
               >(
-                listenWhen: (previous, current) =>
-                    previous.removalRetries != current.removalRetries &&
-                    current.removalRetries.values.any(
-                      (status) =>
-                          status != ReactionRemovalRetryLocalStatus.retrying &&
-                          status != ReactionRemovalRetryLocalStatus.sent,
-                    ),
+                listenWhen: (previous, current) {
+                  final retryFailed =
+                      previous.removalRetries != current.removalRetries &&
+                      current.removalRetries.values.any(
+                        (status) =>
+                            status !=
+                                ReactionRemovalRetryLocalStatus.retrying &&
+                            status != ReactionRemovalRetryLocalStatus.sent,
+                      );
+                  final reactionBlocked =
+                      previous.blockedReactionAttempts !=
+                      current.blockedReactionAttempts;
+                  return retryFailed || reactionBlocked;
+                },
                 listener: (_, _) => _showSnackbar(
                   context.l10n.dmReactionRemovalRefusedTitle,
                   error: true,

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
@@ -1,6 +1,7 @@
 // ABOUTME: "Who reacted" bottom sheet for a DM message — one row per reactor
 // ABOUTME: (avatar + name + emoji). The current account's row removes its
-// ABOUTME: reaction (or retries when failed); other rows are read-only.
+// ABOUTME: reaction (or retries a failed add/refused removal); other rows are
+// ABOUTME: read-only.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -183,6 +184,8 @@ class _ReactorRow extends ConsumerWidget {
 
     final isFailed = reaction.publishStatus == DmReactionPublishStatus.failed;
     final isPending = reaction.publishStatus == DmReactionPublishStatus.pending;
+    final isRemovalRefused =
+        reaction.publishStatus == DmReactionPublishStatus.removalRefused;
 
     final canRetract = isOwn && removalEnabled;
 
@@ -204,6 +207,8 @@ class _ReactorRow extends ConsumerWidget {
           context.l10n.dmReactionChipPendingA11yLabel(reaction.emoji),
         DmReactionPublishStatus.failed =>
           context.l10n.dmReactionChipFailedA11yLabel,
+        DmReactionPublishStatus.removalRefused =>
+          context.l10n.dmReactionRemovalRefusedA11yLabel(reaction.emoji),
         _ => context.l10n.dmReactionChipOwnA11yLabel(reaction.emoji),
       };
     }
@@ -247,19 +252,54 @@ class _ReactorRow extends ConsumerWidget {
           trailing: _Trailing(
             emoji: reaction.emoji,
             showAction: canRetract,
-            isFailed: isFailed,
+            isFailed: isFailed || isRemovalRefused,
             isPending: isPending,
           ),
           onTap: (canRetract && !isPending)
-              ? () => _onOwnTap(context, isFailed: isFailed)
+              ? () => _onOwnTap(
+                  context,
+                  isFailed: isFailed,
+                  isRemovalRefused: isRemovalRefused,
+                )
               : null,
         ),
       ),
     );
   }
 
-  void _onOwnTap(BuildContext context, {required bool isFailed}) {
+  Future<void> _onOwnTap(
+    BuildContext context, {
+    required bool isFailed,
+    required bool isRemovalRefused,
+  }) async {
     final cubit = context.read<ConversationReactionsCubit>();
+    if (isRemovalRefused) {
+      final retry = await VineBottomSheetPrompt.show<bool>(
+        context: context,
+        sticker: DivineStickerName.alert,
+        title: context.l10n.dmReactionRemovalRefusedTitle,
+        subtitle: context.l10n.dmReactionRemovalRefusedDetails,
+        primaryButtonText: context.l10n.authTryAgain,
+        onPrimaryPressed: () => Navigator.of(context).pop(true),
+        secondaryButtonText: context.l10n.commonCancel,
+        onSecondaryPressed: () => Navigator.of(context).pop(false),
+      );
+      if (retry != true || cubit.isClosed) return;
+      if (context.mounted) {
+        SemanticsService.sendAnnouncement(
+          View.of(context),
+          context.l10n.dmReactionChipRetryAnnouncement,
+          Directionality.of(context),
+        );
+      }
+      cubit.add(
+        ConversationReactionRemovalRetryRequested(
+          rumorId: reaction.id,
+          messageAuthorPubkey: messageAuthorPubkey,
+        ),
+      );
+      return;
+    }
     if (isFailed) {
       SemanticsService.sendAnnouncement(
         View.of(context),

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
@@ -195,13 +195,15 @@ class _ReactionPill extends StatelessWidget {
         ownReaction?.publishStatus == DmReactionPublishStatus.pending;
     final isOwnFailed =
         ownReaction?.publishStatus == DmReactionPublishStatus.failed;
+    final isOwnRemovalRefused =
+        ownReaction?.publishStatus == DmReactionPublishStatus.removalRefused;
 
-    final background = isOwnFailed
+    final background = isOwnFailed || isOwnRemovalRefused
         ? context.vineColors.errorContainer
         : hasOwn
         ? context.vineColors.primaryContainer
         : context.vineColors.containerLow;
-    final borderColor = isOwnFailed
+    final borderColor = isOwnFailed || isOwnRemovalRefused
         ? VineTheme.error
         : hasOwn
         ? context.vineColors.accentPositive

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
@@ -126,6 +126,7 @@ class _ReactionsRowState extends State<ReactionsRow> {
               child: _ReactionPill(
                 reactions: reactions,
                 ownerPubkey: widget.ownerPubkey,
+                removalEnabled: widget.removalEnabled,
                 baselineEmojis: _baselineEmojis!,
                 onTap: () => ReactionsDetailSheet.show(
                   context: context,
@@ -151,6 +152,7 @@ class _ReactionPill extends StatelessWidget {
   const _ReactionPill({
     required this.reactions,
     required this.ownerPubkey,
+    required this.removalEnabled,
     required this.baselineEmojis,
     required this.onTap,
   });
@@ -158,6 +160,7 @@ class _ReactionPill extends StatelessWidget {
   /// Live reactions for the message (blocklist-filtered, ascending createdAt).
   final List<DmReaction> reactions;
   final String ownerPubkey;
+  final bool removalEnabled;
 
   /// Emojis already present when the enclosing row first built. A shown glyph
   /// whose emoji is absent here is a post-mount addition and grows in; emojis
@@ -196,6 +199,7 @@ class _ReactionPill extends StatelessWidget {
     final isOwnFailed =
         ownReaction?.publishStatus == DmReactionPublishStatus.failed;
     final isOwnRemovalRefused =
+        removalEnabled &&
         ownReaction?.publishStatus == DmReactionPublishStatus.removalRefused;
 
     final background = isOwnFailed || isOwnRemovalRefused

--- a/mobile/lib/services/dm_reaction_retry_service.dart
+++ b/mobile/lib/services/dm_reaction_retry_service.dart
@@ -72,6 +72,8 @@ class DmReactionRetryConfig {
   }
 }
 
+enum _RetryAttemptOutcome { recovered, refused, failed }
+
 /// Re-drives undelivered own DM reactions on every app-foreground transition,
 /// closing the reliability gap that leaves a reaction lost when its recipient
 /// gift wrap fails to land on a flaky relay.
@@ -244,30 +246,38 @@ class DmReactionRetryService {
         reactionTargets,
         phase: _addPhase,
         applyPendingMinAge: true,
-        driver: (t) async => (await _repository.retry(
-          rumorId: t.rumorId,
-          targetMessageAuthor: t.targetMessageAuthor,
-        )).success,
+        driver: (t) async =>
+            (await _repository.retry(
+              rumorId: t.rumorId,
+              targetMessageAuthor: t.targetMessageAuthor,
+            )).success
+            ? _RetryAttemptOutcome.recovered
+            : _RetryAttemptOutcome.failed,
       );
       final d = await _driveTargets(
         deletionTargets,
         phase: _deletionPhase,
         applyPendingMinAge: false,
-        driver: (t) async =>
-            await _repository.retryDeletion(
-              rumorId: t.rumorId,
-              targetMessageAuthor: t.targetMessageAuthor,
-            ) ==
-            DmReactionDeletionOutcome.sent,
+        driver: (t) async => switch (await _repository.retryDeletion(
+          rumorId: t.rumorId,
+          targetMessageAuthor: t.targetMessageAuthor,
+        )) {
+          DmReactionDeletionOutcome.sent => _RetryAttemptOutcome.recovered,
+          DmReactionDeletionOutcome.refused => _RetryAttemptOutcome.refused,
+          DmReactionDeletionOutcome.unconfirmed ||
+          DmReactionDeletionOutcome.unavailable => _RetryAttemptOutcome.failed,
+        },
       );
 
       Log.info(
         'sweep complete: '
         'reactions(recovered=${r.recovered} failed=${r.failed} '
+        'refused=${r.refused} '
         'skipped-backoff=${r.skippedBackoff} '
         'skipped-exhausted=${r.skippedExhausted} '
         'skipped-too-young=${r.skippedTooYoung}) '
         'deletions(recovered=${d.recovered} failed=${d.failed} '
+        'refused=${d.refused} '
         'skipped-backoff=${d.skippedBackoff} '
         'skipped-exhausted=${d.skippedExhausted})',
         name: 'DmReactionRetryService',
@@ -301,6 +311,7 @@ class DmReactionRetryService {
     ({
       int recovered,
       int failed,
+      int refused,
       int skippedBackoff,
       int skippedExhausted,
       int skippedTooYoung,
@@ -310,10 +321,12 @@ class DmReactionRetryService {
     List<DmReactionRetryTarget> targets, {
     required String phase,
     required bool applyPendingMinAge,
-    required Future<bool> Function(DmReactionRetryTarget) driver,
+    required Future<_RetryAttemptOutcome> Function(DmReactionRetryTarget)
+    driver,
   }) async {
     var recovered = 0;
     var failed = 0;
+    var refused = 0;
     var skippedBackoff = 0;
     var skippedExhausted = 0;
     var skippedTooYoung = 0;
@@ -350,15 +363,19 @@ class DmReactionRetryService {
       }
 
       try {
-        final success = await driver(target);
-        if (success) {
-          _attempts.remove(id);
-          _lastAttempt.remove(id);
-          recovered++;
-        } else {
-          _attempts[id] = attempts + 1;
-          _lastAttempt[id] = _now();
-          failed++;
+        switch (await driver(target)) {
+          case _RetryAttemptOutcome.recovered:
+            _attempts.remove(id);
+            _lastAttempt.remove(id);
+            recovered++;
+          case _RetryAttemptOutcome.refused:
+            _attempts.remove(id);
+            _lastAttempt.remove(id);
+            refused++;
+          case _RetryAttemptOutcome.failed:
+            _attempts[id] = attempts + 1;
+            _lastAttempt[id] = _now();
+            failed++;
         }
       } on Object catch (e, stackTrace) {
         _attempts[id] = attempts + 1;
@@ -385,6 +402,7 @@ class DmReactionRetryService {
     return (
       recovered: recovered,
       failed: failed,
+      refused: refused,
       skippedBackoff: skippedBackoff,
       skippedExhausted: skippedExhausted,
       skippedTooYoung: skippedTooYoung,

--- a/mobile/lib/services/dm_reaction_retry_service.dart
+++ b/mobile/lib/services/dm_reaction_retry_service.dart
@@ -244,19 +244,21 @@ class DmReactionRetryService {
         reactionTargets,
         phase: _addPhase,
         applyPendingMinAge: true,
-        driver: (t) => _repository.retry(
+        driver: (t) async => (await _repository.retry(
           rumorId: t.rumorId,
           targetMessageAuthor: t.targetMessageAuthor,
-        ),
+        )).success,
       );
       final d = await _driveTargets(
         deletionTargets,
         phase: _deletionPhase,
         applyPendingMinAge: false,
-        driver: (t) => _repository.retryDeletion(
-          rumorId: t.rumorId,
-          targetMessageAuthor: t.targetMessageAuthor,
-        ),
+        driver: (t) async =>
+            await _repository.retryDeletion(
+              rumorId: t.rumorId,
+              targetMessageAuthor: t.targetMessageAuthor,
+            ) ==
+            DmReactionDeletionOutcome.sent,
       );
 
       Log.info(
@@ -308,8 +310,7 @@ class DmReactionRetryService {
     List<DmReactionRetryTarget> targets, {
     required String phase,
     required bool applyPendingMinAge,
-    required Future<DmReactionPublishResult> Function(DmReactionRetryTarget)
-    driver,
+    required Future<bool> Function(DmReactionRetryTarget) driver,
   }) async {
     var recovered = 0;
     var failed = 0;
@@ -349,8 +350,8 @@ class DmReactionRetryService {
       }
 
       try {
-        final result = await driver(target);
-        if (result.success) {
+        final success = await driver(target);
+        if (success) {
           _attempts.remove(id);
           _lastAttempt.remove(id);
           recovered++;

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -9852,12 +9852,10 @@ class DirectMessageRow extends DataClass
   /// (confirmed, terminal), `deletion_blocked` (send policy blocked every
   /// failed recipient, terminal; other recipients may have succeeded).
   ///
-  /// `deletion_blocked` is deliberately distinct from `deletion_sent`, unlike
-  /// the reaction path which collapses the two. A blocked *reaction* removal
-  /// is moot because the reaction never arrived either; a *message* may well
-  /// have been delivered before the block took effect, so claiming the
-  /// deletion was sent would be a lie. The distinct value stops the sweep
-  /// without asserting delivery.
+  /// Reaction removals likewise record a distinct `deletion_refused` status
+  /// in their publish-status column. A block describes the current attempt,
+  /// not whether the original message or reaction was previously delivered.
+  /// Both distinct values stop automatic retries without asserting delivery.
   final String? deletionPublishStatus;
   const DirectMessageRow({
     required this.id,
@@ -11035,7 +11033,8 @@ class DmReactionRow extends DataClass implements Insertable<DmReactionRow> {
   /// Publish status for outgoing rows; null for incoming (received from
   /// relay). Values: `pending`, `sent`, `failed`, `blocked` (send-policy
   /// refused, terminal), `deletion_pending` (soft-deleted, kind-5 awaiting
-  /// durable delivery), `deletion_sent` (kind-5 confirmed, terminal).
+  /// durable delivery), `deletion_sent` (kind-5 confirmed, terminal), and
+  /// `deletion_refused` (automatic retries stopped, retained for user retry).
   final String? publishStatus;
   const DmReactionRow({
     required this.id,

--- a/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
@@ -600,7 +600,7 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
   ///
   /// Non-destructive account switches preserve retryable own rows because their
   /// stored `rumor_event_json` is the only durable payload for unpublished
-  /// reactions and pending kind-5 removals.
+  /// reactions and for pending or refused kind-5 removals.
   Future<int> deleteNonRetryableForOwner(String ownerPubkey) async {
     return (delete(dmMessageReactions)..where((t) {
           final retryableOwnReaction =

--- a/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
@@ -454,6 +454,34 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
         .get();
   }
 
+  /// Whether [ownerPubkey] has an own reaction removal for
+  /// [targetMessageId] that has not reached a relay.
+  ///
+  /// Pending removals are intentionally hidden from the conversation stream,
+  /// while refused removals remain available for manual retry. Querying the
+  /// durable queue prevents a newer reaction from making either row
+  /// unreachable in the UI.
+  Future<bool> hasOutstandingOwnDeletion({
+    required String targetMessageId,
+    required String ownerPubkey,
+  }) async {
+    final query = selectOnly(dmMessageReactions)
+      ..addColumns([dmMessageReactions.id])
+      ..where(
+        dmMessageReactions.targetMessageId.equals(targetMessageId) &
+            dmMessageReactions.ownerPubkey.equals(ownerPubkey) &
+            dmMessageReactions.reactorPubkey.equals(ownerPubkey) &
+            dmMessageReactions.isDeleted.equals(true) &
+            dmMessageReactions.rumorEventJson.isNotNull() &
+            dmMessageReactions.publishStatus.isIn(const [
+              _deletionPendingStatus,
+              deletionRefused,
+            ]),
+      )
+      ..limit(1);
+    return (await query.get()).isNotEmpty;
+  }
+
   /// Return the stored rumor JSON for a pending/failed outgoing row, or
   /// `null` if no row matches or the row has no stored rumor.
   Future<String?> getRumorJson({

--- a/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
@@ -36,6 +36,10 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
   /// Terminal `publish_status` for a deletion whose kind-5 reached a relay.
   static const String _deletionSentStatus = 'deletion_sent';
 
+  /// Terminal-for-the-sweep `publish_status` for a deletion that send policy
+  /// refused. The stored rumor remains available for an explicit user retry.
+  static const String deletionRefused = 'deletion_refused';
+
   /// Terminal `publish_status` for an outgoing reaction the send policy (#176
   /// protected-minor DM restriction) refused. Not retryable — excluded from
   /// [getRetryableOwnReactions] — since retrying only re-hits the same policy.
@@ -325,8 +329,9 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
     });
   }
 
-  /// Reactive stream of every live reaction in [conversationId] for the
-  /// account [ownerPubkey].
+  /// Reactive stream of every visible reaction in [conversationId] for the
+  /// account [ownerPubkey]. Refused own removals remain visible as warnings
+  /// even though their local reaction is already soft-deleted.
   Stream<List<DmReactionRow>> watchForConversation({
     required String conversationId,
     required String ownerPubkey,
@@ -336,7 +341,10 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
         (t) =>
             t.conversationId.equals(conversationId) &
             t.ownerPubkey.equals(ownerPubkey) &
-            t.isDeleted.equals(false),
+            (t.isDeleted.equals(false) |
+                (t.isDeleted.equals(true) &
+                    t.reactorPubkey.equals(ownerPubkey) &
+                    t.publishStatus.equals(deletionRefused))),
       )
       ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]);
     return query.watch();
@@ -408,6 +416,21 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
         publishStatus: Value(_deletionSentStatus),
         rumorEventJson: Value(null),
       ),
+    );
+  }
+
+  /// Record that send policy refused a pending own-reaction deletion.
+  ///
+  /// The row stays soft-deleted and leaves the automatic retry worklist, but
+  /// retains the exact kind-5 rumor so a user-driven retry can replay it.
+  Future<void> markDeletionRefused({
+    required String id,
+    required String ownerPubkey,
+  }) async {
+    await (update(
+      dmMessageReactions,
+    )..where((t) => t.id.equals(id) & t.ownerPubkey.equals(ownerPubkey))).write(
+      const DmMessageReactionsCompanion(publishStatus: Value(deletionRefused)),
     );
   }
 
@@ -589,7 +612,10 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
               t.reactorPubkey.equals(ownerPubkey) &
               t.isDeleted.equals(true) &
               t.rumorEventJson.isNotNull() &
-              t.publishStatus.equals(_deletionPendingStatus);
+              t.publishStatus.isIn(const [
+                _deletionPendingStatus,
+                deletionRefused,
+              ]);
           return t.ownerPubkey.equals(ownerPubkey) &
               (retryableOwnReaction | retryableOwnDeletion).not();
         }))

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -874,12 +874,10 @@ class DirectMessages extends Table {
   /// (confirmed, terminal), `deletion_blocked` (send policy blocked every
   /// failed recipient, terminal; other recipients may have succeeded).
   ///
-  /// `deletion_blocked` is deliberately distinct from `deletion_sent`, unlike
-  /// the reaction path which collapses the two. A blocked *reaction* removal
-  /// is moot because the reaction never arrived either; a *message* may well
-  /// have been delivered before the block took effect, so claiming the
-  /// deletion was sent would be a lie. The distinct value stops the sweep
-  /// without asserting delivery.
+  /// Reaction removals likewise record a distinct `deletion_refused` status
+  /// in their publish-status column. A block describes the current attempt,
+  /// not whether the original message or reaction was previously delivered.
+  /// Both distinct values stop automatic retries without asserting delivery.
   TextColumn get deletionPublishStatus =>
       text().nullable().named('deletion_publish_status')();
 
@@ -986,7 +984,8 @@ class DmMessageReactions extends Table {
   /// Publish status for outgoing rows; null for incoming (received from
   /// relay). Values: `pending`, `sent`, `failed`, `blocked` (send-policy
   /// refused, terminal), `deletion_pending` (soft-deleted, kind-5 awaiting
-  /// durable delivery), `deletion_sent` (kind-5 confirmed, terminal).
+  /// durable delivery), `deletion_sent` (kind-5 confirmed, terminal), and
+  /// `deletion_refused` (automatic retries stopped, retained for user retry).
   TextColumn get publishStatus => text().nullable().named('publish_status')();
 
   @override

--- a/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
@@ -223,6 +223,50 @@ void main() {
     );
 
     test(
+      "watchForConversation exposes only the owner's refused removal",
+      () async {
+        await insertPending();
+        await dao.markOwnDeletionPending(
+          id: _pendingId,
+          ownerPubkey: _ownerA,
+          deletionRumorJson: '{"kind":5}',
+        );
+        await dao.markDeletionRefused(id: _pendingId, ownerPubkey: _ownerA);
+
+        const incomingId =
+            'abababababababababababababababababababababababababababababababab';
+        await dao.upsertIncoming(
+          id: incomingId,
+          conversationId: _conversationId,
+          targetMessageId: _targetMessageId,
+          targetMessageAuthor: _ownerA,
+          reactorPubkey: _reactorB,
+          emoji: '👍',
+          createdAt: 1_700_000_010,
+          giftWrapId: incomingId,
+          ownerPubkey: _ownerA,
+        );
+        await dao.softDelete(id: incomingId, ownerPubkey: _ownerA);
+        await (database.update(database.dmMessageReactions)..where(
+              (t) => t.id.equals(incomingId) & t.ownerPubkey.equals(_ownerA),
+            ))
+            .write(
+              const DmMessageReactionsCompanion(
+                publishStatus: Value(DmReactionsDao.deletionRefused),
+              ),
+            );
+
+        final visible = await dao
+            .watchForConversation(
+              conversationId: _conversationId,
+              ownerPubkey: _ownerA,
+            )
+            .first;
+        expect(visible.map((row) => row.id), equals([_pendingId]));
+      },
+    );
+
+    test(
       'insertOwnReactionSuperseding leaves a still-live same-id row untouched '
       'so an idempotent double-tap keeps its publish status',
       () async {
@@ -1089,7 +1133,7 @@ void main() {
         const target4 =
             '9999999999999999999999999999999999999999999999999999999999999999';
         const target5 =
-            'acacacacacacacacacacacacacacacacacacacacacacacacacacacacacac';
+            'acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac';
 
         await insertPending();
         await insertPending(id: failedId, targetMessageId: target2);

--- a/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
@@ -584,6 +584,69 @@ void main() {
     );
 
     test(
+      'hasOutstandingOwnDeletion finds pending and refused removals',
+      () async {
+        await insertPending();
+        await dao.markOwnDeletionPending(
+          id: _pendingId,
+          ownerPubkey: _ownerA,
+          deletionRumorJson: '{"kind":5}',
+        );
+
+        expect(
+          await dao.hasOutstandingOwnDeletion(
+            targetMessageId: _targetMessageId,
+            ownerPubkey: _ownerA,
+          ),
+          isTrue,
+        );
+
+        await dao.markDeletionRefused(id: _pendingId, ownerPubkey: _ownerA);
+
+        expect(
+          await dao.hasOutstandingOwnDeletion(
+            targetMessageId: _targetMessageId,
+            ownerPubkey: _ownerA,
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test('hasOutstandingOwnDeletion is target- and owner-scoped', () async {
+      await insertPending();
+      await dao.markOwnDeletionPending(
+        id: _pendingId,
+        ownerPubkey: _ownerA,
+        deletionRumorJson: '{"kind":5}',
+      );
+
+      expect(
+        await dao.hasOutstandingOwnDeletion(
+          targetMessageId: _otherTargetMessageId,
+          ownerPubkey: _ownerA,
+        ),
+        isFalse,
+      );
+      expect(
+        await dao.hasOutstandingOwnDeletion(
+          targetMessageId: _targetMessageId,
+          ownerPubkey: _ownerB,
+        ),
+        isFalse,
+      );
+
+      await dao.markDeletionSent(id: _pendingId, ownerPubkey: _ownerA);
+      expect(
+        await dao.hasOutstandingOwnDeletion(
+          targetMessageId: _targetMessageId,
+          ownerPubkey: _ownerA,
+        ),
+        isFalse,
+      );
+    });
+
+    test(
       'markDeletionRefused retains the rumor and surfaces a warning row '
       'without returning it to the automatic retry set',
       () async {

--- a/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
@@ -540,6 +540,43 @@ void main() {
     );
 
     test(
+      'markDeletionRefused retains the rumor and surfaces a warning row '
+      'without returning it to the automatic retry set',
+      () async {
+        await insertPending();
+        await dao.markOwnDeletionPending(
+          id: _pendingId,
+          ownerPubkey: _ownerA,
+          deletionRumorJson: '{"kind":5}',
+        );
+
+        await dao.markDeletionRefused(
+          id: _pendingId,
+          ownerPubkey: _ownerA,
+        );
+
+        final row = await dao.getById(
+          id: _pendingId,
+          ownerPubkey: _ownerA,
+        );
+        expect(row!.publishStatus, DmReactionsDao.deletionRefused);
+        expect(row.isDeleted, isTrue);
+        expect(row.rumorEventJson, '{"kind":5}');
+        expect(
+          await dao.getRetryableOwnDeletions(ownerPubkey: _ownerA),
+          isEmpty,
+        );
+        final visible = await dao
+            .watchForConversation(
+              conversationId: _conversationId,
+              ownerPubkey: _ownerA,
+            )
+            .first;
+        expect(visible.map((reaction) => reaction.id), [_pendingId]);
+      },
+    );
+
+    test(
       'getRetryableOwnDeletions is owner-scoped',
       () async {
         await insertPending(ownerPubkey: _ownerB, reactorPubkey: _ownerB);
@@ -1043,12 +1080,16 @@ void main() {
             '5555555555555555555555555555555555555555555555555555555555555555';
         const otherOwnerId =
             '6666666666666666666666666666666666666666666666666666666666666666';
+        const refusedId =
+            'abababababababababababababababababababababababababababababababab';
         const target2 =
             '7777777777777777777777777777777777777777777777777777777777777777';
         const target3 =
             '8888888888888888888888888888888888888888888888888888888888888888';
         const target4 =
             '9999999999999999999999999999999999999999999999999999999999999999';
+        const target5 =
+            'acacacacacacacacacacacacacacacacacacacacacacacacacacacacacac';
 
         await insertPending();
         await insertPending(id: failedId, targetMessageId: target2);
@@ -1061,6 +1102,13 @@ void main() {
         );
         await insertPending(id: blockedId, targetMessageId: target4);
         await dao.markBlocked(id: blockedId, ownerPubkey: _ownerA);
+        await insertPending(id: refusedId, targetMessageId: target5);
+        await dao.markOwnDeletionPending(
+          id: refusedId,
+          ownerPubkey: _ownerA,
+          deletionRumorJson: '{"kind":5}',
+        );
+        await dao.markDeletionRefused(id: refusedId, ownerPubkey: _ownerA);
         await dao.upsertIncoming(
           id: incomingId,
           conversationId: _conversationId,
@@ -1091,6 +1139,10 @@ void main() {
         );
         expect(
           await dao.getById(id: deletionId, ownerPubkey: _ownerA),
+          isNotNull,
+        );
+        expect(
+          await dao.getById(id: refusedId, ownerPubkey: _ownerA),
           isNotNull,
         );
         expect(await dao.getById(id: incomingId, ownerPubkey: _ownerA), isNull);

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -1010,11 +1010,9 @@ class DmReactionsRepository {
   /// ledger so it re-decrypts on a later launch — when the signer is not
   /// ready or on a transient soft-delete failure. Otherwise returns
   /// [DmWrapOutcome.processed] (terminal): the deletion applied, the target
-  /// was already deleted, or the deletion is invalid (author mismatch). An
-  /// own deletion arriving after this device recorded `deletion_refused`
-  /// settles that row as sent, clearing its stale warning state. The
-  /// soft-delete is idempotent, so re-applying on a benign re-decrypt is safe.
-  /// #5452.
+  /// was already deleted, or the deletion is invalid (author mismatch). The
+  /// soft-delete is idempotent, so re-applying on a benign re-decrypt is
+  /// safe. #5452.
   Future<DmWrapOutcome?> applyDeletion({
     required String rumorId,
     required String deleterPubkey,
@@ -1034,6 +1032,8 @@ class DmReactionsRepository {
     // insert live afterwards and never be soft-deleted. Symmetric with
     // persistIncoming's unsynced-target handling. #5452.
     if (row == null) return null;
+    if (row.isDeleted) return DmWrapOutcome.processed;
+
     // NIP-09: only the original reaction author may delete their reaction.
     if (row.reactorPubkey != deleterPubkey) {
       Log.debug(
@@ -1043,26 +1043,6 @@ class DmReactionsRepository {
         'giftWrap=$giftWrapId)',
         category: LogCategory.system,
       );
-      return DmWrapOutcome.processed;
-    }
-
-    if (row.isDeleted) {
-      if (row.publishStatus == DmReactionsDao.deletionRefused) {
-        try {
-          await _reactionsDao.markDeletionSent(
-            id: rumorId,
-            ownerPubkey: _userPubkey,
-          );
-        } on Object catch (e, st) {
-          _errorReporter?.call(
-            e,
-            st,
-            site: DmReactionsRepositoryReportableSites
-                .handleIncomingDeletionSoftDelete,
-          );
-          return DmWrapOutcome.deferred;
-        }
-      }
       return DmWrapOutcome.processed;
     }
 

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -320,6 +320,19 @@ class DmReactionsRepository {
         .map((rows) => _collapsePerReactor(rows.map(_rowToModel).toList()));
   }
 
+  /// Whether the current account has a pending or refused removal for the
+  /// target message. This reads the durable queue because pending removals are
+  /// deliberately absent from [watchForConversation].
+  Future<bool> hasOutstandingOwnDeletion({
+    required String targetMessageId,
+  }) {
+    if (_userPubkey.isEmpty) return Future<bool>.value(false);
+    return _reactionsDao.hasOutstandingOwnDeletion(
+      targetMessageId: targetMessageId,
+      ownerPubkey: _userPubkey,
+    );
+  }
+
   /// Enforce the cap-at-one invariant at the read boundary: keep at most one
   /// live reaction per (targetMessageId, reactorPubkey), the most recent by
   /// `createdAt`.

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -777,8 +777,10 @@ class DmReactionsRepository {
   }
 
   /// Retry a previously-failed/interrupted own reaction removal by replaying
-  /// the stored kind-5 rumor. Clears the pending-deletion marker on a
-  /// confirmed publish; leaves it pending otherwise so the sweep tries again.
+  /// the stored kind-5 rumor. Marks the row `deletion_sent` on a confirmed
+  /// publish and `deletion_refused` when send policy blocks it — off the
+  /// sweep's worklist, rumor retained for a user-driven retry; leaves it
+  /// pending otherwise so the sweep tries again.
   Future<DmReactionDeletionOutcome> retryDeletion({
     required String rumorId,
     required String targetMessageAuthor,

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -54,6 +54,22 @@ class DmReactionPublishResult {
   final bool optimisticInsertSucceeded;
 }
 
+/// Outcome of one own-reaction deletion delivery attempt.
+enum DmReactionDeletionOutcome {
+  /// Every recipient confirmed the kind-5 wrap.
+  sent,
+
+  /// Every failed recipient was refused by send policy. Automatic retries
+  /// stop, while the retained rumor remains available for a user retry.
+  refused,
+
+  /// Delivery was not confirmed. The pending row remains sweep-retryable.
+  unconfirmed,
+
+  /// No initialized repository or stored deletion was available to drive.
+  unavailable,
+}
+
 /// Outcome of ingesting an incoming wrapped rumor — a reaction, or a kind-5
 /// deletion targeting either a reaction or a message — used by `DmRepository`
 /// to decide whether to record the gift wrap in the processed-wrap dedup
@@ -165,6 +181,9 @@ class DmReactionsRepository {
   /// the conversation (1:1 **or** group) for an incoming reaction. Null in
   /// legacy/test wiring → 1:1 inference only.
   final DirectMessagesDao? _directMessagesDao;
+
+  final Map<String, Future<DmReactionDeletionOutcome>>
+  _deletionRecoveriesInFlight = <String, Future<DmReactionDeletionOutcome>>{};
 
   /// Maximum permitted reaction content length. NIP-25 has no hard cap,
   /// but anything over ~128 chars is almost certainly malformed.
@@ -690,12 +709,10 @@ class DmReactionsRepository {
   /// — recipients treat repeats as idempotent. The `deletion_pending` row is
   /// awaited (durability boundary) so a crash before it lands can't lose the
   /// removal; the wire publish itself is `unawaited` and re-driven by the sweep
-  /// via [retryDeletion] on any failed/offline attempt. That unawaited first
-  /// attempt can race a concurrent sweep's [retryDeletion] on the same
-  /// kind-5; both replay the identical stored event, so the worst case is a
-  /// redundant (idempotent) publish, not a divergent delete. On a DAO write
-  /// failure the deletion is reported to [reportSite] and skipped (no wire
-  /// attempt).
+  /// via [retryDeletion] on any failed/offline attempt. The first attempt and
+  /// every retry are coalesced by rumor id, so only one fan-out can drive the
+  /// stored kind-5 at a time. On a DAO write failure the deletion is reported
+  /// to [reportSite] and skipped (no wire attempt).
   Future<void> _durablyDeleteReaction({
     required String rumorId,
     required List<String> recipients,
@@ -726,12 +743,15 @@ class DmReactionsRepository {
     }
 
     unawaited(
-      _driveDeletion(
-        rumorId: rumorId,
-        deletion: deletion,
-        recipients: recipients,
-        messageService: messageService,
-        inboxes: inboxes,
+      _coalesceDeletionAttempt(
+        rumorId,
+        () => _driveDeletion(
+          rumorId: rumorId,
+          deletion: deletion,
+          recipients: recipients,
+          messageService: messageService,
+          inboxes: inboxes,
+        ),
       ),
     );
   }
@@ -759,17 +779,26 @@ class DmReactionsRepository {
   /// Retry a previously-failed/interrupted own reaction removal by replaying
   /// the stored kind-5 rumor. Clears the pending-deletion marker on a
   /// confirmed publish; leaves it pending otherwise so the sweep tries again.
-  Future<DmReactionPublishResult> retryDeletion({
+  Future<DmReactionDeletionOutcome> retryDeletion({
+    required String rumorId,
+    required String targetMessageAuthor,
+  }) {
+    return _coalesceDeletionAttempt(
+      rumorId,
+      () => _retryDeletion(
+        rumorId: rumorId,
+        targetMessageAuthor: targetMessageAuthor,
+      ),
+    );
+  }
+
+  Future<DmReactionDeletionOutcome> _retryDeletion({
     required String rumorId,
     required String targetMessageAuthor,
   }) async {
     final messageService = _messageService;
     if (messageService == null || _userPubkey.isEmpty) {
-      return DmReactionPublishResult(
-        success: false,
-        rumorId: rumorId,
-        errorMessage: 'Repository not initialized',
-      );
+      return DmReactionDeletionOutcome.unavailable;
     }
     final row = await _reactionsDao.getById(
       id: rumorId,
@@ -777,11 +806,7 @@ class DmReactionsRepository {
     );
     final deletionJson = row?.rumorEventJson;
     if (row == null || deletionJson == null) {
-      return DmReactionPublishResult(
-        success: false,
-        rumorId: rumorId,
-        errorMessage: 'No stored deletion to retry',
-      );
+      return DmReactionDeletionOutcome.unavailable;
     }
     final deletion = Event.fromJson(
       jsonDecode(deletionJson) as Map<String, dynamic>,
@@ -803,57 +828,32 @@ class DmReactionsRepository {
             id: rumorId,
             ownerPubkey: _userPubkey,
           );
-          return DmReactionPublishResult(
-            success: true,
-            rumorId: rumorId,
-            optimisticInsertSucceeded: true,
-          );
+          return DmReactionDeletionOutcome.sent;
         case NIP17SendFailure(:final error, :final blocked):
-          // A policy-blocked recipient can never receive the kind-5 — and
-          // never received the reaction it removes — so the removal is moot.
-          // Terminalize it (mirroring the blocked handling on the add path) so
-          // the sweep stops re-driving a send the policy will always refuse.
           if (blocked) {
-            await _reactionsDao.markDeletionSent(
+            await _reactionsDao.markDeletionRefused(
               id: rumorId,
               ownerPubkey: _userPubkey,
             );
-            return DmReactionPublishResult(
-              success: true,
-              rumorId: rumorId,
-              optimisticInsertSucceeded: true,
-            );
+            return DmReactionDeletionOutcome.refused;
           }
-          return DmReactionPublishResult(
-            success: false,
-            rumorId: rumorId,
-            errorMessage: error,
-            optimisticInsertSucceeded: true,
+          Log.warning(
+            'DM reaction deletion retry was unconfirmed: $error',
+            category: LogCategory.system,
           );
+          return DmReactionDeletionOutcome.unconfirmed;
       }
     } on Object catch (e) {
       Log.warning(
         'DM reaction deletion retry threw: $e',
         category: LogCategory.system,
       );
-      return DmReactionPublishResult(
-        success: false,
-        rumorId: rumorId,
-        errorMessage: e.toString(),
-        optimisticInsertSucceeded: true,
-      );
+      return DmReactionDeletionOutcome.unconfirmed;
     }
   }
 
-  /// Publish [deletion] (OK-confirmed) and clear the pending-deletion marker
-  /// on a confirmed send OR a policy block; on any other non-success the
-  /// `'deletion_pending'` row is left for the retry sweep to re-drive.
-  ///
-  /// A blocked recipient can never receive the kind-5 — and never received the
-  /// reaction it removes — so the removal is moot and terminalizing it stops
-  /// the sweep re-driving a send the policy will always refuse (symmetric with
-  /// the blocked handling on the add path).
-  Future<void> _driveDeletion({
+  /// Publish [deletion], preserving an honest durable state for every result.
+  Future<DmReactionDeletionOutcome> _driveDeletion({
     required String rumorId,
     required Event deletion,
     required List<String> recipients,
@@ -869,21 +869,43 @@ class DmReactionsRepository {
         inboxByRecipient: inboxByRecipient,
         awaitRecipientOk: true,
       );
-      final terminal =
-          result is NIP17SendSuccess ||
-          (result is NIP17SendFailure && result.blocked);
-      if (terminal) {
-        await _reactionsDao.markDeletionSent(
-          id: rumorId,
-          ownerPubkey: _userPubkey,
-        );
+      switch (result) {
+        case NIP17SendSuccess():
+          await _reactionsDao.markDeletionSent(
+            id: rumorId,
+            ownerPubkey: _userPubkey,
+          );
+          return DmReactionDeletionOutcome.sent;
+        case NIP17SendFailure(:final blocked):
+          if (blocked) {
+            await _reactionsDao.markDeletionRefused(
+              id: rumorId,
+              ownerPubkey: _userPubkey,
+            );
+            return DmReactionDeletionOutcome.refused;
+          }
+          return DmReactionDeletionOutcome.unconfirmed;
       }
     } on Object catch (e) {
       Log.warning(
         'DM reaction deletion publish threw: $e',
         category: LogCategory.system,
       );
+      return DmReactionDeletionOutcome.unconfirmed;
     }
+  }
+
+  Future<DmReactionDeletionOutcome> _coalesceDeletionAttempt(
+    String rumorId,
+    Future<DmReactionDeletionOutcome> Function() attempt,
+  ) {
+    final existing = _deletionRecoveriesInFlight[rumorId];
+    if (existing != null) return existing;
+    final future = attempt();
+    _deletionRecoveriesInFlight[rumorId] = future;
+    return future.whenComplete(
+      () => _deletionRecoveriesInFlight.remove(rumorId),
+    );
   }
 
   /// Persist an incoming kind-7 reaction rumor. Called from
@@ -1299,6 +1321,7 @@ class DmReactionsRepository {
       'failed' => DmReactionPublishStatus.failed,
       'sent' => DmReactionPublishStatus.sent,
       'blocked' => DmReactionPublishStatus.blocked,
+      DmReactionsDao.deletionRefused => DmReactionPublishStatus.removalRefused,
       _ => DmReactionPublishStatus.received,
     };
     return DmReaction(

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -1010,9 +1010,11 @@ class DmReactionsRepository {
   /// ledger so it re-decrypts on a later launch — when the signer is not
   /// ready or on a transient soft-delete failure. Otherwise returns
   /// [DmWrapOutcome.processed] (terminal): the deletion applied, the target
-  /// was already deleted, or the deletion is invalid (author mismatch). The
-  /// soft-delete is idempotent, so re-applying on a benign re-decrypt is
-  /// safe. #5452.
+  /// was already deleted, or the deletion is invalid (author mismatch). An
+  /// own deletion arriving after this device recorded `deletion_refused`
+  /// settles that row as sent, clearing its stale warning state. The
+  /// soft-delete is idempotent, so re-applying on a benign re-decrypt is safe.
+  /// #5452.
   Future<DmWrapOutcome?> applyDeletion({
     required String rumorId,
     required String deleterPubkey,
@@ -1032,8 +1034,6 @@ class DmReactionsRepository {
     // insert live afterwards and never be soft-deleted. Symmetric with
     // persistIncoming's unsynced-target handling. #5452.
     if (row == null) return null;
-    if (row.isDeleted) return DmWrapOutcome.processed;
-
     // NIP-09: only the original reaction author may delete their reaction.
     if (row.reactorPubkey != deleterPubkey) {
       Log.debug(
@@ -1043,6 +1043,26 @@ class DmReactionsRepository {
         'giftWrap=$giftWrapId)',
         category: LogCategory.system,
       );
+      return DmWrapOutcome.processed;
+    }
+
+    if (row.isDeleted) {
+      if (row.publishStatus == DmReactionsDao.deletionRefused) {
+        try {
+          await _reactionsDao.markDeletionSent(
+            id: rumorId,
+            ownerPubkey: _userPubkey,
+          );
+        } on Object catch (e, st) {
+          _errorReporter?.call(
+            e,
+            st,
+            site: DmReactionsRepositoryReportableSites
+                .handleIncomingDeletionSoftDelete,
+          );
+          return DmWrapOutcome.deferred;
+        }
+      }
       return DmWrapOutcome.processed;
     }
 

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -1559,6 +1559,120 @@ void main() {
       },
     );
 
+    test(
+      'applyDeletion settles a refused own removal delivered by another device',
+      () async {
+        when(
+          () => mockDao.getById(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).thenAnswer(
+          (_) async => makeRow(
+            isDeleted: true,
+            publishStatus: DmReactionsDao.deletionRefused,
+            rumorEventJson: '{}',
+          ),
+        );
+        when(
+          () => mockDao.markDeletionSent(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).thenAnswer((_) async {});
+
+        final outcome = await createRepository().applyDeletion(
+          rumorId: _reactionRumorId,
+          deleterPubkey: _ownerPubkey,
+          giftWrapId: _giftWrapId,
+        );
+
+        expect(outcome, DmWrapOutcome.processed);
+        verify(
+          () => mockDao.markDeletionSent(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).called(1);
+        verifyNever(
+          () => mockDao.softDelete(
+            id: any(named: 'id'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'applyDeletion does not settle a refused removal for another author',
+      () async {
+        when(
+          () => mockDao.getById(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).thenAnswer(
+          (_) async => makeRow(
+            reactorPubkey: _otherPubkey,
+            isDeleted: true,
+            publishStatus: DmReactionsDao.deletionRefused,
+          ),
+        );
+
+        final outcome = await createRepository().applyDeletion(
+          rumorId: _reactionRumorId,
+          deleterPubkey: _ownerPubkey,
+          giftWrapId: _giftWrapId,
+        );
+
+        expect(outcome, DmWrapOutcome.processed);
+        verifyNever(
+          () => mockDao.markDeletionSent(
+            id: any(named: 'id'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'applyDeletion defers when settling a refused own removal fails',
+      () async {
+        when(
+          () => mockDao.getById(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).thenAnswer(
+          (_) async => makeRow(
+            isDeleted: true,
+            publishStatus: DmReactionsDao.deletionRefused,
+          ),
+        );
+        when(
+          () => mockDao.markDeletionSent(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).thenThrow(StateError('boom'));
+
+        final outcome = await createRepository().applyDeletion(
+          rumorId: _reactionRumorId,
+          deleterPubkey: _ownerPubkey,
+          giftWrapId: _giftWrapId,
+        );
+
+        expect(outcome, DmWrapOutcome.deferred);
+        expect(
+          reporterSites,
+          contains(
+            DmReactionsRepositoryReportableSites
+                .handleIncomingDeletionSoftDelete,
+          ),
+        );
+      },
+    );
+
     test('applyDeletion ignores author mismatches', () async {
       when(
         () => mockDao.getById(id: _reactionRumorId, ownerPubkey: _ownerPubkey),

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -103,6 +103,7 @@ void main() {
 
     DmReactionRow makeRow({
       String id = _reactionRumorId,
+      String conversationId = _conversationId,
       String reactorPubkey = _ownerPubkey,
       String emoji = '🔥',
       String? giftWrapId,
@@ -115,7 +116,7 @@ void main() {
     }) {
       return DmReactionRow(
         id: id,
-        conversationId: _conversationId,
+        conversationId: conversationId,
         targetMessageId: targetMessageId,
         targetMessageAuthor: targetAuthor,
         reactorPubkey: reactorPubkey,
@@ -1038,6 +1039,150 @@ void main() {
       },
     );
 
+    test('removeOwn records a blocked first attempt as refused', () async {
+      final deletionRumor = reactionRumor(
+        id: _giftWrapId,
+        content: '',
+        kind: EventKind.eventDeletion,
+        tags: [
+          ['e', _reactionRumorId],
+          ['k', EventKind.reaction.toString()],
+        ],
+      );
+      when(
+        () => mockDao.markOwnDeletionPending(
+          id: _reactionRumorId,
+          ownerPubkey: _ownerPubkey,
+          deletionRumorJson: any(named: 'deletionRumorJson'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockMessageService.buildRumor(
+          recipientPubkey: _otherPubkey,
+          content: '',
+          eventKind: EventKind.eventDeletion,
+          additionalTags: any(named: 'additionalTags'),
+        ),
+      ).thenReturn(deletionRumor);
+      when(
+        () => mockMessageService.sendRumor(
+          rumorEvent: deletionRumor,
+          recipientPubkey: _otherPubkey,
+          awaitRecipientOk: any(named: 'awaitRecipientOk'),
+        ),
+      ).thenAnswer(
+        (_) async => const NIP17SendResult.blocked('policy refused'),
+      );
+      when(
+        () => mockDao.markDeletionRefused(
+          id: _reactionRumorId,
+          ownerPubkey: _ownerPubkey,
+        ),
+      ).thenAnswer((_) async {});
+
+      await createRepository().removeOwn(
+        rumorId: _reactionRumorId,
+        targetMessageAuthor: _otherPubkey,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      verify(
+        () => mockDao.markDeletionRefused(
+          id: _reactionRumorId,
+          ownerPubkey: _ownerPubkey,
+        ),
+      ).called(1);
+      verifyNever(
+        () => mockDao.markDeletionSent(
+          id: any(named: 'id'),
+          ownerPubkey: any(named: 'ownerPubkey'),
+        ),
+      );
+    });
+
+    test(
+      'the initial deletion and a concurrent retry share one fan-out',
+      () async {
+        final deletionRumor = reactionRumor(
+          id: _giftWrapId,
+          content: '',
+          kind: EventKind.eventDeletion,
+          tags: [
+            ['e', _reactionRumorId],
+            ['k', EventKind.reaction.toString()],
+          ],
+        );
+        final send = Completer<NIP17SendResult>();
+        when(
+          () => mockDao.getById(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).thenAnswer(
+          (_) async => makeRow(
+            isDeleted: true,
+            publishStatus: 'deletion_pending',
+            rumorEventJson: jsonEncode(deletionRumor.toJson()),
+          ),
+        );
+        when(
+          () => mockDao.markOwnDeletionPending(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+            deletionRumorJson: any(named: 'deletionRumorJson'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockMessageService.buildRumor(
+            recipientPubkey: _otherPubkey,
+            content: '',
+            eventKind: EventKind.eventDeletion,
+            additionalTags: any(named: 'additionalTags'),
+          ),
+        ).thenReturn(deletionRumor);
+        when(
+          () => mockMessageService.sendRumor(
+            rumorEvent: deletionRumor,
+            recipientPubkey: _otherPubkey,
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          ),
+        ).thenAnswer((_) => send.future);
+        when(
+          () => mockDao.markDeletionSent(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).thenAnswer((_) async {});
+
+        final repository = createRepository();
+        await repository.removeOwn(
+          rumorId: _reactionRumorId,
+          targetMessageAuthor: _otherPubkey,
+        );
+        await Future<void>.delayed(Duration.zero);
+        final retry = repository.retryDeletion(
+          rumorId: _reactionRumorId,
+          targetMessageAuthor: _otherPubkey,
+        );
+        send.complete(
+          NIP17SendResult.success(
+            rumorEventId: deletionRumor.id,
+            messageEventId: _giftWrapId,
+            recipientPubkey: _otherPubkey,
+          ),
+        );
+
+        expect(await retry, DmReactionDeletionOutcome.sent);
+        verify(
+          () => mockMessageService.sendRumor(
+            rumorEvent: deletionRumor,
+            recipientPubkey: _otherPubkey,
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          ),
+        ).called(1);
+      },
+    );
+
     test(
       'retryableDeletions projects pending own deletions from the dao',
       () async {
@@ -1110,7 +1255,7 @@ void main() {
           targetMessageAuthor: _otherPubkey,
         );
 
-        expect(result.success, isTrue);
+        expect(result, DmReactionDeletionOutcome.sent);
         verify(
           () => mockDao.markDeletionSent(
             id: _reactionRumorId,
@@ -1121,9 +1266,7 @@ void main() {
     );
 
     test(
-      'retryDeletion TERMINALIZES a policy-blocked removal instead of looping '
-      "— a blocked recipient can't receive the kind-5 and never had the "
-      'reaction, so the sweep must stop re-driving it',
+      'retryDeletion preserves a policy-refused removal for manual retry',
       () async {
         final deletionRumor = reactionRumor(
           id: _giftWrapId,
@@ -1154,7 +1297,7 @@ void main() {
           (_) async => const NIP17SendResult.blocked('policy refused'),
         );
         when(
-          () => mockDao.markDeletionSent(
+          () => mockDao.markDeletionRefused(
             id: _reactionRumorId,
             ownerPubkey: _ownerPubkey,
           ),
@@ -1166,11 +1309,9 @@ void main() {
           targetMessageAuthor: _otherPubkey,
         );
 
-        // Terminal — the sweep drops it from tracking (success) and the row
-        // leaves the retryable-deletion set.
-        expect(result.success, isTrue);
+        expect(result, DmReactionDeletionOutcome.refused);
         verify(
-          () => mockDao.markDeletionSent(
+          () => mockDao.markDeletionRefused(
             id: _reactionRumorId,
             ownerPubkey: _ownerPubkey,
           ),
@@ -1186,8 +1327,7 @@ void main() {
         targetMessageAuthor: _otherPubkey,
       );
 
-      expect(result.success, isFalse);
-      expect(result.errorMessage, contains('No stored deletion'));
+      expect(result, DmReactionDeletionOutcome.unavailable);
     });
 
     test('persistIncoming validates event shape before upsert', () async {
@@ -1610,6 +1750,99 @@ void main() {
       const thirdPubkey =
           '1111111111111111111111111111111111111111111111111111111111111111';
       const groupConversationId = 'group-convo-id';
+
+      test(
+        'a mixed confirmed and policy-blocked deletion is recorded refused',
+        () async {
+          final mockConversationsDao = _MockConversationsDao();
+          when(
+            () => mockConversationsDao.getConversation(
+              groupConversationId,
+              ownerPubkey: _ownerPubkey,
+            ),
+          ).thenAnswer(
+            (_) async => ConversationRow(
+              id: groupConversationId,
+              participantPubkeys: jsonEncode([
+                _ownerPubkey,
+                _otherPubkey,
+                thirdPubkey,
+              ]),
+              isGroup: true,
+              isRead: true,
+              currentUserHasSent: true,
+              createdAt: 1700000000,
+              ownerPubkey: _ownerPubkey,
+            ),
+          );
+          final deletionRumor = reactionRumor(
+            id: _giftWrapId,
+            content: '',
+            kind: EventKind.eventDeletion,
+            tags: [
+              ['e', _reactionRumorId],
+              ['k', EventKind.reaction.toString()],
+            ],
+          );
+          when(
+            () => mockDao.getById(
+              id: _reactionRumorId,
+              ownerPubkey: _ownerPubkey,
+            ),
+          ).thenAnswer(
+            (_) async => makeRow(
+              conversationId: groupConversationId,
+              isDeleted: true,
+              publishStatus: 'deletion_pending',
+              rumorEventJson: jsonEncode(deletionRumor.toJson()),
+            ),
+          );
+          when(
+            () => mockMessageService.sendRumor(
+              rumorEvent: deletionRumor,
+              recipientPubkey: _otherPubkey,
+              awaitRecipientOk: any(named: 'awaitRecipientOk'),
+            ),
+          ).thenAnswer(
+            (_) async => NIP17SendResult.success(
+              rumorEventId: deletionRumor.id,
+              messageEventId: _giftWrapId,
+              recipientPubkey: _otherPubkey,
+            ),
+          );
+          when(
+            () => mockMessageService.sendRumor(
+              rumorEvent: deletionRumor,
+              recipientPubkey: thirdPubkey,
+              awaitRecipientOk: any(named: 'awaitRecipientOk'),
+            ),
+          ).thenAnswer(
+            (_) async => const NIP17SendResult.blocked('policy refused'),
+          );
+          when(
+            () => mockDao.markDeletionRefused(
+              id: _reactionRumorId,
+              ownerPubkey: _ownerPubkey,
+            ),
+          ).thenAnswer((_) async {});
+
+          final outcome =
+              await createRepository(
+                conversationsDao: mockConversationsDao,
+              ).retryDeletion(
+                rumorId: _reactionRumorId,
+                targetMessageAuthor: _otherPubkey,
+              );
+
+          expect(outcome, DmReactionDeletionOutcome.refused);
+          verify(
+            () => mockDao.markDeletionRefused(
+              id: _reactionRumorId,
+              ownerPubkey: _ownerPubkey,
+            ),
+          ).called(1);
+        },
+      );
 
       test(
         'publish fans the reaction wrap out to every group member',
@@ -2497,7 +2730,7 @@ void main() {
             targetMessageAuthor: _otherPubkey,
           );
 
-          expect(result.success, isFalse);
+          expect(result, DmReactionDeletionOutcome.unconfirmed);
           verifyNever(
             () => mockDao.markDeletionSent(
               id: any(named: 'id'),

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -1560,7 +1560,8 @@ void main() {
     );
 
     test(
-      'applyDeletion settles a refused own removal delivered by another device',
+      'applyDeletion keeps a refused removal retryable when its own '
+      'self-wrap arrives',
       () async {
         when(
           () => mockDao.getById(
@@ -1574,12 +1575,6 @@ void main() {
             rumorEventJson: '{}',
           ),
         );
-        when(
-          () => mockDao.markDeletionSent(
-            id: _reactionRumorId,
-            ownerPubkey: _ownerPubkey,
-          ),
-        ).thenAnswer((_) async {});
 
         final outcome = await createRepository().applyDeletion(
           rumorId: _reactionRumorId,
@@ -1588,86 +1583,16 @@ void main() {
         );
 
         expect(outcome, DmWrapOutcome.processed);
-        verify(
+        verifyNever(
           () => mockDao.markDeletionSent(
-            id: _reactionRumorId,
-            ownerPubkey: _ownerPubkey,
+            id: any(named: 'id'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
-        ).called(1);
+        );
         verifyNever(
           () => mockDao.softDelete(
             id: any(named: 'id'),
             ownerPubkey: any(named: 'ownerPubkey'),
-          ),
-        );
-      },
-    );
-
-    test(
-      'applyDeletion does not settle a refused removal for another author',
-      () async {
-        when(
-          () => mockDao.getById(
-            id: _reactionRumorId,
-            ownerPubkey: _ownerPubkey,
-          ),
-        ).thenAnswer(
-          (_) async => makeRow(
-            reactorPubkey: _otherPubkey,
-            isDeleted: true,
-            publishStatus: DmReactionsDao.deletionRefused,
-          ),
-        );
-
-        final outcome = await createRepository().applyDeletion(
-          rumorId: _reactionRumorId,
-          deleterPubkey: _ownerPubkey,
-          giftWrapId: _giftWrapId,
-        );
-
-        expect(outcome, DmWrapOutcome.processed);
-        verifyNever(
-          () => mockDao.markDeletionSent(
-            id: any(named: 'id'),
-            ownerPubkey: any(named: 'ownerPubkey'),
-          ),
-        );
-      },
-    );
-
-    test(
-      'applyDeletion defers when settling a refused own removal fails',
-      () async {
-        when(
-          () => mockDao.getById(
-            id: _reactionRumorId,
-            ownerPubkey: _ownerPubkey,
-          ),
-        ).thenAnswer(
-          (_) async => makeRow(
-            isDeleted: true,
-            publishStatus: DmReactionsDao.deletionRefused,
-          ),
-        );
-        when(
-          () => mockDao.markDeletionSent(
-            id: _reactionRumorId,
-            ownerPubkey: _ownerPubkey,
-          ),
-        ).thenThrow(StateError('boom'));
-
-        final outcome = await createRepository().applyDeletion(
-          rumorId: _reactionRumorId,
-          deleterPubkey: _ownerPubkey,
-          giftWrapId: _giftWrapId,
-        );
-
-        expect(outcome, DmWrapOutcome.deferred);
-        expect(
-          reporterSites,
-          contains(
-            DmReactionsRepositoryReportableSites
-                .handleIncomingDeletionSoftDelete,
           ),
         );
       },

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -1208,6 +1208,76 @@ void main() {
     );
 
     test(
+      'concurrent retryDeletion calls share one stored-rumor publish',
+      () async {
+        final send = Completer<NIP17SendResult>();
+        final deletionRumor = reactionRumor(
+          id: _giftWrapId,
+          content: '',
+          kind: EventKind.eventDeletion,
+          tags: [
+            ['e', _reactionRumorId],
+            ['k', EventKind.reaction.toString()],
+          ],
+        );
+        when(
+          () => mockDao.getById(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).thenAnswer(
+          (_) async => makeRow(
+            isDeleted: true,
+            publishStatus: 'deletion_refused',
+            rumorEventJson: jsonEncode(deletionRumor.toJson()),
+          ),
+        );
+        when(
+          () => mockMessageService.sendRumor(
+            rumorEvent: deletionRumor,
+            recipientPubkey: _otherPubkey,
+            awaitRecipientOk: true,
+          ),
+        ).thenAnswer((_) => send.future);
+        when(
+          () => mockDao.markDeletionSent(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).thenAnswer((_) async {});
+
+        final repository = createRepository();
+        final first = repository.retryDeletion(
+          rumorId: _reactionRumorId,
+          targetMessageAuthor: _otherPubkey,
+        );
+        final second = repository.retryDeletion(
+          rumorId: _reactionRumorId,
+          targetMessageAuthor: _otherPubkey,
+        );
+        send.complete(
+          NIP17SendResult.success(
+            rumorEventId: deletionRumor.id,
+            messageEventId: _giftWrapId,
+            recipientPubkey: _otherPubkey,
+          ),
+        );
+
+        expect(
+          await Future.wait([first, second]),
+          everyElement(DmReactionDeletionOutcome.sent),
+        );
+        verify(
+          () => mockMessageService.sendRumor(
+            rumorEvent: deletionRumor,
+            recipientPubkey: _otherPubkey,
+            awaitRecipientOk: true,
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
       'retryDeletion replays the stored kind-5 and marks it sent on success',
       () async {
         final deletionRumor = reactionRumor(
@@ -1262,6 +1332,16 @@ void main() {
             ownerPubkey: _ownerPubkey,
           ),
         ).called(1);
+        final sentRumor =
+            verify(
+                  () => mockMessageService.sendRumor(
+                    rumorEvent: captureAny(named: 'rumorEvent'),
+                    recipientPubkey: _otherPubkey,
+                    awaitRecipientOk: true,
+                  ),
+                ).captured.single
+                as Event;
+        expect(sentRumor.toJson(), equals(deletionRumor.toJson()));
       },
     );
 

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -164,6 +164,43 @@ void main() {
       expect(repository.isInitialized, isFalse);
     });
 
+    test('hasOutstandingOwnDeletion is false when uninitialized', () async {
+      final repository = createRepository(initialized: false);
+
+      expect(
+        await repository.hasOutstandingOwnDeletion(
+          targetMessageId: _targetMessageId,
+        ),
+        isFalse,
+      );
+      verifyNever(
+        () => mockDao.hasOutstandingOwnDeletion(
+          targetMessageId: any(named: 'targetMessageId'),
+          ownerPubkey: any(named: 'ownerPubkey'),
+        ),
+      );
+    });
+
+    test(
+      'hasOutstandingOwnDeletion delegates with the current owner',
+      () async {
+        when(
+          () => mockDao.hasOutstandingOwnDeletion(
+            targetMessageId: _targetMessageId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).thenAnswer((_) async => true);
+        final repository = createRepository();
+
+        expect(
+          await repository.hasOutstandingOwnDeletion(
+            targetMessageId: _targetMessageId,
+          ),
+          isTrue,
+        );
+      },
+    );
+
     test('watchForConversation maps dao rows to models', () async {
       when(
         () => mockDao.watchForConversation(

--- a/mobile/packages/models/lib/src/dm_reaction.dart
+++ b/mobile/packages/models/lib/src/dm_reaction.dart
@@ -13,9 +13,18 @@ import 'package:equatable/equatable.dart';
 ///   recipient. Terminal and NOT retryable — retrying only re-hits the same
 ///   policy — so the retry sweep and a chip re-tap must leave it alone. Renders
 ///   as a settled own chip, never a red retry chip.
+/// - [removalRefused]: a kind-5 removal was refused. The local reaction stays
+///   soft-deleted, but its warning chip offers an explicit retry.
 /// - [received]: row originated from an incoming relay event (peer's
 ///   reaction or self-wrap copy of our own).
-enum DmReactionPublishStatus { sent, pending, failed, blocked, received }
+enum DmReactionPublishStatus {
+  sent,
+  pending,
+  failed,
+  blocked,
+  removalRefused,
+  received,
+}
 
 /// A NIP-25 (kind 7) emoji reaction on a NIP-17 direct message.
 ///

--- a/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
+++ b/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
@@ -745,6 +745,46 @@ void main() {
             cubit.state.reactionsFor(_msgId).single.publishStatus,
             DmReactionPublishStatus.removalRefused,
           );
+          expect(cubit.state.blockedReactionAttempts, 1);
+        },
+      );
+
+      blocTest<ConversationReactionsCubit, ConversationReactionsState>(
+        'set cannot orphan a refused removal',
+        build: () => ConversationReactionsCubit(
+          reactionsRepository: repo,
+          ownerPubkey: _owner,
+        ),
+        act: (cubit) async {
+          cubit.add(const ConversationReactionsStarted(conversationId: _convo));
+          await Future<void>.delayed(Duration.zero);
+          streamController.add([
+            ownReactionStatus(
+              '🔥',
+              DmReactionPublishStatus.removalRefused,
+            ),
+          ]);
+          await Future<void>.delayed(Duration.zero);
+          cubit.add(
+            const ConversationReactionSet(
+              conversationId: _convo,
+              messageId: _msgId,
+              messageAuthorPubkey: _peer,
+              emoji: '❤️',
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+        },
+        verify: (cubit) {
+          verifyNever(
+            () => repo.publish(
+              conversationId: any(named: 'conversationId'),
+              targetMessageId: any(named: 'targetMessageId'),
+              targetMessageAuthor: any(named: 'targetMessageAuthor'),
+              emoji: any(named: 'emoji'),
+            ),
+          );
+          expect(cubit.state.blockedReactionAttempts, 1);
         },
       );
 

--- a/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
+++ b/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
@@ -618,6 +618,59 @@ void main() {
       }
 
       blocTest<ConversationReactionsCubit, ConversationReactionsState>(
+        're-tapping a refused removal retries its stored deletion',
+        build: () {
+          when(
+            () => repo.retryDeletion(
+              rumorId: any(named: 'rumorId'),
+              targetMessageAuthor: any(named: 'targetMessageAuthor'),
+            ),
+          ).thenAnswer((_) async => DmReactionDeletionOutcome.sent);
+          return ConversationReactionsCubit(
+            reactionsRepository: repo,
+            ownerPubkey: _owner,
+          );
+        },
+        act: (cubit) async {
+          cubit.add(
+            const ConversationReactionsStarted(conversationId: _convo),
+          );
+          await Future<void>.delayed(Duration.zero);
+          streamController.add([
+            ownReactionStatus(
+              '❤️',
+              DmReactionPublishStatus.removalRefused,
+            ),
+          ]);
+          await Future<void>.delayed(Duration.zero);
+          cubit.add(
+            const ConversationReactionToggled(
+              conversationId: _convo,
+              messageId: _msgId,
+              messageAuthorPubkey: _peer,
+              emoji: '❤️',
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+        },
+        verify: (_) {
+          verify(
+            () => repo.retryDeletion(
+              rumorId: 'own-❤️',
+              targetMessageAuthor: _peer,
+            ),
+          ).called(1);
+          verifyNever(
+            () => repo.removeOwn(
+              rumorId: any(named: 'rumorId'),
+              targetMessageAuthor: any(named: 'targetMessageAuthor'),
+            ),
+          );
+        },
+      );
+
+      blocTest<ConversationReactionsCubit, ConversationReactionsState>(
         'a removal retry replays the stored deletion, not the reaction',
         build: () {
           when(
@@ -652,6 +705,45 @@ void main() {
           );
         },
       );
+
+      for (final outcome in DmReactionDeletionOutcome.values) {
+        blocTest<ConversationReactionsCubit, ConversationReactionsState>(
+          'surfaces the $outcome removal retry outcome',
+          build: () {
+            when(
+              () => repo.retryDeletion(
+                rumorId: any(named: 'rumorId'),
+                targetMessageAuthor: any(named: 'targetMessageAuthor'),
+              ),
+            ).thenAnswer((_) async => outcome);
+            return ConversationReactionsCubit(
+              reactionsRepository: repo,
+              ownerPubkey: _owner,
+            );
+          },
+          act: (cubit) => cubit.add(
+            const ConversationReactionRemovalRetryRequested(
+              rumorId: 'own-❤️',
+              messageAuthorPubkey: _peer,
+            ),
+          ),
+          verify: (cubit) {
+            expect(
+              cubit.state.removalRetries['own-❤️'],
+              switch (outcome) {
+                DmReactionDeletionOutcome.sent =>
+                  ReactionRemovalRetryLocalStatus.sent,
+                DmReactionDeletionOutcome.refused =>
+                  ReactionRemovalRetryLocalStatus.refused,
+                DmReactionDeletionOutcome.unconfirmed =>
+                  ReactionRemovalRetryLocalStatus.unconfirmed,
+                DmReactionDeletionOutcome.unavailable =>
+                  ReactionRemovalRetryLocalStatus.unavailable,
+              },
+            );
+          },
+        );
+      }
 
       blocTest<ConversationReactionsCubit, ConversationReactionsState>(
         'a refused deletion row clears the optimistic removal overlay',

--- a/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
+++ b/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
@@ -706,6 +706,48 @@ void main() {
         },
       );
 
+      blocTest<ConversationReactionsCubit, ConversationReactionsState>(
+        'a different emoji cannot orphan a refused removal',
+        build: () => ConversationReactionsCubit(
+          reactionsRepository: repo,
+          ownerPubkey: _owner,
+        ),
+        act: (cubit) async {
+          cubit.add(const ConversationReactionsStarted(conversationId: _convo));
+          await Future<void>.delayed(Duration.zero);
+          streamController.add([
+            ownReactionStatus(
+              '❤️',
+              DmReactionPublishStatus.removalRefused,
+            ),
+          ]);
+          await Future<void>.delayed(Duration.zero);
+          cubit.add(
+            const ConversationReactionToggled(
+              conversationId: _convo,
+              messageId: _msgId,
+              messageAuthorPubkey: _peer,
+              emoji: '🔥',
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+        },
+        verify: (cubit) {
+          verifyNever(
+            () => repo.publish(
+              conversationId: any(named: 'conversationId'),
+              targetMessageId: any(named: 'targetMessageId'),
+              targetMessageAuthor: any(named: 'targetMessageAuthor'),
+              emoji: any(named: 'emoji'),
+            ),
+          );
+          expect(
+            cubit.state.reactionsFor(_msgId).single.publishStatus,
+            DmReactionPublishStatus.removalRefused,
+          );
+        },
+      );
+
       for (final outcome in DmReactionDeletionOutcome.values) {
         blocTest<ConversationReactionsCubit, ConversationReactionsState>(
           'surfaces the $outcome removal retry outcome',

--- a/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
+++ b/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
@@ -31,6 +31,11 @@ void main() {
       when(
         () => repo.watchForConversation(any()),
       ).thenAnswer((_) => streamController.stream);
+      when(
+        () => repo.hasOutstandingOwnDeletion(
+          targetMessageId: any(named: 'targetMessageId'),
+        ),
+      ).thenAnswer((_) async => false);
     });
 
     tearDown(() async {
@@ -787,6 +792,61 @@ void main() {
           expect(cubit.state.blockedReactionAttempts, 1);
         },
       );
+
+      for (final useSet in [false, true]) {
+        blocTest<ConversationReactionsCubit, ConversationReactionsState>(
+          '${useSet ? 'set' : 'toggle'} cannot overtake a pending removal',
+          setUp: () {
+            when(
+              () => repo.hasOutstandingOwnDeletion(
+                targetMessageId: _msgId,
+              ),
+            ).thenAnswer((_) async => true);
+          },
+          build: () => ConversationReactionsCubit(
+            reactionsRepository: repo,
+            ownerPubkey: _owner,
+          ),
+          act: (cubit) {
+            if (useSet) {
+              cubit.add(
+                const ConversationReactionSet(
+                  conversationId: _convo,
+                  messageId: _msgId,
+                  messageAuthorPubkey: _peer,
+                  emoji: '🔥',
+                ),
+              );
+            } else {
+              cubit.add(
+                const ConversationReactionToggled(
+                  conversationId: _convo,
+                  messageId: _msgId,
+                  messageAuthorPubkey: _peer,
+                  emoji: '🔥',
+                ),
+              );
+            }
+          },
+          expect: () => [
+            isA<ConversationReactionsState>().having(
+              (state) => state.blockedReactionAttempts,
+              'blocked attempts',
+              1,
+            ),
+          ],
+          verify: (_) {
+            verifyNever(
+              () => repo.publish(
+                conversationId: any(named: 'conversationId'),
+                targetMessageId: any(named: 'targetMessageId'),
+                targetMessageAuthor: any(named: 'targetMessageAuthor'),
+                emoji: any(named: 'emoji'),
+              ),
+            );
+          },
+        );
+      }
 
       for (final outcome in DmReactionDeletionOutcome.values) {
         blocTest<ConversationReactionsCubit, ConversationReactionsState>(

--- a/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
+++ b/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
@@ -618,6 +618,84 @@ void main() {
       }
 
       blocTest<ConversationReactionsCubit, ConversationReactionsState>(
+        'a removal retry replays the stored deletion, not the reaction',
+        build: () {
+          when(
+            () => repo.retryDeletion(
+              rumorId: any(named: 'rumorId'),
+              targetMessageAuthor: any(named: 'targetMessageAuthor'),
+            ),
+          ).thenAnswer((_) async => DmReactionDeletionOutcome.sent);
+          return ConversationReactionsCubit(
+            reactionsRepository: repo,
+            ownerPubkey: _owner,
+          );
+        },
+        act: (cubit) => cubit.add(
+          const ConversationReactionRemovalRetryRequested(
+            rumorId: 'own-❤️',
+            messageAuthorPubkey: _peer,
+          ),
+        ),
+        verify: (_) {
+          verify(
+            () => repo.retryDeletion(
+              rumorId: 'own-❤️',
+              targetMessageAuthor: _peer,
+            ),
+          ).called(1);
+          verifyNever(
+            () => repo.retry(
+              rumorId: any(named: 'rumorId'),
+              targetMessageAuthor: any(named: 'targetMessageAuthor'),
+            ),
+          );
+        },
+      );
+
+      blocTest<ConversationReactionsCubit, ConversationReactionsState>(
+        'a refused deletion row clears the optimistic removal overlay',
+        build: () => ConversationReactionsCubit(
+          reactionsRepository: repo,
+          ownerPubkey: _owner,
+        ),
+        act: (cubit) async {
+          cubit.add(const ConversationReactionsStarted(conversationId: _convo));
+          await Future<void>.delayed(Duration.zero);
+          streamController.add([ownReaction('❤️')]);
+          await Future<void>.delayed(Duration.zero);
+          when(
+            () => repo.removeOwn(
+              rumorId: any(named: 'rumorId'),
+              targetMessageAuthor: any(named: 'targetMessageAuthor'),
+            ),
+          ).thenAnswer((_) async {});
+          cubit.add(
+            const ConversationReactionToggled(
+              conversationId: _convo,
+              messageId: _msgId,
+              messageAuthorPubkey: _peer,
+              emoji: '❤️',
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+          streamController.add([
+            ownReactionStatus(
+              '❤️',
+              DmReactionPublishStatus.removalRefused,
+            ),
+          ]);
+        },
+        verify: (cubit) {
+          expect(cubit.state.optimistic, isEmpty);
+          expect(
+            cubit.state.reactionsFor(_msgId).single.publishStatus,
+            DmReactionPublishStatus.removalRefused,
+          );
+        },
+      );
+
+      blocTest<ConversationReactionsCubit, ConversationReactionsState>(
         'keeps the optimistic chip on a durable-row publish failure '
         '(before the DAO stream ticks)',
         build: () {

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -442,6 +442,11 @@ const _knownUntranslatedDebt = <String>{
   'verifyErrorDiscordBotNoAccess',
   'verifyErrorDiscordAuthorMismatch',
   'verifyErrorDiscordContentUnavailable',
+  // Refused reaction-removal recovery (#8563). These mirror the existing
+  // message-removal wording and need the same per-locale human verb choice.
+  'dmReactionRemovalRefusedA11yLabel',
+  'dmReactionRemovalRefusedTitle',
+  'dmReactionRemovalRefusedDetails',
   // Retraction-in-flight screen-reader label (#8201). Deferred to the next
   // human translation pass rather than machine-translated: its translated
   // siblings dmDeleteRefusedMessage / dmDeleteRefusedDetails each chose a

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -1040,6 +1040,44 @@ void main() {
         expect(find.text(l10n.dmReactionRemovalRefusedTitle), findsOneWidget);
       });
 
+      for (final status in [
+        ReactionRemovalRetryLocalStatus.retrying,
+        ReactionRemovalRetryLocalStatus.sent,
+      ]) {
+        testWidgets('$status removal retry does not show failure feedback', (
+          tester,
+        ) async {
+          final controller =
+              StreamController<ConversationReactionsState>.broadcast();
+          addTearDown(controller.close);
+          const initial = ConversationReactionsState();
+          whenListen(
+            mockReactionsCubit,
+            controller.stream,
+            initialState: initial,
+          );
+          await tester.pumpWidget(
+            buildSubject(
+              state: ConversationState(
+                status: ConversationStatus.loaded,
+                messages: [ownMessage()],
+              ),
+            ),
+          );
+          await tester.pump();
+
+          controller.add(
+            initial.copyWith(removalRetries: {'reaction-id': status}),
+          );
+          await tester.pump();
+
+          expect(
+            find.text(l10n.dmReactionRemovalRefusedTitle),
+            findsNothing,
+          );
+        });
+      }
+
       testWidgets('a live thread still offers to remove an own reaction', (
         tester,
       ) async {

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -997,6 +997,49 @@ void main() {
         handle.dispose();
       });
 
+      testWidgets('a refused reaction removal retry shows failure feedback', (
+        tester,
+      ) async {
+        final controller =
+            StreamController<ConversationReactionsState>.broadcast();
+        addTearDown(controller.close);
+        const initial = ConversationReactionsState();
+        whenListen(
+          mockReactionsCubit,
+          controller.stream,
+          initialState: initial,
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [ownMessage()],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        controller.add(
+          initial.copyWith(
+            removalRetries: const {
+              'reaction-id': ReactionRemovalRetryLocalStatus.retrying,
+            },
+          ),
+        );
+        await tester.pump();
+        controller.add(
+          initial.copyWith(
+            removalRetries: const {
+              'reaction-id': ReactionRemovalRetryLocalStatus.refused,
+            },
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text(l10n.dmReactionRemovalRefusedTitle), findsOneWidget);
+      });
+
       testWidgets('a live thread still offers to remove an own reaction', (
         tester,
       ) async {
@@ -2154,10 +2197,13 @@ void main() {
                 value: mockBloc,
                 child: BlocProvider<CollaboratorInviteActionsCubit>.value(
                   value: mockInviteActionsCubit,
-                  child: BlocProvider<DmRestoreStatusCubit>.value(
-                    value: mockRestoreStatusCubit,
-                    child: const ConversationView(
-                      participantPubkeys: [otherPubkey],
+                  child: BlocProvider<ConversationReactionsCubit>.value(
+                    value: mockReactionsCubit,
+                    child: BlocProvider<DmRestoreStatusCubit>.value(
+                      value: mockRestoreStatusCubit,
+                      child: const ConversationView(
+                        participantPubkeys: [otherPubkey],
+                      ),
                     ),
                   ),
                 ),
@@ -2291,10 +2337,13 @@ void main() {
                 value: mockBloc,
                 child: BlocProvider<CollaboratorInviteActionsCubit>.value(
                   value: mockInviteActionsCubit,
-                  child: BlocProvider<DmRestoreStatusCubit>.value(
-                    value: mockRestoreStatusCubit,
-                    child: const ConversationView(
-                      participantPubkeys: [otherPubkey],
+                  child: BlocProvider<ConversationReactionsCubit>.value(
+                    value: mockReactionsCubit,
+                    child: BlocProvider<DmRestoreStatusCubit>.value(
+                      value: mockRestoreStatusCubit,
+                      child: const ConversationView(
+                        participantPubkeys: [otherPubkey],
+                      ),
                     ),
                   ),
                 ),
@@ -2702,10 +2751,13 @@ void main() {
                 value: mockBloc,
                 child: BlocProvider<CollaboratorInviteActionsCubit>.value(
                   value: mockInviteActionsCubit,
-                  child: BlocProvider<DmRestoreStatusCubit>.value(
-                    value: mockRestoreStatusCubit,
-                    child: const ConversationView(
-                      participantPubkeys: [otherPubkey],
+                  child: BlocProvider<ConversationReactionsCubit>.value(
+                    value: mockReactionsCubit,
+                    child: BlocProvider<DmRestoreStatusCubit>.value(
+                      value: mockRestoreStatusCubit,
+                      child: const ConversationView(
+                        participantPubkeys: [otherPubkey],
+                      ),
                     ),
                   ),
                 ),
@@ -2760,10 +2812,13 @@ void main() {
                 value: mockBloc,
                 child: BlocProvider<CollaboratorInviteActionsCubit>.value(
                   value: mockInviteActionsCubit,
-                  child: BlocProvider<DmRestoreStatusCubit>.value(
-                    value: mockRestoreStatusCubit,
-                    child: const ConversationView(
-                      participantPubkeys: [otherPubkey],
+                  child: BlocProvider<ConversationReactionsCubit>.value(
+                    value: mockReactionsCubit,
+                    child: BlocProvider<DmRestoreStatusCubit>.value(
+                      value: mockRestoreStatusCubit,
+                      child: const ConversationView(
+                        participantPubkeys: [otherPubkey],
+                      ),
                     ),
                   ),
                 ),

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -1067,7 +1067,10 @@ void main() {
         await tester.pump();
         await tester.pump();
 
-        expect(find.text(l10n.dmReactionRemovalRefusedTitle), findsOneWidget);
+        expect(
+          find.text(l10n.dmReactionAddBlockedByRemoval),
+          findsOneWidget,
+        );
       });
 
       for (final status in [

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -1040,6 +1040,36 @@ void main() {
         expect(find.text(l10n.dmReactionRemovalRefusedTitle), findsOneWidget);
       });
 
+      testWidgets('a blocked reaction attempt shows refusal feedback', (
+        tester,
+      ) async {
+        final controller =
+            StreamController<ConversationReactionsState>.broadcast();
+        addTearDown(controller.close);
+        const initial = ConversationReactionsState();
+        whenListen(
+          mockReactionsCubit,
+          controller.stream,
+          initialState: initial,
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [ownMessage()],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        controller.add(initial.copyWith(blockedReactionAttempts: 1));
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text(l10n.dmReactionRemovalRefusedTitle), findsOneWidget);
+      });
+
       for (final status in [
         ReactionRemovalRetryLocalStatus.retrying,
         ReactionRemovalRetryLocalStatus.sent,

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -1100,6 +1100,9 @@ void main() {
             initial.copyWith(removalRetries: {'reaction-id': status}),
           );
           await tester.pump();
+          // A SnackBar needs an animation frame to reach the tree, so a single
+          // pump asserts before it would have appeared and passes either way.
+          await tester.pump(const Duration(milliseconds: 500));
 
           expect(
             find.text(l10n.dmReactionRemovalRefusedTitle),

--- a/mobile/test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart
@@ -86,6 +86,7 @@ void main() {
 
     setUp(() {
       cubit = _MockConversationReactionsCubit();
+      when(() => cubit.isClosed).thenReturn(false);
     });
 
     void primeState(List<DmReaction> reactions) {
@@ -285,6 +286,39 @@ void main() {
             messageId: messageId,
             messageAuthorPubkey: otherPubkey,
             emoji: '🔥',
+          ),
+        ),
+      ).called(1);
+    });
+
+    testWidgets('a refused removal offers a confirmed kind-5 retry', (
+      tester,
+    ) async {
+      primeState([
+        makeReaction(
+          id: 'own1',
+          reactorPubkey: ownerPubkey,
+          emoji: '🔥',
+          publishStatus: DmReactionPublishStatus.removalRefused,
+        ),
+      ]);
+
+      await open(tester);
+      expect(find.text(l10n.dmReactionRetryAction), findsOneWidget);
+
+      await tester.tap(find.text(l10n.dmReactionRetryAction));
+      await tester.pumpAndSettle();
+      expect(find.text(l10n.dmReactionRemovalRefusedTitle), findsOneWidget);
+      expect(find.text(l10n.dmReactionRemovalRefusedDetails), findsOneWidget);
+
+      await tester.tap(find.text(l10n.authTryAgain));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => cubit.add(
+          const ConversationReactionRemovalRetryRequested(
+            rumorId: 'own1',
+            messageAuthorPubkey: otherPubkey,
           ),
         ),
       ).called(1);

--- a/mobile/test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart
@@ -324,6 +324,34 @@ void main() {
       ).called(1);
     });
 
+    testWidgets('cancelling a refused removal prompt does not retry', (
+      tester,
+    ) async {
+      primeState([
+        makeReaction(
+          id: 'own1',
+          reactorPubkey: ownerPubkey,
+          emoji: '🔥',
+          publishStatus: DmReactionPublishStatus.removalRefused,
+        ),
+      ]);
+
+      await open(tester);
+      await tester.tap(find.text(l10n.dmReactionRetryAction));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.commonCancel));
+      await tester.pumpAndSettle();
+
+      verifyNever(
+        () => cubit.add(
+          const ConversationReactionRemovalRetryRequested(
+            rumorId: 'own1',
+            messageAuthorPubkey: otherPubkey,
+          ),
+        ),
+      );
+    });
+
     testWidgets('own pending and failed rows expose state semantics', (
       tester,
     ) async {

--- a/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -121,6 +122,35 @@ void main() {
       expect(find.text('😂'), findsOneWidget);
       // One avatar per reactor.
       expect(find.byType(UserAvatar), findsNWidgets(2));
+    });
+
+    testWidgets('a refused own removal renders the error warning pill', (
+      tester,
+    ) async {
+      primeState(
+        stateWith([
+          makeReaction(
+            id: '1',
+            reactorPubkey: ownerPubkey,
+            emoji: '🔥',
+            publishStatus: DmReactionPublishStatus.removalRefused,
+          ),
+        ]),
+      );
+
+      await tester.pumpWidget(buildSubject(cubit));
+      await tester.pump();
+
+      final decorations = tester
+          .widgetList<DecoratedBox>(find.byType(DecoratedBox))
+          .map((widget) => widget.decoration)
+          .whereType<BoxDecoration>();
+      expect(
+        decorations.any(
+          (decoration) => decoration.border?.top.color == VineTheme.error,
+        ),
+        isTrue,
+      );
     });
 
     testWidgets('reactor avatar is vertically centered against the emoji', (

--- a/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
@@ -67,6 +67,7 @@ void main() {
     _MockConversationReactionsCubit cubit, {
     Set<String> blockedPubkeys = const <String>{},
     List<dynamic> additionalOverrides = const <dynamic>[],
+    bool removalEnabled = true,
   }) {
     return testMaterialApp(
       additionalOverrides: additionalOverrides,
@@ -80,6 +81,7 @@ void main() {
             ownerPubkey: ownerPubkey,
             isSentByMe: false,
             blockedPubkeys: blockedPubkeys,
+            removalEnabled: removalEnabled,
           ),
         ),
       ),
@@ -150,6 +152,35 @@ void main() {
           (decoration) => decoration.border?.top.color == VineTheme.error,
         ),
         isTrue,
+      );
+    });
+
+    testWidgets('a refused removal on a closed thread is not warning-styled', (
+      tester,
+    ) async {
+      primeState(
+        stateWith([
+          makeReaction(
+            id: '1',
+            reactorPubkey: ownerPubkey,
+            emoji: '🔥',
+            publishStatus: DmReactionPublishStatus.removalRefused,
+          ),
+        ]),
+      );
+
+      await tester.pumpWidget(buildSubject(cubit, removalEnabled: false));
+      await tester.pump();
+
+      final decorations = tester
+          .widgetList<DecoratedBox>(find.byType(DecoratedBox))
+          .map((widget) => widget.decoration)
+          .whereType<BoxDecoration>();
+      expect(
+        decorations.any(
+          (decoration) => decoration.border?.top.color == VineTheme.error,
+        ),
+        isFalse,
       );
     });
 

--- a/mobile/test/services/dm_reaction_retry_service_test.dart
+++ b/mobile/test/services/dm_reaction_retry_service_test.dart
@@ -441,6 +441,33 @@ void main() {
       ).called(1);
     });
 
+    test('a refused removal does not consume the retry budget', () async {
+      when(repository.retryableDeletions).thenAnswer(
+        (_) async => [
+          _target(rumorId: 'd1', publishStatus: 'deletion_pending'),
+        ],
+      );
+      when(
+        () => repository.retryDeletion(
+          rumorId: 'd1',
+          targetMessageAuthor: _authorPubkey,
+        ),
+      ).thenAnswer((_) async => DmReactionDeletionOutcome.refused);
+
+      final service = buildService(
+        retryConfig: const DmReactionRetryConfig(maxRetries: 1),
+      );
+      await service.sweep();
+      await service.sweep();
+
+      verify(
+        () => repository.retryDeletion(
+          rumorId: 'd1',
+          targetMessageAuthor: _authorPubkey,
+        ),
+      ).called(2);
+    });
+
     test(
       'a removal is re-driven regardless of the pending min-age guard',
       () async {

--- a/mobile/test/services/dm_reaction_retry_service_test.dart
+++ b/mobile/test/services/dm_reaction_retry_service_test.dart
@@ -63,7 +63,7 @@ void main() {
         rumorId: any(named: 'rumorId'),
         targetMessageAuthor: any(named: 'targetMessageAuthor'),
       ),
-    ).thenAnswer((_) async => _ok('r'));
+    ).thenAnswer((_) async => DmReactionDeletionOutcome.sent);
   });
 
   tearDown(() async {
@@ -429,7 +429,7 @@ void main() {
           rumorId: 'd1',
           targetMessageAuthor: _authorPubkey,
         ),
-      ).thenAnswer((_) async => _ok('d1'));
+      ).thenAnswer((_) async => DmReactionDeletionOutcome.sent);
 
       await buildService().sweep();
 
@@ -462,7 +462,7 @@ void main() {
             rumorId: 'd1',
             targetMessageAuthor: _authorPubkey,
           ),
-        ).thenAnswer((_) async => _ok('d1'));
+        ).thenAnswer((_) async => DmReactionDeletionOutcome.sent);
 
         await buildService(now: () => now).sweep();
 
@@ -534,7 +534,7 @@ void main() {
             rumorId: 'x1',
             targetMessageAuthor: _authorPubkey,
           ),
-        ).thenAnswer((_) async => _ok('x1'));
+        ).thenAnswer((_) async => DmReactionDeletionOutcome.sent);
 
         clock = clock.add(const Duration(seconds: 10));
         await service.sweep();

--- a/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
@@ -89,6 +89,11 @@ void main() {
       () => reactionsRepo.watchForConversation(any()),
     ).thenAnswer((_) => reactionStream.stream);
     when(
+      () => reactionsRepo.hasOutstandingOwnDeletion(
+        targetMessageId: any(named: 'targetMessageId'),
+      ),
+    ).thenAnswer((_) async => false);
+    when(
       () => reactionsRepo.publish(
         conversationId: any(named: 'conversationId'),
         targetMessageId: any(named: 'targetMessageId'),


### PR DESCRIPTION
## Problem

When a DM reaction removal was refused by send policy, the app recorded the kind-5 deletion as delivered and deleted its stored rumor. The sender saw the reaction disappear even though a recipient could still have the original reaction, and neither an automatic nor manual retry could recover it.

## Fix

- record refused removals as `deletion_refused`, preserving the exact kind-5 rumor while keeping the reaction soft-deleted
- surface refused own removals as warning chips with localized accessibility copy and a confirmed **Try again** action
- keep the existing refusal warning and retry path visible instead of accepting a different emoji until the removal succeeds
- keep refused removals out of the automatic sweep, matching message retractions, while allowing explicit user retries
- coalesce the initial removal attempt and manual/sweep retries by rumor id so concurrent callers publish only once
- preserve refused removals across account switches and distinguish refused, sent, unconfirmed, and unavailable repository outcomes

This uses a new value in the existing nullable text status column, so no schema migration is required.

## Deliberately unchanged

This is forward-only. Historical blocked removals were already collapsed into `deletion_sent` with their rumors cleared, so they cannot be distinguished safely from genuinely delivered removals and cannot be repaired.

Blocked reaction adds are also unchanged; this PR only fixes the kind-5 removal path tracked by this issue.

## Verification

- `flutter analyze`
- focused DAO, repository, retry-service, cubit, widget, and localization tests
- full local suite: 19,043 passed / 274 skipped; six unrelated environment-sensitive failures in existing design-system goldens and live-relay manual acceptance tests
- pre-push generated-file, analyzer, localization, and changed-file test gates (268 passed)
- orphaned ARB key, Maestro copy-drift, and localization delegate ratchets

Closes #8563