### PR TITLE
fix(perf): reduce memory used by feed and profile images

### DIFF
--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -200,9 +200,23 @@ class _BannerImage extends StatelessWidget {
       foregroundDecoration: scrimDecoration,
       clipBehavior: Clip.hardEdge,
       decoration: BoxDecoration(color: context.vineColors.surface),
-      child: VineCachedImage(
-        imageUrl: bannerUrl,
-        errorWidget: (_, _, _) => fallback,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final pixelRatio = MediaQuery.devicePixelRatioOf(context);
+          return VineCachedImage(
+            imageUrl: bannerUrl,
+            memCacheWidth:
+                constraints.hasBoundedWidth && constraints.maxWidth > 0
+                ? (constraints.maxWidth * pixelRatio).ceil()
+                : null,
+            memCacheHeight:
+                constraints.hasBoundedHeight && constraints.maxHeight > 0
+                ? (constraints.maxHeight * pixelRatio).ceil()
+                : null,
+            resizePolicy: ResizeImagePolicy.fit,
+            errorWidget: (_, _, _) => fallback,
+          );
+        },
       ),
     );
   }

--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -19,6 +19,9 @@ const double _lightboxAvatarCornerRadius = 112;
 const double _avatarHeroCornerRatio =
     _lightboxAvatarCornerRadius / _lightboxAvatarSize;
 
+/// Matches the profile editor's locked banner crop and upload shape.
+const double _profileBannerAspectRatio = 3;
+
 class _AboutText extends StatefulWidget {
   const _AboutText({required this.about});
 
@@ -203,14 +206,30 @@ class _BannerImage extends StatelessWidget {
       child: LayoutBuilder(
         builder: (context, constraints) {
           final pixelRatio = MediaQuery.devicePixelRatioOf(context);
+          final hasBoundedSize =
+              constraints.hasBoundedWidth &&
+              constraints.maxWidth > 0 &&
+              constraints.hasBoundedHeight &&
+              constraints.maxHeight > 0;
+          final logicalDecodeHeight = hasBoundedSize
+              ? constraints.maxHeight >
+                        constraints.maxWidth / _profileBannerAspectRatio
+                    ? constraints.maxHeight
+                    : constraints.maxWidth / _profileBannerAspectRatio
+              : null;
           return VineCachedImage(
             imageUrl: bannerUrl,
-            memCacheWidth:
-                constraints.hasBoundedWidth && constraints.maxWidth > 0
+            // Decode the app's 3:1 banner shape large enough for BoxFit.cover.
+            // A contain-sized decode would be upscaled along the covering axis.
+            memCacheWidth: logicalDecodeHeight != null
+                ? (logicalDecodeHeight * _profileBannerAspectRatio * pixelRatio)
+                      .ceil()
+                : constraints.hasBoundedWidth && constraints.maxWidth > 0
                 ? (constraints.maxWidth * pixelRatio).ceil()
                 : null,
-            memCacheHeight:
-                constraints.hasBoundedHeight && constraints.maxHeight > 0
+            memCacheHeight: logicalDecodeHeight != null
+                ? (logicalDecodeHeight * pixelRatio).ceil()
+                : constraints.hasBoundedHeight && constraints.maxHeight > 0
                 ? (constraints.maxHeight * pixelRatio).ceil()
                 : null,
             resizePolicy: ResizeImagePolicy.fit,

--- a/mobile/lib/widgets/video_feed_item/blurred_video_backdrop.dart
+++ b/mobile/lib/widgets/video_feed_item/blurred_video_backdrop.dart
@@ -115,24 +115,44 @@ class _BackdropContent extends StatelessWidget {
     }
     final posterUrl = url;
     final posterPath = filePath;
-    final Widget poster;
     if (posterUrl != null && posterUrl.isNotEmpty) {
-      poster = VineCachedImage(
-        imageUrl: posterUrl,
-        // Fall back to nothing on error — the parent
-        // [ColoredBox(VineTheme.surfaceContainerHigh)] shows through.
-        errorWidget: (_, _, _) => const SizedBox.shrink(),
+      return LayoutBuilder(
+        builder: (context, constraints) {
+          final pixelRatio = MediaQuery.devicePixelRatioOf(context);
+          return _blurredPoster(
+            VineCachedImage(
+              imageUrl: posterUrl,
+              memCacheWidth:
+                  constraints.hasBoundedWidth && constraints.maxWidth > 0
+                  ? (constraints.maxWidth * pixelRatio).ceil()
+                  : null,
+              memCacheHeight:
+                  constraints.hasBoundedHeight && constraints.maxHeight > 0
+                  ? (constraints.maxHeight * pixelRatio).ceil()
+                  : null,
+              resizePolicy: ResizeImagePolicy.fit,
+              // Fall back to nothing on error — the parent
+              // [ColoredBox(VineTheme.surfaceContainerHigh)] shows through.
+              errorWidget: (_, _, _) => const SizedBox.shrink(),
+            ),
+          );
+        },
       );
-    } else if (posterPath != null && posterPath.isNotEmpty) {
-      poster = ClipThumbnailImage(
-        path: posterPath,
-        fit: BoxFit.cover,
-        excludeFromSemantics: true,
-        placeholder: const SizedBox.shrink(),
-      );
-    } else {
-      return const SizedBox.shrink();
     }
+    if (posterPath != null && posterPath.isNotEmpty) {
+      return _blurredPoster(
+        ClipThumbnailImage(
+          path: posterPath,
+          fit: BoxFit.cover,
+          excludeFromSemantics: true,
+          placeholder: const SizedBox.shrink(),
+        ),
+      );
+    }
+    return const SizedBox.shrink();
+  }
+
+  Widget _blurredPoster(Widget poster) {
     return ClipRect(
       // `ImageFiltered` applies the blur on the GPU side; `ClipRect`
       // keeps the bleeding edge of the blur kernel from leaking

--- a/mobile/lib/widgets/vine_cached_image.dart
+++ b/mobile/lib/widgets/vine_cached_image.dart
@@ -46,6 +46,7 @@ class VineCachedImage extends StatefulWidget {
     this.errorWidget,
     this.memCacheWidth,
     this.memCacheHeight,
+    this.resizePolicy = ResizeImagePolicy.exact,
     this.fadeInDuration = const Duration(milliseconds: 500),
     this.fadeOutDuration = const Duration(milliseconds: 1000),
     this.onImageDimensionsResolved,
@@ -60,6 +61,13 @@ class VineCachedImage extends StatefulWidget {
   final LoadingErrorWidgetBuilder? errorWidget;
   final int? memCacheWidth;
   final int? memCacheHeight;
+
+  /// How two supplied cache dimensions constrain the decoded image.
+  ///
+  /// Existing callers retain the exact-size behavior. Callers bounding an
+  /// arbitrary source inside a layout box can use [ResizeImagePolicy.fit] to
+  /// preserve its aspect ratio while limiting both dimensions.
+  final ResizeImagePolicy resizePolicy;
   final Duration fadeInDuration;
   final Duration fadeOutDuration;
   final ImageDimensionsResolved? onImageDimensionsResolved;
@@ -74,11 +82,21 @@ class _VineCachedImageState extends State<VineCachedImage> {
   Object? _error;
   bool _hasImage = false;
 
-  ImageProvider<Object> get _imageProvider => ResizeImage.resizeIfNeeded(
-    widget.memCacheWidth,
-    widget.memCacheHeight,
-    MediaCacheImageProvider(widget.imageUrl, cacheManager: _activeImageCache),
-  );
+  ImageProvider<Object> get _imageProvider {
+    final provider = MediaCacheImageProvider(
+      widget.imageUrl,
+      cacheManager: _activeImageCache,
+    );
+    if (widget.memCacheWidth == null && widget.memCacheHeight == null) {
+      return provider;
+    }
+    return ResizeImage(
+      provider,
+      width: widget.memCacheWidth,
+      height: widget.memCacheHeight,
+      policy: widget.resizePolicy,
+    );
+  }
 
   @override
   void didChangeDependencies() {
@@ -91,7 +109,8 @@ class _VineCachedImageState extends State<VineCachedImage> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.imageUrl != widget.imageUrl ||
         oldWidget.memCacheWidth != widget.memCacheWidth ||
-        oldWidget.memCacheHeight != widget.memCacheHeight) {
+        oldWidget.memCacheHeight != widget.memCacheHeight ||
+        oldWidget.resizePolicy != widget.resizePolicy) {
       _resolveImageStream();
     }
   }

--- a/mobile/scripts/baseline/l10n_delegates.txt
+++ b/mobile/scripts/baseline/l10n_delegates.txt
@@ -52,7 +52,6 @@ test/widgets/library/pinch_zoom_grid_test.dart	1
 test/widgets/notification_badge_test.dart	2
 test/widgets/notification_type_icon_test.dart	1
 test/widgets/profile/profile_banner_layer_test.dart	1
-test/widgets/profile/profile_banner_test.dart	2
 test/widgets/profile/profile_cache_load_indicator_test.dart	1
 test/widgets/profile/profile_tab_thumbnail_test.dart	1
 test/widgets/profile/profile_videos_grid_skeleton_test.dart	1

--- a/mobile/test/widgets/profile/profile_banner_test.dart
+++ b/mobile/test/widgets/profile/profile_banner_test.dart
@@ -11,7 +11,7 @@ import '../../helpers/test_provider_overrides.dart';
 
 void main() {
   group(ProfileBanner, () {
-    testWidgets('bounds banner decode to its physical layout size', (
+    testWidgets('bounds a 3:1 banner decode at cover resolution', (
       tester,
     ) async {
       tester.view
@@ -43,7 +43,7 @@ void main() {
       final image = tester.widget<VineCachedImage>(
         find.byType(VineCachedImage),
       );
-      expect(image.memCacheWidth, 800);
+      expect(image.memCacheWidth, 2004);
       expect(image.memCacheHeight, 668);
       expect(image.resizePolicy, ResizeImagePolicy.fit);
     });

--- a/mobile/test/widgets/profile/profile_banner_test.dart
+++ b/mobile/test/widgets/profile/profile_banner_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/widgets/profile/profile_header_widget.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
+import '../../helpers/test_provider_overrides.dart';
+
 void main() {
   group(ProfileBanner, () {
     testWidgets('bounds banner decode to its physical layout size', (
@@ -22,7 +24,7 @@ void main() {
       });
 
       await tester.pumpWidget(
-        MaterialApp(
+        testMaterialApp(
           theme: VineTheme.theme,
           home: const Align(
             alignment: Alignment.topCenter,
@@ -52,7 +54,7 @@ void main() {
       const profileColor = Color(0xFF33CCBF);
 
       await tester.pumpWidget(
-        MaterialApp(
+        testMaterialApp(
           theme: VineTheme.theme,
           home: const Scaffold(
             body: ProfileBanner(
@@ -75,7 +77,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        MaterialApp(
+        testMaterialApp(
           theme: VineTheme.theme,
           home: Scaffold(body: fallback),
         ),

--- a/mobile/test/widgets/profile/profile_banner_test.dart
+++ b/mobile/test/widgets/profile/profile_banner_test.dart
@@ -9,6 +9,43 @@ import 'package:openvine/widgets/vine_cached_image.dart';
 
 void main() {
   group(ProfileBanner, () {
+    testWidgets('bounds banner decode to its physical layout size', (
+      tester,
+    ) async {
+      tester.view
+        ..physicalSize = const Size(800, 1600)
+        ..devicePixelRatio = 2;
+      addTearDown(() {
+        tester.view
+          ..resetPhysicalSize()
+          ..resetDevicePixelRatio();
+      });
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: VineTheme.theme,
+          home: const Align(
+            alignment: Alignment.topCenter,
+            child: SizedBox(
+              width: 400,
+              height: 334,
+              child: ProfileBanner(
+                bannerUrl: 'https://cdn.example.com/banner.jpg',
+                height: 334,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final image = tester.widget<VineCachedImage>(
+        find.byType(VineCachedImage),
+      );
+      expect(image.memCacheWidth, 800);
+      expect(image.memCacheHeight, 668);
+      expect(image.resizePolicy, ResizeImagePolicy.fit);
+    });
+
     testWidgets('image load error renders the profile color fallback', (
       tester,
     ) async {

--- a/mobile/test/widgets/video_feed_item/blurred_video_backdrop_test.dart
+++ b/mobile/test/widgets/video_feed_item/blurred_video_backdrop_test.dart
@@ -128,13 +128,26 @@ void main() {
       },
     );
 
-    testWidgets('passes url to $VineCachedImage', (tester) async {
+    testWidgets('bounds the network poster decode to physical layout size', (
+      tester,
+    ) async {
+      tester.view
+        ..physicalSize = const Size(800, 1600)
+        ..devicePixelRatio = 2;
+      addTearDown(() {
+        tester.view
+          ..resetPhysicalSize()
+          ..resetDevicePixelRatio();
+      });
       await tester.pumpWidget(buildWidget());
 
       final image = tester.widget<VineCachedImage>(
         find.byType(VineCachedImage),
       );
       expect(image.imageUrl, equals(testUrl));
+      expect(image.memCacheWidth, 800);
+      expect(image.memCacheHeight, 1600);
+      expect(image.resizePolicy, ResizeImagePolicy.fit);
     });
 
     testWidgets('uses $BoxFit cover with half opacity', (tester) async {

--- a/mobile/test/widgets/vine_cached_image_test.dart
+++ b/mobile/test/widgets/vine_cached_image_test.dart
@@ -109,7 +109,28 @@ void main() {
       final resized = image.image as ResizeImage;
       expect(resized.width, 256);
       expect(resized.height, 512);
+      expect(resized.policy, ResizeImagePolicy.exact);
       expect(resized.imageProvider, isA<MediaCacheImageProvider>());
+    });
+
+    testWidgets('passes the requested resize policy to ResizeImage', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: VineCachedImage(
+            imageUrl: testUrl,
+            memCacheWidth: 256,
+            memCacheHeight: 512,
+            resizePolicy: ResizeImagePolicy.fit,
+          ),
+        ),
+      );
+
+      final image = tester.widget<Image>(find.byType(Image));
+      final resized = image.image as ResizeImage;
+      expect(resized.policy, ResizeImagePolicy.fit);
     });
 
     testWidgets('defaults fit to BoxFit.cover', (tester) async {


### PR DESCRIPTION
## Problem

Feed poster backdrops and profile banners could decode arbitrary user-supplied images at their full source resolution. Those decoded bitmaps can consume far more memory than the displayed image needs, increasing Android memory pressure and making otherwise small scaled allocations fail.

## Why this fix

The feed poster fallback is bounded to its rendered physical size (layout dimensions x device pixel ratio). Profile banners use a finite 3:1 cover-resolution target that matches Divine’s banner crop shape, avoiding a visible cover upscale for normal banners while still bounding oversized external images. Both paths preserve the source aspect ratio. `VineCachedImage` keeps its existing exact-resize default for every other caller.

## Deliberately unchanged

- The 256 MB Flutter image-cache budget is unchanged. The Crashlytics identifier in #8484 resolves to an unrelated network failure, and no matching bitmap event was recoverable from the available data, so there is no valid measurement supporting a budget change.
- Device-aware cache sizing is unchanged.
- Existing memory-pressure telemetry work is not duplicated here.

## Verification

- 42 focused widget tests pass across the shared image widget, feed backdrop, and profile banner on the final head.
- Full `flutter analyze` passes.
- The pre-push hook repeated targeted analysis and all changed-file tests successfully.
- Pull-request CI passed on the final head, including all four test shards, analysis, generated-file guards, formatting, and goldens.

Closes #8484
