### PR TITLE
fix(dm): stop charging a group DM's retry budget twice when the sweep already owns the attempt

### DIFF
--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -96,6 +96,7 @@ jobs:
             integration_test/e2e/dm_reaction_unreadable_inbox_test.dart \
             integration_test/e2e/dm_deletion_unreadable_inbox_test.dart \
             integration_test/e2e/dm_group_send_unreadable_inbox_test.dart \
+            integration_test/e2e/dm_group_send_joined_recovery_retry_test.dart \
             integration_test/e2e/dm_oneway_latch_unlatch_test.dart \
             integration_test/e2e/dm_history_drain_idle_pool_test.dart; do
             echo "── $suite"

--- a/mobile/integration_test/e2e/dm_group_send_joined_recovery_retry_test.dart
+++ b/mobile/integration_test/e2e/dm_group_send_joined_recovery_retry_test.dart
@@ -1,0 +1,385 @@
+// ABOUTME: E2E regression for #8619 — a group DM sibling that JOINS a
+// ABOUTME: recovery the retry sweep already owns must be charged for that one
+// ABOUTME: attempt once, not twice. Drives a real DmRepository + NostrClient
+// ABOUTME: over real sockets, and the real OutgoingDmRetryService in ARM B.
+// ABOUTME: Requires: NO Docker stack — every dependency here is local.
+
+@Tags(['service'])
+library;
+
+import 'dart:async';
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay_base.dart';
+import 'package:nostr_sdk/relay/relay_status.dart';
+import 'package:nostr_sdk/relay/web_socket_connection_manager.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:openvine/services/outgoing_dm_retry_service.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../helpers/fake_relay.dart';
+
+/// Redirects every dial onto the in-process relay, the same way the #8434
+/// suite does, so the harness stays identical across the group-send e2e
+/// suites even though no arm here advertises an inbox host.
+class _RedirectFactory implements WebSocketChannelFactory {
+  _RedirectFactory(this.port);
+
+  final int port;
+
+  @override
+  WebSocketChannel create(Uri uri) => WebSocketChannel.connect(
+    Uri.parse('ws://127.0.0.1:$port${uri.path}'),
+  );
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const senderKey =
+      '4444444444444444444444444444444444444444444444444444444444444444';
+  // "Deliverable" — advertises no inbox (EOSE), so a pool OK is delivery.
+  const deliverableKey =
+      '5555555555555555555555555555555555555555555555555555555555555555';
+  // "Unreadable" — the relay swallows every REQ naming this author, so each
+  // attempt for this sibling ends soft-unconfirmed and keeps its row.
+  const unreadableKey =
+      '6666666666666666666666666666666666666666666666666666666666666666';
+  final senderPubkey = getPublicKey(senderKey);
+  final deliverablePubkey = getPublicKey(deliverableKey);
+  final unreadablePubkey = getPublicKey(unreadableKey);
+
+  final groupConversationId = DmRepository.computeConversationId([
+    senderPubkey,
+    deliverablePubkey,
+    unreadablePubkey,
+  ]);
+
+  /// Long enough for the sweep to register the unreadable sibling's recovery
+  /// while the group loop is still parked on the deliverable sibling's OK;
+  /// well inside the OK-confirm window, so that sibling is still delivered.
+  const deliverableOkDelay = Duration(seconds: 3);
+
+  /// Builds the real stack the way `repository_providers.dart` does, with
+  /// the durable queue wired — the retry budget under test lives on its rows.
+  Future<({DmRepository repository, AppDatabase db})> buildStack(
+    FakeRelay relay,
+  ) async {
+    final factory = _RedirectFactory(relay.port);
+    final signer = LocalNostrSigner(senderKey);
+
+    RelayBase gen(String url) =>
+        RelayBase(url, RelayStatus(url), channelFactory: factory);
+    final nostr = Nostr(signer, [], gen, channelFactory: factory);
+
+    final relayManager = RelayManager(
+      config: RelayManagerConfig(
+        defaultRelayUrl: relay.url,
+        storage: InMemoryRelayStorage(),
+        autoReconnect: false,
+      ),
+      relayPool: nostr.relayPool,
+    );
+    final client = NostrClient.forTesting(
+      nostr: nostr,
+      relayManager: relayManager,
+    );
+
+    final db = AppDatabase.test(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final messageService = NIP17MessageService(
+      signer: signer,
+      senderPublicKey: senderPubkey,
+      nostrService: client,
+    );
+
+    final repository = DmRepository(
+      nostrClient: client,
+      directMessagesDao: db.directMessagesDao,
+      conversationsDao: db.conversationsDao,
+      outgoingDmsDao: db.outgoingDmsDao,
+      userPubkey: senderPubkey,
+      signer: signer,
+      messageService: messageService,
+    );
+    addTearDown(repository.stopListening);
+    addTearDown(nostr.relayPool.removeAll);
+    await client.initialize();
+
+    return (repository: repository, db: db);
+  }
+
+  /// The surviving queue row for [recipient], or null once it was consumed.
+  Future<OutgoingDm?> queueRowFor(AppDatabase db, String recipient) async {
+    final rows = await db.outgoingDmsDao.getForConversation(
+      conversationId: groupConversationId,
+      ownerPubkey: senderPubkey,
+    );
+    for (final row in rows) {
+      if (row.recipientPubkey == recipient) return row;
+    }
+    return null;
+  }
+
+  /// Completes with the batch's rows the moment both siblings are queued —
+  /// the point at which the sweep can see them and the group loop has not
+  /// yet reached the second sibling.
+  Future<List<OutgoingDm>> bothRowsQueued(AppDatabase db) {
+    final seen = Completer<List<OutgoingDm>>();
+    late final StreamSubscription<List<OutgoingDm>> subscription;
+    subscription = db.outgoingDmsDao.watchAllForOwner(senderPubkey).listen((
+      rows,
+    ) {
+      if (rows.length == 2 && !seen.isCompleted) seen.complete(rows);
+    });
+    addTearDown(subscription.cancel);
+    return seen.future;
+  }
+
+  /// How many kind-10050 lookups naming [author] the relay has received.
+  ///
+  /// Only a recovery that RAN its attempt re-resolves the recipient's inbox
+  /// (`_recoverFullSendLocked`); a caller that joined an in-flight attempt
+  /// never does. The delta across a send therefore says which side owned the
+  /// sibling's attempt — the discriminator every arm needs, because the
+  /// charge count alone cannot tell "joined and charged once" from "never
+  /// joined at all".
+  int inboxLookupsFor(FakeRelay relay, String author) {
+    var count = 0;
+    for (final frame in relay.receivedFrames) {
+      if (frame.length < 3 || frame[0] != 'REQ') continue;
+      for (final filter in frame.skip(2)) {
+        if (filter is! Map) continue;
+        final kinds = filter['kinds'];
+        final authors = filter['authors'];
+        if (kinds is List &&
+            kinds.contains(EventKind.dmRelaysList) &&
+            authors is List &&
+            authors.contains(author)) {
+          count++;
+          break;
+        }
+      }
+    }
+    return count;
+  }
+
+  /// How many gift wraps addressed to [recipient] the relay was handed.
+  int wrapsAddressedTo(FakeRelay relay, String recipient) {
+    var count = 0;
+    for (final frame in relay.receivedFrames) {
+      if (frame.length < 2 || frame[0] != 'EVENT' || frame[1] is! Map) {
+        continue;
+      }
+      final event = frame[1] as Map;
+      if (event['kind'] != EventKind.giftWrap) continue;
+      final tags = event['tags'];
+      if (tags is! List) continue;
+      final addressed = tags.any(
+        (tag) =>
+            tag is List &&
+            tag.length >= 2 &&
+            tag[0] == 'p' &&
+            tag[1] == recipient,
+      );
+      if (addressed) count++;
+    }
+    return count;
+  }
+
+  /// One resolution's worth of lookups, measured rather than assumed: the
+  /// client may fan a lookup out to more than one socket, and a literal here
+  /// would silently stop discriminating the moment that shape changed.
+  Future<int> lookupsPerResolution(
+    FakeRelay relay,
+    DmRepository repository,
+  ) async {
+    final before = inboxLookupsFor(relay, unreadablePubkey);
+    final lookup = await repository.resolveDmInboxRelaysDetailed(
+      unreadablePubkey,
+    );
+    expect(
+      lookup.state,
+      DmInboxResolution.unreadable,
+      reason: 'precondition: this recipient must be UNREADABLE, not absent',
+    );
+    final perResolution = inboxLookupsFor(relay, unreadablePubkey) - before;
+    expect(perResolution, greaterThan(0));
+    return perResolution;
+  }
+
+  setUp(() {
+    DmRepository.inboxResolutionBudget = DmSendBudget.inboxResolution;
+  });
+  tearDown(() {
+    DmRepository.inboxResolutionBudget = DmSendBudget.inboxResolution;
+  });
+
+  group('#8619 group DM send overlapping the retry sweep', () {
+    testWidgets(
+      'ARM A: a sibling that joins a recovery the sweep already owns is '
+      'charged for that one attempt once, and still hands back its handle',
+      (tester) async {
+        // The deliverable sibling's OK is delayed so the group loop is parked
+        // on it while the sweep registers the unreadable sibling's recovery.
+        // The unreadable sibling's REQ is swallowed, so every attempt for it
+        // ends soft-unconfirmed with its row kept — the outcome #8619 is
+        // about.
+        final relay = await FakeRelay.start(
+          stallReqForAuthors: {unreadablePubkey},
+          okDelayForRecipients: {deliverablePubkey: deliverableOkDelay},
+        );
+        addTearDown(relay.stop);
+        final stack = await buildStack(relay);
+        final perResolution = await lookupsPerResolution(
+          relay,
+          stack.repository,
+        );
+
+        final rowsQueued = bothRowsQueued(stack.db);
+        final lookupsBeforeSend = inboxLookupsFor(relay, unreadablePubkey);
+        final sendFuture = stack.repository.sendGroupMessage(
+          recipientPubkeys: [deliverablePubkey, unreadablePubkey],
+          content: 'group message joined by the sweep',
+        );
+
+        // The sweep reaches the unreadable sibling's row while the group is
+        // still on the first publish: its recovery owns `full:<queueId>`.
+        final rows = await rowsQueued;
+        final queued = rows.firstWhere(
+          (row) => row.recipientPubkey == unreadablePubkey,
+        );
+        final recoveryFuture = stack.repository.recoverFullSend(
+          rumorId: queued.id,
+        );
+
+        final results = await sendFuture;
+        final recovered = await recoveryFuture;
+
+        expect(
+          inboxLookupsFor(relay, unreadablePubkey) - lookupsBeforeSend,
+          equals(2 * perResolution),
+          reason:
+              'precondition: the recovery RAN its own attempt (it re-resolved '
+              'the inbox), so the group JOINED it rather than the reverse',
+        );
+        expect(
+          wrapsAddressedTo(relay, unreadablePubkey),
+          equals(1),
+          reason: 'one attempt on the wire — the join prevented a duplicate',
+        );
+
+        expect(recovered.retryablePending, isTrue);
+        expect(results, hasLength(2));
+        expect(results[1].retryablePending, isTrue);
+
+        final held = await queueRowFor(stack.db, unreadablePubkey);
+        expect(held, isNotNull, reason: 'a soft-unconfirmed row survives');
+        expect(
+          held!.retryCount,
+          equals(1),
+          reason:
+              'one underlying attempt charges the budget once; before #8619 '
+              'the owner charged it and the joining group send charged it '
+              'again',
+        );
+        expect(
+          results[1].queuedRumorId,
+          equals(held.id),
+          reason: 'a joined sibling still hands the caller its durable handle',
+        );
+
+        // The deliverable sibling is untouched by the fix.
+        expect(results[0].success, isTrue);
+        expect(await queueRowFor(stack.db, deliverablePubkey), isNull);
+      },
+    );
+
+    testWidgets(
+      'ARM B: the real retry sweep that overlaps a group send joins the '
+      'sibling in flight, then wins the next sibling, which is charged once',
+      (tester) async {
+        // Same relay shape as ARM A, but the sweep is the production
+        // OutgoingDmRetryService, driven exactly as a foreground flip would
+        // drive it. Its clock is skewed past the interrupted-send guard so
+        // the batch's fresh rows are eligible — the guard is what normally
+        // keeps a sweep off a live send; #8619 is about what happens once a
+        // batch has outlived it.
+        final relay = await FakeRelay.start(
+          stallReqForAuthors: {unreadablePubkey},
+          okDelayForRecipients: {deliverablePubkey: deliverableOkDelay},
+        );
+        addTearDown(relay.stop);
+        final stack = await buildStack(relay);
+        final perResolution = await lookupsPerResolution(
+          relay,
+          stack.repository,
+        );
+
+        final service = OutgoingDmRetryService(
+          dmRepository: stack.repository,
+          outgoingDmsDao: stack.db.outgoingDmsDao,
+          userPubkey: senderPubkey,
+          appForegroundStream: const Stream<bool>.empty(),
+          isOffline: () async => false,
+          now: () => DateTime.now().add(
+            OutgoingDmRetryService.interruptedMinAge +
+                const Duration(seconds: 10),
+          ),
+        );
+        addTearDown(service.dispose);
+
+        final rowsQueued = bothRowsQueued(stack.db);
+        final lookupsBeforeSend = inboxLookupsFor(relay, unreadablePubkey);
+        final sendFuture = stack.repository.sendGroupMessage(
+          recipientPubkeys: [deliverablePubkey, unreadablePubkey],
+          content: 'group message overlapped by the real sweep',
+        );
+
+        await rowsQueued;
+        final sweepFuture = service.sweep();
+
+        final results = await sendFuture;
+        await sweepFuture;
+
+        // The sweep processes rows in queue order. It joins the deliverable
+        // sibling the group is parked on, and when both resume from that one
+        // future it registers the unreadable sibling's recovery before the
+        // group loop can — the group still has to re-read the row first. So
+        // the sweep OWNS the second attempt, which is what its own inbox
+        // re-resolution proves here.
+        expect(
+          inboxLookupsFor(relay, unreadablePubkey) - lookupsBeforeSend,
+          equals(2 * perResolution),
+          reason:
+              'the sweep ran the unreadable sibling attempt itself; the '
+              'group send joined it',
+        );
+        expect(wrapsAddressedTo(relay, deliverablePubkey), equals(1));
+        expect(wrapsAddressedTo(relay, unreadablePubkey), equals(1));
+
+        final held = await queueRowFor(stack.db, unreadablePubkey);
+        expect(held, isNotNull);
+        expect(
+          held!.retryCount,
+          equals(1),
+          reason: 'one attempt, one charge, whichever side ran it (#8619)',
+        );
+        expect(results, hasLength(2));
+        expect(results[1].retryablePending, isTrue);
+        expect(results[1].queuedRumorId, equals(held.id));
+        expect(results[0].success, isTrue);
+        expect(await queueRowFor(stack.db, deliverablePubkey), isNull);
+      },
+    );
+  });
+}

--- a/mobile/integration_test/helpers/fake_relay.dart
+++ b/mobile/integration_test/helpers/fake_relay.dart
@@ -3,6 +3,7 @@
 // ABOUTME: Answers REQ with a chosen EVENT, OK-confirms inbound EVENTs, and
 // ABOUTME: records what it was sent.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -28,6 +29,7 @@ class FakeRelay {
     this.broadcast,
     this.stallReqForKinds,
     this.stallReqForAuthors,
+    this.okDelayForRecipients,
   );
 
   /// Starts a relay on a loopback port — ephemeral unless [port] is given.
@@ -51,6 +53,12 @@ class FakeRelay {
   /// read as `found` while another's is `unreadable` in the same send — the
   /// partially-unreadable fan-out #8434 is about. A kind-keyed stall cannot
   /// express that: it stalls every recipient at once.
+  /// [okDelayForRecipients] delays the `OK` for an inbound `EVENT` whose `p`
+  /// tag names one of those pubkeys — a relay that accepts the frame promptly
+  /// but confirms it slowly. That holds ONE sibling of a group fan-out in
+  /// flight, still inside the OK-confirm window, for long enough that the
+  /// retry sweep can overlap the batch — the interleaving #8619 is about.
+  /// Events addressed to anyone else confirm immediately.
   /// Pass a stopped relay's [FakeRelay.port] as [port] to bring "the same
   /// relay" back, which is what a client that remembers the URL sees when a
   /// relay recovers.
@@ -61,6 +69,7 @@ class FakeRelay {
     bool broadcast = false,
     Set<int> stallReqForKinds = const <int>{},
     Set<String> stallReqForAuthors = const <String>{},
+    Map<String, Duration> okDelayForRecipients = const <String, Duration>{},
     int port = 0,
   }) async {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
@@ -72,6 +81,7 @@ class FakeRelay {
       broadcast,
       stallReqForKinds,
       stallReqForAuthors,
+      okDelayForRecipients,
     );
     server.listen(relay._handle, onError: (_) {});
     return relay;
@@ -106,6 +116,14 @@ class FakeRelay {
   /// read times out instead of settling empty — but selective per pubkey, so a
   /// fan-out can have a readable recipient and an unreadable one at once.
   final Set<String> stallReqForAuthors;
+
+  /// Recipients (an inbound `EVENT`'s `p` tag) whose `OK` is deferred by the
+  /// mapped duration instead of sent at once; see [start].
+  final Map<String, Duration> okDelayForRecipients;
+
+  /// Deferred `OK`s not yet sent, cancelled by [stop] so a confirmation never
+  /// fires into a socket the test already closed.
+  final List<Timer> _deferredOks = [];
 
   /// Whether a published `EVENT` is forwarded to other open subscriptions.
   ///
@@ -201,7 +219,13 @@ class FakeRelay {
         } else if (frame[0] == 'EVENT' && frame.length >= 2) {
           final event = frame[1] as Map<String, dynamic>;
           if (okConfirms) {
-            send(<dynamic>['OK', event['id'], true, '']);
+            final ok = <dynamic>['OK', event['id'], true, ''];
+            final delay = _okDelayFor(event);
+            if (delay == null) {
+              send(ok);
+            } else {
+              _deferredOks.add(Timer(delay, () => send(ok)));
+            }
           }
           if (broadcast) _fanOut(from: socket, event: event);
         }
@@ -231,6 +255,20 @@ class FakeRelay {
       }
     }
     return false;
+  }
+
+  /// The configured `OK` delay for the recipient [event] is addressed to, or
+  /// null when it confirms immediately; see [okDelayForRecipients].
+  Duration? _okDelayFor(Map<String, dynamic> event) {
+    if (okDelayForRecipients.isEmpty) return null;
+    final tags = event['tags'];
+    if (tags is! List) return null;
+    for (final tag in tags) {
+      if (tag is! List || tag.length < 2 || tag[0] != 'p') continue;
+      final delay = okDelayForRecipients[tag[1]];
+      if (delay != null) return delay;
+    }
+    return null;
   }
 
   bool _namesAnyAuthor(List<dynamic> frame, Set<String> wanted) {
@@ -265,6 +303,10 @@ class FakeRelay {
   }
 
   Future<void> stop() async {
+    for (final timer in _deferredOks) {
+      timer.cancel();
+    }
+    _deferredOks.clear();
     _subscriptions.clear();
     for (final socket in _sockets) {
       await socket.close().catchError((_) => null);

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -820,6 +820,13 @@ class DmRepository {
   /// attempt already running under the same key. Exceptions propagate to
   /// every joiner (both callers handle the documented [StateError] /
   /// [ArgumentError] contract).
+  ///
+  /// The queue row's finalization belongs to whichever caller RAN the
+  /// attempt. A joiner receives an outcome the owner has already recorded
+  /// against the row — [_recoverFullSendLocked] finalizes every branch
+  /// inside its body — so a joiner that finalized again would charge one
+  /// underlying attempt twice (#8619). [sendGroupMessage] learns which side
+  /// it was on from a flag the closure sets when it actually runs.
   Future<NIP17SendResult> _joinOrStartRecovery(
     String key,
     Future<NIP17SendResult> Function() attempt,
@@ -6305,6 +6312,14 @@ class DmRepository {
     // them. Recorded so the finalize below skips them too — a cancelled
     // index must never resurrect a queue transition or a thread.
     final cancelledBeforePublish = <int>{};
+    // Siblings whose outcome came from a recovery another caller already
+    // owned — the sweep's recoverFullSend registered `full:<queueId>` before
+    // this loop reached the row. That owner finalized the row inside its
+    // locked body, so the non-success pass below must not run the same
+    // transition again: a second _finalizeAfterRecipientUnconfirmed charged
+    // one underlying attempt twice, and a five-retry budget then covered four
+    // attempts (#8619). Only the durable handle is stamped for these.
+    final joinedRecovery = <int>{};
     for (var i = 0; i < recipientPubkeys.length; i++) {
       final pubkey = recipientPubkeys[i];
       // Cancel interlock, mirroring _recoverFullSendLocked's pre-publish row
@@ -6332,14 +6347,22 @@ class DmRepository {
       // makes the sweep JOIN the live attempt instead of dispatching a
       // concurrent duplicate. The reverse interleaving (sweep registered
       // first) hands back the recovery's real outcome, and the persistence
-      // transaction below dedups on it. A joined recovery can throw
-      // (ArgumentError after a mid-flight cancel); convert it to a plain
-      // failure so one bad join cannot abort the rest of the batch —
-      // _sendRumorWithTimeout itself classifies instead of throwing.
+      // transaction below dedups on it. That reverse interleaving is the
+      // common one once a sweep overlaps a batch at all: after both sides
+      // resume from a joined sibling, this loop still has to re-read the next
+      // row before it can register, while the sweep registers synchronously.
+      // A joined recovery can throw (ArgumentError after a mid-flight cancel);
+      // convert it to a plain failure so one bad join cannot abort the rest of
+      // the batch — _sendRumorWithTimeout itself classifies instead of
+      // throwing.
       NIP17SendResult result;
       final inbox = inboxByRecipient[pubkey];
+      // Set only when this call runs the attempt; a join never invokes the
+      // closure, so the flag is exact.
+      var attemptRanHere = false;
       try {
         result = await _joinOrStartRecovery('full:${queueIds[i]}', () async {
+          attemptRanHere = true;
           final published = await _sendRumorWithTimeout(
             rumor: groupRumor,
             recipientPubkey: pubkey,
@@ -6374,6 +6397,7 @@ class DmRepository {
           'joined in-flight recovery failed: $e',
         );
       }
+      if (!attemptRanHere) joinedRecovery.add(i);
       results.add(result);
     }
 
@@ -6512,6 +6536,16 @@ class DmRepository {
         }
         final result = results[i];
         if (result.success) continue;
+        // A joined outcome was finalized by the recovery that owns it
+        // (#8619): charging, failure marks and the blocked disposition are
+        // all that owner's. Stamp the handle exactly as the surviving-row
+        // branches below do, so the caller can still re-drive the row.
+        if (joinedRecovery.contains(i)) {
+          if (!result.blocked) {
+            results[i] = _stampQueuedRow(result, queueIds[i]);
+          }
+          continue;
+        }
         if (result.blocked) {
           await _finalizeAfterRecipientBlocked(
             outgoingDao: outgoingDao,

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -23429,6 +23429,164 @@ void main() {
       );
 
       test(
+        'a recovery that JOINS the group send in-flight attempt charges a '
+        'soft-unconfirmed sibling exactly once — the group owns that attempt',
+        () async {
+          // Group-first: B's publish is parked so the sweep's recoverFullSend
+          // finds the group's attempt already registered and joins it. The
+          // group ran the attempt, so the group is the one that finalizes
+          // it; recoverFullSend hands the joined outcome back untouched.
+          final bPublish = Completer<NIP17SendResult>();
+          var bSendRumorCalls = 0;
+          stubSendRumor((_, recipient) {
+            if (recipient == _validPubkeyB) {
+              bSendRumorCalls++;
+              return bPublish.future;
+            }
+            return NIP17SendResult.success(
+              rumorEventId: 'rumor-$recipient',
+              messageEventId: 'wrap-$recipient',
+              recipientPubkey: recipient,
+            );
+          });
+          final enqueued = <OutgoingDm>[];
+          when(() => mockOutgoingDmsDao.enqueue(any())).thenAnswer((inv) {
+            enqueued.add(inv.positionalArguments.first as OutgoingDm);
+            return Future.value();
+          });
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final sendFuture = repository.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'soft-unconfirmed, joined by the sweep',
+          );
+          await pumpEventQueue();
+          expect(enqueued, hasLength(2));
+
+          final recoveryFuture = repository.recoverFullSend(
+            rumorId: enqueued.first.id,
+          );
+
+          bPublish.complete(
+            const NIP17SendResult.failure(
+              'frame written, no OK',
+              retryablePending: true,
+            ),
+          );
+
+          final results = await sendFuture;
+          final recovered = await recoveryFuture;
+
+          expect(recovered.retryablePending, isTrue);
+          expect(results.first.retryablePending, isTrue);
+          expect(
+            results.first.queuedRumorId,
+            equals(enqueued.first.id),
+            reason: 'the caller keeps the durable handle to re-drive the row',
+          );
+          expect(bSendRumorCalls, equals(1));
+          verify(
+            () => mockOutgoingDmsDao.incrementRetry(enqueued.first.id),
+          ).called(1);
+        },
+      );
+
+      test(
+        'a sibling that JOINS a recovery the sweep already owns is charged '
+        'for that attempt exactly once — the owner finalized it (#8619)',
+        () async {
+          // Sweep-first: the sweep's recoverFullSend registers C's recovery
+          // and runs the attempt while the group loop is still parked on B.
+          // When the group reaches C it joins that attempt and receives an
+          // outcome _recoverFullSendLocked has ALREADY finalized, so the
+          // group's own non-success pass must not charge the row again.
+          final bPublish = Completer<NIP17SendResult>();
+          final cPublish = Completer<NIP17SendResult>();
+          var cSendRumorCalls = 0;
+          stubSendRumor((_, recipient) {
+            if (recipient == _validPubkeyB) return bPublish.future;
+            cSendRumorCalls++;
+            return cPublish.future;
+          });
+          final enqueued = <OutgoingDm>[];
+          when(() => mockOutgoingDmsDao.enqueue(any())).thenAnswer((inv) {
+            enqueued.add(inv.positionalArguments.first as OutgoingDm);
+            return Future.value();
+          });
+          // The locked recovery body re-reads the row and rebuilds the rumor
+          // from its stored JSON, so hand back the real enqueued row rather
+          // than the fixture's placeholder.
+          when(() => mockOutgoingDmsDao.getById(any())).thenAnswer((inv) async {
+            final id = inv.positionalArguments.first as String;
+            for (final row in enqueued) {
+              if (row.id == id) return row;
+            }
+            return null;
+          });
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final sendFuture = repository.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'joined a recovery the sweep owns',
+          );
+          await pumpEventQueue();
+          expect(enqueued, hasLength(2));
+
+          // The sweep reaches C's row while the group is still on B: its
+          // recovery owns `full:<C>` and parks on C's publish.
+          final recoveryFuture = repository.recoverFullSend(
+            rumorId: enqueued.last.id,
+          );
+          await pumpEventQueue();
+          expect(cSendRumorCalls, equals(1), reason: 'the sweep published C');
+
+          // Release B so the group loop reaches C and joins.
+          bPublish.complete(
+            NIP17SendResult.success(
+              rumorEventId: 'rumor-$_validPubkeyB',
+              messageEventId: 'wrap-$_validPubkeyB',
+              recipientPubkey: _validPubkeyB,
+            ),
+          );
+          await pumpEventQueue();
+          expect(
+            cSendRumorCalls,
+            equals(1),
+            reason: 'the group joined the in-flight attempt, no second publish',
+          );
+
+          // The sweep's attempt ends soft-unconfirmed.
+          cPublish.complete(
+            const NIP17SendResult.failure(
+              'frame written, no OK',
+              retryablePending: true,
+            ),
+          );
+
+          final results = await sendFuture;
+          final recovered = await recoveryFuture;
+
+          expect(recovered.retryablePending, isTrue);
+          expect(results.last.retryablePending, isTrue);
+          expect(
+            results.last.queuedRumorId,
+            equals(enqueued.last.id),
+            reason:
+                'a joined sibling still hands the caller its durable handle',
+          );
+          verify(
+            () => mockOutgoingDmsDao.incrementRetry(enqueued.last.id),
+          ).called(1);
+        },
+      );
+
+      test(
         'a throwing per-recipient publish is converted to a plain failure '
         'and never aborts the rest of the batch',
         () async {


### PR DESCRIPTION
Fixes #8619

## The problem

A group DM is one rumor wrapped once per recipient, with one durable queue row per recipient. Each row carries a budget of five retry charges; when it is spent, the message turns into the red "Not delivered" bubble.

The group send and the background retry sweep coalesce on the same per-row key, so only one of them publishes a given sibling. When the sweep gets there first, the group send joins the sweep's attempt and receives an outcome the sweep has already recorded against the row. The group send then recorded it again: a soft-unconfirmed outcome charged `incrementRetry` twice for one publish. Each row can be hit at most once per group send, so the five-charge budget covered four attempts instead of five, and the row went red one sweep early.

That order is not rare once a sweep overlaps a batch at all. After the sweep joins the sibling that is in flight, both sides resume from the same future; the group loop still has to re-read the next row before it can register its publish, while the sweep registers synchronously, so the sweep wins every later sibling. #8590 made unreadable-inbox siblings a systematic source of the soft-unconfirmed outcome, which is why this surfaced now.

## Why this fix

The row's finalization belongs to whichever caller ran the attempt. `_recoverFullSendLocked` already finalizes every branch inside its body, so the group send only needs to know whether it ran the attempt or joined one. The closure sets a flag when it actually runs; a joined sibling skips the post-loop finalization (retry charge, failure marks, blocked disposition) and only stamps its durable handle, so the caller can still re-drive the row. No new API, and the coalescing key and duplicate-publish prevention are untouched.

The reverse order, where the sweep joins the group's attempt, was already correct: `recoverFullSend` never finalizes outside its locked body. A test now pins that too.

## Deliberately unchanged

- Success finalization: still protected by the row-liveness re-read inside the persist transaction.
- Blocked and hard-failure finalization when the group send owns the attempt: unchanged.
- The retry budget, the sweep's min-age guard, backoff and the terminal `failed` state: unchanged. The budget of five covers five underlying attempts again.

On the issue's "roughly three sweeps": a row can be double-charged at most once per group send, because the group send touches each sibling exactly once and every other joiner goes through `recoverFullSend`, which never finalizes outside its locked body. The exact effect was one lost attempt out of five.

## Verification

Reproduced first on the unfixed code, then re-run unchanged after the fix.

Unit (`dm_repository`, mocktail): the sweep-first regression test fails on the previous code with `incrementRetry` called twice where once is expected; the group-first test charges once both before and after.

E2E on an iPhone 17 simulator, driving a real `DmRepository`, Drift database and `NostrClient` over real sockets against the in-process FakeRelay:

| arm | unfixed | fixed |
|---|---|---|
| A: the group send joins a recovery started through `recoverFullSend` | fail, `retry_count` 2 | pass, `retry_count` 1 |
| B: the production `OutgoingDmRetryService.sweep()` overlaps the batch, joins the in-flight sibling, then wins the next one | fail, `retry_count` 2 | pass, `retry_count` 1 |

Both arms assert that the sweep owned the attempt (its own inbox re-resolution shows up on the relay) before asserting the charge, so a lost race fails loudly instead of passing vacuously. Arm B is the end-to-end proof of the lockstep described above.

FakeRelay gains `okDelayForRecipients`, a per-recipient delay before the OK for a gift wrap addressed to that pubkey. It defaults to empty, so no existing suite changes behaviour. The new suite is registered in the service integration workflow, since an unlisted suite never runs in CI.

The fixed build was also run on the simulator against the local Docker stack with a freshly imported throwaway key. A two-recipient group send through the real repository published both recipient wraps and both self-wraps to the local relay, both siblings reported delivered, both rows were consumed, and the retry sweep ran clean. That run is a smoke test only: the local stack has one relay that confirms instantly, so it cannot force the overlap the e2e arms force.

```
flutter test (packages/dm_repository)      907 passed
coverage                                   94.66%  (gate 93%)
flutter analyze lib test integration_test  no issues
e2e on iPhone 17 simulator                 2/2 passed (2/2 failed on the unfixed code)
```

Ratchets green: ungrouped tests, skip ceiling, placeholder tests, shared-setup stubs, nostr-id truncation, pubkey log encoding, uncancellable timer wait, future-delayed ceiling, post-close emit, layer direction, test/unit structure.
