### PR TITLE
fix(likes): stop publishing a second like when the first one already landed

### DIFF
--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -250,6 +250,20 @@ class LikesRepository {
   /// Whether the repository has been initialized with data from storage.
   bool _isInitialized = false;
 
+  /// Completes after the startup relay reconciliation attempt finishes.
+  ///
+  /// The app starts [initialize] without awaiting it. Like publication can
+  /// therefore race the initial relay snapshot unless it joins this future.
+  Future<void>? _startupReconciliationFuture;
+
+  /// Whether the last relay reconciliation returned an uncapped snapshot.
+  ///
+  /// A result that fills either fetch limit may have omitted older reactions
+  /// or deletions. In that case individual targets still need a relay check
+  /// before publishing; a smaller result lets ordinary likes stay on the fast
+  /// path for the rest of the session.
+  bool _hasCompleteRelayReactionSnapshot = false;
+
   /// Whether [dispose] has been called.
   ///
   /// Once disposed, all stream emissions are no-ops.
@@ -701,17 +715,29 @@ class LikesRepository {
       }
 
       // Ask the relay first whether this account already holds a live `+` on
-      // the target that this device cannot see: a fresh install or wiped
-      // cache, a like made from another client, or an earlier publish that
-      // landed without its OK. Kind 7 is a regular event with no per-pubkey
-      // uniqueness (NIP-01, NIP-25), so nothing downstream collapses a
-      // second one (#7001). The placeholder is already indexed, so a second
-      // tap inside this round-trip still trips the check above.
+      // the target only while the startup snapshot is still resolving or was
+      // incomplete. A complete snapshot keeps ordinary likes off this relay
+      // read path; replay retains its own check below because a publish may
+      // have landed after the snapshot without its OK reaching the client.
+      // The placeholder is already indexed, so a second tap inside either
+      // round-trip still trips the check above.
       _inFlightLikePublishPlaceholders.add(placeholderId);
-      final remoteRecord = await _resolveRemoteLikeRecordOrNull(
-        eventId,
-        addressableId: addressableId,
-      );
+      await _startupReconciliationFuture;
+      final reconciledRecord =
+          _likeRecords[eventId] ??
+          (addressableId == null
+              ? null
+              : _likeRecordsByAddressableId[addressableId]);
+      final remoteRecord =
+          reconciledRecord != null &&
+              !_isPlaceholderId(reconciledRecord.reactionEventId)
+          ? reconciledRecord
+          : !_hasCompleteRelayReactionSnapshot
+          ? await _resolveRemoteLikeRecordOrNull(
+              eventId,
+              addressableId: addressableId,
+            )
+          : null;
       if (remoteRecord != null) {
         _inFlightLikePublishPlaceholders.remove(placeholderId);
         if (_unlikeRequestedWhilePending.remove(placeholderId)) {
@@ -927,6 +953,11 @@ class LikesRepository {
       return;
     }
 
+    // [restoredCount] already included this pre-existing relay reaction.
+    // unlikeEvent removed only the optimistic +1, so the successful Kind 5
+    // must remove the original reaction from the cached total as well.
+    _adjustCachedLikeCount(countEventId, -1, addressableId: countAddressableId);
+
     // The relay echoes a stored reaction on this account's own subscription
     // within milliseconds, so the echo can re-index the reaction between the
     // unlike and this retraction. It is retracted now; a record naming it
@@ -975,19 +1006,13 @@ class LikesRepository {
     // make them blind to a persisted reaction.
     await _ensureInitialized();
 
-    final indexedRecord = _likeRecords[eventId];
-    if (indexedRecord != null &&
-        !_isPlaceholderId(indexedRecord.reactionEventId)) {
-      return indexedRecord.reactionEventId;
-    }
-
     if (addressableId != null && addressableId.isNotEmpty) {
       final byCoordinate = _likeRecordsByAddressableId[addressableId];
       final ownReactionEventId = _likeRecords[eventId]?.reactionEventId;
       if (byCoordinate != null &&
           byCoordinate.reactionEventId != ownReactionEventId) {
         if (ownReactionEventId != null &&
-            ownReactionEventId.startsWith('pending_')) {
+            _isPlaceholderId(ownReactionEventId)) {
           // Drop the queued placeholder now that the coordinate reaction
           // is authoritative; leaving it would make a later unlike resolve
           // the placeholder by event id, skip the Kind 5 publish, and
@@ -1000,6 +1025,12 @@ class LikesRepository {
         }
         return byCoordinate.reactionEventId;
       }
+    }
+
+    final indexedRecord = _likeRecords[eventId];
+    if (indexedRecord != null &&
+        !_isPlaceholderId(indexedRecord.reactionEventId)) {
+      return indexedRecord.reactionEventId;
     }
 
     final remoteRecord = await _resolveRemoteLikeRecordOrNull(
@@ -1050,7 +1081,7 @@ class LikesRepository {
     // Update local record with real event ID if we have a placeholder
     final existingRecord = _likeRecords[eventId];
     if (existingRecord != null &&
-        existingRecord.reactionEventId.startsWith('pending_')) {
+        _isPlaceholderId(existingRecord.reactionEventId)) {
       final record = LikeRecord(
         targetEventId: eventId,
         reactionEventId: reactionEvent.id,
@@ -1156,7 +1187,7 @@ class LikesRepository {
       // optimistic unlike survives transient relay-pool problems (mirror of
       // [likeEvent]). Without a wired callback, fall back to rollback +
       // rethrow to preserve the original contract.
-      if (snapshotRecord.reactionEventId.startsWith('pending_')) {
+      if (_isPlaceholderId(snapshotRecord.reactionEventId)) {
         // The real reaction id does not exist yet, so nothing can be referenced
         // in a Kind 5 here. If this placeholder belongs to a currently awaited
         // publish, record the intent for that exact attempt — [likeEvent]
@@ -1294,7 +1325,7 @@ class LikesRepository {
     final resolvedEventId = record.targetEventId;
 
     // Skip publishing if this was a pending like
-    if (record.reactionEventId.startsWith('pending_')) {
+    if (_isPlaceholderId(record.reactionEventId)) {
       // Just clean up local storage
       _deindexLikeRecord(resolvedEventId);
       await _localStorage?.deleteLikeRecord(resolvedEventId);
@@ -1622,7 +1653,17 @@ class LikesRepository {
 
     // Signed out: both queries below are author-scoped, and a null author
     // would widen them to every user's votes rather than narrowing to none.
-    final pubkey = await _currentUserPubkey();
+    String? pubkey;
+    try {
+      pubkey = await _currentUserPubkey();
+    } on Exception catch (error) {
+      Log.warning(
+        'Could not resolve the current account for startup reaction sync; '
+        'continuing with target checks: $error',
+        name: 'LikesRepository',
+        category: LogCategory.system,
+      );
+    }
     if (pubkey == null) {
       return (upvotedIds: <String>{}, downvotedIds: <String>{});
     }
@@ -1891,7 +1932,7 @@ class LikesRepository {
 
     // 2. Skip publishing deletion for placeholders that never reached the
     // relay (e.g. publish failed and the user retried before sync).
-    if (snapshotRecord.reactionEventId.startsWith('pending_')) {
+    if (_isPlaceholderId(snapshotRecord.reactionEventId)) {
       return;
     }
 
@@ -2004,8 +2045,21 @@ class LikesRepository {
   ///
   /// Returns a [LikesSyncResult] containing all synced data needed by the UI.
   ///
+  /// When [requireCompleteRelaySnapshot] is true, waits for every configured
+  /// relay to settle and records whether the bounded result proves that the
+  /// in-memory reaction set is complete. Ordinary likes may skip their
+  /// target-specific relay lookup only after that proof succeeds.
+  ///
   /// Throws `SyncFailedException` if syncing fails.
-  Future<LikesSyncResult> syncUserReactions() async {
+  Future<LikesSyncResult> syncUserReactions({
+    bool requireCompleteRelaySnapshot = false,
+  }) async {
+    if (requireCompleteRelaySnapshot) {
+      // Completeness belongs to this attempt. A later timeout or exception
+      // must not inherit success from an earlier forced reconciliation.
+      _hasCompleteRelayReactionSnapshot = false;
+    }
+
     // First, load from local storage (fast). Best-effort and deliberately
     // outside the relay try/catch below: an unreadable cache must not skip
     // the authoritative relay fetch, which is the whole point of a sync.
@@ -2048,14 +2102,33 @@ class LikesRepository {
         limit: _defaultReactionFetchLimit,
       );
 
-      // Fetch reactions and deletions in parallel
-      final results = await Future.wait([
-        _nostrClient.queryEvents([reactionsFilter]),
-        _nostrClient.queryEvents([deletionsFilter]),
-      ]);
-
-      final reactionEvents = results[0];
-      final deletionEvents = results[1];
+      late final List<Event> reactionEvents;
+      late final List<Event> deletionEvents;
+      if (requireCompleteRelaySnapshot) {
+        final results = await Future.wait([
+          _nostrClient.queryEventsDetailed(
+            [reactionsFilter],
+            requireAllRelaysSettled: true,
+          ),
+          _nostrClient.queryEventsDetailed(
+            [deletionsFilter],
+            requireAllRelaysSettled: true,
+          ),
+        ]);
+        reactionEvents = results[0].events;
+        deletionEvents = results[1].events;
+        _hasCompleteRelayReactionSnapshot =
+            results.every((result) => !result.timedOut && !result.noRelays) &&
+            reactionEvents.length < _defaultReactionFetchLimit &&
+            deletionEvents.length < _defaultReactionFetchLimit;
+      } else {
+        final results = await Future.wait([
+          _nostrClient.queryEvents([reactionsFilter]),
+          _nostrClient.queryEvents([deletionsFilter]),
+        ]);
+        reactionEvents = results[0];
+        deletionEvents = results[1];
+      }
 
       // Build set of deleted reaction event IDs from Kind 5 events
       final deletedReactionIds = <String>{};
@@ -2087,7 +2160,7 @@ class LikesRepository {
           continue;
         }
 
-        if (event.content == _likeContent) {
+        if (_isLikeReaction(event)) {
           final record = LikeRecord(
             targetEventId: targetId,
             reactionEventId: event.id,
@@ -2115,6 +2188,7 @@ class LikesRepository {
               record.addressableId != null &&
               record.addressableId!.isNotEmpty;
           if (existing == null ||
+              _isPlaceholderId(existing.reactionEventId) ||
               record.createdAt.isAfter(existing.createdAt) ||
               canBackfillCoordinate) {
             _indexLikeRecord(record);
@@ -2215,7 +2289,7 @@ class LikesRepository {
 
       for (final event in events) {
         // Only process '+' reactions (likes)
-        if (event.content != _likeContent) continue;
+        if (!_isLikeReaction(event)) continue;
 
         final targetId = _extractTargetEventId(event);
         if (targetId != null && !seenIds.contains(targetId)) {
@@ -2543,19 +2617,26 @@ class LikesRepository {
   /// Follows the same pattern as `FollowRepository.initialize()`:
   /// 1. Load persisted records from local storage for immediate UI display.
   /// 2. Set up a persistent Kind 7 subscription for live updates.
-  /// 3. When any loaded record predates the addressable_id column (null
-  ///    coordinate), run [syncUserReactions] to backfill coordinates from
-  ///    the relay reactions' `a` tags — otherwise likes made before the
-  ///    column shipped never resolve by coordinate after an edit (#6123).
+  /// 3. Reconcile the account's recent reactions and deletions. This repairs
+  ///    cold or stale caches once per startup rather than making every normal
+  ///    like wait for target-specific relay reads (#7001), and also backfills
+  ///    coordinates for rows created before the addressable_id column (#6123).
   ///
   /// Safe to call multiple times (idempotent).
-  Future<void> initialize() async {
-    if (_isInitialized) return;
+  Future<void> initialize() {
+    final inFlight = _startupReconciliationFuture;
+    if (inFlight != null) return inFlight;
+    if (_isInitialized) return Future.value();
 
+    final initialization = _initialize();
+    _startupReconciliationFuture = initialization;
+    return initialization;
+  }
+
+  Future<void> _initialize() async {
     // Load from local storage first for immediate UI display. Best-effort:
     // throwing here would skip _subscribeToReactions below, so an unreadable
     // cache would also cost the session its cross-device sync.
-    var hasCoordinatelessRecords = false;
     final localStorage = _localStorage;
     if (localStorage != null) {
       final records = await _bestEffortLocalStorage(
@@ -2565,9 +2646,6 @@ class LikesRepository {
       );
       if (records != null) {
         records.forEach(_indexLikeRecord);
-        hasCoordinatelessRecords = records.any(
-          (r) => r.addressableId == null || r.addressableId!.isEmpty,
-        );
         _emitLikedIds();
       }
     }
@@ -2581,13 +2659,13 @@ class LikesRepository {
     // aren't blocked on a relay round-trip.
     _isInitialized = true;
 
-    if (hasCoordinatelessRecords && pubkey != null) {
+    if (pubkey != null) {
       try {
-        await syncUserReactions();
+        await syncUserReactions(requireCompleteRelaySnapshot: true);
       } on Exception catch (_) {
-        // Best-effort coordinate backfill; initialize() must not fail on
-        // relay errors. Records missing a coordinate on the wire (e.g.
-        // comment likes, which have no a tag) keep a null coordinate.
+        // Best-effort startup reconciliation; initialize() must not fail on
+        // relay errors. A later like retains its target-specific safety check
+        // because the snapshot remains marked incomplete.
       }
     }
   }
@@ -2635,7 +2713,7 @@ class LikesRepository {
       event.createdAt * 1000,
     );
 
-    if (event.content == _likeContent) {
+    if (_isLikeReaction(event)) {
       // Deduplicate upvotes. A placeholder is the absence of a real record,
       // not one to defend: the relay's echo of the reaction it stands for is
       // what upgrades it, and that echo's created_at (whole seconds) never
@@ -2754,6 +2832,8 @@ class LikesRepository {
     _emitLikedIds();
     _emitDownvotedIds();
     _isInitialized = false;
+    _startupReconciliationFuture = null;
+    _hasCompleteRelayReactionSnapshot = false;
   }
 
   /// Dispose of resources.
@@ -3043,7 +3123,7 @@ class LikesRepository {
       targetEventId: eventId,
       reactionEventId: newest.id,
       createdAt: DateTime.fromMillisecondsSinceEpoch(newest.createdAt * 1000),
-      addressableId: _extractAddressableId(newest),
+      addressableId: _extractAddressableId(newest) ?? addressableId,
     );
   }
 }

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -742,6 +742,7 @@ class LikesRepository {
             restoredCount: previousCount,
             countEventId: eventId,
             countAddressableId: addressableId,
+            alreadyCounted: true,
           );
           return liveRecord.reactionEventId;
         }
@@ -796,6 +797,7 @@ class LikesRepository {
             restoredCount: previousCount == null ? null : previousCount + 1,
             countEventId: eventId,
             countAddressableId: addressableId,
+            alreadyCounted: false,
           );
           return reactionEvent.id;
         }
@@ -898,6 +900,11 @@ class LikesRepository {
   /// Publishes the Kind 5 for a reaction the user unliked while its own
   /// publish was still in flight (#7001).
   ///
+  /// [alreadyCounted] says [confirmed] was inside the like count the UI
+  /// showed before this tap — a reaction adopted from the relay — so its
+  /// successful Kind 5 also removes it from the cached total. A reaction this
+  /// tap published never entered that count.
+  ///
   /// On failure the [confirmed] record is indexed after all, so a later
   /// unlike can still reference the real reaction id — dropping it would
   /// leave the reaction live and unreachable by the normal unlike flow.
@@ -906,6 +913,7 @@ class LikesRepository {
     required int? restoredCount,
     required String countEventId,
     required String? countAddressableId,
+    required bool alreadyCounted,
   }) async {
     try {
       final deletion = await _nostrClient.deleteEvent(
@@ -948,10 +956,16 @@ class LikesRepository {
       return;
     }
 
-    // [restoredCount] already included this pre-existing relay reaction.
-    // unlikeEvent removed only the optimistic +1, so the successful Kind 5
-    // must remove the original reaction from the cached total as well.
-    _adjustCachedLikeCount(countEventId, -1, addressableId: countAddressableId);
+    // unlikeEvent already removed this tap's optimistic +1. A pre-existing
+    // relay reaction was inside that count too, so its Kind 5 removes it
+    // from the cached total; one this tap published was never counted.
+    if (alreadyCounted) {
+      _adjustCachedLikeCount(
+        countEventId,
+        -1,
+        addressableId: countAddressableId,
+      );
+    }
 
     // The relay echoes a stored reaction on this account's own subscription
     // within milliseconds, so the echo can re-index the reaction between the

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -624,7 +624,11 @@ class LikesRepository {
   /// ID if the action was queued for offline sync.
   ///
   /// Throws `LikeFailedException` if the operation fails.
-  /// Throws `AlreadyLikedException` if the event is already liked.
+  /// Throws `AlreadyLikedException` if the event is already liked — by a
+  /// local record, or by a live reaction this account already holds on the
+  /// relay that this device did not know about (#7001). In the latter case
+  /// the relay's reaction is adopted into the local record first, so the
+  /// caller's state settles on "liked" without a second publish.
   Future<String> likeEvent({
     required String eventId,
     required String authorPubkey,
@@ -696,6 +700,46 @@ class LikesRepository {
         return placeholderId;
       }
 
+      // Ask the relay first whether this account already holds a live `+` on
+      // the target that this device cannot see: a fresh install or wiped
+      // cache, a like made from another client, or an earlier publish that
+      // landed without its OK. Kind 7 is a regular event with no per-pubkey
+      // uniqueness (NIP-01, NIP-25), so nothing downstream collapses a
+      // second one (#7001). The placeholder is already indexed, so a second
+      // tap inside this round-trip still trips the check above.
+      _inFlightLikePublishPlaceholders.add(placeholderId);
+      final remoteRecord = await _resolveRemoteLikeRecordOrNull(
+        eventId,
+        addressableId: addressableId,
+      );
+      if (remoteRecord != null) {
+        _inFlightLikePublishPlaceholders.remove(placeholderId);
+        if (_unlikeRequestedWhilePending.remove(placeholderId)) {
+          // The like the user just took back is the relay's existing one.
+          await _retractLikeUnlikedMidPublish(
+            confirmed: remoteRecord,
+            restoredCount: previousCount,
+            countEventId: eventId,
+            countAddressableId: addressableId,
+          );
+          return remoteRecord.reactionEventId;
+        }
+        await _adoptRemoteLikeRecord(
+          remoteRecord,
+          site: LikesRepositoryReportableSites.likeEventSaveAdopted,
+        );
+        // The relay's reaction is already inside the count the UI shows.
+        if (previousCount != null) {
+          _writeCachedLikeCount(
+            eventId,
+            previousCount,
+            addressableId: addressableId,
+          );
+        }
+        _emitLikedIds();
+        throw AlreadyLikedException(eventId);
+      }
+
       // 3. Online → publish kind 7; on success swap placeholder for real id.
       // On failure, prefer queuing via [_queueOfflineAction] when wired so the
       // optimistic state survives transient relay-pool problems (e.g. all
@@ -704,7 +748,6 @@ class LikesRepository {
       // relay is technically connected). Without a wired callback, fall back
       // to rollback + rethrow to preserve the original contract for tests
       // and non-app embedders.
-      _inFlightLikePublishPlaceholders.add(placeholderId);
       try {
         final reactionEvent = await _nostrClient.sendLike(
           eventId,
@@ -881,7 +924,22 @@ class LikesRepository {
           addressableId: confirmed.addressableId,
         );
       }
+      return;
     }
+
+    // The relay echoes a stored reaction on this account's own subscription
+    // within milliseconds, so the echo can re-index the reaction between the
+    // unlike and this retraction. It is retracted now; a record naming it
+    // would read as liked for a like the user already took back.
+    final echoed = _likeRecords[confirmed.targetEventId];
+    if (echoed?.reactionEventId != confirmed.reactionEventId) return;
+    _deindexLikeRecord(confirmed.targetEventId);
+    await _bestEffortLocalStorage(
+      () async => _localStorage?.deleteLikeRecord(confirmed.targetEventId),
+      description: 'dropping a retracted reaction the subscription re-indexed',
+      site: LikesRepositoryReportableSites.retractLikeDeleteEchoedRecord,
+    );
+    _emitLikedIds();
   }
 
   /// Execute a like action directly (for use by sync service).
@@ -889,14 +947,23 @@ class LikesRepository {
   /// This method bypasses offline queuing and directly publishes to relays.
   /// Used by PendingActionService to execute queued actions.
   ///
-  /// If [addressableId] is already liked by a *different* reaction than the
-  /// one queued for [eventId] — e.g. cross-device sync delivered a like for
-  /// this coordinate (under a different event id) while this action sat in
-  /// the offline queue — reconciles to that reaction instead of publishing
-  /// a duplicate. The app-layer queue's own dedup only cancels opposite
-  /// actions on the same event id; it has no visibility into reactions
-  /// arriving from other devices, so this is the only guard against a
-  /// duplicate live reaction on replay (#6020).
+  /// A queued row can outlive the reaction it was queued for, and every
+  /// replay that still publishes mints a second live `+` (#7001), so three
+  /// guards run before the publish:
+  ///
+  /// * The record under [eventId] already holds a real reaction id — a
+  ///   confirmed swap, the live subscription, or a sync filled it in while
+  ///   the row sat in the queue.
+  /// * [addressableId] is already liked by a *different* reaction than the
+  ///   one queued for [eventId] — e.g. cross-device sync delivered a like for
+  ///   this coordinate (under a different event id) while this action sat in
+  ///   the offline queue. Reconciles to that reaction instead. The app-layer
+  ///   queue's own dedup only cancels opposite actions on the same event id;
+  ///   it has no visibility into reactions arriving from other devices
+  ///   (#6020).
+  /// * The relay already holds this account's live `+` on the target — the
+  ///   original publish landed without its OK reaching this client, so the
+  ///   queue knows only its own placeholder. Adopts that reaction instead.
   Future<String> executeLikeAction({
     required String eventId,
     required String authorPubkey,
@@ -904,9 +971,15 @@ class LikesRepository {
     int? targetKind,
   }) async {
     // Replay can race initialize(): both are fired unawaited at provider
-    // build, and the coordinate guard below is memory-only, so an empty
-    // cache would make it blind to a persisted cross-device reaction.
+    // build, and the guards below are memory-only, so an empty cache would
+    // make them blind to a persisted reaction.
     await _ensureInitialized();
+
+    final indexedRecord = _likeRecords[eventId];
+    if (indexedRecord != null &&
+        !_isPlaceholderId(indexedRecord.reactionEventId)) {
+      return indexedRecord.reactionEventId;
+    }
 
     if (addressableId != null && addressableId.isNotEmpty) {
       final byCoordinate = _likeRecordsByAddressableId[addressableId];
@@ -927,6 +1000,19 @@ class LikesRepository {
         }
         return byCoordinate.reactionEventId;
       }
+    }
+
+    final remoteRecord = await _resolveRemoteLikeRecordOrNull(
+      eventId,
+      addressableId: addressableId,
+    );
+    if (remoteRecord != null) {
+      await _adoptRemoteLikeRecord(
+        remoteRecord,
+        site: LikesRepositoryReportableSites.executeLikeActionSaveAdopted,
+      );
+      _emitLikedIds();
+      return remoteRecord.reactionEventId;
     }
 
     // Publish Kind 7 reaction event via NostrClient
@@ -2550,9 +2636,17 @@ class LikesRepository {
     );
 
     if (event.content == _likeContent) {
-      // Deduplicate upvotes
+      // Deduplicate upvotes. A placeholder is the absence of a real record,
+      // not one to defend: the relay's echo of the reaction it stands for is
+      // what upgrades it, and that echo's created_at (whole seconds) never
+      // reads as newer than a placeholder stamped milliseconds earlier in
+      // the same second (#7001).
       final existing = _likeRecords[targetId];
-      if (existing != null && !createdAt.isAfter(existing.createdAt)) return;
+      if (existing != null &&
+          !_isPlaceholderId(existing.reactionEventId) &&
+          !createdAt.isAfter(existing.createdAt)) {
+        return;
+      }
 
       final record = LikeRecord(
         targetEventId: targetId,
@@ -2806,6 +2900,75 @@ class LikesRepository {
     return null;
   }
 
+  /// Whether [reactionEventId] is an optimistic placeholder rather than the
+  /// id of a reaction that reached a relay.
+  static bool _isPlaceholderId(String reactionEventId) =>
+      reactionEventId.startsWith('pending_');
+
+  /// NIP-25: a reaction whose `content` is `+` or empty MUST be read as a
+  /// like. Divine writes `+`; another client on the same key may write the
+  /// empty form.
+  static bool _isLikeReaction(Event event) =>
+      event.content == _likeContent || event.content.isEmpty;
+
+  /// Indexes and persists a reaction the relay already holds for this
+  /// account, so local state reflects it instead of minting a second one.
+  Future<void> _adoptRemoteLikeRecord(
+    LikeRecord record, {
+    required String site,
+  }) async {
+    _indexLikeRecord(record);
+    await _bestEffortLocalStorage(
+      () async => _localStorage?.saveLikeRecord(record),
+      description: 'saving a reaction adopted from the relay',
+      site: site,
+    );
+  }
+
+  /// [_resolveRemoteLikeRecord] that fails open.
+  ///
+  /// An unreachable relay must not turn a like into a silent no-op; the
+  /// publish that follows fails the same way and takes the existing retry
+  /// path, which runs this check again before it publishes.
+  Future<LikeRecord?> _resolveRemoteLikeRecordOrNull(
+    String eventId, {
+    String? addressableId,
+  }) async {
+    try {
+      return await _resolveRemoteLikeRecord(
+        eventId,
+        addressableId: addressableId,
+      );
+    } on Object catch (e) {
+      Log.warning(
+        'Could not check the relay for an existing like on $eventId; '
+        'publishing without that check: $e',
+        name: 'LikesRepository',
+        category: LogCategory.relay,
+      );
+      return null;
+    }
+  }
+
+  /// Resolves the current user's still-live `+` on [eventId] from relays.
+  ///
+  /// Returns the newest non-deleted kind-7 like this account has published
+  /// against [eventId] or its coordinate, or `null` when there is none. Backs
+  /// the pre-publish check in [likeEvent] and the replay guard in
+  /// [executeLikeAction] (#7001).
+  Future<LikeRecord?> _resolveRemoteLikeRecord(
+    String eventId, {
+    String? addressableId,
+  }) => _resolveRemoteReactionRecord(
+    eventId,
+    addressableId: addressableId,
+    // The REQ carries `authors`, but a relay that ignores it, or a merged
+    // cache hit, must not hand this account someone else's reaction to
+    // adopt as its own.
+    isMatch: (event, pubkey) =>
+        event.pubkey == pubkey && _isLikeReaction(event),
+  );
+
   /// Resolves the current user's still-live downvote on [eventId] from relays.
   ///
   /// Returns the newest non-deleted kind-7 `-` reaction the user has published
@@ -2815,6 +2978,19 @@ class LikesRepository {
   Future<LikeRecord?> _resolveRemoteDownvoteRecord(
     String eventId, {
     String? addressableId,
+  }) => _resolveRemoteReactionRecord(
+    eventId,
+    addressableId: addressableId,
+    isMatch: (event, _) => event.content == _downvoteContent,
+  );
+
+  /// Resolves the newest still-live kind-7 reaction the current user has
+  /// published against [eventId] or its coordinate that satisfies [isMatch],
+  /// or `null` when there is none.
+  Future<LikeRecord?> _resolveRemoteReactionRecord(
+    String eventId, {
+    required String? addressableId,
+    required bool Function(Event event, String currentUserPubkey) isMatch,
   }) async {
     final pubkey = await _currentUserPubkey();
     if (pubkey == null) return null;
@@ -2830,7 +3006,7 @@ class LikesRepository {
 
     final candidatesById = <String, Event>{};
     for (final event in reactions) {
-      if (event.content != _downvoteContent) continue;
+      if (!isMatch(event, pubkey)) continue;
       final matches =
           _extractTargetEventId(event) == eventId ||
           (hasCoordinate && _extractAddressableId(event) == addressableId);

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -1670,17 +1670,7 @@ class LikesRepository {
 
     // Signed out: both queries below are author-scoped, and a null author
     // would widen them to every user's votes rather than narrowing to none.
-    String? pubkey;
-    try {
-      pubkey = await _currentUserPubkey();
-    } on Exception catch (error) {
-      Log.warning(
-        'Could not resolve the current account for startup reaction sync; '
-        'continuing with target checks: $error',
-        name: 'LikesRepository',
-        category: LogCategory.system,
-      );
-    }
+    final pubkey = await _currentUserPubkey();
     if (pubkey == null) {
       return (upvotedIds: <String>{}, downvotedIds: <String>{});
     }

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -714,44 +714,39 @@ class LikesRepository {
         return placeholderId;
       }
 
-      // Ask the relay first whether this account already holds a live `+` on
-      // the target only while the startup snapshot is still resolving or was
-      // incomplete. A complete snapshot keeps ordinary likes off this relay
-      // read path; replay retains its own check below because a publish may
-      // have landed after the snapshot without its OK reaching the client.
-      // The placeholder is already indexed, so a second tap inside either
-      // round-trip still trips the check above.
+      // Join the startup snapshot, then adopt any live `+` it or the live
+      // subscription already indexed for the target or its coordinate. Only
+      // an incomplete snapshot — timed out, capped, relay-less, failed, or
+      // never run — still sends this tap to the relay for the target itself;
+      // a complete one keeps ordinary likes off that read path. Replay keeps
+      // its own relay check because a publish may have landed after the
+      // snapshot without its OK reaching the client. The placeholder is
+      // already indexed, so a second tap inside either wait still trips the
+      // check above.
       _inFlightLikePublishPlaceholders.add(placeholderId);
       await _startupReconciliationFuture;
-      final reconciledRecord =
-          _likeRecords[eventId] ??
-          (addressableId == null
+      final liveRecord =
+          _reconciledLikeRecord(eventId, addressableId: addressableId) ??
+          (_hasCompleteRelayReactionSnapshot
               ? null
-              : _likeRecordsByAddressableId[addressableId]);
-      final remoteRecord =
-          reconciledRecord != null &&
-              !_isPlaceholderId(reconciledRecord.reactionEventId)
-          ? reconciledRecord
-          : !_hasCompleteRelayReactionSnapshot
-          ? await _resolveRemoteLikeRecordOrNull(
-              eventId,
-              addressableId: addressableId,
-            )
-          : null;
-      if (remoteRecord != null) {
+              : await _resolveRemoteLikeRecordOrNull(
+                  eventId,
+                  addressableId: addressableId,
+                ));
+      if (liveRecord != null) {
         _inFlightLikePublishPlaceholders.remove(placeholderId);
         if (_unlikeRequestedWhilePending.remove(placeholderId)) {
           // The like the user just took back is the relay's existing one.
           await _retractLikeUnlikedMidPublish(
-            confirmed: remoteRecord,
+            confirmed: liveRecord,
             restoredCount: previousCount,
             countEventId: eventId,
             countAddressableId: addressableId,
           );
-          return remoteRecord.reactionEventId;
+          return liveRecord.reactionEventId;
         }
         await _adoptRemoteLikeRecord(
-          remoteRecord,
+          liveRecord,
           site: LikesRepositoryReportableSites.likeEventSaveAdopted,
         );
         // The relay's reaction is already inside the count the UI shows.
@@ -2990,6 +2985,43 @@ class LikesRepository {
   /// empty form.
   static bool _isLikeReaction(Event event) =>
       event.content == _likeContent || event.content.isEmpty;
+
+  /// The live reaction that startup reconciliation or the live subscription
+  /// has already indexed for [eventId] or its coordinate, shaped exactly as
+  /// [_resolveRemoteLikeRecord] would return it: keyed under [eventId], so
+  /// the caller's later unlike resolves it, and carrying [addressableId] when
+  /// the reaction itself has no `a` tag, so adopting it evicts this tap's
+  /// placeholder from the coordinate index too.
+  ///
+  /// The event-id slot holds this tap's own placeholder and so cannot answer
+  /// alone: a like cast on a superseded revision is filed under that
+  /// revision's id, and only the coordinate reveals it. Returns `null` when
+  /// neither slot names a reaction that reached a relay.
+  LikeRecord? _reconciledLikeRecord(
+    String eventId, {
+    required String? addressableId,
+  }) {
+    final hasCoordinate = addressableId != null && addressableId.isNotEmpty;
+    final byEventId = _likeRecords[eventId];
+    final indexed =
+        byEventId != null && !_isPlaceholderId(byEventId.reactionEventId)
+        ? byEventId
+        : hasCoordinate
+        ? _likeRecordsByAddressableId[addressableId]
+        : null;
+    if (indexed == null || _isPlaceholderId(indexed.reactionEventId)) {
+      return null;
+    }
+    final indexedCoordinate = indexed.addressableId;
+    return LikeRecord(
+      targetEventId: eventId,
+      reactionEventId: indexed.reactionEventId,
+      createdAt: indexed.createdAt,
+      addressableId: indexedCoordinate != null && indexedCoordinate.isNotEmpty
+          ? indexedCoordinate
+          : addressableId,
+    );
+  }
 
   /// Indexes and persists a reaction the relay already holds for this
   /// account, so local state reflects it instead of minting a second one.

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -724,7 +724,7 @@ class LikesRepository {
       // already indexed, so a second tap inside either wait still trips the
       // check above.
       _inFlightLikePublishPlaceholders.add(placeholderId);
-      await _startupReconciliationFuture;
+      await _joinStartupReconciliation();
       final liveRecord =
           _reconciledLikeRecord(eventId, addressableId: addressableId) ??
           (_hasCompleteRelayReactionSnapshot
@@ -3087,6 +3087,28 @@ class LikesRepository {
       description: 'saving a reaction adopted from the relay',
       site: site,
     );
+  }
+
+  /// Awaits the startup reconciliation attempt without adopting its failure.
+  ///
+  /// Reconciliation is best-effort. [initialize] reports a failure to its own
+  /// caller, but a like that merely joined the attempt must not fail with it:
+  /// the optimistic heart is already filled and this path has published
+  /// nothing to roll back or queue. The snapshot stays marked incomplete, so
+  /// the target-specific relay check still guards the publish that follows.
+  Future<void> _joinStartupReconciliation() async {
+    final inFlight = _startupReconciliationFuture;
+    if (inFlight == null) return;
+    try {
+      await inFlight;
+    } on Object catch (e) {
+      Log.warning(
+        'Startup reaction reconciliation failed; this like falls back to its '
+        'target-specific relay check: $e',
+        name: 'LikesRepository',
+        category: LogCategory.relay,
+      );
+    }
   }
 
   /// [_resolveRemoteLikeRecord] that fails open.

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -968,17 +968,25 @@ class LikesRepository {
     }
 
     // The relay echoes a stored reaction on this account's own subscription
-    // within milliseconds, so the echo can re-index the reaction between the
-    // unlike and this retraction. It is retracted now; a record naming it
-    // would read as liked for a like the user already took back.
-    final echoed = _likeRecords[confirmed.targetEventId];
-    if (echoed?.reactionEventId != confirmed.reactionEventId) return;
-    _deindexLikeRecord(confirmed.targetEventId);
-    await _bestEffortLocalStorage(
-      () async => _localStorage?.deleteLikeRecord(confirmed.targetEventId),
-      description: 'dropping a retracted reaction the subscription re-indexed',
-      site: LikesRepositoryReportableSites.retractLikeDeleteEchoedRecord,
-    );
+    // within milliseconds, and the startup snapshot can land in the same
+    // window, so the reaction may have been re-indexed between the unlike
+    // and this retraction — under the tapped target, or under the superseded
+    // revision its own `e` tag names. It is retracted now; any record naming
+    // it would read as liked for a like the user already took back.
+    final staleTargetIds = [
+      for (final record in _likeRecords.values)
+        if (record.reactionEventId == confirmed.reactionEventId)
+          record.targetEventId,
+    ];
+    if (staleTargetIds.isEmpty) return;
+    for (final targetId in staleTargetIds) {
+      _deindexLikeRecord(targetId);
+      await _bestEffortLocalStorage(
+        () async => _localStorage?.deleteLikeRecord(targetId),
+        description: 'dropping a retracted reaction that was re-indexed',
+        site: LikesRepositoryReportableSites.retractLikeDeleteEchoedRecord,
+      );
+    }
     _emitLikedIds();
   }
 

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -2154,7 +2154,14 @@ class LikesRepository {
 
       for (final event in reactionEvents) {
         final targetId = _extractTargetEventId(event);
-        if (targetId == null) continue;
+        if (targetId == null) {
+          // The global snapshot has no current target-id context with which to
+          // index an `a`-only reaction. It may still match a later tap's known
+          // coordinate, so this snapshot cannot license skipping that tap's
+          // target-specific query.
+          _hasCompleteRelayReactionSnapshot = false;
+          continue;
+        }
 
         // Skip reactions that have been deleted
         if (deletedReactionIds.contains(event.id)) {
@@ -2635,9 +2642,22 @@ class LikesRepository {
     if (inFlight != null) return inFlight;
     if (_isInitialized) return Future.value();
 
-    final initialization = _initialize();
+    final initialization = _initializeWithFailureReset();
     _startupReconciliationFuture = initialization;
     return initialization;
+  }
+
+  Future<void> _initializeWithFailureReset() async {
+    try {
+      await _initialize();
+    } on Object {
+      // A failed attempt must not poison every later like with the same cached
+      // rejected future. A failure before initialization remains retryable;
+      // one after the local cache/subscription are ready leaves later likes on
+      // their target-specific relay safety check.
+      _startupReconciliationFuture = null;
+      rethrow;
+    }
   }
 
   Future<void> _initialize() async {
@@ -2755,9 +2775,15 @@ class LikesRepository {
       );
       _emitLikedIds();
     } else if (event.content == _downvoteContent) {
-      // Deduplicate downvotes (in-memory only — no local persistence in v1)
+      // Mirror the like placeholder exemption above. A relay echo has
+      // whole-second precision and otherwise loses to the optimistic record
+      // stamped later within that same second, leaving no real id for Kind 5.
       final existing = _downvoteRecords[targetId];
-      if (existing != null && !createdAt.isAfter(existing.createdAt)) return;
+      if (existing != null &&
+          !_isPlaceholderId(existing.reactionEventId) &&
+          !createdAt.isAfter(existing.createdAt)) {
+        return;
+      }
 
       _indexDownvoteRecord(
         LikeRecord(
@@ -3041,6 +3067,20 @@ class LikesRepository {
     LikeRecord record, {
     required String site,
   }) async {
+    final aliasedTargetIds = [
+      for (final indexed in _likeRecords.values)
+        if (indexed.reactionEventId == record.reactionEventId &&
+            indexed.targetEventId != record.targetEventId)
+          indexed.targetEventId,
+    ];
+    for (final targetId in aliasedTargetIds) {
+      _deindexLikeRecord(targetId);
+      await _bestEffortLocalStorage(
+        () async => _localStorage?.deleteLikeRecord(targetId),
+        description: 'dropping an alias of an adopted relay reaction',
+        site: LikesRepositoryReportableSites.adoptRemoteLikeDeleteAlias,
+      );
+    }
     _indexLikeRecord(record);
     await _bestEffortLocalStorage(
       () async => _localStorage?.saveLikeRecord(record),
@@ -3105,7 +3145,8 @@ class LikesRepository {
   }) => _resolveRemoteReactionRecord(
     eventId,
     addressableId: addressableId,
-    isMatch: (event, _) => event.content == _downvoteContent,
+    isMatch: (event, pubkey) =>
+        event.pubkey == pubkey && event.content == _downvoteContent,
   );
 
   /// Resolves the newest still-live kind-7 reaction the current user has

--- a/mobile/packages/likes_repository/lib/src/likes_repository_reportable_sites.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository_reportable_sites.dart
@@ -74,6 +74,11 @@ abstract class LikesRepositoryReportableSites {
   static const String executeLikeActionSaveAdopted =
       'executeLikeAction.saveAdopted';
 
+  /// `_adoptRemoteLikeRecord`: deleting a second local row that names the
+  /// same adopted relay reaction under a superseded target id threw.
+  static const String adoptRemoteLikeDeleteAlias =
+      'adoptRemoteLike.deleteAlias';
+
   /// `_retractLikeUnlikedMidPublish`: dropping a retracted reaction that the
   /// live subscription or the startup snapshot had re-indexed (#7001) threw.
   static const String retractLikeDeleteEchoedRecord =

--- a/mobile/packages/likes_repository/lib/src/likes_repository_reportable_sites.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository_reportable_sites.dart
@@ -64,4 +64,18 @@ abstract class LikesRepositoryReportableSites {
   /// live cross-device subscription threw.
   static const String processIncomingReactionSaveRecord =
       'processIncomingReaction.saveRecord';
+
+  /// `likeEvent`: persisting a reaction adopted from the relay — this account
+  /// already had a live `+` on the target (#7001) — threw.
+  static const String likeEventSaveAdopted = 'likeEvent.saveAdopted';
+
+  /// `executeLikeAction`: persisting a reaction adopted from the relay on
+  /// replay (#7001) threw.
+  static const String executeLikeActionSaveAdopted =
+      'executeLikeAction.saveAdopted';
+
+  /// `_retractLikeUnlikedMidPublish`: dropping a retracted reaction that the
+  /// live subscription had re-indexed (#7001) threw.
+  static const String retractLikeDeleteEchoedRecord =
+      'retractLike.deleteEchoedRecord';
 }

--- a/mobile/packages/likes_repository/lib/src/likes_repository_reportable_sites.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository_reportable_sites.dart
@@ -75,7 +75,7 @@ abstract class LikesRepositoryReportableSites {
       'executeLikeAction.saveAdopted';
 
   /// `_retractLikeUnlikedMidPublish`: dropping a retracted reaction that the
-  /// live subscription had re-indexed (#7001) threw.
+  /// live subscription or the startup snapshot had re-indexed (#7001) threw.
   static const String retractLikeDeleteEchoedRecord =
       'retractLike.deleteEchoedRecord';
 }

--- a/mobile/packages/likes_repository/test/src/likes_repository_pre_column_db_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_pre_column_db_test.dart
@@ -112,9 +112,18 @@ void main() {
         // the same-id backfill exemption can re-derive the coordinate.
         final client = createClient();
         var queryCall = 0;
-        when(() => client.queryEvents(any())).thenAnswer((_) async {
+        when(
+          () => client.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer((_) async {
           queryCall++;
-          return queryCall == 1 ? [createReaction()] : <Event>[];
+          return (
+            events: queryCall == 1 ? [createReaction()] : <Event>[],
+            timedOut: false,
+            noRelays: false,
+          );
         });
         final repository = LikesRepository(
           nostrClient: client,
@@ -143,12 +152,15 @@ void main() {
         expect(persisted, isNotNull);
         expect(persisted!.targetEventId, equals(oldEditEventId));
 
-        // 4. Offline restart over the same database: every row now has a
-        // coordinate, so initialize() skips the backfill sync entirely and
-        // the edited video still resolves as liked with no relay access.
+        // 4. Offline restart over the same database: startup reconciliation
+        // fails open, and the persisted coordinate still resolves without
+        // making ordinary local state depend on relay availability.
         final offlineClient = createClient();
         when(
-          () => offlineClient.queryEvents(any()),
+          () => offlineClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
         ).thenThrow(Exception('offline'));
         final restarted = LikesRepository(
           nostrClient: offlineClient,
@@ -166,7 +178,12 @@ void main() {
           ),
           isTrue,
         );
-        verifyNever(() => offlineClient.queryEvents(any()));
+        verify(
+          () => offlineClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).called(1);
         restarted.dispose();
       },
     );

--- a/mobile/packages/likes_repository/test/src/likes_repository_repeat_publish_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_repeat_publish_test.dart
@@ -790,6 +790,41 @@ void main() {
           expect(await repository.isLikedByCoordinate(coordinate), isFalse);
         },
       );
+
+      test(
+        'settles the count where it started when the reaction this tap '
+        'published is retracted mid-publish',
+        () async {
+          // Unlike the adopted-reaction case above, the retracted reaction
+          // was never inside the count the UI showed before the tap.
+          when(
+            () => nostrClient.countEvents(any()),
+          ).thenAnswer((_) async => const CountResult(count: 10));
+          expect(await repository.getLikeCount(target), equals(10));
+          stubRelay();
+          final publishGate = Completer<Event?>();
+          stubSendLike(() => publishGate.future);
+          when(
+            () => nostrClient.deleteEvent(freshReactionId),
+          ).thenAnswer((_) async => _MockEvent());
+
+          final inFlight = repository.likeEvent(
+            eventId: target,
+            authorPubkey: author,
+          );
+          await Future<void>.delayed(Duration.zero);
+          expect(await repository.getLikeCount(target), equals(11));
+          await repository.unlikeEvent(target);
+          expect(await repository.getLikeCount(target), equals(10));
+
+          publishGate.complete(reaction(id: freshReactionId));
+          expect(await inFlight, equals(freshReactionId));
+
+          verify(() => nostrClient.deleteEvent(freshReactionId)).called(1);
+          expect(await repository.isLiked(target), isFalse);
+          expect(await repository.getLikeCount(target), equals(10));
+        },
+      );
     });
 
     group('live subscription', () {

--- a/mobile/packages/likes_repository/test/src/likes_repository_repeat_publish_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_repeat_publish_test.dart
@@ -110,6 +110,7 @@ void main() {
       List<Event> reactions = const [],
       List<Event> deletions = const [],
       bool timedOut = false,
+      bool noRelays = false,
     }) {
       when(
         () => nostrClient.queryEventsDetailed(
@@ -122,7 +123,7 @@ void main() {
         return (
           events: kinds.contains(EventKind.reaction) ? reactions : deletions,
           timedOut: timedOut,
-          noRelays: false,
+          noRelays: noRelays,
         );
       });
     }
@@ -434,6 +435,24 @@ void main() {
         expect(resolved, equals(freshReactionId));
         expectPublishedOnce();
       });
+
+      test("ignores another account's downvote during adoption", () async {
+        stubRelay(
+          reactions: [
+            reaction(id: landedReactionId, content: '-', pubkey: otherUser),
+          ],
+        );
+        stubSendLike(() async => reaction(id: freshReactionId, content: '-'));
+
+        final resolved = await repository.downvoteEvent(
+          eventId: target,
+          authorPubkey: author,
+          addressableId: coordinate,
+        );
+
+        expect(resolved, equals(freshReactionId));
+        expectPublishedOnce();
+      });
     });
 
     group('likeEvent', () {
@@ -588,6 +607,83 @@ void main() {
 
           verify(() => nostrClient.queryEvents(any())).called(1);
           expectPublishedOnce();
+        },
+      );
+
+      test(
+        'retains the target lookup when startup sees no relays',
+        () async {
+          stubCompleteRelaySnapshot(noRelays: true);
+          await repository.initialize();
+          clearInteractions(nostrClient);
+          stubRelay();
+          stubSendLike(() async => reaction(id: freshReactionId));
+
+          expect(
+            await repository.likeEvent(eventId: target, authorPubkey: author),
+            equals(freshReactionId),
+          );
+
+          verify(() => nostrClient.queryEvents(any())).called(1);
+          expectPublishedOnce();
+        },
+      );
+
+      test(
+        'retains the target lookup when startup reaches the reaction cap',
+        () async {
+          final cappedReactions = List<Event>.generate(
+            500,
+            (index) => reaction(
+              id: 'capped_reaction_$index',
+              tags: [
+                ['e', 'capped_target_$index'],
+              ],
+            ),
+          );
+          stubCompleteRelaySnapshot(reactions: cappedReactions);
+          await repository.initialize();
+          clearInteractions(nostrClient);
+          stubRelay();
+          stubSendLike(() async => reaction(id: freshReactionId));
+
+          expect(
+            await repository.likeEvent(eventId: target, authorPubkey: author),
+            equals(freshReactionId),
+          );
+
+          verify(() => nostrClient.queryEvents(any())).called(1);
+          expectPublishedOnce();
+        },
+      );
+
+      test(
+        'retains the target lookup when startup cannot index an a-only like',
+        () async {
+          final coordinateOnlyReaction = reaction(
+            id: landedReactionId,
+            tags: [
+              ['a', coordinate],
+            ],
+          );
+          stubCompleteRelaySnapshot(reactions: [coordinateOnlyReaction]);
+          await repository.initialize();
+          clearInteractions(nostrClient);
+          stubRelay(reactions: [coordinateOnlyReaction]);
+
+          await expectLater(
+            repository.likeEvent(
+              eventId: target,
+              authorPubkey: author,
+              addressableId: coordinate,
+            ),
+            throwsA(isA<AlreadyLikedException>()),
+          );
+
+          // The target resolver queries by event id and coordinate, then
+          // checks candidate reaction ids for deletions.
+          verify(() => nostrClient.queryEvents(any())).called(3);
+          expectNoPublish();
         },
       );
 
@@ -753,7 +849,9 @@ void main() {
           // publishes the Kind 5 instead of discarding a placeholder.
           await repository.unlikeEvent(target, addressableId: coordinate);
           verify(() => nostrClient.deleteEvent(landedReactionId)).called(1);
+          expect(await repository.isLiked(editedTarget), isFalse);
           expect(await repository.isLikedByCoordinate(coordinate), isFalse);
+          verify(() => storage.deleteLikeRecord(editedTarget)).called(1);
         },
       );
 
@@ -958,6 +1056,65 @@ void main() {
           verify(() => storage.deleteLikeRecord(target)).called(2);
         },
       );
+
+      test(
+        'upgrades a same-second downvote placeholder before removal',
+        () async {
+          final live = StreamController<Event>.broadcast();
+          addTearDown(live.close);
+          when(
+            () => nostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => live.stream);
+          stubCompleteRelaySnapshot();
+          final publishGate = Completer<Event?>();
+          stubSendLike(() => publishGate.future);
+          when(
+            () => nostrClient.deleteEvent(landedReactionId),
+          ).thenAnswer((_) async => _MockEvent());
+          await repository.initialize();
+
+          final inFlight = repository.downvoteEvent(
+            eventId: target,
+            authorPubkey: author,
+          );
+          await Future<void>.delayed(Duration.zero);
+          final sameSecond = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          live.add(
+            reaction(
+              id: landedReactionId,
+              content: '-',
+              createdAt: sameSecond,
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          await repository.removeDownvote(target);
+          verify(() => nostrClient.deleteEvent(landedReactionId)).called(1);
+
+          publishGate.completeError(Exception('publish acknowledgement lost'));
+          await expectLater(inFlight, throwsException);
+        },
+      );
+    });
+
+    test('a failed initialization can be retried', () async {
+      var attempts = 0;
+      when(() => nostrClient.resolvePublicKey()).thenAnswer((_) async {
+        attempts++;
+        if (attempts == 1) throw StateError('signer failed once');
+        return user;
+      });
+
+      await expectLater(repository.initialize(), throwsA(isA<StateError>()));
+
+      stubCompleteRelaySnapshot();
+      await repository.initialize();
+      // The retry resolves once for subscription setup and once for the
+      // author-scoped startup snapshot.
+      expect(attempts, equals(3));
     });
   });
 }

--- a/mobile/packages/likes_repository/test/src/likes_repository_repeat_publish_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_repeat_publish_test.dart
@@ -15,6 +15,27 @@ class _MockLikesLocalStorage extends Mock implements LikesLocalStorage {}
 
 class _MockEvent extends Mock implements Event {}
 
+typedef _RelaySnapshot = ({List<Event> events, bool timedOut, bool noRelays});
+
+/// Holds the startup relay snapshot open so a tap can race it.
+class _GatedRelaySnapshot {
+  final reactions = Completer<_RelaySnapshot>();
+  final deletions = Completer<_RelaySnapshot>();
+
+  /// Lets reconciliation land as a complete, uncapped snapshot.
+  void land({
+    List<Event> reactions = const [],
+    List<Event> deletions = const [],
+  }) {
+    this.reactions.complete(
+      (events: reactions, timedOut: false, noRelays: false),
+    );
+    this.deletions.complete(
+      (events: deletions, timedOut: false, noRelays: false),
+    );
+  }
+}
+
 void main() {
   group('LikesRepository repeat-publish guards (#7001)', () {
     late _MockNostrClient nostrClient;
@@ -104,6 +125,25 @@ void main() {
           noRelays: false,
         );
       });
+    }
+
+    /// Like [stubCompleteRelaySnapshot], but the answer waits for
+    /// [_GatedRelaySnapshot.land] so a tap can be interleaved with startup.
+    _GatedRelaySnapshot gateRelaySnapshot() {
+      final gate = _GatedRelaySnapshot();
+      when(
+        () => nostrClient.queryEventsDetailed(
+          any(),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        ),
+      ).thenAnswer((invocation) {
+        final filters = invocation.positionalArguments.first as List<Filter>;
+        final kinds = filters.first.kinds ?? const <int>[];
+        return kinds.contains(EventKind.reaction)
+            ? gate.reactions.future
+            : gate.deletions.future;
+      });
+      return gate;
     }
 
     void stubSendLike(Future<Event?> Function() answer) {
@@ -554,23 +594,7 @@ void main() {
       test(
         'joins startup reconciliation and adopts its reaction during a tap',
         () async {
-          final reactionsGate =
-              Completer<({List<Event> events, bool timedOut, bool noRelays})>();
-          final deletionsGate =
-              Completer<({List<Event> events, bool timedOut, bool noRelays})>();
-          when(
-            () => nostrClient.queryEventsDetailed(
-              any(),
-              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
-            ),
-          ).thenAnswer((invocation) {
-            final filters =
-                invocation.positionalArguments.first as List<Filter>;
-            final kinds = filters.first.kinds ?? const <int>[];
-            return kinds.contains(EventKind.reaction)
-                ? reactionsGate.future
-                : deletionsGate.future;
-          });
+          final gate = gateRelaySnapshot();
 
           final initialization = repository.initialize();
           await Future<void>.delayed(Duration.zero);
@@ -579,17 +603,7 @@ void main() {
             authorPubkey: author,
           );
           await Future<void>.delayed(Duration.zero);
-
-          reactionsGate.complete((
-            events: [reaction(id: landedReactionId)],
-            timedOut: false,
-            noRelays: false,
-          ));
-          deletionsGate.complete((
-            events: <Event>[],
-            timedOut: false,
-            noRelays: false,
-          ));
+          gate.land(reactions: [reaction(id: landedReactionId)]);
           await initialization;
 
           await expectLater(like, throwsA(isA<AlreadyLikedException>()));
@@ -694,6 +708,86 @@ void main() {
           expectNoPublish();
           expect(await repository.isLiked(target), isFalse);
           expect(await repository.getLikeCount(target), equals(9));
+        },
+      );
+
+      test(
+        'joins startup reconciliation and adopts the reaction it filed under '
+        'a superseded revision of the tapped coordinate',
+        () async {
+          // The snapshot files the like under its own `e` target — the
+          // revision that was current when it was cast — and under the
+          // coordinate. The tapped event id holds only this tap's
+          // placeholder, so the coordinate is the one place the like shows.
+          final gate = gateRelaySnapshot();
+          stubSendLike(() async => reaction(id: freshReactionId));
+          when(
+            () => nostrClient.deleteEvent(landedReactionId),
+          ).thenAnswer((_) async => _MockEvent());
+
+          final initialization = repository.initialize();
+          await Future<void>.delayed(Duration.zero);
+          final like = repository.likeEvent(
+            eventId: target,
+            authorPubkey: author,
+            addressableId: coordinate,
+          );
+          await Future<void>.delayed(Duration.zero);
+          gate.land(
+            reactions: [
+              reaction(
+                id: landedReactionId,
+                tags: [
+                  ['e', editedTarget],
+                  ['a', coordinate],
+                ],
+              ),
+            ],
+          );
+          await initialization;
+
+          await expectLater(like, throwsA(isA<AlreadyLikedException>()));
+          expectNoPublish();
+
+          // The adopted reaction answers the tapped target, so unliking it
+          // publishes the Kind 5 instead of discarding a placeholder.
+          await repository.unlikeEvent(target, addressableId: coordinate);
+          verify(() => nostrClient.deleteEvent(landedReactionId)).called(1);
+          expect(await repository.isLikedByCoordinate(coordinate), isFalse);
+        },
+      );
+
+      test(
+        'joins startup reconciliation and keeps its coordinate-less reaction '
+        'resolvable by the tapped coordinate',
+        () async {
+          // An older reaction carries only an `e` tag. Adopted as-is it
+          // would leave this tap's placeholder in the coordinate index, so
+          // the heart stays filled after the unlike that retracts it.
+          final gate = gateRelaySnapshot();
+          stubSendLike(() async => reaction(id: freshReactionId));
+          when(
+            () => nostrClient.deleteEvent(landedReactionId),
+          ).thenAnswer((_) async => _MockEvent());
+
+          final initialization = repository.initialize();
+          await Future<void>.delayed(Duration.zero);
+          final like = repository.likeEvent(
+            eventId: target,
+            authorPubkey: author,
+            addressableId: coordinate,
+          );
+          await Future<void>.delayed(Duration.zero);
+          gate.land(reactions: [reaction(id: landedReactionId)]);
+          await initialization;
+
+          await expectLater(like, throwsA(isA<AlreadyLikedException>()));
+          expectNoPublish();
+
+          await repository.unlikeEvent(target, addressableId: coordinate);
+          verify(() => nostrClient.deleteEvent(landedReactionId)).called(1);
+          expect(await repository.isLiked(target), isFalse);
+          expect(await repository.isLikedByCoordinate(coordinate), isFalse);
         },
       );
     });

--- a/mobile/packages/likes_repository/test/src/likes_repository_repeat_publish_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_repeat_publish_test.dart
@@ -1100,6 +1100,42 @@ void main() {
       );
     });
 
+    test(
+      'a like that joined a failing initialization still publishes',
+      () async {
+        // Startup reconciliation is best-effort, and a tap that joined the
+        // attempt must not surface its failure as a failed like: the
+        // optimistic heart is already filled and the queue never sees the
+        // action. The snapshot stays incomplete, so the target-specific
+        // safety check still guards the publish.
+        stubStorageWrites();
+        final signerGate = Completer<String?>();
+        when(
+          () => nostrClient.resolvePublicKey(),
+        ).thenAnswer((_) => signerGate.future);
+        stubRelay();
+        stubSendLike(() async => reaction(id: freshReactionId));
+
+        final initialization = repository.initialize();
+        await Future<void>.delayed(Duration.zero);
+        final like = repository.likeEvent(
+          eventId: target,
+          authorPubkey: author,
+        );
+        final published = expectLater(
+          like,
+          completion(equals(freshReactionId)),
+        );
+        final failed = expectLater(initialization, throwsA(isA<StateError>()));
+        await Future<void>.delayed(Duration.zero);
+        signerGate.completeError(StateError('signer failed'));
+
+        await failed;
+        await published;
+        expectPublishedOnce();
+      },
+    );
+
     test('a failed initialization can be retried', () async {
       var attempts = 0;
       when(() => nostrClient.resolvePublicKey()).thenAnswer((_) async {

--- a/mobile/packages/likes_repository/test/src/likes_repository_repeat_publish_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_repeat_publish_test.dart
@@ -1,0 +1,619 @@
+// ABOUTME: Regression tests for #7001 — one account must never publish a
+// ABOUTME: second live `+` on a target it already reacted to, on any path.
+
+import 'dart:async';
+
+import 'package:likes_repository/likes_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:test/test.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockLikesLocalStorage extends Mock implements LikesLocalStorage {}
+
+class _MockEvent extends Mock implements Event {}
+
+void main() {
+  group('LikesRepository repeat-publish guards (#7001)', () {
+    late _MockNostrClient nostrClient;
+    late _MockLikesLocalStorage storage;
+    late LikesRepository repository;
+
+    const user = 'repeat_like_user_pubkey_1234567890abcdef1234567890abcdef';
+    const otherUser = 'repeat_like_other_pubkey_1234567890abcdef1234567890abcd';
+    const author = 'repeat_like_author_pubkey_1234567890abcdef1234567890abcde';
+    const target = 'repeat_like_target_event_id_1234567890abcdef1234567890abc';
+    const editedTarget =
+        'repeat_like_edited_target_id_1234567890abcdef1234567890ab';
+    const coordinate = '34236:$author:repeat-like-d-tag';
+    const landedReactionId =
+        'repeat_like_landed_reaction_1234567890abcdef1234567890abcd';
+    const freshReactionId =
+        'repeat_like_fresh_reaction_1234567890abcdef1234567890abcde';
+
+    _MockEvent reaction({
+      required String id,
+      String content = '+',
+      String pubkey = user,
+      int createdAt = 1700000000,
+      List<List<String>>? tags,
+    }) {
+      final event = _MockEvent();
+      when(() => event.id).thenReturn(id);
+      when(() => event.pubkey).thenReturn(pubkey);
+      when(() => event.kind).thenReturn(EventKind.reaction);
+      when(() => event.content).thenReturn(content);
+      when(() => event.createdAt).thenReturn(createdAt);
+      when(() => event.tags).thenReturn(
+        tags ??
+            [
+              ['e', target],
+            ],
+      );
+      return event;
+    }
+
+    _MockEvent deletion(List<String> reactionIds, {String pubkey = user}) {
+      final event = _MockEvent();
+      when(() => event.id).thenReturn('deletion_of_${reactionIds.join('_')}');
+      when(() => event.pubkey).thenReturn(pubkey);
+      when(() => event.kind).thenReturn(EventKind.eventDeletion);
+      when(() => event.content).thenReturn('');
+      when(() => event.createdAt).thenReturn(1700000001);
+      when(
+        () => event.tags,
+      ).thenReturn([
+        for (final id in reactionIds) ['e', id],
+      ]);
+      return event;
+    }
+
+    /// Answers reaction queries with [reactions] and deletion queries with
+    /// [deletions], whatever order the repository issues them in.
+    void stubRelay({
+      List<Event> reactions = const [],
+      List<Event> deletions = const [],
+    }) {
+      when(() => nostrClient.queryEvents(any())).thenAnswer((invocation) async {
+        final filters = invocation.positionalArguments.first as List<Filter>;
+        final kinds = filters.first.kinds ?? const <int>[];
+        if (kinds.contains(EventKind.reaction)) return reactions;
+        if (kinds.contains(EventKind.eventDeletion)) return deletions;
+        return const <Event>[];
+      });
+    }
+
+    void stubSendLike(Future<Event?> Function() answer) {
+      when(
+        () => nostrClient.sendLike(
+          any(),
+          content: any(named: 'content'),
+          addressableId: any(named: 'addressableId'),
+          targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+          targetKind: any(named: 'targetKind'),
+        ),
+      ).thenAnswer((_) => answer());
+    }
+
+    void expectNoPublish() {
+      verifyNever(
+        () => nostrClient.sendLike(
+          any(),
+          content: any(named: 'content'),
+          addressableId: any(named: 'addressableId'),
+          targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+          targetKind: any(named: 'targetKind'),
+        ),
+      );
+    }
+
+    void expectPublishedOnce() {
+      verify(
+        () => nostrClient.sendLike(
+          target,
+          content: any(named: 'content'),
+          addressableId: any(named: 'addressableId'),
+          targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+          targetKind: any(named: 'targetKind'),
+        ),
+      ).called(1);
+    }
+
+    LikeRecord placeholderRecord() => LikeRecord(
+      targetEventId: target,
+      reactionEventId: 'pending_like_1_$target',
+      createdAt: DateTime.now(),
+      addressableId: coordinate,
+    );
+
+    /// Every group writes through the store; declared per group so the stubs
+    /// sit next to the tests that depend on them.
+    void stubStorageWrites() {
+      when(() => storage.saveLikeRecord(any())).thenAnswer((_) async {});
+      when(
+        () => storage.deleteLikeRecord(any()),
+      ).thenAnswer((_) async => true);
+    }
+
+    setUpAll(() {
+      registerFallbackValue(_MockEvent());
+      registerFallbackValue(<Filter>[]);
+      registerFallbackValue(
+        LikeRecord(
+          targetEventId: 'fallback',
+          reactionEventId: 'fallback',
+          createdAt: DateTime.now(),
+        ),
+      );
+    });
+
+    setUp(() {
+      nostrClient = _MockNostrClient();
+      storage = _MockLikesLocalStorage();
+      when(() => nostrClient.publicKey).thenReturn(user);
+      when(() => nostrClient.resolvePublicKey()).thenAnswer((_) async => user);
+      when(() => nostrClient.hasKeys).thenReturn(true);
+      when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
+      when(
+        () => nostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+        ),
+      ).thenAnswer((_) => const Stream<Event>.empty());
+      when(() => storage.getAllLikeRecords()).thenAnswer((_) async => []);
+      when(() => storage.isLiked(any())).thenAnswer((_) async => false);
+      when(() => storage.getLikeRecord(any())).thenAnswer((_) async => null);
+      when(
+        () => storage.getLikeRecordByAddressableId(any()),
+      ).thenAnswer((_) async => null);
+      repository = LikesRepository(
+        nostrClient: nostrClient,
+        localStorage: storage,
+        isOnline: () => true,
+        queueOfflineAction:
+            ({
+              required isLike,
+              required eventId,
+              required authorPubkey,
+              addressableId,
+              targetKind,
+            }) async {},
+      );
+    });
+
+    tearDown(() => repository.dispose());
+
+    group('executeLikeAction', () {
+      setUp(stubStorageWrites);
+
+      test(
+        'does not publish again when the record already holds a real '
+        'reaction id',
+        () async {
+          // The replay row outlives the reaction it was queued for: the
+          // original publish landed (the live subscription or a confirmed
+          // swap upgraded the record) while the pending row still says
+          // "retry". Publishing again mints a second live `+`.
+          when(() => storage.getAllLikeRecords()).thenAnswer(
+            (_) async => [
+              LikeRecord(
+                targetEventId: target,
+                reactionEventId: landedReactionId,
+                createdAt: DateTime.now(),
+                addressableId: coordinate,
+              ),
+            ],
+          );
+          stubRelay();
+
+          final resolved = await repository.executeLikeAction(
+            eventId: target,
+            authorPubkey: author,
+            addressableId: coordinate,
+          );
+
+          expect(resolved, equals(landedReactionId));
+          expectNoPublish();
+        },
+      );
+
+      test(
+        'adopts the reaction the relay already holds instead of '
+        'republishing a placeholder',
+        () async {
+          // A publish can land without the OK ever reaching the client —
+          // the frame is queued and replayed on reconnect, or the OK is
+          // simply late. The client reports failure, queues a retry, and
+          // the retry finds only its own placeholder locally.
+          when(
+            () => storage.getAllLikeRecords(),
+          ).thenAnswer((_) async => [placeholderRecord()]);
+          stubRelay(
+            reactions: [
+              reaction(
+                id: landedReactionId,
+                tags: [
+                  ['e', target],
+                  ['a', coordinate],
+                ],
+              ),
+            ],
+          );
+
+          final resolved = await repository.executeLikeAction(
+            eventId: target,
+            authorPubkey: author,
+            addressableId: coordinate,
+          );
+
+          expect(resolved, equals(landedReactionId));
+          expectNoPublish();
+          final record = await repository.getLikeRecord(target);
+          expect(record?.reactionEventId, equals(landedReactionId));
+          verify(
+            () => storage.saveLikeRecord(
+              any(
+                that: isA<LikeRecord>().having(
+                  (r) => r.reactionEventId,
+                  'reactionEventId',
+                  landedReactionId,
+                ),
+              ),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'adopts a coordinate-tagged reaction cast on a superseded revision',
+        () async {
+          // NIP-25: an addressable target's reaction carries the `a`
+          // coordinate alongside `e`. After an edit the `e` tag points at
+          // the old revision, so only the coordinate can find it.
+          when(
+            () => storage.getAllLikeRecords(),
+          ).thenAnswer(
+            (_) async => [
+              LikeRecord(
+                targetEventId: editedTarget,
+                reactionEventId: 'pending_like_2_$editedTarget',
+                createdAt: DateTime.now(),
+                addressableId: coordinate,
+              ),
+            ],
+          );
+          stubRelay(
+            reactions: [
+              reaction(
+                id: landedReactionId,
+                tags: [
+                  ['e', target],
+                  ['a', coordinate],
+                ],
+              ),
+            ],
+          );
+
+          final resolved = await repository.executeLikeAction(
+            eventId: editedTarget,
+            authorPubkey: author,
+            addressableId: coordinate,
+          );
+
+          expect(resolved, equals(landedReactionId));
+          expectNoPublish();
+          expect(await repository.isLikedByCoordinate(coordinate), isTrue);
+        },
+      );
+
+      test('republishes when the relay copy was retracted', () async {
+        when(
+          () => storage.getAllLikeRecords(),
+        ).thenAnswer((_) async => [placeholderRecord()]);
+        stubRelay(
+          reactions: [reaction(id: landedReactionId)],
+          deletions: [
+            deletion([landedReactionId]),
+          ],
+        );
+        stubSendLike(() async => reaction(id: freshReactionId));
+
+        final resolved = await repository.executeLikeAction(
+          eventId: target,
+          authorPubkey: author,
+          addressableId: coordinate,
+        );
+
+        expect(resolved, equals(freshReactionId));
+        expectPublishedOnce();
+      });
+
+      test('ignores a live reaction from another account', () async {
+        // The REQ carries an `authors` filter, but a relay that ignores it
+        // (or a merged cache hit) must not make this account adopt someone
+        // else's reaction as its own.
+        when(
+          () => storage.getAllLikeRecords(),
+        ).thenAnswer((_) async => [placeholderRecord()]);
+        stubRelay(
+          reactions: [reaction(id: landedReactionId, pubkey: otherUser)],
+        );
+        stubSendLike(() async => reaction(id: freshReactionId));
+
+        final resolved = await repository.executeLikeAction(
+          eventId: target,
+          authorPubkey: author,
+          addressableId: coordinate,
+        );
+
+        expect(resolved, equals(freshReactionId));
+        expectPublishedOnce();
+      });
+
+      test('ignores a downvote when looking for a live like', () async {
+        when(
+          () => storage.getAllLikeRecords(),
+        ).thenAnswer((_) async => [placeholderRecord()]);
+        stubRelay(
+          reactions: [reaction(id: landedReactionId, content: '-')],
+        );
+        stubSendLike(() async => reaction(id: freshReactionId));
+
+        final resolved = await repository.executeLikeAction(
+          eventId: target,
+          authorPubkey: author,
+          addressableId: coordinate,
+        );
+
+        expect(resolved, equals(freshReactionId));
+        expectPublishedOnce();
+      });
+    });
+
+    group('likeEvent', () {
+      setUp(stubStorageWrites);
+
+      test(
+        'adopts a live relay reaction and reports AlreadyLiked instead of '
+        'minting a second +',
+        () async {
+          // Fresh install, new device, wiped cache: the local store knows
+          // nothing, the heart reads unfilled, and the relay already holds
+          // this account's `+`. Kind 7 is a regular event with no
+          // per-pubkey uniqueness (NIP-01, NIP-25), so nothing downstream
+          // collapses a second one — the client is the only guard.
+          stubRelay(reactions: [reaction(id: landedReactionId)]);
+
+          await expectLater(
+            repository.likeEvent(eventId: target, authorPubkey: author),
+            throwsA(isA<AlreadyLikedException>()),
+          );
+
+          expectNoPublish();
+          expect(await repository.isLiked(target), isTrue);
+          expect(
+            (await repository.getLikeRecord(target))?.reactionEventId,
+            equals(landedReactionId),
+          );
+          verify(
+            () => storage.saveLikeRecord(
+              any(
+                that: isA<LikeRecord>().having(
+                  (r) => r.reactionEventId,
+                  'reactionEventId',
+                  landedReactionId,
+                ),
+              ),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'restores the cached count when adopting a relay reaction',
+        () async {
+          // The existing reaction is already inside the count the UI shows,
+          // so the optimistic +1 has to come back off.
+          when(
+            () => nostrClient.countEvents(any()),
+          ).thenAnswer((_) async => const CountResult(count: 10));
+          stubRelay(reactions: [reaction(id: landedReactionId)]);
+          expect(await repository.getLikeCount(target), equals(10));
+
+          await expectLater(
+            repository.likeEvent(eventId: target, authorPubkey: author),
+            throwsA(isA<AlreadyLikedException>()),
+          );
+
+          expect(await repository.getLikeCount(target), equals(10));
+        },
+      );
+
+      test(
+        'publishes when the relay holds only a retracted reaction',
+        () async {
+          stubRelay(
+            reactions: [reaction(id: landedReactionId)],
+            deletions: [
+              deletion([landedReactionId]),
+            ],
+          );
+          stubSendLike(() async => reaction(id: freshReactionId));
+
+          final result = await repository.likeEvent(
+            eventId: target,
+            authorPubkey: author,
+          );
+
+          expect(result, equals(freshReactionId));
+          expectPublishedOnce();
+        },
+      );
+
+      test('publishes when the relay check itself fails', () async {
+        // The guard fails open: an unreachable relay must not turn a like
+        // into a silent no-op. The publish that follows fails the same way
+        // and takes the existing retry path.
+        when(
+          () => nostrClient.queryEvents(any()),
+        ).thenThrow(Exception('relay unreachable'));
+        stubSendLike(() async => reaction(id: freshReactionId));
+
+        final result = await repository.likeEvent(
+          eventId: target,
+          authorPubkey: author,
+        );
+
+        expect(result, equals(freshReactionId));
+        expectPublishedOnce();
+      });
+
+      test(
+        'keeps the double-tap window closed while the relay check is pending',
+        () async {
+          // The placeholder must be indexed before the first await, or two
+          // taps inside the relay round-trip both pass the already-liked
+          // check and both publish.
+          final relayGate = Completer<List<Event>>();
+          when(
+            () => nostrClient.queryEvents(any()),
+          ).thenAnswer((_) => relayGate.future);
+          stubSendLike(() async => reaction(id: freshReactionId));
+
+          final first = repository.likeEvent(
+            eventId: target,
+            authorPubkey: author,
+          );
+          await expectLater(
+            repository.likeEvent(eventId: target, authorPubkey: author),
+            throwsA(isA<AlreadyLikedException>()),
+          );
+
+          relayGate.complete(const <Event>[]);
+          expect(await first, equals(freshReactionId));
+          expectPublishedOnce();
+        },
+      );
+
+      test(
+        'retracts the adopted reaction when the user unliked during the '
+        'relay check',
+        () async {
+          final relayGate = Completer<List<Event>>();
+          when(
+            () => nostrClient.queryEvents(any()),
+          ).thenAnswer((_) => relayGate.future);
+          when(
+            () => nostrClient.deleteEvent(any()),
+          ).thenAnswer((_) async => _MockEvent());
+
+          final inFlight = repository.likeEvent(
+            eventId: target,
+            authorPubkey: author,
+          );
+          await Future<void>.delayed(Duration.zero);
+          await repository.unlikeEvent(target);
+
+          relayGate.complete([reaction(id: landedReactionId)]);
+          await inFlight;
+
+          verify(() => nostrClient.deleteEvent(landedReactionId)).called(1);
+          expectNoPublish();
+          expect(await repository.isLiked(target), isFalse);
+        },
+      );
+    });
+
+    group('live subscription', () {
+      setUp(stubStorageWrites);
+
+      test(
+        'upgrades a same-second placeholder to the reaction the relay stored',
+        () async {
+          // The relay echoes the stored reaction to the account's own
+          // subscription. Its created_at is whole seconds, so it never
+          // reads as "after" a placeholder stamped milliseconds earlier in
+          // the same second — and a placeholder is not a real record to
+          // defend, it is the absence of one.
+          final live = StreamController<Event>.broadcast();
+          addTearDown(live.close);
+          when(
+            () => nostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => live.stream);
+          stubRelay();
+          final publishGate = Completer<Event?>();
+          stubSendLike(() => publishGate.future);
+          await repository.initialize();
+
+          final inFlight = repository.likeEvent(
+            eventId: target,
+            authorPubkey: author,
+          );
+          await Future<void>.delayed(Duration.zero);
+          final placeholder = await repository.getLikeRecord(target);
+          expect(placeholder?.reactionEventId, startsWith('pending_like_'));
+
+          final sameSecond = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          live.add(reaction(id: landedReactionId, createdAt: sameSecond));
+          await Future<void>.delayed(Duration.zero);
+
+          expect(
+            (await repository.getLikeRecord(target))?.reactionEventId,
+            equals(landedReactionId),
+          );
+
+          publishGate.complete(reaction(id: landedReactionId));
+          await inFlight;
+        },
+      );
+
+      test(
+        'drops a reaction the relay echoed after the user unliked it '
+        'mid-publish, once the retraction lands',
+        () async {
+          // The relay echoes the stored reaction on the account's own
+          // subscription within milliseconds of storing it — before the OK
+          // in the reproduction on the local stack. Unlike → echo → OK
+          // leaves the retracted reaction indexed, so the heart reads liked
+          // for a like the user already took back.
+          final live = StreamController<Event>.broadcast();
+          addTearDown(live.close);
+          when(
+            () => nostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => live.stream);
+          stubRelay();
+          final publishGate = Completer<Event?>();
+          stubSendLike(() => publishGate.future);
+          when(
+            () => nostrClient.deleteEvent(any()),
+          ).thenAnswer((_) async => _MockEvent());
+          await repository.initialize();
+
+          final inFlight = repository.likeEvent(
+            eventId: target,
+            authorPubkey: author,
+          );
+          await Future<void>.delayed(Duration.zero);
+          await repository.unlikeEvent(target);
+
+          live.add(reaction(id: landedReactionId));
+          await Future<void>.delayed(Duration.zero);
+          publishGate.complete(reaction(id: landedReactionId));
+          await inFlight;
+
+          verify(() => nostrClient.deleteEvent(landedReactionId)).called(1);
+          expect(await repository.isLiked(target), isFalse);
+          verify(() => storage.deleteLikeRecord(target)).called(2);
+        },
+      );
+    });
+  });
+}

--- a/mobile/packages/likes_repository/test/src/likes_repository_repeat_publish_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_repeat_publish_test.dart
@@ -825,6 +825,49 @@ void main() {
           expect(await repository.getLikeCount(target), equals(10));
         },
       );
+
+      test(
+        'drops every record naming a startup-indexed reaction retracted '
+        'during the join',
+        () async {
+          // The user takes the like back while the tap is still waiting on
+          // startup, which then files the reaction under its own `e` target
+          // and the coordinate. The Kind 5 lands against a reaction both of
+          // those records still name.
+          final gate = gateRelaySnapshot();
+          when(
+            () => nostrClient.deleteEvent(landedReactionId),
+          ).thenAnswer((_) async => _MockEvent());
+
+          final initialization = repository.initialize();
+          await Future<void>.delayed(Duration.zero);
+          final like = repository.likeEvent(
+            eventId: target,
+            authorPubkey: author,
+            addressableId: coordinate,
+          );
+          await Future<void>.delayed(Duration.zero);
+          await repository.unlikeEvent(target, addressableId: coordinate);
+          gate.land(
+            reactions: [
+              reaction(
+                id: landedReactionId,
+                tags: [
+                  ['e', editedTarget],
+                  ['a', coordinate],
+                ],
+              ),
+            ],
+          );
+          await initialization;
+
+          expect(await like, equals(landedReactionId));
+          verify(() => nostrClient.deleteEvent(landedReactionId)).called(1);
+          expectNoPublish();
+          expect(await repository.isLiked(editedTarget), isFalse);
+          expect(await repository.isLikedByCoordinate(coordinate), isFalse);
+        },
+      );
     });
 
     group('live subscription', () {

--- a/mobile/packages/likes_repository/test/src/likes_repository_repeat_publish_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_repeat_publish_test.dart
@@ -85,6 +85,27 @@ void main() {
       });
     }
 
+    void stubCompleteRelaySnapshot({
+      List<Event> reactions = const [],
+      List<Event> deletions = const [],
+      bool timedOut = false,
+    }) {
+      when(
+        () => nostrClient.queryEventsDetailed(
+          any(),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        ),
+      ).thenAnswer((invocation) async {
+        final filters = invocation.positionalArguments.first as List<Filter>;
+        final kinds = filters.first.kinds ?? const <int>[];
+        return (
+          events: kinds.contains(EventKind.reaction) ? reactions : deletions,
+          timedOut: timedOut,
+          noRelays: false,
+        );
+      });
+    }
+
     void stubSendLike(Future<Event?> Function() answer) {
       when(
         () => nostrClient.sendLike(
@@ -132,6 +153,9 @@ void main() {
     /// sit next to the tests that depend on them.
     void stubStorageWrites() {
       when(() => storage.saveLikeRecord(any())).thenAnswer((_) async {});
+      when(
+        () => storage.saveLikeRecordsBatch(any()),
+      ).thenAnswer((_) async {});
       when(
         () => storage.deleteLikeRecord(any()),
       ).thenAnswer((_) async => true);
@@ -432,6 +456,149 @@ void main() {
       );
 
       test(
+        'keeps an e-tag-only adopted reaction indexed by the known '
+        'coordinate through unlike and re-like',
+        () async {
+          stubRelay(reactions: [reaction(id: landedReactionId)]);
+
+          await expectLater(
+            repository.likeEvent(
+              eventId: target,
+              authorPubkey: author,
+              addressableId: coordinate,
+            ),
+            throwsA(isA<AlreadyLikedException>()),
+          );
+          expect(await repository.isLikedByCoordinate(coordinate), isTrue);
+
+          when(
+            () => nostrClient.deleteEvent(landedReactionId),
+          ).thenAnswer((_) async => _MockEvent());
+          await repository.unlikeEvent(target, addressableId: coordinate);
+          expect(await repository.isLikedByCoordinate(coordinate), isFalse);
+
+          stubRelay(
+            reactions: [reaction(id: landedReactionId)],
+            deletions: [
+              deletion([landedReactionId]),
+            ],
+          );
+          stubSendLike(() async => reaction(id: freshReactionId));
+
+          expect(
+            await repository.toggleLike(
+              eventId: target,
+              authorPubkey: author,
+              addressableId: coordinate,
+            ),
+            isTrue,
+          );
+          expectPublishedOnce();
+        },
+      );
+
+      test(
+        'adopts an empty-content reaction consistently with NIP-25',
+        () async {
+          stubRelay(
+            reactions: [reaction(id: landedReactionId, content: '')],
+          );
+
+          await expectLater(
+            repository.likeEvent(eventId: target, authorPubkey: author),
+            throwsA(isA<AlreadyLikedException>()),
+          );
+
+          expectNoPublish();
+          expect(await repository.isLiked(target), isTrue);
+        },
+      );
+
+      test(
+        'publishes without a target lookup after a complete startup snapshot',
+        () async {
+          stubCompleteRelaySnapshot();
+          await repository.initialize();
+          clearInteractions(nostrClient);
+          stubSendLike(() async => reaction(id: freshReactionId));
+
+          expect(
+            await repository.likeEvent(eventId: target, authorPubkey: author),
+            equals(freshReactionId),
+          );
+
+          verifyNever(() => nostrClient.queryEvents(any()));
+          expectPublishedOnce();
+        },
+      );
+
+      test(
+        'retains the target lookup when startup reconciliation times out',
+        () async {
+          stubCompleteRelaySnapshot(timedOut: true);
+          await repository.initialize();
+          clearInteractions(nostrClient);
+          stubRelay();
+          stubSendLike(() async => reaction(id: freshReactionId));
+
+          expect(
+            await repository.likeEvent(eventId: target, authorPubkey: author),
+            equals(freshReactionId),
+          );
+
+          verify(() => nostrClient.queryEvents(any())).called(1);
+          expectPublishedOnce();
+        },
+      );
+
+      test(
+        'joins startup reconciliation and adopts its reaction during a tap',
+        () async {
+          final reactionsGate =
+              Completer<({List<Event> events, bool timedOut, bool noRelays})>();
+          final deletionsGate =
+              Completer<({List<Event> events, bool timedOut, bool noRelays})>();
+          when(
+            () => nostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((invocation) {
+            final filters =
+                invocation.positionalArguments.first as List<Filter>;
+            final kinds = filters.first.kinds ?? const <int>[];
+            return kinds.contains(EventKind.reaction)
+                ? reactionsGate.future
+                : deletionsGate.future;
+          });
+
+          final initialization = repository.initialize();
+          await Future<void>.delayed(Duration.zero);
+          final like = repository.likeEvent(
+            eventId: target,
+            authorPubkey: author,
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          reactionsGate.complete((
+            events: [reaction(id: landedReactionId)],
+            timedOut: false,
+            noRelays: false,
+          ));
+          deletionsGate.complete((
+            events: <Event>[],
+            timedOut: false,
+            noRelays: false,
+          ));
+          await initialization;
+
+          await expectLater(like, throwsA(isA<AlreadyLikedException>()));
+          expectNoPublish();
+          verifyNever(() => nostrClient.queryEvents(any()));
+        },
+      );
+
+      test(
         'publishes when the relay holds only a retracted reaction',
         () async {
           stubRelay(
@@ -501,6 +668,10 @@ void main() {
         'retracts the adopted reaction when the user unliked during the '
         'relay check',
         () async {
+          when(
+            () => nostrClient.countEvents(any()),
+          ).thenAnswer((_) async => const CountResult(count: 10));
+          expect(await repository.getLikeCount(target), equals(10));
           final relayGate = Completer<List<Event>>();
           when(
             () => nostrClient.queryEvents(any()),
@@ -522,6 +693,7 @@ void main() {
           verify(() => nostrClient.deleteEvent(landedReactionId)).called(1);
           expectNoPublish();
           expect(await repository.isLiked(target), isFalse);
+          expect(await repository.getLikeCount(target), equals(9));
         },
       );
     });

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -87,6 +87,22 @@ void main() {
       });
     }
 
+    void mockDetailedQueryEventsSequence(List<List<Event>> responses) {
+      var callCount = 0;
+      when(
+        () => mockNostrClient.queryEventsDetailed(
+          any(),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        ),
+      ).thenAnswer((_) async {
+        return (
+          events: responses[callCount++ % responses.length],
+          timedOut: false,
+          noRelays: false,
+        );
+      });
+    }
+
     // Helper to create repository with standard setup
     LikesRepository createRepository({
       bool withLocalStorage = true,
@@ -4697,7 +4713,7 @@ void main() {
               ['a', coordinate],
             ],
           );
-          mockQueryEventsSequence([
+          mockDetailedQueryEventsSequence([
             [relayReaction],
             <Event>[],
           ]);
@@ -4708,7 +4724,12 @@ void main() {
           repository = createRepository();
           await repository.initialize();
 
-          verify(() => mockNostrClient.queryEvents(any())).called(2);
+          verify(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).called(2);
           expect(
             await repository.isLikedResolvingCoordinate(
               eventId: newEventId,
@@ -4720,8 +4741,7 @@ void main() {
       );
 
       test(
-        'skips the backfill sync when every loaded record already has a '
-        'coordinate',
+        'reconciles relay state even when loaded records have coordinates',
         () async {
           when(() => mockNostrClient.hasKeys).thenReturn(true);
           when(
@@ -4737,11 +4757,20 @@ void main() {
               ),
             ],
           );
+          mockDetailedQueryEventsSequence([
+            <Event>[],
+            <Event>[],
+          ]);
 
           repository = createRepository();
           await repository.initialize();
 
-          verifyNever(() => mockNostrClient.queryEvents(any()));
+          verify(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).called(2);
         },
       );
 
@@ -4761,7 +4790,12 @@ void main() {
             (_) async => [createLikeRecord(targetEventId: oldEventId)],
           );
           when(
-            () => mockNostrClient.queryEvents(any()),
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(
+                named: 'requireAllRelaysSettled',
+              ),
+            ),
           ).thenThrow(Exception('offline'));
 
           repository = createRepository();

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -1960,6 +1960,7 @@ void main() {
             createMockReaction(
               id: testReactionEventId,
               targetEventId: supersededId,
+              authorPubkey: testUserPubkey,
               content: '-',
               tags: [
                 ['e', supersededId],
@@ -2247,6 +2248,7 @@ void main() {
               createMockReaction(
                 id: testReactionEventId,
                 targetEventId: testEventId,
+                authorPubkey: testUserPubkey,
                 content: '-',
               ),
             ],
@@ -2277,6 +2279,7 @@ void main() {
               createMockReaction(
                 id: 'downvote_$i',
                 targetEventId: testEventId,
+                authorPubkey: testUserPubkey,
                 content: '-',
               ),
           ];


### PR DESCRIPTION
## Description

One account can end up with several live `+` reactions on the same video. Funnelcake counts distinct reaction events, so every extra one adds 1 to the headline like count while the "Liked by" list, which groups by person, does not move. #7001 traced this to three ways the app publishes a second reaction; #7004 closed one (unlike while the publish is in flight). This PR closes the remaining publish and replay paths without putting a relay round-trip on every normal like.

The two reproduced causes were:

1. **A retry after a publish that actually landed.** `sendLike` waits for the relay's `OK` (#8162). When that `OK` does not arrive in time but the relay stored the event, the client reports failure, queues a retry, and the retry could publish a fresh reaction under a new id. The relay echo did not replace the optimistic placeholder because Nostr timestamps have whole-second precision while the placeholder used milliseconds.
2. **No local record, so the heart reads unfilled.** On a fresh install or wiped cache, an existing reaction could be absent locally. The app then showed an empty heart and a tap published another `+`.

Kind 7 is a regular event with no per-pubkey uniqueness (NIP-01, NIP-25), no relay collapses a second one, and a kind 5 is the only retraction (NIP-09). The client must preserve idempotency across its local cache, live subscription, startup reconciliation, and queued replay.

### The fix

All changes are in `likes_repository`:

- Startup now reconciles the account's reactions and deletions once, after loading local state and starting the live subscription. A complete, uncapped, all-relays-settled snapshot lets normal likes publish without a target lookup. A timed-out, relay-less, capped, failed, or unindexable snapshot retains the target-specific safety check.
- A like that races startup joins that reconciliation and adopts whatever it indexed for the target or the video's coordinate — including a like cast on an earlier revision, and one whose reaction carries no `a` tag — so it never publishes a second `+` and a later unlike still resolves the real reaction. The heart and count still update optimistically before network work.
- Queue replay always keeps its target-specific relay check because the original publish may have landed after the startup snapshot without returning its `OK`.
- Live subscription upgrades `pending_` like and downvote placeholders from relay echoes regardless of same-second timestamp ordering.
- Remote reactions are adopted consistently by event id and addressable coordinate, including older reactions that have only an `e` tag. Adoption also removes any persisted alias for the same reaction, so unlike cannot leave a stale filled heart under a superseded revision.
- Remote downvotes are adopted only when authored by the current account; another account's cached reaction cannot block or redirect this account's vote.
- NIP-25's empty-content like form is handled consistently by startup sync, live sync, fetches, and adoption.
- A successful mid-check retraction now removes the pre-existing reaction from the cached count as well as reverting the optimistic increment; a reaction this tap itself published and then retracted leaves the count where the unlike put it. Every local record naming the retracted reaction is dropped, including one filed under a superseded revision.
- Coordinate reconciliation keeps its previous precedence during queue replay, placeholder detection uses the shared helper throughout, and failed startup initialization can be retried instead of poisoning likes for the session.

**Related Issue:** Relates to #7001 (cleanup of duplicates already published and backend count deduplication remain there). Part of #8292.

## Out of Scope

- Duplicates already on relays are not retracted. The app holds one record per target, so it cannot enumerate every older sibling to publish a kind 5 for it safely.
- The backend count still deduplicates by reaction event id rather than reactor (divinevideo/divine-funnelcake#626).

## Verification

- `flutter test packages/likes_repository`: 282 passing, including 29 focused repeat-publish tests.
- `flutter analyze packages/likes_repository`: clean.
- `flutter analyze lib test integration_test`: clean.
- Repository pre-push analyzer and all changed-file tests: passing.
- Regression coverage includes e-tag-only and a-tag-only coordinate adoption, NIP-25 empty-content likes, startup/tap races (including a tap on a video liked at an earlier revision), complete, timed-out, relay-less, capped, and unindexable startup snapshots, same-second like and downvote relay echoes, downvote author isolation, replay idempotency, retry after failed initialization, mid-check unlike count correction for both an adopted and a self-published reaction, and complete alias cleanup after adoption and retraction.
- Original device reproduction on iOS Simulator with a local relay and a WebSocket interposer confirmed both the missing-`OK` replay and fresh-install duplicate paths; the guarded build leaves one live reaction.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that causes existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
