### PR TITLE
fix(dm): stop dropping a DM when the recipient's inbox is on relays we don't already query

### DIFF
--- a/mobile/integration_test/e2e/dm_group_send_joined_recovery_retry_test.dart
+++ b/mobile/integration_test/e2e/dm_group_send_joined_recovery_retry_test.dart
@@ -67,6 +67,7 @@ void main() {
   /// while the group loop is still parked on the deliverable sibling's OK;
   /// well inside the OK-confirm window, so that sibling is still delivered.
   const deliverableOkDelay = Duration(seconds: 3);
+  const recoveryOkDelay = Duration(seconds: 4);
 
   /// Builds the real stack the way `repository_providers.dart` does, with
   /// the durable queue wired — the retry budget under test lives on its rows.
@@ -218,7 +219,11 @@ void main() {
   }
 
   setUp(() {
-    DmRepository.inboxResolutionBudget = DmSendBudget.inboxResolution;
+    // This suite exercises retry-attempt ownership, not the production inbox
+    // timeout. Keep the deliberately stalled lookup shorter than the delayed
+    // deliverable OK so the intended owner/joiner ordering is deterministic
+    // even when recipient reads require full relay settlement (#8630).
+    DmRepository.inboxResolutionBudget = const Duration(seconds: 1);
   });
   tearDown(() {
     DmRepository.inboxResolutionBudget = DmSendBudget.inboxResolution;
@@ -236,7 +241,10 @@ void main() {
         // about.
         final relay = await FakeRelay.start(
           stallReqForAuthors: {unreadablePubkey},
-          okDelayForRecipients: {deliverablePubkey: deliverableOkDelay},
+          okDelayForRecipients: {
+            deliverablePubkey: deliverableOkDelay,
+            unreadablePubkey: recoveryOkDelay,
+          },
         );
         addTearDown(relay.stop);
         final stack = await buildStack(relay);
@@ -316,7 +324,10 @@ void main() {
         // batch has outlived it.
         final relay = await FakeRelay.start(
           stallReqForAuthors: {unreadablePubkey},
-          okDelayForRecipients: {deliverablePubkey: deliverableOkDelay},
+          okDelayForRecipients: {
+            deliverablePubkey: deliverableOkDelay,
+            unreadablePubkey: recoveryOkDelay,
+          },
         );
         addTearDown(relay.stop);
         final stack = await buildStack(relay);

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -730,6 +730,7 @@ DmRepository dmRepository(Ref ref) {
     dmInboxRelayUrl: dmInboxRelayUrl,
     dmInboxTaggedRelays: IndexerRelayConfig.dmInboxTaggedRelays,
     dmInboxDiscoveryRelays: IndexerRelayConfig.dmInboxDiscoveryRelays,
+    dmInboxLookupRelays: IndexerRelayConfig.dmInboxLookupRelays,
     errorReporter: (error, stackTrace, {required site}) {
       unawaited(
         ref

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -1068,7 +1068,7 @@ final class DmRepositoryProvider
   }
 }
 
-String _$dmRepositoryHash() => r'8f260909aefd0e97cf414bf9748cb26fdc21faef';
+String _$dmRepositoryHash() => r'd54263d699b3506506cba06ad0e29b94f4452bdc';
 
 /// Provider for CommentsRepository instance
 ///

--- a/mobile/lib/services/relay_discovery_service.dart
+++ b/mobile/lib/services/relay_discovery_service.dart
@@ -49,6 +49,15 @@ class IndexerRelayConfig {
     'wss://purplepag.es',
   ];
 
+  /// Read-only indexers used to locate another user's kind-10050 DM inbox.
+  ///
+  /// This is intentionally not [dmInboxDiscoveryRelays]. That set is selected
+  /// for accepting writes of Divine's own list; this set is selected for broad
+  /// third-party read coverage. Purple Pages served the indexer-only inbox in
+  /// the #7317 reproduction. Keep the set small because every entry is a cold
+  /// connection on a DM send when it is not already pooled.
+  static const List<String> dmInboxLookupRelays = ['wss://purplepag.es'];
+
   /// Safe fallback relay set for users without a discoverable NIP-65 relay
   /// list (kind 10002).
   ///

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3979,6 +3979,26 @@ class DmRepository {
     _DmRelayListSource source = _DmRelayListSource.remote,
   }) async {
     try {
+      // #7317: widen a COUNTERPARTY lookup to the indexer relays that carry
+      // kind-10050. Without this the recipient's inbox is resolved only from
+      // the relays this device already dials, so a recipient whose inbox lives
+      // elsewhere — the exact "our pool does not carry it" case — reads as an
+      // empty answer and collapses to `absent`, indistinguishable from a
+      // recipient who advertises no inbox. The wrap is then published to the
+      // default pool the recipient never reads and scored delivered. Reaching
+      // the same indexers that store a user's list (`purplepag.es`, the
+      // DM-tagged relays) turns that case into `found`, so the wrap routes to
+      // the advertised inbox. `tempRelays` is additive, so the pool is still
+      // queried; a slow or down indexer only fails to help this send, it never
+      // removes a relay the lookup already had.
+      //
+      // The own-inbox reads (`selfAuthored`) are deliberately left pool-only:
+      // that path resolves the local user's own list (#8212), not a
+      // counterparty's, and an indexer round trip does not belong in front of
+      // the publish path.
+      final discoveryRelays = source == _DmRelayListSource.remote
+          ? _dmInboxDiscoveryRelays
+          : const <String>[];
       final result = await _nostrClient
           .queryEventsDetailed(
             [
@@ -3989,6 +4009,7 @@ class DmRepository {
               ),
             ],
             useCache: !requireAuthoritative,
+            tempRelays: discoveryRelays.isEmpty ? null : discoveryRelays,
             requireAllRelaysSettled: requireAuthoritative,
             timeout: requireAuthoritative
                 ? _ownDmInboxAuthoritativeTimeout

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -187,6 +187,11 @@ const Duration _dmRelayListSignTimeout = Duration(seconds: 10);
 /// about which relays answer.
 const Duration _dmInboxQueryTimeout = Duration(seconds: 5);
 
+/// A discovery-only relay is optional coverage, not the primary read path.
+/// Keep its cold handshake below the pool lookup budget so one unreachable
+/// indexer cannot hold the whole recipient resolution open (#7317).
+const Duration _dmInboxDiscoveryQueryTimeout = Duration(seconds: 2);
+
 /// Budget for the authoritative own-inbox read that gates the RC3 publish.
 ///
 /// Deliberately shorter than [_dmInboxQueryTimeout]. `requireAllRelaysSettled`
@@ -442,6 +447,7 @@ class DmRepository {
     DmConversationRemovalPolicy? removalPolicy,
     String? dmInboxRelayUrl,
     List<String> dmInboxDiscoveryRelays = const <String>[],
+    List<String> dmInboxLookupRelays = const <String>[],
     List<String> dmInboxTaggedRelays = const <String>[],
     Duration readMarkerDebounceDelay = _defaultReadMarkerDebounceDelay,
     String Function()? sendBatchIdGenerator,
@@ -466,6 +472,7 @@ class DmRepository {
        _removalPolicy = removalPolicy ?? allowAllConversationRemoval,
        _dmInboxRelayUrl = dmInboxRelayUrl,
        _dmInboxDiscoveryRelays = dmInboxDiscoveryRelays,
+       _dmInboxLookupRelays = dmInboxLookupRelays,
        _dmInboxTaggedRelays = dmInboxTaggedRelays,
        _newSendBatchId = sendBatchIdGenerator ?? _defaultSendBatchId;
 
@@ -554,6 +561,12 @@ class DmRepository {
   /// logged once and otherwise ignored: it neither fails the publish nor
   /// blocks the idempotence flag, so it can never cause a republish loop.
   final List<String> _dmInboxDiscoveryRelays;
+
+  /// Read-only indexers used to locate somebody else's kind-10050.
+  /// Kept separate from [_dmInboxDiscoveryRelays], whose members are selected
+  /// because they accept publication of Divine's own list. Read coverage and
+  /// write acceptance are different relay capabilities (#7317).
+  final List<String> _dmInboxLookupRelays;
   final List<String> _dmInboxTaggedRelays;
 
   /// Mints the durable, collision-proof identity for one send invocation.
@@ -3979,44 +3992,50 @@ class DmRepository {
     _DmRelayListSource source = _DmRelayListSource.remote,
   }) async {
     try {
-      // #7317: widen a COUNTERPARTY lookup to the indexer relays that carry
-      // kind-10050. Without this the recipient's inbox is resolved only from
-      // the relays this device already dials, so a recipient whose inbox lives
-      // elsewhere — the exact "our pool does not carry it" case — reads as an
-      // empty answer and collapses to `absent`, indistinguishable from a
-      // recipient who advertises no inbox. The wrap is then published to the
-      // default pool the recipient never reads and scored delivered. Reaching
-      // the same indexers that store a user's list (`purplepag.es`, the
-      // DM-tagged relays) turns that case into `found`, so the wrap routes to
-      // the advertised inbox. `tempRelays` is additive, so the pool is still
-      // queried; a slow or down indexer only fails to help this send, it never
-      // removes a relay the lookup already had.
+      final filter = [
+        nostr_filter.Filter(
+          authors: [pubkey],
+          kinds: [EventKind.dmRelaysList],
+          limit: 1,
+        ),
+      ];
+
+      // A recipient lookup has two independent legs. The pool leg retains the
+      // reconnect preflight that a temp relay used to suppress (#8550), while
+      // the lookup-only leg dials the small indexer set in parallel. A cold or
+      // dead indexer is capped independently, so it cannot consume the pool's
+      // five-second budget. Both must settle before an empty answer means
+      // `absent`; if either is incomplete the send stays pending and retries.
       //
-      // The own-inbox reads (`selfAuthored`) are deliberately left pool-only:
-      // that path resolves the local user's own list (#8212), not a
-      // counterparty's, and an indexer round trip does not belong in front of
-      // the publish path.
-      final discoveryRelays = source == _DmRelayListSource.remote
-          ? _dmInboxDiscoveryRelays
-          : const <String>[];
-      final result = await _nostrClient
-          .queryEventsDetailed(
-            [
-              nostr_filter.Filter(
-                authors: [pubkey],
-                kinds: [EventKind.dmRelaysList],
-                limit: 1,
-              ),
-            ],
-            useCache: !requireAuthoritative,
-            tempRelays: discoveryRelays.isEmpty ? null : discoveryRelays,
-            requireAllRelaysSettled: requireAuthoritative,
-            timeout: requireAuthoritative
-                ? _ownDmInboxAuthoritativeTimeout
-                : _dmInboxQueryTimeout,
-          )
-          .timeout(inboxResolutionBudget);
-      final events = result.events;
+      // Own-inbox reads deliberately keep the existing single pool-only leg.
+      // The fast read is in front of the receiving subscription, while the
+      // authoritative read protects publication (#8212); widening receipt is
+      // a separate asynchronous concern and must not add a cold connection to
+      // either synchronous path.
+      final queryFutures = [
+        _nostrClient.queryEventsDetailed(
+          filter,
+          useCache: !requireAuthoritative,
+          requireAllRelaysSettled:
+              requireAuthoritative || source == _DmRelayListSource.remote,
+          timeout: requireAuthoritative
+              ? _ownDmInboxAuthoritativeTimeout
+              : _dmInboxQueryTimeout,
+        ),
+        if (source == _DmRelayListSource.remote &&
+            _dmInboxLookupRelays.isNotEmpty)
+          _nostrClient.queryEventsDetailed(
+            filter,
+            useCache: false,
+            tempRelays: _dmInboxLookupRelays,
+            requireAllRelaysSettled: true,
+            timeout: _dmInboxDiscoveryQueryTimeout,
+          ),
+      ];
+      final results = await Future.wait(queryFutures).timeout(
+        inboxResolutionBudget,
+      );
+      final events = [for (final result in results) ...result.events];
       // Computed here but applied ONLY at the two exits below where nothing
       // matching came back. A read that DID return the list stays `found` even
       // when some relay never settled: the list is in hand, and RC3's job is
@@ -4042,11 +4061,13 @@ class DmRepository {
       // that as `failed`. Callers that merely route to the default pool can
       // live with the guess; callers that latch something permanent must make
       // their own strict read — see [_drainOwnInboxRelays].
-      if (result.noRelays || result.timedOut) {
+      final noRelayAnswered = results.any((result) => result.noRelays);
+      final didNotSettle = results.any((result) => result.timedOut);
+      if (noRelayAnswered || didNotSettle) {
         absentOrFailed = _OwnDmInboxState.failed;
         // `noRelays` first: an offline device sets both flags, and reporting
         // that as a timeout misreads it.
-        inconclusiveReason = result.noRelays
+        inconclusiveReason = noRelayAnswered
             ? 'no relay took the REQ'
             : 'not every relay settled';
       } else {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -865,6 +865,7 @@ void main() {
       // the real path; tests that assert the unconfigured no-op pass null.
       String? dmInboxRelayUrl = 'wss://relay.divine.video',
       List<String> dmInboxDiscoveryRelays = const <String>[],
+      List<String> dmInboxLookupRelays = const <String>[],
       List<String> dmInboxTaggedRelays = const <String>[],
       Duration readMarkerDebounceDelay = const Duration(seconds: 3),
       String Function()? sendBatchIdGenerator,
@@ -894,6 +895,7 @@ void main() {
         dmInboxRelayUrl: dmInboxRelayUrl,
         dmInboxTaggedRelays: dmInboxTaggedRelays,
         dmInboxDiscoveryRelays: dmInboxDiscoveryRelays,
+        dmInboxLookupRelays: dmInboxLookupRelays,
         readMarkerDebounceDelay: readMarkerDebounceDelay,
         sendBatchIdGenerator: sendBatchIdGenerator,
         errorReporter: (error, stackTrace, {required site}) {
@@ -4986,6 +4988,8 @@ void main() {
           // recipient's kind-10050. The answer therefore depends on WHETHER the
           // lookup reached the discovery relay — which is exactly the widening
           // this test pins.
+          final queriedTempRelays = <List<String>?>[];
+          final fullSettlement = <bool>[];
           when(
             () => mockNostrClient.queryEventsDetailed(
               any(),
@@ -4998,6 +5002,10 @@ void main() {
           ).thenAnswer((invocation) async {
             final temp =
                 invocation.namedArguments[#tempRelays] as List<String>?;
+            queriedTempRelays.add(temp);
+            fullSettlement.add(
+              invocation.namedArguments[#requireAllRelaysSettled] as bool,
+            );
             final reachedDiscovery =
                 temp != null && temp.contains('wss://purplepag.es');
             return reachedDiscovery
@@ -5007,13 +5015,18 @@ void main() {
                 : answeredList(const <Event>[]);
           });
           final repository = createRepository(
-            dmInboxDiscoveryRelays: const ['wss://purplepag.es'],
+            dmInboxLookupRelays: const ['wss://purplepag.es'],
           );
           final resolved = await repository.resolveDmInboxRelaysDetailed(
             _validPubkeyB,
           );
           expect(resolved.state, DmInboxResolution.found);
           expect(resolved.relays, ['wss://inbox.example']);
+          expect(queriedTempRelays, [
+            null,
+            ['wss://purplepag.es'],
+          ]);
+          expect(fullSettlement, [isTrue, isTrue]);
         },
       );
 
@@ -5049,6 +5062,39 @@ void main() {
         expect(resolved.state, DmInboxResolution.unreadable);
         expect(resolved.relays, isNull);
       });
+
+      test(
+        'keeps an empty discovery answer unreadable when the pool lookup did '
+        'not settle',
+        () async {
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((invocation) async {
+            final temp =
+                invocation.namedArguments[#tempRelays] as List<String>?;
+            return temp == null
+                ? unansweredList(timedOut: true)
+                : answeredList(const <Event>[]);
+          });
+          final repository = createRepository(
+            dmInboxLookupRelays: const ['wss://purplepag.es'],
+          );
+
+          final resolved = await repository.resolveDmInboxRelaysDetailed(
+            _validPubkeyB,
+          );
+
+          expect(resolved.state, DmInboxResolution.unreadable);
+          expect(resolved.relays, isNull);
+        },
+      );
 
       test(
         'a list returned alongside an unsettled relay is FOUND, not unreadable '
@@ -5095,6 +5141,47 @@ void main() {
         ],
         '',
         createdAt: 1700000000,
+      );
+
+      test(
+        'own-inbox reads stay pool-only when recipient lookup relays are '
+        'configured',
+        () async {
+          final queryTempRelays = <List<String>?>[];
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((invocation) async {
+            queryTempRelays.add(
+              invocation.namedArguments[#tempRelays] as List<String>?,
+            );
+            return answeredList(const <Event>[]);
+          });
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+          final repository = createRepository(
+            dmInboxLookupRelays: const ['wss://purplepag.es'],
+          );
+
+          await repository.startListening();
+
+          expect(queryTempRelays, [null]);
+          await repository.stopListening();
+          await controller.close();
+        },
       );
 
       test(
@@ -6126,7 +6213,7 @@ void main() {
         );
 
         test(
-          'reads a recipient kind-10050 cheaply: cache on, first answer wins',
+          'reads a recipient kind-10050 conclusively before reporting absent',
           () async {
             stubOwnInbox(answeredList(const <Event>[]));
 
@@ -6157,7 +6244,7 @@ void main() {
               expect(captured[i + 1], isTrue, reason: 'useCache');
               expect(
                 captured[i + 2],
-                isFalse,
+                isTrue,
                 reason: 'requireAllRelaysSettled',
               );
             }

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -4977,6 +4977,47 @@ void main() {
       });
 
       test(
+        'resolves a recipient whose kind-10050 is only on a discovery relay: '
+        'the lookup is widened to the indexer relays, so "our pool does not '
+        'carry it" stops masquerading as absent (#7317)',
+        () async {
+          // Model the real relay behaviour: the connected pool holds nothing
+          // for this author, and only the discovery/indexer relay serves the
+          // recipient's kind-10050. The answer therefore depends on WHETHER the
+          // lookup reached the discovery relay — which is exactly the widening
+          // this test pins.
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((invocation) async {
+            final temp =
+                invocation.namedArguments[#tempRelays] as List<String>?;
+            final reachedDiscovery =
+                temp != null && temp.contains('wss://purplepag.es');
+            return reachedDiscovery
+                ? answeredList([
+                    kind10050Event(['wss://inbox.example']),
+                  ])
+                : answeredList(const <Event>[]);
+          });
+          final repository = createRepository(
+            dmInboxDiscoveryRelays: const ['wss://purplepag.es'],
+          );
+          final resolved = await repository.resolveDmInboxRelaysDetailed(
+            _validPubkeyB,
+          );
+          expect(resolved.state, DmInboxResolution.found);
+          expect(resolved.relays, ['wss://inbox.example']);
+        },
+      );
+
+      test(
         'reports absent when the relays answered and there is no inbox',
         () async {
           stubQueryDetailed(answeredList(const <Event>[]));

--- a/mobile/test/services/relay_discovery_service_test.dart
+++ b/mobile/test/services/relay_discovery_service_test.dart
@@ -394,6 +394,14 @@ void main() {
   });
 
   group(IndexerRelayConfig, () {
+    test('keeps DM inbox lookup policy separate from publication targets', () {
+      expect(IndexerRelayConfig.dmInboxLookupRelays, ['wss://purplepag.es']);
+      expect(
+        IndexerRelayConfig.dmInboxLookupRelays,
+        isNot(equals(IndexerRelayConfig.dmInboxDiscoveryRelays)),
+      );
+    });
+
     group('safeFallbackRelays (#2931)', () {
       test('is non-empty so DM reachability degrades gracefully', () {
         // Regression guard for #2931: when NIP-65 discovery fails or


### PR DESCRIPTION
Part of #7317

## Problem

Divine previously resolved a recipient's NIP-17 kind-10050 inbox only through
the relays already configured on the device. If the list existed only on an
indexer, the lookup looked identical to "this recipient published no inbox."
The gift wrap then went to Divine's fallback pool, could be scored delivered,
and lost its durable retry row even though the recipient did not read there.

The first version of this change widened that same query with temporary
relays. That exposed two inverse failures: an outside temporary relay could
skip reconnecting an idle pool, and a cold WebSocket connection could consume
the entire lookup deadline before the query settled.

## Why this fix is safe

Remote-recipient lookup now runs two independent queries in parallel:

- a pool-only query with the existing 5-second budget, preserving the client's
  disconnected-pool reconnect preflight;
- a read-only lookup-indexer query with a 2-second budget.

An inbox returned by either query resolves `found`. An empty response resolves
`absent` only when both queries completed conclusively. If either source times
out or cannot reach a relay, the lookup remains `unreadable`, so the send stays
pending and retryable instead of being reported delivered through fallback.

The lookup indexer is deliberately separate from the relays that accept our
own kind-10050 publications. Recipient reads currently use Purple Pages, the
single measured kind-10050 lookup indexer; write acceptance is not treated as
evidence of useful third-party read coverage.

## Deliberately unchanged

- Self-authored inbox reads remain pool-only and fully settled. Widening the
  receive/subscription path safely is separate work because it must not let a
  transient indexer response replace the user's authoritative local list.
- The existing `found` / `absent` / `unreadable` contract and fallback delivery
  downgrade remain intact.
- A recipient whose list is absent from both the connected pool and the lookup
  indexer can still be classified absent. This PR improves discovery coverage;
  it does not complete every routing and UX decision in #7317.

## Verification

- Added a regression proving an indexer-only recipient resolves `found` while
  the pool query remains present.
- Added regressions proving a pool timeout plus an empty indexer response is
  `unreadable`, and self-authored reads never query the lookup indexer.
- Added configuration coverage separating lookup relays from publication
  relays.
- `flutter test packages/dm_repository/test` — 908 tests passed.
- Focused provider and relay-discovery tests — 43 tests passed.
- `flutter analyze` — no issues.
- Pre-push changed-file suite — 517 tests passed.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
