### PR TITLE
fix(collabs): prevent creators from inviting themselves

### DIFF
--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -158,6 +158,13 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
   /// Whether the profile repository was unavailable at init time.
   bool _profileRepoMissing = false;
 
+  /// [widget.initialSelectedProfiles] without the excluded viewer.
+  ///
+  /// Both the initial selection and the header's clear affordance read this
+  /// list, so a sheet whose only initial selection was the viewer has nothing
+  /// selected and nothing to clear.
+  late final List<UserProfile> _initialSelectedProfiles;
+
   /// Tracks selected pubkeys locally so toggling is reflected immediately.
   /// Initialised from [widget.excludePubkeys] and the viewer-filtered
   /// [widget.initialSelectedProfiles] so pre-selected users show as checked
@@ -180,15 +187,15 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
   @override
   void initState() {
     super.initState();
-    final initialSelectedProfiles = widget.initialSelectedProfiles
+    _initialSelectedProfiles = widget.initialSelectedProfiles
         .where((profile) => !_isExcludedViewer(profile.pubkey))
         .toList();
     _selectedPubkeys = {
       ...widget.excludePubkeys,
-      for (final profile in initialSelectedProfiles) profile.pubkey,
+      for (final profile in _initialSelectedProfiles) profile.pubkey,
     };
-    if (initialSelectedProfiles.isNotEmpty) {
-      _selectedProfiles.addAll(initialSelectedProfiles);
+    if (_initialSelectedProfiles.isNotEmpty) {
+      _selectedProfiles.addAll(_initialSelectedProfiles);
     }
     final profileRepo = ref.read(profileRepositoryProvider);
     if (profileRepo == null) {
@@ -508,7 +515,7 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
                   semanticLabel: context.l10n.userPickerConfirmSemanticLabel,
                   onPressed: _handleDone,
                 )
-              : widget.initialSelectedProfiles.isNotEmpty
+              : _initialSelectedProfiles.isNotEmpty
               ? DivineIconButton(
                   icon: .trash,
                   size: .small,

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -10,6 +10,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
+import 'package:nostr_sdk/nip19/pubkeys_equal.dart';
 import 'package:openvine/blocs/user_search/user_search_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -41,6 +42,7 @@ Future<List<UserProfile>?> showUserPickerSheet(
   ValueChanged<UserProfile>? onUserToggled,
   int? maxCount,
   Set<String> excludePubkeys = const {},
+  String? excludeViewerPubkey,
   List<UserProfile> initialSelectedProfiles = const [],
 }) {
   return VineBottomSheet.show<List<UserProfile>?>(
@@ -58,6 +60,7 @@ Future<List<UserProfile>?> showUserPickerSheet(
       searchText: searchText,
       maxCount: maxCount,
       excludePubkeys: excludePubkeys,
+      excludeViewerPubkey: excludeViewerPubkey,
       searchHint: searchHint,
       onUserToggled: onUserToggled,
       initialSelectedProfiles: initialSelectedProfiles,
@@ -76,6 +79,7 @@ class UserPickerSheet extends ConsumerStatefulWidget {
     this.searchText,
     this.maxCount,
     this.excludePubkeys = const {},
+    this.excludeViewerPubkey,
     this.searchHint,
     this.onUserToggled,
     this.initialSelectedProfiles = const [],
@@ -102,6 +106,9 @@ class UserPickerSheet extends ConsumerStatefulWidget {
 
   /// Pubkeys to exclude from search results (already selected users).
   final Set<String> excludePubkeys;
+
+  /// Viewer pubkey to hide and prevent from being selected.
+  final String? excludeViewerPubkey;
 
   /// Optional override for the search field hint text.
   final String? searchHint;
@@ -180,6 +187,7 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
     _searchBloc = UserSearchBloc(
       profileRepository: profileRepo,
       followRepository: ref.read(followRepositoryProvider),
+      excludedPubkey: widget.excludeViewerPubkey,
     );
 
     if (_useLocalSearch) {
@@ -227,7 +235,8 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
         cached
             .where(
               (profile) =>
-                  !blocklistRepository.shouldFilterFromFeeds(profile.pubkey),
+                  !blocklistRepository.shouldFilterFromFeeds(profile.pubkey) &&
+                  !_isExcludedViewer(profile.pubkey),
             )
             .toList(),
       );
@@ -393,6 +402,8 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
   }
 
   void _onUserSelected(UserProfile profile) {
+    if (_isExcludedViewer(profile.pubkey)) return;
+
     if (widget.onUserToggled != null) {
       setState(() {
         if (_selectedPubkeys.remove(profile.pubkey)) {
@@ -416,6 +427,11 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
     } else {
       Navigator.of(context).pop([profile]);
     }
+  }
+
+  bool _isExcludedViewer(String pubkey) {
+    final viewerPubkey = widget.excludeViewerPubkey;
+    return viewerPubkey != null && pubkeysEqual(pubkey, viewerPubkey);
   }
 
   void _handleDone() {

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -172,12 +172,15 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
   @override
   void initState() {
     super.initState();
+    final initialSelectedProfiles = widget.initialSelectedProfiles
+        .where((profile) => !_isExcludedViewer(profile.pubkey))
+        .toList();
     _selectedPubkeys = {
       ...widget.excludePubkeys,
-      for (final profile in widget.initialSelectedProfiles) profile.pubkey,
+      for (final profile in initialSelectedProfiles) profile.pubkey,
     };
-    if (widget.initialSelectedProfiles.isNotEmpty) {
-      _selectedProfiles.addAll(widget.initialSelectedProfiles);
+    if (initialSelectedProfiles.isNotEmpty) {
+      _selectedProfiles.addAll(initialSelectedProfiles);
     }
     final profileRepo = ref.read(profileRepositoryProvider);
     if (profileRepo == null) {

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -31,7 +31,8 @@ enum UserPickerFilterMode {
 
 /// Shows a [UserPickerSheet] as a modal bottom sheet.
 ///
-/// Returns the selected [UserProfile] or null if dismissed.
+/// Returns the selected profiles (one entry for a single-select sheet, an
+/// empty list when the selection was cleared) or null if dismissed.
 Future<List<UserProfile>?> showUserPickerSheet(
   BuildContext context, {
   required UserPickerFilterMode filterMode,
@@ -104,10 +105,16 @@ class UserPickerSheet extends ConsumerStatefulWidget {
 
   final bool autoFocus;
 
-  /// Pubkeys to exclude from search results (already selected users).
+  /// Pubkeys the caller already tracks as selected. Their rows render in
+  /// the checked state rather than being hidden.
   final Set<String> excludePubkeys;
 
-  /// Viewer pubkey to hide and prevent from being selected.
+  /// Hex pubkey of the signed-in viewer, compared case-insensitively.
+  ///
+  /// A matching row is hidden, a tap on one is ignored, and a matching entry
+  /// in [initialSelectedProfiles] is dropped before it can occupy a slot. A
+  /// contact list written by another client can follow itself, which would
+  /// otherwise make the viewer their own mutual.
   final String? excludeViewerPubkey;
 
   /// Optional override for the search field hint text.
@@ -152,8 +159,9 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
   bool _profileRepoMissing = false;
 
   /// Tracks selected pubkeys locally so toggling is reflected immediately.
-  /// Initialised from [widget.excludePubkeys] so pre-selected users show
-  /// as checked from the start.
+  /// Initialised from [widget.excludePubkeys] and the viewer-filtered
+  /// [widget.initialSelectedProfiles] so pre-selected users show as checked
+  /// from the start.
   late Set<String> _selectedPubkeys;
 
   bool get _useLocalSearch =>

--- a/mobile/lib/widgets/video_metadata/video_metadata_collaborators_input.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_collaborators_input.dart
@@ -4,8 +4,10 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nostr_sdk/nip19/pubkeys_equal.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/widgets/user_picker_sheet.dart';
@@ -18,11 +20,19 @@ Set<String> computeEffectiveCollaboratorResultPubkeys({
   required Set<String> confirmedPubkeys,
   required Set<String> preselectedPubkeys,
   required Set<String> pickerResultPubkeys,
+  required String? viewerPubkey,
 }) {
   final unresolvedConfirmedPubkeys = confirmedPubkeys.difference(
     preselectedPubkeys,
   );
-  return {...pickerResultPubkeys, ...unresolvedConfirmedPubkeys};
+  final effectivePubkeys = {
+    ...pickerResultPubkeys,
+    ...unresolvedConfirmedPubkeys,
+  };
+  if (viewerPubkey == null) return effectivePubkeys;
+  return effectivePubkeys
+      .where((pubkey) => !pubkeysEqual(pubkey, viewerPubkey))
+      .toSet();
 }
 
 /// Input widget for adding and managing collaborators on a video.
@@ -60,6 +70,7 @@ class VideoMetadataCollaboratorsInput extends ConsumerWidget {
 
   Future<void> _addCollaborator(BuildContext context, WidgetRef ref) async {
     final editorState = ref.read(videoEditorProvider);
+    final viewerPubkey = ref.read(authServiceProvider).currentPublicKeyHex;
 
     // Confirmed collaborators shown as pre-selected chips in the picker.
     final confirmedProfiles = editorState.collaboratorPubkeys
@@ -74,6 +85,7 @@ class VideoMetadataCollaboratorsInput extends ConsumerWidget {
       searchText: context.l10n.videoMetadataMutualFollowersSearchText,
       maxCount: VideoEditorConstants.maxCollaborators,
       initialSelectedProfiles: confirmedProfiles,
+      excludeViewerPubkey: viewerPubkey,
     );
 
     if (result == null || !context.mounted) return;
@@ -86,6 +98,7 @@ class VideoMetadataCollaboratorsInput extends ConsumerWidget {
       confirmedPubkeys: confirmedPubkeys,
       preselectedPubkeys: preselectedPubkeys,
       pickerResultPubkeys: resultPubkeys,
+      viewerPubkey: viewerPubkey,
     );
 
     // Remove confirmed collaborators that were deselected in the picker.
@@ -95,11 +108,11 @@ class VideoMetadataCollaboratorsInput extends ConsumerWidget {
       }
     }
 
-    // Confirm newly selected profiles. Mutual-follow is already guaranteed
+    // Confirm newly selected pubkeys. Mutual-follow is already guaranteed
     // by the picker's mutualFollowsOnly filter (verified at sheet open time).
-    for (final profile in result) {
-      if (confirmedPubkeys.contains(profile.pubkey)) continue;
-      notifier.addCollaborator(profile.pubkey);
+    for (final pubkey in effectiveResultPubkeys) {
+      if (confirmedPubkeys.contains(pubkey)) continue;
+      notifier.addCollaborator(pubkey);
     }
   }
 }

--- a/mobile/lib/widgets/video_metadata/video_metadata_collaborators_input.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_collaborators_input.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Input widget for adding/managing video collaborators
-// ABOUTME: Shows collaborator chips with remove buttons, max 5 limit,
-// ABOUTME: and opens UserPickerSheet for inviting via mutual-follow search
+// ABOUTME: Shows the confirmed collaborators' names on a selection tile and
+// ABOUTME: opens UserPickerSheet for inviting via mutual-follow search
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -15,6 +15,11 @@ import 'package:openvine/widgets/video_metadata/video_metadata_selection_tile.da
 
 /// Preserves confirmed collaborators whose profiles were unavailable when the
 /// picker opened, so they are not silently dropped on Done.
+///
+/// Removes [viewerPubkey] from the result, compared case-insensitively, so a
+/// self-collaborator confirmed before the picker excluded the viewer cannot
+/// survive a reconciliation — including one whose profile never resolved and
+/// so never reached the picker's own filter.
 @visibleForTesting
 Set<String> computeEffectiveCollaboratorResultPubkeys({
   required Set<String> confirmedPubkeys,
@@ -37,8 +42,8 @@ Set<String> computeEffectiveCollaboratorResultPubkeys({
 
 /// Input widget for adding and managing collaborators on a video.
 ///
-/// Displays collaborator chips (avatar + name + remove) and an
-/// invite button. Limited to [VideoEditorNotifier.maxCollaborators].
+/// Displays the confirmed collaborators' names on a selection tile that opens
+/// the picker. Limited to [VideoEditorConstants.maxCollaborators].
 class VideoMetadataCollaboratorsInput extends ConsumerWidget {
   /// Creates a video metadata collaborators input widget.
   const VideoMetadataCollaboratorsInput({super.key});
@@ -108,8 +113,9 @@ class VideoMetadataCollaboratorsInput extends ConsumerWidget {
       }
     }
 
-    // Confirm newly selected pubkeys. Mutual-follow is already guaranteed
-    // by the picker's mutualFollowsOnly filter (verified at sheet open time).
+    // Confirm newly selected pubkeys. The picker's mutualFollowsOnly mode
+    // narrows the rows to mutuals as each follower source answers, and only
+    // falls back to plain follows when every follower source failed.
     for (final pubkey in effectiveResultPubkeys) {
       if (confirmedPubkeys.contains(pubkey)) continue;
       notifier.addCollaborator(pubkey);

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -379,6 +379,107 @@ void main() {
     });
 
     group('mutualFollowsOnly mode', () {
+      testWidgets('excludes the viewer from self-following mutuals', (
+        tester,
+      ) async {
+        const viewerPubkey =
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        final viewer = UserProfile(
+          pubkey: viewerPubkey,
+          name: 'Viewer',
+          rawData: const {'name': 'Viewer'},
+          createdAt: DateTime.now(),
+          eventId: 'viewer-event',
+        );
+        final mutual = UserProfile(
+          pubkey:
+              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          name: 'Mutual',
+          rawData: const {'name': 'Mutual'},
+          createdAt: DateTime.now(),
+          eventId: 'mutual-event',
+        );
+        final mockFollowRepo = _createMockFollowRepository(
+          followingPubkeys: [viewer.pubkey, mutual.pubkey],
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              _noVanishedProfiles,
+              profileRepositoryProvider.overrideWithValue(
+                _createMockProfileRepository(
+                  cachedProfiles: [viewer, mutual],
+                ),
+              ),
+              followRepositoryProvider.overrideWithValue(mockFollowRepo),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                _createMockContentBlocklistRepository(),
+              ),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: UserPickerSheet(
+                  title: 'Title',
+                  filterMode: UserPickerFilterMode.mutualFollowsOnly,
+                  excludeViewerPubkey: viewerPubkey,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Viewer'), findsNothing);
+        expect(find.text('Mutual'), findsOneWidget);
+      });
+
+      testWidgets('excludes the viewer case-insensitively', (tester) async {
+        const viewerPubkey =
+            'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+        final viewer = UserProfile(
+          pubkey: viewerPubkey,
+          name: 'Viewer',
+          rawData: const {'name': 'Viewer'},
+          createdAt: DateTime.now(),
+          eventId: 'viewer-event',
+        );
+        final mockFollowRepo = _createMockFollowRepository(
+          followingPubkeys: [viewer.pubkey],
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              _noVanishedProfiles,
+              profileRepositoryProvider.overrideWithValue(
+                _createMockProfileRepository(cachedProfiles: [viewer]),
+              ),
+              followRepositoryProvider.overrideWithValue(mockFollowRepo),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                _createMockContentBlocklistRepository(),
+              ),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: UserPickerSheet(
+                  title: 'Title',
+                  filterMode: UserPickerFilterMode.mutualFollowsOnly,
+                  excludeViewerPubkey: viewerPubkey.toUpperCase(),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Viewer'), findsNothing);
+      });
+
       testWidgets('shows loading indicator until the first follower source '
           'answers', (tester) async {
         final mockFollowRepo = _createMockFollowRepository(

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -255,6 +255,51 @@ void main() {
         );
       });
 
+      testWidgets('header offers nothing to clear when the only initial '
+          'selection is the excluded viewer', (tester) async {
+        const viewerPubkey =
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        final viewer = UserProfile(
+          pubkey: viewerPubkey,
+          name: 'Viewer',
+          rawData: const {'name': 'Viewer'},
+          createdAt: DateTime(2026),
+          eventId: 'viewer-event',
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              _noVanishedProfiles,
+              profileRepositoryProvider.overrideWithValue(
+                _createMockProfileRepository(),
+              ),
+              followRepositoryProvider.overrideWithValue(
+                _createMockFollowRepository(),
+              ),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: UserPickerSheet(
+                  title: 'Title',
+                  filterMode: UserPickerFilterMode.allUsers,
+                  excludeViewerPubkey: viewerPubkey,
+                  initialSelectedProfiles: [viewer],
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.bySemanticsLabel(l10n.userPickerClearSelectionSemanticLabel),
+          findsNothing,
+        );
+      });
+
       testWidgets('search text field', (tester) async {
         await tester.pumpWidget(
           ProviderScope(

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -408,9 +408,7 @@ void main() {
             overrides: [
               _noVanishedProfiles,
               profileRepositoryProvider.overrideWithValue(
-                _createMockProfileRepository(
-                  cachedProfiles: [viewer, mutual],
-                ),
+                _createMockProfileRepository(cachedProfiles: [viewer, mutual]),
               ),
               followRepositoryProvider.overrideWithValue(mockFollowRepo),
               contentBlocklistRepositoryProvider.overrideWithValue(
@@ -478,6 +476,67 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('Viewer'), findsNothing);
+      });
+
+      testWidgets('excluded initial viewer does not consume a selection slot', (
+        tester,
+      ) async {
+        const viewerPubkey =
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        final viewer = UserProfile(
+          pubkey: viewerPubkey,
+          name: 'Viewer',
+          rawData: const {'name': 'Viewer'},
+          createdAt: DateTime.now(),
+          eventId: 'viewer-event',
+        );
+        final mutual = UserProfile(
+          pubkey:
+              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          name: 'Mutual',
+          rawData: const {'name': 'Mutual'},
+          createdAt: DateTime.now(),
+          eventId: 'mutual-event',
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              _noVanishedProfiles,
+              profileRepositoryProvider.overrideWithValue(
+                _createMockProfileRepository(cachedProfiles: [viewer, mutual]),
+              ),
+              followRepositoryProvider.overrideWithValue(
+                _createMockFollowRepository(
+                  followingPubkeys: [viewer.pubkey, mutual.pubkey],
+                ),
+              ),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                _createMockContentBlocklistRepository(),
+              ),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: UserPickerSheet(
+                  title: 'Title',
+                  filterMode: UserPickerFilterMode.mutualFollowsOnly,
+                  maxCount: 1,
+                  excludeViewerPubkey: viewerPubkey,
+                  initialSelectedProfiles: [viewer],
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('0/1 Title'), findsOneWidget);
+        await tester.tap(find.text('Mutual'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('1/1 Title'), findsOneWidget);
       });
 
       testWidgets('shows loading indicator until the first follower source '
@@ -1897,9 +1956,7 @@ void main() {
           .widgetList<Text>(find.byType(Text))
           .map((t) => t.data)
           .whereType<String>()
-          .where(
-            (t) => t == 'Aaron' || t == l10n.profileDeletedAccountName,
-          )
+          .where((t) => t == 'Aaron' || t == l10n.profileDeletedAccountName)
           .toList();
       expect(rendered, ['Aaron', l10n.profileDeletedAccountName]);
     });

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -1330,6 +1330,63 @@ void main() {
     });
 
     group('allUsers mode', () {
+      testWidgets('excludes the viewer from network search results', (
+        tester,
+      ) async {
+        const viewerPubkey =
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        final viewer = UserProfile(
+          pubkey: viewerPubkey,
+          name: 'Viewer',
+          rawData: const {'name': 'Viewer'},
+          createdAt: DateTime.now(),
+          eventId: 'viewer-event',
+        );
+        final other = UserProfile(
+          pubkey:
+              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          name: 'Other',
+          rawData: const {'name': 'Other'},
+          createdAt: DateTime.now(),
+          eventId: 'other-event',
+        );
+        final mockProfileRepo = _createMockProfileRepository(
+          searchResults: [viewer, other],
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              _noVanishedProfiles,
+              profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+              profileReadRepositoryProvider.overrideWithValue(mockProfileRepo),
+              followRepositoryProvider.overrideWithValue(
+                _createMockFollowRepository(),
+              ),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: UserPickerSheet(
+                  title: 'Title',
+                  filterMode: UserPickerFilterMode.allUsers,
+                  excludeViewerPubkey: viewerPubkey,
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField), 'vie');
+        // Past the 300ms search debounce.
+        await tester.pump(const Duration(milliseconds: 400));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Other'), findsOneWidget);
+        expect(find.text('Viewer'), findsNothing);
+      });
+
       testWidgets('shows hint text initially', (tester) async {
         await tester.pumpWidget(
           ProviderScope(

--- a/mobile/test/widgets/video_metadata/video_metadata_collaborators_input_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_collaborators_input_test.dart
@@ -72,6 +72,7 @@ void main() {
         confirmedPubkeys: {'a', 'b'},
         preselectedPubkeys: {'a'},
         pickerResultPubkeys: {'a'},
+        viewerPubkey: null,
       );
 
       expect(effective, equals({'a', 'b'}));
@@ -82,9 +83,56 @@ void main() {
         confirmedPubkeys: {'a', 'b'},
         preselectedPubkeys: {'a', 'b'},
         pickerResultPubkeys: {'a'},
+        viewerPubkey: null,
       );
 
       expect(effective, equals({'a'}));
+    });
+
+    test('removes the viewer from picker results', () {
+      const viewerPubkey =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      final effective = computeEffectiveCollaboratorResultPubkeys(
+        confirmedPubkeys: const {},
+        preselectedPubkeys: const {},
+        pickerResultPubkeys: const {
+          viewerPubkey,
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        },
+        viewerPubkey: viewerPubkey,
+      );
+
+      expect(effective, {
+        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      });
+    });
+
+    test('removes the viewer case-insensitively', () {
+      const viewerPubkey =
+          'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+      final effective = computeEffectiveCollaboratorResultPubkeys(
+        confirmedPubkeys: const {},
+        preselectedPubkeys: const {},
+        pickerResultPubkeys: {viewerPubkey.toUpperCase()},
+        viewerPubkey: viewerPubkey,
+      );
+
+      expect(effective, isEmpty);
+    });
+
+    test('preserves unresolved non-viewer collaborators', () {
+      const viewerPubkey =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const unresolvedPubkey =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      final effective = computeEffectiveCollaboratorResultPubkeys(
+        confirmedPubkeys: const {viewerPubkey, unresolvedPubkey},
+        preselectedPubkeys: const {},
+        pickerResultPubkeys: const {},
+        viewerPubkey: viewerPubkey,
+      );
+
+      expect(effective, {unresolvedPubkey});
     });
   });
 

--- a/mobile/test/widgets/video_metadata/video_metadata_collaborators_input_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_collaborators_input_test.dart
@@ -422,7 +422,7 @@ void main() {
       },
     );
 
-    testWidgets('passes the viewer pubkey to the collaborator picker', (
+    testWidgets('passes the viewer pubkey and removes a stale self-selection', (
       tester,
     ) async {
       const viewerPubkey =
@@ -447,6 +447,11 @@ void main() {
       when(
         () => contentBlocklistRepository.shouldFilterFromFeeds(any()),
       ).thenReturn(false);
+      final editorNotifier = _MockVideoEditorNotifier(
+        VideoEditorProviderState(
+          collaboratorPubkeys: {viewerPubkey},
+        ),
+      );
 
       await tester.pumpWidget(
         ProviderScope(
@@ -461,6 +466,7 @@ void main() {
               ),
             ),
             profileRepositoryProvider.overrideWithValue(profileRepository),
+            videoEditorProvider.overrideWith(() => editorNotifier),
             contentBlocklistRepositoryProvider.overrideWithValue(
               contentBlocklistRepository,
             ),
@@ -481,6 +487,13 @@ void main() {
 
       expect(find.text('Viewer'), findsNothing);
       expect(find.text('Mutual'), findsOneWidget);
+
+      await tester.tap(
+        find.bySemanticsLabel(_l10n.userPickerConfirmSemanticLabel),
+      );
+      await tester.pumpAndSettle();
+
+      expect(editorNotifier.state.collaboratorPubkeys, isEmpty);
     });
   });
 }

--- a/mobile/test/widgets/video_metadata/video_metadata_collaborators_input_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_collaborators_input_test.dart
@@ -1,3 +1,4 @@
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -8,6 +9,7 @@ import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
@@ -17,11 +19,15 @@ import 'package:rxdart/rxdart.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../builders/user_profile_builder.dart';
+import '../../helpers/test_provider_overrides.dart';
 
 final AppLocalizations _l10n = lookupAppLocalizations(const Locale('en'));
 
 /// Mock for FollowRepository
 class _MockFollowRepository extends Mock implements FollowRepository {}
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
 
 /// Mock notifier for testing
 class _MockVideoEditorNotifier extends VideoEditorNotifier {
@@ -60,6 +66,9 @@ _MockFollowRepository _createMockFollowRepository({
   );
   when(() => mock.isInitialized).thenReturn(true);
   when(() => mock.followingCount).thenReturn(followingPubkeys.length);
+  when(
+    mock.streamMyFollowers,
+  ).thenAnswer((_) => Stream.value(followingPubkeys));
   return mock;
 }
 
@@ -412,5 +421,66 @@ void main() {
         expect(tile.value, anyOf(equals('Alice, Bob'), equals('Bob, Alice')));
       },
     );
+
+    testWidgets('passes the viewer pubkey to the collaborator picker', (
+      tester,
+    ) async {
+      const viewerPubkey =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const mutualPubkey =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      final viewer = UserProfileBuilder(
+        pubkey: viewerPubkey,
+        displayName: 'Viewer',
+      ).build();
+      final mutual = UserProfileBuilder(
+        pubkey: mutualPubkey,
+        displayName: 'Mutual',
+      ).build();
+      final profileRepository = createMockProfileRepository();
+      when(
+        () => profileRepository.getCachedProfiles(
+          pubkeys: any(named: 'pubkeys'),
+        ),
+      ).thenAnswer((_) async => [viewer, mutual]);
+      final contentBlocklistRepository = _MockContentBlocklistRepository();
+      when(
+        () => contentBlocklistRepository.shouldFilterFromFeeds(any()),
+      ).thenReturn(false);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            authServiceProvider.overrideWithValue(
+              createMockAuthService(currentPublicKeyHex: viewerPubkey),
+            ),
+            followRepositoryProvider.overrideWithValue(
+              _createMockFollowRepository(
+                followingPubkeys: [viewerPubkey, mutualPubkey],
+              ),
+            ),
+            profileRepositoryProvider.overrideWithValue(profileRepository),
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              contentBlocklistRepository,
+            ),
+            vanishedProfilePubkeysProvider.overrideWith(
+              (ref) => const Stream<Set<String>>.empty(),
+            ),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: VideoMetadataCollaboratorsInput()),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(VideoMetadataSelectionTile));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Viewer'), findsNothing);
+      expect(find.text('Mutual'), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## Description

Creators who follow themselves through another Nostr client could appear in the video collaborator picker and select themselves, causing the invite to fail during publishing. This passes the signed-in creator into the picker, excludes that identity case-insensitively at display and selection boundaries, and removes any stale self-collaborator when picker results are reconciled.

**Related Issue:** Closes #8360

## Out of Scope

People-list membership, Inspired By, and badge recipient pickers are unchanged because their self-selection policies are separate product decisions.

## Verification

- `flutter test test/widgets/user_picker_sheet_test.dart test/widgets/video_metadata/video_metadata_collaborators_input_test.dart` (58 tests)
- `flutter analyze lib test integration_test`
- `flutter test test/l10n/arb_consistency_test.dart` (11 tests)
- Localization hardcoded-string scan on both changed production files

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
