### PR TITLE
fix(observability): stop dropping crash reports filed before Crashlytics finishes initializing

### DIFF
--- a/docs/CRASH_REPORTING_SETUP.md
+++ b/docs/CRASH_REPORTING_SETUP.md
@@ -79,12 +79,10 @@ Without this, iOS crash stacks arrive in Crashlytics unsymbolicated.
 
 ## Custom keys on every report
 
-Set by `CrashReportingService.initialize()` and follow-up helpers:
+Set by `CrashReportingService.initialize()`:
 
 - `environment` — `ENVIRONMENT` build define (default `production`)
 - `build_mode` — `debug` / `release`
-- `cache_hit_rate`, `cache_total_lookups` — set by
-  `updateCacheMetricsKeys()` when the app backgrounds
 
 Bloc/Cubit errors are additionally annotated by `DivineBlocObserver`, which
 forwards to Crashlytics **only** when the error implements `ReportableError`

--- a/mobile/lib/observability/divine_bloc_observer.dart
+++ b/mobile/lib/observability/divine_bloc_observer.dart
@@ -126,8 +126,8 @@ class DivineBlocObserver extends BlocObserver {
     // report it emits. Both are fire-and-forget, but invoked synchronously and
     // in order, so the platform-channel messages stay ordered without blocking
     // the bloc error path. recordError and setCustomKey each swallow their own
-    // failures and return early when uninitialized (see
-    // crash_reporting_service.dart).
+    // failures, and while Crashlytics is still initializing they are held in
+    // that same order for replay (see crash_reporting_service.dart).
     _attachDiagnosticKeys(_diagnostics[bloc]);
     final reason = sanitizeForCrashReport('Bloc.addError $runtimeType');
     unawaited(

--- a/mobile/lib/providers/crash_reporting_provider.dart
+++ b/mobile/lib/providers/crash_reporting_provider.dart
@@ -15,11 +15,12 @@ import 'package:openvine/services/crash_reporting_service.dart';
 /// initialized early so startup failures are reportable — and pinned by
 /// `DeviceScope`, so this provider is override-only.
 /// The fallback instance is deliberately a real but **uninitialized**
-/// service: every reporting method no-ops until `initialize()` runs, which is
-/// exactly what `CrashReportingService.instance` gave a test before #4743. It
-/// exists so a test container need not know about this provider; production
-/// always receives the initialized instance through `DeviceScope`, which every
-/// container is built from (`buildAccountContainer`).
+/// service: nothing calls `initialize()` on it, so it never reaches Firebase —
+/// it writes non-fatal errors to the unified log and holds a bounded number of
+/// calls that are never replayed (#8616). It exists so a test container need
+/// not know about this provider; production always receives the initialized
+/// instance through `DeviceScope`, which every container is built from
+/// (`buildAccountContainer`).
 final crashReportingServiceProvider = Provider<CrashReportingService>(
   (ref) => CrashReportingService(),
 );

--- a/mobile/lib/services/crash_reporting_service.dart
+++ b/mobile/lib/services/crash_reporting_service.dart
@@ -111,7 +111,16 @@ class CrashReportingService implements CrashReporter {
     StackTrace? stack, {
     String? reason,
   }) async {
-    if (!_initialized) return;
+    if (!_initialized) {
+      Log.error(
+        'Non-fatal error not forwarded to Crashlytics (not initialized): '
+        '$reason',
+        name: 'CrashReporting',
+        error: exception,
+        stackTrace: stack,
+      );
+      return;
+    }
 
     try {
       await FirebaseCrashlytics.instance.recordError(

--- a/mobile/lib/services/crash_reporting_service.dart
+++ b/mobile/lib/services/crash_reporting_service.dart
@@ -10,25 +10,77 @@ import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/utils/platform_support.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-/// Crash reporting service for production error tracking
-class CrashReportingService implements CrashReporter {
-  CrashReportingService();
+/// One call against Crashlytics, held until [CrashReportingService.initialize]
+/// has decided whether Crashlytics exists.
+typedef _CrashlyticsCall =
+    Future<void> Function(FirebaseCrashlytics crashlytics);
 
-  bool _initialized = false;
+/// Whether Crashlytics can take a call right now.
+enum _Readiness {
+  /// [CrashReportingService.initialize] has not resolved; calls are held.
+  pending,
+
+  /// Crashlytics is up; calls are forwarded as they arrive.
+  ready,
+
+  /// Firebase is unsupported here or failed to initialize; nothing is
+  /// forwarded, and non-fatal errors fall back to the unified log.
+  unavailable,
+}
+
+/// Crash reporting service for production error tracking.
+///
+/// Nothing handed to this service is discarded silently (#8616). Until
+/// [initialize] resolves, every call is held in order — the first
+/// [pendingReportCapacity] of them — and replayed once Crashlytics is up, so
+/// the breadcrumbs and non-fatal errors from the pre-init startup window still
+/// reach the dashboard. A non-fatal error is also written to the unified log
+/// at once, because that log is what a bug report carries and the process may
+/// never reach [initialize]: a launch that fails closed before it, or an
+/// isolate that never calls it. If Crashlytics turns out to be unavailable the
+/// held calls are dropped with a count; from then on non-fatal errors go to
+/// the unified log, while breadcrumbs and keys — which only mean anything
+/// attached to a Crashlytics report — are dropped.
+class CrashReportingService implements CrashReporter {
+  /// [initializeFirebase] and [crashlytics] default to the real Firebase; tests
+  /// inject stand-ins so the replay can be observed without a Firebase app.
+  CrashReportingService({
+    Future<void> Function() initializeFirebase =
+        ensureDefaultFirebaseInitialized,
+    FirebaseCrashlytics Function() crashlytics = _defaultCrashlytics,
+  }) : _initializeFirebase = initializeFirebase,
+       _crashlytics = crashlytics;
+
+  /// How many calls are held before [initialize] resolves. The earliest are
+  /// kept: in a startup error storm the first report is the root cause and the
+  /// rest are its cascade.
+  static const int pendingReportCapacity = 32;
+
+  static FirebaseCrashlytics _defaultCrashlytics() =>
+      FirebaseCrashlytics.instance;
+
+  final Future<void> Function() _initializeFirebase;
+  final FirebaseCrashlytics Function() _crashlytics;
+
+  _Readiness _readiness = _Readiness.pending;
+  final List<_CrashlyticsCall> _pending = [];
+  int _overflowed = 0;
 
   /// Initialize crash reporting (Firebase Crashlytics)
   Future<void> initialize() async {
-    if (_initialized) return;
+    if (_readiness != _Readiness.pending) return;
 
     // Firebase only supports Android, iOS, macOS, and web.
     // DefaultFirebaseOptions.currentPlatform throws UnsupportedError for
     // Linux and Windows — skip initialization on those platforms.
     if (!isFirebaseSupported) {
+      _giveUp('Firebase is not supported on this platform');
       return;
     }
 
     try {
-      await ensureDefaultFirebaseInitialized();
+      await _initializeFirebase();
+      final crashlytics = _crashlytics();
 
       // Pass all uncaught errors from the framework to Crashlytics
       FlutterError.onError = (errorDetails) {
@@ -39,7 +91,7 @@ class CrashReportingService implements CrashReporter {
         );
 
         // Send to Crashlytics
-        FirebaseCrashlytics.instance.recordFlutterFatalError(errorDetails);
+        crashlytics.recordFlutterFatalError(errorDetails);
       };
 
       // Pass all uncaught asynchronous errors to Crashlytics
@@ -48,16 +100,16 @@ class CrashReportingService implements CrashReporter {
         Log.error('Async error: $error', name: 'CrashReporting');
 
         // Send to Crashlytics
-        FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+        crashlytics.recordError(error, stack, fatal: true);
         return true;
       };
 
       // Set custom keys for debugging
-      await FirebaseCrashlytics.instance.setCustomKey(
+      await crashlytics.setCustomKey(
         'environment',
         const String.fromEnvironment('ENVIRONMENT', defaultValue: 'production'),
       );
-      await FirebaseCrashlytics.instance.setCustomKey(
+      await crashlytics.setCustomKey(
         'build_mode',
         kDebugMode ? 'debug' : 'release',
       );
@@ -70,27 +122,26 @@ class CrashReportingService implements CrashReporter {
         name: 'CrashReportingService',
         category: LogCategory.system,
       );
-      await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(
-        enableCollection,
-      );
+      await crashlytics.setCrashlyticsCollectionEnabled(enableCollection);
 
       // Verify it's actually enabled
-      final isEnabled =
-          FirebaseCrashlytics.instance.isCrashlyticsCollectionEnabled;
+      final isEnabled = crashlytics.isCrashlyticsCollectionEnabled;
       Log.debug(
         '🔥 CRASHLYTICS: Collection enabled check = $isEnabled',
         name: 'CrashReportingService',
         category: LogCategory.system,
       );
 
+      _readiness = _Readiness.ready;
+      await _replayPending();
+
       // Log a breadcrumb to prove connection works (visible in Crashlytics logs)
       if (isEnabled) {
-        FirebaseCrashlytics.instance.log(
+        crashlytics.log(
           'App started: kDebugMode=$kDebugMode, collection=$isEnabled',
         );
       }
 
-      _initialized = true;
       Log.info(
         'Crash reporting initialized: kDebugMode=$kDebugMode, enabled=$isEnabled',
         name: 'CrashReporting',
@@ -101,103 +152,139 @@ class CrashReportingService implements CrashReporter {
         name: 'CrashReporting',
       );
       // Don't throw - app should continue even if crash reporting fails
+      _giveUp('Crashlytics failed to initialize');
     }
   }
 
-  /// Log a non-fatal error to Crashlytics
+  /// Marks Crashlytics unusable for the rest of the process and drops what was
+  /// held for it. Non-fatal errors among the held calls are already in the
+  /// unified log, so only the count is worth a line.
+  void _giveUp(String why) {
+    _readiness = _Readiness.unavailable;
+    final held = _pending.length + _overflowed;
+    _pending.clear();
+    _overflowed = 0;
+    if (held == 0) return;
+    Log.warning(
+      '$why; $held Crashlytics call(s) made before initialization were not '
+      'forwarded',
+      name: 'CrashReporting',
+    );
+  }
+
+  /// Replays the held calls now that Crashlytics is up.
+  Future<void> _replayPending() async {
+    final held = List<_CrashlyticsCall>.of(_pending);
+    _pending.clear();
+    // Started in one synchronous pass so the platform-channel messages keep
+    // their original order ahead of any call that arrives while they settle.
+    await Future.wait([
+      for (final call in held) _forward(call, what: 'replay a held call'),
+    ]);
+    if (_overflowed == 0) return;
+    Log.warning(
+      'Startup buffer overflowed: $_overflowed Crashlytics call(s) made before '
+      'initialization were not forwarded',
+      name: 'CrashReporting',
+    );
+    _overflowed = 0;
+  }
+
+  /// Forwards, holds, or drops [call] depending on readiness.
+  Future<void> _dispatch(_CrashlyticsCall call, {required String what}) async {
+    switch (_readiness) {
+      case _Readiness.ready:
+        await _forward(call, what: what);
+      case _Readiness.pending:
+        _hold(call);
+      case _Readiness.unavailable:
+        // Nothing to forward to; recordError has already logged its error.
+        break;
+    }
+  }
+
+  void _hold(_CrashlyticsCall call) {
+    if (_pending.length >= pendingReportCapacity) {
+      _overflowed++;
+      return;
+    }
+    _pending.add(call);
+  }
+
+  Future<void> _forward(_CrashlyticsCall call, {required String what}) async {
+    try {
+      await call(_crashlytics());
+    } catch (e) {
+      Log.error('Failed to $what in Crashlytics: $e', name: 'CrashReporting');
+    }
+  }
+
+  /// Log a non-fatal error to Crashlytics.
+  ///
+  /// Written to the unified log as well whenever Crashlytics cannot take it
+  /// right now, so a bug report carries it even if the process never gets to
+  /// [initialize].
   @override
   Future<void> recordError(
     dynamic exception,
     StackTrace? stack, {
     String? reason,
-  }) async {
-    if (!_initialized) {
+  }) {
+    if (_readiness != _Readiness.ready) {
+      final fate = _readiness == _Readiness.pending
+          ? 'held until Crashlytics initializes'
+          : 'not forwarded because Crashlytics is unavailable';
       Log.error(
-        'Non-fatal error not forwarded to Crashlytics (not initialized): '
-        '$reason',
+        'Non-fatal error $fate${reason == null ? '' : ': $reason'}',
         name: 'CrashReporting',
         error: exception,
         stackTrace: stack,
       );
-      return;
     }
-
-    try {
-      await FirebaseCrashlytics.instance.recordError(
-        exception,
-        stack,
-        reason: reason,
-      );
-    } catch (e) {
-      Log.error(
-        'Failed to record error to Crashlytics: $e',
-        name: 'CrashReporting',
-      );
-    }
+    return _dispatch(
+      (crashlytics) =>
+          crashlytics.recordError(exception, stack, reason: reason),
+      what: 'record error',
+    );
   }
 
   /// Log a custom message to Crashlytics
   @override
   void log(String message) {
-    if (!_initialized) return;
-
-    try {
-      FirebaseCrashlytics.instance.log(message);
-    } catch (e) {
-      Log.error(
-        'Failed to log message to Crashlytics: $e',
-        name: 'CrashReporting',
-      );
-    }
+    unawaited(
+      _dispatch((crashlytics) => crashlytics.log(message), what: 'log message'),
+    );
   }
 
   /// Set user identifier for crash reports
-  Future<void> setUserId(String? userId) async {
-    if (!_initialized) return;
-
-    try {
-      await FirebaseCrashlytics.instance.setUserIdentifier(userId ?? '');
-    } catch (e) {
-      Log.error(
-        'Failed to set user ID in Crashlytics: $e',
-        name: 'CrashReporting',
-      );
-    }
-  }
+  Future<void> setUserId(String? userId) => _dispatch(
+    (crashlytics) => crashlytics.setUserIdentifier(userId ?? ''),
+    what: 'set user ID',
+  );
 
   /// Add custom key-value pair to crash reports
   @override
-  Future<void> setCustomKey(String key, dynamic value) async {
-    if (!_initialized) return;
-
-    try {
-      await FirebaseCrashlytics.instance.setCustomKey(key, value as Object);
-    } catch (e) {
-      Log.error(
-        'Failed to set custom key in Crashlytics: $e',
-        name: 'CrashReporting',
-      );
-    }
-  }
+  Future<void> setCustomKey(String key, dynamic value) => _dispatch(
+    (crashlytics) => crashlytics.setCustomKey(key, value as Object),
+    what: 'set custom key',
+  );
 
   /// Update Crashlytics custom keys with current cache hit rate.
   ///
   /// Call periodically (e.g., on app background) to keep crash reports
   /// annotated with recent cache performance data.
   Future<void> updateCacheMetricsKeys() async {
-    if (!_initialized || kIsWeb) return;
+    if (_readiness != _Readiness.ready || kIsWeb) return;
 
     try {
       final metrics = openVineMediaCache.metrics;
       final totalLookups = metrics.hits + metrics.misses;
-      await FirebaseCrashlytics.instance.setCustomKey(
+      final crashlytics = _crashlytics();
+      await crashlytics.setCustomKey(
         'cache_hit_rate',
         metrics.hitRate.toStringAsFixed(3),
       );
-      await FirebaseCrashlytics.instance.setCustomKey(
-        'cache_total_lookups',
-        totalLookups,
-      );
+      await crashlytics.setCustomKey('cache_total_lookups', totalLookups);
     } catch (e) {
       Log.error(
         'Failed to set cache metrics keys in Crashlytics: $e',

--- a/mobile/lib/services/crash_reporting_service.dart
+++ b/mobile/lib/services/crash_reporting_service.dart
@@ -6,7 +6,6 @@ import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
 import 'package:openvine/observability/crash_reporter.dart';
 import 'package:openvine/services/firebase_initialization.dart';
-import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/utils/platform_support.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -268,30 +267,6 @@ class CrashReportingService implements CrashReporter {
     (crashlytics) => crashlytics.setCustomKey(key, value as Object),
     what: 'set custom key',
   );
-
-  /// Update Crashlytics custom keys with current cache hit rate.
-  ///
-  /// Call periodically (e.g., on app background) to keep crash reports
-  /// annotated with recent cache performance data.
-  Future<void> updateCacheMetricsKeys() async {
-    if (_readiness != _Readiness.ready || kIsWeb) return;
-
-    try {
-      final metrics = openVineMediaCache.metrics;
-      final totalLookups = metrics.hits + metrics.misses;
-      final crashlytics = _crashlytics();
-      await crashlytics.setCustomKey(
-        'cache_hit_rate',
-        metrics.hitRate.toStringAsFixed(3),
-      );
-      await crashlytics.setCustomKey('cache_total_lookups', totalLookups);
-    } catch (e) {
-      Log.error(
-        'Failed to set cache metrics keys in Crashlytics: $e',
-        name: 'CrashReporting',
-      );
-    }
-  }
 
   /// Log initialization step for debugging startup crashes
   void logInitializationStep(String step) {

--- a/mobile/lib/services/crash_reporting_service.dart
+++ b/mobile/lib/services/crash_reporting_service.dart
@@ -146,12 +146,17 @@ class CrashReportingService implements CrashReporter {
         name: 'CrashReporting',
       );
     } catch (e) {
+      final becameReady = _readiness == _Readiness.ready;
       Log.error(
-        'Failed to initialize crash reporting: $e',
+        becameReady
+            ? 'Crash reporting initialized, but completion logging failed: $e'
+            : 'Failed to initialize crash reporting: $e',
         name: 'CrashReporting',
       );
       // Don't throw - app should continue even if crash reporting fails
-      _giveUp('Crashlytics failed to initialize');
+      if (!becameReady) {
+        _giveUp('Crashlytics failed to initialize');
+      }
     }
   }
 
@@ -197,7 +202,8 @@ class CrashReportingService implements CrashReporter {
       case _Readiness.pending:
         _hold(call);
       case _Readiness.unavailable:
-        // Nothing to forward to; recordError has already logged its error.
+        // Crashlytics is unavailable; recordError has already used its local
+        // fallback, while calls that only annotate Crashlytics can be dropped.
         break;
     }
   }

--- a/mobile/lib/startup/app_bootstrap.dart
+++ b/mobile/lib/startup/app_bootstrap.dart
@@ -861,8 +861,8 @@ String _startupPlatformName() {
 typedef ZoneErrorRecorder =
     Future<void> Function(Object error, StackTrace stack, {String? reason});
 
-/// Files a report for an error that escaped every `try`/`catch` in the app
-/// zone.
+/// Logs, then files a report for, an error that escaped every `try`/`catch`
+/// in the app zone.
 ///
 /// Expected network/IO failures are dropped instead of reported, for the
 /// reason spelled out on [isExpectedNetworkFailure]: a relay handshake that
@@ -886,11 +886,17 @@ Future<void> handleUncaughtZoneError(
     return;
   }
 
-  // NOTE: recordError returns early when the service is not initialized, and
-  // that early return happens BEFORE its internal Log.error, which sits in the
-  // catch around the Crashlytics call. So on the pre-init path this sink is
-  // silent — there is no local log to fall back on. Tracked in #8616; do not
-  // read the guard as "it logs anyway".
+  // The unified log first, unconditionally, as every other handler does: it
+  // is what a bug report carries, and this guard is armed before Crashlytics
+  // initializes, so for that window the sink below may hold or drop the
+  // report (#8616).
+  Log.error(
+    'Uncaught error in the app zone: $error',
+    name: 'Main',
+    category: LogCategory.system,
+    error: error,
+    stackTrace: stack,
+  );
   final record = recordError ?? crashReporting.recordError;
   await record(error, stack, reason: 'runZonedGuarded');
 }

--- a/mobile/test/services/crash_reporting_service_test.dart
+++ b/mobile/test/services/crash_reporting_service_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/observability/crash_reporter.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -32,14 +33,30 @@ void main() {
     });
 
     group('before initialize', () {
-      // Every reporting method opens with `if (!_initialized) return;`. That
-      // makes them inert until initialize() succeeds — and permanently inert if
-      // Firebase initialisation throws, because the flag is only set on the
-      // success path. These tests pin that as the *documented* contract rather
-      // than an accident, and they are what a fix would have to change.
-      //
-      // Whether that silently loses a report in production is tracked
-      // separately; it needs Crashlytics telemetry, not a unit test.
+      // The runZonedGuarded handler is armed before initialize() runs, so
+      // whatever it catches in that window arrives here first. Nothing may
+      // vanish: an error is written to the unified log immediately, and every
+      // call is held for Crashlytics until initialize() decides whether
+      // Crashlytics exists (#8616).
+
+      test('recordError writes the error to the unified log', () async {
+        final marker = 'pre-init-${DateTime.now().microsecondsSinceEpoch}';
+
+        await service.recordError(
+          StateError(marker),
+          StackTrace.current,
+          reason: 'pre-init test',
+        );
+
+        final logged = LogCaptureService()
+            .getRecentLogs(minLevel: LogLevel.error)
+            .where(
+              (entry) =>
+                  entry.name == 'CrashReporting' &&
+                  (entry.error?.contains(marker) ?? false),
+            );
+        expect(logged, hasLength(1));
+      });
 
       test('recordError completes instead of throwing', () async {
         await expectLater(

--- a/mobile/test/services/crash_reporting_service_test.dart
+++ b/mobile/test/services/crash_reporting_service_test.dart
@@ -1,13 +1,51 @@
-// ABOUTME: Tests for CrashReportingService's uninitialized contract
+// ABOUTME: Tests for how CrashReportingService treats reports around initialize()
 // ABOUTME: Possible at all because #4743 gave the service a public constructor
 
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:openvine/observability/crash_reporter.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+class _MockFirebaseCrashlytics extends Mock implements FirebaseCrashlytics {}
+
+/// A Crashlytics that accepts everything initialize() and a replay send it.
+void _stubHealthyCrashlytics(_MockFirebaseCrashlytics crashlytics) {
+  when(() => crashlytics.setCustomKey(any(), any())).thenAnswer((_) async {});
+  when(
+    () => crashlytics.setCrashlyticsCollectionEnabled(any()),
+  ).thenAnswer((_) async {});
+  when(() => crashlytics.isCrashlyticsCollectionEnabled).thenReturn(false);
+  when(() => crashlytics.log(any())).thenAnswer((_) async {});
+  when(
+    () => crashlytics.recordError(any(), any(), reason: any(named: 'reason')),
+  ).thenAnswer((_) async {});
+  when(() => crashlytics.setUserIdentifier(any())).thenAnswer((_) async {});
+}
+
+/// Error-level entries written by the service that carry [marker].
+Iterable<LogEntry> _errorEntriesMentioning(String marker) => LogCaptureService()
+    .getRecentLogs(minLevel: LogLevel.error)
+    .where(
+      (entry) =>
+          entry.name == 'CrashReporting' &&
+          (entry.error?.contains(marker) ?? false),
+    );
+
+/// Warning-level entries whose message contains [pattern].
+Iterable<LogEntry> _warningsMatching(Pattern pattern) => LogCaptureService()
+    .getRecentLogs(minLevel: LogLevel.warning)
+    .where((entry) => entry.message.contains(pattern));
+
+String _uniqueMarker(String prefix) =>
+    '$prefix-${DateTime.now().microsecondsSinceEpoch}';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() => registerFallbackValue(Object()));
 
   group(CrashReportingService, () {
     late CrashReportingService service;
@@ -40,7 +78,7 @@ void main() {
       // Crashlytics exists (#8616).
 
       test('recordError writes the error to the unified log', () async {
-        final marker = 'pre-init-${DateTime.now().microsecondsSinceEpoch}';
+        final marker = _uniqueMarker('pre-init');
 
         await service.recordError(
           StateError(marker),
@@ -48,14 +86,7 @@ void main() {
           reason: 'pre-init test',
         );
 
-        final logged = LogCaptureService()
-            .getRecentLogs(minLevel: LogLevel.error)
-            .where(
-              (entry) =>
-                  entry.name == 'CrashReporting' &&
-                  (entry.error?.contains(marker) ?? false),
-            );
-        expect(logged, hasLength(1));
+        expect(_errorEntriesMentioning(marker), hasLength(1));
       });
 
       test('recordError completes instead of throwing', () async {
@@ -80,6 +111,179 @@ void main() {
       test('logInitializationStep completes instead of throwing', () {
         expect(() => service.logInitializationStep('step'), returnsNormally);
       });
+    });
+
+    group('initialize succeeds', () {
+      late _MockFirebaseCrashlytics crashlytics;
+      var firebaseStarts = 0;
+
+      setUp(() {
+        crashlytics = _MockFirebaseCrashlytics();
+        _stubHealthyCrashlytics(crashlytics);
+        firebaseStarts = 0;
+        service = CrashReportingService(
+          initializeFirebase: () async => firebaseStarts++,
+          crashlytics: () => crashlytics,
+        );
+        // initialize() installs the process-wide Flutter error handlers, which
+        // would otherwise leak into every later test in the merged isolate.
+        final originalOnError = FlutterError.onError;
+        final originalPlatformOnError = PlatformDispatcher.instance.onError;
+        addTearDown(() {
+          FlutterError.onError = originalOnError;
+          PlatformDispatcher.instance.onError = originalPlatformOnError;
+        });
+      });
+
+      test('forwards a report recorded before initialize resolved', () async {
+        final error = StateError('held for Crashlytics');
+        final stack = StackTrace.current;
+        await service.recordError(error, stack, reason: 'startup');
+        verifyNever(
+          () => crashlytics.recordError(
+            any(),
+            any(),
+            reason: any(named: 'reason'),
+          ),
+        );
+
+        await service.initialize();
+
+        verify(
+          () => crashlytics.recordError(error, stack, reason: 'startup'),
+        ).called(1);
+      });
+
+      test('replays held calls in the order they were made', () async {
+        service.log('first breadcrumb');
+        await service.setCustomKey('phase', 'bindings');
+        service.log('second breadcrumb');
+        await service.setUserId('someone');
+
+        await service.initialize();
+
+        verifyInOrder([
+          () => crashlytics.log('first breadcrumb'),
+          () => crashlytics.setCustomKey('phase', 'bindings'),
+          () => crashlytics.log('second breadcrumb'),
+          () => crashlytics.setUserIdentifier('someone'),
+        ]);
+      });
+
+      test('forwards calls made after initialize as they arrive', () async {
+        await service.initialize();
+
+        service.log('live breadcrumb');
+        await service.recordError(StateError('live'), null, reason: 'now');
+
+        verify(() => crashlytics.log('live breadcrumb')).called(1);
+        verify(
+          () => crashlytics.recordError(any(), null, reason: 'now'),
+        ).called(1);
+      });
+
+      test(
+        'keeps the earliest calls when more than the capacity are held',
+        () async {
+          const capacity = CrashReportingService.pendingReportCapacity;
+          for (var i = 0; i < capacity + 8; i++) {
+            service.log('crumb $i');
+          }
+
+          await service.initialize();
+
+          final replayed = verify(() => crashlytics.log(captureAny())).captured
+              .cast<String>()
+              .where((message) => message.startsWith('crumb'))
+              .toList();
+          expect(replayed, List.generate(capacity, (i) => 'crumb $i'));
+          expect(
+            _warningsMatching(RegExp(r'\b8 Crashlytics call')),
+            isNotEmpty,
+          );
+        },
+      );
+
+      test(
+        'a second initialize neither restarts Firebase nor replays',
+        () async {
+          service.log('once');
+
+          await service.initialize();
+          await service.initialize();
+
+          verify(() => crashlytics.log('once')).called(1);
+          expect(firebaseStarts, 1);
+        },
+      );
+    });
+
+    group('initialize fails', () {
+      late _MockFirebaseCrashlytics crashlytics;
+
+      setUp(() {
+        crashlytics = _MockFirebaseCrashlytics();
+        service = CrashReportingService(
+          initializeFirebase: () async => throw StateError('no Firebase here'),
+          crashlytics: () => crashlytics,
+        );
+      });
+
+      test('discards held calls and says how many', () async {
+        service.log('one');
+        service.log('two');
+
+        await service.initialize();
+
+        verifyZeroInteractions(crashlytics);
+        expect(_warningsMatching(RegExp(r'\b2 Crashlytics call')), isNotEmpty);
+      });
+
+      test(
+        'recordError afterwards still writes the error to the unified log',
+        () async {
+          await service.initialize();
+          final marker = _uniqueMarker('after-failure');
+
+          await service.recordError(StateError(marker), StackTrace.current);
+
+          expect(_errorEntriesMentioning(marker), hasLength(1));
+          verifyZeroInteractions(crashlytics);
+        },
+      );
+
+      test('log afterwards is dropped without reaching Firebase', () async {
+        await service.initialize();
+
+        service.log('after failure');
+
+        verifyZeroInteractions(crashlytics);
+      });
+    });
+
+    group('unsupported platform', () {
+      test(
+        'skips Firebase and still writes errors to the unified log',
+        () async {
+          debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+          addTearDown(() => debugDefaultTargetPlatformOverride = null);
+          var firebaseStarted = false;
+          final crashlytics = _MockFirebaseCrashlytics();
+          service = CrashReportingService(
+            initializeFirebase: () async => firebaseStarted = true,
+            crashlytics: () => crashlytics,
+          );
+          service.log('desktop breadcrumb');
+
+          await service.initialize();
+          final marker = _uniqueMarker('desktop');
+          await service.recordError(StateError(marker), null);
+
+          expect(firebaseStarted, isFalse);
+          verifyZeroInteractions(crashlytics);
+          expect(_errorEntriesMentioning(marker), hasLength(1));
+        },
+      );
     });
   });
 }

--- a/mobile/test/services/crash_reporting_service_test.dart
+++ b/mobile/test/services/crash_reporting_service_test.dart
@@ -216,15 +216,34 @@ void main() {
           expect(firebaseStarts, 1);
         },
       );
+
+      test('a completion-log failure does not revoke readiness', () async {
+        when(
+          () => crashlytics.isCrashlyticsCollectionEnabled,
+        ).thenReturn(true);
+        when(
+          () => crashlytics.log(any()),
+        ).thenThrow(StateError('completion log failed'));
+
+        await service.initialize();
+        await service.setCustomKey('still', 'ready');
+
+        verify(() => crashlytics.setCustomKey('still', 'ready')).called(1);
+      });
     });
 
     group('initialize fails', () {
       late _MockFirebaseCrashlytics crashlytics;
+      var firebaseStarts = 0;
 
       setUp(() {
         crashlytics = _MockFirebaseCrashlytics();
+        firebaseStarts = 0;
         service = CrashReportingService(
-          initializeFirebase: () async => throw StateError('no Firebase here'),
+          initializeFirebase: () async {
+            firebaseStarts++;
+            throw StateError('no Firebase here');
+          },
           crashlytics: () => crashlytics,
         );
       });
@@ -237,6 +256,17 @@ void main() {
 
         verifyZeroInteractions(crashlytics);
         expect(_warningsMatching(RegExp(r'\b2 Crashlytics call')), isNotEmpty);
+      });
+
+      test('the discarded count includes calls beyond capacity', () async {
+        const capacity = CrashReportingService.pendingReportCapacity;
+        for (var i = 0; i < capacity + 8; i++) {
+          service.log('call $i');
+        }
+
+        await service.initialize();
+
+        expect(_warningsMatching(RegExp(r'\b40 Crashlytics call')), isNotEmpty);
       });
 
       test(
@@ -259,6 +289,17 @@ void main() {
 
         verifyZeroInteractions(crashlytics);
       });
+
+      test(
+        'a second initialize does not retry failed Firebase setup',
+        () async {
+          await service.initialize();
+          await service.initialize();
+
+          expect(firebaseStarts, 1);
+          verifyZeroInteractions(crashlytics);
+        },
+      );
     });
 
     group('unsupported platform', () {

--- a/mobile/test/startup/uncaught_zone_error_test.dart
+++ b/mobile/test/startup/uncaught_zone_error_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/startup/app_bootstrap.dart' as app;
+import 'package:unified_logger/unified_logger.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 void main() {
@@ -77,5 +78,32 @@ void main() {
       expect(filed.single.error, same(error));
       expect(filed.single.reason, 'runZonedGuarded');
     });
+
+    test(
+      'writes an unexpected error to the unified log before filing it',
+      () async {
+        // The zone guard is installed before Crashlytics initializes, so for
+        // the whole pre-init window recordError is its only sink and that sink
+        // is inert. The unified log is what a bug report carries, so the
+        // handler has to write there itself, as DivineBlocObserver does (#8616).
+        final marker = 'zone-error-${DateTime.now().microsecondsSinceEpoch}';
+        final error = StateError(marker);
+
+        await app.handleUncaughtZoneError(
+          error,
+          StackTrace.current,
+          crashReporting: CrashReportingService(),
+        );
+
+        final logged = LogCaptureService()
+            .getRecentLogs(minLevel: LogLevel.error)
+            .where(
+              (entry) =>
+                  entry.name == 'Main' &&
+                  (entry.error?.contains(marker) ?? false),
+            );
+        expect(logged, hasLength(1));
+      },
+    );
   });
 }


### PR DESCRIPTION
## Description

**Problem.** For roughly the first 120 ms of every launch, and for the whole process on any device where Firebase fails to initialize (or on Linux and Windows, where it is unsupported), everything handed to the crash reporter was thrown away without a trace. Every reporting method on `CrashReportingService` returned early when Crashlytics was not yet initialized, before logging anything, and all of them return `void`, so no caller could tell a delivered report from a discarded one. Two concrete consequences:

- The `runZonedGuarded` handler in `main.dart` is installed before the startup sequence runs and is the catch-all for anything thrown during it. Its only sink was that early-returning method, and it wrote nothing to the unified log itself, so an error thrown in that window (for example the deliberately fail-closed C2PA signing-endpoint check) reached neither Crashlytics nor the log that bug reports carry. The launch dead-ended with zero telemetry.
- The three earliest startup breadcrumbs (`Phase started: bindings`, `Phase completed: bindings`, `Phase started: crash_reporting`) were dropped on every launch, on every device, so every Crashlytics breadcrumb trail started late.

**Fix.**

1. The zone handler now writes the error to the unified log first, unconditionally, the way `DivineBlocObserver` and the `FlutterError` handler already do.
2. `CrashReportingService` no longer discards anything silently. Until `initialize()` resolves it holds every call in order (the first 32: in a startup error storm the first report is the root cause and the rest are its cascade) and replays them once Crashlytics is up. A non-fatal error is also written to the unified log immediately, because the process may never reach `initialize()` at all. If Crashlytics turns out to be unavailable, the held calls are dropped with a logged count, and from then on non-fatal errors go to the unified log while breadcrumbs and custom keys, which only mean anything attached to a Crashlytics report, are dropped.
3. The Firebase initializer and the Crashlytics instance are constructor-injectable so the replay is tested without a Firebase app. Production wiring is unchanged; both default to the real Firebase.
4. `updateCacheMetricsKeys` had no callers anywhere and is deleted rather than ported.

**What changes for people:** nothing in the UI. Crashlytics breadcrumb trails now include the earliest startup phases; a startup failure in the pre-init window now shows up in bug-report logs; devices where Firebase cannot initialize log non-fatal errors locally instead of nowhere.

**Related Issue:** Closes #8616

## Out of Scope

- The `firebaseMessagingBackgroundHandler` isolate never calls `initialize()`. Nothing reports from there today; if something ever does, it now lands in that isolate's log rather than vanishing, but nothing is forwarded from there. Left as documented on the issue.
- How often the pre-init window actually loses a report in the field still needs Crashlytics telemetry. This change makes the loss impossible rather than measuring it.

## Verification

- `flutter analyze lib test integration_test`: no issues.
- `flutter test` over the 39 test files that touch the crash reporter, the zone handler, or the log capture buffer, including the rewritten `test/services/crash_reporting_service_test.dart` (18 tests) and `test/startup/uncaught_zone_error_test.dart` (5 tests): all pass.
- Every new test was written first and watched fail. Four mutation checks against the finished service (buffer evicts oldest instead of keeping earliest, no dropped-count warning, no replay after initialize, no local log for a non-ready error) were each caught by exactly the tests written for them.
- CI-only ratchets run locally and passing: process-global mutations, shared-setup stubs, ungrouped / placeholder / skip ceilings, untested-services floor, singleton services, service god-file ceiling, empty-catch and error-sentinel ceilings, layer direction, UI-service boundary, Nostr-id truncation and pubkey log encoding, Future.delayed ceilings, l10n delegates, test/unit structure, Riverpod and ChangeNotifier boundaries, orphaned ARB keys.
- CI note: on the first run, `Tests (shard 3/4)` failed in one unrelated test, `VideoInteractionsBloc … older restriction cannot roll back a newer tap` (`test/blocs/video_interactions/video_interactions_bloc_test.dart`). That test schedules a 20 ms wall-clock timer in `setUp` and assumes its second tap is dispatched before the timer fires; the recorded state sequence shows the timer won, so the event loop stalled for more than 20 ms in the merged isolate. Neither the bloc nor that test touches anything in this diff, the file passes locally with CI's seed (473528093), and the rerun of the same commit passed. Reported in the handback rather than patched here, since it is outside this change's scope.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🗑️ Chore
