### PR TITLE
fix(a11y): name the profile row's icon-only buttons for screen readers

### DIFF
--- a/mobile/lib/constants/semantic_ids.dart
+++ b/mobile/lib/constants/semantic_ids.dart
@@ -147,6 +147,11 @@ abstract class SemanticIds {
   /// point to Settings in the app, so it gates every E2E flow that ends in
   /// key removal.
   static const String profileSettingsButton = 'settings_button';
+
+  /// Opens the profile editor from the own-profile action row. The pencil is
+  /// the only entry point to Edit Profile in the app, so it anchors the
+  /// edit-profile E2E journey (#6950).
+  static const String profileEditButton = 'edit_profile_button';
   static const String profileBackButton = 'profile_back_button';
   static const String profileMoreButton = 'profile_more_button';
 

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -381,6 +381,7 @@
     "profileLikesLabel": "መውደዶች",
     "profileMyLibraryLabel": "የእኔ ቤተ-መጽሐፍት",
     "profileMessageLabel": "መልእክት",
+    "profileShareLabel": "መገለጫ ማጋራት",
     "profileDeletedAccountName": "የተሰረዘ መለያ",
     "inboxActionReportVanishedAccount": "ሪፖርት ይህን መለያ",
     "inboxActionBlockVanishedAccount": "አግድ ይህን መለያ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2968,6 +2968,7 @@
     "profileLikesLabel": "الإعجابات",
     "profileMyLibraryLabel": "مكتبتي",
     "profileMessageLabel": "رسالة",
+    "profileShareLabel": "مشاركة الملف الشخصي",
     "profileDeletedAccountName": "حساب محذوف",
     "inboxActionReportVanishedAccount": "الإبلاغ عن هذا الحساب",
     "inboxActionBlockVanishedAccount": "حظر هذا الحساب",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -356,6 +356,7 @@
     "profileLikesLabel": "Харесвания",
     "profileMyLibraryLabel": "Моята библиотека",
     "profileMessageLabel": "Съобщение",
+    "profileShareLabel": "Сподели профила",
     "profileDeletedAccountName": "Изтрит акаунт",
     "inboxActionReportVanishedAccount": "Докладвай този акаунт",
     "inboxActionBlockVanishedAccount": "Блокирай този акаунт",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2975,6 +2975,7 @@
     "profileLikesLabel": "Likes",
     "profileMyLibraryLabel": "Meine Bibliothek",
     "profileMessageLabel": "Nachricht",
+    "profileShareLabel": "Profil teilen",
     "profileDeletedAccountName": "Gelöschtes Konto",
     "inboxActionReportVanishedAccount": "Dieses Konto melden",
     "inboxActionBlockVanishedAccount": "Dieses Konto blockieren",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -536,6 +536,10 @@
   "profileLikesLabel": "Likes",
   "profileMyLibraryLabel": "My Library",
   "profileMessageLabel": "Message",
+  "profileShareLabel": "Share profile",
+  "@profileShareLabel": {
+    "description": "Accessible name of the icon-only share button on the profile action row, on both the viewer's own profile and other people's. Announced by screen readers only; the button shows a share icon and no text."
+  },
   "profileDeletedAccountName": "Deleted account",
   "inboxActionReportVanishedAccount": "Report this account",
   "@inboxActionReportVanishedAccount": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2983,6 +2983,7 @@
     "profileLikesLabel": "Me gusta",
     "profileMyLibraryLabel": "Mi biblioteca",
     "profileMessageLabel": "Mensaje",
+    "profileShareLabel": "Compartir perfil",
     "profileDeletedAccountName": "Cuenta eliminada",
     "inboxActionReportVanishedAccount": "Reportar esta cuenta",
     "inboxActionBlockVanishedAccount": "Bloquear esta cuenta",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2492,6 +2492,7 @@
     "profileLikesLabel": "Mga Like",
     "profileMyLibraryLabel": "Aking Library",
     "profileMessageLabel": "Mensahe",
+    "profileShareLabel": "I-share ang profile",
     "profileDeletedAccountName": "Tinanggal na account",
     "inboxActionReportVanishedAccount": "I-report ang account na ito",
     "inboxActionBlockVanishedAccount": "I-block ang account na ito",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2975,6 +2975,7 @@
     "profileLikesLabel": "J'aime",
     "profileMyLibraryLabel": "Ma bibliothèque",
     "profileMessageLabel": "Message",
+    "profileShareLabel": "Partager le profil",
     "profileDeletedAccountName": "Compte supprimé",
     "inboxActionReportVanishedAccount": "Signaler ce compte",
     "inboxActionBlockVanishedAccount": "Bloquer ce compte",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2975,6 +2975,7 @@
     "profileLikesLabel": "Suka",
     "profileMyLibraryLabel": "Pustakaku",
     "profileMessageLabel": "Pesan",
+    "profileShareLabel": "Bagikan profil",
     "profileDeletedAccountName": "Akun dihapus",
     "inboxActionReportVanishedAccount": "Laporkan akun ini",
     "inboxActionBlockVanishedAccount": "Blokir akun ini",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2975,6 +2975,7 @@
     "profileLikesLabel": "Mi piace",
     "profileMyLibraryLabel": "La mia libreria",
     "profileMessageLabel": "Messaggio",
+    "profileShareLabel": "Condividi profilo",
     "profileDeletedAccountName": "Account eliminato",
     "inboxActionReportVanishedAccount": "Segnala questo account",
     "inboxActionBlockVanishedAccount": "Blocca questo account",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2968,6 +2968,7 @@
     "profileLikesLabel": "いいね",
     "profileMyLibraryLabel": "マイライブラリ",
     "profileMessageLabel": "メッセージ",
+    "profileShareLabel": "プロフィールを共有",
     "profileDeletedAccountName": "削除されたアカウント",
     "inboxActionReportVanishedAccount": "このアカウントを報告",
     "inboxActionBlockVanishedAccount": "このアカウントをブロック",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2506,6 +2506,7 @@
     "profileLikesLabel": "좋아요",
     "profileMyLibraryLabel": "내 라이브러리",
     "profileMessageLabel": "메시지",
+    "profileShareLabel": "프로필 공유",
     "profileDeletedAccountName": "삭제된 계정",
     "inboxActionReportVanishedAccount": "이 계정 신고",
     "inboxActionBlockVanishedAccount": "이 계정 차단",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -405,6 +405,7 @@
   "profileLikesLabel": "Sukaan",
   "profileMyLibraryLabel": "Pustaka Saya",
   "profileMessageLabel": "Mesej",
+  "profileShareLabel": "Kongsi profil",
   "profileDeletedAccountName": "Akaun dipadam",
   "inboxActionReportVanishedAccount": "Laporkan akaun ini",
   "inboxActionBlockVanishedAccount": "Sekat akaun ini",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2975,6 +2975,7 @@
     "profileLikesLabel": "Likes",
     "profileMyLibraryLabel": "Mijn bibliotheek",
     "profileMessageLabel": "Bericht",
+    "profileShareLabel": "Profiel delen",
     "profileDeletedAccountName": "Verwijderd account",
     "inboxActionReportVanishedAccount": "Dit account rapporteren",
     "inboxActionBlockVanishedAccount": "Dit account blokkeren",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2975,6 +2975,7 @@
     "profileLikesLabel": "Polubienia",
     "profileMyLibraryLabel": "Moja biblioteka",
     "profileMessageLabel": "Wiadomość",
+    "profileShareLabel": "Udostępnij profil",
     "profileDeletedAccountName": "Usunięte konto",
     "inboxActionReportVanishedAccount": "Zgłoś to konto",
     "inboxActionBlockVanishedAccount": "Zablokuj to konto",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2975,6 +2975,7 @@
     "profileLikesLabel": "Curtidas",
     "profileMyLibraryLabel": "Minha biblioteca",
     "profileMessageLabel": "Mensagem",
+    "profileShareLabel": "Compartilhar perfil",
     "profileDeletedAccountName": "Conta excluída",
     "inboxActionReportVanishedAccount": "Denunciar esta conta",
     "inboxActionBlockVanishedAccount": "Bloquear esta conta",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2975,6 +2975,7 @@
     "profileLikesLabel": "Aprecieri",
     "profileMyLibraryLabel": "Biblioteca mea",
     "profileMessageLabel": "Mesaj",
+    "profileShareLabel": "Partajează profilul",
     "profileDeletedAccountName": "Cont șters",
     "inboxActionReportVanishedAccount": "Raportează acest cont",
     "inboxActionBlockVanishedAccount": "Blochează acest cont",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2975,6 +2975,7 @@
     "profileLikesLabel": "Gilla-markeringar",
     "profileMyLibraryLabel": "Mitt bibliotek",
     "profileMessageLabel": "Meddelande",
+    "profileShareLabel": "Dela profil",
     "profileDeletedAccountName": "Raderat konto",
     "inboxActionReportVanishedAccount": "Rapportera det här kontot",
     "inboxActionBlockVanishedAccount": "Blockera det här kontot",

--- a/mobile/lib/l10n/app_te.arb
+++ b/mobile/lib/l10n/app_te.arb
@@ -536,6 +536,7 @@
   "profileLikesLabel": "ఇష్టాలు",
   "profileMyLibraryLabel": "నా లైబ్రరీ",
   "profileMessageLabel": "సందేశం",
+  "profileShareLabel": "ప్రొఫైల్‌ను భాగస్వామ్యం చేయండి",
   "profileDeletedAccountName": "ఖాతా తొలగించబడింది",
   "inboxActionReportVanishedAccount": "ఈ ఖాతాను నివేదించండి",
   "@inboxActionReportVanishedAccount": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2975,6 +2975,7 @@
     "profileLikesLabel": "Beğeniler",
     "profileMyLibraryLabel": "Kütüphanem",
     "profileMessageLabel": "Mesaj",
+    "profileShareLabel": "Profili paylaş",
     "profileDeletedAccountName": "Silinmiş hesap",
     "inboxActionReportVanishedAccount": "Bu hesabı bildir",
     "inboxActionBlockVanishedAccount": "Bu hesabı engelle",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -405,6 +405,7 @@
   "profileLikesLabel": "پسندیں",
   "profileMyLibraryLabel": "میری لائبریری",
   "profileMessageLabel": "پیغام",
+  "profileShareLabel": "پروفائل شیئر کریں",
   "profileDeletedAccountName": "حذف شدہ اکاؤنٹ",
   "inboxActionReportVanishedAccount": "اس اکاؤنٹ کی رپورٹ کریں",
   "inboxActionBlockVanishedAccount": "اس اکاؤنٹ کو بلاک کریں",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -405,6 +405,7 @@
   "profileLikesLabel": "Lượt thích",
   "profileMyLibraryLabel": "Thư viện của tôi",
   "profileMessageLabel": "Tin nhắn",
+  "profileShareLabel": "Chia sẻ hồ sơ",
   "profileDeletedAccountName": "Tài khoản đã xóa",
   "inboxActionReportVanishedAccount": "Báo cáo tài khoản này",
   "inboxActionBlockVanishedAccount": "Chặn tài khoản này",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -405,6 +405,7 @@
   "profileLikesLabel": "点赞",
   "profileMyLibraryLabel": "我的作品库",
   "profileMessageLabel": "私信",
+  "profileShareLabel": "分享主页",
   "profileDeletedAccountName": "已注销账号",
   "inboxActionReportVanishedAccount": "举报此账号",
   "inboxActionBlockVanishedAccount": "屏蔽此账号",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -1406,6 +1406,12 @@ abstract class AppLocalizations {
   /// **'Message'**
   String get profileMessageLabel;
 
+  /// Accessible name of the icon-only share button on the profile action row, on both the viewer's own profile and other people's. Announced by screen readers only; the button shows a share icon and no text.
+  ///
+  /// In en, this message translates to:
+  /// **'Share profile'**
+  String get profileShareLabel;
+
   /// Stands in for the display name of an account that requested deletion. A noun phrase used wherever a person's name would normally appear, in DM and non-DM surfaces alike — the inbox row, the conversation header, the following bar, the profile screen and header, the people picker, and the shared people row.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -809,6 +809,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get profileMessageLabel => 'መልእክት';
 
   @override
+  String get profileShareLabel => 'መገለጫ ማጋራት';
+
+  @override
   String get profileDeletedAccountName => 'የተሰረዘ መለያ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -810,6 +810,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get profileMessageLabel => 'رسالة';
 
   @override
+  String get profileShareLabel => 'مشاركة الملف الشخصي';
+
+  @override
   String get profileDeletedAccountName => 'حساب محذوف';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -837,6 +837,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get profileMessageLabel => 'Съобщение';
 
   @override
+  String get profileShareLabel => 'Сподели профила';
+
+  @override
   String get profileDeletedAccountName => 'Изтрит акаунт';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -835,6 +835,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get profileMessageLabel => 'Nachricht';
 
   @override
+  String get profileShareLabel => 'Profil teilen';
+
+  @override
   String get profileDeletedAccountName => 'Gelöschtes Konto';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -837,6 +837,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileMessageLabel => 'Message';
 
   @override
+  String get profileShareLabel => 'Share profile';
+
+  @override
   String get profileDeletedAccountName => 'Deleted account';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -835,6 +835,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get profileMessageLabel => 'Mensaje';
 
   @override
+  String get profileShareLabel => 'Compartir perfil';
+
+  @override
   String get profileDeletedAccountName => 'Cuenta eliminada';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -805,6 +805,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get profileMessageLabel => 'Mensahe';
 
   @override
+  String get profileShareLabel => 'I-share ang profile';
+
+  @override
   String get profileDeletedAccountName => 'Tinanggal na account';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -844,6 +844,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get profileMessageLabel => 'Message';
 
   @override
+  String get profileShareLabel => 'Partager le profil';
+
+  @override
   String get profileDeletedAccountName => 'Compte supprimé';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -769,6 +769,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get profileMessageLabel => 'Pesan';
 
   @override
+  String get profileShareLabel => 'Bagikan profil';
+
+  @override
   String get profileDeletedAccountName => 'Akun dihapus';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -839,6 +839,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get profileMessageLabel => 'Messaggio';
 
   @override
+  String get profileShareLabel => 'Condividi profilo';
+
+  @override
   String get profileDeletedAccountName => 'Account eliminato';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -729,6 +729,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get profileMessageLabel => 'メッセージ';
 
   @override
+  String get profileShareLabel => 'プロフィールを共有';
+
+  @override
   String get profileDeletedAccountName => '削除されたアカウント';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -731,6 +731,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get profileMessageLabel => '메시지';
 
   @override
+  String get profileShareLabel => '프로필 공유';
+
+  @override
   String get profileDeletedAccountName => '삭제된 계정';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -798,6 +798,9 @@ class AppLocalizationsMs extends AppLocalizations {
   String get profileMessageLabel => 'Mesej';
 
   @override
+  String get profileShareLabel => 'Kongsi profil';
+
+  @override
   String get profileDeletedAccountName => 'Akaun dipadam';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -830,6 +830,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get profileMessageLabel => 'Bericht';
 
   @override
+  String get profileShareLabel => 'Profiel delen';
+
+  @override
   String get profileDeletedAccountName => 'Verwijderd account';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -851,6 +851,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get profileMessageLabel => 'Wiadomość';
 
   @override
+  String get profileShareLabel => 'Udostępnij profil';
+
+  @override
   String get profileDeletedAccountName => 'Usunięte konto';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -836,6 +836,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get profileMessageLabel => 'Mensagem';
 
   @override
+  String get profileShareLabel => 'Compartilhar perfil';
+
+  @override
   String get profileDeletedAccountName => 'Conta excluída';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -865,6 +865,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get profileMessageLabel => 'Mesaj';
 
   @override
+  String get profileShareLabel => 'Partajează profilul';
+
+  @override
   String get profileDeletedAccountName => 'Cont șters';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -811,6 +811,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get profileMessageLabel => 'Meddelande';
 
   @override
+  String get profileShareLabel => 'Dela profil';
+
+  @override
   String get profileDeletedAccountName => 'Raderat konto';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -849,6 +849,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get profileMessageLabel => 'సందేశం';
 
   @override
+  String get profileShareLabel => 'ప్రొఫైల్‌ను భాగస్వామ్యం చేయండి';
+
+  @override
   String get profileDeletedAccountName => 'ఖాతా తొలగించబడింది';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -766,6 +766,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get profileMessageLabel => 'Mesaj';
 
   @override
+  String get profileShareLabel => 'Profili paylaş';
+
+  @override
   String get profileDeletedAccountName => 'Silinmiş hesap';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -830,6 +830,9 @@ class AppLocalizationsUr extends AppLocalizations {
   String get profileMessageLabel => 'پیغام';
 
   @override
+  String get profileShareLabel => 'پروفائل شیئر کریں';
+
+  @override
   String get profileDeletedAccountName => 'حذف شدہ اکاؤنٹ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -798,6 +798,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get profileMessageLabel => 'Tin nhắn';
 
   @override
+  String get profileShareLabel => 'Chia sẻ hồ sơ';
+
+  @override
   String get profileDeletedAccountName => 'Tài khoản đã xóa';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -752,6 +752,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get profileMessageLabel => '私信';
 
   @override
+  String get profileShareLabel => '分享主页';
+
+  @override
   String get profileDeletedAccountName => '已注销账号';
 
   @override

--- a/mobile/lib/widgets/profile/follow_from_profile_button.dart
+++ b/mobile/lib/widgets/profile/follow_from_profile_button.dart
@@ -224,8 +224,8 @@ class FollowFromProfileButtonView extends StatelessWidget {
   }
 }
 
-/// Button showing "Following" state — icon only; the name reaches screen
-/// readers through [DivineButton.semanticLabel].
+/// Button showing "Following" state — icon only; its accessible name describes
+/// the unfollow action.
 class _FollowingButton extends StatelessWidget {
   const _FollowingButton({required this.onPressed});
 
@@ -238,7 +238,7 @@ class _FollowingButton extends StatelessWidget {
       size: .small,
       onPressed: onPressed,
       label: '',
-      semanticLabel: context.l10n.profileFollowingLabel,
+      semanticLabel: context.l10n.unfollowUserSemanticLabel,
       leadingIcon: .userCheck,
     );
   }

--- a/mobile/lib/widgets/profile/follow_from_profile_button.dart
+++ b/mobile/lib/widgets/profile/follow_from_profile_button.dart
@@ -224,7 +224,8 @@ class FollowFromProfileButtonView extends StatelessWidget {
   }
 }
 
-/// Button showing "Following" state — icon only, no label.
+/// Button showing "Following" state — icon only; the name reaches screen
+/// readers through [DivineButton.semanticLabel].
 class _FollowingButton extends StatelessWidget {
   const _FollowingButton({required this.onPressed});
 
@@ -237,6 +238,7 @@ class _FollowingButton extends StatelessWidget {
       size: .small,
       onPressed: onPressed,
       label: '',
+      semanticLabel: context.l10n.profileFollowingLabel,
       leadingIcon: .userCheck,
     );
   }

--- a/mobile/lib/widgets/profile/profile_action_buttons_widget.dart
+++ b/mobile/lib/widgets/profile/profile_action_buttons_widget.dart
@@ -7,6 +7,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/blocs/notify_bell/notify_bell_cubit.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/l10n.dart';
@@ -147,12 +148,15 @@ class ProfileActionButtons extends ConsumerWidget {
         icon: .pencilSimpleLine,
         type: .secondary,
         size: .small,
+        semanticLabel: context.l10n.profileSetupEditProfileTitle,
+        semanticIdentifier: SemanticIds.profileEditButton,
         onPressed: onEditProfile,
       ),
       DivineIconButton(
         icon: .shareFat,
         type: .secondary,
         size: .small,
+        semanticLabel: context.l10n.profileShareLabel,
         onPressed: onShareProfile == null
             ? null
             : () => onShareProfile!(context),
@@ -247,6 +251,7 @@ class _OtherProfileButtons extends StatelessWidget {
           icon: .shareFat,
           type: .secondary,
           size: .small,
+          semanticLabel: l10n.profileShareLabel,
           onPressed: onShareProfile == null
               ? null
               : () => onShareProfile!(context),
@@ -286,6 +291,7 @@ class _OtherProfileButtons extends StatelessWidget {
                   type: .secondary,
                   size: .small,
                   label: '',
+                  semanticLabel: l10n.profileMessageLabel,
                   onPressed: onMessageUser,
                 ),
             ] else

--- a/mobile/scripts/baseline/maestro_copy_manifest.txt
+++ b/mobile/scripts/baseline/maestro_copy_manifest.txt
@@ -96,6 +96,7 @@ profileSetupPublicKeyLabel	e2e/maestro/asserts/assertEditProfileModal.yaml	bound
 profileSetupUsernameLabel	e2e/maestro/asserts/assertEditProfileModal.yaml	bound:Username (Optional)
 profileSetupUsernameLabel	e2e/maestro/asserts/assertEditYourProfile.yaml	bound:Username (Optional)
 profileSetupUsernameTakenIndicator	e2e/maestro/asserts/assertUserTaken.yaml	bound:Username already taken
+profileShareLabel	e2e/maestro/tests/profileNavigation.yaml	bound:Share profile
 profileSupportButtonLabel	e2e/maestro/asserts/assertMenu.yaml	bound:Support
 profileVideoThumbnailLabel	e2e/maestro/tests/searchTags.yaml	rendered:Video thumbnail 1
 saveOriginalNotNow	e2e/maestro/flows/loginEmailPwd.yaml	bound:Not Now

--- a/mobile/test/widgets/profile/follow_from_profile_button_test.dart
+++ b/mobile/test/widgets/profile/follow_from_profile_button_test.dart
@@ -143,7 +143,7 @@ void main() {
         expect(find.byType(DivineIcon), findsOneWidget);
       });
 
-      testWidgets('announces the icon-only following button by name', (
+      testWidgets('announces the icon-only following button as unfollow', (
         tester,
       ) async {
         final otherPubkey = validPubkey('other');
@@ -159,7 +159,7 @@ void main() {
 
         final l10n = lookupAppLocalizations(const Locale('en'));
         expect(
-          find.bySemanticsLabel(l10n.profileFollowingLabel),
+          find.bySemanticsLabel(l10n.unfollowUserSemanticLabel),
           findsOneWidget,
         );
       });

--- a/mobile/test/widgets/profile/follow_from_profile_button_test.dart
+++ b/mobile/test/widgets/profile/follow_from_profile_button_test.dart
@@ -142,6 +142,27 @@ void main() {
         // Verify it has the userCheck icon
         expect(find.byType(DivineIcon), findsOneWidget);
       });
+
+      testWidgets('announces the icon-only following button by name', (
+        tester,
+      ) async {
+        final otherPubkey = validPubkey('other');
+        when(() => mockMyFollowingBloc.state).thenReturn(
+          MyFollowingState(
+            status: MyFollowingStatus.success,
+            followingPubkeys: [otherPubkey],
+          ),
+        );
+
+        await tester.pumpWidget(createTestWidget(pubkey: otherPubkey));
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.bySemanticsLabel(l10n.profileFollowingLabel),
+          findsOneWidget,
+        );
+      });
     });
 
     group('interactions', () {

--- a/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
@@ -10,13 +10,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/widgets/profile/profile_action_buttons_widget.dart';
 import 'package:openvine/widgets/profile/profile_notify_bell_button.dart';
 import 'package:people_lists_repository/people_lists_repository.dart';
 
+import '../../helpers/accessibility_guidelines.dart';
 import '../../helpers/test_provider_overrides.dart';
 
 class _MockContentBlocklistRepository extends Mock
@@ -94,19 +97,29 @@ void main() {
   });
 
   Widget buildWidget({
+    bool isOwnProfile = false,
     bool isMessageRestricted = false,
     bool newPostNotifications = true,
+    bool constrainWidth = false,
   }) {
+    final row = ProfileActionButtons(
+      userIdHex: isOwnProfile ? viewerPubkey : targetPubkey,
+      isOwnProfile: isOwnProfile,
+      displayName: 'Target User',
+      onEditProfile: () {},
+      onOpenClips: () {},
+      onMessageUser: () {},
+      isMessageRestricted: isMessageRestricted,
+      onShareProfile: (_) {},
+    );
     return testMaterialApp(
       home: Scaffold(
-        body: ProfileActionButtons(
-          userIdHex: targetPubkey,
-          isOwnProfile: false,
-          displayName: 'Target User',
-          onMessageUser: () {},
-          isMessageRestricted: isMessageRestricted,
-          onShareProfile: (_) {},
-        ),
+        // The tap-target guidelines skip nodes that touch the viewport edge,
+        // so the accessibility tests inset the row to keep every button
+        // evaluable.
+        body: constrainWidth
+            ? Center(child: SizedBox(width: 360, child: row))
+            : row,
       ),
       additionalOverrides: [
         contentBlocklistRepositoryProvider.overrideWithValue(
@@ -313,6 +326,87 @@ void main() {
           creatorPubkey: targetPubkey,
         ),
       ).called(1);
+    });
+  });
+
+  group('accessibility', () {
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
+    Future<void> pumpRow(
+      WidgetTester tester, {
+      bool isOwnProfile = false,
+      bool newPostNotifications = true,
+    }) async {
+      await tester.pumpWidget(
+        buildWidget(
+          isOwnProfile: isOwnProfile,
+          newPostNotifications: newPostNotifications,
+          constrainWidth: true,
+        ),
+      );
+      await tester.pump();
+    }
+
+    testWidgets('own-profile row names its edit and share buttons', (
+      tester,
+    ) async {
+      await pumpRow(tester, isOwnProfile: true);
+
+      expect(
+        find.bySemanticsLabel(l10n.profileSetupEditProfileTitle),
+        findsOneWidget,
+      );
+      expect(
+        find.bySemanticsIdentifier(SemanticIds.profileEditButton),
+        findsOneWidget,
+      );
+      expect(find.bySemanticsLabel(l10n.profileShareLabel), findsOneWidget);
+      await expectMeetsAccessibilityGuidelines(
+        tester,
+        guidelines: divineSemanticsGuidelines,
+      );
+    });
+
+    testWidgets(
+      'other-profile row names the icon-only message and share buttons',
+      (tester) async {
+        await pumpRow(tester);
+
+        expect(find.bySemanticsLabel(l10n.profileMessageLabel), findsOneWidget);
+        expect(find.bySemanticsLabel(l10n.profileShareLabel), findsOneWidget);
+        await expectMeetsAccessibilityGuidelines(
+          tester,
+          guidelines: divineSemanticsGuidelines,
+        );
+      },
+    );
+
+    testWidgets('other-profile row names the icon-only following button', (
+      tester,
+    ) async {
+      when(
+        () => followRepository.followingPubkeys,
+      ).thenReturn(const [targetPubkey]);
+      when(
+        () => followRepository.followingStream,
+      ).thenAnswer((_) => Stream<List<String>>.value(const [targetPubkey]));
+      when(() => followRepository.watchMyFollowingCached()).thenAnswer(
+        (_) => Stream.value(
+          const CacheResult.live(
+            FollowingSnapshot(pubkeys: [targetPubkey], count: 1),
+          ),
+        ),
+      );
+
+      // The bell has its own coverage; keep it out so the row under test is
+      // exactly [Message] [Following] [Share].
+      await pumpRow(tester, newPostNotifications: false);
+
+      expect(find.bySemanticsLabel(l10n.profileFollowingLabel), findsOneWidget);
+      await expectMeetsAccessibilityGuidelines(
+        tester,
+        guidelines: divineSemanticsGuidelines,
+      );
     });
   });
 }

--- a/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
@@ -381,7 +381,7 @@ void main() {
       },
     );
 
-    testWidgets('other-profile row names the icon-only following button', (
+    testWidgets('other-profile row names the icon-only unfollow action', (
       tester,
     ) async {
       when(
@@ -402,7 +402,10 @@ void main() {
       // exactly [Message] [Following] [Share].
       await pumpRow(tester, newPostNotifications: false);
 
-      expect(find.bySemanticsLabel(l10n.profileFollowingLabel), findsOneWidget);
+      expect(
+        find.bySemanticsLabel(l10n.unfollowUserSemanticLabel),
+        findsOneWidget,
+      );
       await expectMeetsAccessibilityGuidelines(
         tester,
         guidelines: divineSemanticsGuidelines,


### PR DESCRIPTION
## Description

**Problem.** The icon-only buttons on the profile action row had no accessible name. A screen-reader user landing on the pencil next to "My Library", on the share button, on the envelope shown on another person's profile, or on the "Following" check button hears an unnamed control, and the two empty-label buttons were not even announced as buttons. Every layout of the row fails Flutter's own `labeledTapTargetGuideline`; the measurements are in #8636.

**Why this fix.** `DivineIconButton` and `DivineButton` already accept a `semanticLabel`; the row simply never passed one. Each button now announces what it does: "Edit Profile", "Share profile", "Message", "Unfollow user". The pencil also carries the `edit_profile_button` identifier, the stable anchor the edit-profile end-to-end journey in #6950 needs, because this pencil is the only way into Edit Profile. Three of the four names reuse existing copy; "Share profile" is new and is translated into every locale. All three row layouts are now pinned with the accessibility guideline helper, so the names cannot quietly disappear again.

**Related Issue:** Closes #8636. Relates to #6950 and #7656.

## Out of Scope

- The Maestro copy manifest gains one row. `profileNavigation.yaml` already asserts the literal "Share profile" as an item of the old profile More sheet, which no longer has one, and the guard could only see that literal once an ARB key with the same value existed. That flow step is dead for reasons this change does not touch; it belongs with the #6950 list.
- Regenerating the manifest on today's `main` also flips three reviewed "Follow" rows from `profileFollowLabel` to `listFollowButton`. That is the duplicate-value bug #8633 fixes, so those rows are left as reviewed and only the new row is added by hand.
- No visual change: a `semanticLabel` draws nothing. No tooltips were added, because two existing tests on this row assert that none render.

## Verification

- `flutter test test/widgets/profile/profile_action_buttons_widget_test.dart test/widgets/profile/follow_from_profile_button_test.dart`: 23 passed. The four new tests were written first and failed on exactly the missing names before the fix.
- `flutter test test/l10n/arb_consistency_test.dart`
- `flutter analyze lib test integration_test`: no issues
- `dart format --set-exit-if-changed` over every changed Dart file
- CI-only ratchets run locally: `check_orphaned_arb_key_floor.sh`, `check_ungrouped_tests.sh`, `check_shared_setup_stubs.sh`, `check_l10n_delegates_ceiling.sh`, `check_placeholder_tests.sh`, `check_skip_ceiling.sh`, `check_maestro_copy_drift.sh` (92 bindings, 0 unregistered) and the four design-system ceilings, all green.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

