### PR TITLE
refactor(di): make five more services injectable and delete three dead code paths

### DIFF
--- a/docs/STARTUP_PERFORMANCE_OPTIMIZATIONS.md
+++ b/docs/STARTUP_PERFORMANCE_OPTIMIZATIONS.md
@@ -20,7 +20,6 @@ The original app suffered from:
 A comprehensive monitoring service that:
 - **Tracks timing metrics** for all startup phases
 - **Identifies performance bottlenecks** automatically
-- **Provides lazy loading utilities** (`deferUntilUIReady`)
 - **Monitors for slow startup** and logs warnings
 - **Generates detailed performance reports** in debug mode
 
@@ -29,11 +28,6 @@ A comprehensive monitoring service that:
 // Track phases with automatic timing
 StartupPerformanceService.instance.startPhase('service_init');
 StartupPerformanceService.instance.completePhase('service_init');
-
-// Defer heavy work until UI is ready
-StartupPerformanceService.instance.deferUntilUIReady(() async {
-  // Heavy initialization work
-});
 
 // Measure work with automatic performance tracking
 await StartupPerformanceService.instance.measureWork('task_name', () async {
@@ -89,18 +83,7 @@ await StartupPerformanceService.instance.measureWork(
 );
 ```
 
-### 5. Social Provider Deferred Loading
-
-Social connections load in the background after UI is ready:
-
-```dart
-// DEFER social provider initialization to not block UI
-StartupPerformanceService.instance.deferUntilUIReady(() async {
-  await ref.read(socialNotifierProvider.notifier).initialize();
-}, taskName: 'social_provider_init');
-```
-
-### 6. LazyVideoLoadingService
+### 5. LazyVideoLoadingService
 
 **File:** `lib/services/lazy_video_loading_service.dart`
 
@@ -125,7 +108,7 @@ final request = VideoLoadingRequest(
 final controller = await LazyVideoLoadingService.instance.requestVideo(request);
 ```
 
-### 7. Performance Monitoring Integration
+### 6. Performance Monitoring Integration
 
 Throughout the app, performance checkpoints track timing:
 
@@ -195,16 +178,9 @@ The optimizations can be tested by:
    });
    ```
 
-2. **Defer non-critical work** until UI is ready:
-   ```dart
-   StartupPerformanceService.instance.deferUntilUIReady(() async {
-     // Non-critical initialization
-   });
-   ```
+2. **Check performance reports** in debug builds for bottlenecks
 
-3. **Check performance reports** in debug builds for bottlenecks
-
-4. **Use lazy video loading** for better memory management:
+3. **Use lazy video loading** for better memory management:
    ```dart
    final controller = await LazyVideoLoadingService.instance.requestVideo(request);
    ```

--- a/mobile/integration_test/account_swap_integration_test.dart
+++ b/mobile/integration_test/account_swap_integration_test.dart
@@ -18,6 +18,7 @@ import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/swap_account.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/startup_performance_service.dart';
+import 'package:openvine/utils/log_message_batcher.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'helpers/test_setup.dart';
@@ -81,6 +82,7 @@ void main() {
         appVersion: 'test',
         crashReporting: CrashReportingService(),
         documentsPath: '/documents',
+        logMessageBatcher: LogMessageBatcher(),
       );
 
       // Create two real local-key identities in a setup container. Guarded

--- a/mobile/integration_test/dm_owner_scoped_uniqueness_test.dart
+++ b/mobile/integration_test/dm_owner_scoped_uniqueness_test.dart
@@ -19,6 +19,7 @@ import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/swap_account.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/startup_performance_service.dart';
+import 'package:openvine/utils/log_message_batcher.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'helpers/test_setup.dart';
@@ -91,6 +92,7 @@ void main() {
           appVersion: 'test',
           crashReporting: CrashReportingService(),
           documentsPath: '/documents',
+          logMessageBatcher: LogMessageBatcher(),
         );
 
         String? pubkeyA;
@@ -198,6 +200,7 @@ void main() {
           appVersion: 'test',
           crashReporting: CrashReportingService(),
           documentsPath: '/documents',
+          logMessageBatcher: LogMessageBatcher(),
         );
 
         const ownerA =

--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -104,10 +104,15 @@ KeycastOAuth oauthClient(Ref ref) {
   return oauth;
 }
 
-/// Web authentication service (for web platform only)
-@riverpod
+/// Web authentication service (for web platform only).
+///
+/// Kept alive: the service holds the signed-in web session (method, pubkey,
+/// signer), and the screen that signs in and the iframe sandbox that later
+/// signs with it are different readers. Before #8618 the factory returned a
+/// process singleton, which hid that this provider was autoDispose.
+@Riverpod(keepAlive: true)
 WebAuthService webAuthService(Ref ref) {
-  return WebAuthService();
+  return WebAuthService(nip07Service: ref.watch(nip07ServiceProvider));
 }
 
 /// Authentication service

--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -126,6 +126,7 @@ AuthService authService(Ref ref) {
   final authService = AuthService(
     backgroundActivityManager: ref.read(backgroundActivityManagerProvider),
     crashReporter: ref.read(crashReportingServiceProvider),
+    nip07Service: ref.watch(nip07ServiceProvider),
     userDataCleanupService: userDataCleanupService,
     keyStorage: keyStorage,
     oauthClient: oauthClient,

--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -112,7 +112,11 @@ KeycastOAuth oauthClient(Ref ref) {
 /// process singleton, which hid that this provider was autoDispose.
 @Riverpod(keepAlive: true)
 WebAuthService webAuthService(Ref ref) {
-  return WebAuthService(nip07Service: ref.watch(nip07ServiceProvider));
+  final service = WebAuthService(
+    nip07Service: ref.watch(nip07ServiceProvider),
+  );
+  ref.onDispose(service.dispose);
+  return service;
 }
 
 /// Authentication service

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -345,7 +345,7 @@ final class WebAuthServiceProvider
   }
 }
 
-String _$webAuthServiceHash() => r'f366777957760610f4ecdb1bd8ffe115f0910066';
+String _$webAuthServiceHash() => r'13e5f97f515b68acad668d522d80adef878f25fc';
 
 /// Authentication service
 

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -286,24 +286,39 @@ final class OauthClientProvider
 
 String _$oauthClientHash() => r'217c3c01dd4f147990ee0f189f5d4fe5bcd89d45';
 
-/// Web authentication service (for web platform only)
+/// Web authentication service (for web platform only).
+///
+/// Kept alive: the service holds the signed-in web session (method, pubkey,
+/// signer), and the screen that signs in and the iframe sandbox that later
+/// signs with it are different readers. Before #8618 the factory returned a
+/// process singleton, which hid that this provider was autoDispose.
 
 @ProviderFor(webAuthService)
 final webAuthServiceProvider = WebAuthServiceProvider._();
 
-/// Web authentication service (for web platform only)
+/// Web authentication service (for web platform only).
+///
+/// Kept alive: the service holds the signed-in web session (method, pubkey,
+/// signer), and the screen that signs in and the iframe sandbox that later
+/// signs with it are different readers. Before #8618 the factory returned a
+/// process singleton, which hid that this provider was autoDispose.
 
 final class WebAuthServiceProvider
     extends $FunctionalProvider<WebAuthService, WebAuthService, WebAuthService>
     with $Provider<WebAuthService> {
-  /// Web authentication service (for web platform only)
+  /// Web authentication service (for web platform only).
+  ///
+  /// Kept alive: the service holds the signed-in web session (method, pubkey,
+  /// signer), and the screen that signs in and the iframe sandbox that later
+  /// signs with it are different readers. Before #8618 the factory returned a
+  /// process singleton, which hid that this provider was autoDispose.
   WebAuthServiceProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
         name: r'webAuthServiceProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -330,7 +345,7 @@ final class WebAuthServiceProvider
   }
 }
 
-String _$webAuthServiceHash() => r'53411c0f6a62bb9b59f90a0d7fc738a553a0b575';
+String _$webAuthServiceHash() => r'f366777957760610f4ecdb1bd8ffe115f0910066';
 
 /// Authentication service
 

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -376,7 +376,7 @@ final class AuthServiceProvider
   }
 }
 
-String _$authServiceHash() => r'7e6f12178ba3a43c68e6f95637fcb07b951428eb';
+String _$authServiceHash() => r'3b874e27fd3c2d60e3a5b63ce923dcfa06fe3808';
 
 /// Provider that returns current auth state and rebuilds when it changes.
 /// Widgets should watch this instead of authService.authState directly

--- a/mobile/lib/providers/avatar_svg_repository_provider.dart
+++ b/mobile/lib/providers/avatar_svg_repository_provider.dart
@@ -1,0 +1,21 @@
+// ABOUTME: Provides the app's AvatarSvgRepository to avatar widgets
+// ABOUTME: Replaces the former top-level global instance (#8618)
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:openvine/repositories/avatar_svg_repository.dart';
+
+/// The app's [AvatarSvgRepository], which validates remote avatar SVG payloads
+/// before `flutter_svg` sees them.
+///
+/// Replaces the former top-level `defaultAvatarSvgRepository` global (#8618),
+/// which no test could swap out. Account-scoped like any other provider: the
+/// cache holds only public avatar bytes keyed by URL, so rebuilding it on an
+/// account swap costs a refetch and nothing else. The provider owns the HTTP
+/// client it hands the repository, so the connection pool closes with the
+/// container instead of living for the process.
+final avatarSvgRepositoryProvider = Provider<AvatarSvgRepository>((ref) {
+  final client = http.Client();
+  ref.onDispose(client.close);
+  return HttpAvatarSvgRepository(client: client);
+});

--- a/mobile/lib/providers/device_scope.dart
+++ b/mobile/lib/providers/device_scope.dart
@@ -12,11 +12,13 @@ import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/db_cipher_key_provider.dart';
 import 'package:openvine/providers/documents_path_provider.dart';
 import 'package:openvine/providers/install_source_provider.dart';
+import 'package:openvine/providers/log_message_batcher_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/startup_performance_provider.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/database_corruption_service.dart';
 import 'package:openvine/services/startup_performance_service.dart';
+import 'package:openvine/utils/log_message_batcher.dart';
 // Override lives in riverpod's misc barrel; flutter_riverpod does not
 // re-export the type name even though it accepts List<Override>.
 import 'package:riverpod/misc.dart' show Override;
@@ -55,6 +57,7 @@ class DeviceScope {
     required this.documentsPath,
     required this.startupPerformance,
     required this.crashReporting,
+    required this.logMessageBatcher,
     this.dbCipherKey,
     this.databaseCorruptionService,
     this.installSource = InstallSource.sideload,
@@ -94,6 +97,13 @@ class DeviceScope {
   /// `FlutterError.onError` on every account swap (#4743).
   final CrashReportingService crashReporting;
 
+  /// Collapses repetitive relay log lines into periodic summaries. Device-scoped
+  /// because the `debugPrint` override that feeds it is installed once per
+  /// process in `app_bootstrap`, before any container exists; a per-container
+  /// instance would leave the startup coordinator arming, and the lifecycle
+  /// handler flushing, a batcher nothing writes to (#8618).
+  final LogMessageBatcher logMessageBatcher;
+
   /// The app-lifetime handle the UI calls to switch accounts. Device-scoped so
   /// it outlives — and drives — every container swap.
   final AccountSwitchController switchController;
@@ -132,6 +142,7 @@ class DeviceScope {
     installSourceProvider.overrideWithValue(installSource),
     startupPerformanceServiceProvider.overrideWithValue(startupPerformance),
     crashReportingServiceProvider.overrideWithValue(crashReporting),
+    logMessageBatcherProvider.overrideWithValue(logMessageBatcher),
     deviceScopeProvider.overrideWithValue(this),
     ...accountOverrides,
   ];

--- a/mobile/lib/providers/log_message_batcher_provider.dart
+++ b/mobile/lib/providers/log_message_batcher_provider.dart
@@ -1,0 +1,25 @@
+// ABOUTME: Device-scoped provider for the app's LogMessageBatcher
+// ABOUTME: Replaces the former lazy-static singleton (#8618)
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/utils/log_message_batcher.dart';
+
+/// The app's single [LogMessageBatcher].
+///
+/// Replaces the former `LogMessageBatcher.instance` singleton (#8618). It is
+/// **device-scoped**, not account-scoped: the `debugPrint` override installed
+/// in `app_bootstrap` batches into it for the life of the process, so an
+/// account swap must not hand the startup coordinator or the lifecycle handler
+/// a different instance whose flush timer was never armed. `DeviceScope` pins
+/// the bootstrap-owned instance with `overrideWithValue`.
+///
+/// The fallback is a fresh batcher that no `debugPrint` hook feeds, so it
+/// holds nothing and flushes nothing — the same thing a test got from the old
+/// singleton before anything was batched. Production always receives the
+/// bootstrap-owned instance through `DeviceScope`, which every container is
+/// built from.
+final logMessageBatcherProvider = Provider<LogMessageBatcher>((ref) {
+  final batcher = LogMessageBatcher();
+  ref.onDispose(batcher.dispose);
+  return batcher;
+});

--- a/mobile/lib/providers/service_providers.dart
+++ b/mobile/lib/providers/service_providers.dart
@@ -7,6 +7,7 @@ import 'package:openvine/observability/network/firebase_http_metric_recorder.dar
 import 'package:openvine/observability/network/http_metric_recorder.dart';
 import 'package:openvine/observability/network/performance_http_client.dart';
 import 'package:openvine/services/logging_config_service.dart';
+import 'package:openvine/services/nip07_service.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/top_hashtags_service.dart';
 
@@ -28,6 +29,16 @@ final loggingConfigServiceProvider = Provider<LoggingConfigService>(
 final topHashtagsServiceProvider = Provider<TopHashtagsService>(
   (ref) => TopHashtagsService(),
 );
+
+/// Provides the app's shared [Nip07Service], the bridge to a NIP-07 browser
+/// extension such as Alby or nos2x.
+///
+/// Replaces the former `Nip07Service()` factory singleton (#8618). A single
+/// shared instance is kept alive so `AuthService` and `WebAuthService`
+/// observe the same extension session: a connection made through one is
+/// visible to the other. Constructing it off-web is harmless — `isAvailable`
+/// is false there and nothing touches `window.nostr` until it is true.
+final nip07ServiceProvider = Provider<Nip07Service>((ref) => Nip07Service());
 
 /// Provides the app's [PerformanceMonitoringService].
 ///

--- a/mobile/lib/repositories/avatar_svg_repository.dart
+++ b/mobile/lib/repositories/avatar_svg_repository.dart
@@ -275,6 +275,3 @@ class _AvatarSvgCacheEntry {
   final Uint8List? bytes;
   final DateTime expiresAt;
 }
-
-final AvatarSvgRepository defaultAvatarSvgRepository =
-    HttpAvatarSvgRepository();

--- a/mobile/lib/screens/apps/web_iframe_sandbox_screen_web.dart
+++ b/mobile/lib/screens/apps/web_iframe_sandbox_screen_web.dart
@@ -8,7 +8,9 @@ import 'dart:ui_web' as ui_web;
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
+import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/services/web_auth_service.dart';
 import 'package:openvine/services/web_iframe_nostr_bridge.dart';
 import 'package:web/web.dart' as web;
@@ -18,7 +20,7 @@ import 'package:web/web.dart' as web;
 /// against the host's [WebAuthService] signer, so the embedded app uses
 /// the user's existing Divine session over postMessage and skips its
 /// own login flow.
-class WebIframeSandboxScreen extends StatefulWidget {
+class WebIframeSandboxScreen extends ConsumerStatefulWidget {
   const WebIframeSandboxScreen({required this.app, super.key});
 
   static const String routeName = 'web-iframe-sandbox';
@@ -30,10 +32,12 @@ class WebIframeSandboxScreen extends StatefulWidget {
   final NostrAppDirectoryEntry app;
 
   @override
-  State<WebIframeSandboxScreen> createState() => _WebIframeSandboxScreenState();
+  ConsumerState<WebIframeSandboxScreen> createState() =>
+      _WebIframeSandboxScreenState();
 }
 
-class _WebIframeSandboxScreenState extends State<WebIframeSandboxScreen> {
+class _WebIframeSandboxScreenState
+    extends ConsumerState<WebIframeSandboxScreen> {
   static int _nextViewId = 0;
 
   late final String _viewType;
@@ -45,7 +49,7 @@ class _WebIframeSandboxScreenState extends State<WebIframeSandboxScreen> {
     _viewType = 'divine-iframe-sandbox-${widget.app.id}-${_nextViewId++}';
     _bridge = WebIframeNostrBridge(
       app: widget.app,
-      authService: WebAuthService(),
+      authService: ref.read(webAuthServiceProvider),
     );
     _registerViewFactory();
     _bridge.start();

--- a/mobile/lib/services/analytics_service.dart
+++ b/mobile/lib/services/analytics_service.dart
@@ -153,8 +153,8 @@ class AnalyticsService implements BackgroundAwareService {
 
       // The guard above is not enough on its own: dispose() may have run while
       // the awaits above were in flight. Re-check before the two side effects
-      // it can no longer undo — the periodic timer, and joining the
-      // process-global registry that has no owner left to leave it (#8398).
+      // it can no longer undo — the periodic timer, and joining the manager's
+      // registry with no owner left to leave it (#8398).
       if (_isDisposed) return;
 
       // Set up periodic cleanup of tracked views
@@ -838,18 +838,11 @@ class AnalyticsService implements BackgroundAwareService {
     _isInBackground = false;
   }
 
-  @override
-  void onPeriodicCleanup() {
-    if (!_isInBackground) {
-      _recentlyTrackedViews.clear();
-    }
-  }
-
   void dispose() {
-    // Unregister before tearing down. The manager is a process-global
-    // singleton, so an instance left in its registry keeps receiving
-    // lifecycle callbacks forever — across provider rebuilds in the app, and
-    // across every later suite in the merged test isolate (#6880).
+    // Unregister before tearing down. The manager outlives this service, so
+    // an instance left in its registry keeps receiving lifecycle callbacks —
+    // across provider rebuilds in the app, and across every later suite in
+    // the merged test isolate (#6880).
     if (_isBackgroundRegistered) {
       _backgroundActivityManager.unregisterService(this);
       _isBackgroundRegistered = false;

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -4499,11 +4499,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     );
   }
 
-  @override
-  void onPeriodicCleanup() {
-    // No cleanup needed for auth service during periodic cleanup
-  }
-
   Future<void> dispose() async {
     Log.debug(
       '📱️ Disposing SecureAuthService',

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -2158,8 +2158,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
   /// Connect using a NIP-07 browser extension (Alby, nos2x, Nostore, etc.)
   ///
-  /// Only valid on the web platform. On non-web targets this returns an
-  /// [AuthResult.failure] immediately without touching auth state.
+  /// When the injected bridge is missing or no browser extension is available,
+  /// returns an [AuthResult.failure] without touching auth state. This covers
+  /// non-web targets and web sessions without a NIP-07 extension.
   Future<AuthResult> connectWithNip07() async {
     Log.info(
       'Connecting with NIP-07 browser extension...',

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -125,7 +125,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     List<String>? indexerRelays,
     String? primaryRelayUrl,
     RelayDiscoveryService? relayDiscoveryService,
-    Nip07Service? nip07ServiceForTest,
+    Nip07Service? nip07Service,
     RemoteSignerFactory? remoteSignerFactory,
     Duration oauthRefreshTimeout = defaultOAuthRefreshTimeout,
     Duration expiredSessionRefreshTimeout = defaultExpiredSessionRefreshTimeout,
@@ -146,7 +146,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
        _oauthConfig =
            oauthConfig ??
            const OAuthConfig(serverUrl: '', clientId: '', redirectUri: ''),
-       _injectedNip07ServiceForTest = nip07ServiceForTest,
+       _nip07Extension = nip07Service,
        _remoteSignerFactory = remoteSignerFactory ?? NostrRemoteSigner.new,
        _oauthRefreshTimeout = oauthRefreshTimeout,
        _expiredSessionRefreshTimeout = expiredSessionRefreshTimeout,
@@ -231,10 +231,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// [OAuthSessionCoordinator]. Injectable so tests can use a short bound.
   final Duration _expiredSessionRefreshTimeout;
 
-  /// Test seam: when supplied, bypasses the [Nip07Service] singleton and the
-  /// [kIsWeb] guard so unit tests can exercise the full NIP-07 flow on the VM
-  /// target.
-  final Nip07Service? _injectedNip07ServiceForTest;
+  /// Bridge to a NIP-07 browser extension, or null when none was injected
+  /// (tests off-web). Production injects the shared `nip07ServiceProvider`
+  /// instance, whose [Nip07Service.isAvailable] is false off-web, so the
+  /// NIP-07 paths need no [kIsWeb] guard of their own (#8618).
+  final Nip07Service? _nip07Extension;
 
   /// Relay URL used when self-publishing the bootstrap kind:10002 event for
   /// accounts whose indexer discovery returned empty. Injected from
@@ -413,10 +414,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// True only on web targets where `window.nostr` (a NIP-07 extension) is
   /// reachable. Used by the welcome screen to decide whether to surface the
   /// browser-extension sign-in button.
-  bool get isNip07Available {
-    if (!kIsWeb && _injectedNip07ServiceForTest == null) return false;
-    return (_injectedNip07ServiceForTest ?? Nip07Service()).isAvailable;
-  }
+  bool get isNip07Available => _nip07Extension?.isAvailable ?? false;
 
   /// Current RPC capability state.
   AuthRpcCapability get authRpcCapability => _authRpcCapability;
@@ -2169,9 +2167,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       category: LogCategory.auth,
     );
 
-    if (!kIsWeb && _injectedNip07ServiceForTest == null) {
+    final service = _nip07Extension;
+    if (service == null || !service.isAvailable) {
       return AuthResult.failure(
-        'NIP-07 browser extensions are only available on the web platform.',
+        'No NIP-07 extension found. '
+        'Please install Alby, nos2x, or another compatible extension.',
       );
     }
 
@@ -2179,15 +2179,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     _lastError = null;
 
     try {
-      final service = _injectedNip07ServiceForTest ?? Nip07Service();
-
-      if (!service.isAvailable) {
-        throw Exception(
-          'No NIP-07 extension found. '
-          'Please install Alby, nos2x, or another compatible extension.',
-        );
-      }
-
       final result = await service.connect();
       if (!result.success || result.publicKey == null) {
         throw Exception(result.errorMessage ?? 'NIP-07 authentication failed.');
@@ -2247,12 +2238,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// session by calling getPublicKey() again. If the extension is no
   /// longer present or refuses, fall back to unauthenticated.
   Future<void> _reconnectNip07() async {
-    if (!kIsWeb && _injectedNip07ServiceForTest == null) {
-      _setAuthState(AuthState.unauthenticated);
-      return;
-    }
-    final service = _injectedNip07ServiceForTest ?? Nip07Service();
-    if (!service.isAvailable) {
+    final service = _nip07Extension;
+    if (service == null || !service.isAvailable) {
       Log.info(
         'NIP-07 extension no longer available — falling back to '
         'unauthenticated',

--- a/mobile/lib/services/background_activity_manager.dart
+++ b/mobile/lib/services/background_activity_manager.dart
@@ -11,7 +11,6 @@ class BackgroundActivityManager {
   BackgroundActivityManager();
 
   bool _isAppInForeground = true;
-  bool _isInitialized = false;
   final List<BackgroundAwareService> _registeredServices = [];
 
   // Defensive bound on how long the manager will await a single service's
@@ -23,33 +22,12 @@ class BackgroundActivityManager {
   // `FutureOr<void>` (or an impl starts blocking the microtask chain).
   static const Duration _suspendGracePeriod = Duration(seconds: 1);
 
-  // Timers for delayed actions
+  // Timer for delayed actions
   Timer? _backgroundSuspensionTimer;
-  Timer? _periodicCleanupTimer;
 
   /// Current app foreground state
   bool get isAppInForeground => _isAppInForeground;
   bool get isAppInBackground => !_isAppInForeground;
-
-  /// Initialize the background activity manager
-  Future<void> initialize() async {
-    if (_isInitialized) return;
-
-    _isInitialized = true;
-
-    // Start periodic cleanup timer (runs every 5 minutes)
-    _periodicCleanupTimer = Timer.periodic(const Duration(minutes: 5), (_) {
-      if (_isAppInForeground) {
-        _performPeriodicCleanup();
-      }
-    });
-
-    Log.info(
-      'Background activity manager initialized',
-      name: 'BackgroundActivityManager',
-      category: LogCategory.system,
-    );
-  }
 
   /// Register a service for background state management
   void registerService(BackgroundAwareService service) {
@@ -152,7 +130,6 @@ class BackgroundActivityManager {
     );
 
     _backgroundSuspensionTimer?.cancel();
-    _periodicCleanupTimer?.cancel();
 
     // Force suspend all services
     _suspendAllServices();
@@ -249,36 +226,10 @@ class BackgroundActivityManager {
     }
   }
 
-  /// Periodic cleanup when app is in foreground
-  void _performPeriodicCleanup() {
-    Log.debug(
-      '🧹 Performing periodic cleanup',
-      name: 'BackgroundActivityManager',
-      category: LogCategory.system,
-    );
-
-    for (final service in _registeredServices) {
-      try {
-        service.onPeriodicCleanup();
-      } catch (e) {
-        Log.error(
-          'Error in periodic cleanup for ${service.serviceName}: $e',
-          name: 'BackgroundActivityManager',
-          category: LogCategory.system,
-        );
-      }
-    }
-  }
-
   /// Get status information for debugging
   Map<String, dynamic> getStatus() {
     return {
       'isAppInForeground': _isAppInForeground,
-      // Reported because it gates [initialize] and owns the periodic cleanup
-      // timer: an instance left initialized keeps a 5-minute Timer.periodic
-      // alive, which in the merged test isolate outlives the test that armed
-      // it (#8398).
-      'isInitialized': _isInitialized,
       'registeredServices': _registeredServices.length,
       'serviceNames': _registeredServices.map((s) => s.serviceName).toList(),
     };
@@ -286,26 +237,21 @@ class BackgroundActivityManager {
 
   void dispose() {
     _backgroundSuspensionTimer?.cancel();
-    _periodicCleanupTimer?.cancel();
     _registeredServices.clear();
   }
 
   /// Restores this manager to its construction state.
   ///
-  /// [dispose] is not a substitute: it leaves [_isInitialized] set, so a later
-  /// [initialize] silently no-ops and never re-arms the periodic cleanup, and
-  /// it leaves [_isAppInForeground] wherever the last lifecycle event put it.
-  /// A stale `false` there is what turns a later `resumed` into a fan-out over
-  /// whatever is still registered (#6880).
+  /// [dispose] is not a substitute: it leaves [_isAppInForeground] wherever
+  /// the last lifecycle event put it, and a stale `false` there is what turns
+  /// a later `resumed` into a fan-out over whatever is still registered
+  /// (#6880).
   @visibleForTesting
   void resetForTesting() {
     _backgroundSuspensionTimer?.cancel();
     _backgroundSuspensionTimer = null;
-    _periodicCleanupTimer?.cancel();
-    _periodicCleanupTimer = null;
     _registeredServices.clear();
     _isAppInForeground = true;
-    _isInitialized = false;
   }
 }
 
@@ -322,7 +268,4 @@ abstract class BackgroundAwareService {
 
   /// Called when app returns to foreground
   void onAppResumed();
-
-  /// Called periodically for cleanup (every 5 minutes while in foreground)
-  void onPeriodicCleanup();
 }

--- a/mobile/lib/services/nip07_service.dart
+++ b/mobile/lib/services/nip07_service.dart
@@ -49,16 +49,19 @@ class Nip07SignResult {
 
 /// Service for managing NIP-07 browser extension interactions
 class Nip07Service {
-  factory Nip07Service() => _instance;
-  Nip07Service._internal() : _extensionOverride = null;
+  /// Talks to the extension the page exposes as `window.nostr`.
+  ///
+  /// The app owns one instance, shared by `AuthService` and `WebAuthService`
+  /// through `nip07ServiceProvider` so both observe the same extension
+  /// session (#8618). Off-web, [isAvailable] is false and nothing here
+  /// touches the browser.
+  Nip07Service() : _extensionOverride = null;
 
   /// Test seam: binds the service to [extension] instead of `window.nostr`,
   /// so the extension-facing paths can be exercised off-web.
   @visibleForTesting
   Nip07Service.withExtension(nip07.NostrExtension extension)
     : _extensionOverride = extension;
-
-  static final Nip07Service _instance = Nip07Service._internal();
 
   final nip07.NostrExtension? _extensionOverride;
 

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -147,16 +147,9 @@ class NotificationService {
   /// `PushNotificationSessionCoordinator`, which is the only place the app is
   /// allowed to interrupt the user for it.
   ///
-  /// Call this from main.dart after runApp() to set up notifications:
-  /// ```dart
-  /// void main() async {
-  ///   WidgetsFlutterBinding.ensureInitialized();
-  ///   runApp(MyApp());
-  ///
-  ///   // Initialize notifications (optional - will auto-init on first use)
-  ///   await NotificationService().initialize();
-  /// }
-  /// ```
+  /// `notificationServiceProvider` calls this when it creates the app-owned
+  /// service. Callers should read that provider instead of constructing a
+  /// second instance.
   Future<void> initialize() async {
     Log.debug(
       '🔧 Initializing NotificationService',

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -90,23 +90,11 @@ class AppNotification {
 
 /// Service for managing app notifications
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
+///
+/// The app owns one instance through `notificationServiceProvider`, which
+/// constructs it and disposes it with the container (#8618).
 class NotificationService {
-  /// Factory constructor that returns the singleton instance
-  factory NotificationService() => instance;
-
-  NotificationService._();
-  static NotificationService? _instance;
-
-  /// Singleton instance
-  // A constructor cannot be a getter, and `factory NotificationService()`
-  // would hide both the sharing and the revive-after-dispose below.
-  // ignore: prefer_constructors_over_static_methods
-  static NotificationService get instance {
-    if (_instance == null || _instance!._disposed) {
-      _instance = NotificationService._();
-    }
-    return _instance!;
-  }
+  NotificationService();
 
   final List<AppNotification> _notifications = [];
   _NotificationPermissionState _permissionState =

--- a/mobile/lib/services/startup_performance_service.dart
+++ b/mobile/lib/services/startup_performance_service.dart
@@ -225,42 +225,6 @@ class StartupPerformanceService {
     }
   }
 
-  /// Defer heavy work until after UI is ready
-  Future<T> deferUntilUIReady<T>(
-    Future<T> Function() work, {
-    String? taskName,
-  }) async {
-    // If UI is already ready, execute immediately
-    if (_uiReadyTime != null) {
-      return work();
-    }
-
-    final completer = Completer<T>();
-
-    // Wait for UI to be ready
-    void checkUIReady() {
-      if (_uiReadyTime != null) {
-        // Execute the deferred work
-        work().then(completer.complete).catchError(completer.completeError);
-      } else {
-        // Check again on next frame
-        WidgetsBinding.instance.addPostFrameCallback((_) => checkUIReady());
-      }
-    }
-
-    WidgetsBinding.instance.addPostFrameCallback((_) => checkUIReady());
-
-    if (taskName != null) {
-      Log.debug(
-        '⏳ Deferring task: $taskName until UI ready',
-        name: 'StartupPerformance',
-        category: LogCategory.system,
-      );
-    }
-
-    return completer.future;
-  }
-
   /// Execute work with performance monitoring
   Future<T> measureWork<T>(String taskName, Future<T> Function() work) async {
     startPhase(taskName);

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -1295,12 +1295,6 @@ class UploadManager implements BackgroundAwareService {
     unawaited(_recoverStuckUploads());
   }
 
-  @override
-  void onPeriodicCleanup() {
-    // No-op: recovery is driven by resume/startup events, not the periodic
-    // timer.
-  }
-
   /// Cancel an upload (stops the upload but keeps it for retry)
   Future<void> cancelUpload(String uploadId) async {
     final upload = getUpload(uploadId);

--- a/mobile/lib/services/web_auth_service.dart
+++ b/mobile/lib/services/web_auth_service.dart
@@ -121,12 +121,13 @@ class BunkerSignerImpl implements WebSigner {
 /// Unified web authentication service
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
 class WebAuthService {
-  factory WebAuthService() => _instance;
-  WebAuthService._internal();
-  static final WebAuthService _instance = WebAuthService._internal();
+  /// [nip07Service] is the app's shared extension bridge, injected so the
+  /// NIP-07 session this service observes is the one `AuthService` sees too;
+  /// a private default would strand each on its own connection (#8618).
+  WebAuthService({required Nip07Service nip07Service})
+    : _nip07Service = nip07Service;
 
-  // Service instances
-  final Nip07Service _nip07Service = Nip07Service();
+  final Nip07Service _nip07Service;
   NsecBunkerClient? _bunkerClient; // Injected or created as needed
 
   // Current authentication state

--- a/mobile/lib/startup/app_bootstrap.dart
+++ b/mobile/lib/startup/app_bootstrap.dart
@@ -158,6 +158,11 @@ Future<void> startOpenVineApp({
   final startupPerformance = StartupPerformanceService(
     crashReporting: crashReporting,
   );
+  // Fed by the debugPrint override installed below, which is process-wide, so
+  // the batcher is constructed here and pinned device-scoped via
+  // DeviceScope.overrides — the startup coordinator arms its flush timer and
+  // the lifecycle handler flushes it, and both must reach this instance.
+  final logMessageBatcher = LogMessageBatcher();
   AppUptime.markStarted();
 
   // Ensure bindings are initialized first (required for everything)
@@ -327,14 +332,14 @@ Future<void> startOpenVineApp({
       if (message.contains('[EXTERNAL-EVENT]') &&
           message.contains('already exists in database or was rejected')) {
         // Use our batcher for these specific messages
-        LogMessageBatcher.instance.tryBatchMessage(
+        logMessageBatcher.tryBatchMessage(
           message,
           category: LogCategory.relay,
         );
         return; // Don't print the individual message
       } else if (message.contains('[EXTERNAL-EVENT]') &&
           message.contains('matches subscription')) {
-        LogMessageBatcher.instance.tryBatchMessage(
+        logMessageBatcher.tryBatchMessage(
           message,
           level: LogLevel.debug,
           category: LogCategory.relay,
@@ -343,7 +348,7 @@ Future<void> startOpenVineApp({
       } else if (message.contains('[EXTERNAL-EVENT]') &&
           message.contains('Received event') &&
           message.contains('from')) {
-        LogMessageBatcher.instance.tryBatchMessage(
+        logMessageBatcher.tryBatchMessage(
           message,
           level: LogLevel.debug,
           category: LogCategory.relay,
@@ -646,6 +651,7 @@ Future<void> startOpenVineApp({
     documentsPath: documentsPath,
     startupPerformance: startupPerformance,
     crashReporting: crashReporting,
+    logMessageBatcher: logMessageBatcher,
     dbCipherKey: dbCipherKey,
     databaseCorruptionService: databaseCorruptionService,
     installSource: installSource,

--- a/mobile/lib/startup/startup_coordinator_factory.dart
+++ b/mobile/lib/startup/startup_coordinator_factory.dart
@@ -13,6 +13,7 @@ import 'package:openvine/notifications/notification_tap_router.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/crash_reporting_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/log_message_batcher_provider.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/startup_performance_provider.dart';
@@ -23,7 +24,6 @@ import 'package:openvine/services/video_format_preference.dart';
 import 'package:openvine/startup/app_bootstrap.dart';
 import 'package:openvine/startup/startup_phases.dart';
 import 'package:openvine/startup/timed_startup_task.dart';
-import 'package:openvine/utils/log_message_batcher.dart';
 import 'package:openvine/utils/platform_support.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -172,7 +172,7 @@ StartupCoordinator createStartupCoordinator(ProviderContainer container) {
         initializationStep: 'Initializing logging configuration',
         task: () async {
           await container.read(loggingConfigServiceProvider).initialize();
-          LogMessageBatcher.instance.initialize();
+          container.read(logMessageBatcherProvider).initialize();
         },
       );
     },

--- a/mobile/lib/utils/log_message_batcher.dart
+++ b/mobile/lib/utils/log_message_batcher.dart
@@ -32,10 +32,16 @@ class LogMessageBatcher {
     _flushTimer = Timer.periodic(_flushInterval, (_) => _flushBatches());
   }
 
+  /// Flush pending summaries without stopping periodic batching.
+  ///
+  /// Account-scoped lifecycle handlers use this when they unmount. The timer
+  /// belongs to the device-scoped batcher and must survive account swaps.
+  void flush() => _flushBatches();
+
   /// Dispose the batcher and clean up resources
   void dispose() {
     _flushTimer?.cancel();
-    _flushBatches(); // Flush any remaining messages
+    flush();
     _batchedMessages.clear();
   }
 

--- a/mobile/lib/utils/log_message_batcher.dart
+++ b/mobile/lib/utils/log_message_batcher.dart
@@ -6,12 +6,13 @@ import 'dart:collection';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Batches similar log messages and outputs summaries instead of individual messages
+///
+/// The app owns one instance, constructed in `app_bootstrap` where the
+/// `debugPrint` override that feeds it is installed, and pinned device-scoped
+/// through `DeviceScope` so the startup coordinator and the lifecycle handler
+/// arm and flush the same batcher (#8618).
 class LogMessageBatcher {
-  static final LogMessageBatcher _instance = LogMessageBatcher._internal();
-  factory LogMessageBatcher() => _instance;
-  LogMessageBatcher._internal();
-
-  static LogMessageBatcher get instance => _instance;
+  LogMessageBatcher();
 
   /// Map of message patterns to their batch info
   final Map<String, _BatchInfo> _batchedMessages = {};

--- a/mobile/lib/widgets/app_lifecycle_handler.dart
+++ b/mobile/lib/widgets/app_lifecycle_handler.dart
@@ -94,8 +94,9 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    // Dispose log message batcher and flush any remaining messages
-    _logMessageBatcher.dispose();
+    // This widget is account-scoped while the batcher is device-scoped. Flush
+    // pending summaries without cancelling the timer on account swaps.
+    _logMessageBatcher.flush();
     super.dispose();
   }
 

--- a/mobile/lib/widgets/app_lifecycle_handler.dart
+++ b/mobile/lib/widgets/app_lifecycle_handler.dart
@@ -14,6 +14,7 @@ import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/background_activity_provider.dart';
+import 'package:openvine/providers/log_message_batcher_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
@@ -37,12 +38,15 @@ class AppLifecycleHandler extends ConsumerStatefulWidget {
 class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
     with WidgetsBindingObserver {
   late final BackgroundActivityManager _backgroundManager;
+  // Read here rather than in dispose(), where ref is no longer usable.
+  late final LogMessageBatcher _logMessageBatcher;
   bool _tickersEnabled = true;
 
   @override
   void initState() {
     super.initState();
     _backgroundManager = ref.read(backgroundActivityManagerProvider);
+    _logMessageBatcher = ref.read(logMessageBatcherProvider);
     WidgetsBinding.instance.addObserver(this);
 
     // Resume any pending publish drafts after first frame,
@@ -91,7 +95,7 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     // Dispose log message batcher and flush any remaining messages
-    LogMessageBatcher.instance.dispose();
+    _logMessageBatcher.dispose();
     super.dispose();
   }
 

--- a/mobile/lib/widgets/user_avatar.dart
+++ b/mobile/lib/widgets/user_avatar.dart
@@ -6,8 +6,10 @@ import 'dart:math' as math;
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:openvine/blocs/avatar_svg/avatar_svg_cubit.dart';
+import 'package:openvine/providers/avatar_svg_repository_provider.dart';
 import 'package:openvine/repositories/avatar_svg_repository.dart';
 import 'package:openvine/utils/dead_image_hosts.dart';
 import 'package:openvine/widgets/avatar_failure_cache.dart';
@@ -75,6 +77,8 @@ class UserAvatar extends StatelessWidget {
   static double cornerRadiusForSize(double size) =>
       size <= 24 ? size / 3 : math.min(size * 0.4, 56);
 
+  /// Overrides the repository read from [avatarSvgRepositoryProvider], so a
+  /// test can render an SVG avatar without a `ProviderScope`.
   @visibleForTesting
   final AvatarSvgRepository? avatarSvgRepository;
 
@@ -186,9 +190,16 @@ class UserAvatar extends StatelessWidget {
         return _buildPlaceholder();
       }
 
-      return _AvatarSvgContent(
+      final repository = avatarSvgRepository;
+      if (repository != null) {
+        return _AvatarSvgContent(
+          imageUrl: imageUrl!,
+          repository: repository,
+          placeholderBuilder: _buildPlaceholder,
+        );
+      }
+      return _ProvidedAvatarSvgContent(
         imageUrl: imageUrl!,
-        repository: avatarSvgRepository ?? defaultAvatarSvgRepository,
         placeholderBuilder: _buildPlaceholder,
       );
     }
@@ -225,6 +236,29 @@ class UserAvatar extends StatelessWidget {
     }
 
     return _buildPlaceholder();
+  }
+}
+
+/// Resolves the shared [AvatarSvgRepository] from the container.
+///
+/// Separate from [_AvatarSvgContent] so a caller that injects its own
+/// repository needs no `ProviderScope` above it.
+class _ProvidedAvatarSvgContent extends ConsumerWidget {
+  const _ProvidedAvatarSvgContent({
+    required this.imageUrl,
+    required this.placeholderBuilder,
+  });
+
+  final String imageUrl;
+  final Widget Function() placeholderBuilder;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return _AvatarSvgContent(
+      imageUrl: imageUrl,
+      repository: ref.watch(avatarSvgRepositoryProvider),
+      placeholderBuilder: placeholderBuilder,
+    );
   }
 }
 

--- a/mobile/scripts/baseline/service_god_file_sizes.txt
+++ b/mobile/scripts/baseline/service_god_file_sizes.txt
@@ -6,9 +6,9 @@
 # This hard service baseline is authoritative over the broad advisory check for
 # service god-file ceilings.
 # Regenerate after shrinking/removing: UPDATE_BASELINE=1 bash scripts/check_service_god_file_ceiling.sh
-lib/services/auth_service.dart	4557
-lib/services/curated_list_service.dart	1848
-lib/services/upload_manager.dart	1964
+lib/services/auth_service.dart	4539
+lib/services/curated_list_service.dart	1847
+lib/services/upload_manager.dart	1958
 lib/services/video_editor/video_editor_render_service.dart	1539
-lib/services/video_event_publisher.dart	2303
-lib/services/video_event_service.dart	6619
+lib/services/video_event_publisher.dart	2295
+lib/services/video_event_service.dart	6517

--- a/mobile/scripts/baseline/singleton_services.txt
+++ b/mobile/scripts/baseline/singleton_services.txt
@@ -3,10 +3,9 @@
 # scripts/check_singleton_services.sh. The set may only SHRINK (growth fails CI
 # vs origin/main). Federated-plugin `*_platform_interface.dart` files are
 # excluded — there the settable static IS the test seam. Issue: #4743.
-mobile/lib/repositories/avatar_svg_repository.dart  # defer: #4338 — outside the #4743 audited set
-mobile/lib/services/bandwidth_tracker_service.dart  # defer: #4743 follow-up — read from VideoEvent extension getters (22 call sites)
-mobile/lib/services/nip07_service.dart  # defer: #4338 — outside the #4743 audited set
-mobile/lib/services/notification_service.dart  # defer: #4338 — outside the #4743 audited set
-mobile/lib/services/video_format_preference.dart  # defer: #4743 follow-up — read from VideoEvent extension getters (22 call sites)
-mobile/lib/services/web_auth_service.dart  # defer: #4338 — outside the #4743 audited set
-mobile/lib/utils/log_message_batcher.dart  # defer: #4338 — outside the #4743 audited set
+mobile/lib/repositories/avatar_svg_repository.dart # defer: #4338 — outside the #4743 audited set
+mobile/lib/services/bandwidth_tracker_service.dart # defer: #4743 follow-up — read from VideoEvent extension getters (22 call sites)
+mobile/lib/services/nip07_service.dart # defer: #4338 — outside the #4743 audited set
+mobile/lib/services/notification_service.dart # defer: #4338 — outside the #4743 audited set
+mobile/lib/services/video_format_preference.dart # defer: #4743 follow-up — read from VideoEvent extension getters (22 call sites)
+mobile/lib/services/web_auth_service.dart # defer: #4338 — outside the #4743 audited set

--- a/mobile/scripts/baseline/singleton_services.txt
+++ b/mobile/scripts/baseline/singleton_services.txt
@@ -4,5 +4,4 @@
 # vs origin/main). Federated-plugin `*_platform_interface.dart` files are
 # excluded — there the settable static IS the test seam. Issue: #4743.
 mobile/lib/services/bandwidth_tracker_service.dart # defer: #4743 follow-up — read from VideoEvent extension getters (22 call sites)
-mobile/lib/services/notification_service.dart # defer: #4338 — outside the #4743 audited set
 mobile/lib/services/video_format_preference.dart # defer: #4743 follow-up — read from VideoEvent extension getters (22 call sites)

--- a/mobile/scripts/baseline/singleton_services.txt
+++ b/mobile/scripts/baseline/singleton_services.txt
@@ -3,7 +3,6 @@
 # scripts/check_singleton_services.sh. The set may only SHRINK (growth fails CI
 # vs origin/main). Federated-plugin `*_platform_interface.dart` files are
 # excluded — there the settable static IS the test seam. Issue: #4743.
-mobile/lib/repositories/avatar_svg_repository.dart # defer: #4338 — outside the #4743 audited set
 mobile/lib/services/bandwidth_tracker_service.dart # defer: #4743 follow-up — read from VideoEvent extension getters (22 call sites)
 mobile/lib/services/nip07_service.dart # defer: #4338 — outside the #4743 audited set
 mobile/lib/services/notification_service.dart # defer: #4338 — outside the #4743 audited set

--- a/mobile/scripts/baseline/singleton_services.txt
+++ b/mobile/scripts/baseline/singleton_services.txt
@@ -4,7 +4,6 @@
 # vs origin/main). Federated-plugin `*_platform_interface.dart` files are
 # excluded — there the settable static IS the test seam. Issue: #4743.
 mobile/lib/services/bandwidth_tracker_service.dart # defer: #4743 follow-up — read from VideoEvent extension getters (22 call sites)
-mobile/lib/services/nip07_service.dart # defer: #4338 — outside the #4743 audited set
 mobile/lib/services/notification_service.dart # defer: #4338 — outside the #4743 audited set
 mobile/lib/services/video_format_preference.dart # defer: #4743 follow-up — read from VideoEvent extension getters (22 call sites)
 mobile/lib/services/web_auth_service.dart # defer: #4338 — outside the #4743 audited set

--- a/mobile/scripts/baseline/singleton_services.txt
+++ b/mobile/scripts/baseline/singleton_services.txt
@@ -6,4 +6,3 @@
 mobile/lib/services/bandwidth_tracker_service.dart # defer: #4743 follow-up — read from VideoEvent extension getters (22 call sites)
 mobile/lib/services/notification_service.dart # defer: #4338 — outside the #4743 audited set
 mobile/lib/services/video_format_preference.dart # defer: #4743 follow-up — read from VideoEvent extension getters (22 call sites)
-mobile/lib/services/web_auth_service.dart # defer: #4338 — outside the #4743 audited set

--- a/mobile/scripts/baseline/untested_services.txt
+++ b/mobile/scripts/baseline/untested_services.txt
@@ -30,7 +30,6 @@ video_cache_service
 video_event_service # defer: #4338 Track D demolition
 video_format_preference # defer: #4338 C2 — blocked on VideoEvent extension getters, not the singleton alone
 visibility_tracker
-web_auth_service
 web_iframe_nostr_bridge_binding # noise: web shim
 web_iframe_nostr_bridge_binding_factory # noise: web shim
 web_iframe_nostr_bridge_binding_factory_stub # noise: web shim

--- a/mobile/test/providers/auth_providers_test.dart
+++ b/mobile/test/providers/auth_providers_test.dart
@@ -10,9 +10,14 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/nip07_service.dart';
+import 'package:openvine/services/nip07_types.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
+
+class _FakeExtension extends NostrExtension {}
 
 class _RecordingAnalytics implements AnalyticsEventSink {
   final userIds = <String?>[];
@@ -51,6 +56,33 @@ void main() {
 
       expect(androidOptions['encryptedSharedPreferences'], 'true');
       expect(androidOptions['resetOnError'], 'false');
+    });
+  });
+
+  group('webAuthServiceProvider', () {
+    test('hands WebAuthService the shared NIP-07 bridge', () {
+      final container = ProviderContainer(
+        overrides: [
+          nip07ServiceProvider.overrideWithValue(
+            Nip07Service.withExtension(_FakeExtension()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(webAuthServiceProvider).isNip07Available, isTrue);
+    });
+
+    test('keeps one WebAuthService alive between readers', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final first = container.read(webAuthServiceProvider);
+      // Gives an autoDispose provider — which this must not be — the chance
+      // to drop the unlistened instance.
+      await container.pump();
+
+      expect(container.read(webAuthServiceProvider), same(first));
     });
   });
 

--- a/mobile/test/providers/auth_providers_test.dart
+++ b/mobile/test/providers/auth_providers_test.dart
@@ -17,7 +17,11 @@ import 'package:openvine/services/nip07_types.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
 
-class _FakeExtension extends NostrExtension {}
+class _FakeExtension extends NostrExtension {
+  @override
+  Future<String> getPublicKey() async =>
+      'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
+}
 
 class _RecordingAnalytics implements AnalyticsEventSink {
   final userIds = <String?>[];
@@ -83,6 +87,23 @@ void main() {
       await container.pump();
 
       expect(container.read(webAuthServiceProvider), same(first));
+    });
+
+    test('disposes WebAuthService with its container', () async {
+      final container = ProviderContainer(
+        overrides: [
+          nip07ServiceProvider.overrideWithValue(
+            Nip07Service.withExtension(_FakeExtension()),
+          ),
+        ],
+      );
+      final service = container.read(webAuthServiceProvider);
+      await service.authenticateWithNip07();
+      expect(service.isAuthenticated, isTrue);
+
+      container.dispose();
+
+      expect(service.isAuthenticated, isFalse);
     });
   });
 

--- a/mobile/test/providers/background_activity_provider_test.dart
+++ b/mobile/test/providers/background_activity_provider_test.dart
@@ -75,7 +75,4 @@ class _ProbeService implements BackgroundAwareService {
 
   @override
   void onAppResumed() {}
-
-  @override
-  void onPeriodicCleanup() {}
 }

--- a/mobile/test/providers/device_scope_test.dart
+++ b/mobile/test/providers/device_scope_test.dart
@@ -11,9 +11,11 @@ import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/device_scope.dart';
 import 'package:openvine/providers/documents_path_provider.dart';
 import 'package:openvine/providers/install_source_provider.dart';
+import 'package:openvine/providers/log_message_batcher_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/startup_performance_service.dart';
+import 'package:openvine/utils/log_message_batcher.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -21,12 +23,14 @@ void main() {
 
   late AppDatabase database;
   late SharedPreferences prefs;
+  late LogMessageBatcher logMessageBatcher;
   late DeviceScope deviceScope;
 
   setUp(() async {
     database = AppDatabase.test(NativeDatabase.memory());
     SharedPreferences.setMockInitialValues({});
     prefs = await SharedPreferences.getInstance();
+    logMessageBatcher = LogMessageBatcher();
     deviceScope = DeviceScope(
       database: database,
       sharedPreferences: prefs,
@@ -37,6 +41,7 @@ void main() {
         crashReporting: CrashReportingService(),
       ),
       documentsPath: '/documents',
+      logMessageBatcher: logMessageBatcher,
       installSource: InstallSource.playStore,
     );
   });
@@ -84,6 +89,16 @@ void main() {
 
       expect(a.read(documentsPathProvider), '/documents');
       expect(b.read(documentsPathProvider), '/documents');
+    });
+
+    test('every container reads the same log message batcher', () {
+      final a = buildAccountContainer(deviceScope);
+      addTearDown(a.dispose);
+      final b = buildAccountContainer(deviceScope);
+      addTearDown(b.dispose);
+
+      expect(a.read(logMessageBatcherProvider), same(logMessageBatcher));
+      expect(b.read(logMessageBatcherProvider), same(logMessageBatcher));
     });
 
     test('every container reads the same app version override', () {

--- a/mobile/test/providers/swap_account_test.dart
+++ b/mobile/test/providers/swap_account_test.dart
@@ -28,6 +28,7 @@ import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/push_notification_session_coordinator.dart';
 import 'package:openvine/services/startup_performance_service.dart';
+import 'package:openvine/utils/log_message_batcher.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 // Override lives in riverpod's misc barrel; flutter_riverpod does not
 // re-export the type name even though it accepts List<Override>.
@@ -102,6 +103,7 @@ void main() {
         crashReporting: CrashReportingService(),
       ),
       documentsPath: '/documents',
+      logMessageBatcher: LogMessageBatcher(),
       accountOverrides: [
         secureKeyStorageProvider.overrideWithValue(keyStorage),
         pushNotificationSyncProvider.overrideWithValue(null),
@@ -122,6 +124,7 @@ void main() {
         crashReporting: CrashReportingService(),
       ),
       documentsPath: '/documents',
+      logMessageBatcher: LogMessageBatcher(),
       accountOverrides: [
         secureKeyStorageProvider.overrideWithValue(keyStorage),
         pushNotificationSyncProvider.overrideWithValue(coordinator),
@@ -633,6 +636,7 @@ void main() {
           crashReporting: CrashReportingService(),
         ),
         documentsPath: '/documents',
+        logMessageBatcher: LogMessageBatcher(),
         accountOverrides: [
           secureKeyStorageProvider.overrideWithValue(keyStorage),
           authServiceProvider.overrideWithValue(targetAuthService),

--- a/mobile/test/services/auth_service_bunker_lifecycle_test.dart
+++ b/mobile/test/services/auth_service_bunker_lifecycle_test.dart
@@ -100,10 +100,6 @@ void main() {
     test('onExtendedBackground should not throw when no bunker signer', () {
       expect(() => authService.onExtendedBackground(), returnsNormally);
     });
-
-    test('onPeriodicCleanup should not throw', () {
-      expect(() => authService.onPeriodicCleanup(), returnsNormally);
-    });
   });
 
   group('AuthService BackgroundActivityManager registration (#4743 B3)', () {

--- a/mobile/test/services/auth_service_nip07_test.dart
+++ b/mobile/test/services/auth_service_nip07_test.dart
@@ -123,12 +123,22 @@ void main() {
       userDataCleanupService: mockCleanupService,
       keyStorage: mockKeyStorage,
       flutterSecureStorage: mockSecureStorage,
-      nip07ServiceForTest: mockNip07Service,
+      nip07Service: mockNip07Service,
     );
   });
 
   tearDown(() async {
     await authService.dispose();
+  });
+
+  group('isNip07Available', () {
+    test('mirrors the injected extension bridge', () {
+      when(() => mockNip07Service.isAvailable).thenReturn(true);
+      expect(authService.isNip07Available, isTrue);
+
+      when(() => mockNip07Service.isAvailable).thenReturn(false);
+      expect(authService.isNip07Available, isFalse);
+    });
   });
 
   group('connectWithNip07', () {

--- a/mobile/test/services/background_activity_manager_test.dart
+++ b/mobile/test/services/background_activity_manager_test.dart
@@ -12,7 +12,6 @@ class TestBackgroundService implements BackgroundAwareService {
   bool backgroundCalled = false;
   bool extendedBackgroundCalled = false;
   bool resumedCalled = false;
-  bool cleanupCalled = false;
 
   @override
   void onAppBackgrounded() {
@@ -27,11 +26,6 @@ class TestBackgroundService implements BackgroundAwareService {
   @override
   void onAppResumed() {
     resumedCalled = true;
-  }
-
-  @override
-  void onPeriodicCleanup() {
-    cleanupCalled = true;
   }
 }
 
@@ -54,9 +48,6 @@ class _ThrowingBackgroundService implements BackgroundAwareService {
 
   @override
   void onAppResumed() {}
-
-  @override
-  void onPeriodicCleanup() {}
 }
 
 void main() {
@@ -90,19 +81,6 @@ void main() {
         manager.resetForTesting();
 
         expect(manager.isAppInForeground, isTrue);
-      });
-
-      test('clears the initialized latch', () async {
-        await manager.initialize();
-        // Asserting the pre-state is what makes the post-state meaningful:
-        // without it the test passes whether or not reset clears the latch.
-        expect(manager.getStatus()['isInitialized'], isTrue);
-
-        manager.resetForTesting();
-
-        // dispose() leaves this set, so a later initialize() would no-op and
-        // never re-arm the periodic cleanup. reset must not.
-        expect(manager.getStatus()['isInitialized'], isFalse);
       });
     });
 

--- a/mobile/test/services/notification_service_test.dart
+++ b/mobile/test/services/notification_service_test.dart
@@ -445,6 +445,28 @@ void main() {
     });
 
     test(
+      'a tap handled by another service does not reach this stream',
+      () async {
+        final other = NotificationService();
+        addTearDown(other.dispose);
+        final events = <NotificationTapEvent>[];
+        final sub = service.notificationTapStream.listen(events.add);
+        addTearDown(sub.cancel);
+
+        other.handleNotificationTapPayload(
+          jsonEncode({
+            'referencedEventId': 'abc123',
+            'notificationType': 'reply',
+          }),
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(events, isEmpty);
+      },
+    );
+
+    test(
       'emits the authoritative referencedAddress from JSON payload',
       () async {
         final events = <NotificationTapEvent>[];

--- a/mobile/test/services/web_auth_service_test.dart
+++ b/mobile/test/services/web_auth_service_test.dart
@@ -1,15 +1,25 @@
-// ABOUTME: Unit tests for WebAuthService nsec bunker authentication integration
-// ABOUTME: Tests bunker authentication flow and signer functionality in WebAuthService
+// ABOUTME: Unit tests for WebAuthService: the injected NIP-07 extension bridge
+// ABOUTME: and the nsec bunker authentication flow and signer functionality
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
+import 'package:openvine/services/nip07_service.dart';
+import 'package:openvine/services/nip07_types.dart';
 import 'package:openvine/services/web_auth_service.dart';
 import 'package:unified_logger/unified_logger.dart';
+
+const _extensionPubkey =
+    'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
 
 class MockNsecBunkerClient extends Mock implements NsecBunkerClient {}
 
 class FakeUri extends Fake implements Uri {}
+
+class _FakeExtension extends NostrExtension {
+  @override
+  Future<String> getPublicKey() async => _extensionPubkey;
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -22,16 +32,38 @@ void main() {
     late MockNsecBunkerClient mockBunkerClient;
 
     setUp(() {
-      authService = WebAuthService();
+      authService = WebAuthService(nip07Service: Nip07Service());
       mockBunkerClient = MockNsecBunkerClient();
-      // WebAuthService is a singleton — clear bunker client state that may
-      // have leaked from prior tests (random test ordering exposes this).
-      authService.setBunkerClient(null);
     });
 
     tearDown(() async {
       await authService.disconnect();
-      authService.setBunkerClient(null);
+    });
+
+    group('NIP-07 bridge', () {
+      test('reports the injected extension as an available method', () {
+        final service = WebAuthService(
+          nip07Service: Nip07Service.withExtension(_FakeExtension()),
+        );
+
+        expect(service.isNip07Available, isTrue);
+        expect(service.availableMethods, contains(WebAuthMethod.nip07));
+      });
+
+      test('authenticates through the injected extension', () async {
+        final service = WebAuthService(
+          nip07Service: Nip07Service.withExtension(_FakeExtension()),
+        );
+        addTearDown(service.disconnect);
+
+        final result = await service.authenticateWithNip07();
+
+        expect(result.success, isTrue);
+        expect(result.method, WebAuthMethod.nip07);
+        expect(service.isAuthenticated, isTrue);
+        expect(service.publicKey, _extensionPubkey);
+        expect(service.signer, isNotNull);
+      });
     });
 
     group('Bunker Authentication', () {

--- a/mobile/test/utils/log_message_batcher_test.dart
+++ b/mobile/test/utils/log_message_batcher_test.dart
@@ -12,10 +12,9 @@ void main() {
     late LogCaptureService logCapture;
 
     setUp(() async {
-      batcher = LogMessageBatcher.instance;
+      batcher = LogMessageBatcher();
       logCapture = LogCaptureService();
 
-      batcher.dispose();
       await logCapture.clearAllLogs();
       UnifiedLogger.enableCategories({LogCategory.relay});
       UnifiedLogger.setLogLevel(LogLevel.debug);
@@ -37,6 +36,24 @@ void main() {
       );
 
       batcher.dispose();
+
+      expect(logCapture.getRecentLogs(), isEmpty);
+    });
+
+    test('disposing a second batcher does not flush the first one', () {
+      final other = LogMessageBatcher();
+      addTearDown(other.dispose);
+
+      expect(
+        batcher.tryBatchMessage(
+          '[EXTERNAL-EVENT] Event abc matches subscription feed',
+          level: LogLevel.debug,
+          category: LogCategory.relay,
+        ),
+        isTrue,
+      );
+
+      other.dispose();
 
       expect(logCapture.getRecentLogs(), isEmpty);
     });

--- a/mobile/test/utils/log_message_batcher_test.dart
+++ b/mobile/test/utils/log_message_batcher_test.dart
@@ -95,6 +95,30 @@ void main() {
       });
     });
 
+    test('flushing pending messages keeps the interval armed', () {
+      fakeAsync((async) {
+        batcher.initialize();
+        batcher.tryBatchMessage(
+          '[EXTERNAL-EVENT] Event abc matches subscription feed',
+          level: LogLevel.debug,
+          category: LogCategory.relay,
+        );
+
+        batcher.flush();
+
+        expect(logCapture.getRecentLogs(), hasLength(1));
+        batcher.tryBatchMessage(
+          '[EXTERNAL-EVENT] Event def matches subscription feed',
+          level: LogLevel.debug,
+          category: LogCategory.relay,
+        );
+
+        async.elapse(const Duration(seconds: 10));
+
+        expect(logCapture.getRecentLogs(), hasLength(2));
+      });
+    });
+
     test('flushes immediately when a pattern reaches the max batch size', () {
       for (var i = 0; i < 50; i++) {
         expect(

--- a/mobile/test/widgets/user_avatar_svg_test.dart
+++ b/mobile/test/widgets/user_avatar_svg_test.dart
@@ -4,10 +4,12 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:media_cache/media_cache.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openvine/providers/avatar_svg_repository_provider.dart';
 import 'package:openvine/repositories/avatar_svg_repository.dart';
 import 'package:openvine/widgets/avatar_failure_cache.dart';
 import 'package:openvine/widgets/user_avatar.dart';
@@ -235,6 +237,27 @@ void main() {
 
       expect(AvatarFailureCache.instance.isFailed(failedUrl), isTrue);
     });
+
+    testWidgets(
+      'resolves the SVG repository from the container when none is injected',
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              avatarSvgRepositoryProvider.overrideWithValue(
+                _FakeAvatarSvgRepository(validSvgBytes),
+              ),
+            ],
+            child: buildAvatar(
+              imageUrl: 'https://divine.video/divine-logo.svg',
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byType(SvgPicture), findsOneWidget);
+      },
+    );
 
     testWidgets('SVG render failures are cached briefly', (tester) async {
       const failedUrl = 'https://divine.video/divine-logo.svg';


### PR DESCRIPTION
## Description

**The problem.** After #8615 froze the set of singleton services, seven files were still handing every caller one process-wide instance through static state. A test that needs one of those services cannot replace it, so nothing can assert "this service was consulted" — the failure mode that produced a test unable to fail in #8615. Two of the seven (bandwidth tracker, video-format preference) are blocked on a video-playback design change and stay baselined; this PR converts the other five and takes the three cheap wins listed in the issue's comment.

**What changes**, one commit per finding so any can be reverted alone:

| Service | Shape now |
|---|---|
| `LogMessageBatcher` | Constructed in bootstrap beside the `debugPrint` override that feeds it, then pinned device-scoped through `DeviceScope` (a new required field) the way startup performance and crash reporting already are. The startup coordinator arms it and the lifecycle handler flushes it through the provider, so all three reach one instance. |
| `AvatarSvgRepository` | `avatarSvgRepositoryProvider`, which also owns the HTTP client and closes it with the container (the global never closed it). `UserAvatar` stays a plain widget: only the SVG branch reads the provider, through a small `ConsumerWidget`, and only when no repository was injected — nine test files pump the widget without a `ProviderScope`. |
| `Nip07Service` | Public constructor plus `nip07ServiceProvider`, injected into both `AuthService` and `WebAuthService` so they observe one extension session. `AuthService`'s `!kIsWeb` guards existed only to skip the global off-web; they collapse onto `isAvailable`, which is already false there. |
| `WebAuthService` | Takes the shared bridge through its constructor. The iframe sandbox screen reads `webAuthServiceProvider` instead of constructing its own, and that provider becomes keep-alive (see below). |
| `NotificationService` | Public constructor; the static holder and its revive-after-dispose getter go. `notificationServiceProvider` already constructs and disposes it with the container. |

Plus two deletions: `StartupPerformanceService.deferUntilUIReady` (no callers, and an unbounded wait) and `BackgroundActivityManager`'s periodic-cleanup leg. That manager's `initialize()` was only ever called by tests, so `onPeriodicCleanup` never fired in production; two of the three implementations were explicit no-ops and the third cleared a set the analytics service already clears on its own timer. Removing the leg keeps production behaviour exactly as it is; wiring it would have been a behaviour change.

**Two behaviour notes worth a reviewer's eye:**

- `webAuthServiceProvider` was `@riverpod`, i.e. autoDispose. The singleton hid that: every reader got the same instance regardless. Converted as-is, the web sign-in session would have reset between the screen that signs in and the sandbox that later signs with it, so the provider is now `keepAlive: true` and a test pins it. This preserves what the singleton was providing by accident.
- `connectWithNip07` now returns before touching auth state when no extension is available, instead of bouncing an authenticated session through authenticating → unauthenticated. The NIP-07 button is hidden whenever the bridge is unavailable, so no user flow reaches that branch either way.

**Two commits from the reviewer's takeover are included** and are the reason the last two entries above are safe:

- The lifecycle handler is account-scoped while the batcher is device-scoped, so its `dispose` ran on every account swap and cancelled the batcher's flush timer for the rest of the process. It now flushes without cancelling. (The same call existed before this PR, against the process singleton, so the swap-time cancellation is older than this branch; making the batcher's scope explicit is what surfaced it.)
- `webAuthServiceProvider` now disposes the service it owns, so a container teardown clears an authenticated web session instead of carrying it into the next account.

Both carry a regression test. I re-verified each by mutation: reinstating the timer cancellation, and removing the `onDispose`, each turns its own test red with an on-point failure.

Ratchets: singleton services 7 → 2; untested services 32 → 31 (the bunker test file is renamed to the same-named form the floor recognises and gains NIP-07 tests); service god-file ceilings locked lower (`auth_service` 4557 → 4539, `upload_manager` 1964 → 1958). The startup-performance guide stops describing the deleted helper.

**Related Issue:** Relates to #8618 — the two blocked entries stay open there.

## Out of Scope

- `BandwidthTrackerService` and `VideoFormatPreferenceService` are reached from `VideoEvent` extension getters across 22 call sites. The issue asks for moving format and bandwidth selection into the repository layer, which is its own design pass; both stay baselined with the blocker named. The swallowed preference-write failures noted on the issue belong with that conversion.
- Found but not changed: `lib/screens/web_auth_screen.dart` is imported by nothing and routed nowhere, so nothing in production ever authenticates a `WebAuthService`. That means the iframe sandbox bridge's signer is always null on web today. Pre-existing and unrelated to injection; flagged for whoever owns web sign-in.
- The startup-performance guide still shows `StartupPerformanceService.instance` in unrelated examples, stale since #8615; only the deleted helper's mentions were removed here.
- `CrashReportingService.updateCacheMetricsKeys` was the third dead method this PR originally deleted. #8637 rewrote that file and removed it independently, so the commit was dropped when rebasing rather than carried as a conflict. Nothing is lost: the method and its media-cache import are gone on `main`.

## Verification

Re-run in full after rebasing onto current `main` (which had moved 12 commits, including the crash-reporting rewrite above). From `mobile/` with the mise-pinned SDK:

- `dart format --set-exit-if-changed` on every changed file and `flutter analyze lib test integration_test` — clean
- `flutter test test/services` — 4513 passing; `flutter test test/providers test/startup test/utils test/widgets test/router test/blocs test/screens/apps test/notifications` — 9571 passing
- `mise run test` (the VGV merged isolate with strict shared channels, random order) — 19067 passing, 1 failing: `MemoryTelemetryService image cache peak survives Flutter memory-pressure clearing` with Flutter's `ImageInfo.dispose` handle assertion. That is pre-existing image-cache pollution, not this branch: `test/widgets/video_thumbnail_widget_test.dart` hands one shared `ui.Image` to `ImageInfo`s that land in the global image cache and then disposes that image itself, so whichever later test clears the cache and pumps a frame hits the assertion, and the random seed picks the victim. A two-file bundle running that file directly before the victim fails identically on an untouched `origin/main` checkout, and the victim passes both standalone and after every fixed-order quarter of the bundle. `clip_thumbnail_image_test.dart` already carries a workaround comment for the same family. Worth its own issue; not patched here.
- Every `scripts/check_*.sh` ratchet — passing (two do not run locally: the iOS extension-signing check needs Codemagic's environment, and the coordinator-route check probes live endpoints); the three baselines above regenerated with `UPDATE_BASELINE=1`
- `build_runner` regenerated (`auth_providers.g.dart` carries the hash change and the keep-alive form); tree clean afterwards
- `scripts/golden.sh verify` — the notification-row goldens, which pump `UserAvatar`, pass; the three design-system gallery goldens show the documented macOS antialiasing drift (2.67–3.65%) on files this branch does not touch
- Each conversion started from a red test that only the conversion turns green (a second instance no longer sees the first one's state), and the keep-alive test was watched failing against the autoDispose form before the annotation was added

## Type of Change

- [x] 🧹 Code refactor

