### PR TITLE
fix(ios): stop Xcode builds from failing on the iOS 13 Swift package floor

### DIFF
--- a/.claude/rules/ios_build_troubleshooting.md
+++ b/.claude/rules/ios_build_troubleshooting.md
@@ -1,6 +1,6 @@
 # iOS Build Troubleshooting
 
-When iOS build fails with "Could not resolve package dependencies" and Firebase plugins require different FlutterFire versions (`'X' depends on 'flutterfire' A-firebase-core-swift and 'Y' depends on 'flutterfire' B-firebase-core-swift`), there are two distinct causes. Diagnose which one you have before fixing.
+When iOS build fails with "Could not resolve package dependencies" and Firebase plugins require different FlutterFire versions (`'X' depends on 'flutterfire' A-firebase-core-swift and 'Y' depends on 'flutterfire' B-firebase-core-swift`), there are two distinct causes. Diagnose which one you have before fixing. A third, unrelated failure shape — every plugin "requires minimum platform version 15.0/16.0 ... but this target supports 13" — is covered last.
 
 ## Cause 1: misaligned Firebase plugin versions (check this first)
 
@@ -29,3 +29,20 @@ flutter clean && flutter pub get && cd ios && pod install
 ```
 
 Do not create PRs to change `pubspec.lock` or `Package.resolved` for the stale-cache case.
+
+## Cause 3: the generated Swift package floor is stuck at iOS 13
+
+Xcode reports, for `FlutterGeneratedPluginSwiftPackage`, that `firebase-*` require iOS 15.0 and `c2pa-flutter` / `divine-video-player` require 16.0 "but this target supports 13". The project is not misconfigured: every `IPHONEOS_DEPLOYMENT_TARGET` in `mobile/ios/Runner.xcodeproj/project.pbxproj` and the Podfile `platform` are 16.0. The floor that fails is the `platforms:` line of the generated, gitignored `mobile/ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift`.
+
+Flutter (3.44) writes that manifest at its default `.iOS("13.0")` every time it injects plugins — `flutter pub get`, `flutter analyze`, `flutter test`, and the implicit pub step of most other commands. Only `flutter build ios` and `flutter run` raise it to the project's deployment target afterwards, and that step silently does nothing when `xcodebuild -showBuildSettings` exceeds Flutter's 60-second timeout (a cold machine or a fresh worktree). Building straight from Xcode never raises it.
+
+Fix, from `mobile/`, then verify before opening Xcode:
+
+```bash
+flutter build ios --config-only
+grep -A1 "platforms:" ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift
+```
+
+If the grep still shows `13.0`, run the same command again — the second pass has warm Xcode caches and lands under the timeout. Repeat the two steps after any `flutter pub get`, `flutter analyze` or `flutter test` you run before the next Xcode build.
+
+Do not add a Flutter command to `mobile/pre_build_ios.sh`: it runs as a pre-action of the shared Runner scheme on every Xcode build, so a `flutter pub get` there re-lowered the floor mid-build and made every Xcode build and Profile run fail this way; the script now only syncs CocoaPods. CI patches the generated manifest separately in `codemagic.yaml` before archiving.

--- a/.claude/rules/ios_build_troubleshooting.md
+++ b/.claude/rules/ios_build_troubleshooting.md
@@ -36,12 +36,15 @@ Xcode reports, for `FlutterGeneratedPluginSwiftPackage`, that `firebase-*` requi
 
 Flutter (3.44) writes that manifest at its default `.iOS("13.0")` every time it injects plugins — `flutter pub get`, `flutter analyze`, `flutter test`, and the implicit pub step of most other commands. `flutter build ios` and `flutter run` normally raise it to the project's deployment target afterwards, but that step silently does nothing when `xcodebuild -showBuildSettings` exceeds Flutter's 60-second timeout (a cold machine or a fresh worktree).
 
-The shared Runner scheme's pre-action repairs the generated manifest directly before every Xcode build. To verify the repair, build once from Xcode and then run this from `mobile/`:
+The shared Runner scheme's pre-action repairs the generated manifest in place, without invoking Flutter. **That repair cannot rescue the build it runs in.** Xcode emits `Resolve Package Graph` at the very start of a build, before it runs scheme pre-actions, so a build that starts on a 13.0 floor still fails with all seven errors; the repair then lands, and the *next* build succeeds. Measured 2026-09-06 on a device Profile build: sabotaged floor → `** BUILD FAILED **` with the repair line present in the same log → unchanged rebuild → `** BUILD SUCCEEDED **`.
+
+So the failure is self-limiting rather than prevented: if Xcode fails this way, just build again. To skip the wasted first build after any `flutter pub get`, `flutter analyze` or `flutter test`, run this from `mobile/` before returning to Xcode:
 
 ```bash
+flutter build ios --config-only
 grep -A1 "platforms:" ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift
 ```
 
-The output must show `16.0`. Terminal Flutter commands may reset the generated file to 13.0, but the next Xcode build repairs it again without invoking Flutter.
+The grep must show `16.0`. If it still shows `13.0`, run the build command again — Flutter skips its own bump when `xcodebuild -showBuildSettings` exceeds its 60-second timeout on a cold machine.
 
 Do not add a Flutter command to `mobile/pre_build_ios.sh`: it runs as a pre-action of the shared Runner scheme on every Xcode build, so a `flutter pub get` there re-lowered the floor mid-build and made every Xcode build and Profile run fail this way. The script now repairs the manifest directly and syncs CocoaPods. CI performs the same repair separately in `codemagic.yaml` before archiving.

--- a/.claude/rules/ios_build_troubleshooting.md
+++ b/.claude/rules/ios_build_troubleshooting.md
@@ -34,15 +34,14 @@ Do not create PRs to change `pubspec.lock` or `Package.resolved` for the stale-c
 
 Xcode reports, for `FlutterGeneratedPluginSwiftPackage`, that `firebase-*` require iOS 15.0 and `c2pa-flutter` / `divine-video-player` require 16.0 "but this target supports 13". The project is not misconfigured: every `IPHONEOS_DEPLOYMENT_TARGET` in `mobile/ios/Runner.xcodeproj/project.pbxproj` and the Podfile `platform` are 16.0. The floor that fails is the `platforms:` line of the generated, gitignored `mobile/ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift`.
 
-Flutter (3.44) writes that manifest at its default `.iOS("13.0")` every time it injects plugins — `flutter pub get`, `flutter analyze`, `flutter test`, and the implicit pub step of most other commands. Only `flutter build ios` and `flutter run` raise it to the project's deployment target afterwards, and that step silently does nothing when `xcodebuild -showBuildSettings` exceeds Flutter's 60-second timeout (a cold machine or a fresh worktree). Building straight from Xcode never raises it.
+Flutter (3.44) writes that manifest at its default `.iOS("13.0")` every time it injects plugins — `flutter pub get`, `flutter analyze`, `flutter test`, and the implicit pub step of most other commands. `flutter build ios` and `flutter run` normally raise it to the project's deployment target afterwards, but that step silently does nothing when `xcodebuild -showBuildSettings` exceeds Flutter's 60-second timeout (a cold machine or a fresh worktree).
 
-Fix, from `mobile/`, then verify before opening Xcode:
+The shared Runner scheme's pre-action repairs the generated manifest directly before every Xcode build. To verify the repair, build once from Xcode and then run this from `mobile/`:
 
 ```bash
-flutter build ios --config-only
 grep -A1 "platforms:" ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift
 ```
 
-If the grep still shows `13.0`, run the same command again — the second pass has warm Xcode caches and lands under the timeout. Repeat the two steps after any `flutter pub get`, `flutter analyze` or `flutter test` you run before the next Xcode build.
+The output must show `16.0`. Terminal Flutter commands may reset the generated file to 13.0, but the next Xcode build repairs it again without invoking Flutter.
 
-Do not add a Flutter command to `mobile/pre_build_ios.sh`: it runs as a pre-action of the shared Runner scheme on every Xcode build, so a `flutter pub get` there re-lowered the floor mid-build and made every Xcode build and Profile run fail this way; the script now only syncs CocoaPods. CI patches the generated manifest separately in `codemagic.yaml` before archiving.
+Do not add a Flutter command to `mobile/pre_build_ios.sh`: it runs as a pre-action of the shared Runner scheme on every Xcode build, so a `flutter pub get` there re-lowered the floor mid-build and made every Xcode build and Profile run fail this way. The script now repairs the manifest directly and syncs CocoaPods. CI performs the same repair separately in `codemagic.yaml` before archiving.

--- a/docs/BUILD_SCRIPTS_README.md
+++ b/docs/BUILD_SCRIPTS_README.md
@@ -27,7 +27,7 @@ The iOS and macOS Xcode projects have been modified to automatically run `pod in
 
 - **`ios/Scripts/check_pods.sh`** - Auto-installed iOS CocoaPods check (runs automatically)
 - **`macos/Scripts/check_pods.sh`** - Auto-installed macOS CocoaPods check (runs automatically)
-- **`pre_build_ios.sh`** - Optional pre-build script for custom Xcode iOS builds
+- **`pre_build_ios.sh`** - Runs as a pre-action of the shared `Runner` scheme on every Xcode iOS build; syncs CocoaPods only. It must never run a Flutter command: plugin injection rewrites the generated `FlutterGeneratedPluginSwiftPackage` manifest at Flutter's default iOS 13 floor, and nothing on the Xcode-driven build path raises it back to 16.0 (see `.claude/rules/ios_build_troubleshooting.md`, Cause 3)
 - **`pre_build_macos.sh`** - Optional pre-build script for custom Xcode macOS builds
 
 ## Usage

--- a/docs/BUILD_SCRIPTS_README.md
+++ b/docs/BUILD_SCRIPTS_README.md
@@ -27,7 +27,7 @@ The iOS and macOS Xcode projects have been modified to automatically run `pod in
 
 - **`ios/Scripts/check_pods.sh`** - Auto-installed iOS CocoaPods check (runs automatically)
 - **`macos/Scripts/check_pods.sh`** - Auto-installed macOS CocoaPods check (runs automatically)
-- **`pre_build_ios.sh`** - Runs as a pre-action of the shared `Runner` scheme on every Xcode iOS build; repairs Flutter's generated Swift package deployment target and syncs CocoaPods. It must never run a Flutter command because plugin injection resets that generated target to iOS 13 (see `.claude/rules/ios_build_troubleshooting.md`, Cause 3)
+- **`pre_build_ios.sh`** - Runs as a pre-action of the shared `Runner` scheme on every Xcode iOS build; repairs Flutter's generated Swift package deployment target and syncs CocoaPods. The repair takes effect on the *next* build, because Xcode resolves the package graph before pre-actions run. It must never run a Flutter command because plugin injection resets that generated target to iOS 13 (see `.claude/rules/ios_build_troubleshooting.md`, Cause 3)
 - **`pre_build_macos.sh`** - Optional pre-build script for custom Xcode macOS builds
 
 ## Usage

--- a/docs/BUILD_SCRIPTS_README.md
+++ b/docs/BUILD_SCRIPTS_README.md
@@ -27,7 +27,7 @@ The iOS and macOS Xcode projects have been modified to automatically run `pod in
 
 - **`ios/Scripts/check_pods.sh`** - Auto-installed iOS CocoaPods check (runs automatically)
 - **`macos/Scripts/check_pods.sh`** - Auto-installed macOS CocoaPods check (runs automatically)
-- **`pre_build_ios.sh`** - Runs as a pre-action of the shared `Runner` scheme on every Xcode iOS build; syncs CocoaPods only. It must never run a Flutter command: plugin injection rewrites the generated `FlutterGeneratedPluginSwiftPackage` manifest at Flutter's default iOS 13 floor, and nothing on the Xcode-driven build path raises it back to 16.0 (see `.claude/rules/ios_build_troubleshooting.md`, Cause 3)
+- **`pre_build_ios.sh`** - Runs as a pre-action of the shared `Runner` scheme on every Xcode iOS build; repairs Flutter's generated Swift package deployment target and syncs CocoaPods. It must never run a Flutter command because plugin injection resets that generated target to iOS 13 (see `.claude/rules/ios_build_troubleshooting.md`, Cause 3)
 - **`pre_build_macos.sh`** - Optional pre-build script for custom Xcode macOS builds
 
 ## Usage

--- a/mobile/pre_build_ios.sh
+++ b/mobile/pre_build_ios.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# ABOUTME: Pre-action of the shared Runner scheme: syncs CocoaPods before every Xcode iOS build.
-# ABOUTME: Runs no Flutter command; plugin injection would reset the generated Swift package floor to iOS 13.
+# ABOUTME: Pre-action of the shared Runner scheme: repairs the generated Swift package floor, syncs CocoaPods.
+# ABOUTME: Runs no Flutter command; plugin injection would reset that floor to iOS 13.
 
 set -e
 
@@ -12,8 +12,14 @@ cd "$SCRIPT_DIR"
 
 # Never run a Flutter command here. Plugin injection rewrites
 # ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift
-# at Flutter's default .iOS("13.0"). Patch that generated input directly before
-# Xcode resolves it, without invoking Flutter and causing another regeneration.
+# at Flutter's default .iOS("13.0"), which every plugin needing 15/16 then
+# fails against. Repair it in place, without invoking Flutter.
+#
+# This cannot rescue the build it runs in. Xcode emits "Resolve Package Graph"
+# before it runs scheme pre-actions, so a build that starts at 13.0 still fails;
+# measured 2026-09-06. What this buys is that the failure stops repeating: the
+# next build reads 16.0 and succeeds. Run `flutter build ios --config-only`
+# after a terminal Flutter command to skip the wasted first build.
 # See .claude/rules/ios_build_troubleshooting.md, Cause 3.
 SWIFT_PACKAGE_MANIFEST="ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift"
 if [ -f "$SWIFT_PACKAGE_MANIFEST" ]; then

--- a/mobile/pre_build_ios.sh
+++ b/mobile/pre_build_ios.sh
@@ -12,10 +12,28 @@ cd "$SCRIPT_DIR"
 
 # Never run a Flutter command here. Plugin injection rewrites
 # ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift
-# at Flutter's default .iOS("13.0"), and only `flutter build ios` / `flutter run`
-# raise it back to 16.0 -- an Xcode build never does, so every Xcode build would
-# fail on "requires minimum platform version 16.0 ... but this target supports 13".
+# at Flutter's default .iOS("13.0"). Patch that generated input directly before
+# Xcode resolves it, without invoking Flutter and causing another regeneration.
 # See .claude/rules/ios_build_troubleshooting.md, Cause 3.
+SWIFT_PACKAGE_MANIFEST="ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift"
+if [ -f "$SWIFT_PACKAGE_MANIFEST" ]; then
+    if grep -Eq '\.iOS\(("13\.0"|\.v13)\)' "$SWIFT_PACKAGE_MANIFEST"; then
+        SWIFT_PACKAGE_TMP="$(mktemp "${SWIFT_PACKAGE_MANIFEST}.XXXXXX")"
+        trap 'rm -f "$SWIFT_PACKAGE_TMP"' EXIT
+        sed \
+            -e 's/\.iOS("13\.0")/.iOS("16.0")/g' \
+            -e 's/\.iOS(\.v13)/.iOS("16.0")/g' \
+            "$SWIFT_PACKAGE_MANIFEST" > "$SWIFT_PACKAGE_TMP"
+        mv "$SWIFT_PACKAGE_TMP" "$SWIFT_PACKAGE_MANIFEST"
+        trap - EXIT
+        echo "✅ Raised generated Swift package deployment target to iOS 16.0"
+    fi
+
+    if ! grep -Eq '\.iOS\(("16\.0"|\.v16)\)' "$SWIFT_PACKAGE_MANIFEST"; then
+        echo "❌ ERROR: Generated Swift package does not target iOS 16.0"
+        exit 1
+    fi
+fi
 
 # Navigate to iOS directory
 cd ios
@@ -23,6 +41,13 @@ cd ios
 # Set environment for CocoaPods to avoid Ruby issues
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
+
+# Make rbenv-managed executables discoverable before resolving CocoaPods. The
+# shims work from PATH directly; shell initialization is unnecessary here and
+# must not be allowed to fail every Xcode build.
+if [ -d "$HOME/.rbenv" ]; then
+    export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH"
+fi
 
 # Find CocoaPods command
 POD_CMD=""
@@ -36,12 +61,6 @@ else
     echo "❌ ERROR: CocoaPods not found!"
     echo "   Please install: sudo gem install cocoapods"
     exit 1
-fi
-
-# Ensure we use the correct Ruby environment (rbenv if available)
-if [ -d "$HOME/.rbenv" ]; then
-    export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH"
-    eval "$(rbenv init -)"
 fi
 
 # Check if CocoaPods needs to be installed or updated

--- a/mobile/pre_build_ios.sh
+++ b/mobile/pre_build_ios.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# ABOUTME: Pre-build script for iOS Xcode builds to ensure CocoaPods sync
-# ABOUTME: Can be added as a pre-action in Xcode scheme to fix pod install issues
+# ABOUTME: Pre-action of the shared Runner scheme: syncs CocoaPods before every Xcode iOS build.
+# ABOUTME: Runs no Flutter command; plugin injection would reset the generated Swift package floor to iOS 13.
 
 set -e
 
@@ -10,26 +10,12 @@ echo "🔧 Pre-build: Ensuring iOS CocoaPods dependencies are synced..."
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-# Find Flutter command
-FLUTTER_CMD=""
-if command -v flutter >/dev/null 2>&1; then
-    FLUTTER_CMD="flutter"
-elif [ -n "$FLUTTER_ROOT" ] && [ -f "$FLUTTER_ROOT/bin/flutter" ]; then
-    FLUTTER_CMD="$FLUTTER_ROOT/bin/flutter"
-elif [ -f "/opt/homebrew/Caskroom/flutter/3.27.4/flutter/bin/flutter" ]; then
-    FLUTTER_CMD="/opt/homebrew/Caskroom/flutter/3.27.4/flutter/bin/flutter"
-else
-    echo "⚠️  Flutter not found, skipping pub get..."
-    FLUTTER_CMD=""
-fi
-
-# Ensure Flutter pub get is run first (if Flutter is available)
-if [ -n "$FLUTTER_CMD" ]; then
-    echo "📦 Running flutter pub get..."
-    "$FLUTTER_CMD" pub get
-else
-    echo "⚠️  Skipping flutter pub get (Flutter not found)"
-fi
+# Never run a Flutter command here. Plugin injection rewrites
+# ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift
+# at Flutter's default .iOS("13.0"), and only `flutter build ios` / `flutter run`
+# raise it back to 16.0 -- an Xcode build never does, so every Xcode build would
+# fail on "requires minimum platform version 16.0 ... but this target supports 13".
+# See .claude/rules/ios_build_troubleshooting.md, Cause 3.
 
 # Navigate to iOS directory
 cd ios

--- a/mobile/test/tools/pre_build_ios_test.dart
+++ b/mobile/test/tools/pre_build_ios_test.dart
@@ -1,0 +1,145 @@
+// ABOUTME: Tests for mobile/pre_build_ios.sh, the Runner scheme's pre-action.
+// ABOUTME: Pins that it syncs CocoaPods without ever invoking Flutter.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+/// Drives `pre_build_ios.sh` against a sandboxed copy of the project layout.
+///
+/// The shared Runner scheme runs this script as a pre-action of every Xcode
+/// build. Any Flutter command it runs there re-injects plugins, which rewrites
+/// `ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/
+/// Package.swift` at Flutter's default `.iOS("13.0")` floor. Nothing on the
+/// Xcode-driven build path raises that floor back to the project's 16.0, so
+/// the build then fails with "requires minimum platform version 16.0 ... but
+/// this target supports 13.0" for every plugin with a higher floor. The
+/// script must therefore never invoke `flutter`; that property is pinned here.
+void main() {
+  group('pre_build_ios.sh', () {
+    late Directory sandbox;
+    late String scriptPath;
+    late Directory stubBin;
+    late Directory stubLogs;
+
+    File stubLog(String tool) => File(p.join(stubLogs.path, '$tool.log'));
+
+    /// Installs a `tool` shim on the sandboxed PATH that records its argv.
+    void installStub(String tool) {
+      final stub = File(p.join(stubBin.path, tool))
+        ..writeAsStringSync(
+          '#!/bin/sh\n'
+          'printf \'%s\\n\' "\$*" >> "\$STUB_LOG_DIR/$tool.log"\n',
+        );
+      final chmod = Process.runSync('chmod', ['+x', stub.path]);
+      expect(chmod.exitCode, 0, reason: chmod.stderr.toString());
+    }
+
+    void writeFile(String relativePath, DateTime modified) {
+      File(p.join(sandbox.path, relativePath))
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync('# $relativePath\n')
+        ..setLastModifiedSync(modified);
+    }
+
+    ProcessResult runScript() {
+      return Process.runSync(
+        'bash',
+        [scriptPath],
+        workingDirectory: sandbox.path,
+        environment: {
+          'PATH': '${stubBin.path}:/usr/bin:/bin',
+          'HOME': p.join(sandbox.path, 'home'),
+          'STUB_LOG_DIR': stubLogs.path,
+        },
+        includeParentEnvironment: false,
+      );
+    }
+
+    void expectSuccess(ProcessResult result) {
+      expect(
+        result.exitCode,
+        0,
+        reason: 'stdout:\n${result.stdout}\nstderr:\n${result.stderr}',
+      );
+    }
+
+    setUp(() {
+      sandbox = Directory.systemTemp.createTempSync('pre_build_ios_');
+      final realScript = File(
+        p.join(Directory.current.path, 'pre_build_ios.sh'),
+      );
+      expect(
+        realScript.existsSync(),
+        isTrue,
+        reason: 'mobile/pre_build_ios.sh must exist',
+      );
+      scriptPath = p.join(sandbox.path, 'pre_build_ios.sh');
+      File(scriptPath).writeAsStringSync(realScript.readAsStringSync());
+      stubBin = Directory(p.join(sandbox.path, 'bin'))..createSync();
+      stubLogs = Directory(p.join(sandbox.path, 'logs'))..createSync();
+      Directory(p.join(sandbox.path, 'home')).createSync();
+      installStub('flutter');
+      installStub('pod');
+    });
+
+    tearDown(() {
+      sandbox.deleteSync(recursive: true);
+    });
+
+    test('never invokes flutter, which would reset the Swift package floor '
+        'to iOS 13.0', () {
+      final now = DateTime.now();
+      writeFile('ios/Podfile.lock', now.subtract(const Duration(hours: 1)));
+      writeFile('ios/Pods/Manifest.lock', now);
+
+      expectSuccess(runScript());
+
+      final flutterLog = stubLog('flutter');
+      final invocations = flutterLog.existsSync()
+          ? flutterLog.readAsStringSync()
+          : '';
+      expect(
+        flutterLog.existsSync(),
+        isFalse,
+        reason: 'flutter was invoked with: $invocations',
+      );
+    });
+
+    test('skips pod install when Pods/Manifest.lock is as new as '
+        'Podfile.lock', () {
+      final now = DateTime.now();
+      writeFile('ios/Podfile.lock', now.subtract(const Duration(hours: 1)));
+      writeFile('ios/Pods/Manifest.lock', now);
+
+      final result = runScript();
+
+      expectSuccess(result);
+      expect(stubLog('pod').existsSync(), isFalse);
+      expect(result.stdout, contains('CocoaPods dependencies are up to date'));
+    });
+
+    test('runs pod install when Podfile.lock is newer than '
+        'Pods/Manifest.lock', () {
+      final now = DateTime.now();
+      writeFile(
+        'ios/Pods/Manifest.lock',
+        now.subtract(const Duration(hours: 1)),
+      );
+      writeFile('ios/Podfile.lock', now);
+
+      expectSuccess(runScript());
+
+      expect(stubLog('pod').readAsStringSync(), contains('install'));
+    });
+
+    test('runs pod install when Pods has never been installed', () {
+      writeFile('ios/Podfile.lock', DateTime.now());
+
+      expectSuccess(runScript());
+
+      expect(stubLog('pod').readAsStringSync(), contains('install'));
+    });
+  });
+}

--- a/mobile/test/tools/pre_build_ios_test.dart
+++ b/mobile/test/tools/pre_build_ios_test.dart
@@ -25,6 +25,14 @@ void main() {
 
     File stubLog(String tool) => File(p.join(stubLogs.path, '$tool.log'));
 
+    File swiftPackageManifest() => File(
+      p.join(
+        sandbox.path,
+        'ios/Flutter/ephemeral/Packages/'
+        'FlutterGeneratedPluginSwiftPackage/Package.swift',
+      ),
+    );
+
     /// Installs a `tool` shim on the sandboxed PATH that records its argv.
     void installStub(String tool) {
       final stub = File(p.join(stubBin.path, tool))
@@ -63,6 +71,15 @@ void main() {
         0,
         reason: 'stdout:\n${result.stdout}\nstderr:\n${result.stderr}',
       );
+      final flutterLog = stubLog('flutter');
+      final invocations = flutterLog.existsSync()
+          ? flutterLog.readAsStringSync()
+          : '';
+      expect(
+        flutterLog.existsSync(),
+        isFalse,
+        reason: 'flutter was invoked with: $invocations',
+      );
     }
 
     setUp(() {
@@ -76,7 +93,12 @@ void main() {
         reason: 'mobile/pre_build_ios.sh must exist',
       );
       scriptPath = p.join(sandbox.path, 'pre_build_ios.sh');
-      File(scriptPath).writeAsStringSync(realScript.readAsStringSync());
+      File(scriptPath).writeAsStringSync(
+        realScript
+            .readAsStringSync()
+            .replaceAll('/opt/homebrew/bin/pod', '/nonexistent/homebrew/pod')
+            .replaceAll('/usr/local/bin/pod', '/nonexistent/local/pod'),
+      );
       stubBin = Directory(p.join(sandbox.path, 'bin'))..createSync();
       stubLogs = Directory(p.join(sandbox.path, 'logs'))..createSync();
       Directory(p.join(sandbox.path, 'home')).createSync();
@@ -96,21 +118,13 @@ void main() {
 
       expectSuccess(runScript());
 
-      final flutterLog = stubLog('flutter');
-      final invocations = flutterLog.existsSync()
-          ? flutterLog.readAsStringSync()
-          : '';
-      expect(
-        flutterLog.existsSync(),
-        isFalse,
-        reason: 'flutter was invoked with: $invocations',
-      );
+      expect(stubLog('flutter').existsSync(), isFalse);
     });
 
     test('skips pod install when Pods/Manifest.lock is as new as '
         'Podfile.lock', () {
       final now = DateTime.now();
-      writeFile('ios/Podfile.lock', now.subtract(const Duration(hours: 1)));
+      writeFile('ios/Podfile.lock', now);
       writeFile('ios/Pods/Manifest.lock', now);
 
       final result = runScript();
@@ -140,6 +154,73 @@ void main() {
       expectSuccess(runScript());
 
       expect(stubLog('pod').readAsStringSync(), contains('install'));
+    });
+
+    test('raises the generated Swift package floor without Flutter', () {
+      final now = DateTime.now();
+      writeFile('ios/Podfile.lock', now);
+      writeFile('ios/Pods/Manifest.lock', now);
+      swiftPackageManifest()
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync(
+          'let package = Package(\n'
+          '    name: "FlutterGeneratedPluginSwiftPackage",\n'
+          '    platforms: [\n'
+          '        .iOS("13.0")\n'
+          '    ]\n'
+          ')\n',
+        );
+
+      expectSuccess(runScript());
+      expectSuccess(runScript());
+
+      expect(
+        swiftPackageManifest().readAsStringSync(),
+        contains('.iOS("16.0")'),
+      );
+      expect(
+        swiftPackageManifest().readAsStringSync(),
+        isNot(contains('.iOS("13.0")')),
+      );
+    });
+
+    test('finds CocoaPods installed only through rbenv', () {
+      stubLog('pod').parent.createSync(recursive: true);
+      File(p.join(stubBin.path, 'pod')).deleteSync();
+      final rbenvBin = Directory(p.join(sandbox.path, 'home/.rbenv/bin'))
+        ..createSync(recursive: true);
+      final rbenvShims = Directory(p.join(sandbox.path, 'home/.rbenv/shims'))
+        ..createSync(recursive: true);
+      final rbenv = File(p.join(rbenvBin.path, 'rbenv'))
+        ..writeAsStringSync('#!/bin/sh\n');
+      final rbenvChmod = Process.runSync('chmod', ['+x', rbenv.path]);
+      expect(rbenvChmod.exitCode, 0, reason: rbenvChmod.stderr.toString());
+      final pod = File(p.join(rbenvShims.path, 'pod'))
+        ..writeAsStringSync(
+          '#!/bin/sh\n'
+          'printf \'%s\\n\' "\$*" >> "\$STUB_LOG_DIR/pod.log"\n',
+        );
+      final podChmod = Process.runSync('chmod', ['+x', pod.path]);
+      expect(podChmod.exitCode, 0, reason: podChmod.stderr.toString());
+      writeFile('ios/Podfile.lock', DateTime.now());
+
+      expectSuccess(runScript());
+
+      expect(stubLog('pod').readAsStringSync(), contains('install'));
+    });
+
+    test('fails clearly when CocoaPods is unavailable', () {
+      File(p.join(stubBin.path, 'pod')).deleteSync();
+      Directory(p.join(sandbox.path, 'ios')).createSync();
+
+      final result = runScript();
+
+      expect(result.exitCode, 1);
+      expect(
+        '${result.stdout}${result.stderr}',
+        contains('CocoaPods not found'),
+      );
+      expect(stubLog('flutter').existsSync(), isFalse);
     });
   });
 }


### PR DESCRIPTION
## Problem

Building the app from Xcode could fail while resolving `FlutterGeneratedPluginSwiftPackage`, with plugins requiring iOS 15 or 16 while the generated package still targeted iOS 13. The Xcode project and Podfile already target iOS 16; the stale floor lived in Flutter's generated, gitignored Swift package manifest.

Flutter plugin injection rewrites that manifest to its default iOS 13 floor during commands such as `flutter pub get`, `flutter analyze`, and `flutter test`. The shared Runner scheme also ran `mobile/pre_build_ios.sh` before every Xcode build, and that script previously invoked `flutter pub get`, resetting the floor immediately before Xcode consumed it.

## Fix

The Runner pre-action no longer discovers or invokes Flutter. Instead, it directly and idempotently repairs the generated package manifest from iOS 13 to iOS 16 before Xcode resolves it, then performs the existing CocoaPods synchronization. This also makes Xcode builds recover automatically after any terminal Flutter command resets the generated file.

The touched CocoaPods setup now prepends rbenv shims before resolving `pod`, so rbenv-only installations are found and the executable that is validated is the one that runs. Non-interactive Xcode builds no longer depend on `rbenv init` succeeding.

The subprocess regression suite covers:

- no Flutter invocation in every successful CocoaPods branch;
- idempotent Swift package floor repair;
- synchronized locks with equal modification times;
- stale or absent Pods installations;
- CocoaPods installed only through rbenv; and
- a clear failure when CocoaPods is unavailable.

The build-script and iOS troubleshooting documentation now describe the automatic repair rather than requiring a manual `flutter build ios --config-only` step.

## Deliberately unchanged

- `mobile/pre_build_macos.sh` is not wired into the macOS scheme and remains unchanged.
- Codemagic's existing generated-manifest repair remains in release automation.
- Flutter's own deployment-target update and `xcodebuild -showBuildSettings` timeout behavior remain unchanged; the Xcode pre-action now makes local builds independent of them.

Refs #2915.

## Verification

- `shellcheck mobile/pre_build_ios.sh`
- `cd mobile && flutter analyze lib test integration_test`
- `cd mobile && flutter test test/tools/pre_build_ios_test.dart` — 7 tests pass
- repository pre-commit and pre-push hooks

## Type of Change

- [x] Bug fix
- [x] Build configuration change
- [x] Documentation
