### PR TITLE
fix(dm): stop telling established accounts that chats haven't finished restoring

### DIFF
--- a/mobile/integration_test/e2e/dm_history_drain_idle_pool_test.dart
+++ b/mobile/integration_test/e2e/dm_history_drain_idle_pool_test.dart
@@ -169,7 +169,7 @@ void main() {
         await stack.repository.backfillHistoryIfNeeded();
 
         expect(
-          stack.repository.isHistoryRecoveryComplete,
+          stack.repository.hasCompletedHistoryRecoveryBefore,
           isTrue,
           reason:
               'the page must bring the pool back before fanning out, not '
@@ -193,7 +193,7 @@ void main() {
 
         await stack.repository.backfillHistoryIfNeeded();
         expect(
-          stack.repository.isHistoryRecoveryComplete,
+          stack.repository.hasCompletedHistoryRecoveryBefore,
           isFalse,
           reason: 'nothing could answer while the relay was down',
         );
@@ -205,7 +205,7 @@ void main() {
         await stack.client.retryDisconnectedRelays();
 
         await waitUntil(
-          () => stack.repository.isHistoryRecoveryComplete,
+          () => stack.repository.hasCompletedHistoryRecoveryBefore,
           reason: 'the deferred drain never resumed after the relay connected',
         );
       },

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -317,7 +317,8 @@ class ConversationListBloc
             ? InboxFilter.all
             : state.filter;
 
-        final recoveryComplete = _dmRepository.isHistoryRecoveryComplete;
+        final recoveryComplete =
+            _dmRepository.hasCompletedHistoryRecoveryBefore;
         final requestConversations = recoveryComplete
             ? pin.requests
             : const <DmConversation>[];

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_state.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_state.dart
@@ -167,12 +167,17 @@ class ConversationListState extends Equatable {
   ///
   /// Distinct from [isRestoringHistory] on purpose. That flag tracks whether a
   /// drain is *actively running* (`_activeRecoveryOps > 0`), but the gate reads
-  /// the *persisted* `historyDrainComplete`, which only ever flips on a clean
+  /// the *persisted* completion record, which only ever flips on a clean
   /// exhaustion. A drain that stops at the page cap, hits an exception, or
   /// finds no connected relay clears the running flag while leaving the gate
   /// shut — so the progress bar vanished while requests stayed hidden, with no
   /// banner, no badge and no spinner to show anything was missing. Drives the
   /// restore-paused banner, which offers the retry that reopens the gate.
+  ///
+  /// Only a first-ever drain can shut the gate. A forced recovery pass on an
+  /// install that completed one before keeps it open: that install already
+  /// holds its own replies, so nothing would be misclassified, and the banner
+  /// read as lost chats to users who had lost nothing (#8550).
   final bool requestsWithheld;
 
   /// Size of the render window over [conversations] — grows as the user pages.

--- a/mobile/lib/blocs/dm/restore_status/dm_restore_status_cubit.dart
+++ b/mobile/lib/blocs/dm/restore_status/dm_restore_status_cubit.dart
@@ -59,10 +59,10 @@ class DmRestoreStatusCubit extends Cubit<DmRestoreStatusState>
       ) {
     // `historyRecoveryStream` does not replay, hence the constructor seed above.
     _subscription = _dmRepository.historyRecoveryStream.listen((isRestoring) {
-      // Re-read the persisted flag on every tick: it is what actually gates the
-      // request split, and it only flips on a clean drain exhaustion. A pass
-      // that stops at the page cap, throws, or finds no connected relay ends
-      // with isRestoring false while this stays false too.
+      // Re-read the persisted completion record on every tick: it is what
+      // actually gates the request split. A deferred first-ever drain leaves
+      // it false, while a later forced recovery pass keeps it true once an
+      // earlier drain has completed cleanly.
       emitIfOpen(
         DmRestoreStatusState(
           isRestoring: isRestoring,

--- a/mobile/lib/blocs/dm/restore_status/dm_restore_status_cubit.dart
+++ b/mobile/lib/blocs/dm/restore_status/dm_restore_status_cubit.dart
@@ -23,7 +23,8 @@ class DmRestoreStatusState extends Equatable {
   /// History recovery has run, completed, or is running for this user.
   final bool hasAttempted;
 
-  /// The one-time history drain has completed cleanly for this user.
+  /// The history drain has completed cleanly for this user at least once, so
+  /// a later forced recovery pass never re-qualifies an empty view (#8550).
   ///
   /// Defaults to `true` so a screen never claims history is missing before the
   /// repository has answered — the same fail-open stance as

--- a/mobile/lib/blocs/dm/restore_status/dm_restore_status_cubit.dart
+++ b/mobile/lib/blocs/dm/restore_status/dm_restore_status_cubit.dart
@@ -28,8 +28,8 @@ class DmRestoreStatusState extends Equatable {
   ///
   /// Defaults to `true` so a screen never claims history is missing before the
   /// repository has answered — the same fail-open stance as
-  /// [DmRepository.isHistoryRecoveryComplete], which returns `true` when it has
-  /// no sync state or pubkey to consult.
+  /// [DmRepository.hasCompletedHistoryRecoveryBefore], which returns `true`
+  /// when it has no sync state or pubkey to consult.
   final bool isComplete;
 
   /// Whether an empty view might simply not have its messages yet.
@@ -54,7 +54,7 @@ class DmRestoreStatusCubit extends Cubit<DmRestoreStatusState>
         DmRestoreStatusState(
           isRestoring: dmRepository.isRecoveringHistory,
           hasAttempted: dmRepository.hasAttemptedHistoryRecovery,
-          isComplete: dmRepository.isHistoryRecoveryComplete,
+          isComplete: dmRepository.hasCompletedHistoryRecoveryBefore,
         ),
       ) {
     // `historyRecoveryStream` does not replay, hence the constructor seed above.
@@ -67,7 +67,7 @@ class DmRestoreStatusCubit extends Cubit<DmRestoreStatusState>
         DmRestoreStatusState(
           isRestoring: isRestoring,
           hasAttempted: _dmRepository.hasAttemptedHistoryRecovery,
-          isComplete: _dmRepository.isHistoryRecoveryComplete,
+          isComplete: _dmRepository.hasCompletedHistoryRecoveryBefore,
         ),
       );
     });

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1492,8 +1492,7 @@ class DmRepository {
   /// `historyRecoveryStream.startWith(repo.isRecoveringHistory)`). See #5202.
   Stream<bool> get historyRecoveryStream => _recoveryStateController.stream;
 
-  /// Whether the one-time history-recovery drain has fully completed for the
-  /// current user.
+  /// Whether history recovery has completed at least once for the current user.
   ///
   /// Until this is `true` — notably the post-reinstall window while the drain
   /// pages back through history — the inbox MUST NOT segregate conversations
@@ -1515,7 +1514,7 @@ class DmRepository {
   /// yesterday and raise the "haven't finished restoring" banner each time
   /// the pass deferred. Those passes recover history the user never saw;
   /// they must not read as history the user lost. See #8550.
-  bool get isHistoryRecoveryComplete {
+  bool get hasCompletedHistoryRecoveryBefore {
     final syncState = _syncState;
     if (syncState == null || _userPubkey.isEmpty) return true;
     return syncState.historyDrainCompletedBefore(_userPubkey);
@@ -1760,6 +1759,10 @@ class DmRepository {
     // this run defers too it arms a fresh one against the pool it saw.
     unawaited(_drainRelayReadySubscription?.cancel());
     _drainRelayReadySubscription = null;
+    // Run this before the ordinary version stamp: that ordering distinguishes
+    // a pre-fix generation-5 install from a fresh install starting its first
+    // drain on this build. See #8550 and #8646.
+    await syncState.migrateHistoryDrainCompletion(pubkey);
     // One-time forced re-drain: installs that completed under an older,
     // buggy drain (pre-#5202) are stuck with historyDrainComplete=true while
     // the relay still holds unrecovered history. A drain-version bump clears

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2106,8 +2106,8 @@ class DmRepository {
     }
   }
 
-  /// Resumes a deferred history drain once a relay that was not connected
-  /// when the drain gave up connects.
+  /// Resumes a deferred history drain once a relay connects that was not
+  /// connected the last time the pool was observed.
   ///
   /// Every relay-availability deferral leaves `historyDrainComplete` unset
   /// and waits for "the next inbox open". But the inbox is already open,
@@ -2115,33 +2115,48 @@ class DmRepository {
   /// against whatever the pool looks like at that instant — against an
   /// idle-disconnected pool that is the same failure again. Like the labeler
   /// and feed services, this holds a one-shot relay-status listener, but uses
-  /// a finer trigger: it re-runs the drain when any relay the deferral did not
-  /// have becomes connected. A relay that repeatedly reconnects without
-  /// answering can therefore re-drive the bounded drain. At most one listener
-  /// is armed at a time, a new run supersedes it, and teardown cancels it. A
-  /// page-cap pause deliberately does not arm one: that budget resumes on the
-  /// next inbox open by design. See #8550.
+  /// a finer trigger: a rising edge. It re-runs the drain when a relay becomes
+  /// connected that was not connected at the previous observation — one the
+  /// deferral did not have, or one it had whose socket has since dropped and
+  /// come back. The second case is how a relay that took the REQ and never
+  /// answered gets a second chance: it still counts as connected when the
+  /// drain gives up, the SDK's silent-relay repair then cycles that socket,
+  /// and only the reconnection can say the relay is answering again. Keyed on
+  /// the deferral-time snapshot alone, that reconnection was ignored and the
+  /// banner stayed up until a manual retry (verified against a paused relay,
+  /// #8643). A relay merely reporting again while still connected is not an
+  /// edge. A relay that repeatedly reconnects without answering can therefore
+  /// re-drive the bounded drain. At most one listener is armed at a time, a
+  /// new run supersedes it, and teardown cancels it. A page-cap pause
+  /// deliberately does not arm one: that budget resumes on the next inbox
+  /// open by design. See #8550.
   void _resumeDrainWhenRelayConnects(String pubkey, int generation) {
     unawaited(_drainRelayReadySubscription?.cancel());
     _drainRelayReadySubscription = null;
     if (_ingestSessionEnded(pubkey, generation)) return;
-    final connectedAtDeferral = <String>{
+    final lastConnected = <String>{
       for (final entry in _nostrClient.relayStatuses.entries)
         if (entry.value.isConnected) entry.key,
     };
     Log.info(
       'DM history drain for ${pubkeyForLogs(pubkey)} will resume when a relay '
-      'connects (connected now: ${connectedAtDeferral.length}/'
+      'connects (connected now: ${lastConnected.length}/'
       '${_nostrClient.configuredRelayCount})',
       category: LogCategory.system,
     );
     _drainRelayReadySubscription = _nostrClient.relayStatusStream.listen((
       statuses,
     ) {
-      final newlyConnected = statuses.entries.any(
-        (entry) =>
-            entry.value.isConnected && !connectedAtDeferral.contains(entry.key),
+      final nowConnected = <String>{
+        for (final entry in statuses.entries)
+          if (entry.value.isConnected) entry.key,
+      };
+      final newlyConnected = nowConnected.any(
+        (url) => !lastConnected.contains(url),
       );
+      lastConnected
+        ..clear()
+        ..addAll(nowConnected);
       if (!newlyConnected) return;
       unawaited(_drainRelayReadySubscription?.cancel());
       _drainRelayReadySubscription = null;

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1291,6 +1291,22 @@ class DmRepository {
     };
   }
 
+  /// Whether [relays] names at least one relay the configured pool does not.
+  ///
+  /// The history drain pages the pool on every run, so an advertised inbox
+  /// made up entirely of pool members was asked by any run that completed;
+  /// re-arming for it would replay the whole history to recover nothing.
+  /// Compared on normalized URLs, since the pool stores them that way and a
+  /// trailing slash must not make a pool member look like an outsider.
+  bool _namesRelayOutsidePool(List<String> relays) {
+    final pooled = _nostrClient.configuredRelays
+        .map((url) => normalizeRelayUrl(url) ?? url)
+        .toSet();
+    return relays.any(
+      (url) => !pooled.contains(normalizeRelayUrl(url) ?? url),
+    );
+  }
+
   /// Where the sender's own gift-wrap copy of an outgoing DM should land: the
   /// configured pool UNION the user's advertised kind-10050 DM inbox.
   ///
@@ -1776,17 +1792,27 @@ class DmRepository {
       final recovery = await _drainOwnInboxRelays(pubkey, gen);
       if (_ingestSessionEnded(pubkey, gen)) return;
       if (recovery.conclusive) {
-        // Either answer settles it. A list means the earlier run may have
-        // missed whole relays, so re-arm once. No list means the pool was
-        // always the whole story and the completion was honest. Recording it
-        // either way is what stops this costing a read on every inbox open.
+        // Either answer settles it. A list naming a relay outside the pool
+        // means the earlier run may have missed whole relays, so re-arm once.
+        // A list of pool members only, or no list, means the pool was always
+        // the whole story and the completion was honest — every run pages
+        // the pool, so those relays were asked. Recording it either way is
+        // what stops this costing a read on every inbox open.
         await syncState.setDrainCoveredOwnInbox(pubkey);
-        if (recovery.relays != null) {
+        final advertised = recovery.relays;
+        if (advertised != null && _namesRelayOutsidePool(advertised)) {
           await syncState.rearmDrainForOwnInbox(pubkey);
           Log.info(
             'DM history drain re-armed for ${pubkeyForLogs(pubkey)}: the '
             "completed run never read the account's own DM inbox relays, "
-            'which are now known',
+            'which are now known and name a relay outside the pool',
+            category: LogCategory.system,
+          );
+        } else if (advertised != null) {
+          Log.info(
+            'DM history drain coverage settled for ${pubkeyForLogs(pubkey)}: '
+            "the account's own DM inbox relays are all pool members the "
+            'completed run already paged',
             category: LogCategory.system,
           );
         }

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1291,22 +1291,6 @@ class DmRepository {
     };
   }
 
-  /// Whether [relays] names at least one relay the configured pool does not.
-  ///
-  /// The history drain pages the pool on every run, so an advertised inbox
-  /// made up entirely of pool members was asked by any run that completed;
-  /// re-arming for it would replay the whole history to recover nothing.
-  /// Compared on normalized URLs, since the pool stores them that way and a
-  /// trailing slash must not make a pool member look like an outsider.
-  bool _namesRelayOutsidePool(List<String> relays) {
-    final pooled = _nostrClient.configuredRelays
-        .map((url) => normalizeRelayUrl(url) ?? url)
-        .toSet();
-    return relays.any(
-      (url) => !pooled.contains(normalizeRelayUrl(url) ?? url),
-    );
-  }
-
   /// Where the sender's own gift-wrap copy of an outgoing DM should land: the
   /// configured pool UNION the user's advertised kind-10050 DM inbox.
   ///
@@ -1792,27 +1776,17 @@ class DmRepository {
       final recovery = await _drainOwnInboxRelays(pubkey, gen);
       if (_ingestSessionEnded(pubkey, gen)) return;
       if (recovery.conclusive) {
-        // Either answer settles it. A list naming a relay outside the pool
-        // means the earlier run may have missed whole relays, so re-arm once.
-        // A list of pool members only, or no list, means the pool was always
-        // the whole story and the completion was honest — every run pages
-        // the pool, so those relays were asked. Recording it either way is
-        // what stops this costing a read on every inbox open.
+        // Either answer settles it. A list means the earlier run may have
+        // missed whole relays, so re-arm once. No list means the pool was
+        // always the whole story and the completion was honest. Recording it
+        // either way is what stops this costing a read on every inbox open.
         await syncState.setDrainCoveredOwnInbox(pubkey);
-        final advertised = recovery.relays;
-        if (advertised != null && _namesRelayOutsidePool(advertised)) {
+        if (recovery.relays != null) {
           await syncState.rearmDrainForOwnInbox(pubkey);
           Log.info(
             'DM history drain re-armed for ${pubkeyForLogs(pubkey)}: the '
             "completed run never read the account's own DM inbox relays, "
-            'which are now known and name a relay outside the pool',
-            category: LogCategory.system,
-          );
-        } else if (advertised != null) {
-          Log.info(
-            'DM history drain coverage settled for ${pubkeyForLogs(pubkey)}: '
-            "the account's own DM inbox relays are all pool members the "
-            'completed run already paged',
+            'which are now known',
             category: LogCategory.system,
           );
         }

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1506,10 +1506,19 @@ class DmRepository {
   /// [_endRecovery]) when the drain reaches relay exhaustion. Falls back to
   /// `true` when uninitialized so the inbox never hides the split forever.
   /// See #5304.
+  ///
+  /// It stays `true` through a later forced recovery pass — a drain-version
+  /// bump, or the own-inbox coverage re-arm — on an install that already
+  /// completed a drain once. That install's own replies are already in its
+  /// database, so the misclassification this guards against cannot happen,
+  /// while a closed gate would hide every request the user could see
+  /// yesterday and raise the "haven't finished restoring" banner each time
+  /// the pass deferred. Those passes recover history the user never saw;
+  /// they must not read as history the user lost. See #8550.
   bool get isHistoryRecoveryComplete {
     final syncState = _syncState;
     if (syncState == null || _userPubkey.isEmpty) return true;
-    return syncState.historyDrainComplete(_userPubkey);
+    return syncState.historyDrainCompletedBefore(_userPubkey);
   }
 
   /// Whether history recovery has run, completed, or is currently running for

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -34,6 +34,10 @@ class DmSyncState {
   static const _groupRecoveryVersionPrefix = 'dm.groupRecoveryVersion.';
   static const _drainInboxCoveredPrefix = 'dm.drainCoveredOwnInbox.';
   static const _drainCompletedBeforePrefix = 'dm.historyDrainCompletedBefore.';
+  static const _drainCompletionMigrationPrefix =
+      'dm.historyDrainCompletionMigration.';
+
+  static const int _currentDrainCompletionMigration = 1;
 
   /// Current history-drain logic version. Installs whose persisted
   /// [drainVersion] is below this re-run the drain once, even if
@@ -277,14 +281,41 @@ class DmSyncState {
   ///
   /// A re-arm records this before clearing the completion latch, so the
   /// answer survives the pass it triggers. Installs whose completion or re-arm
-  /// was written by a build that predates this key are recovered through
-  /// [drainCoveredOwnInbox]: that bit is only ever written by a run that
-  /// observed a completion — at completion itself, or in the re-arm branch,
-  /// which requires one — so it is proof of the same fact.
+  /// was written by a build that predates this key are recovered by
+  /// [migrateHistoryDrainCompletion]. Until that migration runs, drain version
+  /// 5 identifies the pre-fix population directly.
   bool historyDrainCompletedBefore(String pubkey) =>
       historyDrainComplete(pubkey) ||
       (_prefs.getBool('$_drainCompletedBeforePrefix$pubkey') ?? false) ||
-      drainCoveredOwnInbox(pubkey);
+      (_drainCompletionMigration(pubkey) == 0 && drainVersion(pubkey) == 5);
+
+  int _drainCompletionMigration(String pubkey) =>
+      _prefs.getInt('$_drainCompletionMigrationPrefix$pubkey') ?? 0;
+
+  /// Migrates the completion record for installs that ran drain generation 5
+  /// before [historyDrainCompletedBefore] existed.
+  ///
+  /// Generation 5 overwrote the only completion latch while forcing a repeat
+  /// recovery pass, so its persisted state cannot distinguish an established
+  /// install whose repeat pass deferred from a first-ever drain that deferred.
+  /// The product decision for #8550 is to keep that shipped population's inbox
+  /// open. Recording the migration before [upgradeDrainVersionIfNeeded] stamps
+  /// a fresh install means newly installed builds remain gated.
+  ///
+  // TODO(realmeylisdev): Remove the generation-5 migration after builds
+  // through +856 are outside the supported upgrade window. See #8646.
+  Future<void> migrateHistoryDrainCompletion(String pubkey) async {
+    if (_drainCompletionMigration(pubkey) >= _currentDrainCompletionMigration) {
+      return;
+    }
+    if (drainVersion(pubkey) == 5) {
+      await _prefs.setBool('$_drainCompletedBeforePrefix$pubkey', true);
+    }
+    await _prefs.setInt(
+      '$_drainCompletionMigrationPrefix$pubkey',
+      _currentDrainCompletionMigration,
+    );
+  }
 
   /// The history-drain logic version last completed for [pubkey], or `0`
   /// if none has been recorded (pre-#5202 installs, fresh installs).
@@ -440,6 +471,7 @@ class DmSyncState {
     await _prefs.remove('$_groupRecoveryVersionPrefix$pubkey');
     await _prefs.remove('$_drainInboxCoveredPrefix$pubkey');
     await _prefs.remove('$_drainCompletedBeforePrefix$pubkey');
+    await _prefs.remove('$_drainCompletionMigrationPrefix$pubkey');
   }
 
   /// Removes all DM sync state entries for every pubkey.
@@ -460,7 +492,8 @@ class DmSyncState {
               key.startsWith(_dmRelayListPublishedPrefix) ||
               key.startsWith(_groupRecoveryVersionPrefix) ||
               key.startsWith(_drainInboxCoveredPrefix) ||
-              key.startsWith(_drainCompletedBeforePrefix),
+              key.startsWith(_drainCompletedBeforePrefix) ||
+              key.startsWith(_drainCompletionMigrationPrefix),
         )
         .toList();
     for (final key in keysToRemove) {

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -7,6 +7,8 @@
 //     is the stamp relays actually filter `since:` against
 //   - oldestSyncedAt: lowest rumor `created_at` successfully processed
 //   - historyDrainComplete: whether the one-time full-history drain is done
+//   - historyDrainCompletedBefore: whether it has ever been done, which a
+//     forced recovery pass leaves intact
 //   - historyDrainCursor: the drain's resumable pagination boundary
 //
 // Timestamps are unix seconds matching Nostr event timestamps. Used by
@@ -31,6 +33,7 @@ class DmSyncState {
   static const _dmRelayListPublishedPrefix = 'dm.dmRelayListPublished.';
   static const _groupRecoveryVersionPrefix = 'dm.groupRecoveryVersion.';
   static const _drainInboxCoveredPrefix = 'dm.drainCoveredOwnInbox.';
+  static const _drainCompletedBeforePrefix = 'dm.historyDrainCompletedBefore.';
 
   /// Current history-drain logic version. Installs whose persisted
   /// [drainVersion] is below this re-run the drain once, even if
@@ -252,8 +255,36 @@ class DmSyncState {
   /// in-progress drain.
   Future<void> markHistoryDrainComplete(String pubkey) async {
     await _prefs.setBool('$_drainCompletePrefix$pubkey', true);
+    await _prefs.setBool('$_drainCompletedBeforePrefix$pubkey', true);
     await _prefs.remove('$_drainCursorPrefix$pubkey');
   }
+
+  /// Whether a full-history drain has completed for [pubkey] at least once
+  /// on this install, even if a later forced recovery pass has since cleared
+  /// [historyDrainComplete].
+  ///
+  /// [historyDrainComplete] answers "is the drain done right now", which is
+  /// the right question for deciding whether to run it. It is the wrong
+  /// question for the inbox's recovery gate: that gate hides would-be message
+  /// requests and shows a "haven't finished restoring" banner because, on a
+  /// fresh install, the user's own replies have not been re-ingested yet and
+  /// an accepted chat would transiently classify as a request. An install
+  /// that already completed a drain has those replies in its database, so a
+  /// forced re-drain — a [currentDrainVersion] bump, or the own-inbox coverage
+  /// re-arm — changes nothing the gate protects against, and the banner it
+  /// produced on every deferral read as lost chats to users who had lost
+  /// nothing (#8550).
+  ///
+  /// A re-arm records this before clearing the completion latch, so the
+  /// answer survives the pass it triggers. Installs whose completion or re-arm
+  /// was written by a build that predates this key are recovered through
+  /// [drainCoveredOwnInbox]: that bit is only ever written by a run that
+  /// observed a completion — at completion itself, or in the re-arm branch,
+  /// which requires one — so it is proof of the same fact.
+  bool historyDrainCompletedBefore(String pubkey) =>
+      historyDrainComplete(pubkey) ||
+      (_prefs.getBool('$_drainCompletedBeforePrefix$pubkey') ?? false) ||
+      drainCoveredOwnInbox(pubkey);
 
   /// The history-drain logic version last completed for [pubkey], or `0`
   /// if none has been recorded (pre-#5202 installs, fresh installs).
@@ -302,6 +333,12 @@ class DmSyncState {
   }
 
   Future<void> _armRedrainFromNow(String pubkey, int nowSec) async {
+    // Clearing a completion must not erase the fact that one happened; see
+    // [historyDrainCompletedBefore]. A boundary repair on an install that
+    // never completed records nothing.
+    if (historyDrainComplete(pubkey)) {
+      await _prefs.setBool('$_drainCompletedBeforePrefix$pubkey', true);
+    }
     await _prefs.remove('$_drainCompletePrefix$pubkey');
     await _prefs.setInt('$_drainCursorPrefix$pubkey', nowSec);
   }
@@ -402,6 +439,7 @@ class DmSyncState {
     await _prefs.remove('$_dmRelayListPublishedPrefix$pubkey');
     await _prefs.remove('$_groupRecoveryVersionPrefix$pubkey');
     await _prefs.remove('$_drainInboxCoveredPrefix$pubkey');
+    await _prefs.remove('$_drainCompletedBeforePrefix$pubkey');
   }
 
   /// Removes all DM sync state entries for every pubkey.
@@ -421,7 +459,8 @@ class DmSyncState {
               key.startsWith(_drainVersionPrefix) ||
               key.startsWith(_dmRelayListPublishedPrefix) ||
               key.startsWith(_groupRecoveryVersionPrefix) ||
-              key.startsWith(_drainInboxCoveredPrefix),
+              key.startsWith(_drainInboxCoveredPrefix) ||
+              key.startsWith(_drainCompletedBeforePrefix),
         )
         .toList();
     for (final key in keysToRemove) {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -460,6 +460,7 @@ class _FakeDmSyncState implements DmSyncState {
   bool completedBeforeOverride = false;
   final List<String> inboxCoveredPubkeys = <String>[];
   final List<String> rearmedForInboxPubkeys = <String>[];
+  final List<String> drainPreambleOperations = <String>[];
 
   @override
   int? newestSyncedAt(String pubkey) => newestOverride;
@@ -482,10 +483,12 @@ class _FakeDmSyncState implements DmSyncState {
   }
 
   @override
-  bool historyDrainCompletedBefore(String pubkey) =>
-      drainCompleteOverride ||
-      completedBeforeOverride ||
-      drainCoveredOwnInboxOverride;
+  bool historyDrainCompletedBefore(String pubkey) => completedBeforeOverride;
+
+  @override
+  Future<void> migrateHistoryDrainCompletion(String pubkey) async {
+    drainPreambleOperations.add('migrate-completion');
+  }
 
   @override
   bool drainCoveredOwnInbox(String pubkey) => drainCoveredOwnInboxOverride;
@@ -522,6 +525,7 @@ class _FakeDmSyncState implements DmSyncState {
 
   @override
   Future<void> upgradeDrainVersionIfNeeded(String pubkey) async {
+    drainPreambleOperations.add('upgrade-version');
     if (drainVersionOverride >= DmSyncState.currentDrainVersion) return;
     upgradedPubkeys.add(pubkey);
     if (drainCompleteOverride) {
@@ -6699,18 +6703,23 @@ void main() {
       );
 
       test(
-        'isHistoryRecoveryComplete reflects the persisted drain-complete flag '
-        '(#5304)',
+        'hasCompletedHistoryRecoveryBefore reflects prior completion (#5304)',
         () {
           final incomplete = _FakeDmSyncState()..drainCompleteOverride = false;
           expect(
-            createRepository(syncState: incomplete).isHistoryRecoveryComplete,
+            createRepository(
+              syncState: incomplete,
+            ).hasCompletedHistoryRecoveryBefore,
             isFalse,
           );
 
-          final complete = _FakeDmSyncState()..drainCompleteOverride = true;
+          final complete = _FakeDmSyncState()
+            ..drainCompleteOverride = true
+            ..completedBeforeOverride = true;
           expect(
-            createRepository(syncState: complete).isHistoryRecoveryComplete,
+            createRepository(
+              syncState: complete,
+            ).hasCompletedHistoryRecoveryBefore,
             isTrue,
           );
         },
@@ -6722,24 +6731,25 @@ void main() {
       // closed gate here hid every existing request and raised the "haven't
       // finished restoring" banner on each deferral. #8550.
       test(
-        'isHistoryRecoveryComplete stays true while a recovery pass re-runs '
-        'on an install that completed a drain before',
+        'hasCompletedHistoryRecoveryBefore stays true while recovery re-runs',
         () {
           final rearmed = _FakeDmSyncState()
             ..drainCompleteOverride = false
             ..completedBeforeOverride = true;
 
           expect(
-            createRepository(syncState: rearmed).isHistoryRecoveryComplete,
+            createRepository(
+              syncState: rearmed,
+            ).hasCompletedHistoryRecoveryBefore,
             isTrue,
           );
         },
       );
 
       test(
-        'isHistoryRecoveryComplete is true when no sync state is wired (#5304)',
+        'hasCompletedHistoryRecoveryBefore is true without sync state (#5304)',
         () {
-          expect(createRepository().isHistoryRecoveryComplete, isTrue);
+          expect(createRepository().hasCompletedHistoryRecoveryBefore, isTrue);
         },
       );
 
@@ -7101,6 +7111,10 @@ void main() {
 
           await repository.backfillHistoryIfNeeded();
 
+          expect(syncState.drainPreambleOperations.take(2), [
+            'migrate-completion',
+            'upgrade-version',
+          ]);
           expect(syncState.upgradedPubkeys, isNotEmpty);
           expect(
             capturedUntil.any((until) => (until ?? 0) >= strandedOuter),
@@ -7266,6 +7280,7 @@ void main() {
           // are the ones most likely to hold the missing history.
           expect(syncState.markedCompletePubkeys, isEmpty);
           expect(syncState.drainCompleteOverride, isFalse);
+          expect(syncState.inboxCoveredPubkeys, isEmpty);
         });
 
         test(

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -8122,6 +8122,43 @@ void main() {
         },
       );
 
+      // A relay that took the REQ and never answered still counts as connected
+      // when the drain gives up; the SDK's silent-relay repair then cycles its
+      // socket. Only that reconnection can say the relay is answering again,
+      // and keyed on the deferral snapshot alone it was ignored — against a
+      // paused relay the banner stayed up until a manual retry (#8643).
+      test(
+        'resumes when a relay connected at deferral drops and reconnects',
+        () async {
+          final relayStatus = stubRelayStatus(
+            connectedNow: connected(['wss://a.example']),
+          );
+          stubUnansweredThenExhausted();
+          final syncState = armedSyncState();
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+          expect(relayStatus.hasListener, isTrue);
+
+          relayStatus.add({
+            'wss://a.example': RelayConnectionStatus.disconnected(
+              'wss://a.example',
+            ),
+          });
+          await pumpEventQueue();
+          expect(
+            syncState.markedCompletePubkeys,
+            isEmpty,
+            reason: 'a drop is not capacity',
+          );
+          expect(relayStatus.hasListener, isTrue);
+
+          relayStatus.add(connected(['wss://a.example']));
+          await untilMarkedComplete(syncState);
+          expect(syncState.markedCompletePubkeys, [_validPubkeyA]);
+        },
+      );
+
       test(
         'stops waiting for a relay once the repository is torn down',
         () async {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -7309,14 +7309,11 @@ void main() {
       // already in that state, and there is no user-facing resync.
       test(
         'a completed drain that never read the inbox is re-armed once the '
-        'relays are known and name a relay outside the pool',
+        'relays are known',
         () async {
           final syncState = _FakeDmSyncState()
             ..drainCompleteOverride = true
             ..drainVersionOverride = DmSyncState.currentDrainVersion;
-          when(
-            () => mockNostrClient.configuredRelays,
-          ).thenReturn(const ['wss://pool.example']);
           when(
             () => mockNostrClient.queryEventsDetailed(
               any(),
@@ -7346,69 +7343,6 @@ void main() {
 
           expect(syncState.rearmedForInboxPubkeys, contains(_validPubkeyA));
           expect(syncState.inboxCoveredPubkeys, contains(_validPubkeyA));
-        },
-      );
-
-      // Every run pages the pool, so an inbox made only of pool members was
-      // asked by the run that completed. Re-arming would replay the account's
-      // whole history to recover nothing — which, before #8550, every
-      // fallback-pool account paid on its first inbox open after upgrading.
-      test(
-        'a completed drain is left alone when the advertised inbox names only '
-        'pool members',
-        () async {
-          final syncState = _FakeDmSyncState()
-            ..drainCompleteOverride = true
-            ..drainVersionOverride = DmSyncState.currentDrainVersion;
-          // The pool stores normalized URLs; the advertised list is compared
-          // the same way, so a trailing slash is not an outsider.
-          when(
-            () => mockNostrClient.configuredRelays,
-          ).thenReturn(const ['wss://own.example', 'wss://pool.example']);
-          when(
-            () => mockNostrClient.queryEventsDetailed(
-              any(),
-              subscriptionId: any(named: 'subscriptionId'),
-              useCache: any(named: 'useCache'),
-              tempRelays: any(named: 'tempRelays'),
-              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
-              timeout: any(named: 'timeout'),
-            ),
-          ).thenAnswer(
-            (_) async => answeredList([
-              Event(
-                _validPubkeyA,
-                EventKind.dmRelaysList,
-                const [
-                  ['relay', 'wss://own.example/'],
-                ],
-                '',
-                createdAt: 1700000000,
-              ),
-            ]),
-          );
-
-          await createRepository(
-            syncState: syncState,
-          ).backfillHistoryIfNeeded();
-
-          expect(syncState.rearmedForInboxPubkeys, isEmpty);
-          expect(syncState.inboxCoveredPubkeys, contains(_validPubkeyA));
-          // Still complete, so no drain page was issued.
-          verifyNever(
-            () => mockNostrClient.queryEventsDetailed(
-              any(
-                that: predicate<List<nostr_filter.Filter>>(
-                  (filters) => filters.first.kinds?.contains(4) ?? false,
-                ),
-              ),
-              subscriptionId: any(named: 'subscriptionId'),
-              useCache: any(named: 'useCache'),
-              tempRelays: any(named: 'tempRelays'),
-              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
-              timeout: any(named: 'timeout'),
-            ),
-          );
         },
       );
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -457,6 +457,7 @@ class _FakeDmSyncState implements DmSyncState {
   final List<({String pubkey, int createdAt})> recordedWire =
       <({String pubkey, int createdAt})>[];
   bool drainCoveredOwnInboxOverride = false;
+  bool completedBeforeOverride = false;
   final List<String> inboxCoveredPubkeys = <String>[];
   final List<String> rearmedForInboxPubkeys = <String>[];
 
@@ -476,8 +477,15 @@ class _FakeDmSyncState implements DmSyncState {
   Future<void> markHistoryDrainComplete(String pubkey) async {
     markedCompletePubkeys.add(pubkey);
     drainCompleteOverride = true;
+    completedBeforeOverride = true;
     drainCursorOverride = null;
   }
+
+  @override
+  bool historyDrainCompletedBefore(String pubkey) =>
+      drainCompleteOverride ||
+      completedBeforeOverride ||
+      drainCoveredOwnInboxOverride;
 
   @override
   bool drainCoveredOwnInbox(String pubkey) => drainCoveredOwnInboxOverride;
@@ -491,6 +499,7 @@ class _FakeDmSyncState implements DmSyncState {
   @override
   Future<void> rearmDrainForOwnInbox(String pubkey) async {
     rearmedForInboxPubkeys.add(pubkey);
+    if (drainCompleteOverride) completedBeforeOverride = true;
     drainCompleteOverride = false;
     drainCursorOverride = DateTime.now().millisecondsSinceEpoch ~/ 1000;
   }
@@ -6702,6 +6711,26 @@ void main() {
           final complete = _FakeDmSyncState()..drainCompleteOverride = true;
           expect(
             createRepository(syncState: complete).isHistoryRecoveryComplete,
+            isTrue,
+          );
+        },
+      );
+
+      // A forced recovery pass on an established install clears the
+      // completion latch, but the install's own replies are already in its
+      // database, so the request split has nothing to protect against. A
+      // closed gate here hid every existing request and raised the "haven't
+      // finished restoring" banner on each deferral. #8550.
+      test(
+        'isHistoryRecoveryComplete stays true while a recovery pass re-runs '
+        'on an install that completed a drain before',
+        () {
+          final rearmed = _FakeDmSyncState()
+            ..drainCompleteOverride = false
+            ..completedBeforeOverride = true;
+
+          expect(
+            createRepository(syncState: rearmed).isHistoryRecoveryComplete,
             isTrue,
           );
         },

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -7309,11 +7309,14 @@ void main() {
       // already in that state, and there is no user-facing resync.
       test(
         'a completed drain that never read the inbox is re-armed once the '
-        'relays are known',
+        'relays are known and name a relay outside the pool',
         () async {
           final syncState = _FakeDmSyncState()
             ..drainCompleteOverride = true
             ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          when(
+            () => mockNostrClient.configuredRelays,
+          ).thenReturn(const ['wss://pool.example']);
           when(
             () => mockNostrClient.queryEventsDetailed(
               any(),
@@ -7343,6 +7346,69 @@ void main() {
 
           expect(syncState.rearmedForInboxPubkeys, contains(_validPubkeyA));
           expect(syncState.inboxCoveredPubkeys, contains(_validPubkeyA));
+        },
+      );
+
+      // Every run pages the pool, so an inbox made only of pool members was
+      // asked by the run that completed. Re-arming would replay the account's
+      // whole history to recover nothing — which, before #8550, every
+      // fallback-pool account paid on its first inbox open after upgrading.
+      test(
+        'a completed drain is left alone when the advertised inbox names only '
+        'pool members',
+        () async {
+          final syncState = _FakeDmSyncState()
+            ..drainCompleteOverride = true
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          // The pool stores normalized URLs; the advertised list is compared
+          // the same way, so a trailing slash is not an outsider.
+          when(
+            () => mockNostrClient.configuredRelays,
+          ).thenReturn(const ['wss://own.example', 'wss://pool.example']);
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => answeredList([
+              Event(
+                _validPubkeyA,
+                EventKind.dmRelaysList,
+                const [
+                  ['relay', 'wss://own.example/'],
+                ],
+                '',
+                createdAt: 1700000000,
+              ),
+            ]),
+          );
+
+          await createRepository(
+            syncState: syncState,
+          ).backfillHistoryIfNeeded();
+
+          expect(syncState.rearmedForInboxPubkeys, isEmpty);
+          expect(syncState.inboxCoveredPubkeys, contains(_validPubkeyA));
+          // Still complete, so no drain page was issued.
+          verifyNever(
+            () => mockNostrClient.queryEventsDetailed(
+              any(
+                that: predicate<List<nostr_filter.Filter>>(
+                  (filters) => filters.first.kinds?.contains(4) ?? false,
+                ),
+              ),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          );
         },
       );
 

--- a/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
@@ -173,6 +173,7 @@ void main() {
       test('is false until a drain completes', () async {
         expect(state.historyDrainCompletedBefore(pkA), isFalse);
 
+        await state.migrateHistoryDrainCompletion(pkA);
         await state.setHistoryDrainCursor(pkA, 1234);
         await state.setDrainVersion(pkA, DmSyncState.currentDrainVersion);
 
@@ -208,20 +209,32 @@ void main() {
         expect(state.historyDrainCompletedBefore(pkA), isTrue);
       });
 
-      // Installs re-armed by a build that predates the flag carry only the
-      // coverage bit, which that build wrote solely off an observed
-      // completion. Without this inference every such install would stay
-      // gated until its pass completed — the population #8550 was filed on.
       test(
-        'is inferred from the coverage bit for installs written before the '
-        'flag existed',
+        'is inferred from drain generation 5 before migration',
         () async {
-          await state.setDrainCoveredOwnInbox(pkA);
+          await state.setDrainVersion(pkA, 5);
 
           expect(state.historyDrainComplete(pkA), isFalse);
           expect(state.historyDrainCompletedBefore(pkA), isTrue);
         },
       );
+
+      test('migrates generation 5 to the durable completion record', () async {
+        await state.setDrainVersion(pkA, 5);
+
+        await state.migrateHistoryDrainCompletion(pkA);
+
+        expect(state.historyDrainCompletedBefore(pkA), isTrue);
+        await state.setDrainVersion(pkA, DmSyncState.currentDrainVersion + 1);
+        expect(state.historyDrainCompletedBefore(pkA), isTrue);
+      });
+
+      test('keeps a fresh install gated when stamping its version', () async {
+        await state.migrateHistoryDrainCompletion(pkA);
+        await state.upgradeDrainVersionIfNeeded(pkA);
+
+        expect(state.historyDrainCompletedBefore(pkA), isFalse);
+      });
 
       test(
         'is not implied by a boundary repair on an install that never '
@@ -576,6 +589,7 @@ void main() {
           expect(state.newestSyncedAt(pkA), closeTo(nowSec(), 5));
           expect(state.historyDrainComplete(pkA), isFalse);
           expect(state.historyDrainCursor(pkA), closeTo(nowSec(), 5));
+          expect(state.historyDrainCompletedBefore(pkA), isTrue);
         },
       );
 

--- a/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
@@ -165,6 +165,93 @@ void main() {
       });
     });
 
+    // The inbox's recovery gate reads this rather than historyDrainComplete:
+    // a forced recovery pass clears the latch on an install whose own replies
+    // are already local, and gating on the latch alone hid every request and
+    // raised the "haven't finished restoring" banner on each deferral (#8550).
+    group('historyDrainCompletedBefore', () {
+      test('is false until a drain completes', () async {
+        expect(state.historyDrainCompletedBefore(pkA), isFalse);
+
+        await state.setHistoryDrainCursor(pkA, 1234);
+        await state.setDrainVersion(pkA, DmSyncState.currentDrainVersion);
+
+        expect(state.historyDrainCompletedBefore(pkA), isFalse);
+      });
+
+      test('is true once a drain completes', () async {
+        await state.markHistoryDrainComplete(pkA);
+
+        expect(state.historyDrainCompletedBefore(pkA), isTrue);
+        expect(state.historyDrainCompletedBefore(pkB), isFalse);
+      });
+
+      test(
+        'survives a drain-version bump clearing the completion latch',
+        () async {
+          await state.markHistoryDrainComplete(pkA);
+          await state.setDrainVersion(pkA, DmSyncState.currentDrainVersion - 1);
+
+          await state.upgradeDrainVersionIfNeeded(pkA);
+
+          expect(state.historyDrainComplete(pkA), isFalse);
+          expect(state.historyDrainCompletedBefore(pkA), isTrue);
+        },
+      );
+
+      test('survives the own-inbox coverage re-arm', () async {
+        await state.markHistoryDrainComplete(pkA);
+
+        await state.rearmDrainForOwnInbox(pkA);
+
+        expect(state.historyDrainComplete(pkA), isFalse);
+        expect(state.historyDrainCompletedBefore(pkA), isTrue);
+      });
+
+      // Installs re-armed by a build that predates the flag carry only the
+      // coverage bit, which that build wrote solely off an observed
+      // completion. Without this inference every such install would stay
+      // gated until its pass completed — the population #8550 was filed on.
+      test(
+        'is inferred from the coverage bit for installs written before the '
+        'flag existed',
+        () async {
+          await state.setDrainCoveredOwnInbox(pkA);
+
+          expect(state.historyDrainComplete(pkA), isFalse);
+          expect(state.historyDrainCompletedBefore(pkA), isTrue);
+        },
+      );
+
+      test(
+        'is not implied by a boundary repair on an install that never '
+        'completed a drain',
+        () async {
+          // recordSeen clamps to now, so the poisoned value has to be written
+          // the way an older build left it.
+          final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          await prefs.setInt('dm.newestSyncedAt.$pkA', nowSec + 7 * 86400);
+
+          await state.repairPoisonedBoundaries(pkA);
+
+          expect(state.historyDrainCursor(pkA), isNotNull);
+          expect(state.historyDrainCompletedBefore(pkA), isFalse);
+        },
+      );
+
+      test('clear and clearAll reset it', () async {
+        await state.markHistoryDrainComplete(pkA);
+        await state.markHistoryDrainComplete(pkB);
+
+        await state.clear(pkA);
+        expect(state.historyDrainCompletedBefore(pkA), isFalse);
+        expect(state.historyDrainCompletedBefore(pkB), isTrue);
+
+        await state.clearAll();
+        expect(state.historyDrainCompletedBefore(pkB), isFalse);
+      });
+    });
+
     group('historyDrainCursor', () {
       test('defaults to null when nothing persisted', () {
         expect(state.historyDrainCursor(pkA), isNull);

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -147,7 +147,9 @@ void _stubStreams(
   when(() => repo.isRecoveringHistory).thenReturn(isRecovering);
   // Recovery-aware request gate (#5304): defaults to "complete" so the normal
   // follow-based split applies; gate tests pass `recoveryComplete: false`.
-  when(() => repo.isHistoryRecoveryComplete).thenReturn(recoveryComplete);
+  when(
+    () => repo.hasCompletedHistoryRecoveryBefore,
+  ).thenReturn(recoveryComplete);
   when(
     () => repo.historyRecoveryStream,
   ).thenAnswer((_) => recoveryStream ?? const Stream<bool>.empty());
@@ -181,7 +183,7 @@ void main() {
       // Recovery-aware request gate (#5304): default to "recovery complete"
       // so existing split assertions hold; gate tests override to false.
       when(
-        () => mockDmRepository.isHistoryRecoveryComplete,
+        () => mockDmRepository.hasCompletedHistoryRecoveryBefore,
       ).thenReturn(true);
 
       // Stub subscription lifecycle methods (#2766).
@@ -1463,7 +1465,7 @@ void main() {
             // stream so the combined stream re-fires and re-classifies.
             Future<void>.delayed(const Duration(milliseconds: 50)).then((_) {
               when(
-                () => mockDmRepository.isHistoryRecoveryComplete,
+                () => mockDmRepository.hasCompletedHistoryRecoveryBefore,
               ).thenReturn(true);
               recoveryController.add(false);
             });
@@ -1556,7 +1558,7 @@ void main() {
             await Future<void>.delayed(const Duration(milliseconds: 250));
             // The drain succeeded this time.
             when(
-              () => mockDmRepository.isHistoryRecoveryComplete,
+              () => mockDmRepository.hasCompletedHistoryRecoveryBefore,
             ).thenReturn(true);
             bloc.add(const ConversationListRestoreRetryRequested());
           },
@@ -3423,7 +3425,7 @@ void main() {
       ).thenAnswer((_) => const Stream<List<String>>.empty());
       when(() => mockDmRepository.userPubkey).thenReturn(_testPubkey1);
       when(
-        () => mockDmRepository.isHistoryRecoveryComplete,
+        () => mockDmRepository.hasCompletedHistoryRecoveryBefore,
       ).thenReturn(true);
       when(() => mockDmRepository.startListening()).thenAnswer((_) async {});
       when(() => mockDmRepository.stopListening()).thenAnswer((_) async {});
@@ -3484,7 +3486,9 @@ void main() {
         () => mockFollowRepository.followingStream,
       ).thenAnswer((_) => const Stream<List<String>>.empty());
       when(() => mockDmRepository.userPubkey).thenReturn(_testPubkey1);
-      when(() => mockDmRepository.isHistoryRecoveryComplete).thenReturn(true);
+      when(
+        () => mockDmRepository.hasCompletedHistoryRecoveryBefore,
+      ).thenReturn(true);
       when(() => mockDmRepository.startListening()).thenAnswer((_) async {});
       when(() => mockDmRepository.stopListening()).thenAnswer((_) async {});
       when(

--- a/mobile/test/blocs/dm/restore_status/dm_restore_status_cubit_test.dart
+++ b/mobile/test/blocs/dm/restore_status/dm_restore_status_cubit_test.dart
@@ -20,7 +20,9 @@ void main() {
       dmRepository = _MockDmRepository();
       when(() => dmRepository.isRecoveringHistory).thenReturn(false);
       when(() => dmRepository.hasAttemptedHistoryRecovery).thenReturn(false);
-      when(() => dmRepository.isHistoryRecoveryComplete).thenReturn(true);
+      when(
+        () => dmRepository.hasCompletedHistoryRecoveryBefore,
+      ).thenReturn(true);
       when(
         () => dmRepository.historyRecoveryStream,
       ).thenAnswer((_) => const Stream<bool>.empty());
@@ -29,7 +31,9 @@ void main() {
     test('seeds from the repository because the stream does not replay', () {
       when(() => dmRepository.isRecoveringHistory).thenReturn(true);
       when(() => dmRepository.hasAttemptedHistoryRecovery).thenReturn(true);
-      when(() => dmRepository.isHistoryRecoveryComplete).thenReturn(false);
+      when(
+        () => dmRepository.hasCompletedHistoryRecoveryBefore,
+      ).thenReturn(false);
 
       final cubit = DmRestoreStatusCubit(dmRepository: dmRepository);
       addTearDown(cubit.close);
@@ -42,7 +46,9 @@ void main() {
     test(
       'a fresh repository reports nothing outstanding before a drain runs',
       () {
-        when(() => dmRepository.isHistoryRecoveryComplete).thenReturn(false);
+        when(
+          () => dmRepository.hasCompletedHistoryRecoveryBefore,
+        ).thenReturn(false);
 
         final cubit = DmRestoreStatusCubit(dmRepository: dmRepository);
         addTearDown(cubit.close);
@@ -68,7 +74,9 @@ void main() {
         // the running flag while leaving the persisted flag false.
         when(() => dmRepository.isRecoveringHistory).thenReturn(true);
         when(() => dmRepository.hasAttemptedHistoryRecovery).thenReturn(true);
-        when(() => dmRepository.isHistoryRecoveryComplete).thenReturn(false);
+        when(
+          () => dmRepository.hasCompletedHistoryRecoveryBefore,
+        ).thenReturn(false);
         when(
           () => dmRepository.historyRecoveryStream,
         ).thenAnswer((_) => Stream<bool>.value(false));
@@ -88,13 +96,17 @@ void main() {
       setUp: () {
         when(() => dmRepository.isRecoveringHistory).thenReturn(true);
         when(() => dmRepository.hasAttemptedHistoryRecovery).thenReturn(true);
-        when(() => dmRepository.isHistoryRecoveryComplete).thenReturn(false);
+        when(
+          () => dmRepository.hasCompletedHistoryRecoveryBefore,
+        ).thenReturn(false);
         final controller = StreamController<bool>();
         when(
           () => dmRepository.historyRecoveryStream,
         ).thenAnswer((_) => controller.stream);
         Future<void>.delayed(const Duration(milliseconds: 20)).then((_) {
-          when(() => dmRepository.isHistoryRecoveryComplete).thenReturn(true);
+          when(
+            () => dmRepository.hasCompletedHistoryRecoveryBefore,
+          ).thenReturn(true);
           when(() => dmRepository.hasAttemptedHistoryRecovery).thenReturn(true);
           controller.add(false);
         });

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -672,7 +672,9 @@ void main() {
       // Consumed by DmRestoreStatusCubit, which qualifies the empty state.
       when(() => mockDmRepository.isRecoveringHistory).thenReturn(false);
       when(() => mockDmRepository.hasAttemptedHistoryRecovery).thenReturn(true);
-      when(() => mockDmRepository.isHistoryRecoveryComplete).thenReturn(true);
+      when(
+        () => mockDmRepository.hasCompletedHistoryRecoveryBefore,
+      ).thenReturn(true);
       when(
         () => mockDmRepository.historyRecoveryStream,
       ).thenAnswer((_) => const Stream<bool>.empty());

--- a/mobile/test/screens/inbox/conversation/conversation_page_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_page_test.dart
@@ -65,7 +65,7 @@ void main() {
       when(() => mockDmRepository.isRecoveringHistory).thenReturn(false);
       when(() => mockDmRepository.hasAttemptedHistoryRecovery).thenReturn(true);
       when(
-        () => mockDmRepository.isHistoryRecoveryComplete,
+        () => mockDmRepository.hasCompletedHistoryRecoveryBefore,
       ).thenReturn(true);
       when(
         () => mockDmRepository.historyRecoveryStream,

--- a/mobile/test/screens/inbox/inbox_page_test.dart
+++ b/mobile/test/screens/inbox/inbox_page_test.dart
@@ -217,7 +217,9 @@ void main() {
           () => repo.historyRecoveryStream,
         ).thenAnswer((_) => const Stream<bool>.empty());
         when(() => repo.isRecoveringHistory).thenReturn(false);
-        when(() => repo.isHistoryRecoveryComplete).thenReturn(true);
+        when(
+          () => repo.hasCompletedHistoryRecoveryBefore,
+        ).thenReturn(true);
         when(() => repo.backfillHistoryIfNeeded()).thenAnswer((_) async {});
         when(() => repo.retryPendingDecryptions()).thenAnswer((_) async {});
         when(() => repo.startListening()).thenAnswer((_) async {});

--- a/mobile/test/screens/inbox/message_requests/message_requests_page_test.dart
+++ b/mobile/test/screens/inbox/message_requests/message_requests_page_test.dart
@@ -66,7 +66,7 @@ void main() {
       // Recovery-aware request gate (#5304): recovery complete so the normal
       // accepted/request split applies.
       when(
-        () => mockDmRepository.isHistoryRecoveryComplete,
+        () => mockDmRepository.hasCompletedHistoryRecoveryBefore,
       ).thenReturn(true);
       when(() => mockDmRepository.userPubkey).thenReturn(testPubkey);
       // Identity stream (#5374): ConversationListBloc subscribes to it via
@@ -201,7 +201,9 @@ void main() {
         when(
           () => notReadyRepo.historyRecoveryStream,
         ).thenAnswer((_) => const Stream<bool>.empty());
-        when(() => notReadyRepo.isHistoryRecoveryComplete).thenReturn(true);
+        when(
+          () => notReadyRepo.hasCompletedHistoryRecoveryBefore,
+        ).thenReturn(true);
         when(() => notReadyRepo.userPubkey).thenReturn('');
         when(
           () => notReadyRepo.userPubkeyStream,


### PR DESCRIPTION
## Description

Since the last set of 1.0.22 builds, established accounts have been seeing **“Some chats haven't finished restoring”** with a Retry button at the top of Messages, and their message requests disappearing, even though their existing chats are already present on the device.

**What is happening.** Two DM changes forced a one-time history recovery pass on existing installs: the drain-version bump in +855 (#8442) and the own-inbox coverage re-arm in +856 (#8597). Both clear the same “drain complete” latch that a brand-new install starts without. The inbox request gate read that latch, so it treated established accounts like half-restored fresh installs. Whenever the pass deferred, the app hid existing message requests and showed the restore warning even though no locally known chats were missing.

**Why this fix.** The gate is needed on a genuinely fresh install, before the account's own replies have been re-ingested; without it, an accepted chat can briefly look like a message request. An account that completed recovery before already has those replies locally, so later maintenance passes should run silently. Sync state now records the durable fact that recovery completed at least once, preserves it when maintenance re-arms the current pass, and gates requests on that durable fact instead of the current-pass latch.

**Legacy migration and product choice.** +855 erased the only persisted completion signal when it re-armed generation 5, before +856 introduced the own-inbox coverage bit. That means persisted generation-5 state cannot distinguish an established account whose maintenance pass kept deferring from a fresh install whose first pass kept deferring. For this shipped population, we deliberately prefer avoiding a false lost-chat warning: accounts that already carry generation 5 are migrated as established. Fresh installs on this fixed build are still protected because the migration marker is written before their drain version is first stamped. The temporary generation-5 compatibility rule is tracked for removal in #8646.

**Relay reconnect fix.** While reproducing the problem against the local Docker relay, a separate resume gap was found. A relay that accepted a request but never answered still counted as connected when the drain deferred. If the SDK then cycled that socket, its reconnection was ignored because resume only looked for a relay outside the original connected set. The listener now recognizes a real disconnected-to-connected edge, so a repaired relay resumes a deferred drain while duplicate connected notifications do not.

**On the reverted optimization.** The earlier attempt to skip the #8597 coverage re-arm when advertised inbox relays were already pool members remains reverted. The current pool does not prove those relays participated in the earlier completed drain, and skipping would permanently miss history that #8597 is meant to recover. With this fix, the bounded background pass is invisible to established users.

**Related issue:** Relates to #8550. The temporary compatibility migration is tracked by #8646.

## Out of Scope

- Why an individual page fails to settle, and the page cap itself, are unchanged. A genuinely fresh install that defers still shows the banner with Retry.
- Two SDK-scope behaviors observed locally remain unchanged: reconnecting an empty pool after silent-relay repair, and a cold-start race between the coverage read budget and pool connection.
- No copy or localization changes.

## Verification

- DM repository tests: 542 passed (`dm_repository_test.dart` and `dm_sync_state_test.dart`).
- App DM BLoC tests: 127 passed (`dm_restore_status_cubit_test.dart` and `conversation_list_bloc_test.dart`).
- Additional router and inbox UI tests covering the renamed recovery contract: 42 passed.
- Full `flutter analyze`: no issues.
- Pre-push changed-file suite: 711 passed.
- Local Docker relay reproduction: established accounts keep requests visible while a maintenance pass defers; the pass resumes after a hung relay reconnects. Fresh-install behavior remains gated.
- iOS simulator against production relays: an established account with a pending request no longer shows the warning or hides the request while its maintenance pass completes silently.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
