### PR TITLE
fix(collabs): prevent saved drafts from inviting their creator

### DIFF
--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -25,6 +25,7 @@ import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_metadata/video_metadata_expiration.dart';
+import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/crash_reporting_provider.dart';
 import 'package:openvine/providers/database_provider.dart';
@@ -40,6 +41,7 @@ import 'package:openvine/services/file_cleanup_service.dart';
 import 'package:openvine/services/video_editor/video_editor_audio_render.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
+import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_video_editor/core/models/video/progress_model.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -1083,7 +1085,10 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       editorEditingParameters: completeParametersFromDraftMap(
         draft.editorEditingParameters,
       ),
-      collaboratorPubkeys: draft.collaboratorPubkeys,
+      collaboratorPubkeys: withoutPublicIdentifier(
+        draft.collaboratorPubkeys,
+        ref.read(authServiceProvider).currentPublicKeyHex ?? '',
+      ),
       inspiredByVideo: draft.inspiredByVideo,
       inspiredByNpub: draft.inspiredByNpub,
       selectedSound: draft.selectedSound,

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -10,7 +10,6 @@ import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
 import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
-import 'package:nostr_sdk/nip19/pubkeys_equal.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/exceptions/video_exceptions.dart';
@@ -342,7 +341,7 @@ class VideoPublishService {
         return const PublishError(PublishErrorKind.notSignedIn);
       }
       final pubkey = authService.currentPublicKeyHex!;
-      final collaboratorPubkeys = _withoutSelfCollaborator(
+      final collaboratorPubkeys = withoutPublicIdentifier(
         draft.collaboratorPubkeys,
         pubkey,
       );
@@ -1281,18 +1280,4 @@ List<String> _excludeCollaboratorPubkeys(
   }
 
   return result;
-}
-
-Set<String> _withoutSelfCollaborator(
-  Set<String> collaboratorPubkeys,
-  String creatorPubkey,
-) {
-  if (!collaboratorPubkeys.any(
-    (pubkey) => pubkeysEqual(pubkey, creatorPubkey),
-  )) {
-    return collaboratorPubkeys;
-  }
-  return collaboratorPubkeys
-      .where((pubkey) => !pubkeysEqual(pubkey, creatorPubkey))
-      .toSet();
 }

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -10,6 +10,7 @@ import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
 import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
+import 'package:nostr_sdk/nip19/pubkeys_equal.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/exceptions/video_exceptions.dart';
@@ -341,6 +342,10 @@ class VideoPublishService {
         return const PublishError(PublishErrorKind.notSignedIn);
       }
       final pubkey = authService.currentPublicKeyHex!;
+      final collaboratorPubkeys = _withoutSelfCollaborator(
+        draft.collaboratorPubkeys,
+        pubkey,
+      );
 
       // Use existing upload if available, otherwise start new upload
       final pendingUpload = await timeline.measure(
@@ -389,7 +394,11 @@ class VideoPublishService {
 
       final mentionedPubkeys = await timeline.measure(
         PublishPhases.mentions,
-        () => _resolveMentionedPubkeys(draft, currentUserPubkey: pubkey),
+        () => _resolveMentionedPubkeys(
+          draft,
+          currentUserPubkey: pubkey,
+          collaboratorPubkeys: collaboratorPubkeys,
+        ),
       );
 
       final captionTrack = _captionTrackForPublish(draft);
@@ -415,7 +424,7 @@ class VideoPublishService {
                     draft.expireTime!.inSeconds
               : null,
           allowAudioReuse: draft.allowAudioReuse,
-          collaboratorPubkeys: draft.collaboratorPubkeys.toList(),
+          collaboratorPubkeys: collaboratorPubkeys.toList(),
           mentionedPubkeys: mentionedPubkeys,
           inspiredByAddressableId: draft.inspiredByVideo?.addressableId,
           inspiredByRelayUrl: draft.inspiredByVideo?.relayUrl,
@@ -459,6 +468,7 @@ class VideoPublishService {
           draft: draft,
           upload: pendingUpload,
           creatorPubkey: pubkey,
+          collaboratorPubkeys: collaboratorPubkeys,
         ),
       );
 
@@ -584,6 +594,7 @@ class VideoPublishService {
   Future<List<String>> _resolveMentionedPubkeys(
     DivineVideoDraft draft, {
     required String currentUserPubkey,
+    required Set<String> collaboratorPubkeys,
   }) async {
     final resolver = mentionResolutionService;
     if (resolver == null) return const [];
@@ -598,7 +609,7 @@ class VideoPublishService {
       );
       return _excludeCollaboratorPubkeys(
         result.resolvedPubkeys,
-        draft.collaboratorPubkeys,
+        collaboratorPubkeys,
       );
     } catch (error) {
       Log.warning(
@@ -613,11 +624,12 @@ class VideoPublishService {
     required DivineVideoDraft draft,
     required PendingUpload upload,
     required String creatorPubkey,
+    required Set<String> collaboratorPubkeys,
   }) async {
     final inviteService = collaboratorInviteService;
     final videoId = upload.videoId;
     if (inviteService == null ||
-        draft.collaboratorPubkeys.isEmpty ||
+        collaboratorPubkeys.isEmpty ||
         videoId == null ||
         videoId.isEmpty) {
       return const [];
@@ -630,7 +642,7 @@ class VideoPublishService {
 
     try {
       final result = await inviteService.sendInvites(
-        collaboratorPubkeys: draft.collaboratorPubkeys,
+        collaboratorPubkeys: collaboratorPubkeys,
         creatorPubkey: creatorPubkey,
         videoAddress: videoAddress,
         title: draft.title,
@@ -672,7 +684,7 @@ class VideoPublishService {
         '(creator=${pubkeyForLogs(creatorPubkey)}): $e\n$stackTrace',
         category: .video,
       );
-      return draft.collaboratorPubkeys
+      return collaboratorPubkeys
           .map(
             (pubkey) => CollaboratorInviteWarning(
               collaboratorPubkey: pubkey,
@@ -1269,4 +1281,18 @@ List<String> _excludeCollaboratorPubkeys(
   }
 
   return result;
+}
+
+Set<String> _withoutSelfCollaborator(
+  Set<String> collaboratorPubkeys,
+  String creatorPubkey,
+) {
+  if (!collaboratorPubkeys.any(
+    (pubkey) => pubkeysEqual(pubkey, creatorPubkey),
+  )) {
+    return collaboratorPubkeys;
+  }
+  return collaboratorPubkeys
+      .where((pubkey) => !pubkeysEqual(pubkey, creatorPubkey))
+      .toSet();
 }

--- a/mobile/lib/utils/public_identifier_normalizer.dart
+++ b/mobile/lib/utils/public_identifier_normalizer.dart
@@ -83,6 +83,22 @@ String? normalizeToHex(String identifier, {String? currentUserHex}) {
   )?.hexPubkey;
 }
 
+/// Returns [identifiers] without values that resolve to [excludedIdentifier].
+///
+/// Surviving values retain their original representation. Invalid values are
+/// preserved so callers can apply their own boundary-validation policy.
+Set<String> withoutPublicIdentifier(
+  Iterable<String> identifiers,
+  String excludedIdentifier,
+) {
+  final excludedHex = normalizeToHex(excludedIdentifier);
+  if (excludedHex == null) return identifiers.toSet();
+
+  return identifiers
+      .where((identifier) => normalizeToHex(identifier) != excludedHex)
+      .toSet();
+}
+
 /// Normalize to npub format
 ///
 /// Returns null if invalid

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -30,6 +30,7 @@ import 'package:openvine/services/native_proofmode_service.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/video_editor/video_editor_audio_render.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/video_editor/sticker_editor/video_editor_sticker.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
@@ -38,6 +39,7 @@ import 'package:pro_image_editor/pro_image_editor.dart'
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../helpers/test_provider_overrides.dart';
 import '../mocks/mock_path_provider_platform.dart';
 
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
@@ -2065,6 +2067,7 @@ void main() {
       late Directory tempDir;
       late String clipVideoPath;
       late String clipThumbnailPath;
+      late MockAuthService mockAuthService;
 
       setUpAll(() {
         registerFallbackValue(
@@ -2083,10 +2086,12 @@ void main() {
         SharedPreferences.setMockInitialValues({});
         final prefs = await SharedPreferences.getInstance();
         mockDraftStorage = _MockDraftStorageService();
+        mockAuthService = createMockAuthService();
         container = ProviderContainer(
           overrides: [
             sharedPreferencesProvider.overrideWithValue(prefs),
             draftStorageServiceProvider.overrideWithValue(mockDraftStorage),
+            authServiceProvider.overrideWithValue(mockAuthService),
           ],
         );
         // A restorable clip must point at media that actually exists on disk;
@@ -2144,6 +2149,55 @@ void main() {
           () => mockDraftStorage.getDraftById(VideoEditorConstants.autoSaveId),
         ).called(1);
       });
+
+      test(
+        'removes the signed-in creator from restored collaborator state',
+        () async {
+          const creatorPubkey =
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+          const collaboratorPubkey =
+              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+          when(
+            () => mockAuthService.currentPublicKeyHex,
+          ).thenReturn(creatorPubkey);
+          final draft = DivineVideoDraft.create(
+            id: 'draft-1',
+            clips: [
+              DivineVideoClip(
+                id: 'present',
+                video: EditorVideo.file(clipVideoPath),
+                thumbnailPath: clipThumbnailPath,
+                duration: const Duration(seconds: 3),
+                recordedAt: DateTime.now(),
+                targetAspectRatio: .vertical,
+                originalAspectRatio: 9 / 16,
+              ),
+            ],
+            title: 'Title',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'video',
+            collaboratorPubkeys: {
+              creatorPubkey.toUpperCase(),
+              NostrKeyUtils.encodePubKey(creatorPubkey),
+              collaboratorPubkey,
+            },
+          );
+          when(
+            () => mockDraftStorage.getDraftById('draft-1'),
+          ).thenAnswer((_) async => draft);
+
+          final result = await container
+              .read(videoEditorProvider.notifier)
+              .restoreDraft('draft-1');
+
+          expect(result, isTrue);
+          expect(
+            container.read(videoEditorProvider).collaboratorPubkeys,
+            {collaboratorPubkey},
+          );
+        },
+      );
 
       test(
         'drops clips whose source video file is missing on restore',

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -1175,6 +1175,95 @@ void main() {
         ).called(1);
       });
 
+      test(
+        'excludes a restored self-collaborator from publishing and invites',
+        () async {
+          const creatorPubkey =
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+          const collaboratorPubkey =
+              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+          _setupSuccessfulPublish(
+            mockAuthService: mockAuthService,
+            mockUploadManager: mockUploadManager,
+            mockDraftService: mockDraftService,
+            mockVideoEventPublisher: mockVideoEventPublisher,
+          );
+          when(
+            () => mockAuthService.currentPublicKeyHex,
+          ).thenReturn(creatorPubkey);
+          when(
+            () => mockCollaboratorInviteService.sendInvites(
+              collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
+              creatorPubkey: any(named: 'creatorPubkey'),
+              videoAddress: any(named: 'videoAddress'),
+              title: any(named: 'title'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              relayHint: any(named: 'relayHint'),
+            ),
+          ).thenAnswer(
+            (_) async => const CollaboratorInviteBatchResult(results: {}),
+          );
+          final draft = _createTestDraft(
+            collaboratorPubkeys: {
+              creatorPubkey.toUpperCase(),
+              collaboratorPubkey,
+            },
+          );
+
+          final result = await service.publishVideo(draft: draft);
+
+          expect(result, isA<PublishSuccess>());
+          final publishedCollaborators =
+              verify(
+                    () => mockVideoEventPublisher.publishVideoEvent(
+                      upload: any(named: 'upload'),
+                      title: any(named: 'title'),
+                      description: any(named: 'description'),
+                      hashtags: any(named: 'hashtags'),
+                      expirationTimestamp: any(named: 'expirationTimestamp'),
+                      allowAudioReuse: any(named: 'allowAudioReuse'),
+                      collaboratorPubkeys: captureAny(
+                        named: 'collaboratorPubkeys',
+                      ),
+                      mentionedPubkeys: any(named: 'mentionedPubkeys'),
+                      inspiredByAddressableId: any(
+                        named: 'inspiredByAddressableId',
+                      ),
+                      inspiredByRelayUrl: any(named: 'inspiredByRelayUrl'),
+                      inspiredByNpub: any(named: 'inspiredByNpub'),
+                      clipSourceCredits: any(named: 'clipSourceCredits'),
+                      selectedAudio: any(named: 'selectedAudio'),
+                      selectedAudioEventId: any(named: 'selectedAudioEventId'),
+                      selectedAudioRelay: any(named: 'selectedAudioRelay'),
+                      language: any(named: 'language'),
+                      contentWarning: any(named: 'contentWarning'),
+                      thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
+                      replyContext: any(named: 'replyContext'),
+                      addReplyToFeed: any(named: 'addReplyToFeed'),
+                      onEventSigned: any(named: 'onEventSigned'),
+                      onAudioReuseDegraded: any(named: 'onAudioReuseDegraded'),
+                    ),
+                  ).captured.single
+                  as List<String>;
+          final invitedCollaborators =
+              verify(
+                    () => mockCollaboratorInviteService.sendInvites(
+                      collaboratorPubkeys: captureAny(
+                        named: 'collaboratorPubkeys',
+                      ),
+                      creatorPubkey: creatorPubkey,
+                      videoAddress: any(named: 'videoAddress'),
+                      title: any(named: 'title'),
+                      thumbnailUrl: any(named: 'thumbnailUrl'),
+                      relayHint: any(named: 'relayHint'),
+                    ),
+                  ).captured.single
+                  as Iterable<String>;
+          expect(publishedCollaborators, [collaboratorPubkey]);
+          expect(invitedCollaborators, [collaboratorPubkey]);
+        },
+      );
+
       test('collaborator invites include the uploaded thumbnail URL', () async {
         const thumbnailUrl = 'https://cdn.divine.video/thumbs/test_video.jpg';
         final readyUpload = _createPendingUpload(

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -27,6 +27,7 @@ import 'package:openvine/services/video_publish/draft_upload_materializer.dart';
 import 'package:openvine/services/video_publish/publish_error_kind.dart';
 import 'package:openvine/services/video_publish/publish_timeline.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -1206,6 +1207,7 @@ void main() {
           final draft = _createTestDraft(
             collaboratorPubkeys: {
               creatorPubkey.toUpperCase(),
+              NostrKeyUtils.encodePubKey(creatorPubkey),
               collaboratorPubkey,
             },
           );

--- a/mobile/test/utils/public_identifier_normalizer_test.dart
+++ b/mobile/test/utils/public_identifier_normalizer_test.dart
@@ -1,5 +1,6 @@
 // ABOUTME: Pins that normalizeToHex canonicalizes hex casing so every
-// ABOUTME: consumer agrees on identity regardless of deep-link encoding
+// ABOUTME: consumer agrees on identity regardless of deep-link encoding, and
+// ABOUTME: that withoutPublicIdentifier excludes by resolved hex, not by text
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
@@ -24,6 +25,75 @@ void main() {
 
     test('decodes an npub to the same canonical hex', () {
       expect(normalizeToHex(NostrKeyUtils.encodePubKey(selfHex)), selfHex);
+    });
+  });
+
+  group('withoutPublicIdentifier', () {
+    const otherHex =
+        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+    // A draft written before the collaborator picker excluded the viewer can
+    // hold the creator in any encoding it was saved with, so exclusion has to
+    // resolve both sides rather than compare the stored text.
+    test('removes an entry stored in a different encoding', () {
+      expect(
+        withoutPublicIdentifier({
+          selfHex,
+          selfHex.toUpperCase(),
+          NostrKeyUtils.encodePubKey(selfHex),
+          otherHex,
+        }, selfHex),
+        {otherHex},
+      );
+    });
+
+    test('resolves an npub passed as the excluded identifier', () {
+      expect(
+        withoutPublicIdentifier({
+          selfHex,
+          otherHex,
+        }, NostrKeyUtils.encodePubKey(selfHex)),
+        {otherHex},
+      );
+    });
+
+    test('leaves surviving entries in their original representation', () {
+      final npub = NostrKeyUtils.encodePubKey(otherHex);
+      expect(withoutPublicIdentifier({npub}, selfHex), {npub});
+    });
+
+    // restoreFromDraft passes `currentPublicKeyHex ?? ''`, so a draft restored
+    // while signed out must keep every collaborator rather than drop them all.
+    test('keeps every entry when the excluded identifier is empty', () {
+      expect(withoutPublicIdentifier({selfHex, otherHex}, ''), {
+        selfHex,
+        otherHex,
+      });
+    });
+
+    test('keeps every entry when the excluded identifier is unresolvable', () {
+      expect(withoutPublicIdentifier({selfHex, otherHex}, 'not-a-pubkey'), {
+        selfHex,
+        otherHex,
+      });
+    });
+
+    // Boundary validation belongs to the caller, so an unresolvable entry
+    // survives instead of being silently dropped here.
+    test('preserves an entry that does not resolve to a pubkey', () {
+      expect(withoutPublicIdentifier({'not-a-pubkey', selfHex}, selfHex), {
+        'not-a-pubkey',
+      });
+    });
+
+    test('returns an empty set when every entry is the excluded identity', () {
+      expect(
+        withoutPublicIdentifier({
+          selfHex,
+          NostrKeyUtils.encodePubKey(selfHex),
+        }, selfHex),
+        isEmpty,
+      );
     });
   });
 }


### PR DESCRIPTION
## Problem

Video drafts saved before #8631 can retain the signed-in creator as a collaborator. Publishing one without reopening the collaborator picker can add a malformed self-collaborator p tag to the video event. That tag reaches the network and can notify the creator about their own video.

The invitation path also receives the stale identity, but DmRepository rejects the self-addressed NIP-17 message before sending it. The visible result is therefore a spurious refused-invite warning rather than a delivered self-invite.

## Why this fix

Draft restoration now removes the signed-in creator before collaborator state reaches the editor UI, so the stale identity is neither displayed nor counted toward the five-collaborator limit.

The publish service remains the final boundary for every restored draft, including drafts that never reopen the editor. Both boundaries compare canonical public keys, so legacy uppercase hex and npub representations are treated as the same identity. The publishing boundary passes one filtered set to mention reconciliation, event publishing, and invitation delivery. Valid collaborators remain unchanged.

## Out of scope

This does not rewrite saved draft data or change collaborator selection behavior; #8631 owns picker filtering. Restoration and publishing reject stale legacy state without mutating the stored draft.

## Verification

- Regression cases failed before the fixes:
  - an npub representation of the creator reached event publishing and invitation delivery
  - restored editor state displayed and counted uppercase-hex and npub representations of the creator
- dart format --output=none --set-exit-if-changed lib test integration_test tools
- flutter analyze lib test integration_test tools
- flutter test test/services/video_publish/video_publish_service_test.dart test/providers/video_editor_provider_test.dart
- Pre-push changed-file analysis and tests, including test/utils/public_identifier_normalizer_test.dart

Closes #8644