### PR TITLE
fix(collabs): prevent malformed collaborator keys from reaching video events

### DIFF
--- a/mobile/lib/services/video_metadata_update_service.dart
+++ b/mobile/lib/services/video_metadata_update_service.dart
@@ -18,6 +18,7 @@ import 'package:openvine/services/video_event_tag_source.dart';
 import 'package:openvine/utils/collaborator_tags.dart';
 import 'package:openvine/utils/inspired_by_tags.dart';
 import 'package:openvine/utils/nostr_replacement_timestamp.dart';
+import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Result returned by [VideoMetadataUpdateService.updateVideo].
@@ -179,8 +180,15 @@ sendPostPublishCollaboratorInvites({
   required Iterable<String> updatedCollaboratorPubkeys,
   String relayHint = collaboratorInviteRelayHint,
 }) async {
-  final previous = previousCollaboratorPubkeys.toSet();
-  final newCollaborators = updatedCollaboratorPubkeys
+  final previous = canonicalCollaboratorPubkeys(
+    identifiers: previousCollaboratorPubkeys,
+    creatorIdentifier: video.pubkey,
+  );
+  final updated = canonicalCollaboratorPubkeys(
+    identifiers: updatedCollaboratorPubkeys,
+    creatorIdentifier: video.pubkey,
+  );
+  final newCollaborators = updated
       .where((pubkey) => !previous.contains(pubkey))
       .toSet();
   if (newCollaborators.isEmpty) return const {};
@@ -276,14 +284,18 @@ class VideoMetadataUpdateService {
       // A pubkey promoted from a plain mention to a collaborator in this
       // edit changes role: drop its stale 'mention' p-tag so it is not
       // double-listed alongside the rebuilt 'collaborator' p-tag.
-      final collaboratorPubkeys = editorState.collaboratorPubkeys
-          .map((pubkey) => pubkey.toLowerCase())
-          .toSet();
-      bool isPromotedMentionPTag(List<String> tag) =>
-          tag.length >= 4 &&
-          tag.first == 'p' &&
-          tag[3].toLowerCase() == 'mention' &&
-          collaboratorPubkeys.contains(tag[1].toLowerCase());
+      final collaboratorPubkeys = canonicalCollaboratorPubkeys(
+        identifiers: editorState.collaboratorPubkeys,
+        creatorIdentifier: _authService.currentPublicKeyHex,
+      );
+      bool isPromotedMentionPTag(List<String> tag) {
+        if (tag.length < 4 ||
+            tag.first != 'p' ||
+            tag[3].toLowerCase() != 'mention') {
+          return false;
+        }
+        return collaboratorPubkeys.contains(normalizeToHex(tag[1].trim()));
+      }
 
       // Preserve every tag the edit flow does not own; the owned ones are
       // rebuilt from the editor state below.
@@ -387,9 +399,7 @@ class VideoMetadataUpdateService {
         tags.add(['alt', originalVideo.altText!]);
       }
 
-      for (final pubkey in editorState.collaboratorPubkeys) {
-        tags.add(buildCollaboratorPTag(pubkey));
-      }
+      tags.addAll(buildCollaboratorPTags(collaboratorPubkeys));
 
       // The parser exposes an unmarked lowercase reply-root a-tag through
       // inspiredByVideo too. Do not turn that parent reference into creator
@@ -475,7 +485,7 @@ class VideoMetadataUpdateService {
       final inviteFailureCount = await _sendCollaboratorInvites(
         video: updatedVideoEvent,
         initialCollaboratorPubkeys: initialCollaboratorPubkeys,
-        updatedCollaboratorPubkeys: editorState.collaboratorPubkeys,
+        updatedCollaboratorPubkeys: collaboratorPubkeys,
       );
 
       return VideoUpdateSuccess(

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -29,6 +29,7 @@ import 'package:openvine/services/video_event_publisher.dart';
 import 'package:openvine/services/video_publish/draft_upload_materializer.dart';
 import 'package:openvine/services/video_publish/publish_error_kind.dart';
 import 'package:openvine/services/video_publish/publish_timeline.dart';
+import 'package:openvine/utils/collaborator_tags.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -341,9 +342,9 @@ class VideoPublishService {
         return const PublishError(PublishErrorKind.notSignedIn);
       }
       final pubkey = authService.currentPublicKeyHex!;
-      final collaboratorPubkeys = withoutPublicIdentifier(
-        draft.collaboratorPubkeys,
-        pubkey,
+      final collaboratorPubkeys = canonicalCollaboratorPubkeys(
+        identifiers: draft.collaboratorPubkeys,
+        creatorIdentifier: pubkey,
       );
 
       // Use existing upload if available, otherwise start new upload

--- a/mobile/lib/utils/collaborator_tags.dart
+++ b/mobile/lib/utils/collaborator_tags.dart
@@ -2,25 +2,57 @@
 // ABOUTME: direct-upload and edit-video publish paths.
 
 import 'package:models/models.dart' show NostrHexUtils;
+import 'package:openvine/utils/public_identifier_normalizer.dart';
 
 /// Default relay hint embedded in Divine collaborator p-tags.
 const collaboratorInviteRelayHint = 'wss://relay.divine.video';
 
-/// Builds the Divine collaborator-marked `p` tag for [pubkey].
-List<String> buildCollaboratorPTag(String pubkey) => [
-  'p',
-  pubkey,
-  collaboratorInviteRelayHint,
-  'collaborator',
-];
+/// Resolves collaborator identifiers to canonical lowercase-hex pubkeys.
+///
+/// Invalid identifiers are omitted. The creator is excluded after
+/// canonicalization, and duplicate representations retain input order.
+Set<String> canonicalCollaboratorPubkeys({
+  required Iterable<String> identifiers,
+  String? creatorIdentifier,
+}) {
+  final creatorPubkey = creatorIdentifier == null
+      ? null
+      : normalizeToHex(creatorIdentifier.trim());
+  final pubkeys = <String>{};
+
+  for (final identifier in identifiers) {
+    final pubkey = normalizeToHex(identifier.trim());
+    if (pubkey == null ||
+        !NostrHexUtils.isValidPubkey(pubkey) ||
+        pubkey == creatorPubkey) {
+      continue;
+    }
+    pubkeys.add(pubkey);
+  }
+
+  return pubkeys;
+}
+
+/// Builds the Divine collaborator-marked `p` tag for [identifier].
+///
+/// Throws when [identifier] cannot resolve to a valid public key. Publishing
+/// callers with untrusted collections should use [buildCollaboratorPTags],
+/// which omits invalid values.
+List<String> buildCollaboratorPTag(String identifier) {
+  final pubkey = normalizeToHex(identifier.trim());
+  if (pubkey == null || !NostrHexUtils.isValidPubkey(pubkey)) {
+    throw ArgumentError.value(identifier, 'identifier', 'Invalid pubkey');
+  }
+  return ['p', pubkey, collaboratorInviteRelayHint, 'collaborator'];
+}
 
 /// Builds Divine collaborator-marked `p` tags for each [pubkey].
 ///
-/// Equivalent to `pubkeys.map(buildCollaboratorPTag).toList()`. Accepts any
-/// [Iterable] so callers can pass a `List`, a `Set`, or another iterable
-/// without converting.
-List<List<String>> buildCollaboratorPTags(Iterable<String> pubkeys) => [
-  for (final pubkey in pubkeys) buildCollaboratorPTag(pubkey),
+/// Invalid identifiers are omitted and equivalent representations are
+/// deduplicated. Accepts any [Iterable] so callers need not convert first.
+List<List<String>> buildCollaboratorPTags(Iterable<String> identifiers) => [
+  for (final pubkey in canonicalCollaboratorPubkeys(identifiers: identifiers))
+    buildCollaboratorPTag(pubkey),
 ];
 
 List<List<String>> buildMentionPTags(

--- a/mobile/test/services/video_event_publisher_collaborator_tags_test.dart
+++ b/mobile/test/services/video_event_publisher_collaborator_tags_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_event_publisher.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/utils/collaborator_tags.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 
 class _MockUploadManager extends Mock implements UploadManager {}
 
@@ -262,5 +263,24 @@ void main() {
         );
       },
     );
+
+    test('emits only canonical collaborator p-tags', () async {
+      stubSignAndPublish();
+
+      final result = await publisher.publishDirectUpload(
+        createUpload(),
+        collaboratorPubkeys: [
+          collaboratorPubkey.toUpperCase(),
+          NostrKeyUtils.encodePubKey(collaboratorPubkey),
+          'not-a-pubkey',
+        ],
+      );
+
+      expect(result, isTrue);
+      final collaboratorTags = capturedTags
+          .where((tag) => tag.length >= 4 && tag[3] == 'collaborator')
+          .toList();
+      expect(collaboratorTags, [buildCollaboratorPTag(collaboratorPubkey)]);
+    });
   });
 }

--- a/mobile/test/services/video_metadata_update_service_test.dart
+++ b/mobile/test/services/video_metadata_update_service_test.dart
@@ -897,6 +897,90 @@ void main() {
         );
       });
 
+      test(
+        'canonicalizes collaborator tags and invite recipients',
+        () async {
+          const collaborator =
+              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+          when(
+            () => mockDmRepository.sendMessage(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+              additionalTags: any(named: 'additionalTags'),
+              skipNip04Fallback: any(named: 'skipNip04Fallback'),
+            ),
+          ).thenAnswer(
+            (_) async => NIP17SendResult.success(
+              rumorEventId: 'rumor-id',
+              messageEventId: 'invite-id',
+              recipientPubkey: collaborator,
+            ),
+          );
+
+          final result = await service.updateVideo(
+            originalVideo: _testVideo(),
+            editorState: VideoEditorProviderState(
+              collaboratorPubkeys: {
+                collaborator.toUpperCase(),
+                NostrKeyUtils.encodePubKey(collaborator),
+                NostrKeyUtils.encodePubKey(_ownerPubkey),
+                'not-a-pubkey',
+              },
+            ),
+            initialCollaboratorPubkeys: const {},
+          );
+
+          expect(result, isA<VideoUpdateSuccess>());
+          final collaboratorTags = capturedTags
+              .where((tag) => tag.length >= 4 && tag[3] == 'collaborator')
+              .toList();
+          expect(
+            collaboratorTags,
+            [
+              [
+                'p',
+                collaborator,
+                'wss://relay.divine.video',
+                'collaborator',
+              ],
+            ],
+          );
+          verify(
+            () => mockDmRepository.sendMessage(
+              recipientPubkey: collaborator,
+              content: any(named: 'content'),
+              additionalTags: any(named: 'additionalTags'),
+              skipNip04Fallback: true,
+            ),
+          ).called(1);
+        },
+      );
+
+      test('compares existing collaborators in canonical form', () async {
+        const collaborator =
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+        final result = await service.updateVideo(
+          originalVideo: _testVideo(),
+          editorState: VideoEditorProviderState(
+            collaboratorPubkeys: {collaborator.toUpperCase()},
+          ),
+          initialCollaboratorPubkeys: {
+            NostrKeyUtils.encodePubKey(collaborator),
+          },
+        );
+
+        expect(result, isA<VideoUpdateSuccess>());
+        verifyNever(
+          () => mockDmRepository.sendMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: any(named: 'content'),
+            additionalTags: any(named: 'additionalTags'),
+            skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          ),
+        );
+      });
+
       test('replaces the inspired-by a-tag without duplicating it', () async {
         final video = _testVideo(
           extraTags: const [
@@ -1111,15 +1195,20 @@ void main() {
           const promoted =
               '1111111111111111111111111111111111111111111111111111111111111111';
           final video = _testVideo(
-            extraTags: const [
-              ['p', promoted, 'wss://relay.divine.video', 'mention'],
+            extraTags: [
+              [
+                'p',
+                NostrKeyUtils.encodePubKey(promoted),
+                'wss://relay.divine.video',
+                'mention',
+              ],
             ],
           );
 
           final result = await service.updateVideo(
             originalVideo: video,
             editorState: VideoEditorProviderState(
-              collaboratorPubkeys: {promoted},
+              collaboratorPubkeys: {promoted.toUpperCase()},
             ),
             // Already known as a collaborator so no invite DM is attempted.
             initialCollaboratorPubkeys: const {promoted},

--- a/mobile/test/services/video_metadata_update_service_test.dart
+++ b/mobile/test/services/video_metadata_update_service_test.dart
@@ -1215,10 +1215,16 @@ void main() {
           );
 
           expect(result, isA<VideoUpdateSuccess>());
+          // The stale tag carries the npub, so a filter keyed on the hex
+          // cannot see it and a preserved 'mention' tag would go unnoticed.
+          // Match either representation so the count catches a double-listing.
+          final promotedNpub = NostrKeyUtils.encodePubKey(promoted);
           final pTagsForPromoted = capturedTags
               .where(
                 (tag) =>
-                    tag.length >= 2 && tag.first == 'p' && tag[1] == promoted,
+                    tag.length >= 2 &&
+                    tag.first == 'p' &&
+                    (tag[1] == promoted || tag[1] == promotedNpub),
               )
               .toList();
           expect(pTagsForPromoted, hasLength(1));

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -1208,7 +1208,9 @@ void main() {
             collaboratorPubkeys: {
               creatorPubkey.toUpperCase(),
               NostrKeyUtils.encodePubKey(creatorPubkey),
-              collaboratorPubkey,
+              collaboratorPubkey.toUpperCase(),
+              NostrKeyUtils.encodePubKey(collaboratorPubkey),
+              'not-a-pubkey',
             },
           );
 

--- a/mobile/test/utils/collaborator_tags_test.dart
+++ b/mobile/test/utils/collaborator_tags_test.dart
@@ -48,6 +48,21 @@ void main() {
 
       expect(result, <String>{pubkeyB, pubkeyC});
     });
+
+    test('keeps the first occurrence of each pubkey in input order', () {
+      // Set equality ignores order, so assert over an ordered list with input
+      // order deliberately unsorted — otherwise a sorting implementation would
+      // satisfy the documented guarantee's tests without honouring it.
+      final result = canonicalCollaboratorPubkeys(
+        identifiers: [
+          pubkeyC,
+          pubkeyB,
+          NostrKeyUtils.encodePubKey(pubkeyC),
+        ],
+      );
+
+      expect(result.toList(), <String>[pubkeyC, pubkeyB]);
+    });
   });
 
   group('buildCollaboratorPTags', () {

--- a/mobile/test/utils/collaborator_tags_test.dart
+++ b/mobile/test/utils/collaborator_tags_test.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/utils/collaborator_tags.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 
 void main() {
   final pubkeyA = 'a' * 64;
@@ -18,6 +19,35 @@ void main() {
         );
       },
     );
+
+    test('canonicalizes supported identifiers and rejects invalid input', () {
+      expect(buildCollaboratorPTag(pubkeyA.toUpperCase())[1], pubkeyA);
+      expect(
+        buildCollaboratorPTag(NostrKeyUtils.encodePubKey(pubkeyA))[1],
+        pubkeyA,
+      );
+      expect(
+        () => buildCollaboratorPTag('not-a-pubkey'),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('canonicalCollaboratorPubkeys', () {
+    test('normalizes, filters, excludes, and deduplicates in input order', () {
+      final result = canonicalCollaboratorPubkeys(
+        identifiers: [
+          '  ${pubkeyB.toUpperCase()}  ',
+          NostrKeyUtils.encodePubKey(pubkeyB),
+          'not-a-pubkey',
+          NostrKeyUtils.encodePubKey(pubkeyA),
+          pubkeyC,
+        ],
+        creatorIdentifier: pubkeyA.toUpperCase(),
+      );
+
+      expect(result, <String>{pubkeyB, pubkeyC});
+    });
   });
 
   group('buildCollaboratorPTags', () {
@@ -49,6 +79,20 @@ void main() {
           ),
         ),
       );
+    });
+
+    test('emits only canonical valid pubkeys', () {
+      final result = buildCollaboratorPTags([
+        pubkeyA.toUpperCase(),
+        NostrKeyUtils.encodePubKey(pubkeyA),
+        'not-a-pubkey',
+        pubkeyB,
+      ]);
+
+      expect(result, [
+        buildCollaboratorPTag(pubkeyA),
+        buildCollaboratorPTag(pubkeyB),
+      ]);
     });
   });
 }


### PR DESCRIPTION
Saved or externally produced collaborator state can contain npub, mixed-case hex, duplicate representations, or invalid values. Those values previously flowed into signed video-event p tags and collaborator invitations without one shared publishing boundary.

This change canonicalizes collaborator identifiers to valid lowercase hexadecimal public keys before either direct publishing or metadata republishing. The same ordered set now drives mention reconciliation, event tags, invite delivery, and warning reporting. The edit path also canonicalizes its previous-versus-updated comparison, preventing representation-only changes from sending duplicate invitations, and resolves promoted mention tags before comparing them.

Invalid identifiers are dropped so one stale collaborator does not block an otherwise valid publish. Event parsing remains unchanged; this PR hardens the publishing boundaries and tag builder only.

Verification:
- Focused collaborator utility, direct-publish, event-publisher, metadata-update, and neighboring share-menu tests
- flutter analyze
- Repository pre-push checks

Closes #8648