### PR TITLE
ci(e2e): ensure iOS tests run against the newly built app

### DIFF
--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -101,8 +101,25 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
             'simctl get_app_container "$MAESTRO_DEVICE_UDID" "$BUNDLE_ID"',
             install,
         )
+        self.assertIn('if [ -n "${MAESTRO_DEVICE_UDID:-}" ]; then', maestro)
         self.assertIn('set -- --device "$MAESTRO_DEVICE_UDID"', maestro)
         self.assertIn('maestro "$@" test', maestro)
+
+        workflow = self._workflow_block("e2e-smoke-ios")
+        for step in (
+            "- *boot_ios_simulator",
+            "- *install_app_ios_simulator",
+            "- *run_maestro_smoke_tests",
+        ):
+            self.assertIn(step, workflow)
+        self.assertLess(
+            workflow.index("- *boot_ios_simulator"),
+            workflow.index("- *install_app_ios_simulator"),
+        )
+        self.assertLess(
+            workflow.index("- *install_app_ios_simulator"),
+            workflow.index("- *run_maestro_smoke_tests"),
+        )
 
     def test_android_e2e_excludes_unbounded_maestro_artifacts(self) -> None:
         workflow = self._workflow_block("e2e-smoke-android")

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -80,6 +80,7 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         boot = self._definition_block("boot_ios_simulator")
         install = self._definition_block("install_app_ios_simulator")
         maestro = self._definition_block("run_maestro_smoke_tests")
+        build = self._definition_block("build_ios_e2e")
 
         self.assertIn(
             'echo "MAESTRO_DEVICE_UDID=$DEVICE_UDID" >> "$CM_ENV"',
@@ -104,6 +105,15 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         self.assertIn('if [ -n "${MAESTRO_DEVICE_UDID:-}" ]; then', maestro)
         self.assertIn('set -- --device "$MAESTRO_DEVICE_UDID"', maestro)
         self.assertIn('maestro "$@" test', maestro)
+        self.assertIn(
+            'phase.name == "[firebase_crashlytics] Crashlytics Upload Symbols"',
+            build,
+        )
+        self.assertIn("phase.remove_from_project", build)
+        self.assertLess(
+            build.index("phase.remove_from_project"),
+            build.index("flutter build ios --simulator"),
+        )
 
         workflow = self._workflow_block("e2e-smoke-ios")
         self.assertIn("BUNDLE_ID: co.openvine.app.staging", workflow)

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -131,6 +131,7 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
     def test_android_e2e_excludes_unbounded_maestro_artifacts(self) -> None:
         workflow = self._workflow_block("e2e-smoke-android")
 
+        self.assertIn("BUNDLE_ID: co.openvine.app.staging", workflow)
         self.assertNotIn("- ~/.maestro/tests/**\n", workflow)
         for artifact in (
             "screenshots/**",

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -122,6 +122,12 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
             workflow.index("- *run_maestro_smoke_tests"),
         )
 
+    def test_pod_install_only_targets_the_app_workspace(self) -> None:
+        pod_install = self._definition_block("pod_install")
+
+        self.assertIn("pod install --project-directory=ios", pod_install)
+        self.assertNotIn("find ", pod_install)
+
     def test_android_e2e_excludes_unbounded_maestro_artifacts(self) -> None:
         workflow = self._workflow_block("e2e-smoke-android")
 

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -106,6 +106,7 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         self.assertIn('maestro "$@" test', maestro)
 
         workflow = self._workflow_block("e2e-smoke-ios")
+        self.assertIn("BUNDLE_ID: co.openvine.app.staging", workflow)
         for step in (
             "- *boot_ios_simulator",
             "- *install_app_ios_simulator",

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -74,6 +74,48 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_ios_e2e_uses_one_simulator_for_boot_install_and_maestro(
+        self,
+    ) -> None:
+        boot = self._definition_block("boot_ios_simulator")
+        install = self._definition_block("install_app_ios_simulator")
+        maestro = self._definition_block("run_maestro_smoke_tests")
+
+        self.assertIn(
+            'echo "MAESTRO_DEVICE_UDID=$DEVICE_UDID" >> "$CM_ENV"',
+            boot,
+        )
+        self.assertIn(
+            (
+                ': "${MAESTRO_DEVICE_UDID:?The boot step did not export a '
+                'simulator UDID}"'
+            ),
+            install,
+        )
+        self.assertNotIn("simctl list devices booted", install)
+        self.assertIn(
+            'simctl install "$MAESTRO_DEVICE_UDID" "$APP_PATH"',
+            install,
+        )
+        self.assertIn(
+            'simctl get_app_container "$MAESTRO_DEVICE_UDID" "$BUNDLE_ID"',
+            install,
+        )
+        self.assertIn('set -- --device "$MAESTRO_DEVICE_UDID"', maestro)
+        self.assertIn('maestro "$@" test', maestro)
+
+    def test_android_e2e_excludes_unbounded_maestro_artifacts(self) -> None:
+        workflow = self._workflow_block("e2e-smoke-android")
+
+        self.assertNotIn("- ~/.maestro/tests/**\n", workflow)
+        for artifact in (
+            "screenshots/**",
+            "screen-hierarchy/**",
+            "logs/maestro.log",
+            "commands.json",
+        ):
+            self.assertIn(f"- ~/.maestro/tests/**/{artifact}", workflow)
+
     def test_android_aab_build_uses_google_play_floor(self) -> None:
         self.assertIn(
             'google-play get-latest-build-number --package-name "co.openvine.app"',

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -80,7 +80,6 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         boot = self._definition_block("boot_ios_simulator")
         install = self._definition_block("install_app_ios_simulator")
         maestro = self._definition_block("run_maestro_smoke_tests")
-        build = self._definition_block("build_ios_e2e")
 
         self.assertIn(
             'echo "MAESTRO_DEVICE_UDID=$DEVICE_UDID" >> "$CM_ENV"',
@@ -105,51 +104,46 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         self.assertIn('if [ -n "${MAESTRO_DEVICE_UDID:-}" ]; then', maestro)
         self.assertIn('set -- --device "$MAESTRO_DEVICE_UDID"', maestro)
         self.assertIn('maestro "$@" test', maestro)
-        self.assertIn(
-            'phase.name == "[firebase_crashlytics] Crashlytics Upload Symbols"',
-            build,
-        )
-        self.assertIn("phase.remove_from_project", build)
-        self.assertLess(
-            build.index("phase.remove_from_project"),
-            build.index("flutter build ios --simulator"),
-        )
 
-        workflow = self._workflow_block("e2e-smoke-ios")
-        self.assertIn("BUNDLE_ID: co.openvine.app.staging", workflow)
-        for step in (
-            "- *boot_ios_simulator",
-            "- *install_app_ios_simulator",
-            "- *run_maestro_smoke_tests",
-        ):
-            self.assertIn(step, workflow)
+        workflow = self._resolved_config()["workflows"]["e2e-smoke-ios"]
+        self.assertEqual(
+            "co.openvine.app.staging",
+            workflow["environment"]["vars"]["BUNDLE_ID"],
+        )
+        step_names = [step["name"] for step in workflow["scripts"]]
         self.assertLess(
-            workflow.index("- *boot_ios_simulator"),
-            workflow.index("- *install_app_ios_simulator"),
+            step_names.index("Boot iOS Simulator"),
+            step_names.index("Install app on iOS Simulator"),
         )
         self.assertLess(
-            workflow.index("- *install_app_ios_simulator"),
-            workflow.index("- *run_maestro_smoke_tests"),
+            step_names.index("Install app on iOS Simulator"),
+            step_names.index("Run Maestro Smoke Tests"),
         )
 
     def test_pod_install_only_targets_the_app_workspace(self) -> None:
         pod_install = self._definition_block("pod_install")
 
-        self.assertIn("pod install --project-directory=ios", pod_install)
+        self.assertIn("cd ios && pod install", pod_install)
+        self.assertNotIn("--project-directory", pod_install)
         self.assertNotIn("find ", pod_install)
 
     def test_android_e2e_excludes_unbounded_maestro_artifacts(self) -> None:
-        workflow = self._workflow_block("e2e-smoke-android")
+        workflow = self._resolved_config()["workflows"]["e2e-smoke-android"]
 
-        self.assertIn("BUNDLE_ID: co.openvine.app.staging", workflow)
-        self.assertNotIn("- ~/.maestro/tests/**\n", workflow)
-        for artifact in (
-            "screenshots/**",
-            "screen-hierarchy/**",
-            "logs/maestro.log",
-            "commands.json",
-        ):
-            self.assertIn(f"- ~/.maestro/tests/**/{artifact}", workflow)
+        self.assertEqual(
+            "co.openvine.app.staging",
+            workflow["environment"]["vars"]["BUNDLE_ID"],
+        )
+        self.assertEqual(
+            [
+                "build/app/outputs/flutter-apk/app-debug.apk",
+                "~/.maestro/tests/**/screenshots/**",
+                "~/.maestro/tests/**/screen-hierarchy/**",
+                "~/.maestro/tests/**/logs/maestro.log",
+                "~/.maestro/tests/**/commands.json",
+            ],
+            workflow["artifacts"],
+        )
 
     def test_android_aab_build_uses_google_play_floor(self) -> None:
         self.assertIn(
@@ -367,21 +361,7 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         self.assertIn('"refs/heads/main:refs/remotes/origin/main"', step)
 
     def test_shorebird_workflows_define_every_variable_their_scripts_read(self) -> None:
-        resolved = json.loads(
-            subprocess.run(
-                [
-                    "ruby",
-                    "-ryaml",
-                    "-rjson",
-                    "-e",
-                    "print JSON.generate(YAML.safe_load(File.read(ARGV[0]), aliases: true))",
-                    str(CODEMAGIC_PATH),
-                ],
-                check=True,
-                text=True,
-                capture_output=True,
-            ).stdout
-        )
+        resolved = self._resolved_config()
 
         for name in ("ios-build", "android-build", "ios-patch", "android-patch"):
             workflow = resolved["workflows"][name]
@@ -600,6 +580,23 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         if next_definition is None:
             return self.contents[start:]
         return self.contents[start : start + 1 + next_definition.start()]
+
+    def _resolved_config(self) -> dict[str, object]:
+        return json.loads(
+            subprocess.run(
+                [
+                    "ruby",
+                    "-ryaml",
+                    "-rjson",
+                    "-e",
+                    "print JSON.generate(YAML.safe_load(File.read(ARGV[0]), aliases: true))",
+                    str(CODEMAGIC_PATH),
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+            ).stdout
+        )
 
     def _workflow_block(self, workflow_name: str) -> str:
         start = self.contents.index(f"  {workflow_name}:")

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1428,7 +1428,7 @@ workflows:
         - proofmode_credentials
       vars:
         DEFAULT_ENV: STAGING
-        BUNDLE_ID: co.openvine.app
+        BUNDLE_ID: co.openvine.app.staging
     cache:
       cache_paths:
         - $HOME/.gradle/caches

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -151,7 +151,7 @@ definitions:
       script: flutter pub get
     - &pod_install
       name: Run pod install
-      script: find . -name "Podfile" -execdir pod install \;
+      script: pod install --project-directory=ios
     - &precache_shorebird_android_artifacts
       name: Precache Shorebird Android engine artifacts
       script: |

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -151,7 +151,7 @@ definitions:
       script: flutter pub get
     - &pod_install
       name: Run pod install
-      script: pod install --project-directory=ios
+      script: cd ios && pod install
     - &precache_shorebird_android_artifacts
       name: Precache Shorebird Android engine artifacts
       script: |
@@ -734,25 +734,6 @@ definitions:
     - &build_ios_e2e
       name: Build iOS Simulator app
       script: |
-        # firebase_crashlytics injects a dSYM upload phase during pod install.
-        # Hybrid SPM/CocoaPods builds can point that phase at a nonexistent
-        # Pods/FirebaseCrashlytics tool. Simulator smoke tests do not produce
-        # release symbols, so remove the generated phase for this build only.
-        ruby <<'RUBY'
-        require 'xcodeproj'
-
-        project = Xcodeproj::Project.open('ios/Runner.xcodeproj')
-        runner = project.targets.find { |target| target.name == 'Runner' }
-        abort('Runner target not found') unless runner
-
-        phases = runner.shell_script_build_phases.select do |phase|
-          phase.name == "[firebase_crashlytics] Crashlytics Upload Symbols"
-        end
-        phases.each { |phase| phase.remove_from_project }
-        project.save if phases.any?
-        puts "Removed #{phases.length} Crashlytics upload phase(s) from simulator build"
-        RUBY
-
         flutter build ios --simulator \
           --dart-define=ZENDESK_APP_ID=$ZENDESK_APP_ID \
           --dart-define=ZENDESK_CLIENT_ID=$ZENDESK_CLIENT_ID \
@@ -1389,11 +1370,11 @@ workflows:
         - $HOME/Library/Caches/CocoaPods
         - $HOME/.pub-cache
     triggering:
-      # Runs on every PR to main. NOT a required check: per team decision it
-      # stays non-blocking until a flake baseline exists (target ≥30 runs at
-      # ≥95%). Note #7204 — a fixed 3m31s hierarchy stall on the Explore screen
-      # makes flows a coin flip, so a baseline collected before that is fixed
-      # measures the stall rather than the app.
+      # Configured for PRs to main, but #7504 tracks the inactive webhook that
+      # currently prevents automatic builds. NOT a required check: per team
+      # decision it stays non-blocking until a flake baseline exists (target
+      # ≥30 runs at ≥95%). #7204 records the fixed 3m31s Explore hierarchy
+      # stall; restoring the affected flows is tracked by #7619 and #7620.
       #
       # If PR builds do not fire after merge, check the GitHub webhook for the
       # Codemagic app before touching this YAML — a misconfigured webhook

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,5 +1,5 @@
 # ABOUTME: Codemagic CI/CD configuration for Divine mobile app builds.
-# ABOUTME: Store builds are manual. e2e-smoke-ios runs on PRs that touch mobile/.
+# ABOUTME: Store builds are manual. e2e-smoke-ios is configured for mobile PRs.
 
 # Steps to setup:
 # 1 - Create the Codemagic project with access to the repository.
@@ -787,7 +787,13 @@ definitions:
         # with no per-flow detail — so a failure says only "the suite failed"
         # and `test_report` cannot name the flow. Per-flow invocation yields one
         # <testcase> each, carrying name, file, timing and tags.
-        maestro test \
+        # The iOS boot step persists its selected simulator across Codemagic
+        # steps. Android leaves the variable unset and uses Maestro's default.
+        set --
+        if [ -n "${MAESTRO_DEVICE_UDID:-}" ]; then
+          set -- --device "$MAESTRO_DEVICE_UDID"
+        fi
+        maestro "$@" test \
           --format junit \
           --output report.xml \
           e2e/maestro/tests/loginFreshInstall.yaml \
@@ -837,6 +843,7 @@ definitions:
         xcrun simctl boot "$DEVICE_UDID" || true
         xcrun simctl bootstatus "$DEVICE_UDID" -b
         echo "Booted simulator: $DEVICE_UDID"
+        echo "MAESTRO_DEVICE_UDID=$DEVICE_UDID" >> "$CM_ENV"
 
         # Ask the simulator for reduced motion before the app is installed.
         #
@@ -855,21 +862,16 @@ definitions:
     - &install_app_ios_simulator
       name: Install app on iOS Simulator
       script: |
+        set -e
+        : "${MAESTRO_DEVICE_UDID:?The boot step did not export a simulator UDID}"
         APP_PATH="build/ios/iphonesimulator/Runner.app"
-        DEVICE_UDID=$(xcrun simctl list devices booted -j | \
-          python3 -c "
-        import json, sys
-        data = json.load(sys.stdin)
-        for runtime, devices in data['devices'].items():
-            for d in devices:
-                if d['state'] == 'Booted':
-                    print(d['udid'])
-                    sys.exit(0)
-        sys.exit(1)
-        ")
-        xcrun simctl uninstall "$DEVICE_UDID" "$BUNDLE_ID" 2>/dev/null || true
-        xcrun simctl install "$DEVICE_UDID" "$APP_PATH"
-        echo "App installed on iOS simulator: $DEVICE_UDID"
+        xcrun simctl uninstall "$MAESTRO_DEVICE_UDID" "$BUNDLE_ID" 2>/dev/null || true
+        xcrun simctl install "$MAESTRO_DEVICE_UDID" "$APP_PATH"
+        if ! xcrun simctl get_app_container "$MAESTRO_DEVICE_UDID" "$BUNDLE_ID" >/dev/null 2>&1; then
+          echo "ERROR: $BUNDLE_ID was not installed on $MAESTRO_DEVICE_UDID" >&2
+          exit 1
+        fi
+        echo "App installed and verified on iOS simulator: $MAESTRO_DEVICE_UDID"
     - &launch_android_emulator
       name: Launch Android emulator
       script: |
@@ -1445,4 +1447,7 @@ workflows:
       - *run_maestro_smoke_tests
     artifacts:
       - build/app/outputs/flutter-apk/app-debug.apk
-      - ~/.maestro/tests/**
+      - ~/.maestro/tests/**/screenshots/**
+      - ~/.maestro/tests/**/screen-hierarchy/**
+      - ~/.maestro/tests/**/logs/maestro.log
+      - ~/.maestro/tests/**/commands.json

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1364,7 +1364,7 @@ workflows:
         - proofmode_credentials
       vars:
         DEFAULT_ENV: STAGING
-        BUNDLE_ID: co.openvine.app
+        BUNDLE_ID: co.openvine.app.staging
     cache:
       cache_paths:
         - $HOME/Library/Caches/CocoaPods

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -734,6 +734,25 @@ definitions:
     - &build_ios_e2e
       name: Build iOS Simulator app
       script: |
+        # firebase_crashlytics injects a dSYM upload phase during pod install.
+        # Hybrid SPM/CocoaPods builds can point that phase at a nonexistent
+        # Pods/FirebaseCrashlytics tool. Simulator smoke tests do not produce
+        # release symbols, so remove the generated phase for this build only.
+        ruby <<'RUBY'
+        require 'xcodeproj'
+
+        project = Xcodeproj::Project.open('ios/Runner.xcodeproj')
+        runner = project.targets.find { |target| target.name == 'Runner' }
+        abort('Runner target not found') unless runner
+
+        phases = runner.shell_script_build_phases.select do |phase|
+          phase.name == "[firebase_crashlytics] Crashlytics Upload Symbols"
+        end
+        phases.each { |phase| phase.remove_from_project }
+        project.save if phases.any?
+        puts "Removed #{phases.length} Crashlytics upload phase(s) from simulator build"
+        RUBY
+
         flutter build ios --simulator \
           --dart-define=ZENDESK_APP_ID=$ZENDESK_APP_ID \
           --dart-define=ZENDESK_CLIENT_ID=$ZENDESK_CLIENT_ID \

--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -17,8 +17,11 @@ The full smoke suite is the manual target. The PR gate in Codemagic runs
 `tests/loginFreshInstall.yaml` and `tests/removeKeys.yaml` as individual files so the
 JUnit report keeps per-flow names and timings. `likeFlow` and `commentFlow` stay
 off the gate: after the reduced-motion fix they still fail on Codemagic with a
-blocked main thread ([#7619](https://github.com/divinevideo/divine-mobile/issues/7619),
-[#7620](https://github.com/divinevideo/divine-mobile/issues/7620)). The iOS
+blocked main thread, as documented in
+[#7204](https://github.com/divinevideo/divine-mobile/issues/7204). Restoring
+those flows is tracked by
+[#7619](https://github.com/divinevideo/divine-mobile/issues/7619) and
+[#7620](https://github.com/divinevideo/divine-mobile/issues/7620). The iOS
 simulator is still set to reduced motion so XCUITest can settle on the flows
 that do run.
 

--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -17,8 +17,10 @@ The full smoke suite is the manual target. The PR gate in Codemagic runs
 `tests/loginFreshInstall.yaml` and `tests/removeKeys.yaml` as individual files so the
 JUnit report keeps per-flow names and timings. `likeFlow` and `commentFlow` stay
 off the gate: after the reduced-motion fix they still fail on Codemagic with a
-blocked main thread (#7204). The iOS simulator is still set to reduced motion
-so XCUITest can settle on the flows that do run.
+blocked main thread ([#7619](https://github.com/divinevideo/divine-mobile/issues/7619),
+[#7620](https://github.com/divinevideo/divine-mobile/issues/7620)). The iOS
+simulator is still set to reduced motion so XCUITest can settle on the flows
+that do run.
 
 Nothing is held back from `smoke.yaml`. The last two were restored by
 [#6952](https://github.com/divinevideo/divine-mobile/issues/6952) —
@@ -44,9 +46,11 @@ The lesson generalises: **before filing a Maestro failure as flaky data,
 check whether the screen is stuck in a state the app has no exit from.**
 A permanent loading placeholder looks exactly like slow live content.
 
-The `e2e-smoke-ios` Codemagic workflow runs on pull requests that touch
-`mobile/`. It is non-blocking until a flake baseline exists. The
-`e2e-smoke-android` workflow remains a manual dispatch.
+The `e2e-smoke-ios` Codemagic workflow is configured to run on pull requests
+that touch `mobile/`, but the webhook integration must be restored under
+[#7504](https://github.com/divinevideo/divine-mobile/issues/7504) before those
+builds can fire. It remains non-blocking until a flake baseline exists. The
+`e2e-smoke-android` workflow is a manual dispatch.
 
 ## The recorder flows
 
@@ -492,6 +496,11 @@ or Maestro may target a different one from the one you installed onto.
 Failure artifacts — a screenshot and the command log — land in
 `~/.maestro/tests/<timestamp>/`. Read the screenshot first; it is usually
 faster than reasoning about the selector.
+
+If CI reports a selector failure that does not match the screenshot, confirm
+that Maestro targeted the simulator containing the current app build before
+debugging the selector. A stale build on another booted simulator can produce
+the same symptom.
 
 ### Iterating
 

--- a/mobile/e2e/maestro/suites/smoke.yaml
+++ b/mobile/e2e/maestro/suites/smoke.yaml
@@ -15,7 +15,8 @@ name: Divine Smoke regression test
 # `loginEmailPwd` and `searchUserFlow` need credentials present on the runners.
 # `likeFlow` and `commentFlow` are credential-free but stay off the PR gate:
 # after the reduced-motion fix they still hit a blocked main thread on
-# Codemagic (4m11s, "process main thread busy for 30.0s"). #7204 stays open.
+# Codemagic (4m11s, "process main thread busy for 30.0s"). Tracked by #7619
+# and #7620.
 
 # Account management tests
 - runFlow: ../tests/loginFreshInstall.yaml

--- a/mobile/e2e/maestro/suites/smoke.yaml
+++ b/mobile/e2e/maestro/suites/smoke.yaml
@@ -15,8 +15,8 @@ name: Divine Smoke regression test
 # `loginEmailPwd` and `searchUserFlow` need credentials present on the runners.
 # `likeFlow` and `commentFlow` are credential-free but stay off the PR gate:
 # after the reduced-motion fix they still hit a blocked main thread on
-# Codemagic (4m11s, "process main thread busy for 30.0s"). Tracked by #7619
-# and #7620.
+# Codemagic (4m11s, "process main thread busy for 30.0s"). Evidence is in
+# #7204; restoring the flows is tracked by #7619 and #7620.
 
 # Account management tests
 - runFlow: ../tests/loginFreshInstall.yaml


### PR DESCRIPTION
## Problem

The iOS Maestro lane could boot one simulator, install the current build on another, and let Maestro select a third. With more than one simulator booted, the test could therefore exercise a stale app bundle and report a misleading selector failure.

## Why this fix

The boot step now persists its chosen UDID through Codemagic's shared environment. Installation fails fast unless that value exists, installs and verifies the app on that exact simulator, and the shared Maestro command passes the UDID explicitly on iOS while retaining its existing default-device behavior on Android.

Android artifact collection now uses the same bounded diagnostic globs as iOS, avoiding oversized simulator logs. Regression tests lock the Android fallback, the iOS step order, and the shared simulator selection into the parsed Codemagic configuration.

Both e2e smoke workflows set `BUNDLE_ID` to `co.openvine.app.staging`, matching the Debug simulator and debug APK identities. The shared `pod_install` step now runs `cd ios && pod install`, bounding discovery to the iOS workspace while preserving Flutter's Swift Package Manager plugin detection. Flutter still installs macOS pods during the macOS build.

## Deliberately unchanged

This does not add the social flows to the PR gate. Their Codemagic main-thread blockage is documented in #7204, while restoring the flows remains tracked by #7619 and #7620. It also does not repair the inactive Codemagic pull-request webhook (#7504) or change the app's animation behavior (#8651).

The manual dispatch reached and exercised the newly built staging app on the selected simulator, then encountered a separate XCUITest hierarchy transport failure after account creation. That failure is tracked by #8681.

## Verification

- `python3 .github/scripts/tests/test_codemagic_shorebird_config.py`
- `bash mobile/scripts/check_codemagic_groups.sh`
- `.codex/scripts/test-config.sh`
- YAML parsing with aliases enabled
- `git diff --check`
- Earlier manual `e2e-smoke-ios` dispatch: build, boot, installation, bundle verification, and Maestro all used the same simulator; the subsequent hierarchy timeout is tracked by #8681
- Fresh manual dispatch required on the current head after the CocoaPods working-directory correction

Closes #7104