### PR TITLE
feat(tooling): distinguish concurrent sessions by active worktree

### DIFF
--- a/.claude/hooks/session-start-worktree-guard.sh
+++ b/.claude/hooks/session-start-worktree-guard.sh
@@ -34,15 +34,17 @@
 # Detection prefers Claude Code's pid-keyed session registry. The registry cwd
 # is the session's working root; it changes when the harness enters a worktree,
 # but not for a `cd` inside an ephemeral Bash tool call. The Claude process cwd
-# from lsof remains the launch root. Comparing both signals distinguishes an
-# active same-worktree session from one that merely launched here, without
-# suppressing a warning based on cwd alone: tools can still write absolute paths.
+# from lsof is the process cwd. On current macOS Claude that tracks harness
+# chdir, so the two roots usually match; comparing both still covers sessions
+# whose cwd lsof cannot read, and any case where the roots differ. A launch-root
+# match is never suppressed: tools can still write absolute paths.
 #
 # The registry is undocumented Claude Code internal state, macOS-verified only,
 # and includes a version field because its shape may change. If it is absent,
-# unreadable, incompatible, or jq is unavailable, the hook falls back to the
-# older /tmp/cc-socks*/<pid>.sock launch-directory signal. Set
-# CLAUDE_SESSIONS_DIR and CC_SOCK_DIR to test or override those locations.
+# unreadable, incompatible, empty of live confirmed records, or jq is
+# unavailable, the hook falls back to the older /tmp/cc-socks*/<pid>.sock
+# launch-directory signal. Set CLAUDE_SESSIONS_DIR and CC_SOCK_DIR to test or
+# override those locations.
 #
 # Always exits 0. This warns; it never blocks a session.
 
@@ -130,7 +132,6 @@ if command -v jq >/dev/null 2>&1 && [ -d "$sessions_dir" ] && [ -r "$sessions_di
     ' "$session_file" 2>/dev/null); then
       continue
     fi
-    registry_supported=true
 
     IFS=$'\x1f' read -r pid recorded_start session_cwd kind entrypoint name status \
       <<< "$registry_record"
@@ -145,6 +146,7 @@ if command -v jq >/dev/null 2>&1 && [ -d "$sessions_dir" ] && [ -r "$sessions_di
     recorded_start=$(printf '%s\n' "$recorded_start" \
       | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
     [ -n "$actual_start" ] && [ "$actual_start" = "$recorded_start" ] || continue
+    registry_supported=true
 
     launch_cwd=$(process_cwd "$pid")
     launch_root=""

--- a/.claude/hooks/session-start-worktree-guard.sh
+++ b/.claude/hooks/session-start-worktree-guard.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# SessionStart hook: warn when another live Claude Code session appears to
-# have been launched from this git worktree.
+# SessionStart hook: warn when another live Claude Code session may be using
+# this git worktree.
 #
 # Two agent sessions writing one working tree is a silent hazard. In the
 # incident that prompted this hook, one session ran an authorized
 # `git reset --hard` while a second was still reasoning from a pre-reset
 # snapshot; the second read the result as data loss and "restored" work that
-# had been discarded on purpose. No permission prompt catches this — both
+# had been discarded on purpose. No permission prompt catches this -- both
 # sessions were doing exactly what they had been told.
 #
 # Sharing a worktree read-only is fine. Concurrent *writers* are the problem,
@@ -31,34 +31,29 @@
 # Deliberately not registered in the team settings.json: anyone already running
 # it at user scope would get the warning twice.
 #
-# Detection: each live session owns a /tmp/cc-socks*/<pid>.sock socket. For
-# every other live Claude process with a matching socket, resolve its process
-# cwd and compare git roots. This is a launch-directory signal: descendant tool
-# shells can cd elsewhere without changing the Claude process cwd. If no socket
-# directory exists on your setup, the hook is a silent no-op. Set CC_SOCK_DIR to
-# test or override the socket dir.
+# Detection prefers Claude Code's pid-keyed session registry. The registry cwd
+# is the session's working root; it changes when the harness enters a worktree,
+# but not for a `cd` inside an ephemeral Bash tool call. The Claude process cwd
+# from lsof remains the launch root. Comparing both signals distinguishes an
+# active same-worktree session from one that merely launched here, without
+# suppressing a warning based on cwd alone: tools can still write absolute paths.
+#
+# The registry is undocumented Claude Code internal state, macOS-verified only,
+# and includes a version field because its shape may change. If it is absent,
+# unreadable, incompatible, or jq is unavailable, the hook falls back to the
+# older /tmp/cc-socks*/<pid>.sock launch-directory signal. Set
+# CLAUDE_SESSIONS_DIR and CC_SOCK_DIR to test or override those locations.
 #
 # Always exits 0. This warns; it never blocks a session.
 
 set -uo pipefail
 
-SOCK_DIRS=()
-if [ -n "${CC_SOCK_DIR:-}" ]; then
-  SOCK_DIRS=("$CC_SOCK_DIR")
-else
-  for dir in /tmp/cc-socks*; do
-    [ -d "$dir" ] || continue
-    SOCK_DIRS+=("$dir")
-  done
-fi
-
 root="${CLAUDE_PROJECT_DIR:-$PWD}"
 mine=$(git -C "$root" rev-parse --show-toplevel 2>/dev/null) || exit 0
 [ -n "$mine" ] || exit 0
-[ "${#SOCK_DIRS[@]}" -gt 0 ] || exit 0
 
 # Walk up the process tree to find this session's own claude pid, so the
-# guard never reports itself.
+# guard never reports itself in either detection mode.
 self=""
 p=$$
 for _ in 1 2 3 4 5 6 7 8; do
@@ -68,32 +63,139 @@ for _ in 1 2 3 4 5 6 7 8; do
   p=$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')
 done
 
-others=""
-count=0
-while read -r pid cm; do
-  case "$pid" in '' | *[!0-9]*) continue ;; esac
-  [ "$pid" = "$self" ] && continue
-  [ "${cm##*/}" = "claude" ] || continue
+process_start_utc() {
+  TZ=UTC ps -o lstart= -p "$1" 2>/dev/null \
+    | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+}
 
-  has_socket=false
-  for dir in "${SOCK_DIRS[@]}"; do
-    [ -S "$dir/$pid.sock" ] || continue
-    has_socket=true
-    break
-  done
-  [ "$has_socket" = true ] || continue
+process_cwd() {
+  lsof -a -p "$1" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1
+}
 
-  cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)
-  [ -n "$cwd" ] || continue
+append_registry_match() {
+  local pid="$1" name="$2" status="$3" launch_root="$4" session_root="$5"
+  local label detail
 
-  their=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || continue
-  # Compare the peer Claude process launch-directory git root. This cannot see
-  # the live cwd of shells spawned later by that session.
-  [ "$their" = "$mine" ] || continue
+  label="pid ${pid}"
+  [ -n "$name" ] && label="${name}, pid ${pid}"
+  [ -n "$status" ] && label="${label} (${status})"
+
+  if [ "$launch_root" = "$mine" ] && [ "$session_root" = "$mine" ]; then
+    detail="launch and session roots both match this worktree"
+  elif [ "$launch_root" = "$mine" ] && [ -n "$session_root" ]; then
+    detail="launched here, now working in ${session_root} -- likely not a conflict, but it can still write here by absolute path"
+  elif [ "$launch_root" = "$mine" ]; then
+    detail="launched here; current session root is unavailable -- it can still write here by absolute path"
+  elif [ -n "$launch_root" ]; then
+    detail="now working here after launching from ${launch_root} -- active worktree match"
+  else
+    detail="active session root matches this worktree; launch root is unavailable"
+  fi
 
   count=$((count + 1))
-  others="${others}  - pid ${pid} (cwd ${cwd})"$'\n'
-done < <(ps -eo pid=,comm= 2>/dev/null)
+  others="${others}  - ${label}: ${detail}"$'\n'
+}
+
+count=0
+others=""
+registry_supported=false
+sessions_dir="${CLAUDE_SESSIONS_DIR:-$HOME/.claude/sessions}"
+
+if command -v jq >/dev/null 2>&1 && [ -d "$sessions_dir" ] && [ -r "$sessions_dir" ]; then
+  shopt -s nullglob
+  for session_file in "$sessions_dir"/*.json; do
+    if ! registry_record=$(jq -er '
+      select(
+        (.pid | type == "number") and
+        (.procStart | type == "string") and
+        (.cwd | type == "string") and
+        (.version | type == "string") and
+        (.kind | type == "string") and
+        (.entrypoint | type == "string")
+      )
+      | [
+          (.pid | tostring),
+          .procStart,
+          .cwd,
+          .kind,
+          .entrypoint,
+          (.name // "" | tostring),
+          (.status // "" | tostring)
+        ]
+      | map(gsub("[\u0000-\u001f\u007f]"; " "))
+      | join("\u001f")
+    ' "$session_file" 2>/dev/null); then
+      continue
+    fi
+    registry_supported=true
+
+    IFS=$'\x1f' read -r pid recorded_start session_cwd kind entrypoint name status \
+      <<< "$registry_record"
+    case "$pid" in '' | *[!0-9]*) continue ;; esac
+    [ "$pid" = "$self" ] && continue
+    [ "$kind" = "interactive" ] || continue
+    [ "$entrypoint" = "cli" ] || continue
+
+    cm=$(ps -o comm= -p "$pid" 2>/dev/null)
+    [ "${cm##*/}" = "claude" ] || continue
+    actual_start=$(process_start_utc "$pid")
+    recorded_start=$(printf '%s\n' "$recorded_start" \
+      | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+    [ -n "$actual_start" ] && [ "$actual_start" = "$recorded_start" ] || continue
+
+    launch_cwd=$(process_cwd "$pid")
+    launch_root=""
+    session_root=""
+    if [ -n "$launch_cwd" ]; then
+      launch_root=$(git -C "$launch_cwd" rev-parse --show-toplevel 2>/dev/null) || launch_root=""
+    fi
+    if [ -n "$session_cwd" ]; then
+      session_root=$(git -C "$session_cwd" rev-parse --show-toplevel 2>/dev/null) || session_root=""
+    fi
+    if [ "$launch_root" != "$mine" ] && [ "$session_root" != "$mine" ]; then
+      continue
+    fi
+
+    append_registry_match "$pid" "$name" "$status" "$launch_root" "$session_root"
+  done
+  shopt -u nullglob
+fi
+
+if [ "$registry_supported" = false ]; then
+  sock_dirs=()
+  if [ -n "${CC_SOCK_DIR:-}" ]; then
+    sock_dirs=("$CC_SOCK_DIR")
+  else
+    for dir in /tmp/cc-socks*; do
+      [ -d "$dir" ] || continue
+      sock_dirs+=("$dir")
+    done
+  fi
+
+  if [ "${#sock_dirs[@]}" -gt 0 ]; then
+    while read -r pid cm; do
+      case "$pid" in '' | *[!0-9]*) continue ;; esac
+      [ "$pid" = "$self" ] && continue
+      [ "${cm##*/}" = "claude" ] || continue
+
+      has_socket=false
+      for dir in "${sock_dirs[@]}"; do
+        [ -S "$dir/$pid.sock" ] || continue
+        has_socket=true
+        break
+      done
+      [ "$has_socket" = true ] || continue
+
+      cwd=$(process_cwd "$pid")
+      [ -n "$cwd" ] || continue
+      their=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || continue
+      [ "$their" = "$mine" ] || continue
+
+      count=$((count + 1))
+      others="${others}  - pid ${pid} (cwd ${cwd})"$'\n'
+    done < <(ps -eo pid=,comm= 2>/dev/null)
+  fi
+fi
 
 [ "$count" -gt 0 ] || exit 0
 
@@ -105,19 +207,25 @@ if [ "$count" -ne 1 ]; then
 fi
 
 if ! command -v jq >/dev/null 2>&1; then
-  printf 'Session worktree guard detected %s other Claude %s launched from %s, but jq is unavailable; skipping JSON warning.\n' \
+  printf 'Session worktree guard detected %s other Claude %s associated with %s, but jq is unavailable; skipping JSON warning.\n' \
     "$count" "$plural" "$mine" >&2
   exit 0
 fi
 
-human="⚠️  ${count} other Claude ${plural} already ${verb} a matching launch-directory worktree:
+if [ "$registry_supported" = true ]; then
+  signal_description="a launch or active session root associated with this worktree"
+else
+  signal_description="a launch root matching this worktree according to the legacy socket fallback"
+fi
+
+human="⚠️  ${count} other Claude ${plural} ${verb} ${signal_description}:
 ${others}
   worktree: ${mine}
 
 Reading together is fine. If both sessions will EDIT code or run git state commands (reset/checkout/stash), give this task its own worktree:
   git worktree add .worktrees/<task> -b <branch> origin/main"
 
-agent="CONCURRENCY WARNING: ${count} other live Claude Code ${plural} currently ${verb} a matching launch-directory git worktree (${mine}).
+agent="CONCURRENCY WARNING: ${count} other live Claude Code ${plural} ${verb} ${signal_description} (${mine}).
 ${others}
 Consequences to respect this session:
 - Your git snapshot may go stale at any moment; re-check \`git status\` before reasoning about working-tree state, and never assume an unexpected change was an accident.

--- a/.claude/hooks/session-start-worktree-guard.sh
+++ b/.claude/hooks/session-start-worktree-guard.sh
@@ -39,8 +39,9 @@
 # whose cwd lsof cannot read, and any case where the roots differ. A launch-root
 # match is never suppressed: tools can still write absolute paths.
 #
-# The registry is undocumented Claude Code internal state, macOS-verified only,
-# and includes a version field because its shape may change. If it is absent,
+# The registry is undocumented Claude Code internal state. Detection accepts
+# macOS `ps -o lstart=` text and Linux /proc starttime jiffies. It includes a
+# version field because its shape may change. If it is absent,
 # unreadable, incompatible, empty of live confirmed records, or jq is
 # unavailable, the hook falls back to $XDG_RUNTIME_DIR/cc-socks (Linux) and
 # /tmp/cc-socks*/<pid>.sock. Set CLAUDE_SESSIONS_DIR, CC_SOCK_DIR, and

--- a/.claude/hooks/session-start-worktree-guard.sh
+++ b/.claude/hooks/session-start-worktree-guard.sh
@@ -63,8 +63,11 @@ for _ in 1 2 3 4 5 6 7 8; do
   p=$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')
 done
 
+# Claude records procStart in UTC and in the C locale, but `ps -o lstart=`
+# renders month and weekday names through LC_TIME, so an unpinned locale makes
+# every record mismatch and silently empties the registry path.
 process_start_utc() {
-  TZ=UTC ps -o lstart= -p "$1" 2>/dev/null \
+  TZ=UTC LC_ALL=C ps -o lstart= -p "$1" 2>/dev/null \
     | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
 }
 

--- a/.claude/hooks/session-start-worktree-guard.sh
+++ b/.claude/hooks/session-start-worktree-guard.sh
@@ -102,7 +102,7 @@ append_registry_match() {
 count=0
 others=""
 registry_supported=false
-sessions_dir="${CLAUDE_SESSIONS_DIR:-$HOME/.claude/sessions}"
+sessions_dir="${CLAUDE_SESSIONS_DIR:-${HOME:-}/.claude/sessions}"
 
 if command -v jq >/dev/null 2>&1 && [ -d "$sessions_dir" ] && [ -r "$sessions_dir" ]; then
   shopt -s nullglob

--- a/.claude/hooks/session-start-worktree-guard.sh
+++ b/.claude/hooks/session-start-worktree-guard.sh
@@ -42,9 +42,9 @@
 # The registry is undocumented Claude Code internal state, macOS-verified only,
 # and includes a version field because its shape may change. If it is absent,
 # unreadable, incompatible, empty of live confirmed records, or jq is
-# unavailable, the hook falls back to the older /tmp/cc-socks*/<pid>.sock
-# launch-directory signal. Set CLAUDE_SESSIONS_DIR and CC_SOCK_DIR to test or
-# override those locations.
+# unavailable, the hook falls back to $XDG_RUNTIME_DIR/cc-socks (Linux) and
+# /tmp/cc-socks*/<pid>.sock. Set CLAUDE_SESSIONS_DIR, CC_SOCK_DIR, and
+# CLAUDE_PROC_STAT_DIR to test or override those locations.
 #
 # Always exits 0. This warns; it never blocks a session.
 
@@ -67,10 +67,29 @@ done
 
 # Claude records procStart in UTC and in the C locale, but `ps -o lstart=`
 # renders month and weekday names through LC_TIME, so an unpinned locale makes
-# every record mismatch and silently empties the registry path.
+# every record mismatch and silently empties the registry path. Linux Claude
+# stores /proc starttime jiffies instead; accept either shape.
 process_start_utc() {
   TZ=UTC LC_ALL=C ps -o lstart= -p "$1" 2>/dev/null \
     | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+}
+
+process_start_matches() {
+  local pid="$1" recorded="$2" actual stat_file rest
+  recorded=$(printf '%s\n' "$recorded" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+  case "$recorded" in
+    '' | *[!0-9]*)
+      actual=$(process_start_utc "$pid")
+      [ -n "$actual" ] && [ "$actual" = "$recorded" ]
+      ;;
+    *)
+      stat_file="${CLAUDE_PROC_STAT_DIR:-/proc}/${pid}/stat"
+      [ -r "$stat_file" ] || return 1
+      rest=$(sed 's/.*) //' "$stat_file")
+      actual=$(printf '%s\n' "$rest" | awk '{print $20}')
+      [ -n "$actual" ] && [ "$actual" = "$recorded" ]
+      ;;
+  esac
 }
 
 process_cwd() {
@@ -142,10 +161,7 @@ if command -v jq >/dev/null 2>&1 && [ -d "$sessions_dir" ] && [ -r "$sessions_di
 
     cm=$(ps -o comm= -p "$pid" 2>/dev/null)
     [ "${cm##*/}" = "claude" ] || continue
-    actual_start=$(process_start_utc "$pid")
-    recorded_start=$(printf '%s\n' "$recorded_start" \
-      | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
-    [ -n "$actual_start" ] && [ "$actual_start" = "$recorded_start" ] || continue
+    process_start_matches "$pid" "$recorded_start" || continue
     registry_supported=true
 
     launch_cwd=$(process_cwd "$pid")
@@ -171,6 +187,9 @@ if [ "$registry_supported" = false ]; then
   if [ -n "${CC_SOCK_DIR:-}" ]; then
     sock_dirs=("$CC_SOCK_DIR")
   else
+    if [ -n "${XDG_RUNTIME_DIR:-}" ] && [ -d "$XDG_RUNTIME_DIR/cc-socks" ]; then
+      sock_dirs+=("$XDG_RUNTIME_DIR/cc-socks")
+    fi
     for dir in /tmp/cc-socks*; do
       [ -d "$dir" ] || continue
       sock_dirs+=("$dir")

--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -96,13 +96,14 @@ script header) and deliberately not registered in the team
 `settings.json`, so anyone already running it at user scope is not warned
 twice. It warns only — it never blocks a session.
 
-The preferred signal combines the Claude process cwd (the launch root)
-with `~/.claude/sessions/<pid>.json` (the active session root). The
-registry cwd follows harness-level worktree changes but not `cd` inside
-an ephemeral Bash tool call. Cwd is evidence of where a session usually
-writes, never a boundary on where absolute paths can write, so moving to
-a different worktree changes the warning's wording but never suppresses
-the launch-root warning.
+The preferred signal combines the Claude process cwd with
+`~/.claude/sessions/<pid>.json` (the active session root). The registry
+cwd follows harness-level worktree changes but not `cd` inside an
+ephemeral Bash tool call. On current macOS Claude the process cwd tracks
+harness `chdir`, so the two roots usually match; the comparison still
+covers lsof-unavailable sessions. Cwd is evidence of where a session
+usually writes, never a boundary on where absolute paths can write, so a
+launch-root match is never suppressed.
 
 The session registry is undocumented Claude Code internal state and has
 only been verified on macOS. Its own version field may accompany future

--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -90,14 +90,27 @@ authorized `git reset --hard` while another reasons from a pre-reset
 snapshot is enough to lose, or wrongly "restore", a changeset.
 
 `.claude/hooks/session-start-worktree-guard.sh` warns at session start
-when another live session appears to have been launched from the same
-git worktree root. It is opt-in (registration snippet is in the script
-header) and deliberately not registered in the team `settings.json`, so
-anyone already running it at user scope is not warned twice. It warns
-only — it never blocks a session. The signal comes from Claude's process
-cwd and `/tmp/cc-socks*/<pid>.sock`, so it cannot see later `cd` calls
-inside tool shells and can become a silent no-op if Claude changes that
-internal socket path.
+when another live session's launch root or active session root matches
+the current git worktree. It is opt-in (registration snippet is in the
+script header) and deliberately not registered in the team
+`settings.json`, so anyone already running it at user scope is not warned
+twice. It warns only — it never blocks a session.
+
+The preferred signal combines the Claude process cwd (the launch root)
+with `~/.claude/sessions/<pid>.json` (the active session root). The
+registry cwd follows harness-level worktree changes but not `cd` inside
+an ephemeral Bash tool call. Cwd is evidence of where a session usually
+writes, never a boundary on where absolute paths can write, so moving to
+a different worktree changes the warning's wording but never suppresses
+the launch-root warning.
+
+The session registry is undocumented Claude Code internal state and has
+only been verified on macOS. Its own version field may accompany future
+schema changes; Linux behavior remains unverified. If the registry is
+absent, unreadable, incompatible, or `jq` is unavailable, the hook falls
+back to the older `/tmp/cc-socks*/<pid>.sock` launch-directory signal.
+Anyone who installed an older copy of the hook at user scope must copy
+the updated repo version again to receive this detection.
 
 ### Build artifacts are purged from linked worktrees at session end
 

--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -105,13 +105,14 @@ covers lsof-unavailable sessions. Cwd is evidence of where a session
 usually writes, never a boundary on where absolute paths can write, so a
 launch-root match is never suppressed.
 
-The session registry is undocumented Claude Code internal state and has
-only been verified on macOS. Its own version field may accompany future
-schema changes; Linux behavior remains unverified. If the registry is
-absent, unreadable, incompatible, or `jq` is unavailable, the hook falls
-back to the older `/tmp/cc-socks*/<pid>.sock` launch-directory signal.
-Anyone who installed an older copy of the hook at user scope must copy
-the updated repo version again to receive this detection.
+The session registry is undocumented Claude Code internal state. macOS
+Claude records `procStart` as `ps -o lstart=` text; Linux Claude records
+`/proc/<pid>/stat` starttime jiffies — the hook accepts both. If the
+registry is absent, unreadable, incompatible, empty of live confirmed
+records, or `jq` is unavailable, the hook falls back to
+`$XDG_RUNTIME_DIR/cc-socks` and `/tmp/cc-socks*/<pid>.sock`. Anyone who
+installed an older copy of the hook at user scope must copy the updated
+repo version again to receive this detection.
 
 ### Build artifacts are purged from linked worktrees at session end
 

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -383,7 +383,17 @@ if [ "$1" = "-o" ] && [ "$2" = "comm=" ] && [ "$3" = "-p" ]; then
 fi
 
 if [ "$1" = "-o" ] && [ "$2" = "lstart=" ] && [ "$3" = "-p" ]; then
-  printf ' Sat Sep  5 21:24:30 2026 \n'
+  # Real `ps -o lstart=` renders through LC_TIME and TZ, while Claude records
+  # procStart with LC_ALL=C and TZ=UTC. Match that rendering only when the guard
+  # pinned both, so an unpinned locale or timezone fails the suite instead of
+  # silently emptying the registry path.
+  if [ "${LC_ALL:-}" != "C" ]; then
+    printf ' Sa.  5 Sep. 21:24:30 2026 \n'
+  elif [ "${TZ:-}" != "UTC" ]; then
+    printf ' Sun Sep  6 02:24:30 2026 \n'
+  else
+    printf ' Sat Sep  5 21:24:30 2026 \n'
+  fi
   exit 0
 fi
 
@@ -445,7 +455,7 @@ EOF
 printf '{not valid json\n' > "$GUARD_SESSIONS_DIR/888.json"
 
 REGISTRY_GUARD_OUTPUT=$(cd "$TEST_REPO" && \
-  env PATH="$GUARD_BIN_DIR:$PATH" \
+  env -u LC_ALL -u TZ PATH="$GUARD_BIN_DIR:$PATH" \
     TEST_REPO="$TEST_REPO" \
     OTHER_REPO="$OTHER_REPO" \
     CLAUDE_PROJECT_DIR="$TEST_REPO" \

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -571,6 +571,24 @@ if ! printf '%s\n' "$NO_JQ_GUARD_OUTPUT" \
   exit 1
 fi
 
+# The header promises the hook always exits 0. `set -u` plus a bare $HOME broke
+# that wherever HOME is not exported, taking the socket fallback down with it.
+NO_HOME_STATUS=0
+NO_HOME_GUARD_OUTPUT=$(cd "$TEST_REPO" && \
+  env -u HOME -u CLAUDE_SESSIONS_DIR PATH="$GUARD_BIN_DIR:$PATH" \
+    TEST_REPO="$TEST_REPO" \
+    OTHER_REPO="$OTHER_REPO" \
+    CLAUDE_PROJECT_DIR="$TEST_REPO" \
+    CC_SOCK_DIR="$GUARD_SOCKET_DIR" \
+    "$WORKTREE_GUARD_HOOK") || NO_HOME_STATUS=$?
+if [ "$NO_HOME_STATUS" -ne 0 ] || ! printf '%s\n' "$NO_HOME_GUARD_OUTPUT" | jq -e \
+  '.systemMessage | contains("legacy socket fallback")' >/dev/null; then
+  echo "Session worktree guard did not survive an unset HOME." >&2
+  echo "Exit status was: $NO_HOME_STATUS" >&2
+  echo "Output was: $NO_HOME_GUARD_OUTPUT" >&2
+  exit 1
+fi
+
 CLAUDE_ANALYZE_PAYLOAD=$(jq -n --arg path "$TEST_REPO/mobile/lib/clean.dart" \
   '{tool_input: {file_path: $path}}')
 : > "$CALL_LOG"

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -363,6 +363,9 @@ case "$*" in
 666 claude
 777 claude
 999 claude
+1010 claude
+1011 claude
+1012 node
 PSOUT
     exit 0
     ;;
@@ -378,6 +381,9 @@ if [ "$1" = "-o" ] && [ "$2" = "comm=" ] && [ "$3" = "-p" ]; then
     666) echo "claude"; exit 0 ;;
     777) echo "claude"; exit 0 ;;
     999) echo "claude"; exit 0 ;;
+    1010) echo "claude"; exit 0 ;;
+    1011) echo "claude"; exit 0 ;;
+    1012) echo "node"; exit 0 ;;
     *) echo "bash"; exit 0 ;;
   esac
 fi
@@ -426,6 +432,8 @@ case "$pid" in
   555) printf 'n%s\n' "$TEST_REPO" ;;
   666) printf 'n%s\n' "$TEST_REPO" ;;
   777) printf 'n%s\n' "$TEST_REPO" ;;
+  1010) printf 'n%s\n' "$TEST_REPO" ;;
+  1012) printf 'n%s\n' "$TEST_REPO" ;;
   *) exit 1 ;;
 esac
 EOF
@@ -452,6 +460,15 @@ EOF
 cat > "$GUARD_SESSIONS_DIR/999.json" <<EOF
 {"pid":999,"cwd":"$TEST_REPO","procStart":"Sat Sep  5 21:24:30 2026","version":"2.1.261","kind":"interactive","entrypoint":"cli","status":"idle","name":"active-only"}
 EOF
+cat > "$GUARD_SESSIONS_DIR/1010.json" <<EOF
+{"pid":1010,"cwd":"$TEST_REPO","procStart":"Sat Sep  5 21:24:30 2026","version":"2.1.261","kind":"headless","entrypoint":"cli","status":"busy","name":"non-interactive"}
+EOF
+cat > "$GUARD_SESSIONS_DIR/1011.json" <<EOF
+{"pid":1011,"cwd":"$TEST_REPO","procStart":"Sat Sep  5 21:24:30 2026","version":1,"kind":"interactive","entrypoint":"cli","status":"busy","name":"bad-version"}
+EOF
+cat > "$GUARD_SESSIONS_DIR/1012.json" <<EOF
+{"pid":1012,"cwd":"$TEST_REPO","procStart":"Sat Sep  5 21:24:30 2026","version":"2.1.261","kind":"interactive","entrypoint":"cli","status":"busy","name":"not-claude"}
+EOF
 printf '{not valid json\n' > "$GUARD_SESSIONS_DIR/888.json"
 
 REGISTRY_GUARD_OUTPUT=$(cd "$TEST_REPO" && \
@@ -476,6 +493,9 @@ if ! printf '%s\n' "$REGISTRY_GUARD_OUTPUT" | jq -e '
     and (contains("pid 555") | not)
     and (contains("pid 666") | not)
     and (contains("pid 777") | not)
+    and (contains("pid 1010") | not)
+    and (contains("pid 1011") | not)
+    and (contains("pid 1012") | not)
 ' >/dev/null; then
   echo "Session worktree guard did not classify registry launch and active roots correctly." >&2
   echo "Output was: $REGISTRY_GUARD_OUTPUT" >&2
@@ -524,6 +544,34 @@ if ! printf '%s\n' "$EMPTY_REGISTRY_GUARD_OUTPUT" | jq -e \
   '.systemMessage | contains("legacy socket fallback")' >/dev/null; then
   echo "Session worktree guard did not fall back for an empty registry." >&2
   echo "Output was: $EMPTY_REGISTRY_GUARD_OUTPUT" >&2
+  exit 1
+fi
+
+# Parseable registry records that fail host probes are not "supported": a
+# single unpinned locale used to take this path, and an older peer with only a
+# socket would stay invisible. Fall back instead of going silent.
+PROBE_MISMATCH_SESSIONS_DIR="$SCRATCH_DIR/probe-mismatch-claude-sessions"
+mkdir -p "$PROBE_MISMATCH_SESSIONS_DIR"
+cat > "$PROBE_MISMATCH_SESSIONS_DIR/111.json" <<EOF
+{"pid":111,"cwd":"$TEST_REPO","procStart":"Sat Sep  5 20:00:00 2026","version":"2.1.261","kind":"interactive","entrypoint":"cli","status":"busy","name":"stale-start"}
+EOF
+PROBE_MISMATCH_GUARD_OUTPUT=$(cd "$TEST_REPO" && \
+  env PATH="$GUARD_BIN_DIR:$PATH" \
+    TEST_REPO="$TEST_REPO" \
+    OTHER_REPO="$OTHER_REPO" \
+    CLAUDE_PROJECT_DIR="$TEST_REPO" \
+    CLAUDE_SESSIONS_DIR="$PROBE_MISMATCH_SESSIONS_DIR" \
+    CC_SOCK_DIR="$GUARD_SOCKET_DIR" \
+    "$WORKTREE_GUARD_HOOK")
+if ! printf '%s\n' "$PROBE_MISMATCH_GUARD_OUTPUT" | jq -e '
+  .systemMessage
+  | contains("legacy socket fallback")
+    and contains("pid 111")
+    and contains("pid 333")
+    and (contains("stale-start") | not)
+' >/dev/null; then
+  echo "Session worktree guard did not fall back when registry probes failed." >&2
+  echo "Output was: $PROBE_MISMATCH_GUARD_OUTPUT" >&2
   exit 1
 fi
 

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -575,6 +575,84 @@ if ! printf '%s\n' "$PROBE_MISMATCH_GUARD_OUTPUT" | jq -e '
   exit 1
 fi
 
+# A confirmed live record that does not match this worktree must stay silent
+# and must not fall through to the socket scan (false positives on peers the
+# registry already classified as elsewhere).
+ELSEWHERE_SESSIONS_DIR="$SCRATCH_DIR/elsewhere-claude-sessions"
+mkdir -p "$ELSEWHERE_SESSIONS_DIR"
+cat > "$ELSEWHERE_SESSIONS_DIR/444.json" <<EOF
+{"pid":444,"cwd":"$OTHER_REPO","procStart":"Sat Sep  5 21:24:30 2026","version":"2.1.261","kind":"interactive","entrypoint":"cli","status":"idle","name":"elsewhere"}
+EOF
+ELSEWHERE_GUARD_OUTPUT=$(cd "$TEST_REPO" && \
+  env PATH="$GUARD_BIN_DIR:$PATH" \
+    TEST_REPO="$TEST_REPO" \
+    OTHER_REPO="$OTHER_REPO" \
+    CLAUDE_PROJECT_DIR="$TEST_REPO" \
+    CLAUDE_SESSIONS_DIR="$ELSEWHERE_SESSIONS_DIR" \
+    CC_SOCK_DIR="$GUARD_SOCKET_DIR" \
+    "$WORKTREE_GUARD_HOOK")
+if [ -n "$ELSEWHERE_GUARD_OUTPUT" ]; then
+  echo "Session worktree guard fell back after confirming a non-matching registry peer." >&2
+  echo "Output was: $ELSEWHERE_GUARD_OUTPUT" >&2
+  exit 1
+fi
+
+# Linux Claude stores procStart as /proc starttime jiffies, not ps lstart text.
+JIFFIES_SESSIONS_DIR="$SCRATCH_DIR/jiffies-claude-sessions"
+JIFFIES_PROC_DIR="$SCRATCH_DIR/fake-proc"
+mkdir -p "$JIFFIES_SESSIONS_DIR" "$JIFFIES_PROC_DIR/111"
+cat > "$JIFFIES_SESSIONS_DIR/111.json" <<EOF
+{"pid":111,"cwd":"$TEST_REPO","procStart":"174985782","version":"2.1.261","kind":"interactive","entrypoint":"cli","status":"busy","name":"linux-jiffies"}
+EOF
+printf '111 (claude) S 1 1 1 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 174985782\n' \
+  > "$JIFFIES_PROC_DIR/111/stat"
+JIFFIES_GUARD_OUTPUT=$(cd "$TEST_REPO" && \
+  env PATH="$GUARD_BIN_DIR:$PATH" \
+    TEST_REPO="$TEST_REPO" \
+    OTHER_REPO="$OTHER_REPO" \
+    CLAUDE_PROJECT_DIR="$TEST_REPO" \
+    CLAUDE_SESSIONS_DIR="$JIFFIES_SESSIONS_DIR" \
+    CLAUDE_PROC_STAT_DIR="$JIFFIES_PROC_DIR" \
+    CC_SOCK_DIR="$GUARD_SOCKET_DIR" \
+    "$WORKTREE_GUARD_HOOK")
+if ! printf '%s\n' "$JIFFIES_GUARD_OUTPUT" | jq -e '
+  .systemMessage
+  | contains("linux-jiffies, pid 111")
+    and (contains("legacy socket fallback") | not)
+' >/dev/null; then
+  echo "Session worktree guard did not accept Linux jiffies procStart." >&2
+  echo "Output was: $JIFFIES_GUARD_OUTPUT" >&2
+  exit 1
+fi
+
+# Linux socket fallback lives under $XDG_RUNTIME_DIR/cc-socks, not /tmp.
+XDG_RUNTIME="$SCRATCH_DIR/xdg-runtime"
+mkdir -p "$XDG_RUNTIME/cc-socks"
+python3 - "$XDG_RUNTIME/cc-socks" <<'PY'
+import os, socket, sys
+path = os.path.join(sys.argv[1], "111.sock")
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+try:
+    sock.bind(path)
+finally:
+    sock.close()
+PY
+XDG_GUARD_OUTPUT=$(cd "$TEST_REPO" && \
+  env -u CC_SOCK_DIR PATH="$GUARD_BIN_DIR:$PATH" \
+    TEST_REPO="$TEST_REPO" \
+    OTHER_REPO="$OTHER_REPO" \
+    CLAUDE_PROJECT_DIR="$TEST_REPO" \
+    CLAUDE_SESSIONS_DIR="$SCRATCH_DIR/missing-sessions" \
+    XDG_RUNTIME_DIR="$XDG_RUNTIME" \
+    "$WORKTREE_GUARD_HOOK")
+if ! printf '%s\n' "$XDG_GUARD_OUTPUT" | jq -e \
+  '.systemMessage | contains("legacy socket fallback") and contains("pid 111")' \
+  >/dev/null; then
+  echo "Session worktree guard did not use XDG_RUNTIME_DIR/cc-socks." >&2
+  echo "Output was: $XDG_GUARD_OUTPUT" >&2
+  exit 1
+fi
+
 # A present registry with no compatible records must also fall back instead of
 # silently disabling the guard after an upstream schema change.
 INCOMPATIBLE_SESSIONS_DIR="$SCRATCH_DIR/incompatible-claude-sessions"

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -330,9 +330,10 @@ if ! git -C "$TEST_REPO" diff --cached --name-only \
 fi
 
 GUARD_SOCKET_DIR="$SCRATCH_DIR/cc-socks-test"
+GUARD_SESSIONS_DIR="$SCRATCH_DIR/claude-sessions-test"
 GUARD_BIN_DIR="$SCRATCH_DIR/guard-bin"
 OTHER_REPO="$SCRATCH_DIR/other-repo"
-mkdir -p "$GUARD_SOCKET_DIR" "$GUARD_BIN_DIR" "$OTHER_REPO"
+mkdir -p "$GUARD_SOCKET_DIR" "$GUARD_SESSIONS_DIR" "$GUARD_BIN_DIR" "$OTHER_REPO"
 git -C "$OTHER_REPO" init -q
 python3 - "$GUARD_SOCKET_DIR" <<'PY'
 import os
@@ -340,7 +341,7 @@ import socket
 import sys
 
 socket_dir = sys.argv[1]
-for pid in ("111", "222", "333", "444", "777"):
+for pid in ("111", "222", "333", "444", "555", "666", "777"):
     path = os.path.join(socket_dir, f"{pid}.sock")
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     try:
@@ -359,7 +360,9 @@ case "$*" in
 333 claude
 444 claude
 555 claude
+666 claude
 777 claude
+999 claude
 PSOUT
     exit 0
     ;;
@@ -372,9 +375,16 @@ if [ "$1" = "-o" ] && [ "$2" = "comm=" ] && [ "$3" = "-p" ]; then
     333) echo "claude"; exit 0 ;;
     444) echo "claude"; exit 0 ;;
     555) echo "claude"; exit 0 ;;
+    666) echo "claude"; exit 0 ;;
     777) echo "claude"; exit 0 ;;
+    999) echo "claude"; exit 0 ;;
     *) echo "bash"; exit 0 ;;
   esac
+fi
+
+if [ "$1" = "-o" ] && [ "$2" = "lstart=" ] && [ "$3" = "-p" ]; then
+  printf ' Sat Sep  5 21:24:30 2026 \n'
+  exit 0
 fi
 
 if [ "$1" = "-o" ] && [ "$2" = "ppid=" ] && [ "$3" = "-p" ]; then
@@ -404,32 +414,150 @@ case "$pid" in
   333) printf 'n%s\n' "$TEST_REPO/mobile" ;;
   444) printf 'n%s\n' "$OTHER_REPO" ;;
   555) printf 'n%s\n' "$TEST_REPO" ;;
+  666) printf 'n%s\n' "$TEST_REPO" ;;
   777) printf 'n%s\n' "$TEST_REPO" ;;
   *) exit 1 ;;
 esac
 EOF
 chmod +x "$GUARD_BIN_DIR/ps" "$GUARD_BIN_DIR/lsof"
 
-GUARD_OUTPUT=$(cd "$TEST_REPO" && \
+cat > "$GUARD_SESSIONS_DIR/111.json" <<EOF
+{"pid":111,"cwd":"$TEST_REPO","procStart":"Sat Sep  5 21:24:30 2026","version":"2.1.261","kind":"interactive","entrypoint":"cli","status":"busy","name":"same\\nroot"}
+EOF
+cat > "$GUARD_SESSIONS_DIR/333.json" <<EOF
+{"pid":333,"cwd":"$OTHER_REPO","procStart":"Sat Sep  5 21:24:30 2026","version":"2.1.261","kind":"interactive","entrypoint":"cli","status":"idle","name":"moved-session"}
+EOF
+cat > "$GUARD_SESSIONS_DIR/444.json" <<EOF
+{"pid":444,"cwd":"$TEST_REPO","procStart":"Sat Sep  5 21:24:30 2026","version":"2.1.261","kind":"interactive","entrypoint":"cli"}
+EOF
+cat > "$GUARD_SESSIONS_DIR/555.json" <<EOF
+{"pid":555,"cwd":"$TEST_REPO","procStart":"Sat Sep  5 21:24:30 2026","version":"2.1.261","kind":"interactive","entrypoint":"sdk-cli","status":"busy","name":"sdk-agent"}
+EOF
+cat > "$GUARD_SESSIONS_DIR/666.json" <<EOF
+{"pid":666,"cwd":"$TEST_REPO","procStart":"Sat Sep  5 20:00:00 2026","version":"2.1.261","kind":"interactive","entrypoint":"cli","status":"busy","name":"reused-pid"}
+EOF
+cat > "$GUARD_SESSIONS_DIR/777.json" <<EOF
+{"pid":777,"cwd":"$TEST_REPO","procStart":"Sat Sep  5 21:24:30 2026","version":"2.1.261","kind":"interactive","entrypoint":"cli","status":"busy","name":"self"}
+EOF
+cat > "$GUARD_SESSIONS_DIR/999.json" <<EOF
+{"pid":999,"cwd":"$TEST_REPO","procStart":"Sat Sep  5 21:24:30 2026","version":"2.1.261","kind":"interactive","entrypoint":"cli","status":"idle","name":"active-only"}
+EOF
+printf '{not valid json\n' > "$GUARD_SESSIONS_DIR/888.json"
+
+REGISTRY_GUARD_OUTPUT=$(cd "$TEST_REPO" && \
   env PATH="$GUARD_BIN_DIR:$PATH" \
     TEST_REPO="$TEST_REPO" \
     OTHER_REPO="$OTHER_REPO" \
     CLAUDE_PROJECT_DIR="$TEST_REPO" \
+    CLAUDE_SESSIONS_DIR="$GUARD_SESSIONS_DIR" \
     CC_SOCK_DIR="$GUARD_SOCKET_DIR" \
     "$WORKTREE_GUARD_HOOK")
 
-if ! printf '%s\n' "$GUARD_OUTPUT" | jq -e '
+if ! printf '%s\n' "$REGISTRY_GUARD_OUTPUT" | jq -e '
   .systemMessage
-  | contains("2 other Claude sessions already have a matching launch-directory worktree")
-    and contains("pid 111")
-    and contains("pid 333")
+  | contains("4 other Claude sessions have a launch or active session root associated with this worktree")
+    and contains("same root, pid 111 (busy): launch and session roots both match this worktree")
+    and contains("moved-session, pid 333 (idle): launched here, now working in")
+    and contains("likely not a conflict, but it can still write here by absolute path")
+    and contains("pid 444: now working here after launching from")
+    and contains("active worktree match")
+    and contains("active-only, pid 999 (idle): active session root matches this worktree; launch root is unavailable")
     and (contains("pid 222") | not)
-    and (contains("pid 444") | not)
     and (contains("pid 555") | not)
+    and (contains("pid 666") | not)
     and (contains("pid 777") | not)
 ' >/dev/null; then
-  echo "Session worktree guard did not report only live Claude sessions in the same canonical worktree." >&2
-  echo "Output was: $GUARD_OUTPUT" >&2
+  echo "Session worktree guard did not classify registry launch and active roots correctly." >&2
+  echo "Output was: $REGISTRY_GUARD_OUTPUT" >&2
+  exit 1
+fi
+
+# An absent registry preserves the older socket-and-launch-cwd behavior.
+LEGACY_GUARD_OUTPUT=$(cd "$TEST_REPO" && \
+  env PATH="$GUARD_BIN_DIR:$PATH" \
+    TEST_REPO="$TEST_REPO" \
+    OTHER_REPO="$OTHER_REPO" \
+    CLAUDE_PROJECT_DIR="$TEST_REPO" \
+    CLAUDE_SESSIONS_DIR="$SCRATCH_DIR/missing-sessions" \
+    CC_SOCK_DIR="$GUARD_SOCKET_DIR" \
+    "$WORKTREE_GUARD_HOOK")
+
+if ! printf '%s\n' "$LEGACY_GUARD_OUTPUT" | jq -e '
+  .systemMessage
+  | contains("a launch root matching this worktree according to the legacy socket fallback")
+    and contains("pid 111")
+    and contains("pid 333")
+    and contains("pid 555")
+    and contains("pid 666")
+    and (contains("pid 222") | not)
+    and (contains("pid 444") | not)
+    and (contains("pid 777") | not)
+' >/dev/null; then
+  echo "Session worktree guard did not retain its legacy socket fallback." >&2
+  echo "Output was: $LEGACY_GUARD_OUTPUT" >&2
+  exit 1
+fi
+
+# Claude may leave the registry directory present but empty after all other
+# sessions exit. Bash 3.2 must treat that exactly like an absent registry.
+EMPTY_SESSIONS_DIR="$SCRATCH_DIR/empty-claude-sessions"
+mkdir -p "$EMPTY_SESSIONS_DIR"
+EMPTY_REGISTRY_GUARD_OUTPUT=$(cd "$TEST_REPO" && \
+  env PATH="$GUARD_BIN_DIR:$PATH" \
+    TEST_REPO="$TEST_REPO" \
+    OTHER_REPO="$OTHER_REPO" \
+    CLAUDE_PROJECT_DIR="$TEST_REPO" \
+    CLAUDE_SESSIONS_DIR="$EMPTY_SESSIONS_DIR" \
+    CC_SOCK_DIR="$GUARD_SOCKET_DIR" \
+    "$WORKTREE_GUARD_HOOK")
+if ! printf '%s\n' "$EMPTY_REGISTRY_GUARD_OUTPUT" | jq -e \
+  '.systemMessage | contains("legacy socket fallback")' >/dev/null; then
+  echo "Session worktree guard did not fall back for an empty registry." >&2
+  echo "Output was: $EMPTY_REGISTRY_GUARD_OUTPUT" >&2
+  exit 1
+fi
+
+# A present registry with no compatible records must also fall back instead of
+# silently disabling the guard after an upstream schema change.
+INCOMPATIBLE_SESSIONS_DIR="$SCRATCH_DIR/incompatible-claude-sessions"
+mkdir -p "$INCOMPATIBLE_SESSIONS_DIR"
+printf '{"newSchema":true}\n' > "$INCOMPATIBLE_SESSIONS_DIR/111.json"
+INCOMPATIBLE_GUARD_OUTPUT=$(cd "$TEST_REPO" && \
+  env PATH="$GUARD_BIN_DIR:$PATH" \
+    TEST_REPO="$TEST_REPO" \
+    OTHER_REPO="$OTHER_REPO" \
+    CLAUDE_PROJECT_DIR="$TEST_REPO" \
+    CLAUDE_SESSIONS_DIR="$INCOMPATIBLE_SESSIONS_DIR" \
+    CC_SOCK_DIR="$GUARD_SOCKET_DIR" \
+    "$WORKTREE_GUARD_HOOK")
+if ! printf '%s\n' "$INCOMPATIBLE_GUARD_OUTPUT" | jq -e \
+  '.systemMessage | contains("legacy socket fallback")' >/dev/null; then
+  echo "Session worktree guard did not fall back for an incompatible registry." >&2
+  echo "Output was: $INCOMPATIBLE_GUARD_OUTPUT" >&2
+  exit 1
+fi
+
+# jq is optional: without it, legacy detection still runs and explains why it
+# cannot emit the structured SessionStart warning.
+GUARD_NO_JQ_BIN="$SCRATCH_DIR/guard-bin-no-jq"
+mkdir -p "$GUARD_NO_JQ_BIN"
+for tool in bash cat git sed head tr; do
+  ln -s "$(command -v "$tool")" "$GUARD_NO_JQ_BIN/$tool"
+done
+ln -s "$GUARD_BIN_DIR/ps" "$GUARD_NO_JQ_BIN/ps"
+ln -s "$GUARD_BIN_DIR/lsof" "$GUARD_NO_JQ_BIN/lsof"
+NO_JQ_GUARD_OUTPUT=$(cd "$TEST_REPO" && \
+  env PATH="$GUARD_NO_JQ_BIN" \
+    TEST_REPO="$TEST_REPO" \
+    OTHER_REPO="$OTHER_REPO" \
+    CLAUDE_PROJECT_DIR="$TEST_REPO" \
+    CLAUDE_SESSIONS_DIR="$GUARD_SESSIONS_DIR" \
+    CC_SOCK_DIR="$GUARD_SOCKET_DIR" \
+    "$WORKTREE_GUARD_HOOK" 2>&1)
+if ! printf '%s\n' "$NO_JQ_GUARD_OUTPUT" \
+  | grep -Fq 'but jq is unavailable; skipping JSON warning'; then
+  echo "Session worktree guard did not retain detection when jq was unavailable." >&2
+  echo "Output was: $NO_JQ_GUARD_OUTPUT" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Problem

The opt-in session guard could only compare Claude process launch directories. A session launched at the repository root still looked like a collision after the harness moved it into a dedicated worktree, while a session launched elsewhere and moved into the current worktree was invisible.

## Why this fix

Use the pid-keyed Claude session registry for the active session root while retaining lsof for the process cwd. The guard now explains whether both roots match, a peer moved away after launching here, or a peer moved into this worktree. It continues warning on launch-root matches because cwd does not prevent absolute-path writes.

Registry records are limited to live interactive CLI sessions and checked against the process start time, which excludes SDK subagents and reused PIDs. Name and busy/idle status are included when available. A registry is treated as usable only after at least one non-self record survives those host probes; otherwise the socket fallback still runs.

## Deliberate limits

The registry is undocumented Claude Code state. macOS Claude records procStart as `ps -o lstart=` text. Linux Claude records `/proc/<pid>/stat` starttime jiffies. The hook accepts both. Missing, empty, unreadable, incompatible, or host-probe-failing registry data, and environments without jq, fall back to `$XDG_RUNTIME_DIR/cc-socks` and `/tmp/cc-socks*`. On current macOS Claude, harness worktree enter moves process cwd with the registry cwd, so the two roots usually match. The comparison still covers sessions whose cwd lsof cannot read. Bash tool-call cd operations are not represented by the registry cwd.

Anyone who copied this hook into a user-scoped hooks directory must copy the updated repository version again after this change lands.

## Verification

- bash -n .claude/hooks/session-start-worktree-guard.sh
- .codex/scripts/test-config.sh
- Live registry path on Linux against concurrent Claude sessions
- Author: shellcheck and macOS smoke against the current Claude session registry

Closes #7580