### PR TITLE
chore(process): stop ungrounded post-merge reviews

### DIFF
--- a/.claude/rules/pr_takeover.md
+++ b/.claude/rules/pr_takeover.md
@@ -76,13 +76,19 @@ every cited path, line range, identifier, and quoted snippet against that
 commit, not the current checkout or a reconstructed version of the code:
 
 ```bash
+gh pr view <number> --json mergedAt,headRefOid
 git fetch origin pull/<number>/head
-gh pr view <number> --json state,mergedAt,headRefOid
+git cat-file -e '<commit>^{commit}'
 git cat-file -e '<commit>:<path>'
 git show '<commit>:<path>' | sed -n '<start>,<end>p'
 git grep -n -F -- '<snippet>' '<commit>' -- '<path>'
 git log --all -S'<snippet>' -- '<path>'
 ```
+
+The commit-object check must succeed before any path or snippet check. Treat a
+`fatal:` result or exit status 128 as a broken lookup and stop; it is not
+evidence that the cited content is absent. For `git grep`, exit status 1 means
+the lookup succeeded and the snippet was not found.
 
 The last command is supporting history only; the reviewed commit is the
 authority. A nearby comment that describes a rejected pattern is not evidence

--- a/.claude/rules/pr_takeover.md
+++ b/.claude/rules/pr_takeover.md
@@ -66,6 +66,35 @@ Working as the author is not the relaxed path — it is the stricter one:
   decide it yourself because you happen to hold the author's
   credentials.
 
+### Ground the review before choosing a review state
+
+These checks apply to every review, including report-only reviews and reviews
+where no branch modification is planned.
+
+After establishing authorship, pin the exact commit being reviewed. Verify
+every cited path, line range, identifier, and quoted snippet against that
+commit, not the current checkout or a reconstructed version of the code:
+
+```bash
+gh pr view <number> --json state,mergedAt,headRefOid
+git cat-file -e '<commit>:<path>'
+git show '<commit>:<path>' | sed -n '<start>,<end>p'
+git grep -n -F -- '<snippet>' '<commit>' -- '<path>'
+git log --all -S'<snippet>' -- '<path>'
+```
+
+The last command is supporting history only; the reviewed commit is the
+authority. A nearby comment that describes a rejected pattern is not evidence
+that the implementation contains that pattern. If a citation or claim cannot
+be grounded in the reviewed commit, remove the finding rather than softening
+or qualifying it.
+
+Check `mergedAt` before choosing a GitHub review state. Never submit
+`CHANGES_REQUESTED` after a pull request has merged: it cannot block the merge
+and reads as an outstanding author action. Use a plain `COMMENT` for useful
+retrospective feedback, or file a separately authorized issue when verified
+follow-up work is required.
+
 ---
 
 ## 2. Answer every review item, or say why not

--- a/.claude/rules/pr_takeover.md
+++ b/.claude/rules/pr_takeover.md
@@ -76,6 +76,7 @@ every cited path, line range, identifier, and quoted snippet against that
 commit, not the current checkout or a reconstructed version of the code:
 
 ```bash
+git fetch origin pull/<number>/head
 gh pr view <number> --json state,mergedAt,headRefOid
 git cat-file -e '<commit>:<path>'
 git show '<commit>:<path>' | sed -n '<start>,<end>p'

--- a/.claude/rules/self_review_checklist.md
+++ b/.claude/rules/self_review_checklist.md
@@ -26,6 +26,11 @@ a fix. See [`pr_takeover.md`](pr_takeover.md).
   issue comment, clearly labelled.
 - [ ] If it's **someone else's**: every gate in `PR_REVIEW.md` clears
   before you push. Draft or feedback-only ⇒ read-only.
+- [ ] Pin `headRefOid`, fetch the PR head, and verify every cited path, line,
+  identifier, and snippet against that exact commit. A `fatal:` lookup or exit
+  status 128 stops the review; it does not disprove the finding. Check
+  `mergedAt` before choosing a review state, and never submit
+  `CHANGES_REQUESTED` after merge.
 - [ ] Every review item sorted into fixed / escalated / declined —
   including inline threads fetched via GraphQL, and outdated ones.
 - [ ] Unrequested changes called out separately from review fixes.


### PR DESCRIPTION
## Problem

Agent review guidance can produce plausible findings whose paths, line ranges, or quoted constructs do not exist in the commit being reviewed. It also does not prohibit `CHANGES_REQUESTED` reviews after a pull request has already merged.

## Why this fix

This adds a repository-local review floor that preserves the existing authorship-first gate, then requires every finding to be checked against the exact target commit. It also requires checking `mergedAt` before choosing a review state and prohibits post-merge change requests.

## Deliberately unchanged

This does not change application code, CI behavior, or takeover authority. The shared cross-repository handbook and personal review skills are updated separately.

## Verification

- `.codex/scripts/test-config.sh`
- `git diff --check`

Refs #7884