### PR TITLE
test(dm): pin that closed moderation threads offer no reaction-removal retry

### DIFF
--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -1095,6 +1095,7 @@ void main() {
           initialState: reactionsState,
         );
 
+        final handle = tester.ensureSemantics();
         await tester.pumpWidget(
           buildSubject(
             state: ConversationState(
@@ -1110,6 +1111,15 @@ void main() {
         await tester.pump(const Duration(milliseconds: 400));
 
         expect(find.text(l10n.dmReactionRetryAction), findsOneWidget);
+        expect(
+          find.bySemanticsLabel(
+            RegExp(
+              RegExp.escape(l10n.dmReactionRemovalRefusedA11yLabel(emoji)),
+            ),
+          ),
+          findsWidgets,
+        );
+        handle.dispose();
       });
 
       testWidgets('a refused reaction removal retry shows failure feedback', (

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -999,6 +999,119 @@ void main() {
         handle.dispose();
       });
 
+      // #8622 introduced `removalRefused` after the `failed` case above was
+      // written. Both statuses reach the trailing through the same
+      // `canRetract` gate, and the action this one offers publishes a kind-5
+      // the send policy refuses for a retired recipient — so it needs its own
+      // case rather than inheriting the `failed` one's coverage.
+      testWidgets('a refused removal offers no retry on a closed thread', (
+        tester,
+      ) async {
+        const emoji = '\u{2764}\u{FE0F}';
+        const ownReaction = DmReaction(
+          id: 'r-own-retired-removal-refused',
+          conversationId: ownConversationId,
+          targetMessageId: ownMessageId,
+          targetMessageAuthor: currentPubkey,
+          reactorPubkey: currentPubkey,
+          emoji: emoji,
+          createdAt: 1700000000,
+          ownerPubkey: currentPubkey,
+          publishStatus: DmReactionPublishStatus.removalRefused,
+        );
+        const reactionsState = ConversationReactionsState(
+          status: ConversationReactionsStatus.loaded,
+          reactionsByMessageId: {
+            ownMessageId: [ownReaction],
+          },
+        );
+        whenListen(
+          mockReactionsCubit,
+          Stream<ConversationReactionsState>.value(reactionsState),
+          initialState: reactionsState,
+        );
+
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(
+          buildSubject(
+            counterparty: retired,
+            state: ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [ownMessage()],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.text(emoji));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        // The sheet rendered the own reaction row, so the absences below are
+        // not trivially satisfied by a missing row.
+        expect(find.text(l10n.dmReactionsSheetTitle), findsOneWidget);
+        expect(find.text(l10n.dmReactionRetryAction), findsNothing);
+        expect(
+          find.bySemanticsLabel(
+            RegExp(
+              RegExp.escape(l10n.dmReactionRemovalRefusedA11yLabel(emoji)),
+            ),
+          ),
+          findsNothing,
+        );
+        expect(
+          find.bySemanticsLabel(
+            RegExp(RegExp.escape(l10n.dmReactionChipOwnA11yLabel(emoji))),
+          ),
+          findsWidgets,
+        );
+        handle.dispose();
+      });
+
+      testWidgets('a live thread still offers to retry a refused removal', (
+        tester,
+      ) async {
+        const emoji = '\u{2764}\u{FE0F}';
+        const ownReaction = DmReaction(
+          id: 'r-own-live-removal-refused',
+          conversationId: ownConversationId,
+          targetMessageId: ownMessageId,
+          targetMessageAuthor: currentPubkey,
+          reactorPubkey: currentPubkey,
+          emoji: emoji,
+          createdAt: 1700000000,
+          ownerPubkey: currentPubkey,
+          publishStatus: DmReactionPublishStatus.removalRefused,
+        );
+        const reactionsState = ConversationReactionsState(
+          status: ConversationReactionsStatus.loaded,
+          reactionsByMessageId: {
+            ownMessageId: [ownReaction],
+          },
+        );
+        whenListen(
+          mockReactionsCubit,
+          Stream<ConversationReactionsState>.value(reactionsState),
+          initialState: reactionsState,
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [ownMessage()],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.text(emoji));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.text(l10n.dmReactionRetryAction), findsOneWidget);
+      });
+
       testWidgets('a refused reaction removal retry shows failure feedback', (
         tester,
       ) async {

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -931,7 +931,7 @@ void main() {
         );
         await tester.pump();
 
-        await tester.tap(find.text('\u{2764}\u{FE0F}'));
+        await tester.tap(find.text(ownReactionEmoji));
         // Avoid pumpAndSettle: the view's async profile providers can schedule
         // continuous micro-tasks. Pump the bottom-sheet enter animation.
         await tester.pump();
@@ -1046,6 +1046,18 @@ void main() {
           ),
           findsWidgets,
         );
+
+        // `showAction` and `onTap` are separate expressions sharing only
+        // `canRetract`, so the trailing's absence does not prove the row is
+        // inert. Tap it. The refused-removal arm opens a confirm prompt and
+        // only publishes the kind-5 once it is accepted, so the prompt — not
+        // the dispatch — is what a still-wired onTap surfaces here.
+        expect(find.byType(ListTile), findsOneWidget);
+        await tester.tap(find.byType(ListTile));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+        expect(find.text(l10n.dmReactionRemovalRefusedTitle), findsNothing);
+        verifyNever(() => mockReactionsCubit.add(any()));
         handle.dispose();
       });
 

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -830,6 +830,39 @@ void main() {
             'aaaaaaaabbbbbbbbccccccccddddddddaaaaaaaabbbbbbbbccccccccdddddddd',
       );
 
+      const ownReactionEmoji = '\u{2764}\u{FE0F}';
+
+      /// Stubs the reactions cubit with one own reaction on [ownMessageId].
+      /// Every case below differs only in the publish status under test, so
+      /// the fixture is shared and the status is the argument.
+      void primeOwnReaction({
+        required String id,
+        required DmReactionPublishStatus publishStatus,
+      }) {
+        final reaction = DmReaction(
+          id: id,
+          conversationId: ownConversationId,
+          targetMessageId: ownMessageId,
+          targetMessageAuthor: currentPubkey,
+          reactorPubkey: currentPubkey,
+          emoji: ownReactionEmoji,
+          createdAt: 1700000000,
+          ownerPubkey: currentPubkey,
+          publishStatus: publishStatus,
+        );
+        final reactionsState = ConversationReactionsState(
+          status: ConversationReactionsStatus.loaded,
+          reactionsByMessageId: {
+            ownMessageId: [reaction],
+          },
+        );
+        whenListen(
+          mockReactionsCubit,
+          Stream<ConversationReactionsState>.value(reactionsState),
+          initialState: reactionsState,
+        );
+      }
+
       testWidgets('an own bubble offers no delete-for-everyone', (
         tester,
       ) async {
@@ -882,27 +915,9 @@ void main() {
 
       testWidgets('an own reaction cannot be retracted from the '
           'who-reacted sheet', (tester) async {
-        const ownReaction = DmReaction(
+        primeOwnReaction(
           id: 'r-own-retired',
-          conversationId: ownConversationId,
-          targetMessageId: ownMessageId,
-          targetMessageAuthor: currentPubkey,
-          reactorPubkey: currentPubkey,
-          emoji: '\u{2764}\u{FE0F}',
-          createdAt: 1700000000,
-          ownerPubkey: currentPubkey,
           publishStatus: DmReactionPublishStatus.received,
-        );
-        const reactionsState = ConversationReactionsState(
-          status: ConversationReactionsStatus.loaded,
-          reactionsByMessageId: {
-            ownMessageId: [ownReaction],
-          },
-        );
-        whenListen(
-          mockReactionsCubit,
-          Stream<ConversationReactionsState>.value(reactionsState),
-          initialState: reactionsState,
         );
 
         await tester.pumpWidget(
@@ -940,28 +955,9 @@ void main() {
 
       testWidgets('a failed own reaction announces no retry action on a '
           'closed thread', (tester) async {
-        const emoji = '\u{2764}\u{FE0F}';
-        const ownReaction = DmReaction(
+        primeOwnReaction(
           id: 'r-own-retired-failed',
-          conversationId: ownConversationId,
-          targetMessageId: ownMessageId,
-          targetMessageAuthor: currentPubkey,
-          reactorPubkey: currentPubkey,
-          emoji: emoji,
-          createdAt: 1700000000,
-          ownerPubkey: currentPubkey,
           publishStatus: DmReactionPublishStatus.failed,
-        );
-        const reactionsState = ConversationReactionsState(
-          status: ConversationReactionsStatus.loaded,
-          reactionsByMessageId: {
-            ownMessageId: [ownReaction],
-          },
-        );
-        whenListen(
-          mockReactionsCubit,
-          Stream<ConversationReactionsState>.value(reactionsState),
-          initialState: reactionsState,
         );
 
         final handle = tester.ensureSemantics();
@@ -976,7 +972,7 @@ void main() {
         );
         await tester.pump();
 
-        await tester.tap(find.text(emoji));
+        await tester.tap(find.text(ownReactionEmoji));
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 400));
 
@@ -1007,28 +1003,9 @@ void main() {
       testWidgets('a refused removal offers no retry on a closed thread', (
         tester,
       ) async {
-        const emoji = '\u{2764}\u{FE0F}';
-        const ownReaction = DmReaction(
+        primeOwnReaction(
           id: 'r-own-retired-removal-refused',
-          conversationId: ownConversationId,
-          targetMessageId: ownMessageId,
-          targetMessageAuthor: currentPubkey,
-          reactorPubkey: currentPubkey,
-          emoji: emoji,
-          createdAt: 1700000000,
-          ownerPubkey: currentPubkey,
           publishStatus: DmReactionPublishStatus.removalRefused,
-        );
-        const reactionsState = ConversationReactionsState(
-          status: ConversationReactionsStatus.loaded,
-          reactionsByMessageId: {
-            ownMessageId: [ownReaction],
-          },
-        );
-        whenListen(
-          mockReactionsCubit,
-          Stream<ConversationReactionsState>.value(reactionsState),
-          initialState: reactionsState,
         );
 
         final handle = tester.ensureSemantics();
@@ -1043,7 +1020,7 @@ void main() {
         );
         await tester.pump();
 
-        await tester.tap(find.text(emoji));
+        await tester.tap(find.text(ownReactionEmoji));
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 400));
 
@@ -1054,14 +1031,18 @@ void main() {
         expect(
           find.bySemanticsLabel(
             RegExp(
-              RegExp.escape(l10n.dmReactionRemovalRefusedA11yLabel(emoji)),
+              RegExp.escape(
+                l10n.dmReactionRemovalRefusedA11yLabel(ownReactionEmoji),
+              ),
             ),
           ),
           findsNothing,
         );
         expect(
           find.bySemanticsLabel(
-            RegExp(RegExp.escape(l10n.dmReactionChipOwnA11yLabel(emoji))),
+            RegExp(
+              RegExp.escape(l10n.dmReactionChipOwnA11yLabel(ownReactionEmoji)),
+            ),
           ),
           findsWidgets,
         );
@@ -1071,28 +1052,9 @@ void main() {
       testWidgets('a live thread still offers to retry a refused removal', (
         tester,
       ) async {
-        const emoji = '\u{2764}\u{FE0F}';
-        const ownReaction = DmReaction(
+        primeOwnReaction(
           id: 'r-own-live-removal-refused',
-          conversationId: ownConversationId,
-          targetMessageId: ownMessageId,
-          targetMessageAuthor: currentPubkey,
-          reactorPubkey: currentPubkey,
-          emoji: emoji,
-          createdAt: 1700000000,
-          ownerPubkey: currentPubkey,
           publishStatus: DmReactionPublishStatus.removalRefused,
-        );
-        const reactionsState = ConversationReactionsState(
-          status: ConversationReactionsStatus.loaded,
-          reactionsByMessageId: {
-            ownMessageId: [ownReaction],
-          },
-        );
-        whenListen(
-          mockReactionsCubit,
-          Stream<ConversationReactionsState>.value(reactionsState),
-          initialState: reactionsState,
         );
 
         final handle = tester.ensureSemantics();
@@ -1106,7 +1068,7 @@ void main() {
         );
         await tester.pump();
 
-        await tester.tap(find.text(emoji));
+        await tester.tap(find.text(ownReactionEmoji));
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 400));
 
@@ -1114,7 +1076,9 @@ void main() {
         expect(
           find.bySemanticsLabel(
             RegExp(
-              RegExp.escape(l10n.dmReactionRemovalRefusedA11yLabel(emoji)),
+              RegExp.escape(
+                l10n.dmReactionRemovalRefusedA11yLabel(ownReactionEmoji),
+              ),
             ),
           ),
           findsWidgets,
@@ -1242,28 +1206,9 @@ void main() {
       testWidgets('a live thread still offers to remove an own reaction', (
         tester,
       ) async {
-        const emoji = '\u{2764}\u{FE0F}';
-        const ownReaction = DmReaction(
+        primeOwnReaction(
           id: 'r-own-live',
-          conversationId: ownConversationId,
-          targetMessageId: ownMessageId,
-          targetMessageAuthor: currentPubkey,
-          reactorPubkey: currentPubkey,
-          emoji: emoji,
-          createdAt: 1700000000,
-          ownerPubkey: currentPubkey,
           publishStatus: DmReactionPublishStatus.received,
-        );
-        const reactionsState = ConversationReactionsState(
-          status: ConversationReactionsStatus.loaded,
-          reactionsByMessageId: {
-            ownMessageId: [ownReaction],
-          },
-        );
-        whenListen(
-          mockReactionsCubit,
-          Stream<ConversationReactionsState>.value(reactionsState),
-          initialState: reactionsState,
         );
 
         await tester.pumpWidget(
@@ -1276,7 +1221,7 @@ void main() {
         );
         await tester.pump();
 
-        await tester.tap(find.text(emoji));
+        await tester.tap(find.text(ownReactionEmoji));
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 400));
 


### PR DESCRIPTION
## Description

A retired moderation thread is closed because nothing on the other end reads it.
Every write affordance on that screen is therefore removed rather than merely
disabled — the composer, delete-for-everyone, the resend sheet, and the "Remove"
on your own reaction. They all hang off one gate, `removalEnabled`, which is
`!isRetiredModerationThread`.

#8622 added a new status to that screen last week, `removalRefused`, and with it
a new affordance: a **"Try again"** prompt on a reaction whose removal the send
policy refused. It is correctly gated — it reaches the trailing through the same
`canRetract = isOwn && removalEnabled` check as every other retraction — but it
was the only one of them with no test of its own. The neighbouring `failed`
status has had a closed-thread case since #8490; the newer status inherited none.

That gap matters more than a missing case usually would, because of what the
affordance does if the gate ever slips: the retry publishes a NIP-09 kind-5 that
the send policy refuses for a retired recipient, after the local row is already
gone. The reaction disappears for the viewer while the copy the recipient
received before the rotation stays exactly where it is — the same false success
the closed composer exists to prevent.

This adds the missing case, plus a live-thread control so it cannot pass by the
affordance being hidden everywhere.

**No production code changes.** The behaviour is already correct; this pins it.

**Related Issue:** Relates to #7848, #8228

## Out of Scope

- **No behaviour change.** I verified on an iOS simulator that every reaction
  write on a retired thread is already closed, so there was nothing to fix. The
  investigation behind that is summarised on #7848.
- The `_ReactionPill` suppressing its refused-removal error styling when
  `removalEnabled` is false is left alone — that is a read-state presentation
  question, not a write gate.

## Verification

- `flutter analyze lib test integration_test` — no issues found
- `flutter test test/screens/inbox/conversation/` — 296/296 passed
- **Mutation-tested.** With `removalEnabled: retractionsEnabled` changed to
  `removalEnabled: true` in `conversation_view.dart`, the retired case fails at
  its retry-label assertion and the live control stays green — one failure, and
  it is the right one. Reverted before commit.
- Reproduced on device (iPhone 17 Pro Max, iOS 26.5, staging) with a stand-in key
  patched into `kLegacyModerationPubkeys` locally: the long-press picker,
  double-tap, and the sheet's Remove are all absent on the retired thread and all
  present on a live one in the same run.

## Type of Change

- [x] 🗑️ Chore
