### PR TITLE
fix(test): stop one widget test from failing unrelated tests at random

### DIFF
--- a/mobile/test/services/memory_telemetry_service_test.dart
+++ b/mobile/test/services/memory_telemetry_service_test.dart
@@ -10,6 +10,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/app/divine_app.dart';
 import 'package:openvine/services/memory_telemetry_service.dart';
 
+/// The [ImageCache] key this suite installs, so teardown can evict exactly it.
+const _cacheKey = 'memory-telemetry-test';
+
 void main() {
   group(MemoryTelemetryService, () {
     late List<MemorySnapshot> emitted;
@@ -160,17 +163,17 @@ void main() {
       tester,
     ) async {
       final cache = PaintingBinding.instance.imageCache;
-      addTearDown(() {
-        cache
-          ..clear()
-          ..clearLiveImages();
-      });
+      // Evict only this test's key. Clearing the whole cache would also
+      // dispose what every other suite in the merged-isolate run put there,
+      // and `ImageCache` defers that disposal to a post-frame callback that
+      // lands in the next test's first frame.
+      addTearDown(() => cache.evict(_cacheKey));
       final recorder = ui.PictureRecorder();
       final canvas = ui.Canvas(recorder);
       canvas.drawPaint(ui.Paint()..color = const ui.Color(0xFFFFFFFF));
       final image = await recorder.endRecording().toImage(4, 4);
       cache.putIfAbsent(
-        'memory-telemetry-test',
+        _cacheKey,
         () => OneFrameImageStreamCompleter(
           Future<ImageInfo>.value(ImageInfo(image: image)),
         ),

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -38,6 +38,14 @@ double _thumbnailAspectRatio(WidgetTester tester) =>
 
 /// An [ImageProvider] that synchronously yields a pre-built [ui.Image] so a
 /// widget test can drive the image stream without an async decode.
+///
+/// The framework takes ownership of whatever [ImageInfo] receives and disposes
+/// it, so this hands over a clone and leaves the caller's [image] to the
+/// caller. Passing the original instead lets the test's own `dispose` close
+/// the last handle while the process-global [ImageCache] still holds the
+/// completer; the cache's deferred eviction then trips
+/// `ImageInfo.dispose`'s open-handle assertion inside whichever unrelated test
+/// pumps the next frame.
 class _SyncImageProvider extends ImageProvider<_SyncImageProvider> {
   _SyncImageProvider(this.image);
 
@@ -52,7 +60,7 @@ class _SyncImageProvider extends ImageProvider<_SyncImageProvider> {
     _SyncImageProvider key,
     ImageDecoderCallback decode,
   ) => OneFrameImageStreamCompleter(
-    SynchronousFuture<ImageInfo>(ImageInfo(image: image)),
+    SynchronousFuture<ImageInfo>(ImageInfo(image: image.clone())),
   );
 }
 
@@ -90,6 +98,14 @@ ui.Image _syncImage(int width, int height) {
   final recorder = ui.PictureRecorder();
   ui.Canvas(recorder);
   return recorder.endRecording().toImageSync(width, height);
+}
+
+/// Builds a [_SyncImageProvider] for [image] and drops its [ImageCache] entry
+/// when the test ends, so the resolved completer does not outlive the suite.
+_SyncImageProvider _syncImageProvider(ui.Image image) {
+  final provider = _SyncImageProvider(image);
+  addTearDown(provider.evict);
+  return provider;
 }
 
 void main() {
@@ -1287,7 +1303,7 @@ void main() {
         await tester.pumpWidget(
           MaterialApp(
             home: ImageWithDimensionsListener(
-              imageProvider: _SyncImageProvider(image),
+              imageProvider: _syncImageProvider(image),
               onImageDimensionsResolved: (w, h) {
                 width = w;
                 height = h;
@@ -1311,7 +1327,7 @@ void main() {
         await tester.pumpWidget(
           MaterialApp(
             home: _DimensionCallbackParent(
-              imageProvider: _SyncImageProvider(image),
+              imageProvider: _syncImageProvider(image),
             ),
           ),
         );

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -1369,6 +1369,33 @@ void main() {
       },
     );
 
+    testWidgets(
+      'a cached sync image outlives the test disposing its original handle',
+      (tester) async {
+        // Regression for #8652: ImageInfo owns the handle it is given, so the
+        // completer must hold its own clone. Sharing the test's handle put the
+        // cache's deferred disposal onto an already-disposed image and failed
+        // whichever later test pumped that frame.
+        final image = _syncImage(8, 8);
+        final provider = _SyncImageProvider(image);
+        await tester.pumpWidget(
+          ImageWithDimensionsListener(
+            imageProvider: provider,
+            child: const SizedBox.shrink(),
+          ),
+        );
+        await tester.pumpWidget(const SizedBox.shrink());
+        final cache = PaintingBinding.instance.imageCache;
+        expect(cache.containsKey(provider), isTrue);
+
+        image.dispose();
+        expect(cache.evict(provider), isTrue);
+        await tester.pump();
+
+        expect(tester.takeException(), isNull);
+      },
+    );
+
     testWidgets('displays flat placeholder when only blurhash is available', (
       tester,
     ) async {

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -1338,6 +1338,37 @@ void main() {
       },
     );
 
+    testWidgets(
+      'ImageWithDimensionsListener leaves the framework its own image handle',
+      (tester) async {
+        final image = _syncImage(640, 360);
+        addTearDown(image.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: ImageWithDimensionsListener(
+              imageProvider: _syncImageProvider(image),
+              onImageDimensionsResolved: (_, _) {},
+              child: const SizedBox.shrink(),
+            ),
+          ),
+        );
+
+        // More than one open handle means the framework got a clone of its
+        // own, so the `image.dispose` above is not the last one. Drop the
+        // clone from [_SyncImageProvider] and this reads exactly one: the
+        // cache's deferred disposal then trips `ImageInfo.dispose`'s
+        // open-handle assertion inside whichever unrelated test pumps the
+        // next frame.
+        expect(
+          image.debugGetOpenHandleStackTraces(),
+          hasLength(greaterThan(1)),
+        );
+      },
+    );
+
     testWidgets('displays flat placeholder when only blurhash is available', (
       tester,
     ) async {


### PR DESCRIPTION
## The problem

A full test run sometimes failed one test with a Flutter framework assertion that had nothing to do with what that test does:

```
'package:flutter/src/painting/image_stream.dart': line 138:
'(image.debugGetOpenHandleStackTraces()?.length ?? 1) > 0': is not true.
```

The victim changed from run to run, because the suite is shuffled with a random seed. It read like several unrelated flaky tests. It was one cause, and it was always the same culprit.

`video_thumbnail_widget_test.dart` built a `ui.Image`, handed it to a test `ImageProvider`, and disposed that image in its own teardown. But `ImageInfo` **takes ownership** of the image it is given — so the teardown closed the last handle while the process-global `ImageCache` still held the completer for it. `ImageCache` defers an evicted entry's disposal to a post-frame callback, so the assertion fired during the *next* test's first frame, blaming a test that never touched an image.

## Why this fix

The provider now hands the framework a **clone**. The cache owns a handle the test cannot close, so the ownership split is correct no matter when either side disposes. The two call sites additionally evict their cache entry on teardown, so nothing this suite resolved outlives it.

The clone is the load-bearing half. Eviction on its own does not fix the bug — it only makes the same assertion fire sooner, against the polluter's own later tests instead of a distant suite. That was checked directly by reverting the clone and keeping the eviction.

The two files here are the only ones in `test/`, `integration_test/`, and `packages/*/test/` that construct an `ImageInfo` at all, so this shape is not repeated elsewhere.

## What it also cleans up

`memory_telemetry_service_test.dart` cleared the **entire** image cache in its teardown. That disposes what every other suite in the merged-isolate run put there, deferred into someone else's frame — the exact hazard `clip_thumbnail_image_test.dart` already carries a comment about. It is what detonated the bug in one of the two reported sightings. Its teardown now evicts only its own key. Its in-body memory-pressure clear is untouched: that one is the thing the test exists to verify.

## What it deliberately leaves alone

The workaround in `clip_thumbnail_image_test.dart` stays. It guards a genuinely different case (a *failed* resolution that stays live in the cache), and it is already scoped to its own keys.

## Verification

- The two-file bundle from the issue, in the optimizer's shape, fails on `main` and passes here — checked in both orderings, and with the second reported victim added.
- `flutter test test/widgets test/services` on the reported seed `511612721` with `DIVINE_STRICT_CHANNELS=true`: **8230 passed**.
- `flutter analyze lib test integration_test`: clean.

Fixes #8652

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2abciaTcx31eCWipykpDR