### PR TITLE
fix(dm): stop three ways a moderation notice becomes unreachable, and write down what each DM store keeps

### DIFF
--- a/mobile/docs/DM_RETENTION.md
+++ b/mobile/docs/DM_RETENTION.md
@@ -1,0 +1,122 @@
+# DM retention
+
+How long a direct message survives, and where. Written because the answer
+differs per store, the stores disagree, and until #7850 nobody had written it
+down.
+
+**This file records what the code does today. It is not a policy ruling.** The
+retention decision for the server-side moderation DM log is open and belongs to
+Trust & Safety; see [The open decision](#the-open-decision).
+
+## The short version
+
+| Store | Owner | Holds | Lifetime |
+|---|---|---|---|
+| `direct_messages`, `conversations` (Drift) | the device | decrypted rumors | until the user removes the thread, or the account is switched or signed out |
+| `removed_conversations` (Drift) | the device | tombstones | the account's lifetime; cleared only on a full data delete |
+| `processed_gift_wraps` (Drift) | the device | wrap-id dedup ledger | unbounded — see [Client tables](#client-tables) |
+| relay (`kind:1059` gift wraps) | funnelcake | the encrypted wraps | at the relay's discretion; **destroyed on a NIP-62 vanish** |
+| `dm_log` (D1, `divine-moderation-service`) | Divine | a plaintext copy of every moderation DM | indefinite — nothing deletes it |
+
+The last two rows are the ones that matter, and they point in opposite
+directions: the user's copy is the destructible one and ours is not.
+
+## Why the user's copy is fragile — and why that is the protocol working
+
+None of this is a Divine bug. NIP-59 says both parts outright:
+
+- *"Relays may choose not to store gift wrapped events due to them not being
+  publicly useful."* Storage of a `kind:1059` is optional.
+- *"Since signing keys are random, relays SHOULD delete `kind:1059` events whose
+  p-tag matches the signer of NIP-09 deletions or **NIP-62 vanish requests**."*
+
+Funnelcake implements exactly that: its vanish cascade selects gift wraps by
+recipient `p` tag and hard-deletes them. So when a user exercises the
+account-deletion flow this app ships, **every gift wrap addressed to them is
+destroyed**, an enforcement notice among them.
+
+The local copy is no safer. An account switch or sign-out clears the DM tables
+for the departing account, and a reinstall takes the whole database. Recovery
+after any of those is by re-reading wraps from relays — and after a vanish there
+is nothing left to re-read.
+
+NIP-17 lists *"Fully Recoverable: Messages can be fully recoverable by any
+client with the user's private key"* among its benefits. That is the property
+that does not hold here, and it is why "the user still has their copy" is not a
+safe assumption to build on.
+
+Divine does **not** set a NIP-40 `expiration` tag on enforcement notices, so
+the intent is clearly that the user keeps them. There is simply no mechanism
+that delivers it.
+
+## Client tables
+
+Every DM table on the device, and what bounds it. Only one is bounded by code.
+
+| Table | Bounded | By what |
+|---|---|---|
+| `direct_messages` | no | user removal or account teardown only. A NIP-09 "delete for everyone" is a **soft** delete: the row and its content stay so gift-wrap dedup keeps working |
+| `conversations` | no | same |
+| `removed_conversations` | no | deliberately. The tombstone must outlive relay replay, so it is kept for the account's lifetime and cleared only when the user deletes their data |
+| `outgoing_dms` | partly | deleted on successful send or user cancel; a permanently failed row is marked `failed` and kept for manual retry |
+| `dm_message_reactions` | no | removed with their conversation; NIP-09 and own-supersede are soft deletes |
+| `pending_gift_wraps` | **yes** | attempts cap plus `deleteExhausted`, run at the top of every retry pass |
+| `processed_gift_wraps` | no | nothing. Its `processed_at` column is documented as *"available for any future time-based retention"* that was never built |
+
+`processed_gift_wraps` is the odd one out: its sibling `pending_gift_wraps` is
+bounded, and its own schema anticipated the prune. It is not free to fix —
+it is the only record of wraps that write no message row (reactions,
+deletions, and messages suppressed by a removal tombstone), and #8209 covers
+why moving a sync boundary for a message an account never stored is permanent
+damage. Tracked separately rather than bolted onto a retention doc.
+
+## The server copy
+
+`dm_log` lives in `divine-moderation-service` (`migrations/003-dm-support.sql`).
+It is **not** on the device and is not the mobile DM list — the issue that
+prompted this file conflated the two.
+
+Three facts about it, each verifiable from that repo:
+
+1. **Nothing deletes it.** Every `DELETE FROM dm_log` in the repo is in a test.
+   There is no TTL, no scheduled sweep (the worker's two cron triggers run the
+   creator-delete pipeline and the relay poller), and no lifecycle rule.
+2. **`content` is the message itself.** The same string that is gift-wrapped is
+   stored, so the row is a byte-identical server-side plaintext copy of an
+   end-to-end-encrypted message. No `UPDATE` ever rewrites it.
+3. **The vanish cascade does not reach it.** It is ClickHouse-side and names no
+   D1 table; the moderation service has no vanish, erasure, or NIP-62 handling
+   at all.
+
+Its own design doc says it was meant to be neither of those things:
+
+> - **D1 `dm_log` table** as operational index for the admin dashboard
+> - **Relay** as source of truth for message content
+
+The index now outlives the source of truth it indexes, and holds in the clear
+what the source of truth only ever held encrypted. Nothing chose that; it is
+what happens when one store is given a lifetime and the other is not.
+
+## The open decision
+
+Whether Divine should retain moderation DM records indefinitely is a Trust &
+Safety call, not an engineering one, and it has not been made. Retaining
+enforcement records through an erasure request is a normal and defensible
+posture — but it has to be decided, not inherited.
+
+`divine-moderation-service/docs/trust-safety-report.md` carries a
+**Data Storage & Retention** table giving a lifetime for every store the
+service writes. `dm_log` is absent from it. Adding a row there is the last step
+of #7850 and needs the decision first.
+
+Until then, treat the client behaviour as the contract: the app protects the
+user's copy of a moderation notice from deletion, and cannot protect it from a
+relay that no longer serves the wrap.
+
+## Related
+
+- `mobile/docs/RETIRED_MODERATION_KEYS.md` — the rotation register. A key
+  rotation forks the conversation id, so retired-key rows are a disjoint set.
+- #7850 — this retention question.
+- #8304 — what a user is entitled to be told about an enforcement action.
+- #8391 / #8400 — the removal guard that stops the user destroying their copy.

--- a/mobile/docs/RETIRED_MODERATION_KEYS.md
+++ b/mobile/docs/RETIRED_MODERATION_KEYS.md
@@ -139,7 +139,15 @@ The client half is small and belongs in one PR:
    — it reads the list, so it does, but the test should say so.
 5. Record the outgoing key's [custody status](#key-custody). Unrecovered means
    the closed composer is permanent for it; archived means the reader could in
-   principle be pointed at it, and the decision is then a real one.
+   principle be pointed at it, and the decision is then a real one. Custody is
+   also what lets a DM-restricted minor read a retired-key thread
+   (`OfficialAccountsService.isReadableByProtectedMinor`): that widening rests
+   on nobody being able to sign as the key, so an **archived** key has to be
+   reconsidered there before it is added.
+6. Note that a rotation forks `conversation_id` on the service side, so the
+   outgoing key's rows become a disjoint set that the admin UI's pubkey lookup
+   can no longer reach. What happens to them is a retention question, open at
+   `divinevideo/divine-mobile#7850`; see `mobile/docs/DM_RETENTION.md`.
 
 The service and infrastructure half — rotating the signing key, updating
 Funnelcake's `RELAY_PUBKEY` and its `ADMIN_PUBKEYS` allowlist (replacing only

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -284,7 +284,8 @@ class ConversationListBloc
 
         // Lift the moderation thread out of the list into the pinned row, so
         // the inbox never renders it twice (#6283). Runs after both filters so
-        // the pin inherits them rather than bypassing them.
+        // an adopted pin still inherits them; the synthetic fallback in
+        // `_extractPinnedSupport` deliberately bypasses the blocklist (#7850).
         final pin = _extractPinnedSupport(
           userPubkey: userPubkey,
           inbox: visibleInbox,
@@ -631,12 +632,14 @@ class ConversationListBloc
   /// gives it an archived read-only presentation.
   ///
   /// Called with lists that have ALREADY passed the blocklist filter and the
-  /// protected-minor gate, so an existing moderation thread that those filters
-  /// removed simply is not found here. The synthetic fallback is pushed back
-  /// through both filters for the same reason: without that, a user who blocked
-  /// the moderation account — or a restricted minor whose approval was revoked
-  /// — would get a row that `ConversationPage`'s route guard bounces straight
-  /// back to the inbox.
+  /// protected-minor gate, so an existing moderation thread those filters
+  /// removed is not adopted here. The synthetic fallback is pushed through the
+  /// **minor gate only**. Blocking the moderation account used to suppress that
+  /// fallback too, on the grounds that `ConversationPage` would bounce — but
+  /// that guard never consults the blocklist, so the pin staying reachable is
+  /// the point of #7850. The minor gate still applies: that is a safety rule,
+  /// not a user preference, and it is the one filter the pin has never been
+  /// allowed to bypass (#176).
   ({
     PinnedSupport? pinned,
     List<DmConversation> inbox,

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -678,14 +678,25 @@ class ConversationListBloc
       createdAt: _pinnedSupportEpoch,
     );
 
-    final allowed =
-        _blocklistRepository?.filterBlockedConversations([
+    // Deliberately NOT blocklist-filtered, unlike every other row.
+    //
+    // The pinned row is Divine's support channel, not a peer thread. Blocking
+    // the moderation account used to remove it outright — the adopted pin
+    // never survives the list filter, and this synthetic fallback was filtered
+    // too — leaving the enforcement notice reachable only through a Blocked
+    // chip that itself renders conditionally. One tap on Block silently took
+    // away the route to the only document saying why the account was actioned
+    // (#7850). Blocking a peer means "stop delivering me their messages"; it
+    // must not mean "you can never reach support again".
+    //
+    // The minor gate below still applies: that is a safety rule, not a user
+    // preference, and it is the one filter the pin has never been allowed to
+    // bypass (#176).
+    final visible =
+        _protectedMinorInboxGate?.filter([
           synthetic,
         ], userPubkey: userPubkey) ??
         [synthetic];
-    final visible =
-        _protectedMinorInboxGate?.filter(allowed, userPubkey: userPubkey) ??
-        allowed;
 
     return (
       pinned: visible.isEmpty

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_state.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_state.dart
@@ -41,10 +41,11 @@ class ConversationNavigationTarget extends Equatable {
 
 /// The pinned Divine Moderation support row (#6283).
 ///
-/// Composed inside the same pipeline that applies the blocklist filter and the
-/// protected-minor inbound gate, so a user who blocked the moderation account —
-/// or a restricted minor whose approval was revoked — gets no pin at all rather
-/// than a row the conversation route guard would bounce.
+/// The protected-minor inbound gate still withholds this: a restricted minor
+/// whose approval was revoked gets no pin rather than a row the conversation
+/// route guard would bounce (#176). Blocking the moderation account does not —
+/// that is a user preference, the guard never consults the blocklist, and the
+/// pin staying reachable is the point of #7850.
 class PinnedSupport extends Equatable {
   const PinnedSupport({required this.conversation, required this.isPersisted});
 

--- a/mobile/lib/blocs/dm/conversation_list/protected_minor_inbox_gate_impl.dart
+++ b/mobile/lib/blocs/dm/conversation_list/protected_minor_inbox_gate_impl.dart
@@ -69,7 +69,7 @@ class ProtectedMinorInboxGateImpl implements ProtectedMinorInboxGate {
         // flip fires onVerdictChanged -> the list re-filters and this
         // counterparty drops.
         unawaited(_officials.isApprovedMinorDmRecipient(p));
-        if (!_officials.isApprovedMinorDmRecipientSync(p)) {
+        if (!_officials.isReadableByProtectedMinor(p)) {
           allApproved = false;
         }
       }

--- a/mobile/lib/screens/inbox/conversation/conversation_page.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_page.dart
@@ -86,7 +86,7 @@ class ConversationPage extends ConsumerWidget {
         conversationId: conversationId,
         initialParticipantPubkeys: participantPubkeys,
         isDmRestricted: () => isDmRestricted,
-        isApprovedRecipient: officialAccounts.isApprovedMinorDmRecipientSync,
+        isApprovedRecipient: officialAccounts.isReadableByProtectedMinor,
       )..load(),
       child: _ConversationPageContent(
         conversationId: conversationId,

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -969,9 +969,9 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
     required InboxFilter filter,
     required String query,
   }) {
-    // The Blocked slice is a list of accounts the viewer blocked. Moderation
-    // is not one of them — a blocked moderation account produces no pin at all
-    // (`_extractPinnedSupport`) — so the row has no business sitting above it.
+    // The Blocked slice is the viewer's blocked peers. The pin is the support
+    // channel, not a blocked-account row, so it does not sit above that list
+    // even when the viewer has blocked the moderation account (#7850).
     if (filter == InboxFilter.blocked) return false;
     if (filter == InboxFilter.unread && pinned.isRead) return false;
     if (query.isEmpty) return true;

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -513,10 +513,9 @@ class _RestorePausedBannerGate extends StatelessWidget {
 /// no timestamp and would sink out of reach.
 ///
 /// The caller only builds this when [ConversationListState.pinnedSupport] is
-/// non-null: the bloc composes that inside the same pipeline that applies the
-/// blocklist filter and the protected-minor gate, so a user who blocked the
-/// moderation account, or a restricted minor whose approval was revoked, gets
-/// no row rather than one the conversation route guard would bounce.
+/// non-null. The bloc withholds that for a restricted minor whose approval was
+/// revoked, so this tile is never the row the conversation route guard would
+/// bounce (#176). Blocking the moderation account does not withhold it (#7850).
 class _PinnedSupportRow extends StatelessWidget {
   const _PinnedSupportRow({
     required this.pinned,

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -1186,6 +1186,9 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
             // the sheet drops it for a protected peer (#8391).
             final refusedText =
                 context.l10n.messageRequestModerationNoticeCannotBeRemoved;
+            // Captured before the await for the same reason as the two above:
+            // this context can retire while the removal is in flight.
+            final errorText = context.l10n.commonSomethingWentWrong;
             final outcome = await actionsCubit.removeConversation(
               conversation.id,
             );
@@ -1199,7 +1202,14 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
                   SnackBar(content: Text(refusedText)),
                 );
               case RemoveConversationOutcome.failed:
-                break;
+                // Silence here reads as a mistap: the dialog closes and the
+                // row is still there. Both sibling surfaces already say so
+                // (`request_preview_view`, `message_requests_view`), and a
+                // failure must not be mistaken for the refusal above — that
+                // one is the guard working, this one is Drift throwing.
+                messenger.showSnackBar(
+                  DivineSnackbarContainer.snackBar(errorText, error: true),
+                );
             }
           }
       }

--- a/mobile/lib/screens/inbox/message_requests/request_preview_page.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_page.dart
@@ -71,7 +71,7 @@ class RequestPreviewPage extends ConsumerWidget {
             isDmRestricted: () => ref.read(isDmRestrictedProvider),
             isApprovedRecipient: ref
                 .read(officialAccountsServiceProvider)
-                .isApprovedMinorDmRecipientSync,
+                .isReadableByProtectedMinor,
           )..load(),
         ),
         BlocProvider(

--- a/mobile/lib/services/official_accounts_service.dart
+++ b/mobile/lib/services/official_accounts_service.dart
@@ -104,6 +104,33 @@ class OfficialAccountsService {
     return _load(hex)?.approved ?? true;
   }
 
+  /// Whether a DM-restricted minor may READ an existing thread with [hex].
+  ///
+  /// Deliberately wider than [isApprovedMinorDmRecipientSync], which answers
+  /// whether they may *reach* an identity and stays the gate on every send
+  /// affordance. This one answers whether an existing thread may be rendered.
+  ///
+  /// The two differ on exactly one case: a **retired** Divine moderation key.
+  /// A minor who was sent an enforcement notice before a rotation holds a
+  /// thread the pin no longer covers, and the strict predicate hid it from the
+  /// inbox, from Message Requests, and from the blocked slice — while
+  /// `DmRepository`'s removal policy protects it, because that policy counts
+  /// retired keys as moderation. The thread was therefore undeletable *and*
+  /// unreadable, which is the one combination that helps nobody (#7850).
+  ///
+  /// Widening the read path adds no contact surface. The rotation register
+  /// (`mobile/docs/RETIRED_MODERATION_KEYS.md`) records the current entry's
+  /// private key as unrecovered with no known holder, so nobody can sign a new
+  /// event as it — the key cannot deliver anything to a minor. The composer
+  /// stays closed for it independently, via `isRetiredModerationAccount`.
+  ///
+  /// That argument rests on custody, which the register records per entry. A
+  /// future retired key whose private half is *archived* rather than
+  /// unrecovered has to be reconsidered here before it is added.
+  bool isReadableByProtectedMinor(String hex) =>
+      isApprovedMinorDmRecipientSync(hex) ||
+      isRetiredModerationAccount(_normHex(hex));
+
   /// Pin ∩ live NIP-05, graded. Awaits a fresh resolution when the cached
   /// verdict is stale (send-time freshness); returns the cached verdict while
   /// fresh. Grading:

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -437,6 +437,24 @@ class DmMessageDeletionRetryTarget {
 /// Amber, etc.) for NIP-17 gift-wrap decryption. The signer is held for
 /// the lifetime of this object; callers should ensure the repository is
 /// disposed when the user logs out.
+///
+/// ## Retention
+///
+/// Nothing here expires. No DM table is pruned by age or size: rows leave only
+/// when the user removes a conversation, when an account is switched or signed
+/// out, or when the account's data is deleted. `pending_gift_wraps` is the one
+/// exception, bounded by its decrypt-attempt cap.
+///
+/// That makes the **relay** the binding constraint on how long a message
+/// survives, not this repository. NIP-59 makes storing a `kind:1059` optional
+/// and tells relays to delete wraps addressed to a pubkey that requests a
+/// NIP-62 vanish, so a copy this device drops may be unrecoverable rather than
+/// merely re-fetched. [removeConversation]'s tombstone is written with that in
+/// mind, and is why it must never be recorded for a conversation this device
+/// does not actually have.
+///
+/// The full cross-store picture, including the server-side moderation DM log
+/// that behaves in the opposite direction, is in `mobile/docs/DM_RETENTION.md`.
 class DmRepository {
   /// Creates a [DmRepository] with the given dependencies.
   ///

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -268,6 +268,25 @@ enum _Nip04DedupHit {
   otherAccount,
 }
 
+/// What a removal request resolves to, before anything is written.
+///
+/// [absent] and [removable] both report `removed` to the caller — a stale id
+/// must never become an undeletable row — but they differ in what they leave
+/// behind. Only [removable] earns a `removed_conversations` tombstone, because
+/// that marker is permanent and suppresses every replayed message at or before
+/// its timestamp (#7850).
+enum _RemovalDisposition {
+  /// No row for this id under this owner. Nothing to delete, nothing to
+  /// suppress.
+  absent,
+
+  /// The injected policy protects this conversation.
+  protected,
+
+  /// On disk and not protected.
+  removable,
+}
+
 enum _OwnDmInboxState {
   /// The user advertises a kind-10050 with at least one allowed relay.
   found,
@@ -7965,12 +7984,28 @@ class DmRepository {
     );
   }
 
-  /// [isRemovalProtected] for an id the caller has not already resolved.
+  /// What a removal request resolves to before any row is touched.
   ///
-  /// A missing row is NOT protected: removal of a stale id must fail open.
-  Future<bool> _isRemovalProtectedById(String conversationId) async {
-    final conversation = await getConversation(conversationId);
-    return conversation != null && isRemovalProtected(conversation);
+  /// Three-valued because [_RemovalDisposition.absent] and
+  /// [_RemovalDisposition.removable] both report success to the caller but must
+  /// write different things: only a conversation that is actually on disk earns
+  /// a suppression tombstone. See [_resolveRemoval].
+  ///
+  /// Resolving once and reusing the answer is also what keeps the guard's read
+  /// and the delete on the same account by construction rather than by comment.
+  Future<_RemovalDisposition> _resolveRemoval(
+    String conversationId, {
+    required String ownerPubkey,
+  }) async {
+    await _awaitInitialConversationMaintenance();
+    final row = await _conversationsDao.getConversation(
+      conversationId,
+      ownerPubkey: ownerPubkey,
+    );
+    if (row == null) return _RemovalDisposition.absent;
+    return isRemovalProtected(_conversationFromRow(row))
+        ? _RemovalDisposition.protected
+        : _RemovalDisposition.removable;
   }
 
   /// Remove a conversation, its messages, its queued sends, and its queued
@@ -7980,6 +8015,11 @@ class DmRepository {
   /// history at or before the removal time. The marker is kept for the
   /// account's lifetime: a newer message recreates the conversation while
   /// earlier history stays suppressed.
+  ///
+  /// The tombstone is written **only for a conversation that is on disk**. It
+  /// is a record of what this device removed, not of what it was asked to
+  /// remove, and it is permanent — so writing one for an id with no local row
+  /// suppresses a conversation the user never had (#7850).
   ///
   /// The `dm_message_reactions` delete is not housekeeping. Those rows are
   /// the durable outgoing queue for unpublished reactions and pending kind-5
@@ -8006,8 +8046,24 @@ class DmRepository {
     if (owner == null) {
       throw StateError('Cannot remove a conversation without a known owner.');
     }
-    if (await _isRemovalProtectedById(conversationId)) {
-      return ConversationRemovalOutcome.refused;
+    final disposition = await _resolveRemoval(
+      conversationId,
+      ownerPubkey: owner,
+    );
+    switch (disposition) {
+      case _RemovalDisposition.protected:
+        return ConversationRemovalOutcome.refused;
+      case _RemovalDisposition.absent:
+        // Fails open, as before — a stale id must never become an undeletable
+        // row. What changed is that it no longer leaves a tombstone behind
+        // (#7850). Nothing local was removed, so there is no local history to
+        // suppress; a marker here would instead drop every future relay replay
+        // of a conversation this device never had, permanently and silently.
+        // A moderation enforcement notice is the case that matters: its
+        // created_at is always in the past, so it would never arrive again.
+        return ConversationRemovalOutcome.removed;
+      case _RemovalDisposition.removable:
+        break;
     }
     await _conversationsDao.runInTransaction<void>(() async {
       // Snapshot the owner for the whole transaction: an account switch
@@ -8064,10 +8120,19 @@ class DmRepository {
     final removable = <String>[];
     var refused = 0;
     for (final conversationId in conversationIds) {
-      if (await _isRemovalProtectedById(conversationId)) {
-        refused++;
-      } else {
-        removable.add(conversationId);
+      switch (await _resolveRemoval(conversationId, ownerPubkey: owner)) {
+        case _RemovalDisposition.protected:
+          refused++;
+        case _RemovalDisposition.absent:
+          // Dropped from the batch rather than tombstoned, for the reason on
+          // [removeConversation]. This is the reachable form of that bug: ids
+          // are collected when the list renders and acted on later, so a row
+          // that goes away in between arrives here absent. It stays out of
+          // `removed` too, which already counted DAO deletes rather than
+          // requests.
+          break;
+        case _RemovalDisposition.removable:
+          removable.add(conversationId);
       }
     }
     if (removable.isEmpty) return (removed: 0, refused: refused);

--- a/mobile/packages/dm_repository/test/src/dm_removal_policy_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_removal_policy_test.dart
@@ -227,7 +227,8 @@ void main() {
           // for an id this device never held suppressed that notice on every
           // future relay replay, permanently and silently.
           //
-          // Nothing local was removed, so there is no local history to suppress.
+          // Nothing local was removed, so there is no local history to
+          // suppress.
           final repository = buildRepository(
             removalPolicy: _protectsTheProtectedPeer,
           );

--- a/mobile/packages/dm_repository/test/src/dm_removal_policy_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_removal_policy_test.dart
@@ -198,6 +198,82 @@ void main() {
       });
     });
 
+    group('removal tombstones', () {
+      Future<int?> tombstoneFor(String conversationId) =>
+          db.removedConversationsDao.removedAtFor(
+            conversationId: conversationId,
+            ownerPubkey: _owner,
+          );
+
+      test('records a tombstone for a conversation that IS on disk', () async {
+        // The control. Suppression of replayed history is the whole point of
+        // the marker, so the absent-row tests below only mean something if
+        // this one proves the present-row path still writes it.
+        final repository = buildRepository();
+        final conversationId = await seedConversation([_owner, _ordinaryPeer]);
+
+        await repository.removeConversation(conversationId);
+
+        expect(await tombstoneFor(conversationId), isNotNull);
+      });
+
+      test(
+        'writes NO tombstone for a conversation that is not on disk',
+        () async {
+          // #7850. The guard fails open on a missing row so a stale id never
+          // becomes undeletable — but the tombstone used to be written anyway,
+          // and ingest drops every message at or before `removedAt`. A
+          // moderation notice's created_at is always in the past, so one marker
+          // for an id this device never held suppressed that notice on every
+          // future relay replay, permanently and silently.
+          //
+          // Nothing local was removed, so there is no local history to suppress.
+          final repository = buildRepository(
+            removalPolicy: _protectsTheProtectedPeer,
+          );
+          const absentId = 'conversation-this-device-never-had';
+
+          final outcome = await repository.removeConversation(absentId);
+
+          expect(outcome, equals(ConversationRemovalOutcome.removed));
+          expect(await tombstoneFor(absentId), isNull);
+        },
+      );
+
+      test('writes no tombstone for the absent members of a batch', () async {
+        // `removeConversations` collects ids when the list renders and acts on
+        // them later, so a row that disappears in between reaches the batch
+        // absent. That is the reachable form of the single-path bug above.
+        final repository = buildRepository(
+          removalPolicy: _protectsTheProtectedPeer,
+        );
+        final ordinaryId = await seedConversation([_owner, _ordinaryPeer]);
+        const absentId = 'vanished-between-render-and-tap';
+
+        final outcome = await repository.removeConversations([
+          ordinaryId,
+          absentId,
+        ]);
+
+        expect(outcome.removed, equals(1));
+        expect(outcome.refused, equals(0));
+        expect(await tombstoneFor(ordinaryId), isNotNull);
+        expect(await tombstoneFor(absentId), isNull);
+      });
+
+      test('writes no tombstone for a refused conversation', () async {
+        // A refusal deletes nothing, so it must also suppress nothing.
+        final repository = buildRepository(
+          removalPolicy: _protectsTheProtectedPeer,
+        );
+        final protectedId = await seedConversation([_owner, _protectedPeer]);
+
+        await repository.removeConversation(protectedId);
+
+        expect(await tombstoneFor(protectedId), isNull);
+      });
+    });
+
     group('isRemovalProtected', () {
       test('answers for a peer the policy protects', () async {
         final repository = buildRepository(

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -10706,16 +10706,31 @@ void main() {
     // -----------------------------------------------------------------
 
     group('removeConversation', () {
-      // The removal policy resolves each conversation before deleting it
-      // (#8391). These pure-mock tests care about the delete ordering, so the
-      // lookup returns null — absent rows fail open and removal proceeds.
+      // The removal path resolves each conversation before deleting it
+      // (#8391), and since #7850 an absent row is skipped entirely rather than
+      // deleted-and-tombstoned. These pure-mock tests care about the delete
+      // ordering, which only happens for a row that exists — so the lookup
+      // echoes back a plain unprotected conversation for whatever id it is
+      // asked about. `dm_removal_policy_test.dart` owns the absent-row case.
       setUp(() {
         when(
           () => mockConversationsDao.getConversation(
             any(),
             ownerPubkey: any(named: 'ownerPubkey'),
           ),
-        ).thenAnswer((_) async => null);
+        ).thenAnswer(
+          (invocation) async => ConversationRow(
+            id: invocation.positionalArguments.first as String,
+            participantPubkeys: jsonEncode(
+              [_validPubkeyA, _validPubkeyB]..sort(),
+            ),
+            isGroup: false,
+            createdAt: 1699999000,
+            isRead: true,
+            currentUserHasSent: true,
+            ownerPubkey: _validPubkeyA,
+          ),
+        );
       });
 
       test(
@@ -10826,16 +10841,31 @@ void main() {
     });
 
     group('removeConversations', () {
-      // The removal policy resolves each conversation before deleting it
-      // (#8391). These pure-mock tests care about the delete ordering, so the
-      // lookup returns null — absent rows fail open and removal proceeds.
+      // The removal path resolves each conversation before deleting it
+      // (#8391), and since #7850 an absent row is skipped entirely rather than
+      // deleted-and-tombstoned. These pure-mock tests care about the delete
+      // ordering, which only happens for a row that exists — so the lookup
+      // echoes back a plain unprotected conversation for whatever id it is
+      // asked about. `dm_removal_policy_test.dart` owns the absent-row case.
       setUp(() {
         when(
           () => mockConversationsDao.getConversation(
             any(),
             ownerPubkey: any(named: 'ownerPubkey'),
           ),
-        ).thenAnswer((_) async => null);
+        ).thenAnswer(
+          (invocation) async => ConversationRow(
+            id: invocation.positionalArguments.first as String,
+            participantPubkeys: jsonEncode(
+              [_validPubkeyA, _validPubkeyB]..sort(),
+            ),
+            isGroup: false,
+            createdAt: 1699999000,
+            isRead: true,
+            currentUserHasSent: true,
+            ownerPubkey: _validPubkeyA,
+          ),
+        );
       });
 
       const convIdA =

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -3889,8 +3889,23 @@ void main() {
     );
 
     test(
-      'is null when the user has blocked the moderation account',
+      'survives blocking the moderation account, unlike every other row',
       () async {
+        // Reverses #6388's behaviour on purpose (#7850).
+        //
+        // #6388 suppressed the pin for a blocked peer on the stated grounds
+        // that "ConversationPage's route guard bounces straight back to the
+        // inbox". That is true of the #176 minor gate — which this test's
+        // sibling above still covers — but NOT of the blocklist:
+        // `ConversationPage`'s guard consults `isDmRestricted` and the
+        // official-accounts predicate only, never the blocklist. So a blocked
+        // pin opens normally; suppressing it removed the route to the
+        // enforcement notice for nothing.
+        //
+        // The cost of getting this wrong was real: blocking is one tap in the
+        // conversation sheet, the adopted pin never survives the list filter,
+        // and #7025's recovery slice is reachable only through a chip that
+        // renders conditionally on having blocked someone.
         final blocklist = _MockContentBlocklistRepository();
         when(
           () => blocklist.runtimeBlockedUsers,
@@ -3915,7 +3930,11 @@ void main() {
 
         final state = await loadedState(bloc);
 
-        expect(state.pinnedSupport, isNull);
+        expect(state.pinnedSupport, isNotNull);
+        expect(
+          state.pinnedSupport!.conversation.participantPubkeys,
+          contains(moderationPubkey),
+        );
       },
     );
 

--- a/mobile/test/blocs/dm/conversation_list/protected_minor_inbox_gate_impl_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/protected_minor_inbox_gate_impl_test.dart
@@ -25,10 +25,10 @@ void main() {
       () => officials.isApprovedMinorDmRecipient(any()),
     ).thenAnswer((_) async => true);
     when(
-      () => officials.isApprovedMinorDmRecipientSync(approved),
+      () => officials.isReadableByProtectedMinor(approved),
     ).thenReturn(true);
     when(
-      () => officials.isApprovedMinorDmRecipientSync(blocked),
+      () => officials.isReadableByProtectedMinor(blocked),
     ).thenReturn(false);
     when(
       () => officials.onVerdictChanged,

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -1895,10 +1895,10 @@ void main() {
         );
       });
 
-      // The bloc withholds the pin for a user who blocked moderation, for a
-      // restricted minor whose approval was revoked, and wherever no
-      // moderation pubkey is configured. The view must render nothing at all
-      // in that case, not an empty tile.
+      // The bloc withholds the pin for a restricted minor whose approval was
+      // revoked, and wherever no moderation pubkey is configured. Blocking
+      // moderation no longer withholds it (#7850). The view must render
+      // nothing at all when the bloc emits no pin, not an empty tile.
       testWidgets('is absent when the bloc emits no pin', (tester) async {
         final l10n = lookupAppLocalizations(const Locale('en'));
         await tester.pumpWidget(

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -2763,6 +2763,49 @@ void main() {
         expect(find.text(l10n.inboxRemovedConversation), findsNothing);
       });
 
+      testWidgets('reports a failed removal instead of staying silent', (
+        tester,
+      ) async {
+        // #7850. `failed` used to `break`, so a Drift throw closed the dialog,
+        // showed nothing, and left the row in place — indistinguishable from a
+        // mistap. It must also not borrow the refusal copy: a refusal is the
+        // guard working, a failure is not.
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final actionsCubit = _MockConversationActionsCubit();
+
+        await tester.pumpWidget(
+          buildSubject(
+            actionsCubit: actionsCubit,
+            wrapInScaffold: true,
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              pinnedSupport: supportPin(
+                isPersisted: true,
+                lastMessageContent: 'We looked into your report',
+              ),
+            ),
+          ),
+        );
+        when(
+          () => actionsCubit.removeConversation(any()),
+        ).thenAnswer((_) async => RemoveConversationOutcome.failed);
+        await openMessages(tester);
+
+        await tester.longPress(find.text(l10n.inboxSupportRowTitle));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(l10n.inboxActionRemove));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(l10n.inboxRemoveConfirmConfirm));
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.commonSomethingWentWrong), findsOneWidget);
+        expect(find.text(l10n.inboxRemovedConversation), findsNothing);
+        expect(
+          find.text(l10n.messageRequestModerationNoticeCannotBeRemoved),
+          findsNothing,
+        );
+      });
+
       testWidgets(
         'keeps moderation safety actions named when the vanish lookup fails',
         (tester) async {

--- a/mobile/test/screens/inbox/message_requests/request_preview_page_test.dart
+++ b/mobile/test/screens/inbox/message_requests/request_preview_page_test.dart
@@ -103,7 +103,7 @@ void main() {
         'to the inbox before any request data renders',
         (tester) async {
           when(
-            () => mockOfficials.isApprovedMinorDmRecipientSync(any()),
+            () => mockOfficials.isReadableByProtectedMinor(any()),
           ).thenReturn(false);
 
           await tester.pumpWidget(
@@ -141,7 +141,7 @@ void main() {
         'bounced to the inbox without the conversation being read',
         (tester) async {
           when(
-            () => mockOfficials.isApprovedMinorDmRecipientSync(any()),
+            () => mockOfficials.isReadableByProtectedMinor(any()),
           ).thenReturn(true);
 
           await tester.pumpWidget(
@@ -185,7 +185,7 @@ void main() {
         'a DM-restricted user with an approved counterparty sees the preview',
         (tester) async {
           when(
-            () => mockOfficials.isApprovedMinorDmRecipientSync(otherPubkey),
+            () => mockOfficials.isReadableByProtectedMinor(otherPubkey),
           ).thenReturn(true);
 
           await tester.pumpWidget(

--- a/mobile/test/services/official_accounts_service_test.dart
+++ b/mobile/test/services/official_accounts_service_test.dart
@@ -39,6 +39,47 @@ void main() {
 
   const modNip05 = 'moderation@divine.video';
 
+  group('isReadableByProtectedMinor', () {
+    // #7850. `DmRepository`'s removal policy protects a retired-key moderation
+    // thread, because `isModerationAccount` counts retired keys. The minor
+    // gate approved pinned accounts only, so that same thread was stripped
+    // from the inbox, from Message Requests and from the blocked slice —
+    // undeletable and unreadable at once.
+    final retiredModHex = kLegacyModerationPubkeys.first;
+
+    test('reads a retired moderation thread the send gate still refuses', () {
+      final svc = build();
+
+      expect(svc.isReadableByProtectedMinor(retiredModHex), isTrue);
+      // The send gate is deliberately untouched: a retired key is readable but
+      // never reachable, and the composer stays closed for it independently.
+      expect(svc.isApprovedMinorDmRecipientSync(retiredModHex), isFalse);
+      expect(svc.isPinnedMinorContactable(retiredModHex), isFalse);
+    });
+
+    test('still refuses a stranger', () {
+      final svc = build();
+
+      expect(svc.isReadableByProtectedMinor(strangerHex), isFalse);
+      expect(svc.isReadableByProtectedMinor(attackerHex), isFalse);
+    });
+
+    test('still reads the current moderation account', () {
+      final svc = build();
+
+      expect(svc.isReadableByProtectedMinor(modHex), isTrue);
+    });
+
+    test('normalizes hex the same way the pin does', () {
+      final svc = build();
+
+      expect(
+        svc.isReadableByProtectedMinor('  ${retiredModHex.toUpperCase()}  '),
+        isTrue,
+      );
+    });
+  });
+
   group('isApprovedMinorDmRecipient', () {
     test('unpinned pubkey is never an approved recipient', () async {
       final svc = build();


### PR DESCRIPTION
Closes #7850

## The problem

A moderation enforcement notice — the DM that tells someone why their account
was actioned — exists in two places with opposite lifetimes.

The copy the **user** holds is a NIP-17 gift wrap. NIP-59 makes storing one
optional for relays and tells them to delete wraps addressed to anyone who
requests a NIP-62 vanish, which funnelcake duly does. On the device it survives
only until an account switch, sign-out, or reinstall, after which recovery means
re-reading it from a relay that may no longer have it.

The copy **Divine** holds is a row in `dm_log`. Nothing has ever deleted it.

#8304 settled that the reason is not exposed through any API and there is no
appeal surface, so that DM really is the only record the user gets. #8400
stopped them destroying it with the delete button. This PR closes the gaps that
were left, and writes down what each store actually keeps — which had never been
recorded anywhere.

Investigation and evidence: #7850. The retention *policy* question raised there
is a Trust & Safety decision and is deliberately **not** made here.

## What changed

Five commits, one per finding, each revertable alone.

**1. A removal could silently suppress a conversation the device never had.**
The removal guard fails open when the conversation is not on disk — a stale id
must never become an undeletable row — but the permanent suppression tombstone
was written anyway, before anything checked whether there was a row. Ingest
drops every message at or before that timestamp, and an enforcement notice's
timestamp is always in the past, so one such marker meant the notice could never
arrive again, on any relay, for the life of the account. It survives an account
switch. The bulk path is the reachable one: ids are collected when the list
renders and acted on later, so a row that disappears in between arrives absent.

**2. A failed removal told the user nothing.** `failed` fell through to `break`,
so a database error closed the dialog and left the row — indistinguishable from
a mistap. Both sibling screens already handled it.

**3. A protected minor could not read a notice sent before a key rotation.** Two
rules disagreed: the removal guard protects retired-key moderation threads, the
protected-minor gate approved pinned accounts only. The thread was undeletable
and unreadable at once. Reaching an identity is still gated exactly as before —
only rendering an existing thread was widened.

**4. Blocking Divine Moderation removed the pinned support row entirely,**
leaving the notice reachable only through a filter chip that appears only once
something is blocked.

**5. Documentation.** `mobile/docs/DM_RETENTION.md` records what each store
keeps; the retention contract also goes on `DmRepository` itself.

## Why these fixes are right

**On (1)**, the fail-open contract is unchanged: an absent conversation still
reports `removed`, so a stale id still never becomes undeletable. Only the
tombstone is withheld, and a conversation with no local row has no local history
to suppress. Resolving the row once also puts the guard's read and the delete on
the same account by construction rather than by comment.

**On (3)**, widening the read path adds no contact surface. The rotation
register records the current retired key's private half as unrecovered with no
known holder, so nobody can sign as it — it cannot deliver anything to anyone,
and its composer is closed independently. That argument rests on custody, so the
register now says a future *archived* key must be reconsidered before it is
added.

**On (4)**, this reverses behaviour #6388 chose deliberately, so it needs a
reason. #6388's reason was that a suppressed row cannot be "tapped into a
route-guard bounce". That holds for the protected-minor gate — unchanged here,
and still tested — but not for the blocklist: `ConversationPage`'s guard
consults the DM-restriction status and the official-accounts predicate only, and
never the blocklist. A blocked pin opens the thread normally. The row was being
hidden to prevent a bounce that cannot happen.

## What this deliberately leaves alone

- **The retention decision itself.** Whether Divine should keep moderation DM
  records indefinitely belongs to Trust & Safety. The new doc states current
  behaviour and says plainly that it is not a ruling. `dm_log`'s absent row in
  the moderation service's retention table is the last step and needs the
  decision first.
- **The server side.** Every code path that could implement a retention decision
  lives in `divine-moderation-service`. Nothing here touches it.
- **The relay.** Deleting gift wraps on a vanish is what NIP-59 tells relays to
  do. It is not a bug and should not be changed.
- **`processed_gift_wraps` growth.** It is the one unbounded DM table and its
  schema anticipated a prune that was never written — but it is also the only
  record of wraps that write no message row, and #8209 covers why moving a sync
  boundary for a message an account never stored is permanent damage. Filed
  separately rather than bolted on here.

## Not requested by any review

(3) and (4) are behaviour changes found during the investigation, not review
fixes. (4) in particular reverses a shipped, tested decision; the reasoning is
above and in the commit.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test test/services test/blocs/dm test/screens/inbox` — 5618 passing
- `flutter test` in `packages/dm_repository` — 932 passing
- All 19 CI-only ratchets run locally and passing
- The tombstone regression tests were written failing-first and observed
  failing before the fix; the silent-failure test was mutation-checked by
  restoring `break` and confirming it goes red
- Built and ran the shipped PRODUCTION config on an iPhone 17 Pro Max simulator
  against `wss://relay.divine.video` to confirm the affordances and the pinned
  support row behave as traced. Read-only: no message sent, no block published,
  no removal confirmed.
