### PR TITLE
fix(ui): show the right account on a second profile link, and announce the closed-thread exit

### DIFF
--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -101,6 +101,31 @@ class RouteContext {
   final String? videoId;
   final String? draftId;
   final String? conversationId;
+
+  /// What this route is *about*, with [videoIndex] deliberately left out.
+  ///
+  /// A shell branch re-creates its provider scope when this changes and
+  /// reuses it when it does not. That split matters because two feeds
+  /// rewrite their own URL on every swipe — `ExploreFeedContent`'s and
+  /// `ProfileVideoFeedView`'s `onPageChanged` both call `context.go` with a
+  /// new index — so keying on the whole path would tear down the players and
+  /// scroll position mid-swipe. Opening a different account or list is a
+  /// different subject and does rebuild.
+  ///
+  /// Add any new subject-bearing field here. [videoIndex] is the only one
+  /// that must stay out.
+  Object get subjectKey => (
+    type,
+    appSlug,
+    npub,
+    hashtag,
+    categoryName,
+    listId,
+    soundId,
+    videoId,
+    draftId,
+    conversationId,
+  );
 }
 
 /// Decodes a URL path segment, returning the raw input on malformed

--- a/mobile/lib/router/routes/shell.dart
+++ b/mobile/lib/router/routes/shell.dart
@@ -26,7 +26,7 @@ List<RouteBase> shellRoutes() {
     //
     // Each branch screen reads the *globally-active* route via
     // pageContextProvider and renders a placeholder when it doesn't match.
-    // Because all branches stay mounted, [_branchPage] scopes
+    // Because all branches stay mounted, [branchPage] scopes
     // pageContextProvider per branch so each tab sees *its own* route context
     // (not the active tab's) and keeps rendering real content while inactive.
     StatefulShellRoute(
@@ -75,7 +75,7 @@ List<RouteBase> shellRoutes() {
             GoRoute(
               path: VideoFeedPage.pathWithIndex,
               name: VideoFeedPage.routeName,
-              pageBuilder: (ctx, st) => _branchPage(
+              pageBuilder: (ctx, st) => branchPage(
                 st,
                 VideoFeedPage(
                   initialIndex: homeInitialIndexFromPathParameters(
@@ -95,14 +95,14 @@ List<RouteBase> shellRoutes() {
             GoRoute(
               path: ExploreScreen.path,
               name: ExploreScreen.routeName,
-              pageBuilder: (ctx, st) => _branchPage(st, const ExploreScreen()),
+              pageBuilder: (ctx, st) => branchPage(st, const ExploreScreen()),
             ),
             GoRoute(
               path: ExploreScreen.pathTabSubpath,
               pageBuilder: (_, st) {
                 final slug = st.pathParameters['name'];
                 final tabName = ExploreScreen.tabNameFromPathParameter(slug);
-                return _branchPage(
+                return branchPage(
                   st,
                   ExploreScreen(initialTabName: tabName, initialTabSlug: slug),
                 );
@@ -110,7 +110,7 @@ List<RouteBase> shellRoutes() {
             ),
             GoRoute(
               path: ExploreScreen.pathWithIndex,
-              pageBuilder: (ctx, st) => _branchPage(st, const ExploreScreen()),
+              pageBuilder: (ctx, st) => branchPage(st, const ExploreScreen()),
             ),
           ],
         ),
@@ -124,12 +124,12 @@ List<RouteBase> shellRoutes() {
               path: NotificationsPage.pathWithIndex,
               name: NotificationsPage.routeName,
               pageBuilder: (ctx, st) =>
-                  _branchPage(st, const NotificationsPage()),
+                  branchPage(st, const NotificationsPage()),
             ),
             GoRoute(
               path: InboxPage.path,
               name: InboxPage.routeName,
-              pageBuilder: (ctx, st) => _branchPage(st, const InboxPage()),
+              pageBuilder: (ctx, st) => branchPage(st, const InboxPage()),
             ),
           ],
         ),
@@ -143,28 +143,28 @@ List<RouteBase> shellRoutes() {
               path: ProfileScreenRouter.path,
               name: ProfileScreenRouter.routeName,
               pageBuilder: (ctx, st) =>
-                  _branchPage(st, const ProfileScreenRouter()),
+                  branchPage(st, const ProfileScreenRouter()),
             ),
             GoRoute(
               path: ProfileScreenRouter.pathWithNpub,
               pageBuilder: (ctx, st) =>
-                  _branchPage(st, const ProfileScreenRouter()),
+                  branchPage(st, const ProfileScreenRouter()),
             ),
             GoRoute(
               path: ProfileScreenRouter.pathWithIndex,
               pageBuilder: (ctx, st) =>
-                  _branchPage(st, const ProfileScreenRouter()),
+                  branchPage(st, const ProfileScreenRouter()),
             ),
             GoRoute(
               path: LikedVideosScreenRouter.path,
               name: LikedVideosScreenRouter.routeName,
               pageBuilder: (ctx, st) =>
-                  _branchPage(st, const LikedVideosScreenRouter()),
+                  branchPage(st, const LikedVideosScreenRouter()),
             ),
             GoRoute(
               path: LikedVideosScreenRouter.pathWithIndex,
               pageBuilder: (ctx, st) =>
-                  _branchPage(st, const LikedVideosScreenRouter()),
+                  branchPage(st, const LikedVideosScreenRouter()),
             ),
           ],
         ),
@@ -194,7 +194,8 @@ List<RouteBase> shellRoutes() {
 /// gating must follow the genuinely-active tab. Any new provider that reads
 /// [pageContextProvider] inherits this global behaviour even when consumed
 /// inside a branch; reach for the scoped value only via a direct widget read.
-Page<void> _branchPage(GoRouterState state, Widget child) {
+@visibleForTesting
+Page<void> branchPage(GoRouterState state, Widget child) {
   return NoTransitionPage<void>(
     key: state.pageKey,
     name: goRouterPageName(state),
@@ -203,7 +204,26 @@ Page<void> _branchPage(GoRouterState state, Widget child) {
       ...state.uri.queryParameters,
     },
     restorationId: state.pageKey.value,
+    // Keyed on the route's SUBJECT, not on `state.pageKey`. go_router keys a
+    // page on the route *pattern* — `newMatchedPath` is built from
+    // `route.path`, so `/profile/<a>` and `/profile/<b>` both come back as
+    // `ValueKey('/profile/:npub')`. Without a key of its own this scope is
+    // never re-created when only a path parameter changes, and the
+    // single-value override below keeps replaying the first subject the
+    // branch ever rendered: the shell's app bar follows the live route while
+    // the branch body stays on the previous account.
+    //
+    // Not the whole path, because two feeds rewrite their own URL on every
+    // swipe (`ExploreFeedContent` and `ProfileVideoFeedView` both call
+    // `context.go` from `onPageChanged`); a path key would dispose their
+    // players and scroll position mid-swipe. `subjectKey` excludes the video
+    // index for exactly that reason.
+    //
+    // Neither key weakens the freeze this scope exists for: an inactive
+    // branch is not rebuilt at all, so its key cannot change and it goes on
+    // rendering its own content.
     child: ProviderScope(
+      key: ValueKey(parseRoute(state.uri.path).subjectKey),
       overrides: [
         pageContextProvider.overrideWith(
           (ref) => Stream<RouteContext>.value(parseRoute(state.uri.path)),

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -757,8 +757,15 @@ class _ClosedThreadNotice extends StatelessWidget {
                 color: context.vineColors.onSurfaceVariant,
               ),
             ),
+            // `semanticLabel` is what makes this announce as a button:
+            // `DivineButton` only wires `Semantics(button: true)` when it is
+            // given one. The composer is gone here, so this is the screen's
+            // only control and the only route to a moderation account that
+            // reads — without the flag a screen reader gets a third line of
+            // prose after the title and body, naming no way out.
             DivineButton(
               label: l10n.dmRetiredThreadOpenSupport,
+              semanticLabel: l10n.dmRetiredThreadOpenSupport,
               type: DivineButtonType.secondary,
               expanded: true,
               onPressed: currentPubkey.isEmpty

--- a/mobile/scripts/baseline/l10n_delegates.txt
+++ b/mobile/scripts/baseline/l10n_delegates.txt
@@ -24,7 +24,6 @@ test/router/app_router_divine_scheme_gating_test.dart	1
 test/router/app_router_test.dart	1
 test/router/app_router_universal_link_gating_test.dart	1
 test/router/app_shell_tab_fade_test.dart	1
-test/router/branch_scoped_context_test.dart	2
 test/router/explore_tab_route_test.dart	1
 test/router/flat_route_cold_entry_back_test.dart	1
 test/router/fullscreen_feed_redirect_test.dart	1

--- a/mobile/test/router/branch_scoped_context_test.dart
+++ b/mobile/test/router/branch_scoped_context_test.dart
@@ -5,22 +5,31 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/router/router.dart';
+import 'package:openvine/router/routes/shell.dart' show branchPage;
 
-/// Mirrors `_branchPage` in app_router.dart: scopes [pageContextProvider] to
-/// this branch's own route so it doesn't read the globally-active route.
-Page<void> _scopedPage(GoRouterState st, Widget child) =>
-    NoTransitionPage<void>(
-      key: st.pageKey,
-      child: ProviderScope(
-        overrides: [
-          pageContextProvider.overrideWith(
-            (ref) => Stream<RouteContext>.value(parseRoute(st.uri.path)),
-          ),
-        ],
-        child: child,
-      ),
-    );
+/// Counts how many times it is built from scratch, so a test can tell a
+/// re-scope (new element, new State) from a plain rebuild.
+class _MountCounter extends StatefulWidget {
+  const _MountCounter();
+
+  static int mounts = 0;
+
+  @override
+  State<_MountCounter> createState() => _MountCounterState();
+}
+
+class _MountCounterState extends State<_MountCounter> {
+  @override
+  void initState() {
+    super.initState();
+    _MountCounter.mounts++;
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox();
+}
 
 class _Probe extends ConsumerWidget {
   const _Probe(this.label);
@@ -54,7 +63,7 @@ GoRouter _buildRouter() => GoRouter(
             GoRoute(
               path: '/home/:index',
               pageBuilder: (context, state) =>
-                  _scopedPage(state, const _Probe('home')),
+                  branchPage(state, const _Probe('home')),
             ),
           ],
         ),
@@ -64,7 +73,7 @@ GoRouter _buildRouter() => GoRouter(
             GoRoute(
               path: '/explore',
               pageBuilder: (context, state) =>
-                  _scopedPage(state, const _Probe('explore')),
+                  branchPage(state, const _Probe('explore')),
             ),
           ],
         ),
@@ -82,7 +91,13 @@ void main() {
       addTearDown(router.dispose);
 
       await tester.pumpWidget(
-        ProviderScope(child: MaterialApp.router(routerConfig: router)),
+        ProviderScope(
+          child: MaterialApp.router(
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -97,6 +112,152 @@ void main() {
       // NOT blank to the active 'explore' route) — that is what gives the
       // cross-fade two live tabs to dissolve between.
       expect(find.text('home scoped=home'), findsOneWidget);
+    });
+
+    // go_router keys a branch page on the route PATTERN, so `/profile/<a>`
+    // and `/profile/<b>` arrive with the identical `state.pageKey`. Before
+    // #7851's patrol the scope was therefore never re-created for a changed
+    // path parameter, and the single-value override replayed the first npub
+    // for the life of the element: the shell app bar named the account the
+    // user tapped while the body below it still showed the previous one —
+    // wrong name, wrong npub, wrong counts, and a Follow button pointed at
+    // an account the user never opened.
+    testWidgets('a changed path parameter re-scopes the branch', (
+      tester,
+    ) async {
+      const npubA =
+          'npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqlz5yt';
+      const npubB =
+          'npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqp6yfjr';
+
+      final router = GoRouter(
+        initialLocation: '/profile/$npubA',
+        routes: [
+          StatefulShellRoute(
+            builder: (context, state, shell) => shell,
+            navigatorContainerBuilder: (context, shell, children) =>
+                AppShellBranchContainer(
+                  currentIndex: shell.currentIndex,
+                  children: children,
+                ),
+            branches: [
+              StatefulShellBranch(
+                initialLocation: '/profile/$npubA',
+                routes: [
+                  GoRoute(
+                    path: '/profile/:npub',
+                    pageBuilder: (context, state) => branchPage(
+                      state,
+                      Consumer(
+                        builder: (context, ref, _) {
+                          final ctx = ref
+                              .watch(pageContextProvider)
+                              .asData
+                              ?.value;
+                          return Text(
+                            'scoped=${ctx?.npub ?? 'none'}',
+                            textDirection: TextDirection.ltr,
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp.router(
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('scoped=$npubA'), findsOneWidget);
+
+      router.go('/profile/$npubB');
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('scoped=$npubB'),
+        findsOneWidget,
+        reason:
+            'the branch must re-scope to the npub actually navigated to; '
+            "replaying the first one renders another account's profile",
+      );
+      expect(find.text('scoped=$npubA'), findsNothing);
+    });
+
+    // ExploreFeedContent and ProfileVideoFeedView both write their own URL
+    // from `onPageChanged`, so a feed rewrites its path on EVERY swipe.
+    // Keying the branch scope on the whole path would therefore dispose the
+    // video players and the scroll position mid-swipe — which is why
+    // `RouteContext.subjectKey` leaves `videoIndex` out.
+    testWidgets('paging within the same subject does not re-scope', (
+      tester,
+    ) async {
+      _MountCounter.mounts = 0;
+
+      final router = GoRouter(
+        initialLocation: '/explore/0',
+        routes: [
+          StatefulShellRoute(
+            builder: (context, state, shell) => shell,
+            navigatorContainerBuilder: (context, shell, children) =>
+                AppShellBranchContainer(
+                  currentIndex: shell.currentIndex,
+                  children: children,
+                ),
+            branches: [
+              StatefulShellBranch(
+                initialLocation: '/explore/0',
+                routes: [
+                  GoRoute(
+                    path: '/explore/:index',
+                    pageBuilder: (context, state) =>
+                        branchPage(state, const _MountCounter()),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp.router(
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(_MountCounter.mounts, 1);
+
+      // Three swipes.
+      for (final index in [1, 2, 3]) {
+        router.go('/explore/$index');
+        await tester.pumpAndSettle();
+      }
+
+      expect(
+        _MountCounter.mounts,
+        1,
+        reason:
+            'paging a feed must not tear down its subtree; a feed rewrites '
+            'its own URL on every swipe',
+      );
     });
 
     testWidgets('branch-scoped pageContext ignores query parameters', (
@@ -120,7 +281,7 @@ void main() {
                 routes: [
                   GoRoute(
                     path: '/profile/:npub',
-                    pageBuilder: (context, state) => _scopedPage(
+                    pageBuilder: (context, state) => branchPage(
                       state,
                       Consumer(
                         builder: (context, ref, _) {
@@ -143,7 +304,13 @@ void main() {
       addTearDown(router.dispose);
 
       await tester.pumpWidget(
-        ProviderScope(child: MaterialApp.router(routerConfig: router)),
+        ProviderScope(
+          child: MaterialApp.router(
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
+        ),
       );
       await tester.pumpAndSettle();
 

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -12,6 +12,7 @@ import 'package:db_client/db_client.dart' hide ProfileStats;
 import 'package:divine_ui/divine_ui.dart';
 import 'package:dm_repository/dm_repository.dart' show DmRepository;
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -771,6 +772,37 @@ void main() {
             extra: const [kModerationPubkeyHex],
           ),
         ).called(1);
+      });
+
+      // The composer is gone here, so this button is the ONLY control on the
+      // screen and the only route back to a moderation account that reads.
+      // `DivineButton` wires `Semantics(button: true)` only when it is given a
+      // `semanticLabel`; without one it inherits the InkWell's tap action but
+      // no button flag, so VoiceOver reads it as a third line of prose after
+      // the title and body and never announces that it can be activated.
+      testWidgets('announces the escape route as a button', (tester) async {
+        final handle = tester.ensureSemantics();
+
+        await tester.pumpWidget(buildSubject(counterparty: retired));
+        await tester.pump();
+
+        final node = tester.getSemantics(
+          find.bySemanticsLabel(l10n.dmRetiredThreadOpenSupport),
+        );
+
+        expect(
+          node.getSemanticsData().flagsCollection.isButton,
+          isTrue,
+          reason:
+              "the closed thread's only escape route must announce itself "
+              'as a button, not as static text',
+        );
+        expect(
+          node.getSemanticsData().hasAction(SemanticsAction.tap),
+          isTrue,
+        );
+
+        handle.dispose();
       });
 
       testWidgets('a live thread keeps its composer', (tester) async {


### PR DESCRIPTION
## Description

Two unrelated defects, both found while patrolling a retired moderation DM thread on an iOS simulator for #7851. They are separate fixes in separate commits; the profile one is much the larger.

### 1. A second profile link shows the previous account's identity

Open one shared profile link, then another, and the app bar names the account you tapped while everything under it still belongs to the previous one — display name, npub, follower and following counts, and a Follow button pointed at an account you never opened. Only the first profile of a session is right. Switching tabs does not clear it; only relaunching the app does.

Ordinary in-app navigation is unaffected, because that pushes `OtherProfileScreen` outside the shell. The broken path is `/profile/<npub>`, which is what an external profile link and any profile deep link resolve to.

**Why it happened.** `go_router` keys a page on the route *pattern*, not the resolved path — `match.dart` builds `newMatchedPath` from `route.path`, so `/profile/<a>` and `/profile/<b>` both arrive as `ValueKey('/profile/:npub')`. The per-branch provider scope built around that page was therefore never re-created when only a path parameter changed, and its single-value `pageContext` override kept replaying the first subject the branch ever rendered. The app bar looked right because it belongs to the shell and reads the live route; only the body reads the branch scope.

**The fix** keys that scope on the route's *subject* rather than the whole path. A whole-path key would have been wrong: `ExploreFeedContent` and `ProfileVideoFeedView` both rewrite their own URL from `onPageChanged`, so a feed changes its path on every swipe and a path key would dispose its players and scroll position mid-swipe. `RouteContext.subjectKey` leaves `videoIndex` out for exactly that reason.

The behaviour the scope exists for is unchanged — an inactive branch is never rebuilt, so its key cannot change and it goes on rendering its own content.

`branchPage` is `@visibleForTesting` now. The test meant to cover this asserted against a *local copy* of the production function, so it could not have caught the change; it now exercises the real one.

### 2. A closed moderation thread's only exit is not announced as a button

A retired moderation thread replaces its composer with a notice whose single control routes the reader to the moderation account that still reads. That button was reaching VoiceOver as static text, so the one way off a dead enforcement thread announced itself as a third line of prose after the title and body, with nothing saying it could be activated. Double-tap still worked; discovering it did not.

`DivineButton` wires `Semantics(button: true)` only when it is given a `semanticLabel`; with just a `label` it inherits the `InkWell`'s tap action and no button flag. Passing the label it already renders fixes it, and makes the disabled state announce correctly too.

**Related Issue:** Relates to #7851, #7848

## Out of Scope

- **#7851 itself is not closed by this.** It remains blocked on `divinevideo/support-trust-safety#199`. Its three mobile items were re-verified on device during the patrol and all hold; the NIP-05 rotation asymmetry stays #8253's.
- **The wider `DivineButton` gap.** 271 of 276 call sites under `mobile/lib` pass no `semanticLabel` and so render without the button role, while `check_material_button_ceiling.sh` actively migrates Material buttons — which do set it — into `DivineButton`. Fixed only at this call site here; being written up separately.
- **#7848** ("disable the reaction picker on closed retired moderation threads") is already fixed on `main` and needs no code — evidence is going on that issue.
- Neither share picker filters retired moderation accounts, so one remains selectable with full official branding. The send is refused — by `DmRepository.sendMessage`'s gate at `dm_repository.dart:4512-4520`, before the rumor is built or enqueued, so `sendRumor` is never reached on this path. For a **single** recipient the sheet reports failure correctly. For **more than one**, `share_sheet_bloc.dart:334-366` branches on `delivered.isNotEmpty` and reports success naming only the delivered recipients, dropping the refused one silently — a real false success, filed separately. Not changed here.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test test/router test/screens/inbox/conversation/conversation_view_test.dart` — 672 passing
- Ratchets, all passing: layer direction, ungrouped tests, placeholder tests, divine_ui semantic labels, l10n delegates, skip ceiling, test/unit structure, shared setup stubs, post-close emit, Nostr id truncation, pubkey log encoding
- **Mutation-checked.** Each new test fails for its own distinct reason and no other: with no scope key the re-scope test fails; with a whole-path key the paging test fails; both pass only together. Removing the `semanticLabel` fails the a11y test.
- **On device** (iPhone 17 simulator, local stack): four consecutive profile deep links each render the account named in the app bar. Before the fix the second onward showed the first account's body. The closed-thread control reported `role: AXStaticText` with no Button trait beforehand.
- The l10n-delegates baseline shrinks by one entry: every `MaterialApp` in the touched test file now carries the delegates, including the two that predate this change.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

