### PR TITLE
fix(media): dispose the images that blurhash placeholders and watermark rendering create

### DIFF
--- a/mobile/lib/services/watermark_image_generator.dart
+++ b/mobile/lib/services/watermark_image_generator.dart
@@ -34,6 +34,9 @@ class WatermarkImageGenerator {
     required String watermarkText,
   }) async {
     final wordmarkImage = await _loadWordmarkImage();
+    ui.Paragraph? textParagraph;
+    ui.Picture? picture;
+    ui.Image? image;
 
     try {
       final recorder = ui.PictureRecorder();
@@ -45,7 +48,7 @@ class WatermarkImageGenerator {
       // Build the single-line watermark text using the resolved identity.
       // Available width = from left margin to right margin
       final maxTextWidth = videoWidth - 2 * _margin;
-      final textParagraph = _buildParagraph(
+      textParagraph = _buildParagraph(
         watermarkText,
         fontSize,
         maxTextWidth,
@@ -98,8 +101,8 @@ class WatermarkImageGenerator {
       canvas.drawParagraph(textParagraph, ui.Offset(textLeft, textTop));
 
       // Convert to image
-      final picture = recorder.endRecording();
-      final image = await picture.toImage(videoWidth, videoHeight);
+      picture = recorder.endRecording();
+      image = await picture.toImage(videoWidth, videoHeight);
       final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
 
       if (byteData == null) {
@@ -110,6 +113,11 @@ class WatermarkImageGenerator {
 
       return byteData.buffer.asUint8List();
     } finally {
+      // Every native drawing resource this call created; only the PNG bytes
+      // may outlive it.
+      image?.dispose();
+      picture?.dispose();
+      textParagraph?.dispose();
       wordmarkImage.dispose();
     }
   }

--- a/mobile/lib/services/watermark_image_generator.dart
+++ b/mobile/lib/services/watermark_image_generator.dart
@@ -48,11 +48,7 @@ class WatermarkImageGenerator {
       // Build the single-line watermark text using the resolved identity.
       // Available width = from left margin to right margin
       final maxTextWidth = videoWidth - 2 * _margin;
-      textParagraph = _buildParagraph(
-        watermarkText,
-        fontSize,
-        maxTextWidth,
-      );
+      textParagraph = _buildParagraph(watermarkText, fontSize, maxTextWidth);
       textParagraph.layout(ui.ParagraphConstraints(width: maxTextWidth));
 
       // Calculate wordmark draw size preserving aspect ratio
@@ -127,9 +123,12 @@ class WatermarkImageGenerator {
     try {
       final data = await rootBundle.load(_wordmarkAssetPath);
       final codec = await ui.instantiateImageCodec(data.buffer.asUint8List());
-      final frame = await codec.getNextFrame();
-      codec.dispose();
-      return frame.image;
+      try {
+        final frame = await codec.getNextFrame();
+        return frame.image;
+      } finally {
+        codec.dispose();
+      }
     } catch (e) {
       throw WatermarkGenerationException('Failed to load wordmark asset: $e');
     }

--- a/mobile/lib/widgets/blurhash_display.dart
+++ b/mobile/lib/widgets/blurhash_display.dart
@@ -39,6 +39,14 @@ class _BlurhashDisplayState extends State<BlurhashDisplay> {
   BlurhashData? _blurhashData;
   Future<ui.Image?>? _imageFuture;
 
+  /// The decoded image this state owns. [FutureBuilder] only borrows it; it is
+  /// disposed here once a newer decode lands, and in [dispose].
+  ui.Image? _image;
+
+  /// Bumped per decode and in [dispose], so a decode that lands late disposes
+  /// its own result instead of replacing a newer one.
+  int _decodeGeneration = 0;
+
   @override
   void initState() {
     super.initState();
@@ -52,6 +60,14 @@ class _BlurhashDisplayState extends State<BlurhashDisplay> {
         oldWidget.contentType != widget.contentType) {
       _decodeBlurhash();
     }
+  }
+
+  @override
+  void dispose() {
+    _decodeGeneration++;
+    _image?.dispose();
+    _image = null;
+    super.dispose();
   }
 
   void _decodeBlurhash() {
@@ -69,8 +85,9 @@ class _BlurhashDisplayState extends State<BlurhashDisplay> {
         // rebuilds — otherwise FutureBuilder restarts the decode and re-shows
         // the gradient fallback every time the surrounding tree rebuilds. #4196
         final pixels = data.pixels;
+        final generation = ++_decodeGeneration;
         final imageFuture = pixels != null
-            ? _createImageFromPixels(pixels, data.width, data.height)
+            ? _decodeImage(pixels, data.width, data.height, generation)
             : null;
         setState(() {
           _blurhashData = data;
@@ -155,6 +172,27 @@ class _BlurhashDisplayState extends State<BlurhashDisplay> {
         ),
       ),
     );
+  }
+
+  /// Decodes [pixels] and takes ownership of the result.
+  ///
+  /// A result that lands after a newer decode started, or after [dispose], has
+  /// nothing left to paint it, so it is disposed on the spot.
+  Future<ui.Image?> _decodeImage(
+    Uint8List pixels,
+    int width,
+    int height,
+    int generation,
+  ) async {
+    final image = await _createImageFromPixels(pixels, width, height);
+    if (image == null) return null;
+    if (generation != _decodeGeneration) {
+      image.dispose();
+      return null;
+    }
+    _image?.dispose();
+    _image = image;
+    return image;
   }
 
   Future<ui.Image?> _createImageFromPixels(

--- a/mobile/test/services/watermark_image_generator_test.dart
+++ b/mobile/test/services/watermark_image_generator_test.dart
@@ -102,6 +102,35 @@ void main() {
       _clearAssetMock();
     });
 
+    test('disposes every image it rasterizes', () async {
+      final live = <ui.Image>{};
+      final previousOnCreate = ui.Image.onCreate;
+      final previousOnDispose = ui.Image.onDispose;
+      ui.Image.onCreate = (image) {
+        previousOnCreate?.call(image);
+        live.add(image);
+      };
+      ui.Image.onDispose = (image) {
+        previousOnDispose?.call(image);
+        live.remove(image);
+      };
+      addTearDown(() {
+        ui.Image.onCreate = previousOnCreate;
+        ui.Image.onDispose = previousOnDispose;
+      });
+
+      await WatermarkImageGenerator.generateWatermark(
+        videoWidth: 64,
+        videoHeight: 64,
+        watermarkText: '@divine.video',
+      );
+
+      // The wordmark decode and the full-frame raster are both handles this
+      // call owns; leaving either open keeps its native pixels alive until the
+      // garbage collector finalizes the wrapper.
+      expect(live, isEmpty);
+    });
+
     test('bundled wordmark asset matches the refreshed logo mark', () async {
       final decoded = await _decodeRgba(wordmarkBytes);
       const expectedLogoAspectRatio = 125 / 33;

--- a/mobile/test/widgets/blurhash_display_test.dart
+++ b/mobile/test/widgets/blurhash_display_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
@@ -9,6 +10,8 @@ void main() {
     // A real, decodable blurhash — the decode path under test rejects
     // malformed strings before it ever produces an image.
     const validBlurhash = 'L5H2EC=PM+yV0g-mq.wG9c010J}I';
+    // A second decodable hash, so a widget update actually re-decodes.
+    const otherValidBlurhash = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj';
 
     testWidgets('keeps decode future stable across parent rebuilds', (
       tester,
@@ -76,5 +79,76 @@ void main() {
       expect(gradient.colors.first.a, closeTo(0.5, 0.01));
       expect(find.byType(Opacity), findsNothing);
     });
+
+    testWidgets('disposes the decoded image when unmounted', (tester) async {
+      await tester.pumpWidget(
+        const SizedBox(
+          width: 100,
+          height: 100,
+          child: BlurhashDisplay(blurhash: validBlurhash),
+        ),
+      );
+      final image = await _decodedImage(tester);
+      expect(image.debugDisposed, isFalse);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      expect(image.debugDisposed, isTrue);
+    });
+
+    testWidgets('disposes the previous image once a new blurhash decodes', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const SizedBox(
+          width: 100,
+          height: 100,
+          child: BlurhashDisplay(blurhash: validBlurhash),
+        ),
+      );
+      final first = await _decodedImage(tester);
+
+      await tester.pumpWidget(
+        const SizedBox(
+          width: 100,
+          height: 100,
+          child: BlurhashDisplay(blurhash: otherValidBlurhash),
+        ),
+      );
+      final second = await _decodedImage(tester);
+
+      expect(second, isNot(same(first)));
+      expect(first.debugDisposed, isTrue);
+      expect(second.debugDisposed, isFalse);
+    });
   });
+}
+
+/// Resolves the image the widget's [FutureBuilder] is waiting on.
+///
+/// The decode hops between the engine, which needs real time, and `then`
+/// callbacks queued in the test's fake-async zone, which only run on a pump.
+/// Awaiting the future inside a single `runAsync` therefore never completes;
+/// alternating the two does, the same way `clip_thumbnail_image_test` polls.
+Future<ui.Image> _decodedImage(WidgetTester tester) async {
+  final future = tester
+      .widget<FutureBuilder<ui.Image?>>(find.byType(FutureBuilder<ui.Image?>))
+      .future!;
+  ui.Image? image;
+  var completed = false;
+  unawaited(
+    future.then((value) {
+      image = value;
+      completed = true;
+    }),
+  );
+  for (var attempt = 0; attempt < 50 && !completed; attempt++) {
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 20)),
+    );
+    await tester.pump();
+  }
+  expect(completed, isTrue, reason: 'blurhash decode never completed');
+  expect(image, isNotNull);
+  return image!;
 }

--- a/mobile/test/widgets/blurhash_display_test.dart
+++ b/mobile/test/widgets/blurhash_display_test.dart
@@ -126,10 +126,9 @@ void main() {
 
 /// Resolves the image the widget's [FutureBuilder] is waiting on.
 ///
-/// The decode hops between the engine, which needs real time, and `then`
-/// callbacks queued in the test's fake-async zone, which only run on a pump.
-/// Awaiting the future inside a single `runAsync` therefore never completes;
-/// alternating the two does, the same way `clip_thumbnail_image_test` polls.
+/// The decode hops between the engine and `then` callbacks queued in the test's
+/// fake-async zone. Awaiting the future inside a single `runAsync` therefore
+/// never completes; alternating real event-queue turns with pumps does.
 Future<ui.Image> _decodedImage(WidgetTester tester) async {
   final future = tester
       .widget<FutureBuilder<ui.Image?>>(find.byType(FutureBuilder<ui.Image?>))
@@ -143,9 +142,7 @@ Future<ui.Image> _decodedImage(WidgetTester tester) async {
     }),
   );
   for (var attempt = 0; attempt < 50 && !completed; attempt++) {
-    await tester.runAsync(
-      () => Future<void>.delayed(const Duration(milliseconds: 20)),
-    );
+    await tester.runAsync(pumpEventQueue);
     await tester.pump();
   }
   expect(completed, isTrue, reason: 'blurhash decode never completed');


### PR DESCRIPTION
## Description

Two places in the app create a `ui.Image` and never dispose it, so the native pixels stay alive until the garbage collector finalizes the Dart wrapper instead of being released when the app is done with them.

**Blurhash placeholders.** `BlurhashDisplay` decodes each blurhash into a 32×32 image and had no `dispose()`; changing the hash on a mounted widget decoded a second image and left the first one live as well. The state now owns the decoded image: it disposes the previous one once a newer decode lands, disposes the current one on unmount, and a decode that lands late, after `dispose()` or after a newer decode started, disposes its own result instead of replacing a newer one. The swap happens before the new future completes, so `FutureBuilder` never paints a disposed image.

**Watermark rendering.** `WatermarkImageGenerator.generateWatermark` rasterized the overlay with `picture.toImage`, encoded it to PNG and returned; only the wordmark image was disposed. At 1080×1920 that was roughly 8 MB of native pixels per watermarked export. The full-frame image, the picture and the text paragraph are now disposed in the existing `finally`.

Found while auditing `ui.Image` ownership for #8652. That issue's bug cannot happen in production because no app code constructs an `ImageInfo`; these two sites were the only `ui.Image` owners under `lib/` that did not release their handles.

**Related Issue:** Fixes #8674, Fixes #8675

## Out of Scope

- The visible layout of either widget. Nothing changes on screen.
- The other `ui.Image` owners under `lib/` (`ReactionOverlay`, `PinchZoomGrid`, `ImageWithDimensionsListener`), which already dispose correctly.

## Verification

- New tests fail on `main` and pass here: `BlurhashDisplay` disposes the decoded image on unmount and disposes the previous image once a new blurhash decodes (checked through `debugDisposed`); `generateWatermark` leaves no live `ui.Image` behind (tracked through `ui.Image.onCreate` / `onDispose`, restored in teardown).
- `flutter test` on the two suites plus every suite that pumps `BlurhashDisplay` or calls the generator: 118 tests green.
- `flutter analyze lib test integration_test`: clean.
- CI-only ratchets run locally and unchanged: placeholder tests, ungrouped tests, l10n delegates, unpinned unchanged assertions, process-global mutations, empty catch ceiling, untested services floor, skip ceiling.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
