### PR TITLE
test: catch inactive negative-path mechanisms

### DIFF
--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -1443,6 +1443,7 @@ void main() {
       'wrong key leaves an encrypted hot journal byte-for-byte intact',
       () async {
         _createHotJournalFixture(dbPath, key: validKey);
+        _expectReadOnlyRollback(dbPath);
         final databaseBefore = File(dbPath).readAsBytesSync();
         final journalBefore = File('$dbPath-journal').readAsBytesSync();
         const wrongKey =
@@ -1465,6 +1466,7 @@ void main() {
       'wrong key leaves a spilled-schema journal byte-for-byte intact',
       () async {
         _createSpilledSchemaHotJournalFixture(dbPath, key: validKey);
+        _expectReadOnlyRollback(dbPath);
         final databaseBefore = File(dbPath).readAsBytesSync();
         final journalBefore = File('$dbPath-journal').readAsBytesSync();
         const wrongKey =

--- a/mobile/packages/dm_repository/test/src/collaborator_invite_recovery_test.dart
+++ b/mobile/packages/dm_repository/test/src/collaborator_invite_recovery_test.dart
@@ -419,6 +419,16 @@ void main() {
 
     test('parseCollaboratorInviteRumor rejects non-invite rumor tags', () {
       expect(
+        parseCollaboratorInviteRumorTags([
+          [
+            CollaboratorInviteTags.markerName,
+            CollaboratorInviteTags.markerValue,
+          ],
+          [CollaboratorInviteTags.address, _videoAddress],
+        ]),
+        isNotNull,
+      );
+      expect(
         parseCollaboratorInviteRumor(
           Event(_ownerPubkey, 14, const [], 'invite'),
         ),
@@ -456,6 +466,17 @@ void main() {
     });
 
     test('parseCollaboratorInviteRumor rejects mismatched creator pubkey', () {
+      expect(
+        parseCollaboratorInviteRumorTags([
+          [
+            CollaboratorInviteTags.markerName,
+            CollaboratorInviteTags.markerValue,
+          ],
+          [CollaboratorInviteTags.address, _videoAddress],
+          [CollaboratorInviteTags.pubkey, _ownerPubkey],
+        ]),
+        isNotNull,
+      );
       final metadata = parseCollaboratorInviteRumorTags([
         [CollaboratorInviteTags.markerName, CollaboratorInviteTags.markerValue],
         [CollaboratorInviteTags.address, _videoAddress],
@@ -483,6 +504,21 @@ void main() {
     );
 
     test('parseCollaboratorInviteRumor rejects non-collaborator role', () {
+      expect(
+        parseCollaboratorInviteRumorTags([
+          [
+            CollaboratorInviteTags.markerName,
+            CollaboratorInviteTags.markerValue,
+          ],
+          [CollaboratorInviteTags.address, _videoAddress],
+          [CollaboratorInviteTags.pubkey, _ownerPubkey],
+          [
+            CollaboratorInviteTags.role,
+            CollaboratorInviteTags.collaboratorRole,
+          ],
+        ]),
+        isNotNull,
+      );
       final metadata = parseCollaboratorInviteRumorTags([
         [CollaboratorInviteTags.markerName, CollaboratorInviteTags.markerValue],
         [CollaboratorInviteTags.address, _videoAddress],

--- a/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
+++ b/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
@@ -640,7 +640,9 @@ void main() {
           fake.flushMicrotasks();
           fake.elapse(const Duration(milliseconds: 5));
           fake.flushMicrotasks();
+          expect(fake.pendingTimers, isNotEmpty);
           cubit.close();
+          expect(fake.pendingTimers, isEmpty);
 
           final countAfterClose = loadCount;
           // One initial load plus at least one 1ms poll; without this pin a
@@ -819,11 +821,13 @@ void main() {
           );
           fake.flushMicrotasks();
 
+          expect(fake.pendingTimers, isNotEmpty);
           fake.elapse(const Duration(milliseconds: 2));
           fake.flushMicrotasks();
 
           expect(cubit.state.provisioningPollAttempts, 2);
           expect(cubit.state.provisioningPollingTimedOut, isTrue);
+          expect(fake.pendingTimers, isEmpty);
           final cappedCount = loadCount;
 
           fake.elapse(const Duration(milliseconds: 5));

--- a/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
+++ b/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
@@ -694,6 +694,58 @@ void main() {
         },
       );
 
+      test('stops polling after the max failed poll attempts is reached', () {
+        var loadCount = 0;
+        when(() => repository.loadStatus(pubkey: testPubkey)).thenAnswer((
+          _,
+        ) async {
+          loadCount += 1;
+          return const BlueskyCrosspostAccountStatus(
+            crosspostEnabled: true,
+            username: 'testuser',
+            handle: 'testuser.divine.video',
+            provisioningState: AtprotoProvisioningState.pending,
+            usernameClaimStatus: UsernameClaimStatus.claimed,
+          );
+        });
+        when(() => repository.loadKeycastStatus()).thenAnswer((_) async {
+          loadCount += 1;
+          throw const CrosspostApiException(
+            'unavailable',
+            statusCode: 503,
+            kind: CrosspostApiErrorKind.unavailable,
+          );
+        });
+
+        fakeAsync((fake) {
+          final cubit = buildCubit(
+            pollInterval: const Duration(milliseconds: 1),
+            maxProvisioningPollAttempts: 2,
+          );
+          fake.flushMicrotasks();
+
+          expect(fake.pendingTimers, isNotEmpty);
+          fake.elapse(const Duration(milliseconds: 2));
+          fake.flushMicrotasks();
+
+          expect(cubit.state.provisioningPollAttempts, 2);
+          expect(cubit.state.provisioningPollingTimedOut, isTrue);
+          // The quiet-failure cap owns its own cancel, separate from the
+          // success-path cap in _syncProvisioningPoller.
+          expect(fake.pendingTimers, isEmpty);
+          expect(cubit.state.error, isNull);
+          final cappedCount = loadCount;
+          // One initial load plus the capped failing polls; without this pin a
+          // cubit that never polled would pass on 1 == 1 (#8617).
+          expect(cappedCount, greaterThan(1));
+
+          fake.elapse(const Duration(milliseconds: 5));
+          fake.flushMicrotasks();
+          expect(loadCount, cappedCount);
+          cubit.close();
+        });
+      });
+
       test('stale poll result does not overwrite toggle result', () async {
         final pollCompleter = Completer<CrosspostStatus>();
         when(() => repository.loadStatus(pubkey: testPubkey)).thenAnswer(

--- a/mobile/test/screens/inbox/inbox_page_test.dart
+++ b/mobile/test/screens/inbox/inbox_page_test.dart
@@ -384,6 +384,9 @@ void main() {
           ).read(_profileRepoSwap.notifier).state = 1;
           await tester.pump();
 
+          // Pin the ref.listen handoff: unchanged widget identities alone
+          // would also pass if the profile-repository flip were never handled.
+          verify(readyProfileRepo.watchVanishedPubkeys).called(1);
           expect(
             readBloc(tester),
             same(conversationBloc),


### PR DESCRIPTION
Four negative-path tests could pass when the mechanism they intended to protect never ran. That left repository handoff, collaborator-invite rejection attribution, hot-journal fixture validity, and crosspost poller cleanup vulnerable to silent test regressions.

This test-only change adds a positive control at each boundary: it verifies the profile repository listener fires, compares each rejected invite shape with an accepted one-field baseline, proves both journal fixtures require rollback before checking preservation, and observes the periodic timer itself before and after shutdown.

No production behavior, generated code, localization, migrations, or test baselines change.

Verification:
- 131 focused tests across the four changed files pass
- flutter analyze lib test integration_test passes
- dm_repository and db_client package analysis pass
- mutation checks turn each strengthened assertion red, including all three poller leak paths

Closes #8658
