### PR TITLE
fix(tooling): make the stale-branch report able to recommend anything

### DIFF
--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -74,12 +74,16 @@ work do not:
   `fix/7606-semantic-tokens` was destroyed exactly this way: unpushed
   local work on a parallel attempt at the same task.
 
-The useful signal is GitHub reporting a same-repo merged PR to `main` with
-that head ref. Everything else is KEEP, and two vetoes apply on top even
-to matched branches: the local branch tip must exist in GitHub's repository
-object database, and the worktree must have no uncommitted or ignored
-files. That keeps branch-name reuse, unpushed commits, and local-only
-worktree files out of the prunable set.
+The useful signals are GitHub reporting a same-repo merged PR to `main` with
+that head ref, or a worktree tip that belongs to a merged PR but is not already
+an ancestor of `main`. The latter identifies review worktrees whose scratch
+branch name never matched the reviewed PR while excluding fresh worktrees
+created at `origin/main`. Two vetoes apply on top: the local branch tip must
+exist in GitHub's repository object database, and the worktree must have no
+uncommitted, untracked, or non-regenerable ignored files. Ignored toolchain
+output such as `build/`, `.dart_tool/`, and generated plugin registrants does
+not veto because tracked inputs can recreate it. This keeps branch-name reuse,
+unpushed commits, and local-only worktree files out of the prunable set.
 
 ### Optional: warn on concurrent sessions in one worktree
 

--- a/mobile/test/tools/prune_merged_branches_test.dart
+++ b/mobile/test/tools/prune_merged_branches_test.dart
@@ -131,7 +131,14 @@ exit 2
       git(['init']);
       git(['config', 'user.email', 'test@example.com']);
       git(['config', 'user.name', 'Test User']);
-      write('.gitignore', '.env\nbuild/\n');
+      write(
+        '.gitignore',
+        '.env\n'
+            'build/\n'
+            '.dart_tool/\n'
+            'local.properties\n'
+            '**/GeneratedPluginRegistrant.java\n',
+      );
       write('README.md', 'fixture\n');
       commit('initial');
       git(['branch', '-M', 'main']);
@@ -171,9 +178,56 @@ exit 2
       );
 
       expect(result.exitCode, 0, reason: result.stderr.toString());
-      expect(result.stdout, contains('KEEP-DIRTY'));
-      expect(result.stdout, contains('dirty-worktree'));
+      expect(result.stdout, contains('KEEP-DIRTY     dirty-worktree'));
+      expect(result.stdout, contains('0 likely prunable'));
       expect(File(p.join(worktree.path, '.env')).existsSync(), isTrue);
+    });
+
+    test('toolchain output in a worktree does not block a merged branch', () {
+      makeBranch('regenerable-worktree', 'merged');
+      final tip = branchTip('regenerable-worktree');
+      final worktree = Directory(p.join(sandbox.path, 'regenerable-worktree'));
+      git(['worktree', 'add', worktree.path, 'regenerable-worktree']);
+      write('build/app.apk', 'binary\n', root: worktree.path);
+      write('.dart_tool/package_config.json', '{}\n', root: worktree.path);
+      write(
+        'android/app/src/main/java/io/flutter/plugins/'
+            'GeneratedPluginRegistrant.java',
+        'generated\n',
+        root: worktree.path,
+      );
+      write('local.properties', 'sdk.dir=/tmp\n', root: worktree.path);
+
+      final result = runScript(
+        mergedHeadRefs: ['regenerable-worktree'],
+        githubCommitShas: [tip],
+      );
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('MERGED-PR      regenerable-worktree'));
+      expect(
+        result.stdout,
+        isNot(contains('KEEP-DIRTY     regenerable-worktree')),
+      );
+      expect(result.stdout, contains('1 likely prunable'));
+    });
+
+    test('an untracked non-ignored file still blocks a merged branch', () {
+      makeBranch('untracked-worktree', 'merged');
+      final tip = branchTip('untracked-worktree');
+      final worktree = Directory(p.join(sandbox.path, 'untracked-worktree'));
+      git(['worktree', 'add', worktree.path, 'untracked-worktree']);
+      write('build/app.apk', 'binary\n', root: worktree.path);
+      write('scratch-notes.md', 'unsaved thinking\n', root: worktree.path);
+
+      final result = runScript(
+        mergedHeadRefs: ['untracked-worktree'],
+        githubCommitShas: [tip],
+      );
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('KEEP-DIRTY     untracked-worktree'));
+      expect(result.stdout, contains('0 likely prunable'));
     });
 
     test('asks GitHub for a broad filtered merged PR set', () {

--- a/mobile/test/tools/prune_merged_branches_test.dart
+++ b/mobile/test/tools/prune_merged_branches_test.dart
@@ -292,6 +292,26 @@ exit 2
 
       expect(result.exitCode, 0, reason: result.stderr.toString());
       expect(result.stdout, contains('MERGED-TIP     pr-8511'));
+      final args = ghArgs.readAsStringSync();
+      expect(args, contains('merged_at != null'));
+      expect(args, contains('base.ref == "main"'));
+    });
+
+    test('keeps a fresh worktree whose tip is already on main', () {
+      git(['branch', 'fresh-worktree', 'main']);
+      final tip = branchTip('fresh-worktree');
+      final worktree = Directory(p.join(sandbox.path, 'fresh-worktree'));
+      git(['worktree', 'add', worktree.path, 'fresh-worktree']);
+
+      final result = runScript(
+        mergedHeadRefs: const [],
+        githubCommitShas: [tip],
+        mergedTipShas: [tip],
+      );
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('KEEP           fresh-worktree'));
+      expect(result.stdout, contains('0 likely prunable'));
     });
 
     test('a tip-matched branch still fails when the tip is not on GitHub', () {

--- a/mobile/test/tools/prune_merged_branches_test.dart
+++ b/mobile/test/tools/prune_merged_branches_test.dart
@@ -63,6 +63,7 @@ void main() {
     ProcessResult runScript({
       required List<String> mergedHeadRefs,
       required List<String> githubCommitShas,
+      List<String> mergedTipShas = const [],
       List<String> args = const [],
     }) {
       return Process.runSync(
@@ -77,6 +78,7 @@ void main() {
           'MERGED_PR_LIMIT': '100000',
           'FAKE_MERGED_HEAD_REFS': mergedHeadRefs.join('\n'),
           'FAKE_GITHUB_COMMIT_SHAS': githubCommitShas.join('\n'),
+          'FAKE_MERGED_TIP_SHAS': mergedTipShas.join('\n'),
           'FAKE_GH_ARGS': ghArgs.path,
         },
       );
@@ -112,8 +114,23 @@ if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
 fi
 
 if [ "$1" = "api" ]; then
-  sha="${*: -1}"
-  sha="${sha##*/}"
+  api_path=""
+  for arg in "$@"; do
+    case "$arg" in repos/*) api_path="$arg" ;; esac
+  done
+  case "$api_path" in
+    */pulls)
+      sha="${api_path%/pulls}"
+      sha="${sha##*/}"
+      if printf '%s\n' "${FAKE_MERGED_TIP_SHAS:-}" | grep -qxF -- "$sha"; then
+        printf '1\n'
+      else
+        printf '0\n'
+      fi
+      exit 0
+      ;;
+  esac
+  sha="${api_path##*/}"
   if printf '%s\n' "${FAKE_GITHUB_COMMIT_SHAS:-}" | grep -qxF -- "$sha"; then
     printf '{}\n'
     exit 0
@@ -183,6 +200,37 @@ exit 2
       expect(File(p.join(worktree.path, '.env')).existsSync(), isTrue);
     });
 
+    test('asks GitHub for a broad filtered merged PR set', () {
+      makeBranch('merged-branch', 'merged');
+
+      final result = runScript(
+        mergedHeadRefs: ['merged-branch'],
+        githubCommitShas: [branchTip('merged-branch')],
+      );
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      final args = ghArgs.readAsStringSync();
+      expect(args, contains('--limit 100000'));
+      expect(
+        args,
+        contains('--json headRefName,isCrossRepository,baseRefName'),
+      );
+      expect(args, contains('isCrossRepository == false'));
+      expect(args, contains('baseRefName == "main"'));
+    });
+
+    test('--help prints usage and exits without fetching', () {
+      final result = runScript(
+        args: ['--help'],
+        mergedHeadRefs: const [],
+        githubCommitShas: const [],
+      );
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('bash scripts/prune-merged-branches.sh'));
+      expect(result.stdout, isNot(contains('Fetching origin')));
+    });
+
     test('toolchain output in a worktree does not block a merged branch', () {
       makeBranch('regenerable-worktree', 'merged');
       final tip = branchTip('regenerable-worktree');
@@ -230,35 +278,51 @@ exit 2
       expect(result.stdout, contains('0 likely prunable'));
     });
 
-    test('asks GitHub for a broad filtered merged PR set', () {
-      makeBranch('merged-branch', 'merged');
+    test('reports a review worktree whose tip a merged PR contains', () {
+      makeBranch('pr-8511', 'review checkout');
+      final tip = branchTip('pr-8511');
+      final worktree = Directory(p.join(sandbox.path, 'pr-8511'));
+      git(['worktree', 'add', worktree.path, 'pr-8511']);
 
       final result = runScript(
-        mergedHeadRefs: ['merged-branch'],
-        githubCommitShas: [branchTip('merged-branch')],
+        mergedHeadRefs: ['an-unrelated-head-ref'],
+        githubCommitShas: [tip],
+        mergedTipShas: [tip],
       );
 
       expect(result.exitCode, 0, reason: result.stderr.toString());
-      final args = ghArgs.readAsStringSync();
-      expect(args, contains('--limit 100000'));
-      expect(
-        args,
-        contains('--json headRefName,isCrossRepository,baseRefName'),
-      );
-      expect(args, contains('isCrossRepository == false'));
-      expect(args, contains('baseRefName == "main"'));
+      expect(result.stdout, contains('MERGED-TIP     pr-8511'));
     });
 
-    test('--help prints usage and exits without fetching', () {
+    test('a tip-matched branch still fails when the tip is not on GitHub', () {
+      makeBranch('pr-9000', 'review checkout');
+      final tip = branchTip('pr-9000');
+      final worktree = Directory(p.join(sandbox.path, 'pr-9000'));
+      git(['worktree', 'add', worktree.path, 'pr-9000']);
+
       final result = runScript(
-        args: ['--help'],
         mergedHeadRefs: const [],
         githubCommitShas: const [],
+        mergedTipShas: [tip],
       );
 
       expect(result.exitCode, 0, reason: result.stderr.toString());
-      expect(result.stdout, contains('bash scripts/prune-merged-branches.sh'));
-      expect(result.stdout, isNot(contains('Fetching origin')));
+      expect(result.stdout, contains('KEEP-LOCAL     pr-9000'));
+    });
+
+    test('does not ask about tips for branches that have no worktree', () {
+      makeBranch('no-worktree-branch', 'local');
+      final tip = branchTip('no-worktree-branch');
+
+      final result = runScript(
+        mergedHeadRefs: const [],
+        githubCommitShas: [tip],
+        mergedTipShas: [tip],
+      );
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('KEEP           no-worktree-branch'));
+      expect(ghArgs.readAsStringSync(), isNot(contains('/pulls')));
     });
 
     test('--execute is rejected while deletion lives outside this PR', () {

--- a/scripts/prune-merged-branches.sh
+++ b/scripts/prune-merged-branches.sh
@@ -149,9 +149,12 @@ while IFS= read -r branch; do
 
   if grep -qxF -- "$branch" "$MERGED_REFS"; then
     verdict="MERGED-PR"
-  elif [ -n "$wt" ] && [ -d "$wt" ] && merged_pr_contains_commit "$tip"; then
+  elif [ -n "$wt" ] && [ -d "$wt" ] \
+    && ! git merge-base --is-ancestor "$tip" "$BASE" \
+    && merged_pr_contains_commit "$tip"; then
     # Only worktree branches get this lookup: it is one API call per branch,
-    # and a branch with no worktree costs a ref, not 4GB of build output.
+    # and a branch with no worktree costs a ref, not 4GB of build output. Tips
+    # already on main belong to fresh worktrees, not squashed-away PR heads.
     verdict="MERGED-TIP"
   else
     verdict="KEEP"

--- a/scripts/prune-merged-branches.sh
+++ b/scripts/prune-merged-branches.sh
@@ -19,7 +19,13 @@
 # So the useful signal in a squash-merge repo is GitHub reporting a same-repo PR
 # to main with this head ref merged. Everything else is KEEP.
 #
-# 4. Vetoing on any ignored file makes the script report nothing, ever. Every
+# 4. A head-ref name match alone misses review worktrees. A worktree created to
+#    review someone else's PR sits on a scratch branch (`pr-8511`, `pr-8634`)
+#    whose name is the head ref of no PR at all, so the name lookup scores it
+#    KEEP forever. For those, ask GitHub which PRs contain the worktree's tip
+#    COMMIT — an exact SHA, so it needs no name inference. That is MERGED-TIP.
+#
+# 5. Vetoing on any ignored file makes the script report nothing, ever. Every
 #    Flutter worktree carries build/, .dart_tool/ and a pile of generated
 #    plugin registrants, so Veto 2 below used to fire on all of them and the
 #    run always ended "0 likely prunable". Ignored paths that a toolchain step
@@ -27,9 +33,9 @@
 #    (a .env, a scratch note, a patch) still are. Only the latter veto.
 #
 # The bias is deliberate. A false KEEP costs disk. A false DELETE costs work
-# that exists nowhere else — an unpushed branch has no backup. The rule above
-# keeps that asymmetry: an ignored path absent from the regenerable list still
-# vetoes.
+# that exists nowhere else — an unpushed branch has no backup. Both additions
+# above keep that asymmetry: MERGED-TIP still needs Veto 1 to pass, and an
+# ignored path that is not on the regenerable list still vetoes.
 #
 # Usage:
 #   bash scripts/prune-merged-branches.sh
@@ -95,6 +101,14 @@ commit_exists_on_github() {
   "$GH" api -X GET "repos/$REPO/commits/$1" >/dev/null 2>&1
 }
 
+# A merged-to-main PR containing this exact commit. Used only for branches
+# whose NAME matches no merged head ref, so review worktrees are still seen.
+merged_pr_contains_commit() {
+  "$GH" api -X GET "repos/$REPO/commits/$1/pulls" \
+    --jq '[.[] | select(.merged_at != null) | select(.base.ref == "main")] | length' \
+    2>/dev/null | grep -qxE '[1-9][0-9]*'
+}
+
 # Ignored paths any Flutter toolchain step recreates from tracked sources.
 # `flutter pub get` plus a build regenerates every one, so a worktree holding
 # only these holds no work. Anything absent from this list vetoes, which is
@@ -135,41 +149,51 @@ while IFS= read -r branch; do
 
   if grep -qxF -- "$branch" "$MERGED_REFS"; then
     verdict="MERGED-PR"
+  elif [ -n "$wt" ] && [ -d "$wt" ] && merged_pr_contains_commit "$tip"; then
+    # Only worktree branches get this lookup: it is one API call per branch,
+    # and a branch with no worktree costs a ref, not 4GB of build output.
+    verdict="MERGED-TIP"
   else
     verdict="KEEP"
   fi
 
-  # Vetoes are applied even to MERGED-PR branches.
+  # Vetoes are applied even to MERGED-PR and MERGED-TIP branches.
+  case "$verdict" in MERGED-*) prunable=yes ;; *) prunable=no ;; esac
 
   # Veto 1: the local tip must exist in GitHub's repository object database.
   # This catches unpushed work and branch-name reuse after an older PR merged.
-  if [ "$verdict" = "MERGED-PR" ]; then
+  if [ "$prunable" = yes ]; then
     if ! commit_exists_on_github "$tip"; then
       verdict="KEEP-LOCAL"
+      prunable=no
     fi
   fi
 
   # Veto 2: uncommitted, untracked, or non-regenerable ignored work in the
   # branch's worktree exists in no commit anywhere, merged PR or not.
-  if [ "$verdict" = "MERGED-PR" ] && [ -n "$wt" ] && [ -d "$wt" ]; then
+  if [ "$prunable" = yes ] && [ -n "$wt" ] && [ -d "$wt" ]; then
     if [ -n "$(worktree_blocking_paths "$wt")" ]; then
       verdict="KEEP-DIRTY"
+      prunable=no
     fi
   fi
 
   printf '%-14s %-50s %s\n' "$verdict" "$branch" "${wt:-—}"
-  if [ "$verdict" = "MERGED-PR" ]; then
+  if [ "$prunable" = yes ]; then
     merged=$((merged + 1))
   else
     keep=$((keep + 1))
   fi
 done < <(git for-each-ref --format='%(refname:short)' refs/heads/ | sort)
 
-printf '\n%s likely prunable (merged same-repo PR to main, local tip on GitHub, clean) / %s kept.\n' "$merged" "$keep"
+printf '\n%s likely prunable (merged PR to main, local tip on GitHub, clean) / %s kept.\n' "$merged" "$keep"
 echo
 echo "Report only. This script does not delete branches or worktrees."
-echo "KEEP includes branches with no matching merged same-repo PR to main,"
-echo "branches whose local tip is not on GitHub, and branches whose worktree"
-echo "holds uncommitted, untracked, or non-regenerable ignored files."
-echo "Toolchain output (build/, .dart_tool/, generated registrants) does not"
-echo "count. Review kept branches by hand."
+echo "  MERGED-PR   head ref of a merged same-repo PR to main."
+echo "  MERGED-TIP  no head-ref match, but a merged PR to main contains the"
+echo "              worktree tip. Only branches with a worktree get this check."
+echo "  KEEP        no merged PR signal at all."
+echo "  KEEP-LOCAL  local tip is not in GitHub's object database (unpushed)."
+echo "  KEEP-DIRTY  worktree holds uncommitted, untracked, or non-regenerable"
+echo "              ignored files. Toolchain output (build/, .dart_tool/,"
+echo "              generated registrants) does not count. Review these by hand."

--- a/scripts/prune-merged-branches.sh
+++ b/scripts/prune-merged-branches.sh
@@ -19,8 +19,17 @@
 # So the useful signal in a squash-merge repo is GitHub reporting a same-repo PR
 # to main with this head ref merged. Everything else is KEEP.
 #
+# 4. Vetoing on any ignored file makes the script report nothing, ever. Every
+#    Flutter worktree carries build/, .dart_tool/ and a pile of generated
+#    plugin registrants, so Veto 2 below used to fire on all of them and the
+#    run always ended "0 likely prunable". Ignored paths that a toolchain step
+#    recreates from tracked sources are not work; ignored paths it does not
+#    (a .env, a scratch note, a patch) still are. Only the latter veto.
+#
 # The bias is deliberate. A false KEEP costs disk. A false DELETE costs work
-# that exists nowhere else — an unpushed branch has no backup.
+# that exists nowhere else — an unpushed branch has no backup. The rule above
+# keeps that asymmetry: an ignored path absent from the regenerable list still
+# vetoes.
 #
 # Usage:
 #   bash scripts/prune-merged-branches.sh
@@ -86,6 +95,31 @@ commit_exists_on_github() {
   "$GH" api -X GET "repos/$REPO/commits/$1" >/dev/null 2>&1
 }
 
+# Ignored paths any Flutter toolchain step recreates from tracked sources.
+# `flutter pub get` plus a build regenerates every one, so a worktree holding
+# only these holds no work. Anything absent from this list vetoes, which is
+# also how a git-quoted or unusual path fails: safely, toward KEEP.
+REGENERABLE_DIR='build|\.dart_tool|\.gradle|\.symlinks|ephemeral|Pods|DerivedData|xcuserdata|\.swiftpm|coverage'
+REGENERABLE_FILE='\.DS_Store|\.flutter-plugins|\.flutter-plugins-dependencies|\.packages|local\.properties|Generated\.xcconfig|flutter_export_environment\.sh|Flutter\.podspec|gradlew|gradlew\.bat|gradle-wrapper\.jar|generated_plugins\.cmake|GeneratedPluginRegistrant\.(java|h|m|swift)|generated_plugin_registrant\.(cc|h|dart)'
+REGENERABLE_RE="(^|/)(${REGENERABLE_DIR})/|(^|/)(${REGENERABLE_FILE})\$"
+
+# Paths in a worktree that exist in no commit anywhere: every uncommitted or
+# untracked entry, plus ignored entries that are not toolchain output.
+worktree_blocking_paths() {
+  git -C "$1" status --porcelain --ignored=matching 2>/dev/null \
+    | while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        path=${line#??}
+        path=${path# }
+        case "$line" in
+          '!!'*)
+            printf '%s\n' "$path" | grep -qE "$REGENERABLE_RE" || printf '%s\n' "$path"
+            ;;
+          *) printf '%s\n' "$path" ;;
+        esac
+      done
+}
+
 CURRENT="$(git rev-parse --abbrev-ref HEAD)"
 
 printf '\n%-14s %-50s %s\n' "VERDICT" "BRANCH" "WORKTREE"
@@ -115,10 +149,10 @@ while IFS= read -r branch; do
     fi
   fi
 
-  # Veto 2: uncommitted or ignored work in the branch's worktree exists in no
-  # commit anywhere, merged PR or not.
+  # Veto 2: uncommitted, untracked, or non-regenerable ignored work in the
+  # branch's worktree exists in no commit anywhere, merged PR or not.
   if [ "$verdict" = "MERGED-PR" ] && [ -n "$wt" ] && [ -d "$wt" ]; then
-    if [ -n "$(git -C "$wt" status --porcelain --ignored=matching 2>/dev/null)" ]; then
+    if [ -n "$(worktree_blocking_paths "$wt")" ]; then
       verdict="KEEP-DIRTY"
     fi
   fi
@@ -135,5 +169,7 @@ printf '\n%s likely prunable (merged same-repo PR to main, local tip on GitHub, 
 echo
 echo "Report only. This script does not delete branches or worktrees."
 echo "KEEP includes branches with no matching merged same-repo PR to main,"
-echo "branches whose local tip is not on GitHub, and branches with dirty or"
-echo "ignored worktree files. Review kept branches by hand."
+echo "branches whose local tip is not on GitHub, and branches whose worktree"
+echo "holds uncommitted, untracked, or non-regenerable ignored files."
+echo "Toolchain output (build/, .dart_tool/, generated registrants) does not"
+echo "count. Review kept branches by hand."


### PR DESCRIPTION
Closes #8683

## Problem

`scripts/prune-merged-branches.sh` is the sanctioned way to find local branches and worktrees that are safe to delete. Run against this checkout it reported **0 prunable out of 270**, while 27 worktrees holding roughly 96GB were in fact deletable. A report that can never name a row is not a conservative report — it is one nobody can act on, so worktrees accumulate until the disk fills.

Two independent causes, one commit each.

**Veto 2 rejected a worktree holding any ignored file.** Every Flutter worktree carries `build/`, `.dart_tool/` and a set of generated plugin registrants, so the veto fired on all of them, always. The instinct behind it is right — an ignored `.env` or scratch note is work that exists nowhere else — but build output is regenerated by `flutter pub get`, and treating the two alike is what silenced the whole report.

**Branch-name matching cannot see a review worktree.** A worktree opened to review someone else's PR sits on a scratch branch (`pr-8511`, `pr-8634`, `pr-8645-local`) whose name is the head ref of no PR at all, so it scored KEEP permanently, long after the PR it was opened for had merged. Eleven such worktrees had built up here.

## Why this fix

The script's stated bias is deliberate and worth keeping: a false KEEP costs disk, a false DELETE costs work that has no backup. Both changes preserve that asymmetry rather than trading it away for a shorter report.

- Ignored entries veto unless they appear on an explicit list of toolchain output. Anything the list does not cover — including a path git quoted for unusual characters — still vetoes. Uncommitted and untracked entries veto exactly as before.
- Merged-ness is established from the **tip commit** via `commits/{sha}/pulls`, an exact SHA. It deliberately does not infer a PR from the directory or branch name; that heuristic previously destroyed unpushed work on `fix/7606-semantic-tokens`. The result is reported as its own `MERGED-TIP` verdict, and both vetoes still apply to it.

The verdict legend is now printed, because there are five verdicts and the summary line alone no longer explains them.

## What this deliberately leaves alone

- **Still report-only.** No deletion, no `--execute`; the existing test pinning that rejection stays.
- **Detached worktrees stay invisible.** The script iterates `refs/heads/`, so a worktree on a detached HEAD is never classified. One exists in this checkout holding uncommitted work. Fixing it means iterating worktrees independently of branches, which is a larger restructure than this.
- **Branches without a worktree get no tip lookup.** That would be one API call per branch across ~250 branches. A branch with no worktree costs a ref, not gigabytes.
- **Orphaned tips are not resolved.** A tip that was force-pushed away belongs to no PR, so it stays KEEP even when its content did land. Deciding that needs a content comparison against `main`, which is a judgment call this report should not make silently.

## Verification

- `flutter test test/tools/prune_merged_branches_test.dart` — 11 passed (was 5).
- The three behavioural tests were confirmed to **fail** against the pre-fix script and pass after, so they are real regression tests. The untracked-file test passes both before and after by design: it guards against the veto being weakened.
- `shellcheck` clean; `bash -n` clean; `dart format` clean; `flutter analyze lib test integration_test` — no issues.
- Run against this checkout, the report now correctly distinguishes the two merged-but-dirty worktrees as `KEEP-DIRTY` and leaves open-PR worktrees as `KEEP`. Independently confirmed that name matching still works: exactly 4 local branches match a merged head ref, and the script flags precisely those 4 as `KEEP-LOCAL` (reused names with unpushed tips).