### PR TITLE
chore(config): delete the unused AppConfig.appVersion constant

### DIFF
--- a/mobile/lib/config/app_config.dart
+++ b/mobile/lib/config/app_config.dart
@@ -45,7 +45,6 @@ class AppConfig {
 
   // App configuration
   static const String appName = 'Divine';
-  static const String appVersion = '1.0.0';
 
   // Relay configuration handled by NostrClient
 


### PR DESCRIPTION
## The problem

`mobile/lib/config/app_config.dart` declared a hardcoded app version:

```dart
static const String appVersion = '1.0.0';
```

Nothing read it. It has been dead since it was added on 2025-06-18, and it named a version three release trains behind what the app actually ships.

That is worse than harmless clutter. A `const appVersion` sitting in the config file is an invitation for the next person to wire it up — and it would be wrong the moment they did, because a compile-time constant cannot track the version bumps the App Store and Shorebird release processes depend on.

## Why deleting is the right fix, rather than repairing it

The app's real version has never come from here, and the path it does come from is already correct and fail-loud:

`pubspec.yaml` → `packageInfo.version` → `app_bootstrap.dart` → `DeviceScope` → `appVersionProvider`

From there it reaches uploads, auth, curation, notifications and analytics. `appVersionProvider` throws a `StateError` if it is ever read without that override, so the live path cannot silently degrade.

Repairing the constant instead — pointing it at a `--dart-define`, say — would create a *second* source of truth for the version. It could not be made correct either: no build site (CI, Codemagic, or the Shorebird release path) passes such a define, so the default would remain a stale hardcoded string. There is nothing here worth keeping.

## What this deliberately leaves alone

- **`AppConfig.appName`**, on the line immediately above, is live — `auth_hero_section.dart`, `caption_style_preview.dart`, and four assertions in `auth_hero_section_test.dart`. Untouched.
- **`AppConfig.getConfigSummary()`** is also dead, but removing it belongs in its own issue. Every dead-symbol removal under epic #4339 is filed and shipped one symbol at a time (#7757, #7802, #8251), which is what keeps each one independently revertable.
- The five `enable*` feature-flag getters are unverified and were not touched.

## Verification

- **No reader exists.** Searched every tracked file of every type, not just Dart. The constant is also absent from `getConfigSummary()`, so no string-keyed map reaches it, and Flutter ships no `dart:mirrors`, so there is no reflective path either.
- **`flutter analyze lib test integration_test` → `No issues found!`** This is the load-bearing check. Note that a clean analyzer *before* the deletion would have proven nothing — Dart's unused-declaration diagnostic only fires on private members, which is exactly why this survived fourteen months. But *after* the deletion it is decisive: any remaining Dart reader would now be an undefined-getter compile error.
- `dart format` clean; `scripts/check_backend_host_defaults.sh` green (it reads this file, but matches on `defaultValue:` URLs, which this line is not).
- No test is added. There is no `app_config_test.dart` today, and a test asserting a deleted constant is absent cannot be written in Dart — it would not compile. The compiler enforces this more strongly than a test could.

## Note for reviewers

The issue body cites `mobile/lib/main.dart:1405` as the override site. That line no longer exists — `main.dart` is 98 lines today and the override moved into `app_bootstrap.dart` in #8640. The conclusion is unaffected; only the citation was stale.

Closes #7986

🤖 Generated with [Claude Code](https://claude.com/claude-code)