### PR TITLE
refactor(bookmarks): stop exporting a bookmark-lookup helper nothing calls

### DIFF
--- a/docs/superpowers/plans/2026-09-06-issue8315-privatize-is-in-global-bookmarks.md
+++ b/docs/superpowers/plans/2026-09-06-issue8315-privatize-is-in-global-bookmarks.md
@@ -1,0 +1,141 @@
+# Plan: privatise `isInGlobalBookmarks` (#8315)
+
+Date: 2026-09-06
+Type: **Task** (GitHub issue type: Task)
+Complexity: **Low** — single layer, one file, two lines
+Sources: `tasks/findings_8315.md`,
+`mobile/docs/brainstorm/2026-09-06-issue8315-privatize-is-in-global-bookmarks-brainstorm.md`
+
+## Hypothesis this fixes
+
+**H1 — `isInGlobalBookmarks` is public with zero references outside its own
+class. Confidence 1.0** (grep-verified repo-wide across `*.dart`, `*.md`,
+`*.yaml`, `*.yml`; plus a per-member consumer audit in which it is the only
+member at 0 app-lib / 0 app-test / 0 package-test).
+
+Supporting hypotheses, all at 1.0:
+
+| | Claim | How verified |
+|---|---|---|
+| H2 | Rename is behaviour-preserving and breaks no build or test | Executed: analyze + 88/88 pkg + 116/116 app tests |
+| H3 | The package's 100 % coverage gate is unaffected | Executed: `lcov.info` byte-identical, 293/293 |
+| H4 | #7135 does not need the two-arg form public | Consumer + protocol analysis (Rounds 4-5) |
+| H5 | `_`-prefixed twin is the house convention here | 4 existing pairs in the same class |
+
+Chosen direction: **Approach A** from the brainstorm (rename). B (inline) is
+rework #7135 would undo, C (narrow the barrel) is infeasible in Dart at member
+granularity, D (won't-fix) declines a correct finding, E (also fix the saved-
+videos filter) is scope creep into #7135.
+
+## Issue summary
+
+Since #6969 extracted this class into a package whose barrel re-exports the
+whole source file, every public member is package API. `isInGlobalBookmarks` is
+in that contract with no consumer — reachable only from the line directly below
+it. It is not dead code and must not be deleted; it is the general form that
+`isVideoBookmarkedGlobally` specialises to `type: 'e'`, and the form #7135 will
+need a second caller for.
+
+**The issue body is stale on two points** (it predates #6969 by ~3 hours):
+- Path is now `mobile/packages/bookmarks_repository/lib/src/bookmarks_repository.dart`,
+  not `mobile/lib/services/bookmark_service.dart`.
+- Class is now `BookmarksRepository`, not `BookmarkService`.
+- Lines are `:918` / `:925`, not `:898` / `:905`.
+
+## Affected layers and files
+
+**Layer: Repository only.** No Client, BLoC, UI, router, l10n, theme, codegen,
+ARB or golden involvement.
+
+| File | Action | Change |
+|---|---|---|
+| `mobile/packages/bookmarks_repository/lib/src/bookmarks_repository.dart` | Modify | `:918` declaration → `_isInGlobalBookmarks`; `:925` call site updated |
+
+**No other file changes.** Explicitly *not* touched:
+
+- `lib/bookmarks_repository.dart` (barrel) — nothing to change; Dart cannot
+  hide a class member from an export.
+- Any test file — no test references the symbol.
+- Any `.mocks.dart` — none exist; all three `BookmarksRepository` mocks are
+  mocktail (`extends Mock implements …`), which is runtime `noSuchMethod`.
+- `mobile/scripts/baseline/*` — no ratchet counts this shape.
+
+## Implementation steps
+
+1. **Repository: rename the member and its one call site.**
+   - File: `mobile/packages/bookmarks_repository/lib/src/bookmarks_repository.dart`
+   - `:918` `bool isInGlobalBookmarks(` → `bool _isInGlobalBookmarks(`
+   - `:925` `return isInGlobalBookmarks(videoEventId, 'e');`
+        → `return _isInGlobalBookmarks(videoEventId, 'e');`
+   - **Keep the dartdoc verbatim.** It records #7136 — consulting only the
+     public tags made a privately-bookmarked video read as unsaved and then let
+     a save republish it in the clear. That rationale is why the method reads
+     both `_globalBookmarks` and `_privateBookmarks`, and it stays true when
+     the member is private.
+   - Why: the class already pairs a public entry point with a `_`-prefixed
+     implementation four times (`syncGlobalBookmarks`,
+     `toggleVideoInGlobalBookmarks`, `addToGlobalBookmarks`,
+     `removeFromGlobalBookmarks`). This is the fifth.
+
+That is the whole change. There is no step 2.
+
+## Testing strategy
+
+**No new test.** This is deliberate and defensible under
+`.claude/rules/testing.md`'s "a test must be able to fail" bar: privacy is a
+compile-time property, so a test asserting it could only assert the compiler's
+own behaviour. The change's correctness is proven by the *existing* suites
+continuing to pass with an unchanged coverage profile.
+
+| Layer | Command | Expected (already measured on `origin/main` + this diff) |
+|---|---|---|
+| Format | `dart format --set-exit-if-changed lib/src/bookmarks_repository.dart` | clean, 0 changed |
+| Package analyze | `flutter analyze` in `mobile/packages/bookmarks_repository` | No issues found |
+| Package tests | `flutter test --coverage` in that package | **88/88 pass**, `293/293 = 100.00 %` |
+| Coverage gate | `diff` new `lcov.info` against baseline | **byte-identical** |
+| App analyze | `flutter analyze lib test integration_test` from `mobile/` | No issues found |
+| Consumer tests | `flutter test test/blocs/share_sheet/share_sheet_bloc_test.dart test/widgets/share_video_menu_comprehensive_test.dart test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart` | **116/116 pass** |
+
+The five package tests that call `isVideoBookmarkedGlobally`
+(`bookmarks_repository_test.dart:933,1469,1556,1614,1651`) are what keep the
+renamed body covered — including `:1469`/`:1556`/`:1651`, which exercise the
+private-items path the #7136 dartdoc describes. They are the regression net.
+
+## Risks and considerations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| An external caller exists that grep missed | **None** | Grep covered `*.dart`/`*.md`/`*.yaml`/`*.yml` repo-wide; app analyze over `lib test integration_test` is clean with the rename applied — a missed caller would be a compile error |
+| Coverage drops below the 100 % gate | **None** | `lcov.info` measured byte-identical |
+| Mock regeneration needed | **None** | Zero `.mocks.dart` in any source tree; mocktail is runtime |
+| #7135 later needs the two-arg form publicly | **Low** | Its dual `('e', id)` / `('a', coord)` read belongs inside `isVideoBookmarkedGlobally`; keeping `type` private is what stops tag-form policy leaking into BLoCs |
+| Divine later bookmarks articles/hashtags/URLs from the UI | **Low, reversible** | NIP-51 admits `a`/`t`/`r` and the repo parses all four — but only for round-trip fidelity to a shared document. Nothing in `mobile/lib` constructs a `BookmarkItem`. Re-widening is a one-line, migration-free edit |
+| CI job not triggered | **None** | `bookmarks_repository.yaml` triggers on `mobile/packages/bookmarks_repository/**` — this path matches |
+
+## Delivery
+
+- **Worktree**: `.worktrees/8315-privatize-isinglobalbookmarks`
+  **Branch**: `refactor/8315-privatize-is-in-global-bookmarks`, off `origin/main`
+  (`d061eccaf`). Already created and clean; verification was run there and reverted.
+- **One commit**, one finding.
+- **PR title** (Conventional Commit, effect in plain language rather than the
+  symbol — per `AGENTS.md`):
+  `refactor(bookmarks): stop exporting a bookmark-lookup helper nothing outside the package calls`
+- **PR body**: lead with the problem (a package API member with no consumer
+  since the #6969 extraction), then why privatising is right rather than
+  deleting (it is the implementation of the method that *is* used, and the
+  general form #7135 needs), then what it deliberately leaves alone
+  (the saved-videos `type == 'e'` filter → #7135; the stale strict-coverage
+  list in `.claude/rules/testing.md` → separate docs issue), then verification.
+  Include `Closes #8315` outside backticks.
+  Add one sentence noting the four existing `_private` twins are `_serialized`
+  wrappers whereas this one narrows the type — same shape, different motive.
+- **Reviewers**: `divinevideo/reviewers` once checks are green.
+- **Watch checks to completion** (`gh pr checks <n> --watch`) before handback.
+
+## Out of scope, with homes
+
+| Observation | Home |
+|---|---|
+| `profile_saved_videos_bloc.dart:173` filters `type == 'e'`, so `a`-tagged bookmarks would silently drop from Saved | Already named in **#7135** |
+| `.claude/rules/testing.md` names only `divine_ui` as strict-coverage, but **30 of 58** package workflows effectively gate at 100 (3 explicit, 27 relying on the VeryGood default) | Separate `docs:` issue |

--- a/docs/superpowers/plans/2026-09-06-issue8315-privatize-is-in-global-bookmarks.md
+++ b/docs/superpowers/plans/2026-09-06-issue8315-privatize-is-in-global-bookmarks.md
@@ -117,7 +117,8 @@ private-items path the #7136 dartdoc describes. They are the regression net.
 - **Worktree**: `.worktrees/8315-privatize-isinglobalbookmarks`
   **Branch**: `refactor/8315-privatize-is-in-global-bookmarks`, off `origin/main`
   (`d061eccaf`). Already created and clean; verification was run there and reverted.
-- **One commit**, one finding.
+- **Separate commits** for the repository change, its supporting documentation,
+  and any review cleanup; one finding overall.
 - **PR title** (Conventional Commit, effect in plain language rather than the
   symbol — per `AGENTS.md`):
   `refactor(bookmarks): stop exporting a bookmark-lookup helper nothing outside the package calls`
@@ -126,7 +127,8 @@ private-items path the #7136 dartdoc describes. They are the regression net.
   deleting (it is the implementation of the method that *is* used, and the
   general form #7135 needs), then what it deliberately leaves alone
   (the saved-videos `type == 'e'` filter → #7135; the stale strict-coverage
-  list in `.claude/rules/testing.md` → separate docs issue), then verification.
+  list in `.claude/rules/testing.md` → already tracked by #6269), then
+  verification.
   Include `Closes #8315` outside backticks.
   Add one sentence noting the four existing `_private` twins are `_serialized`
   wrappers whereas this one narrows the type — same shape, different motive.
@@ -138,4 +140,4 @@ private-items path the #7136 dartdoc describes. They are the regression net.
 | Observation | Home |
 |---|---|
 | `profile_saved_videos_bloc.dart:173` filters `type == 'e'`, so `a`-tagged bookmarks would silently drop from Saved | Already named in **#7135** |
-| `.claude/rules/testing.md` names only `divine_ui` as strict-coverage, but **30 of 58** package workflows effectively gate at 100 (3 explicit, 27 relying on the VeryGood default) | Separate `docs:` issue |
+| `.claude/rules/testing.md` names only `divine_ui` as strict-coverage, but **30 of 58** package workflows effectively gate at 100 (3 explicit, 27 relying on the VeryGood default) | Already tracked by **#6269** |

--- a/mobile/docs/brainstorm/2026-09-06-issue8315-privatize-is-in-global-bookmarks-brainstorm.md
+++ b/mobile/docs/brainstorm/2026-09-06-issue8315-privatize-is-in-global-bookmarks-brainstorm.md
@@ -195,7 +195,7 @@ scope creep into #7135's territory.
       and `BookmarksRepository`.
 - [x] Does codegen need re-running? No — mocktail only, zero `.mocks.dart`.
 - [x] Does the 100 % coverage gate move? No — lcov byte-identical.
-- [ ] Commit/PR wording: note that the existing four `_private` twins are
+- [x] Commit/PR wording: note that the existing four `_private` twins are
       `_serialized` wrappers whereas this one narrows the type — same shape,
       different motive. One sentence in the PR body.
 
@@ -208,7 +208,7 @@ None. No design input, no protocol decision, no new package, no dependency.
 | Observation | Where it belongs |
 |---|---|
 | `profile_saved_videos_bloc.dart:173` filters `type == 'e'` and will drop `a`-tagged bookmarks | Already named in **#7135** |
-| `.claude/rules/testing.md` lists only `divine_ui` as strict-coverage, but **30 of 58** package workflows effectively gate at 100 | Separate `docs:` issue |
+| `.claude/rules/testing.md` lists only `divine_ui` as strict-coverage, but **30 of 58** package workflows effectively gate at 100 | Already tracked by **#6269** |
 | `addToGlobalBookmarks` / `removeFromGlobalBookmarks` have no *app* caller | Not comparable — both are directly exercised by package tests; only `isInGlobalBookmarks` is at 0/0/0 |
 
 ## Next Step

--- a/mobile/docs/brainstorm/2026-09-06-issue8315-privatize-is-in-global-bookmarks-brainstorm.md
+++ b/mobile/docs/brainstorm/2026-09-06-issue8315-privatize-is-in-global-bookmarks-brainstorm.md
@@ -1,0 +1,216 @@
+# Brainstorm: privatising `isInGlobalBookmarks` (#8315)
+
+Date: 2026-09-06
+
+Seeded with `tasks/findings_8315.md` (5 investigation rounds, all load-bearing
+hypotheses at 1.0, three verified by execution).
+
+## Problem Statement
+
+`BookmarksRepository.isInGlobalBookmarks(String itemId, String type)` is a
+public member of the `bookmarks_repository` package with **zero references
+anywhere** except the one line below it. Since #6969 extracted the class into
+a package whose barrel re-exports the whole source file, it is now part of the
+package's exported API contract without a single consumer. It is not dead code
+— it is the implementation of `isVideoBookmarkedGlobally` — so the question is
+one of visibility, not deletion.
+
+## Constraints
+
+- **Layered architecture** — `UI → BLoC → Repository → Client`. Tag-form
+  selection is repository policy; it must not leak upward.
+- **100 % coverage gate** — `bookmarks_repository.yaml` pins
+  `min_coverage: 100` explicitly. Any change must keep every line reachable.
+- **NIP-51 fidelity** — kind 10003 is a *shared* document. The repository must
+  round-trip `a`/`t`/`r` items written by other clients, so the generic `type`
+  dimension cannot be removed from the model.
+- **One finding, one commit** — the repo's review rule; resist bundling.
+- **The dartdoc is load-bearing** — it records #7136 (consulting only public
+  tags made a privately-bookmarked video read as unsaved, then let a save
+  republish it in the clear). It must survive any restructuring.
+
+## Prior Art
+
+- `tasks/findings_6969.md` and
+  `docs/superpowers/specs/2026-08-29-bookmarks-repository-extraction-design.md`
+  both record #8315 as a **deliberate deferral** from the extraction, with the
+  correct framing ("needlessly public", explicitly *not* dead code).
+- The class already contains four public-entry-point / `_private`-implementation
+  pairs (`syncGlobalBookmarks`, `toggleVideoInGlobalBookmarks`,
+  `addToGlobalBookmarks`, `removeFromGlobalBookmarks`).
+- `#1847` migrated the repo off Mockito to mocktail. A generated Mockito mock
+  (visible in `f0caff995`) once contained this method — which is very likely
+  *why* it is public. That constraint no longer exists: zero `.mocks.dart`
+  files remain in any source tree.
+
+## Approaches Explored
+
+### Approach A: Rename to `_isInGlobalBookmarks`
+
+**Description:** Prefix the member with `_` and update its single call site
+inside `isVideoBookmarkedGlobally`. Nothing else moves; the body, the dartdoc
+and the tests are untouched.
+
+**Layers affected:** Repository only (one file, two lines).
+
+**Pros:**
+- Matches the four existing public/`_private` pairs in the same class — reads
+  as a fifth instance of an established shape, not a new idea.
+- Keeps the general `(itemId, type)` form that #7135 will need as its second
+  internal caller (matching `('a', coordinate)` alongside `('e', eventId)`).
+- Preserves the #7136 dartdoc verbatim.
+- **Verified empirically**: format clean, package analyze clean, 88/88 package
+  tests pass, app analyze clean across `lib test integration_test`, 116/116
+  consumer tests pass, and the generated `lcov.info` is *byte-identical*
+  (293/293 = 100.00 %).
+
+**Cons:**
+- If Divine ever bookmarks articles/hashtags/URLs from the UI, the member has
+  to come back. Reversal is a one-line, migration-free edit.
+
+**Risks / Unknowns:** None remaining. All resolved in investigation.
+
+**Complexity:** Low.
+
+### Approach B: Inline the helper and delete the member
+
+**Description:** Fold the two-line body directly into
+`isVideoBookmarkedGlobally` and remove `isInGlobalBookmarks` entirely, leaving
+one public method with no helper at all.
+
+**Layers affected:** Repository only.
+
+**Pros:**
+- Removes a member rather than hiding one — the smallest possible API surface.
+- No naming question at all.
+
+**Cons:**
+- **Throws away the abstraction #7135 needs.** Its fix must match a video by
+  *both* `('e', eventId)` and `('a', coordinate)`; with the helper inlined,
+  #7135 would have to re-extract it, making this change churn that gets
+  reverted within one issue.
+- The #7136 dartdoc explains the *public-and-private* matching rule, which is
+  the helper's job. Merged into `isVideoBookmarkedGlobally`'s doc it becomes
+  a paragraph about two different concerns.
+- Loses the symmetry with the four sibling `_private` implementations.
+
+**Risks / Unknowns:** Guaranteed rework once #7135 is picked up.
+
+**Complexity:** Low, but negative value.
+
+### Approach C: Narrow the barrel export instead of the member
+
+**Description:** Attack the root cause the issue actually names — the barrel
+re-exports `src/bookmarks_repository.dart` wholesale — by exporting a curated
+surface with `show`/`hide` so that unused members simply are not exported.
+
+**Layers affected:** Package barrel.
+
+**Verdict: technically infeasible.** Dart's `export … show/hide` operates on
+**top-level declaration** names, not on class members. The only thing the
+barrel could hide here is the entire `BookmarksRepository` class. Nor can
+`part`/`part of` help: privacy in Dart is library-scoped, and parts share the
+library, so splitting the file changes nothing about member visibility.
+
+Worth recording precisely *because* it is the intuitive fix — the only lever
+Dart gives you at member granularity is the `_` prefix, which is Approach A.
+
+**Complexity:** N/A — does not exist.
+
+### Approach D: Close as won't-fix; keep it public for multi-type bookmarking
+
+**Description:** NIP-51 kind 10003 admits four item types (`e`, `a`, `t`, `r`)
+and the repository already parses all four. Argue the type-general predicate is
+legitimate forward-looking API and leave it exported.
+
+**Layers affected:** None.
+
+**Pros:**
+- Zero work; zero risk of reversal churn if Divine adds article or hashtag
+  bookmarking.
+
+**Cons:**
+- **Fails YAGNI.** No app code constructs a `BookmarkItem` at all, so nothing
+  chooses a `type` today, and nothing on the backlog does either.
+- Misreads why the four types exist: the repository parses `a`/`t`/`r` so it
+  can *faithfully round-trip other clients' items* in a shared NIP-51
+  document — protocol fidelity, not a Divine product capability. That makes
+  `type` repository-internal state, which is exactly what a private helper is
+  for.
+- Leaves a package API member that no consumer has ever called, which is the
+  precise thing #6969's design doc flagged.
+
+**Complexity:** Zero, but it declines a correct finding.
+
+### Approach E: Privatise, and also add a repository accessor for saved videos
+
+**Description:** Approach A plus fixing the one place tag-form knowledge leaked
+upward — `profile_saved_videos_bloc.dart:173` does
+`.where((item) => item.type == 'e')` — by moving that filter behind a new
+repository accessor.
+
+**Layers affected:** Repository + BLoC + tests.
+
+**Pros:**
+- Genuinely related: both are "the app should not know about tag forms".
+
+**Cons:**
+- **Scope creep on a one-line issue.** It adds a new public member to the very
+  package whose surface this issue is trimming.
+- That filter is already named in #7135's body as something its fix must
+  change. Doing it here would collide with #7135 and pre-empt a decision that
+  belongs with the coordinate-migration design.
+- Breaks "one finding, one commit".
+
+**Complexity:** Medium.
+
+## Recommendation
+
+**Approach A** — rename to `_isInGlobalBookmarks`, nothing else.
+
+It is what the issue proposes, and every independent line of evidence converged
+on it:
+
+- **Convention** (Round 1): the class already has four public/`_private` pairs;
+  this becomes the fifth.
+- **History** (Round 3): the member is public because a *generated Mockito mock*
+  needed it to be, and that mock has not existed since #1847. Public by
+  accident, not by design.
+- **Consumers** (Round 4): the app never constructs a `BookmarkItem`, so no
+  caller can want a `(id, type)` predicate.
+- **Protocol** (Round 5): the `type` dimension exists for NIP-51 round-trip
+  fidelity — repository-internal by nature. This also kills B, because #7135
+  needs exactly this helper's general form.
+- **Measurement** (Round 2): the change is provably inert — identical coverage
+  profile, all suites green.
+
+B is rework, C does not exist in Dart, D declines a correct finding, and E is
+scope creep into #7135's territory.
+
+## Open Questions for /plan
+
+- [x] Path and class name — the issue body is stale on both (#6969 moved and
+      renamed them). Plan must use
+      `mobile/packages/bookmarks_repository/lib/src/bookmarks_repository.dart`
+      and `BookmarksRepository`.
+- [x] Does codegen need re-running? No — mocktail only, zero `.mocks.dart`.
+- [x] Does the 100 % coverage gate move? No — lcov byte-identical.
+- [ ] Commit/PR wording: note that the existing four `_private` twins are
+      `_serialized` wrappers whereas this one narrows the type — same shape,
+      different motive. One sentence in the PR body.
+
+## Prerequisites
+
+None. No design input, no protocol decision, no new package, no dependency.
+
+## Deliberately out of scope (each with its home)
+
+| Observation | Where it belongs |
+|---|---|
+| `profile_saved_videos_bloc.dart:173` filters `type == 'e'` and will drop `a`-tagged bookmarks | Already named in **#7135** |
+| `.claude/rules/testing.md` lists only `divine_ui` as strict-coverage, but **30 of 58** package workflows effectively gate at 100 | Separate `docs:` issue |
+| `addToGlobalBookmarks` / `removeFromGlobalBookmarks` have no *app* caller | Not comparable — both are directly exercised by package tests; only `isInGlobalBookmarks` is at 0/0/0 |
+
+## Next Step
+
+`/plan 8315` — Approach A.

--- a/mobile/packages/bookmarks_repository/lib/src/bookmarks_repository.dart
+++ b/mobile/packages/bookmarks_repository/lib/src/bookmarks_repository.dart
@@ -915,14 +915,14 @@ class BookmarksRepository {
   ///
   /// Consulting only the public tags is what made a privately-bookmarked video
   /// read as unsaved, and then let a save publish it in the clear (#7136).
-  bool isInGlobalBookmarks(String itemId, String type) {
+  bool _isInGlobalBookmarks(String itemId, String type) {
     bool matches(BookmarkItem item) => item.id == itemId && item.type == type;
     return _globalBookmarks.any(matches) || _privateBookmarks.any(matches);
   }
 
   /// Check if a video event is bookmarked globally
   bool isVideoBookmarkedGlobally(String videoEventId) {
-    return isInGlobalBookmarks(videoEventId, 'e');
+    return _isInGlobalBookmarks(videoEventId, 'e');
   }
 
   // === NOSTR PUBLISHING ===


### PR DESCRIPTION
## The problem

`BookmarksRepository.isInGlobalBookmarks(itemId, type)` has no caller anywhere
except the line directly below it. Sweeping `mobile/lib`, `mobile/test`,
`mobile/integration_test` and `mobile/packages` turns up exactly two references:
the declaration, and one internal call inside `isVideoBookmarkedGlobally`.

That was a private detail until #6969 moved the class into the
`bookmarks_repository` package. The package barrel re-exports its source file
wholesale, so every public member is now the package's exported API — and this
one entered that contract on day one with no consumer on either side of the
boundary.

An audit of every public member makes it clear how unusual that is. Several
others have no *app* caller, but each is exercised directly by the package's
own tests, which under a 100% coverage gate is how they earn their lines.
`isInGlobalBookmarks` is the only member referenced by nothing at all:

| Member | app `lib/` | app `test/` | package `test/` |
|---|---|---|---|
| `syncGlobalBookmarks` | 3 | 11 | 49 |
| `toggleVideoInGlobalBookmarks` | 1 | 21 | 33 |
| `addToGlobalBookmarks` | 0 | 0 | 20 |
| `removeFromGlobalBookmarks` | 0 | 0 | 11 |
| **`isInGlobalBookmarks`** | **0** | **0** | **0** |
| `isVideoBookmarkedGlobally` | 2 | 19 | 5 |

## Why rename rather than delete

It is not dead code. It is the general form that `isVideoBookmarkedGlobally`
specialises to `type: 'e'`, and #7135 will add a second internal caller when a
video also has to be matched by its `a` coordinate. Deleting it would be churn
that #7135 immediately undoes.

Keeping `type` private is also the point. NIP-51 kind 10003 admits four item
types (`e`, `a`, `t`, `r`) and this repository parses all four — but it does
that for round-trip fidelity to a *shared* document, so it does not destroy
bookmarks other Nostr clients wrote. That makes `type` repository-internal
state rather than a Divine product capability. Nothing in `mobile/lib`
constructs a `BookmarkItem` at all, so no caller picks a type today.

The method looks public by accident rather than by design: git history shows
the symbol inside a generated Mockito mock (`f0caff995`), and Mockito can only
override public members. #1847 migrated the repo to mocktail and removed that
mock. No source tree contains a `.mocks.dart` today.

The class already pairs a public entry point with a `_`-prefixed implementation
four times (`syncGlobalBookmarks`, `toggleVideoInGlobalBookmarks`,
`addToGlobalBookmarks`, `removeFromGlobalBookmarks`). Those four differ in
motive — the public half is a `_serialized` wrapper, where here it narrows the
type — but the shape is the same, and this is a fifth instance of it.

## What it deliberately leaves alone

- **`profile_saved_videos_bloc.dart:173`** filters `globalBookmarks` by
  `type == 'e'`, which will silently drop `a`-tagged bookmarks from Saved.
  That is real, but #7135 already names those exact lines as something its fix
  must change — pre-empting it here would collide with that design.
- **`.claude/rules/testing.md`** names only `divine_ui` as a strict-coverage
  package, but 30 of 58 package workflows effectively gate at 100 (3 explicit,
  27 relying on the VeryGood default). A genuine docs gap already tracked by #6269, but not this PR's
  job; it would drag a one-line refactor into a shared rules file.
- **The dartdoc is kept verbatim.** It records why the method reads private
  items as well as public tags (#7136), which stays true once it is private.

## Verification

No new test. Privacy is a compile-time property, so a test asserting it could
only assert the compiler's own behaviour. What proves the change is inert is
the existing suites passing with an unchanged coverage profile — the five
package tests that call `isVideoBookmarkedGlobally` are the regression net, and
three of them exercise the private-items path the dartdoc describes.

| Check | Result |
|---|---|
| `dart format --set-exit-if-changed` | clean |
| `flutter analyze` (package) | No issues found |
| `flutter test --coverage` (package) | 88/88 passed, **293/293 = 100.00%** |
| `lcov.info` vs `origin/main` baseline | **byte-identical** |
| `flutter analyze lib test integration_test` (app) | No issues found |
| `share_sheet_bloc` + `share_video_menu_comprehensive` + `profile_saved_videos_bloc` | 116/116 passed |

Commits are split so the two-line change can be reverted without the docs.
The planning docs ship alongside the code the same way #8325 shipped its own.

Closes #8315

