### PR TITLE
fix(dm): hide conversations that only contain yourself

### DIFF
--- a/mobile/docs/brainstorm/2026-09-06-issue7683-classify-degenerate-participants-brainstorm.md
+++ b/mobile/docs/brainstorm/2026-09-06-issue7683-classify-degenerate-participants-brainstorm.md
@@ -1,7 +1,7 @@
 # Brainstorm: #7683 — degenerate participant sets in `classifyPotentialRequests`
 
 Date: 2026-09-06
-Seeded by: `tasks/findings_7683.md` (7 investigation rounds)
+Seeded by: investigation of #7683 and the surrounding DM history
 Issue: https://github.com/divinevideo/divine-mobile/issues/7683 · Epic: #8229
 
 ## Problem Statement
@@ -18,7 +18,8 @@ documented in-repo convention that it should not be.
 
 ## Constraints
 
-- Layered architecture; this is a pure static method in the Repository layer — no UI/BLoC change.
+- Layered architecture; classification stays in the Repository layer, while the UI/BLoC consumers
+  share one pure peer-resolution helper.
 - `.claude/rules/testing.md`: a test must be able to fail for a real reason.
 - Epic #8229 success criterion: *"a DM docstring is evidence of what the code does."*
 - `dm_repository_test.dart` sits at **14** in `mobile/scripts/baseline/shared_setup_stubs.txt` — a
@@ -28,10 +29,8 @@ documented in-repo convention that it should not be.
 
 ## Prior Art
 
-- `mobile/lib/blocs/dm/minor_dm_approval.dart` — `allParticipantsApprovedForMinor`: the exact
-  structural twin, which **guards `isNotEmpty` and documents why**, naming `[].every(...)`.
-- `conversation_bloc.dart:405,410` and `inline_reel_reply_cubit.dart:77,79` — the same
-  `isNotEmpty && every(...)` idiom, four more times.
+- `mobile/lib/blocs/dm/minor_dm_approval.dart` — `allParticipantsApprovedForMinor` documents why an
+  empty counterparty list must fail closed.
 - `_isSelf` (`dm_repository.dart:8961`) + `pubkeysEqual` — the case-insensitive self-compare and the
   dartdoc explaining why exact `==` is wrong.
 - #8261 (closed) — Divine does **not** support self-addressed conversations. #8351 shipped the
@@ -40,17 +39,15 @@ documented in-repo convention that it should not be.
 
 ## Approaches Explored
 
-### Approach A: Inline `isNotEmpty` guard + case-insensitive self-filter  ← RECOMMENDED
-**Description:** At L7632 compare self case-insensitively; at L7641 guard the vacuous `every()`.
+### Approach A: Hide self-only rows + case-insensitive self-filter  ← RECOMMENDED
+**Description:** Compare self case-insensitively and omit a conversation from both lists when no peer remains.
 Document both in the dartdoc, citing #8261 and #6294. Add regression tests.
-**Layers affected:** Repository only.
-**Pros:** Matches the idiom already used at four DM sites. ~2 lines. Correct whether or not the
-state is reachable, so it does not rest on the 0.97 H3 claim. A degenerate row now routes to
-`requests`, which passes through the existing `_classifyDiagnostics` branch and **logs itself for
-free** — the diagnostic `lessons.md` recommends, at zero cost.
-**Cons:** Changes behaviour for a state believed unreachable. `isNotEmpty &&` is terser than prose.
-**Risks:** If a degenerate row *is* reachable, its thread moves inbox → requests. Under #8261 that
-is the more correct destination, and quieter.
+**Layers affected:** Repository classification and the UI/BLoC peer resolvers that consume it.
+**Pros:** Correct whether or not the state is reachable. A degenerate row is logged explicitly but
+never exposed through actions that would target the viewer.
+**Cons:** Changes behaviour for a malformed state.
+**Risks:** If a degenerate row is reachable, its thread disappears from both lists. Under #8261 that
+is the correct destination because every available action would target the viewer.
 **Complexity:** Low.
 
 ### Approach B: Extract a shared `allParticipantsFollowed` predicate
@@ -61,11 +58,10 @@ conversations.
 **Cons:** **Only one call site exists.** Speculative reuse; YAGNI.
 **Complexity:** Low–Medium.
 
-### Approach C: Explicit `if (otherPubkeys.isEmpty)` branch
-**Description:** Restore #2219's explicit shape with the opposite destination and an #8261 comment.
+### Approach C: Route self-only rows to Message requests
+**Description:** Keep the row visible but move it out of the main inbox.
 **Pros:** Most self-documenting.
-**Cons:** A dedicated branch implies the case is expected; a guard reads more honestly for a state
-that should not occur. More lines for identical behaviour.
+**Cons:** The row remains unusable, and Report, Block, and Mute still target the viewer.
 **Complexity:** Low.
 
 ### Approach D: Normalize pubkey case at ingest/storage
@@ -80,23 +76,10 @@ unobservable premise.
 ## Recommendation
 
 **Approach A**, adopting C's comment discipline in the dartdoc. Rationale: smallest change that is
-correct independent of the reachability question, matches an idiom used four times in this
-subsystem, satisfies epic #8229's docstring criterion, and yields the device-side diagnostic for
-free. B is deferred until a second caller exists. D is rejected on blast radius vs. evidence.
-
-## Open Questions for /plan
-
-- [ ] Exact dartdoc wording — must state the empty case, its destination, and cite #8261/#6294.
-- [ ] Test placement inside the existing `group('classifyPotentialRequests', …)` without adding a
-      shared-setup stub (baseline ceiling 14).
-- [ ] Whether to assert the diagnostics log line, or only the routing.
-- [ ] Whether the case-insensitive fix reuses `pubkeysEqual` — note `classifyPotentialRequests` is
-      `static` and `_isSelf` is an instance method, so `pubkeysEqual` must be imported directly.
+correct independent of the reachability question, satisfies epic #8229's docstring criterion, and
+keeps a device-side diagnostic without exposing the malformed row. B is deferred until a second
+classification caller exists. D is rejected on blast radius vs. evidence.
 
 ## Prerequisites
 
 None. No design, protocol, or product decision is blocked — #8261 already ruled.
-
-## Next Step
-
-`/plan 7683`.

--- a/mobile/docs/brainstorm/2026-09-06-issue7683-classify-degenerate-participants-brainstorm.md
+++ b/mobile/docs/brainstorm/2026-09-06-issue7683-classify-degenerate-participants-brainstorm.md
@@ -1,0 +1,102 @@
+# Brainstorm: #7683 — degenerate participant sets in `classifyPotentialRequests`
+
+Date: 2026-09-06
+Seeded by: `tasks/findings_7683.md` (7 investigation rounds)
+Issue: https://github.com/divinevideo/divine-mobile/issues/7683 · Epic: #8229
+
+## Problem Statement
+
+#7683 asks to remove a "redundant" `otherPubkeys.isEmpty` early-return guard in
+`DmRepository.classifyPotentialRequests`. **That guard does not exist and never did.** Full git
+history shows the empty check was always a disjunct inside one `if` (introduced #2219, unchanged
+through #5387) and was **deleted by #6294 — the very PR the issue cites as its context**. The
+issue's literal ask is a no-op.
+
+Underneath it sit two real, verified residuals: the empty-participant route to the inbox is now
+implicit/undocumented/untested vacuous truth, and the self-filter is case-sensitive against a
+documented in-repo convention that it should not be.
+
+## Constraints
+
+- Layered architecture; this is a pure static method in the Repository layer — no UI/BLoC change.
+- `.claude/rules/testing.md`: a test must be able to fail for a real reason.
+- Epic #8229 success criterion: *"a DM docstring is evidence of what the code does."*
+- `dm_repository_test.dart` sits at **14** in `mobile/scripts/baseline/shared_setup_stubs.txt` — a
+  ceiling that may only shrink, so any new stub must go in a leaf group.
+- `tasks/lessons.md` (#5374): do not ship a fix whose premise is an unobservable on-device value.
+- Report-only on GitHub until explicitly authorized.
+
+## Prior Art
+
+- `mobile/lib/blocs/dm/minor_dm_approval.dart` — `allParticipantsApprovedForMinor`: the exact
+  structural twin, which **guards `isNotEmpty` and documents why**, naming `[].every(...)`.
+- `conversation_bloc.dart:405,410` and `inline_reel_reply_cubit.dart:77,79` — the same
+  `isNotEmpty && every(...)` idiom, four more times.
+- `_isSelf` (`dm_repository.dart:8961`) + `pubkeysEqual` — the case-insensitive self-compare and the
+  dartdoc explaining why exact `==` is wrong.
+- #8261 (closed) — Divine does **not** support self-addressed conversations. #8351 shipped the
+  send-side refusal.
+- `tasks/lessons.md` #5374 — a prior wrong-theory fix on this same function.
+
+## Approaches Explored
+
+### Approach A: Inline `isNotEmpty` guard + case-insensitive self-filter  ← RECOMMENDED
+**Description:** At L7632 compare self case-insensitively; at L7641 guard the vacuous `every()`.
+Document both in the dartdoc, citing #8261 and #6294. Add regression tests.
+**Layers affected:** Repository only.
+**Pros:** Matches the idiom already used at four DM sites. ~2 lines. Correct whether or not the
+state is reachable, so it does not rest on the 0.97 H3 claim. A degenerate row now routes to
+`requests`, which passes through the existing `_classifyDiagnostics` branch and **logs itself for
+free** — the diagnostic `lessons.md` recommends, at zero cost.
+**Cons:** Changes behaviour for a state believed unreachable. `isNotEmpty &&` is terser than prose.
+**Risks:** If a degenerate row *is* reachable, its thread moves inbox → requests. Under #8261 that
+is the more correct destination, and quieter.
+**Complexity:** Low.
+
+### Approach B: Extract a shared `allParticipantsFollowed` predicate
+**Description:** Mirror `minor_dm_approval.dart` exactly — a small file with a documented predicate,
+called from classify.
+**Pros:** Follows the closest structural precedent. Directly unit-testable without constructing
+conversations.
+**Cons:** **Only one call site exists.** Speculative reuse; YAGNI.
+**Complexity:** Low–Medium.
+
+### Approach C: Explicit `if (otherPubkeys.isEmpty)` branch
+**Description:** Restore #2219's explicit shape with the opposite destination and an #8261 comment.
+**Pros:** Most self-documenting.
+**Cons:** A dedicated branch implies the case is expected; a guard reads more honestly for a state
+that should not occur. More lines for identical behaviour.
+**Complexity:** Low.
+
+### Approach D: Normalize pubkey case at ingest/storage
+**Description:** Lowercase pubkeys in `_extractParticipants` and on write, killing the H4a class.
+**Pros:** Root-cause rather than per-site.
+**Cons:** **`computeConversationId` is case-sensitive**, so normalizing changes ids for any existing
+mixed-case row — splitting or merging threads and requiring a Drift migration. All of it for a
+defect scored **0.10 reachable**. This is the #5478 mistake `lessons.md` records: a wide fix on an
+unobservable premise.
+**Complexity:** High. **Rejected.**
+
+## Recommendation
+
+**Approach A**, adopting C's comment discipline in the dartdoc. Rationale: smallest change that is
+correct independent of the reachability question, matches an idiom used four times in this
+subsystem, satisfies epic #8229's docstring criterion, and yields the device-side diagnostic for
+free. B is deferred until a second caller exists. D is rejected on blast radius vs. evidence.
+
+## Open Questions for /plan
+
+- [ ] Exact dartdoc wording — must state the empty case, its destination, and cite #8261/#6294.
+- [ ] Test placement inside the existing `group('classifyPotentialRequests', …)` without adding a
+      shared-setup stub (baseline ceiling 14).
+- [ ] Whether to assert the diagnostics log line, or only the routing.
+- [ ] Whether the case-insensitive fix reuses `pubkeysEqual` — note `classifyPotentialRequests` is
+      `static` and `_isSelf` is an instance method, so `pubkeysEqual` must be imported directly.
+
+## Prerequisites
+
+None. No design, protocol, or product decision is blocked — #8261 already ruled.
+
+## Next Step
+
+`/plan 7683`.

--- a/mobile/lib/blocs/dm/conversation/conversation_participants_cubit.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_participants_cubit.dart
@@ -5,6 +5,7 @@ import 'package:dm_repository/dm_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/close_guard.dart';
+import 'package:openvine/blocs/dm/dm_peer_name.dart';
 import 'package:openvine/blocs/dm/minor_dm_approval.dart';
 
 /// Resolution status for a conversation's counterparties.
@@ -150,8 +151,9 @@ class ConversationParticipantsCubit extends Cubit<ConversationParticipantsState>
     final conversation = await _dmRepository.getConversation(conversationId);
     if (conversation == null) return const [];
     final userPubkey = _dmRepository.userPubkey;
-    return conversation.participantPubkeys
-        .where((pubkey) => pubkey != userPubkey)
-        .toList();
+    return dmConversationPeerPubkeys(
+      participantPubkeys: conversation.participantPubkeys,
+      currentUserPubkey: userPubkey,
+    );
   }
 }

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -611,9 +611,9 @@ class ConversationListBloc
   }
 
   static String _otherParticipant(DmConversation conversation, String self) {
-    return conversation.participantPubkeys.firstWhere(
-      (pk) => pk != self,
-      orElse: () => conversation.participantPubkeys.first,
+    return dmConversationFirstPeer(
+      participantPubkeys: conversation.participantPubkeys,
+      currentUserPubkey: self,
     );
   }
 

--- a/mobile/lib/blocs/dm/dm_peer_name.dart
+++ b/mobile/lib/blocs/dm/dm_peer_name.dart
@@ -4,6 +4,31 @@
 
 import 'package:equatable/equatable.dart';
 import 'package:models/models.dart';
+import 'package:nostr_sdk/nip19/pubkeys_equal.dart';
+
+/// The conversation participants other than the signed-in viewer.
+///
+/// Nostr hex keys are case-insensitive. Keeping this comparison here prevents
+/// inbox rows, navigation, actions, and search from disagreeing about which
+/// participant is the viewer when stored keys use different casing.
+List<String> dmConversationPeerPubkeys({
+  required List<String> participantPubkeys,
+  required String currentUserPubkey,
+}) => participantPubkeys
+    .where((pubkey) => !pubkeysEqual(pubkey, currentUserPubkey))
+    .toList();
+
+/// The first non-viewer participant, with the historical first-participant
+/// fallback for malformed rows.
+String dmConversationFirstPeer({
+  required List<String> participantPubkeys,
+  required String currentUserPubkey,
+}) =>
+    dmConversationPeerPubkeys(
+      participantPubkeys: participantPubkeys,
+      currentUserPubkey: currentUserPubkey,
+    ).firstOrNull ??
+    participantPubkeys.first;
 
 /// The localized strings [dmPeerName] substitutes for a peer whose own name
 /// must not be shown.
@@ -48,9 +73,10 @@ int dmGroupOtherCount({
   required List<String> participantPubkeys,
   required String currentUserPubkey,
 }) {
-  final peers = participantPubkeys
-      .where((pubkey) => pubkey != currentUserPubkey)
-      .length;
+  final peers = dmConversationPeerPubkeys(
+    participantPubkeys: participantPubkeys,
+    currentUserPubkey: currentUserPubkey,
+  ).length;
   return peers <= 1 ? 0 : peers - 1;
 }
 

--- a/mobile/lib/blocs/dm/message_requests/request_preview_cubit.dart
+++ b/mobile/lib/blocs/dm/message_requests/request_preview_cubit.dart
@@ -5,6 +5,7 @@ import 'package:bloc/bloc.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/dm/dm_peer_name.dart';
 import 'package:openvine/blocs/dm/minor_dm_approval.dart';
 
 enum RequestPreviewStatus { loading, loaded, error, denied }
@@ -147,8 +148,9 @@ class RequestPreviewCubit extends Cubit<RequestPreviewState> {
     final conversation = await _dmRepository.getConversation(conversationId);
     if (conversation == null) return [];
     final userPubkey = _dmRepository.userPubkey;
-    return conversation.participantPubkeys
-        .where((pk) => pk != userPubkey)
-        .toList();
+    return dmConversationPeerPubkeys(
+      participantPubkeys: conversation.participantPubkeys,
+      currentUserPubkey: userPubkey,
+    );
   }
 }

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -15,6 +15,7 @@ import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
 import 'package:openvine/blocs/dm/conversation_actions/conversation_actions_cubit.dart';
 import 'package:openvine/blocs/dm/conversation_list/conversation_list_bloc.dart';
 import 'package:openvine/blocs/dm/conversation_mute/conversation_mute_cubit.dart';
+import 'package:openvine/blocs/dm/dm_peer_name.dart';
 import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
 import 'package:openvine/blocs/notifications/badge/notification_badge_cubit.dart';
 import 'package:openvine/extensions/modal_pop_extension.dart';
@@ -560,9 +561,10 @@ class _PinnedSupportRow extends StatelessWidget {
         // reads `extra` as the COUNTERPARTY list, so passing the raw
         // participants opens a conversation with the signed-in user instead
         // of with moderation.
-        conversation.participantPubkeys
-            .where((pk) => pk != currentUserPubkey)
-            .toList(),
+        dmConversationPeerPubkeys(
+          participantPubkeys: conversation.participantPubkeys,
+          currentUserPubkey: currentUserPubkey,
+        ),
       ),
       onLongPress: onLongPress,
     );
@@ -994,9 +996,10 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
       name: 'InboxView',
       category: LogCategory.ui,
     );
-    final otherPubkeys = conversation.participantPubkeys
-        .where((pk) => pk != widget.currentUserPubkey)
-        .toList();
+    final otherPubkeys = dmConversationPeerPubkeys(
+      participantPubkeys: conversation.participantPubkeys,
+      currentUserPubkey: widget.currentUserPubkey,
+    );
 
     _pushConversation(
       context,
@@ -1012,9 +1015,9 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
     DmConversation conversation, {
     String? displayNameOverride,
   }) async {
-    final otherPubkey = conversation.participantPubkeys.firstWhere(
-      (pk) => pk != widget.currentUserPubkey,
-      orElse: () => conversation.participantPubkeys.first,
+    final otherPubkey = dmConversationFirstPeer(
+      participantPubkeys: conversation.participantPubkeys,
+      currentUserPubkey: widget.currentUserPubkey,
     );
 
     // Match [ConversationTile]'s identity chain, so the row and the sheet it

--- a/mobile/lib/screens/inbox/message_requests/message_requests_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/message_requests_view.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation_list/conversation_list_bloc.dart';
+import 'package:openvine/blocs/dm/dm_peer_name.dart';
 import 'package:openvine/blocs/dm/message_requests/message_request_actions_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -179,9 +180,10 @@ class _RequestList extends StatelessWidget {
   }
 
   void _onRequestTapped(BuildContext context, DmConversation conversation) {
-    final otherPubkeys = conversation.participantPubkeys
-        .where((pk) => pk != currentPubkey)
-        .toList();
+    final otherPubkeys = dmConversationPeerPubkeys(
+      participantPubkeys: conversation.participantPubkeys,
+      currentUserPubkey: currentPubkey,
+    );
 
     final extra = conversation.subject == null
         ? otherPubkeys

--- a/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
+++ b/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
@@ -5,6 +5,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/dm/dm_peer_name.dart';
 import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
@@ -33,9 +34,9 @@ class RequestTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final otherPubkey = conversation.participantPubkeys.firstWhere(
-      (pk) => pk != currentUserPubkey,
-      orElse: () => conversation.participantPubkeys.first,
+    final otherPubkey = dmConversationFirstPeer(
+      participantPubkeys: conversation.participantPubkeys,
+      currentUserPubkey: currentUserPubkey,
     );
 
     final profileAsync = ref.watch(userProfileReactiveProvider(otherPubkey));

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -6,6 +6,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/dm/dm_peer_name.dart';
 import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
@@ -62,9 +63,9 @@ class ConversationTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final otherPubkey = conversation.participantPubkeys.firstWhere(
-      (pk) => pk != currentUserPubkey,
-      orElse: () => conversation.participantPubkeys.first,
+    final otherPubkey = dmConversationFirstPeer(
+      participantPubkeys: conversation.participantPubkeys,
+      currentUserPubkey: currentUserPubkey,
     );
 
     final profileAsync = ref.watch(fetchUserProfileProvider(otherPubkey));

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -7619,6 +7619,26 @@ class DmRepository {
   /// from `participants.length > 2` and overwritten on every upsert, so
   /// it can drift from a row's real participants — which was stranding
   /// followed 1:1 peers under "Message requests" (#5374).
+  ///
+  /// A participant set that collapses to the viewer alone is a
+  /// self-conversation, which Divine does not support (#8261). It is
+  /// classified as a **request**, deliberately: `Set.every` is vacuously
+  /// true on an empty set, so without the `isNotEmpty` guard such a row
+  /// would land in the inbox — the most visible surface — and render as a
+  /// conversation with yourself, since every caller resolves the
+  /// counterparty via `orElse: () => participantPubkeys.first`. #2219
+  /// routed the empty case to the followed list through an explicit
+  /// `otherPubkeys.isEmpty ||` disjunct; #6294 folded that into `every`,
+  /// leaving the behaviour resting on vacuous truth with nothing naming
+  /// it. Routing to requests also puts the row through the diagnostics
+  /// branch below, which is the only signal that one exists at all.
+  ///
+  /// No live writer can persist such a row: the NIP-17 ingest rejects a
+  /// collapsed participant list twice (#2824), and every send path sets
+  /// `currentUserHasSent`, which excludes the row from this method's only
+  /// input. It is reachable only for a legacy row read during the
+  /// `identityKnown` -> `nostrReady` window, before `setCredentials`
+  /// installs the post-auth maintenance that both cleans and backfills it.
   static ({List<DmConversation> followed, List<DmConversation> requests})
   classifyPotentialRequests(
     List<DmConversation> potentialRequests, {
@@ -7638,7 +7658,12 @@ class DmRepository {
       // 1:1 or group alike. Derived from actual participants rather than
       // the stored `isGroup` flag, which can drift from the row's real
       // participants and mis-route followed 1:1 peers to requests (#5374).
-      final allFollowed = otherPubkeys.every(isFollowing);
+      //
+      // `isNotEmpty` first: an empty set passes `every` vacuously, which
+      // would route a self-collapsed row to the inbox. Same guard, and the
+      // same reason, as `allParticipantsApprovedForMinor` (#7683).
+      final allFollowed =
+          otherPubkeys.isNotEmpty && otherPubkeys.every(isFollowing);
 
       if (allFollowed) {
         followed.add(conversation);

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -7649,8 +7649,12 @@ class DmRepository {
     final requests = <DmConversation>[];
 
     for (final conversation in potentialRequests) {
+      // Case-insensitive, matching [_isSelf]: `validatePubkey` accepts
+      // upper-case hex, so an exact `!=` would keep the viewer in
+      // `otherPubkeys` under a different casing and strand a followed 1:1
+      // peer under Message requests — the #5374 failure mode.
       final otherPubkeys = conversation.participantPubkeys
-          .where((pk) => pk != userPubkey)
+          .where((pk) => !pubkeysEqual(pk, userPubkey))
           .toSet();
 
       // A conversation whose every (deduplicated) non-self participant is

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2854,7 +2854,7 @@ class DmRepository {
         // Reject self-conversations (all participants are the same pubkey).
         // Defense-in-depth: should not happen after the self-wrap fix above,
         // but guards against any future code path producing degenerate lists.
-        if (participants.toSet().length < 2) {
+        if (!containsDistinctPubkeys(participants)) {
           await _recordProcessedWrap(
             giftWrapEvent.id,
             ownerPubkey: ownerPubkey,
@@ -7621,24 +7621,17 @@ class DmRepository {
   /// followed 1:1 peers under "Message requests" (#5374).
   ///
   /// A participant set that collapses to the viewer alone is a
-  /// self-conversation, which Divine does not support (#8261). It is
-  /// classified as a **request**, deliberately: `Set.every` is vacuously
-  /// true on an empty set, so without the `isNotEmpty` guard such a row
-  /// would land in the inbox — the most visible surface — and render as a
-  /// conversation with yourself, since every caller resolves the
-  /// counterparty via `orElse: () => participantPubkeys.first`. #2219
-  /// routed the empty case to the followed list through an explicit
-  /// `otherPubkeys.isEmpty ||` disjunct; #6294 folded that into `every`,
-  /// leaving the behaviour resting on vacuous truth with nothing naming
-  /// it. Routing to requests also puts the row through the diagnostics
-  /// branch below, which is the only signal that one exists at all.
+  /// self-conversation, which Divine does not support (#8261). It is omitted
+  /// from both user-facing lists: moving an unusable row from Messages to
+  /// Message requests would only relocate the same broken experience. #2219
+  /// routed the empty case to the followed list explicitly; #6294 folded that
+  /// branch into `Set.every`'s vacuous truth, leaving the behaviour implicit.
+  /// The diagnostics branch below still records the malformed row.
   ///
-  /// No live writer can persist such a row: the NIP-17 ingest rejects a
-  /// collapsed participant list twice (#2824), and every send path sets
-  /// `currentUserHasSent`, which excludes the row from this method's only
-  /// input. It is reachable only for a legacy row read during the
-  /// `identityKnown` -> `nostrReady` window, before `setCredentials`
-  /// installs the post-auth maintenance that both cleans and backfills it.
+  /// NIP-17 ingest rejects case-insensitively collapsed participant lists,
+  /// while post-auth maintenance cleans the known legacy `[self, self]`
+  /// shape. Classification remains defensive because older or otherwise
+  /// malformed rows can use a different participant shape.
   static ({List<DmConversation> followed, List<DmConversation> requests})
   classifyPotentialRequests(
     List<DmConversation> potentialRequests, {
@@ -7657,17 +7650,24 @@ class DmRepository {
           .where((pk) => !pubkeysEqual(pk, userPubkey))
           .toSet();
 
+      if (otherPubkeys.isEmpty) {
+        if (_classifyDiagnostics) {
+          Log.debug(
+            'classifyPotentialRequests → hidden self-only conversation: '
+            '${conversation.id}',
+            category: LogCategory.system,
+          );
+        }
+        continue;
+      }
+
       // A conversation whose every (deduplicated) non-self participant is
       // followed is not a request even if the user hasn't replied yet —
       // 1:1 or group alike. Derived from actual participants rather than
       // the stored `isGroup` flag, which can drift from the row's real
       // participants and mis-route followed 1:1 peers to requests (#5374).
       //
-      // `isNotEmpty` first: an empty set passes `every` vacuously, which
-      // would route a self-collapsed row to the inbox. Same guard, and the
-      // same reason, as `allParticipantsApprovedForMinor` (#7683).
-      final allFollowed =
-          otherPubkeys.isNotEmpty && otherPubkeys.every(isFollowing);
+      final allFollowed = otherPubkeys.every(isFollowing);
 
       if (allFollowed) {
         followed.add(conversation);

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -16641,12 +16641,10 @@ void main() {
       });
 
       // A participant set that collapses to the viewer alone is a
-      // self-conversation, which Divine does not support (#8261). Before
-      // #7683 these fell through `Set.every()`'s vacuous truth on an empty
-      // set and landed in the inbox — the loudest surface — even with
-      // nothing followed. They belong in requests, where the existing
-      // diagnostics branch also logs them.
-      test('self-only participants go to requests, not the inbox', () {
+      // self-conversation, which Divine does not support (#8261). It belongs
+      // in neither user-facing list: moving the unusable row from Messages to
+      // Message requests would only relocate the same broken experience.
+      test('self-only participants are hidden from both lists', () {
         final conv = makeConversation(
           id: 'conv1',
           participantPubkeys: [_validPubkeyA],
@@ -16659,12 +16657,12 @@ void main() {
         );
 
         expect(result.followed, isEmpty);
-        expect(result.requests, hasLength(1));
+        expect(result.requests, isEmpty);
       });
 
       // `[self, self]` is the shape `_cleanupSelfConversations` targets and
       // the one a pre-#2824 self-wrap persisted.
-      test('duplicated self participants go to requests', () {
+      test('duplicated self participants are hidden from both lists', () {
         final conv = makeConversation(
           id: 'conv1',
           participantPubkeys: [_validPubkeyA, _validPubkeyA],
@@ -16677,7 +16675,26 @@ void main() {
         );
 
         expect(result.followed, isEmpty);
-        expect(result.requests, hasLength(1));
+        expect(result.requests, isEmpty);
+      });
+
+      test('mixed-case duplicated self participants are hidden', () {
+        final conv = makeConversation(
+          id: 'conv1',
+          participantPubkeys: [
+            _validPubkeyA,
+            _validPubkeyA.toUpperCase(),
+          ],
+        );
+
+        final result = DmRepository.classifyPotentialRequests(
+          [conv],
+          userPubkey: _validPubkeyA,
+          isFollowing: (_) => false,
+        );
+
+        expect(result.followed, isEmpty);
+        expect(result.requests, isEmpty);
       });
 
       // `validatePubkey` accepts upper-case hex, so the viewer can appear

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -16679,6 +16679,28 @@ void main() {
         expect(result.followed, isEmpty);
         expect(result.requests, hasLength(1));
       });
+
+      // `validatePubkey` accepts upper-case hex, so the viewer can appear
+      // in a stored participant list under a different casing than
+      // `userPubkey`. An exact `!=` would leave them in `otherPubkeys` and
+      // strand a followed 1:1 peer under Message requests — the #5374
+      // failure mode. Matches `_isSelf`, which compares case-insensitively
+      // for this reason.
+      test('viewer is filtered out regardless of pubkey casing', () {
+        final conv = makeConversation(
+          id: 'conv1',
+          participantPubkeys: [_validPubkeyA.toUpperCase(), _validPubkeyB],
+        );
+
+        final result = DmRepository.classifyPotentialRequests(
+          [conv],
+          userPubkey: _validPubkeyA,
+          isFollowing: (pk) => pk == _validPubkeyB,
+        );
+
+        expect(result.followed, hasLength(1));
+        expect(result.requests, isEmpty);
+      });
     });
 
     group('mergeAndSort', () {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -16639,6 +16639,46 @@ void main() {
         expect(result.followed, isEmpty);
         expect(result.requests, isEmpty);
       });
+
+      // A participant set that collapses to the viewer alone is a
+      // self-conversation, which Divine does not support (#8261). Before
+      // #7683 these fell through `Set.every()`'s vacuous truth on an empty
+      // set and landed in the inbox — the loudest surface — even with
+      // nothing followed. They belong in requests, where the existing
+      // diagnostics branch also logs them.
+      test('self-only participants go to requests, not the inbox', () {
+        final conv = makeConversation(
+          id: 'conv1',
+          participantPubkeys: [_validPubkeyA],
+        );
+
+        final result = DmRepository.classifyPotentialRequests(
+          [conv],
+          userPubkey: _validPubkeyA,
+          isFollowing: (_) => false,
+        );
+
+        expect(result.followed, isEmpty);
+        expect(result.requests, hasLength(1));
+      });
+
+      // `[self, self]` is the shape `_cleanupSelfConversations` targets and
+      // the one a pre-#2824 self-wrap persisted.
+      test('duplicated self participants go to requests', () {
+        final conv = makeConversation(
+          id: 'conv1',
+          participantPubkeys: [_validPubkeyA, _validPubkeyA],
+        );
+
+        final result = DmRepository.classifyPotentialRequests(
+          [conv],
+          userPubkey: _validPubkeyA,
+          isFollowing: (_) => false,
+        );
+
+        expect(result.followed, isEmpty);
+        expect(result.requests, hasLength(1));
+      });
     });
 
     group('mergeAndSort', () {

--- a/mobile/packages/nostr_sdk/lib/nip19/pubkeys_equal.dart
+++ b/mobile/packages/nostr_sdk/lib/nip19/pubkeys_equal.dart
@@ -7,3 +7,14 @@
 /// either value so callers can use it after their own boundary validation.
 bool pubkeysEqual(String first, String second) =>
     first.toLowerCase() == second.toLowerCase();
+
+/// Whether [pubkeys] contains more than one case-insensitive identity.
+bool containsDistinctPubkeys(Iterable<String> pubkeys) {
+  final iterator = pubkeys.iterator;
+  if (!iterator.moveNext()) return false;
+  final first = iterator.current;
+  while (iterator.moveNext()) {
+    if (!pubkeysEqual(iterator.current, first)) return true;
+  }
+  return false;
+}

--- a/mobile/packages/nostr_sdk/test/nip19/pubkeys_equal_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip19/pubkeys_equal_test.dart
@@ -14,4 +14,14 @@ void main() {
       expect(pubkeysEqual('a1b2', 'a1b3'), isFalse);
     });
   });
+
+  group('containsDistinctPubkeys', () {
+    test('treats differently cased hex as the same key', () {
+      expect(containsDistinctPubkeys(['a1b2', 'A1B2']), isFalse);
+    });
+
+    test('detects a different key', () {
+      expect(containsDistinctPubkeys(['a1b2', 'a1b3']), isTrue);
+    });
+  });
 }

--- a/mobile/test/blocs/dm/dm_peer_name_test.dart
+++ b/mobile/test/blocs/dm/dm_peer_name_test.dart
@@ -16,6 +16,33 @@ const _ordinaryPubkey =
     'd4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5';
 
 void main() {
+  group('DM conversation peers', () {
+    const me =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const alice =
+        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+    test('excludes the viewer regardless of hex casing', () {
+      expect(
+        dmConversationPeerPubkeys(
+          participantPubkeys: [me.toUpperCase(), alice],
+          currentUserPubkey: me,
+        ),
+        equals([alice]),
+      );
+    });
+
+    test('selects the peer when the viewer uses different hex casing', () {
+      expect(
+        dmConversationFirstPeer(
+          participantPubkeys: [me.toUpperCase(), alice],
+          currentUserPubkey: me,
+        ),
+        equals(alice),
+      );
+    });
+  });
+
   group(dmPeerName, () {
     group('precedence', () {
       test('vanished outranks every other branch', () {


### PR DESCRIPTION
## The problem

A malformed direct-message conversation whose only participant is the signed-in viewer could appear as a chat with yourself. The row was unusable because its profile and safety actions all targeted your own account.

The same identity comparison used exact text casing in several places. Nostr hex public keys are case-insensitive, so a differently-cased copy of the viewer's key could be mistaken for another participant, misfile a normal conversation, or make the UI render and navigate to the viewer instead of the real peer.

## Why this fix

Self-only conversations are now omitted from both Messages and Message requests. Divine does not support messaging yourself (#8261), so moving an unusable row between tabs would only relocate the broken experience. The malformed row is still logged for diagnosis, and existing maintenance continues to clean the known legacy shape.

Participant identity is compared case-insensitively at every affected boundary:

- classification removes the viewer before deciding whether peers are followed;
- NIP-17 ingest rejects participant lists that contain only differently-cased copies of one key; and
- inbox rows, actions, navigation, search, and request previews share one peer-resolution helper.

## What this deliberately leaves alone

- Stored pubkeys and conversation IDs are not normalized. Changing either would require a data migration and could split existing conversation identities.
- The existing self-send refusal remains unchanged.
- Existing maintenance still targets the known legacy `[self, self]` conversation ID; classification defensively hides other malformed shapes.
- Group-send behavior and #7684 remain outside this change.

## Verification

- Red/green regression coverage for single, duplicated, and mixed-case self-only participant lists.
- Case-insensitive peer-resolution and distinct-participant unit tests.
- 971 affected repository, BLoC, inbox, request, and widget tests passed locally during takeover.
- The repository pre-push analyzer and its 826 selected tests passed.

Closes #7683
