### PR TITLE
test(dm): catch a silent screen-reader regression in the who-reacted sheet

### DIFF
--- a/mobile/test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart
@@ -57,6 +57,7 @@ void main() {
     _MockConversationReactionsCubit cubit, {
     List<dynamic> additionalOverrides = const <dynamic>[],
     Locale? locale,
+    bool removalEnabled = true,
   }) {
     return testMaterialApp(
       additionalOverrides: additionalOverrides,
@@ -72,6 +73,7 @@ void main() {
                 messageId: messageId,
                 messageAuthorPubkey: otherPubkey,
                 ownerPubkey: ownerPubkey,
+                removalEnabled: removalEnabled,
               ),
               child: const Text('open'),
             ),
@@ -97,8 +99,12 @@ void main() {
       whenListen(cubit, Stream.value(state), initialState: state);
     }
 
-    Future<void> open(WidgetTester tester, {bool settle = true}) async {
-      await tester.pumpWidget(host(cubit));
+    Future<void> open(
+      WidgetTester tester, {
+      bool settle = true,
+      bool removalEnabled = true,
+    }) async {
+      await tester.pumpWidget(host(cubit, removalEnabled: removalEnabled));
       await tester.pump();
       await tester.tap(find.text('open'));
       if (settle) {
@@ -425,6 +431,46 @@ void main() {
           (widget) =>
               widget is Semantics &&
               widget.properties.label == l10n.dmReactionChipOwnA11yLabel('🔥'),
+        ),
+        findsNothing,
+      );
+
+      semantics.dispose();
+    });
+
+    testWidgets('a closed thread keeps the plain own-reaction label on a '
+        'refused removal, promising no retry', (tester) async {
+      final semantics = tester.ensureSemantics();
+      primeState([
+        makeReaction(
+          id: 'own-removal-refused',
+          reactorPubkey: ownerPubkey,
+          emoji: '🔥',
+          publishStatus: DmReactionPublishStatus.removalRefused,
+        ),
+      ]);
+
+      await open(tester, removalEnabled: false);
+
+      // `removalEnabled: false` collapses the trailing to a bare emoji, so the
+      // row must not announce a retry it cannot perform. Priming the *refused*
+      // status is what makes this discriminating: the `!canRetract` guard and
+      // the status switch below it disagree, so only the guard running first
+      // produces the plain label.
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics &&
+              widget.properties.label == l10n.dmReactionChipOwnA11yLabel('🔥'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics &&
+              widget.properties.label ==
+                  l10n.dmReactionRemovalRefusedA11yLabel('🔥'),
         ),
         findsNothing,
       );

--- a/mobile/test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart
@@ -395,6 +395,43 @@ void main() {
       semantics.dispose();
     });
 
+    testWidgets('own refused-removal row announces the retry, not the plain '
+        'own-reaction label', (tester) async {
+      final semantics = tester.ensureSemantics();
+      primeState([
+        makeReaction(
+          id: 'own-removal-refused',
+          reactorPubkey: ownerPubkey,
+          emoji: '🔥',
+          publishStatus: DmReactionPublishStatus.removalRefused,
+        ),
+      ]);
+
+      await open(tester);
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics &&
+              widget.properties.label ==
+                  l10n.dmReactionRemovalRefusedA11yLabel('🔥'),
+        ),
+        findsOneWidget,
+      );
+      // Deleting the refused arm falls through to the own-reaction label, which
+      // is grammatical and localized — so only its absence proves which arm ran.
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics &&
+              widget.properties.label == l10n.dmReactionChipOwnA11yLabel('🔥'),
+        ),
+        findsNothing,
+      );
+
+      semantics.dispose();
+    });
+
     group('deleted accounts', () {
       const picture = 'https://example.com/alice.jpg';
 


### PR DESCRIPTION
## Problem

The who-reacted sheet announces a different screen-reader label depending on a reaction's publish status. One of those labels — the one telling you a removal was refused and can be retried — had no assertion in the sheet's own test suite.

That local gap is dangerous because the failure mode is invisible. Deleting the arm falls through to the default, which announces "Your reaction: 🔥" — a grammatical, localized string. There is no crash, analyzer warning, visual difference, or golden diff. Someone using a screen reader simply stops being told the removal failed.

The behavior did have screen-level coverage two directories away in `conversation_view_test.dart`, but a defect in this widget should also be caught by this widget's focused tests.

## Why this fix

The new assertions land in the group that already covers the pending and failed labels, using the same technique those neighboring tests use: matching the label the row sets rather than the merged announcement, so a reactor's display name cannot interfere.

Each label test carries a negative control as well as a positive one. Because the fallback string is perfectly plausible, its absence proves which branch produced the announcement.

## Additional component-level coverage

The first commit is the scope of #8676. The second is a small, test-only locality improvement found while working in the same label-selection code.

`conversation_view_test.dart` already covers the closed-thread behavior end to end: it verifies the retry action is absent, the row is inert, the refused-removal label is absent, and the plain own-reaction label is present. The second commit does not fill a previously unguarded behavior gap. It adds a focused assertion beside `_ReactorRow` so a regression in the widget's `!canRetract` label guard fails the widget suite directly.

The test primes a refused removal and disables retraction, making the guard and the status switch disagree. Only the guard running first yields the plain label. The helper defaults preserve the behavior of every pre-existing test.

**No production behavior changes in this PR.** Both behaviors are already correct on `main`; this only adds regression coverage.

## What this deliberately leaves alone

- The broader conversation-screen assertions for closed threads. They continue to cover the retry affordance and interaction behavior end to end.
- Translating the key. It is English-only and already tracked as known translation debt.
- The `_` wildcard in the switch itself. Removing it would make a deleted arm a compile error, but that is a production change and requires a product decision about what `blocked` and `received` mean for an own reaction.

## Verification

Both label paths were mutation-tested. Deleting the refused-removal switch arm fails the new refused-removal widget test. Breaking the `!canRetract` label guard fails the new closed-thread widget test; the existing conversation-screen test also guards the broader closed-thread behavior.

- `flutter analyze lib test integration_test` — no issues found
- `dart format --set-exit-if-changed` — unchanged
- `flutter test test/screens/inbox/` — 632 passed
- Takeover verification: `flutter test test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart` — 15 passed

Closes #8676
