### PR TITLE
fix(nostr): keep Divine's client tag off ephemeral gift wraps

### DIFF
--- a/docs/NIP89_CLIENT_TAG.md
+++ b/docs/NIP89_CLIENT_TAG.md
@@ -16,7 +16,8 @@ Tag shape:
 ["client", "Divine", "31990:d95aa8fc0eff8e488952495b8064991d27fb96ed8652f12cdedc5a4e8b5ae540:divine-mobile", "wss://relay.divine.video"]
 ```
 
-The app injects this centrally in `nostr_client` and skips protocol-sensitive
+The app injects this through both `nostr_client`'s publish preparation and
+`SignerFactory.createAndSignEvent`, with both paths skipping protocol-sensitive
 kinds. That includes every NIP-59 outer wrapper — both the `kind:1059` gift
 wrap and the ephemeral `kind:21059` — because those are broadcast in the clear
 and a public `client` tag on one would undercut NIP-17's metadata guarantee.

--- a/docs/NIP89_CLIENT_TAG.md
+++ b/docs/NIP89_CLIENT_TAG.md
@@ -17,7 +17,9 @@ Tag shape:
 ```
 
 The app injects this centrally in `nostr_client` and skips protocol-sensitive
-outer wrapper kinds such as `kind:1059` gift wraps.
+kinds. That includes every NIP-59 outer wrapper — both the `kind:1059` gift
+wrap and the ephemeral `kind:21059` — because those are broadcast in the clear
+and a public `client` tag on one would undercut NIP-17's metadata guarantee.
 
 ## Handler event
 

--- a/mobile/packages/nostr_client/lib/src/nip89_client_tag.dart
+++ b/mobile/packages/nostr_client/lib/src/nip89_client_tag.dart
@@ -20,9 +20,23 @@ abstract final class Nip89ClientTag {
   /// Relay hint embedded in the NIP-89 client tag.
   static const String relayHint = 'wss://relay.divine.video';
 
+  /// Kinds that must never carry the public `client` tag.
+  ///
+  /// The app's signing path consults this set before it appends the tag and
+  /// signs, and that path takes a caller-supplied kind — including a kind
+  /// chosen by a third-party app through the Nostr apps bridge. This set is
+  /// its only guard, so an omission here is a real exposure rather than a
+  /// missing belt alongside a brace.
   static const Set<int> _excludedKinds = {
+    // NIP-59 requires a seal's tags be empty ("Tags MUST always be empty in a
+    // `kind:13`"), so this entry is a spec requirement, not a preference.
     EventKind.sealEventKind,
+    // Both NIP-59 outer wrappers. They are broadcast in the clear to the
+    // recipient's relays, so a `client` tag on either is publicly visible and
+    // would undercut NIP-17's "No Metadata Leak" guarantee. Keep them together:
+    // 21059 was added to NIP-59 after this set was first written (#8177).
     EventKind.giftWrap,
+    EventKind.ephemeralGiftWrap,
     EventKind.authentication,
     EventKind.nostrRemoteSigning,
     EventKind.blossomHttpAuth,

--- a/mobile/packages/nostr_client/test/src/nip89_client_tag_test.dart
+++ b/mobile/packages/nostr_client/test/src/nip89_client_tag_test.dart
@@ -68,6 +68,32 @@ void main() {
       expect(event.id, originalId);
     });
 
+    test('skips NIP-59 ephemeral gift wraps', () async {
+      final event = _event(
+        kind: EventKind.ephemeralGiftWrap,
+        tags: const [
+          ['p', _pubkey],
+        ],
+      );
+      final originalId = event.id;
+
+      final changed = await Nip89ClientTag.applyToEvent(event);
+
+      expect(changed, isFalse);
+      expect(event.tags, isNot(contains(Nip89ClientTag.tag)));
+      expect(event.id, originalId);
+    });
+
+    test('excludes both NIP-59 wrapper kinds at the shared guard', () async {
+      // Both injection sites gate on shouldSkipKind, so this covers the
+      // signing path as well as applyToEvent above.
+      expect(Nip89ClientTag.shouldSkipKind(EventKind.giftWrap), isTrue);
+      expect(
+        Nip89ClientTag.shouldSkipKind(EventKind.ephemeralGiftWrap),
+        isTrue,
+      );
+    });
+
     test('respects opt-out preference', () async {
       await Nip89ClientTag.setEnabled(enabled: false);
       final event = _event();

--- a/mobile/packages/nostr_client/test/src/nip89_client_tag_test.dart
+++ b/mobile/packages/nostr_client/test/src/nip89_client_tag_test.dart
@@ -84,16 +84,6 @@ void main() {
       expect(event.id, originalId);
     });
 
-    test('excludes both NIP-59 wrapper kinds at the shared guard', () async {
-      // Both injection sites gate on shouldSkipKind, so this covers the
-      // signing path as well as applyToEvent above.
-      expect(Nip89ClientTag.shouldSkipKind(EventKind.giftWrap), isTrue);
-      expect(
-        Nip89ClientTag.shouldSkipKind(EventKind.ephemeralGiftWrap),
-        isTrue,
-      );
-    });
-
     test('respects opt-out preference', () async {
       await Nip89ClientTag.setEnabled(enabled: false);
       final event = _event();

--- a/mobile/packages/nostr_sdk/lib/event_kind.dart
+++ b/mobile/packages/nostr_sdk/lib/event_kind.dart
@@ -100,6 +100,16 @@ class EventKind {
 
   static const int nwcInfoEvent = 13194;
 
+  /// NIP-59 ephemeral gift wrap. The outer wrapper for real-time wrapped
+  /// messaging ("live chat or real-time gaming"), structurally identical to
+  /// [giftWrap] but with ephemeral semantics — relays MUST NOT store it.
+  ///
+  /// Like [giftWrap] it is broadcast in the clear to the recipient's relays,
+  /// so its public tags must never carry identifying metadata. NIP-59 added
+  /// this kind after Divine's NIP-89 client-tag exclusion set was written
+  /// (#8177); keep the two wrapper kinds together wherever one is handled.
+  static const int ephemeralGiftWrap = 21059;
+
   static const int authentication = 22242;
 
   static const int nwcRequestEvent = 23194;

--- a/mobile/test/services/auth/signer_factory_test.dart
+++ b/mobile/test/services/auth/signer_factory_test.dart
@@ -326,6 +326,25 @@ void main() {
         expect(event!.tags.any((t) => t.first == 'client'), isFalse);
       });
 
+      // The apps bridge hands this method a caller-supplied kind, so the
+      // exclusion set is the only thing standing between a NIP-59 wrapper and
+      // a public attribution tag on this path. NIP-59 defines two outer
+      // wrapper kinds; 21059 arrived after the set was written (#8177).
+      test('omits the NIP-89 client tag for ephemeral gift wraps even when '
+          'enabled', () async {
+        await Nip89ClientTag.setEnabled(enabled: true);
+
+        final event = await factory.createAndSignEvent(
+          identity: localIdentity(),
+          authSource: AuthenticationSource.importedKeys,
+          kind: EventKind.ephemeralGiftWrap,
+          content: 'sealed',
+        );
+
+        expect(event, isNotNull);
+        expect(event!.tags.any((t) => t.first == 'client'), isFalse);
+      });
+
       test('does not duplicate a caller-supplied client tag', () async {
         await Nip89ClientTag.setEnabled(enabled: true);
 


### PR DESCRIPTION
## The problem

Divine stamps a public NIP-89 `client` tag on outgoing events unless the event kind is on an exclusion list. NIP-59's `kind:1059` gift wrap is on that list, because a wrapper's tags are readable by anyone and a `client` tag there would undercut NIP-17's stated guarantee that "participant identities, each message's real date and time, event kinds, and other event tags are all hidden from the public."

NIP-59 defines a **second** outer wrapper: `kind:21059`, the ephemeral gift wrap. Same structure, same one-time-use signing key, broadcast to the recipient's relays in the same way — it differs only in that relays must not store it. It was not on the list.

Not an oversight. The exclusion list was written on **2026-05-24**; NIP-59 gained kind 21059 on **2026-05-28**, four days later. A hand-written enumeration of spec kinds has nothing that notices when the spec grows one.

## Why it's worth fixing now rather than when we adopt the kind

No Divine code emits 21059, and our own relay would reject it today (funnelcake allow-lists ephemeral kinds individually, and 21059 has no row). So nothing is leaking. But "latent" undersells it in one specific way:

The Nostr **apps bridge** hands `SignerFactory.createAndSignEvent` an event kind taken straight from a third-party web app's `sign_event` request. On that path the tag is appended **before** signing, so the #8166 already-signed early return never fires and the exclusion list is the *only* guard. What stops 21059 there is a per-app allow-list parsed from remote JSON at `apps.divine.video/v1/apps` — a directory-side edit, not an app release.

So this is one server-side change away from a live leak, and the remedy is three lines.

## What's here

- `EventKind.ephemeralGiftWrap = 21059`, documented as `giftWrap`'s sibling.
- The kind added to the exclusion set, which is consulted by both injection sites, so one entry closes both.
- Comments on the wrapper entries naming NIP-59 as their source, and on the `kind:13` seal entry recording that NIP-59 *requires* its tags be empty — so a future cleanup doesn't prune it as redundant.
- `docs/NIP89_CLIENT_TAG.md` now states the rule instead of a single example.

## Verification

Tests were checked against a **mutant** with the exclusion entry removed, not just run green. The `signer_factory` test fails with `Expected: false, Actual: true` — the client tag really is appended to a signed kind-21059 event without this fix. The new `nip89_client_tag` test fails too. With the fix, all pass.

The primary test lives in `signer_factory_test.dart` deliberately: it covers the live path. A test against `applyToEvent` alone would guard a path a conformant gift wrap never takes, since NIP-59 requires the wrap be signed at construction and the publish path skips anything already signed.

Also run locally: `dart format` (clean), `flutter analyze lib test integration_test packages/nostr_client packages/nostr_sdk` (no issues), and the CI-only ratchets most likely to be affected — `unpinned_unchanged_assertions`, `placeholder_tests`, `ungrouped_tests`, `shared_setup_stubs`, `skip_ceiling`, `nostr_id_log_truncation`, `pubkey_log_encoding` — all green.

## What this deliberately leaves alone

**No ephemeral-range rule.** Excluding all of `20000-29999` would close this class of gap permanently and a sibling repo (`divine-web`'s `republishSkipReason`) already does exactly that for a related problem. But it would also silently strip the `client` tag from our live **kind-22236** view-analytics events, which do carry it today. That's a product call about analytics attribution, not a privacy fix, and it shouldn't ride along inside this one. Worth its own issue.

**Kinds 14/15.** The NIP-17 rumor kinds are in the bridge's default allow-list and are not excluded, so a bridge app signing a kind-14 rumor gets the tag baked in. Severity is much lower — the rumor ends up sealed and gift-wrapped, so the tag reaches only the conversation participants, who already know who they're talking to — and Divine's own DM path is unaffected. Flagging it rather than fixing it here: different path, different severity, different decision.

**One open question for whoever owns Keycast.** `signEvent` round-trips the event as JSON and we reconstruct from the response; our validation checks the pubkey and recomputes the id *from the returned tags*. A signer that appended a tag and re-hashed would pass both checks. Not verifiable from this repo, and not a blocker — but worth a definite answer.

Closes #8177
