### PR TITLE
docs(video): explain which auth signal gates what in the video providers

### DIFF
--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -323,7 +323,13 @@ CategoriesRepository categoriesRepository(Ref ref) {
 /// Provider for ProfileRepository instance
 ///
 /// Creates a ProfileRepository for managing user profiles (Kind 0 metadata).
-/// Requires authentication.
+///
+/// Returns `null` until `nostrSessionProvider` reports
+/// `isReadyForActiveClient` — a keyed [NostrClient] for the active identity,
+/// not merely `AuthState.authenticated`. A signed-in user whose signer is
+/// still warming up gets `null` here, so callers must null-check. Reads that
+/// only need a pubkey should take [profileReadRepositoryProvider] instead,
+/// which is available one phase earlier.
 ///
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -330,7 +330,13 @@ String _$categoriesRepositoryHash() =>
 /// Provider for ProfileRepository instance
 ///
 /// Creates a ProfileRepository for managing user profiles (Kind 0 metadata).
-/// Requires authentication.
+///
+/// Returns `null` until `nostrSessionProvider` reports
+/// `isReadyForActiveClient` — a keyed [NostrClient] for the active identity,
+/// not merely `AuthState.authenticated`. A signed-in user whose signer is
+/// still warming up gets `null` here, so callers must null-check. Reads that
+/// only need a pubkey should take [profileReadRepositoryProvider] instead,
+/// which is available one phase earlier.
 ///
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)
@@ -342,7 +348,13 @@ final profileRepositoryProvider = ProfileRepositoryProvider._();
 /// Provider for ProfileRepository instance
 ///
 /// Creates a ProfileRepository for managing user profiles (Kind 0 metadata).
-/// Requires authentication.
+///
+/// Returns `null` until `nostrSessionProvider` reports
+/// `isReadyForActiveClient` — a keyed [NostrClient] for the active identity,
+/// not merely `AuthState.authenticated`. A signed-in user whose signer is
+/// still warming up gets `null` here, so callers must null-check. Reads that
+/// only need a pubkey should take [profileReadRepositoryProvider] instead,
+/// which is available one phase earlier.
 ///
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)
@@ -359,7 +371,13 @@ final class ProfileRepositoryProvider
   /// Provider for ProfileRepository instance
   ///
   /// Creates a ProfileRepository for managing user profiles (Kind 0 metadata).
-  /// Requires authentication.
+  ///
+  /// Returns `null` until `nostrSessionProvider` reports
+  /// `isReadyForActiveClient` — a keyed [NostrClient] for the active identity,
+  /// not merely `AuthState.authenticated`. A signed-in user whose signer is
+  /// still warming up gets `null` here, so callers must null-check. Reads that
+  /// only need a pubkey should take [profileReadRepositoryProvider] instead,
+  /// which is available one phase earlier.
   ///
   /// Uses:
   /// - NostrClient from nostrServiceProvider (for relay communication)

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -145,7 +145,15 @@ SubscriptionManager subscriptionManager(Ref ref) {
   return SubscriptionManager(nostrService);
 }
 
-/// Video event service depends on Nostr, SeenVideos, Blocklist, AgeVerification, and SubscriptionManager
+/// Video event service: the keystone that owns relay subscriptions and the
+/// in-memory video-event set every feed reads from.
+///
+/// Composes the blocklist, moderation labels, the content/NSFW filter, and
+/// the hosting and provenance filters; reattaches [brokenVideoTrackerProvider]
+/// through a `ref.listen` rather than capturing one at build time.
+///
+/// `keepAlive` is load-bearing, not an optimisation: every NostrService client
+/// swap would otherwise orphan a service whose periodic timers keep running.
 @Riverpod(keepAlive: true)
 VideoEventService videoEventService(Ref ref) {
   final nostrService = ref.watch(nostrServiceProvider);

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -403,6 +403,15 @@ SubscribedListVideoCache? subscribedListVideoCache(Ref ref) {
 
 /// Video sharing service
 ///
+/// Returns `null` until an identity is known, because it is built from
+/// [profileReadRepositoryProvider], which stays null below
+/// `NostrSessionPhase.identityKnown` — so a caller during cold start must
+/// null-check rather than assume Share is available.
+///
+/// It takes the read-only profile handle deliberately: gating on the
+/// relay-ready client instead made Share a dead tap for that whole window
+/// (#6423). The send path gates itself on `canPublishNostrWritesNow`.
+///
 /// When a [DmRepository] is available the service sends videos via NIP-17
 /// encrypted DMs (NIP-17). Otherwise falls back to NIP-04 kind 4.
 @riverpod
@@ -631,8 +640,34 @@ VideosRepository videosRepository(Ref ref) {
 
 /// Provider for LikesRepository instance
 ///
-/// Creates a LikesRepository. Local storage is attached when the user is
-/// authenticated; signed-out relay queries are guarded by the repository.
+/// Always returns an instance, signed in or out. "Authenticated" is three
+/// different questions here, and this provider answers them with three
+/// different signals — see [NostrSessionPhase] for the vocabulary.
+///
+/// - **Identity known** — `AuthService.currentPublicKeyHex`. Decides *only*
+///   whether `DbLikesLocalStorage` is attached. Without it likes still publish
+///   and still stream, but nothing persists across a restart.
+/// - **Key resolved** — `NostrClient.resolvePublicKey()`, a *different* cache
+///   that retries the signer at call time. Decides whether an author-scoped
+///   relay query runs at all. When it yields null the repository logs and
+///   keeps local state rather than filtering on an empty author (#6813).
+/// - **Signer capable** — `AuthService.canPublishNostrWritesNow`, sampled per
+///   call in `isOnline` below because no stream carries it. Decides whether a
+///   write publishes now or queues through `PendingActionService`. This is a
+///   *relay-bound* use of that predicate; `state_management.md` documents only
+///   the relay-free NIP-98 one.
+///
+/// Rebuilt on any `AuthState` change — sign-in, sign-out, account switch —
+/// which disposes the old instance and re-runs `initialize()`. **Not** rebuilt
+/// when a Keycast signer finishes warming up, because that moves
+/// `AuthRpcCapability`, not `AuthState`. A cold start that loses that race gets
+/// no live Kind-7 subscription and no backfill for the session (#6838, #7933).
+///
+/// So an empty result from `syncUserReactions()` is not proof of emptiness.
+/// `ProfileLikedVideosBloc` currently renders one as `success` and persists it.
+/// The guards themselves are pinned by `likes_repository_test.dart`'s
+/// `signer readiness (#6813)` and `initialize` groups; what is not pinned is
+/// this provider's rebuild wiring.
 ///
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)
@@ -738,8 +773,16 @@ LikesRepository likesRepository(Ref ref) {
 
 /// Provider for RepostsRepository instance
 ///
-/// Creates a RepostsRepository for managing user reposts (Kind 16 generic
-/// reposts).
+/// Manages user reposts (Kind 16 generic reposts). Same auth shape as
+/// [likesRepositoryProvider] — see its doc for which signal gates what, and
+/// for the cold-start race that leaves a session unsynced (#6838, #7933).
+///
+/// One asymmetry worth knowing: `RepostsRepository.initialize()` loads local
+/// storage and subscribes, but calls no reconciliation sync. `syncUserReposts()`
+/// is a separate entry point this provider never invokes, so reposts are
+/// reconciled only where a caller asks for it.
+///
+/// `PersonalRepostsDao` below is attached only when an identity is known.
 ///
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -152,8 +152,8 @@ SubscriptionManager subscriptionManager(Ref ref) {
 /// the hosting and provenance filters; reattaches [brokenVideoTrackerProvider]
 /// through a `ref.listen` rather than capturing one at build time.
 ///
-/// `keepAlive` is load-bearing, not an optimisation: every NostrService client
-/// swap would otherwise orphan a service whose periodic timers keep running.
+/// `keepAlive` is load-bearing, not an optimisation: it keeps the service and
+/// its relay subscriptions alive while no consumer is listening.
 @Riverpod(keepAlive: true)
 VideoEventService videoEventService(Ref ref) {
   final nostrService = ref.watch(nostrServiceProvider);
@@ -426,9 +426,6 @@ SubscribedListVideoCache? subscribedListVideoCache(Ref ref) {
 VideoSharingService? videoSharingService(Ref ref) {
   final nostrService = ref.watch(nostrServiceProvider);
   final authService = ref.watch(authServiceProvider);
-  // Read-only handle: the service only reads profiles, and gating it on the
-  // relay-ready client made Share a dead tap during cold start (#6423). The
-  // send path gates itself on `canPublishNostrWritesNow`.
   final profileRepository = ref.watch(profileReadRepositoryProvider);
   final dmRepository = ref.watch(dmRepositoryProvider);
 
@@ -650,11 +647,14 @@ VideosRepository videosRepository(Ref ref) {
 ///
 /// Always returns an instance, signed in or out. "Authenticated" is three
 /// different questions here, and this provider answers them with three
-/// different signals — see [NostrSessionPhase] for the vocabulary.
+/// different signals — compare [NostrSessionPhase] for the app-wide readiness
+/// vocabulary.
 ///
-/// - **Identity known** — `AuthService.currentPublicKeyHex`. Decides *only*
-///   whether `DbLikesLocalStorage` is attached. Without it likes still publish
-///   and still stream, but nothing persists across a restart.
+/// - **Auth identity cached** — `AuthService.currentPublicKeyHex`. This is wider
+///   than `NostrSessionPhase.identityKnown` because it can fall back to the key
+///   container or profile. It decides *only* whether `DbLikesLocalStorage` is
+///   attached. Without it likes still publish and stream, but nothing persists
+///   across a restart.
 /// - **Key resolved** — `NostrClient.resolvePublicKey()`, a *different* cache
 ///   that retries the signer at call time. Decides whether an author-scoped
 ///   relay query runs at all. When it yields null the repository logs and

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -197,9 +197,6 @@ VideoEventService videoEventService(Ref ref) {
     videoFilterBuilder: videoFilterBuilder,
     performanceMonitor: ref.watch(performanceMonitoringServiceProvider),
   );
-  // Without this, every NostrService client swap (auth cold start, account
-  // switch) orphans a service whose periodic timers and auth subscription
-  // keep running against the disposed EventRouter above (#6174).
   ref.onDispose(service.dispose);
   var persistedDeletions = const <ContentDeletion>[];
   try {

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -154,6 +154,11 @@ SubscriptionManager subscriptionManager(Ref ref) {
 ///
 /// `keepAlive` is load-bearing, not an optimisation: it keeps the service and
 /// its relay subscriptions alive while no consumer is listening.
+///
+/// Tearing the old one down is a separate guard — `ref.onDispose` below.
+/// Without it a NostrService client swap (auth cold start, account switch)
+/// orphans a service whose periodic timers and auth subscription keep
+/// running against the disposed EventRouter (#6174).
 @Riverpod(keepAlive: true)
 VideoEventService videoEventService(Ref ref) {
   final nostrService = ref.watch(nostrServiceProvider);

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -456,6 +456,15 @@ String _$subscribedListVideoCacheHash() =>
 
 /// Video sharing service
 ///
+/// Returns `null` until an identity is known, because it is built from
+/// [profileReadRepositoryProvider], which stays null below
+/// `NostrSessionPhase.identityKnown` — so a caller during cold start must
+/// null-check rather than assume Share is available.
+///
+/// It takes the read-only profile handle deliberately: gating on the
+/// relay-ready client instead made Share a dead tap for that whole window
+/// (#6423). The send path gates itself on `canPublishNostrWritesNow`.
+///
 /// When a [DmRepository] is available the service sends videos via NIP-17
 /// encrypted DMs (NIP-17). Otherwise falls back to NIP-04 kind 4.
 
@@ -463,6 +472,15 @@ String _$subscribedListVideoCacheHash() =>
 final videoSharingServiceProvider = VideoSharingServiceProvider._();
 
 /// Video sharing service
+///
+/// Returns `null` until an identity is known, because it is built from
+/// [profileReadRepositoryProvider], which stays null below
+/// `NostrSessionPhase.identityKnown` — so a caller during cold start must
+/// null-check rather than assume Share is available.
+///
+/// It takes the read-only profile handle deliberately: gating on the
+/// relay-ready client instead made Share a dead tap for that whole window
+/// (#6423). The send path gates itself on `canPublishNostrWritesNow`.
 ///
 /// When a [DmRepository] is available the service sends videos via NIP-17
 /// encrypted DMs (NIP-17). Otherwise falls back to NIP-04 kind 4.
@@ -476,6 +494,15 @@ final class VideoSharingServiceProvider
         >
     with $Provider<VideoSharingService?> {
   /// Video sharing service
+  ///
+  /// Returns `null` until an identity is known, because it is built from
+  /// [profileReadRepositoryProvider], which stays null below
+  /// `NostrSessionPhase.identityKnown` — so a caller during cold start must
+  /// null-check rather than assume Share is available.
+  ///
+  /// It takes the read-only profile handle deliberately: gating on the
+  /// relay-ready client instead made Share a dead tap for that whole window
+  /// (#6423). The send path gates itself on `canPublishNostrWritesNow`.
   ///
   /// When a [DmRepository] is available the service sends videos via NIP-17
   /// encrypted DMs (NIP-17). Otherwise falls back to NIP-04 kind 4.
@@ -957,8 +984,34 @@ String _$videosRepositoryHash() => r'ed76873b99e97dac7980173e4b0cefdc79a03aae';
 
 /// Provider for LikesRepository instance
 ///
-/// Creates a LikesRepository. Local storage is attached when the user is
-/// authenticated; signed-out relay queries are guarded by the repository.
+/// Always returns an instance, signed in or out. "Authenticated" is three
+/// different questions here, and this provider answers them with three
+/// different signals — see [NostrSessionPhase] for the vocabulary.
+///
+/// - **Identity known** — `AuthService.currentPublicKeyHex`. Decides *only*
+///   whether `DbLikesLocalStorage` is attached. Without it likes still publish
+///   and still stream, but nothing persists across a restart.
+/// - **Key resolved** — `NostrClient.resolvePublicKey()`, a *different* cache
+///   that retries the signer at call time. Decides whether an author-scoped
+///   relay query runs at all. When it yields null the repository logs and
+///   keeps local state rather than filtering on an empty author (#6813).
+/// - **Signer capable** — `AuthService.canPublishNostrWritesNow`, sampled per
+///   call in `isOnline` below because no stream carries it. Decides whether a
+///   write publishes now or queues through `PendingActionService`. This is a
+///   *relay-bound* use of that predicate; `state_management.md` documents only
+///   the relay-free NIP-98 one.
+///
+/// Rebuilt on any `AuthState` change — sign-in, sign-out, account switch —
+/// which disposes the old instance and re-runs `initialize()`. **Not** rebuilt
+/// when a Keycast signer finishes warming up, because that moves
+/// `AuthRpcCapability`, not `AuthState`. A cold start that loses that race gets
+/// no live Kind-7 subscription and no backfill for the session (#6838, #7933).
+///
+/// So an empty result from `syncUserReactions()` is not proof of emptiness.
+/// `ProfileLikedVideosBloc` currently renders one as `success` and persists it.
+/// The guards themselves are pinned by `likes_repository_test.dart`'s
+/// `signer readiness (#6813)` and `initialize` groups; what is not pinned is
+/// this provider's rebuild wiring.
 ///
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)
@@ -971,8 +1024,34 @@ final likesRepositoryProvider = LikesRepositoryProvider._();
 
 /// Provider for LikesRepository instance
 ///
-/// Creates a LikesRepository. Local storage is attached when the user is
-/// authenticated; signed-out relay queries are guarded by the repository.
+/// Always returns an instance, signed in or out. "Authenticated" is three
+/// different questions here, and this provider answers them with three
+/// different signals — see [NostrSessionPhase] for the vocabulary.
+///
+/// - **Identity known** — `AuthService.currentPublicKeyHex`. Decides *only*
+///   whether `DbLikesLocalStorage` is attached. Without it likes still publish
+///   and still stream, but nothing persists across a restart.
+/// - **Key resolved** — `NostrClient.resolvePublicKey()`, a *different* cache
+///   that retries the signer at call time. Decides whether an author-scoped
+///   relay query runs at all. When it yields null the repository logs and
+///   keeps local state rather than filtering on an empty author (#6813).
+/// - **Signer capable** — `AuthService.canPublishNostrWritesNow`, sampled per
+///   call in `isOnline` below because no stream carries it. Decides whether a
+///   write publishes now or queues through `PendingActionService`. This is a
+///   *relay-bound* use of that predicate; `state_management.md` documents only
+///   the relay-free NIP-98 one.
+///
+/// Rebuilt on any `AuthState` change — sign-in, sign-out, account switch —
+/// which disposes the old instance and re-runs `initialize()`. **Not** rebuilt
+/// when a Keycast signer finishes warming up, because that moves
+/// `AuthRpcCapability`, not `AuthState`. A cold start that loses that race gets
+/// no live Kind-7 subscription and no backfill for the session (#6838, #7933).
+///
+/// So an empty result from `syncUserReactions()` is not proof of emptiness.
+/// `ProfileLikedVideosBloc` currently renders one as `success` and persists it.
+/// The guards themselves are pinned by `likes_repository_test.dart`'s
+/// `signer readiness (#6813)` and `initialize` groups; what is not pinned is
+/// this provider's rebuild wiring.
 ///
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)
@@ -986,8 +1065,34 @@ final class LikesRepositoryProvider
     with $Provider<LikesRepository> {
   /// Provider for LikesRepository instance
   ///
-  /// Creates a LikesRepository. Local storage is attached when the user is
-  /// authenticated; signed-out relay queries are guarded by the repository.
+  /// Always returns an instance, signed in or out. "Authenticated" is three
+  /// different questions here, and this provider answers them with three
+  /// different signals — see [NostrSessionPhase] for the vocabulary.
+  ///
+  /// - **Identity known** — `AuthService.currentPublicKeyHex`. Decides *only*
+  ///   whether `DbLikesLocalStorage` is attached. Without it likes still publish
+  ///   and still stream, but nothing persists across a restart.
+  /// - **Key resolved** — `NostrClient.resolvePublicKey()`, a *different* cache
+  ///   that retries the signer at call time. Decides whether an author-scoped
+  ///   relay query runs at all. When it yields null the repository logs and
+  ///   keeps local state rather than filtering on an empty author (#6813).
+  /// - **Signer capable** — `AuthService.canPublishNostrWritesNow`, sampled per
+  ///   call in `isOnline` below because no stream carries it. Decides whether a
+  ///   write publishes now or queues through `PendingActionService`. This is a
+  ///   *relay-bound* use of that predicate; `state_management.md` documents only
+  ///   the relay-free NIP-98 one.
+  ///
+  /// Rebuilt on any `AuthState` change — sign-in, sign-out, account switch —
+  /// which disposes the old instance and re-runs `initialize()`. **Not** rebuilt
+  /// when a Keycast signer finishes warming up, because that moves
+  /// `AuthRpcCapability`, not `AuthState`. A cold start that loses that race gets
+  /// no live Kind-7 subscription and no backfill for the session (#6838, #7933).
+  ///
+  /// So an empty result from `syncUserReactions()` is not proof of emptiness.
+  /// `ProfileLikedVideosBloc` currently renders one as `success` and persists it.
+  /// The guards themselves are pinned by `likes_repository_test.dart`'s
+  /// `signer readiness (#6813)` and `initialize` groups; what is not pinned is
+  /// this provider's rebuild wiring.
   ///
   /// Uses:
   /// - NostrClient from nostrServiceProvider (for relay communication)

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -231,12 +231,28 @@ final class SubscriptionManagerProvider
 String _$subscriptionManagerHash() =>
     r'b65a6978927d3004c6f841e0b80075f9db9645d2';
 
-/// Video event service depends on Nostr, SeenVideos, Blocklist, AgeVerification, and SubscriptionManager
+/// Video event service: the keystone that owns relay subscriptions and the
+/// in-memory video-event set every feed reads from.
+///
+/// Composes the blocklist, moderation labels, the content/NSFW filter, and
+/// the hosting and provenance filters; reattaches [brokenVideoTrackerProvider]
+/// through a `ref.listen` rather than capturing one at build time.
+///
+/// `keepAlive` is load-bearing, not an optimisation: every NostrService client
+/// swap would otherwise orphan a service whose periodic timers keep running.
 
 @ProviderFor(videoEventService)
 final videoEventServiceProvider = VideoEventServiceProvider._();
 
-/// Video event service depends on Nostr, SeenVideos, Blocklist, AgeVerification, and SubscriptionManager
+/// Video event service: the keystone that owns relay subscriptions and the
+/// in-memory video-event set every feed reads from.
+///
+/// Composes the blocklist, moderation labels, the content/NSFW filter, and
+/// the hosting and provenance filters; reattaches [brokenVideoTrackerProvider]
+/// through a `ref.listen` rather than capturing one at build time.
+///
+/// `keepAlive` is load-bearing, not an optimisation: every NostrService client
+/// swap would otherwise orphan a service whose periodic timers keep running.
 
 final class VideoEventServiceProvider
     extends
@@ -246,7 +262,15 @@ final class VideoEventServiceProvider
           VideoEventService
         >
     with $Provider<VideoEventService> {
-  /// Video event service depends on Nostr, SeenVideos, Blocklist, AgeVerification, and SubscriptionManager
+  /// Video event service: the keystone that owns relay subscriptions and the
+  /// in-memory video-event set every feed reads from.
+  ///
+  /// Composes the blocklist, moderation labels, the content/NSFW filter, and
+  /// the hosting and provenance filters; reattaches [brokenVideoTrackerProvider]
+  /// through a `ref.listen` rather than capturing one at build time.
+  ///
+  /// `keepAlive` is load-bearing, not an optimisation: every NostrService client
+  /// swap would otherwise orphan a service whose periodic timers keep running.
   VideoEventServiceProvider._()
     : super(
         from: null,

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -238,8 +238,8 @@ String _$subscriptionManagerHash() =>
 /// the hosting and provenance filters; reattaches [brokenVideoTrackerProvider]
 /// through a `ref.listen` rather than capturing one at build time.
 ///
-/// `keepAlive` is load-bearing, not an optimisation: every NostrService client
-/// swap would otherwise orphan a service whose periodic timers keep running.
+/// `keepAlive` is load-bearing, not an optimisation: it keeps the service and
+/// its relay subscriptions alive while no consumer is listening.
 
 @ProviderFor(videoEventService)
 final videoEventServiceProvider = VideoEventServiceProvider._();
@@ -251,8 +251,8 @@ final videoEventServiceProvider = VideoEventServiceProvider._();
 /// the hosting and provenance filters; reattaches [brokenVideoTrackerProvider]
 /// through a `ref.listen` rather than capturing one at build time.
 ///
-/// `keepAlive` is load-bearing, not an optimisation: every NostrService client
-/// swap would otherwise orphan a service whose periodic timers keep running.
+/// `keepAlive` is load-bearing, not an optimisation: it keeps the service and
+/// its relay subscriptions alive while no consumer is listening.
 
 final class VideoEventServiceProvider
     extends
@@ -269,8 +269,8 @@ final class VideoEventServiceProvider
   /// the hosting and provenance filters; reattaches [brokenVideoTrackerProvider]
   /// through a `ref.listen` rather than capturing one at build time.
   ///
-  /// `keepAlive` is load-bearing, not an optimisation: every NostrService client
-  /// swap would otherwise orphan a service whose periodic timers keep running.
+  /// `keepAlive` is load-bearing, not an optimisation: it keeps the service and
+  /// its relay subscriptions alive while no consumer is listening.
   VideoEventServiceProvider._()
     : super(
         from: null,
@@ -1010,11 +1010,14 @@ String _$videosRepositoryHash() => r'ed76873b99e97dac7980173e4b0cefdc79a03aae';
 ///
 /// Always returns an instance, signed in or out. "Authenticated" is three
 /// different questions here, and this provider answers them with three
-/// different signals — see [NostrSessionPhase] for the vocabulary.
+/// different signals — compare [NostrSessionPhase] for the app-wide readiness
+/// vocabulary.
 ///
-/// - **Identity known** — `AuthService.currentPublicKeyHex`. Decides *only*
-///   whether `DbLikesLocalStorage` is attached. Without it likes still publish
-///   and still stream, but nothing persists across a restart.
+/// - **Auth identity cached** — `AuthService.currentPublicKeyHex`. This is wider
+///   than `NostrSessionPhase.identityKnown` because it can fall back to the key
+///   container or profile. It decides *only* whether `DbLikesLocalStorage` is
+///   attached. Without it likes still publish and stream, but nothing persists
+///   across a restart.
 /// - **Key resolved** — `NostrClient.resolvePublicKey()`, a *different* cache
 ///   that retries the signer at call time. Decides whether an author-scoped
 ///   relay query runs at all. When it yields null the repository logs and
@@ -1050,11 +1053,14 @@ final likesRepositoryProvider = LikesRepositoryProvider._();
 ///
 /// Always returns an instance, signed in or out. "Authenticated" is three
 /// different questions here, and this provider answers them with three
-/// different signals — see [NostrSessionPhase] for the vocabulary.
+/// different signals — compare [NostrSessionPhase] for the app-wide readiness
+/// vocabulary.
 ///
-/// - **Identity known** — `AuthService.currentPublicKeyHex`. Decides *only*
-///   whether `DbLikesLocalStorage` is attached. Without it likes still publish
-///   and still stream, but nothing persists across a restart.
+/// - **Auth identity cached** — `AuthService.currentPublicKeyHex`. This is wider
+///   than `NostrSessionPhase.identityKnown` because it can fall back to the key
+///   container or profile. It decides *only* whether `DbLikesLocalStorage` is
+///   attached. Without it likes still publish and stream, but nothing persists
+///   across a restart.
 /// - **Key resolved** — `NostrClient.resolvePublicKey()`, a *different* cache
 ///   that retries the signer at call time. Decides whether an author-scoped
 ///   relay query runs at all. When it yields null the repository logs and
@@ -1091,11 +1097,14 @@ final class LikesRepositoryProvider
   ///
   /// Always returns an instance, signed in or out. "Authenticated" is three
   /// different questions here, and this provider answers them with three
-  /// different signals — see [NostrSessionPhase] for the vocabulary.
+  /// different signals — compare [NostrSessionPhase] for the app-wide readiness
+  /// vocabulary.
   ///
-  /// - **Identity known** — `AuthService.currentPublicKeyHex`. Decides *only*
-  ///   whether `DbLikesLocalStorage` is attached. Without it likes still publish
-  ///   and still stream, but nothing persists across a restart.
+  /// - **Auth identity cached** — `AuthService.currentPublicKeyHex`. This is wider
+  ///   than `NostrSessionPhase.identityKnown` because it can fall back to the key
+  ///   container or profile. It decides *only* whether `DbLikesLocalStorage` is
+  ///   attached. Without it likes still publish and stream, but nothing persists
+  ///   across a restart.
   /// - **Key resolved** — `NostrClient.resolvePublicKey()`, a *different* cache
   ///   that retries the signer at call time. Decides whether an author-scoped
   ///   relay query runs at all. When it yields null the repository logs and

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -240,6 +240,11 @@ String _$subscriptionManagerHash() =>
 ///
 /// `keepAlive` is load-bearing, not an optimisation: it keeps the service and
 /// its relay subscriptions alive while no consumer is listening.
+///
+/// Tearing the old one down is a separate guard — `ref.onDispose` below.
+/// Without it a NostrService client swap (auth cold start, account switch)
+/// orphans a service whose periodic timers and auth subscription keep
+/// running against the disposed EventRouter (#6174).
 
 @ProviderFor(videoEventService)
 final videoEventServiceProvider = VideoEventServiceProvider._();
@@ -253,6 +258,11 @@ final videoEventServiceProvider = VideoEventServiceProvider._();
 ///
 /// `keepAlive` is load-bearing, not an optimisation: it keeps the service and
 /// its relay subscriptions alive while no consumer is listening.
+///
+/// Tearing the old one down is a separate guard — `ref.onDispose` below.
+/// Without it a NostrService client swap (auth cold start, account switch)
+/// orphans a service whose periodic timers and auth subscription keep
+/// running against the disposed EventRouter (#6174).
 
 final class VideoEventServiceProvider
     extends
@@ -271,6 +281,11 @@ final class VideoEventServiceProvider
   ///
   /// `keepAlive` is load-bearing, not an optimisation: it keeps the service and
   /// its relay subscriptions alive while no consumer is listening.
+  ///
+  /// Tearing the old one down is a separate guard — `ref.onDispose` below.
+  /// Without it a NostrService client swap (auth cold start, account switch)
+  /// orphans a service whose periodic timers and auth subscription keep
+  /// running against the disposed EventRouter (#6174).
   VideoEventServiceProvider._()
     : super(
         from: null,


### PR DESCRIPTION
Closes #7932

## First, a correction to the issue

The issue says the doc at `video_providers.dart:389-390` claims *"Returns null when user is not authenticated"* against a non-nullable return type. That line is not there, and the line numbers never pointed at it:

- PR #6819 removed that wording on 2026-08-08, **eleven days before the issue was filed**. `git log -S'Returns null when user is not authenticated' -- mobile/lib/providers/video_providers.dart` returns exactly two commits: the one that added it, and #6819, which deleted it.
- Its actual positions over time were lines 341 → 530 → 550 → gone. Never 389-390.

So there is nothing to fix there. What #6819 did *not* do is any of the issue's three substantive asks — document the auth-readiness contract, say what "authenticated" means, explain the cold-start race. Those are what this PR does.

## The problem

"Authenticated" was doing the work of three different signals, and the code gates a different thing on each:

| Signal | Decides |
|---|---|
| `AuthService.currentPublicKeyHex` (auth identity cache) | **only** whether local storage is attached |
| `NostrClient.resolvePublicKey()` (signer cache, retried at call time) | whether an author-scoped relay query runs at all |
| `AuthService.canPublishNostrWritesNow` (sampled per call) | whether a write publishes now or queues offline |

These are two different pubkey caches and a third capability check. A reader of the old one-liner could not tell which applied where — and the codebase reads the empty-able signer cache directly in fourteen places today (#8321).

## Why this fix

The sharp edge is the rebuild trigger. These providers watch `currentAuthStateProvider`, so they rebuild on sign-in, sign-out and account switch — that recovery works. But a Keycast signer finishing its warm-up moves `AuthRpcCapability`, not `AuthState`, so the provider does not rebuild and `initialize()` is never re-run. That cold start gets **no live Kind-7 subscription and no backfill for the session**, and nothing re-drives it (#6838, #7933).

Downstream, `ProfileLikedVideosBloc` renders that empty result as `success` and persists the empty snapshot through `CacheSync`. So an empty sync is not proof of emptiness — a Liked tab can look identical to a genuinely empty account, and cache that. The docs now say so, because #6819's replacement wording was true but thin, and that thinness is why the gap stayed invisible.

The docs **point at** `NostrSessionPhase` and `state_management.md` rather than restating them. The contract is already written twice; a third copy is a third thing to keep in sync, and duplication is how the current doc drifted.

## What it deliberately leaves alone

- **The sync-recovery gap itself** — documented, not fixed. That is #6838 / #7933.
- **The fourteen direct reads of the empty-able `publicKey` cache** — #8321.
- **Making the distinction unrepresentable** by gating these providers on readiness and returning nullable, the way `profileReadRepository` does. Architecturally the better answer; evaluated and closed as not planned in #3523, and a behaviour change across twelve consumers.
- **Two code bugs found while investigating**, reported separately rather than folded in: a missing `ValueKey` on two `BlocProvider<ProfileLikedVideosBloc>` in `liked_videos_screen_router.dart`, and the empty-sync-persisted-as-success above.
- The neighboring `profileRepository` wording was corrected after review to name its signer-ready gate.

## One commit not requested by the issue

The second commit corrects `videoEventService`'s doc, which claimed dependencies on `SeenVideos` and `AgeVerification`. Neither exists in that function — `seenVideosServiceProvider` is watched by `videosRepository` instead. Flagged separately here because it is not auth-related; fixed because it is a false statement in a doc block this branch was already editing.

## Verification

Comments only — **no executable line changes in the whole branch.** Verify with
`git diff -U0 $(git merge-base origin/main HEAD)` filtered to lines that are neither `///` nor `//`: it is empty.
(Filter on `///` alone and you will still see the three `//` inline comments the de-duplication commits removed.
Diff against `origin/main` directly rather than the merge base and you will see every commit `main` has gained since,
read as removals.)

- `dart format` clean, `flutter analyze lib` clean.
- `riverpod_generator` copies dartdoc onto the generated providers, so `video_providers.g.dart` moves too. Its diff is also comment-only, with no provider hash change. Regenerated with `build_runner` and committed.
- `check_file_size_ceiling.sh` warns `841 -> 894` lines. It is advisory and always exits 0 — flagging so it does not read as an unnoticed regression.

**No test added**, following #8440's precedent rather than #7592's. #7592 added one because its investigation surfaced a claim nothing pinned; here the guards the docs describe are already pinned — `likes_repository_test.dart`'s `signer readiness (#6813)` and `initialize` groups, mirrored in `reposts_repository_test.dart`. What stays unpinned is this provider's rebuild wiring, and `comment_references: ignore` means even the `[NostrSessionPhase]` reference is unchecked. So nothing mechanically stops these docs going stale: when #6838 lands, the "no backfill for the session" sentence has to be deleted by hand. Naming #6838 in the doc text is what makes that discoverable — a weaker guarantee than a test, and worth saying plainly rather than glossing.
