### PR TITLE
fix(dm): stop rebuilding messages after local encryption fails

### DIFF
--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -133,9 +133,9 @@ class NIP17MessageService {
   /// NIP-46) cannot cross a `SendPort`, so they fall back to the
   /// on-main-isolate [_giftWrapBuilder] — already async RPC/IPC, not a block.
   ///
-  /// Any failure of the isolate path (thrown error, null/failed result) falls
-  /// back to the main-isolate builder, mirroring the receive-side decrypt
-  /// offload in DmRepository. See #5391.
+  /// A thrown isolate error falls back to the main-isolate builder, mirroring
+  /// the receive-side decrypt offload in DmRepository. A returned failed slot
+  /// is deterministic local crypto and is not rebuilt. See #5391 and #8534.
   Future<Event?> _buildWrap({
     required Nostr nostr,
     required Event rumorEvent,
@@ -156,11 +156,13 @@ class NIP17MessageService {
         if (result.isSuccess) {
           return Event.fromJson(result.giftWrap!);
         }
-        Log.debug(
+        Log.warning(
           'Isolate gift-wrap build returned failure for rumor '
-          '${rumorEvent.id}: ${result.error}; falling back to main isolate',
+          '${rumorEvent.id}: ${result.error}; not rebuilding on the main '
+          'isolate because it would repeat the same local crypto',
           category: LogCategory.system,
         );
+        return null;
       } on Object catch (e, stackTrace) {
         Log.error(
           'Isolate gift-wrap build threw for rumor ${rumorEvent.id}: $e',
@@ -236,19 +238,9 @@ class NIP17MessageService {
           final r = results[0];
           final s = results[1];
           if (!r.isSuccess) {
-            // Terminal, and deliberately not a fallback. The main-isolate
-            // builder derives the same NIP-44 conversation key from the same
-            // recipient pubkey (`LocalNostrSigner.nip44Encrypt` and
-            // `buildGiftWrapFromHex` both call `NIP44V2.shareSecret`), so a
-            // rebuild re-runs the identical ECDH and fails identically —
-            // verified by probe on #8534. The sibling server path DOES fall
-            // back because ITS slot failures are transient (5xx, expired
-            // token, policy refusal); these are local deterministic crypto.
-            // Warning, not debug: this ends the send, and `buildLogsSummary`
-            // keeps 200 error/warning entries against a 50-entry any-level
-            // tail, so debug almost never reaches a bug report. Not error:
-            // #7288 established that expected degradation on this path does
-            // not carry a stack trace.
+            // Local slot failures are deterministic: both builders derive the
+            // same NIP-44 key from the same recipient pubkey, so rebuilding
+            // repeats the failure. Server slot failures may be transient.
             Log.warning(
               'Batch gift-wrap: recipient slot failed (${r.error}); '
               'the send fails — rebuilding on the main isolate would run the '

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -196,11 +196,18 @@ class NIP17MessageService {
   /// remote signer whose backend supports it — in a single `nip17_wrap_batch`
   /// round trip.
   ///
-  /// Returns `(recipientWrap, selfWrap?)`. When neither batch path applies —
-  /// or either one fails — only the recipient wrap is built here and
+  /// Returns `(recipientWrap, selfWrap?)`. When no batch path applies — or a
+  /// batch attempt is abandoned (it threw, returned the wrong slot count, or
+  /// the server path declined) — only the recipient wrap is built here and
   /// `selfWrap` is `null`; [_publishSelfWrap] then builds the self-wrap
   /// lazily after the recipient publish confirms delivery (avoids an extra
   /// signing round-trip on publish failure).
+  ///
+  /// One case returns a `null` recipient wrap rather than rebuilding: the
+  /// local-isolate batch reporting a failed *recipient* slot. That failure is
+  /// deterministic local crypto, so the caller terminalises the send instead
+  /// of spending a rebuild that would fail the same way. See the comment at
+  /// that branch, and #8534.
   ///
   /// Security: `withPrivateKeyHex((k) => k)` copies the raw private-key hex
   /// out of its scoped callback so it can be serialised across the [compute]
@@ -229,9 +236,23 @@ class NIP17MessageService {
           final r = results[0];
           final s = results[1];
           if (!r.isSuccess) {
-            Log.debug(
+            // Terminal, and deliberately not a fallback. The main-isolate
+            // builder derives the same NIP-44 conversation key from the same
+            // recipient pubkey (`LocalNostrSigner.nip44Encrypt` and
+            // `buildGiftWrapFromHex` both call `NIP44V2.shareSecret`), so a
+            // rebuild re-runs the identical ECDH and fails identically —
+            // verified by probe on #8534. The sibling server path DOES fall
+            // back because ITS slot failures are transient (5xx, expired
+            // token, policy refusal); these are local deterministic crypto.
+            // Warning, not debug: this ends the send, and `buildLogsSummary`
+            // keeps 200 error/warning entries against a 50-entry any-level
+            // tail, so debug almost never reaches a bug report. Not error:
+            // #7288 established that expected degradation on this path does
+            // not carry a stack trace.
+            Log.warning(
               'Batch gift-wrap: recipient slot failed (${r.error}); '
-              'falling back to main-isolate builder',
+              'the send fails — rebuilding on the main isolate would run the '
+              'same ECDH against the same recipient key and fail identically',
               category: LogCategory.system,
             );
           }
@@ -268,10 +289,12 @@ class NIP17MessageService {
       // trip returns both wraps, replacing the four (`nip44Encrypt` +
       // `signEvent`, per wrap) this path otherwise spends. See #7090.
       //
-      // Deliberately in the `else` arm, never before the isolate check: a
-      // local-key signer whose isolate hop fails still falls through to
-      // [_buildWrap], which signs in-process at zero round trips — reaching
-      // for the network there would be a regression, not a speed-up.
+      // Deliberately in the `else` arm, never before the isolate check: when a
+      // local-key signer's isolate hop is abandoned (it threw, or returned the
+      // wrong slot count) it still falls through to [_buildWrap], which signs
+      // in-process at zero round trips — reaching for the network there would
+      // be a regression, not a speed-up. A failed recipient *slot* does not
+      // reach here at all; it ends the send above (#8534).
       final wraps = await _buildBothWrapsOnServer(
         wrapper: wrapper,
         rumorEvent: rumorEvent,
@@ -279,8 +302,8 @@ class NIP17MessageService {
       );
       if (wraps != null) return wraps;
     }
-    // No batch path applied, or it did not produce a recipient wrap: build
-    // only the recipient wrap. The self-wrap is built lazily by
+    // No batch path applied, or one was abandoned before producing slots:
+    // build only the recipient wrap. The self-wrap is built lazily by
     // _publishSelfWrap after the recipient publish confirms delivery — avoids
     // an extra signing round-trip for remote signers when the publish fails.
     return (

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -2298,13 +2298,27 @@ void main() {
 
       test(
         'batch builder reports recipient slot failure causes sendRumor to '
-        'return failure',
+        'return failure without rebuilding on the main isolate',
         () async {
+          // #8534: the branch deliberately does NOT fall back. Both builders
+          // derive the conversation key from the same recipient pubkey via
+          // `NIP44V2.shareSecret`, so a rebuild fails identically; spending
+          // one is pure cost. The zero-main-builder assertion is the point of
+          // this test — without it, making the branch fall back would leave
+          // it green, which is how the log line and the code disagreed for
+          // two months.
+          // Counting seam calls, not main-builder calls: a fall-through would
+          // reach [_buildWrap], which retries the isolate with ONE receiver
+          // and would succeed against this fake — so `giftWrapBuilder` would
+          // never run and a main-builder counter would read zero in both
+          // worlds. The receiver-count sequence is what distinguishes them.
+          final seamReceiverCounts = <int>[];
           final service = NIP17MessageService(
             signer: _LocalIsolateSigner(localPrivateKey),
             senderPublicKey: localPubkey,
             nostrService: mockNostrClient,
             isolateGiftWrapBatchBuilder: (request) async {
+              seamReceiverCounts.add(request.receiverPublicKeys.length);
               final all = await buildGiftWrapBatch(request);
               if (request.receiverPublicKeys.length == 2) {
                 // Recipient slot fails; self-wrap slot succeeds.
@@ -2327,7 +2341,64 @@ void main() {
           );
 
           expect(result.success, isFalse);
+          expect(
+            seamReceiverCounts,
+            equals([2]),
+            reason:
+                'no per-receiver rebuild may follow a failed recipient slot',
+          );
           verifyNever(() => mockNostrClient.publishEvent(any()));
+        },
+      );
+
+      test(
+        'batch builder returning the wrong slot count DOES rebuild on the '
+        'main isolate',
+        () async {
+          // The contrast to the test above, and the branch whose "falling
+          // back" log is accurate. Unexercised before #8534: the only
+          // empty-list fake in this file sat behind a remote signer and was
+          // never invoked, so nothing pinned that these two adjacent branches
+          // behave differently on purpose.
+          // Fall-through is observable as a SECOND seam call carrying one
+          // receiver: the tail calls [_buildWrap], which prefers the isolate
+          // for a single receiver and only reaches `giftWrapBuilder` if that
+          // also fails. So counting main-builder calls would read zero here
+          // even though the fallback ran — the receiver-count sequence is
+          // what actually proves it.
+          final seamReceiverCounts = <int>[];
+          final service = NIP17MessageService(
+            signer: _LocalIsolateSigner(localPrivateKey),
+            senderPublicKey: localPubkey,
+            nostrService: mockNostrClient,
+            isolateGiftWrapBatchBuilder: (request) async {
+              seamReceiverCounts.add(request.receiverPublicKeys.length);
+              final all = await buildGiftWrapBatch(request);
+              if (request.receiverPublicKeys.length == 2) {
+                // One slot for a two-receiver request: misshapen, so the
+                // batch attempt is abandoned rather than partially trusted.
+                return [all.first];
+              }
+              return all;
+            },
+          );
+
+          final rumor = service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'wrong-slot-count',
+          );
+          final result = await service.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _recipientPubkey,
+          );
+
+          expect(result.success, isTrue);
+          expect(seamReceiverCounts.first, equals(2));
+          expect(
+            seamReceiverCounts.skip(1),
+            contains(1),
+            reason: 'the abandoned batch must be retried per-receiver',
+          );
         },
       );
 

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -2297,6 +2297,37 @@ void main() {
       );
 
       test(
+        'single-receiver slot failure does not rebuild on the main isolate',
+        () async {
+          var mainBuilderCalls = 0;
+          final service = NIP17MessageService(
+            signer: _LocalIsolateSigner(localPrivateKey),
+            senderPublicKey: localPubkey,
+            nostrService: mockNostrClient,
+            giftWrapBuilder: (nostr, rumor, recipient) async {
+              mainBuilderCalls++;
+              return Event(localPubkey, EventKind.giftWrap, [
+                ['p', recipient],
+              ], 'ciphertext');
+            },
+            isolateGiftWrapBatchBuilder: (_) async => const [
+              BuiltGiftWrapResult.failure('deterministic local crypto'),
+            ],
+          );
+
+          final rumor = service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'single-slot-failure',
+          );
+          final result = await service.publishSelfWrap(rumorEvent: rumor);
+
+          expect(result.success, isFalse);
+          expect(mainBuilderCalls, equals(0));
+          verifyNever(() => mockNostrClient.publishEvent(any()));
+        },
+      );
+
+      test(
         'batch builder reports recipient slot failure causes sendRumor to '
         'return failure without rebuilding on the main isolate',
         () async {


### PR DESCRIPTION
## Description

When local direct-message encryption failed for a recipient, support logs said
the app would rebuild the message on the main isolate. One batch path returned
without rebuilding, while the adjacent single-recipient path did rebuild even
though both builders repeat the same local cryptography with the same key.

This change makes those paths consistent. A returned failed local-crypto slot
now ends that build attempt and logs a warning that describes what actually
happened. Errors thrown by the isolate machinery still fall back to the main
isolate because those can be isolate-specific rather than cryptographic.

The immediate fallback is deliberately not restored. Both builders derive the
same NIP-44 conversation key through `NIP44V2.shareSecret`; repeating the work
against an invalid recipient key produces the same failure.

This does **not** make the durable outgoing row non-retryable. The repository
marks hard recipient failures as failed, and `OutgoingDmRetryService` can
re-drive the full send up to five times. Rejecting identifiers that cannot be
secp256k1 public keys is the underlying fix and remains tracked in #8706.

The change also corrects the dartdoc and nearby comments that described the
old fallback behavior. The warning level keeps terminal build failures visible
in bug-report summaries without attaching an error stack to expected
degradation.

Closes #8534.

## Out of Scope

- Public-key shape validation still accepts off-curve identifiers. Fixing that
  safely requires replacing widespread fabricated test fixtures and deciding
  where invalid profile identifiers should be rejected; #8706 tracks that
  work.
- `(Event?, Event?)` still permits a self-wrap without a recipient wrap. That
  return shape is unchanged because reshaping the send path is unrelated to
  correcting this retry behavior.

## Verification

- `flutter test packages/dm_repository` — 934 passing.
- `flutter analyze packages/dm_repository/lib packages/dm_repository/test` —
  clean.
- `dart format` on both changed files — clean.
- Regression coverage confirms that returned recipient and single-recipient
  slot failures do not rebuild, while wrong slot counts and thrown isolate
  errors still take their intended fallback paths.

## Type of Change

- [x] Bug fix (non-breaking change)
