### PR TITLE
fix(dm): run the DM startup repairs once an identity is known, not a signer

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -800,6 +800,11 @@ class DmRepository {
   /// emitting stale denormalized previews before repairs land.
   Future<void>? _postAuthMaintenance;
 
+  /// The owner [_postAuthMaintenance] was started for, so a run is not
+  /// repeated for the same identity and is not reused across an account
+  /// switch that left the credentials untouched.
+  String? _maintenanceOwner;
+
   /// The in-flight one-time history drain, shared by concurrent callers so
   /// repeated [backfillHistoryIfNeeded] calls (e.g. every inbox open) never
   /// launch overlapping drains. Cleared when the drain settles.
@@ -970,10 +975,7 @@ class DmRepository {
       _userPubkeyController.add(userPubkey);
     }
 
-    // Run post-auth maintenance sequentially so each step operates on the
-    // final state of the previous one.
-    _postAuthMaintenance = _runPostAuthMaintenance();
-    unawaited(_postAuthMaintenance);
+    unawaited(_ensurePostAuthMaintenance());
   }
 
   /// Reset internal state so the repository can be re-initialized for a
@@ -1036,6 +1038,7 @@ class DmRepository {
       // Ignore if subscription doesn't exist
     }
     _postAuthMaintenance = null;
+    _maintenanceOwner = null;
     _userPubkey = '';
     _signer = null;
     _batchUnwrapUnsupported = false;
@@ -8279,18 +8282,45 @@ class DmRepository {
     return rows.map(_messageFromRow).toList();
   }
 
+  /// Starts post-auth maintenance for the current owner unless it has
+  /// already run for them, and returns the future the owner-scoped reads
+  /// gate on.
+  ///
+  /// Keyed on the OWNER, not on credentials. Every step is local database
+  /// work scoped by `ownerPubkey` and none of it needs a signer, while the
+  /// reads it repairs are deliberately served for a signer-less identity
+  /// (see [isInitialized]). Scheduling it only from [setCredentials] left
+  /// those reads ungated between `identityKnown` and `nostrReady` — and
+  /// permanently un-repaired for an identity whose signer never became
+  /// ready, so replied-to conversations stayed under Message requests
+  /// (#8703, the state #2834's backfill exists to correct).
+  ///
+  /// Returns a completed future when no owner is known; the callers below
+  /// already return early in that case, so nothing is gated on nothing.
+  Future<void> _ensurePostAuthMaintenance() {
+    final owner = _ownerPubkey;
+    if (owner == null) return Future<void>.value();
+    final existing = _postAuthMaintenance;
+    if (existing != null && _maintenanceOwner == owner) return existing;
+    // Sequential inside, so each step operates on the previous one's result.
+    final started = _runPostAuthMaintenance();
+    _maintenanceOwner = owner;
+    _postAuthMaintenance = started;
+    unawaited(started);
+    return started;
+  }
+
   Future<void> _awaitInitialConversationMaintenance() async {
-    await _postAuthMaintenance;
+    await _ensurePostAuthMaintenance();
   }
 
   Stream<List<DmConversation>> _watchConversationRows(
     Stream<List<ConversationRow>> Function() watchRows,
   ) {
-    final maintenance = _postAuthMaintenance;
-    final gatedRows = maintenance == null
-        ? watchRows()
-        : Stream.fromFuture(maintenance).asyncExpand((_) => watchRows());
-    return gatedRows.map((streamRows) {
+    final maintenance = _ensurePostAuthMaintenance();
+    return Stream.fromFuture(
+      maintenance,
+    ).asyncExpand((_) => watchRows()).map((streamRows) {
       return streamRows.map(_conversationFromRow).toList();
     });
   }

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2241,6 +2241,7 @@ class DmRepository {
     // flag as its first statement, precisely so a stop can be followed by a
     // restart, and nothing user-facing reads it.
     _disposed = true;
+    final postAuthMaintenance = _postAuthMaintenance;
     // Bump the session token too: an intentional stop must invalidate any
     // startListening()/ensureDmRelayListPublished() resolve already in flight,
     // so its post-await continuation bails instead of re-opening the
@@ -2289,6 +2290,7 @@ class DmRepository {
     // have cursor/read-state writes after it. Preserve the handles captured
     // above and wait for every writer to observe the teardown before declaring
     // the repository quiescent. See #7318.
+    await postAuthMaintenance;
     await historyDrain;
     await pendingDecryptRetry;
     while (_eventLock != null) {
@@ -8299,7 +8301,7 @@ class DmRepository {
   /// already return early in that case, so nothing is gated on nothing.
   Future<void> _ensurePostAuthMaintenance() {
     final owner = _ownerPubkey;
-    if (owner == null) return Future<void>.value();
+    if (owner == null || _disposed) return Future<void>.value();
     final existing = _postAuthMaintenance;
     if (existing != null && _maintenanceOwner == owner) return existing;
     // Sequential inside, so each step operates on the previous one's result.

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -7889,6 +7889,72 @@ void main() {
       // awaits it before wiping the DM tables and DmSyncState. A drain
       // suspended mid-page must stop with it; otherwise it resumes after the
       // wipe and re-seeds the state that was just cleared.
+      test('stopListening waits for post-auth maintenance', () async {
+        final maintenanceRelease = Completer<int>();
+
+        when(
+          () => mockConversationsDao.backfillLatestMessagePreviews(
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) => maintenanceRelease.future);
+        when(
+          () => mockConversationsDao.getConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockConversationsDao.watchAcceptedConversations(
+            limit: any(named: 'limit'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) => Stream.value(const <ConversationRow>[]));
+
+        // An owner-scoped read can start maintenance before a signer exists.
+        final repository = createRepository();
+        final conversations = repository.watchAcceptedConversations().first;
+        await untilCalled(
+          () => mockConversationsDao.backfillLatestMessagePreviews(
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+
+        var stopCompleted = false;
+        final stop = repository.stopListening().whenComplete(() {
+          stopCompleted = true;
+        });
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          stopCompleted,
+          isFalse,
+          reason: 'stopListening returned while maintenance was still writing',
+        );
+
+        maintenanceRelease.complete(0);
+        await stop;
+        await conversations;
+      });
+
+      test('a maintenance pass cannot start after listening stops', () async {
+        when(
+          () => mockConversationsDao.watchAcceptedConversations(
+            limit: any(named: 'limit'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) => Stream.value(const <ConversationRow>[]));
+        final repository = createRepository();
+
+        await repository.stopListening();
+        await repository.watchAcceptedConversations().first;
+
+        verifyNever(
+          () => mockConversationsDao.backfillLatestMessagePreviews(
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      });
+
       test('stops a suspended history drain when listening stops', () async {
         var pageCalls = 0;
         final secondPageStarted = Completer<void>();

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -17039,6 +17039,85 @@ void main() {
         },
       );
 
+      // The same contract when only an identity is known and no signer has
+      // arrived yet. The repository deliberately serves owner-scoped reads
+      // in that state, and post-auth maintenance is local database work that
+      // needs no signer — so the gate must hold here too. Before #8703 the
+      // maintenance future was scheduled only by `setCredentials`, so this
+      // path skipped the gate entirely and served un-repaired rows. A signer
+      // that never becomes ready made that permanent.
+      test(
+        'waits for post-auth maintenance when only an identity is known',
+        () async {
+          final maintenanceCompleter = Completer<int>();
+          final participants = [_validPubkeyA, _validPubkeyB]..sort();
+          final convId = DmRepository.computeConversationId(participants);
+
+          when(
+            () => mockConversationsDao.backfillLatestMessagePreviews(
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) => maintenanceCompleter.future);
+          when(
+            () => mockConversationsDao.getConversation(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockConversationsDao.watchAcceptedConversations(
+              limit: any(named: 'limit'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer(
+            (_) => Stream.value([
+              ConversationRow(
+                ownerPubkey: '',
+                id: convId,
+                participantPubkeys: jsonEncode(participants),
+                isGroup: false,
+                isRead: true,
+                currentUserHasSent: true,
+                createdAt: 1700000000,
+              ),
+            ]),
+          );
+
+          // Identity only: no signer, no setCredentials.
+          final repository = DmRepository(
+            nostrClient: mockNostrClient,
+            directMessagesDao: mockDirectMessagesDao,
+            conversationsDao: mockConversationsDao,
+            userPubkey: _validPubkeyA,
+          );
+          expect(repository.isInitialized, isFalse);
+
+          final conversationsFuture = repository
+              .watchAcceptedConversations()
+              .first;
+
+          verifyNever(
+            () => mockConversationsDao.watchAcceptedConversations(
+              limit: any(named: 'limit'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          );
+
+          maintenanceCompleter.complete(0);
+
+          await untilCalled(
+            () => mockConversationsDao.watchAcceptedConversations(
+              limit: any(named: 'limit'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          );
+
+          final conversations = await conversationsFuture;
+          expect(conversations, hasLength(1));
+          expect(conversations.first.id, equals(convId));
+        },
+      );
+
       test('maps $ConversationRow stream to $DmConversation stream', () async {
         final participants = [_validPubkeyA, _validPubkeyB]..sort();
         final convId = DmRepository.computeConversationId(participants);


### PR DESCRIPTION
## The problem

Opening direct messages runs five one-off repairs before showing anything: moving conversations you have replied to out of Message requests, restoring group chats an old startup pass destroyed, filling in the preview line under each conversation, deleting a stale conversation-with-yourself row, and clearing orphaned reactions.

Those repairs were scheduled only when the **signer** became ready. The conversation lists, however, start serving as soon as your **identity** is known — which happens earlier, and is deliberate: a signer-less identity is meant to still be able to read its messages.

Between those two moments the repairs had not been scheduled, so the mechanism that makes the lists wait for them had nothing to wait on and was skipped. The lists rendered un-repaired.

For almost everyone this is invisible. The repairs write to the conversations table and declare it, so the live queries re-emit and the lists correct themselves within milliseconds.

**The case that is not invisible is a signer that never becomes ready** — a remote signer that is offline, unreachable, or failing. Then the scheduling call never happens at all, the repairs never run, and the person reads a permanently un-repaired inbox:

- conversations they have already replied to keep showing under **Message requests** — exactly the state #2834's backfill exists to correct;
- group chats destroyed by the pre-#8401 startup pass are never restored (#8407);
- preview lines stay blank.

Nothing is lost, and everything corrects itself the moment a signer appears. But until then the inbox is wrong and there is no way to tell why or to trigger a fix.

## Why this fix

All five repairs are local database work scoped by owner. **None of them needs a signer.** So the trigger was simply attached to the wrong signal.

Scheduling now keys on the owner within each repository instance: the run starts the first time an owner-scoped read needs it, and every later caller on that instance gets the same run back. The gate therefore always has something to wait on. The provider rebuilds the repository as the session phase changes, so the lightweight idempotent steps may run again on the replacement instance; the expensive group recovery still short-circuits through its persisted version marker.

The owner key also prevents an explicitly reused repository instance from handing a previous identity's run to a new identity. The reset path clears that marker alongside the future.

## What this deliberately leaves alone

- **`setCredentials` still triggers the repairs**, so the ordinary path is unchanged — it just no longer has sole responsibility.
- **No change to what the repairs do**, only to when they are scheduled.
- **The signer-less read policy is unchanged.** Serving reads for a known identity without a signer stays intentional; this makes those reads correct rather than restricting them.
- **No provider or UI changes.** The fix is inside the repository, so no caller has to know about it.

## A note on the trade-off

On the identity-only path the first render now waits for the repairs instead of showing un-repaired rows immediately. That is the intended behaviour — it is what the gate was written for — and the heaviest step already carries a version marker that short-circuits it after its first successful run.

## How this was verified

- 486 tests in `dm_repository` (935 across the package), including the signer-less read regression plus two teardown regressions. The signer-less read test was confirmed to **fail before** this change and pass after; the teardown wait test was likewise confirmed to fail before the takeover fix and pass after.
- 1069 tests across `test/blocs/dm/` and `test/screens/inbox/`.
- `flutter analyze lib test integration_test` clean; `dart format` clean.
- Ratchets green locally: shared-setup stubs, placeholder tests, unpinned assertions, ungrouped tests, skip ceiling, post-close emit, empty catch.

The pre-existing gate test covered only the path where `setCredentials` had already run — the half that was never broken. The new test is its mirror for an identity with no signer.

Closes #8703

