### PR TITLE
fix(verifier): sign the account-unlink request with the URL it actually sends

### DIFF
--- a/mobile/packages/verifier_client/lib/src/verifier_client.dart
+++ b/mobile/packages/verifier_client/lib/src/verifier_client.dart
@@ -38,6 +38,11 @@ class VerifierClient {
   /// Keep this in sync if the service raises it.
   static const int maxBatchSize = 10;
 
+  /// Path of the OAuth revoke endpoint, shared by [revokeOAuth] and
+  /// [oauthRevokeUrl] so the request and the string it is signed against
+  /// cannot drift apart.
+  static const String _oauthRevokePath = '/auth/oauth/revoke';
+
   final String _baseUrl;
   final http.Client _httpClient;
   final Duration _timeout;
@@ -135,7 +140,7 @@ class VerifierClient {
         'is required to start the bluesky OAuth flow',
       );
     }
-    return Uri.parse('$_baseUrl/auth/$platform/start').replace(
+    return _uriFor('/auth/$platform/start').replace(
       queryParameters: <String, String>{
         'pubkey': pubkey,
         'return_url': returnUrl,
@@ -228,20 +233,32 @@ class VerifierClient {
       'pubkey': pubkey,
       'event': nip98Event,
     });
-    await _post('/auth/oauth/revoke', body);
+    await _post(_oauthRevokePath, body);
   }
 
   /// Absolute URL of the OAuth revoke endpoint.
   ///
   /// The NIP-98 event passed to [revokeOAuth] must carry this exact string in
   /// its `u` tag, so it is exposed rather than rebuilt at the call site.
-  String get oauthRevokeUrl => '$_baseUrl/auth/oauth/revoke';
+  ///
+  /// Built through [_uriFor], the same builder the request goes through, so
+  /// what is signed is what reaches the wire. Composing it from [_baseUrl]
+  /// directly would skip the normalization `Uri.parse` applies, and the
+  /// verifier compares the `u` tag to the request URL exactly.
+  String get oauthRevokeUrl => _uriFor(_oauthRevokePath).toString();
+
+  /// The one place a request URL is built.
+  ///
+  /// Every caller — including [oauthRevokeUrl] — goes through here, which is
+  /// what keeps a signed URL and the URL it is sent to identical by
+  /// construction rather than by convention.
+  Uri _uriFor(String path) => Uri.parse('$_baseUrl$path');
 
   Future<Map<String, dynamic>> _get(
     String path, {
     Map<String, String>? query,
   }) async {
-    var uri = Uri.parse('$_baseUrl$path');
+    var uri = _uriFor(path);
     if (query != null && query.isNotEmpty) {
       uri = uri.replace(queryParameters: query);
     }
@@ -249,7 +266,7 @@ class VerifierClient {
   }
 
   Future<Map<String, dynamic>> _post(String path, String body) {
-    final uri = Uri.parse('$_baseUrl$path');
+    final uri = _uriFor(path);
     return _send(
       () => _httpClient.post(
         uri,

--- a/mobile/packages/verifier_client/test/src/verifier_client_test.dart
+++ b/mobile/packages/verifier_client/test/src/verifier_client_test.dart
@@ -508,13 +508,58 @@ void main() {
       });
     });
 
-    test('oauthRevokeUrl matches the URL revokeOAuth posts to', () {
-      final client = VerifierClient(baseUrl: 'https://verifier.example/');
+    group('oauthRevokeUrl', () {
+      const revokePath = '/auth/oauth/revoke';
+      const canonical = 'https://verifier.example$revokePath';
 
-      expect(
-        client.oauthRevokeUrl,
-        equals('https://verifier.example/auth/oauth/revoke'),
-      );
+      // NIP-98 binds the signed `u` tag to the absolute request URL, and the
+      // verifier compares the two with a strict `!==` against
+      // `new URL(req.url).toString()`. The request URI goes through
+      // `Uri.parse`, which lowercases the scheme and host, drops a default
+      // port, resolves dot segments and decodes unreserved escapes. So the
+      // signed string has to come from that same builder: composing it from
+      // the raw base instead makes the two disagree for every base below, and
+      // the revoke 401s while all the unauthenticated calls keep working.
+      const bases = <(String, String)>[
+        ('https://verifier.example', canonical),
+        ('https://verifier.example/', canonical),
+        ('https://VERIFIER.example', canonical),
+        ('HTTPS://verifier.example', canonical),
+        ('https://verifier.example:443', canonical),
+        ('https://verifier.example/.', canonical),
+        (
+          'https://verifier.example/%7Ea',
+          'https://verifier.example/~a$revokePath',
+        ),
+        (
+          'https://verifier.example:8443',
+          'https://verifier.example:8443$revokePath',
+        ),
+      ];
+
+      for (final (base, expected) in bases) {
+        test('signs the URL it posts to, for a base of $base', () async {
+          late Uri posted;
+          final mock = MockClient((req) async {
+            posted = req.url;
+            return http.Response(jsonEncode({'revoked': true}), 200);
+          });
+          final client = VerifierClient(baseUrl: base, httpClient: mock);
+
+          await client.revokeOAuth(
+            platform: 'twitter',
+            identity: 'jack',
+            pubkey: _hex,
+            nip98Event: const {'kind': 27235},
+          );
+
+          expect(client.oauthRevokeUrl, equals(posted.toString()));
+          // Pins the value as well as the coupling: both operands above come
+          // from the object under test, so on their own they would still
+          // match if the getter and the request both went wrong together.
+          expect(client.oauthRevokeUrl, equals(expected));
+        });
+      }
     });
   });
 }


### PR DESCRIPTION
## Description

When you unlink a verified account (GitHub, Bluesky, Twitter/X…), the app tells the
verifier to drop its cached verification. That call is authenticated by signing the
request's own URL. We were signing one spelling of that URL and sending a different
one, so the verifier could reject the call as unauthenticated.

`VerifierClient` exposed `oauthRevokeUrl` as the exact string to sign, building it by
pasting the endpoint onto whatever base URL it was given. The actual request went
through `Uri.parse`, which rewrites a URL into canonical form — it lowercases the
scheme and host, drops a redundant `:443`, resolves `/.` segments, and decodes escapes
like `%7E` into `~`. Any base that was not already in that exact form produced two
different strings. The verifier compares them character for character, so the revoke
would fail with a 401 while every unauthenticated call to the same service kept working.

That combination is unusually hard to diagnose: only the signed endpoint breaks, and
the failure is caught and logged as a warning one layer up. The unlink's other half —
rewriting your identity event — has already succeeded by then, so the app reports
success while the verifier goes on serving the stale verification.

**Nobody is affected on any shipped build.** The production base URL is a hardcoded
canonical literal, locked by a test across every environment, so the defect was only
ever reachable through the injection parameter that exists for tests and alternate
deployments. This is a robustness fix, not a live bug.

### Why this fix

Every URL the client builds now goes through one private `_uriFor`, including the
string that gets signed. The signed URL and the sent URL become the same expression,
so they cannot drift — this is correct by construction rather than by two spellings
being kept in agreement.

The sibling issue #3367 was fixed differently, by canonicalizing the base URL once in
the constructor, and this issue suggested copying that. I went the other way, because
that shape appears at exactly one site in the repo while this one appears at eight —
including every package whose base URL is genuinely configurable at build time
(`invite_api_client`, `supporter_api_client`, `nostr_app_audit_service` and others,
which build the `Uri` once and sign its `toString()`). Copying the sibling would also
have added a third private copy of a helper that has no shared home, sitting among six
similar-looking helpers that only trim a trailing slash.

The constructor's trailing-slash trim stays, and that is deliberate: `Uri.parse` does
**not** collapse a double slash, so removing it would leave the signed and sent URLs
equal to each other and both pointing at a 404 — a change the new test would not catch.

**Related Issue:** Closes #7690

## Out of Scope

- **The same defect class exists at three other sites**, found while verifying this one
  and left alone to keep this PR reviewable: `event_api_client.dart:83`,
  `analytics_ingest_client.dart:60` (a character-identical helper to the first), and
  `zendesk_support_service.dart:382`. All three are latent for the same reason this one
  was — their bases are canonical today. The Zendesk one is the most exposed, since its
  base arrives as a public static method parameter rather than from config. A fourth,
  `nostr_sdk/lib/upload/nip96_uploader.dart:80`, takes its base from a remote server but
  has no call sites. Happy to file these as a follow-up if useful.
- `funnelcake_api_client` has the same trailing-slash-only base handling but signs
  nothing, so it is not affected today.
- One thing this change cannot cover: if the verifier's edge routing ever exposes an
  internal URL to the handler instead of the public one, the comparison breaks again
  from the server side. That is noted in the shared context docs and is not fixable here.

## Verification

- `dart test` in `mobile/packages/verifier_client` — **64 passed**.
- New test run against the **unfixed** code first: failed for all five diverging bases
  with the expected/actual pairs, and passed for the three control bases. It fails for
  the right reason.
- `dart analyze lib test` — no issues. `dart format` — clean.
- Package coverage 94.0%, unchanged, against the workflow floor of 76. No baseline touched.
- `flutter test test/src/identity_claims_repository_test.dart` in the consuming package
  `profile_repository` — **109 passed**.
- Cross-checked the fix against the verifier's own source: it compares the signed tag to
  `new URL(req.url).toString()` with a strict `!==`. Confirmed that the form Dart produces
  survives that normalization unchanged for every shape tested — including non-ASCII,
  encoded slashes and punycode — so the client and server agree, not just the client with
  itself.

### The test this replaces

The old test was named "oauthRevokeUrl matches the URL revokeOAuth posts to" but never
looked at the URL the request went to — it compared the getter against a hardcoded
string, using the one non-canonical base the old code already handled. It passed under
every base its name implied it covered. The replacement is table-driven over each
distinct way a URL can be non-canonical, and asserts both that the signed string equals
the URL actually posted *and* that it equals the expected canonical value. The second
assertion is load-bearing: both operands of the first come from the object under test,
so on their own they would still agree if the getter and the request went wrong together.

Two of those cases — an uppercase scheme, and a percent-encoded `~` — were not in the
issue's original list; they turned up while measuring which bases actually diverge.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)