### PR TITLE
fix(mentions): tag handles that contain a dot or a hyphen

### DIFF
--- a/mobile/lib/constants/mention_pattern.dart
+++ b/mobile/lib/constants/mention_pattern.dart
@@ -1,0 +1,25 @@
+// ABOUTME: The `@mention` alternative shared by the caption tokenizers, so
+// ABOUTME: the render path and the publish path cannot drift apart.
+
+/// Matches an `@handle`, capturing the handle without its `@`.
+///
+/// A dot or hyphen is admitted only when a word character follows it, because
+/// Divine handles carry both — a NIP-05 local part allows `.`, `-` and `_` —
+/// while a trailing one is sentence punctuation. That keeps `@st.allison.` a
+/// mention of `st.allison` plus a period, and holds the handle to 31
+/// characters.
+///
+/// Shared rather than written twice because the render path
+/// (`LinkifiedTextSpanBuilder`) and the publish path
+/// (`MentionResolutionService`) must tokenize a caption identically: fixing
+/// #8717 meant changing this pattern in both, and any later change carries
+/// the same lockstep hazard. Both append it last, after URL/email, hashtag,
+/// bech32 and bare hex. `notification_repository` deliberately omits a
+/// mention alternative and does not consume this.
+///
+/// Free of backslash escapes, so it needs no `r` prefix and composes into a
+/// raw literal unchanged. Restore the prefix if that changes: Dart resolves
+/// an unknown escape such as `\w` to the bare letter, silently altering the
+/// pattern.
+const mentionTokenPattern =
+    '@([a-zA-Z](?:[a-zA-Z0-9_]|[.-](?=[a-zA-Z0-9_])){0,30})';

--- a/mobile/lib/services/mention_resolution_service.dart
+++ b/mobile/lib/services/mention_resolution_service.dart
@@ -98,7 +98,7 @@ class MentionResolutionService {
 
     final replacements = <_TextReplacement>[];
     for (final mention in typedMentions) {
-      final pubkey = typedResult.pubkeyByToken[mention.normalizedToken];
+      final pubkey = typedResult.pubkeyByToken[mention.lookupKey];
       if (pubkey == null) continue;
       replacements.add(
         _TextReplacement(
@@ -188,13 +188,12 @@ class MentionResolutionService {
     List<_TypedMention> mentions, {
     required String? currentUserPubkey,
   }) async {
-    // Deduplicate by the normalized token, which is also the key the caller
-    // maps replacements back through, but search on the token as typed:
-    // profile search is a substring match, so the separator-stripped `ogab`
-    // cannot find the handle `OG-AB` that produced it.
+    // Deduplicate case-insensitively while preserving separators in the key.
+    // Profiles may legitimately own both `og-ab` and `ogab`, so collapsing
+    // both to the separator-stripped comparison form would tag the wrong one.
     final queryByToken = <String, String>{};
     for (final mention in mentions) {
-      queryByToken.putIfAbsent(mention.normalizedToken, () => mention.token);
+      queryByToken.putIfAbsent(mention.lookupKey, () => mention.token);
     }
 
     final pubkeyByToken = <String, String>{};
@@ -281,6 +280,7 @@ List<_TypedMention> _extractTypedMentions(String text) {
         token: token,
         start: match.start,
         end: match.end,
+        lookupKey: token.toLowerCase(),
         normalizedToken: _normalizeMentionValue(token),
       ),
     );
@@ -407,8 +407,8 @@ class _TypedResolutionResult {
   factory _TypedResolutionResult.empty(List<_TypedMention> mentions) {
     final unresolved = <String>[];
     for (final mention in mentions) {
-      if (!unresolved.contains(mention.normalizedToken)) {
-        unresolved.add(mention.normalizedToken);
+      if (!unresolved.contains(mention.lookupKey)) {
+        unresolved.add(mention.lookupKey);
       }
     }
     return _TypedResolutionResult(
@@ -426,12 +426,14 @@ class _TypedMention {
     required this.token,
     required this.start,
     required this.end,
+    required this.lookupKey,
     required this.normalizedToken,
   });
 
   final String token;
   final int start;
   final int end;
+  final String lookupKey;
   final String normalizedToken;
 }
 

--- a/mobile/lib/services/mention_resolution_service.dart
+++ b/mobile/lib/services/mention_resolution_service.dart
@@ -12,7 +12,7 @@ const _typedRemoteLookupLimit = 5;
 const _profileSearchLimit = 10;
 
 final _linkifiedTokenRegex = RegExp(
-  r'((?:[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})|(?:https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?))|#(\w+)|(?<![A-Za-z0-9])(?:nostr:)?((?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+)\b|(?<![A-Fa-f0-9])([A-Fa-f0-9]{64})(?![A-Fa-f0-9])|@([a-zA-Z][a-zA-Z0-9_]{0,30})',
+  r'((?:[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})|(?:https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?))|#(\w+)|(?<![A-Za-z0-9])(?:nostr:)?((?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+)\b|(?<![A-Fa-f0-9])([A-Fa-f0-9]{64})(?![A-Fa-f0-9])|@([a-zA-Z](?:[a-zA-Z0-9_]|[.-](?=[a-zA-Z0-9_])){0,30})',
   caseSensitive: false,
 );
 
@@ -188,33 +188,35 @@ class MentionResolutionService {
     List<_TypedMention> mentions, {
     required String? currentUserPubkey,
   }) async {
-    final uniqueTokens = <String>[];
+    // Deduplicate by the normalized token, which is also the key the caller
+    // maps replacements back through, but search on the token as typed:
+    // profile search is a substring match, so the separator-stripped `ogab`
+    // cannot find the handle `OG-AB` that produced it.
+    final queryByToken = <String, String>{};
     for (final mention in mentions) {
-      if (!uniqueTokens.contains(mention.normalizedToken)) {
-        uniqueTokens.add(mention.normalizedToken);
-      }
+      queryByToken.putIfAbsent(mention.normalizedToken, () => mention.token);
     }
 
     final pubkeyByToken = <String, String>{};
     final unresolvedTokens = <String>[];
     var remoteLookups = 0;
 
-    for (final token in uniqueTokens) {
+    for (final MapEntry(key: token, value: query) in queryByToken.entries) {
       String? resolved;
       try {
         final localCandidates = await _profileRepository.searchUsersLocally(
-          query: token,
+          query: query,
           limit: _profileSearchLimit,
         );
-        resolved = _exactSingleMatch(token, localCandidates);
+        resolved = _exactSingleMatch(query, localCandidates);
 
         if (resolved == null && remoteLookups < _typedRemoteLookupLimit) {
           remoteLookups += 1;
           final apiCandidates = await _profileRepository.searchUsersFromApi(
-            query: token,
+            query: query,
             limit: _profileSearchLimit,
           );
-          resolved = _exactSingleMatch(token, apiCandidates);
+          resolved = _exactSingleMatch(query, apiCandidates);
         }
       } on Exception {
         resolved = null;

--- a/mobile/lib/services/mention_resolution_service.dart
+++ b/mobile/lib/services/mention_resolution_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:meta/meta.dart';
 import 'package:models/models.dart';
+import 'package:openvine/constants/mention_pattern.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:profile_repository/profile_repository.dart';
@@ -12,7 +13,8 @@ const _typedRemoteLookupLimit = 5;
 const _profileSearchLimit = 10;
 
 final _linkifiedTokenRegex = RegExp(
-  r'((?:[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})|(?:https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?))|#(\w+)|(?<![A-Za-z0-9])(?:nostr:)?((?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+)\b|(?<![A-Fa-f0-9])([A-Fa-f0-9]{64})(?![A-Fa-f0-9])|@([a-zA-Z](?:[a-zA-Z0-9_]|[.-](?=[a-zA-Z0-9_])){0,30})',
+  r'((?:[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})|(?:https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?))|#(\w+)|(?<![A-Za-z0-9])(?:nostr:)?((?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+)\b|(?<![A-Fa-f0-9])([A-Fa-f0-9]{64})(?![A-Fa-f0-9])|'
+  '$mentionTokenPattern',
   caseSensitive: false,
 );
 

--- a/mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart
@@ -44,8 +44,15 @@ class LinkifiedTextSpanBuilder {
     this.initialHeartBudget = kDivineHeartMaxPainted,
   });
 
+  /// Token precedence: URL/email, hashtag, bech32, bare hex, then `@mention`.
+  ///
+  /// The mention alternative admits a dot or hyphen only when a word
+  /// character follows it, because Divine handles carry both — a NIP-05 local
+  /// part allows `.`, `-` and `_` — while a trailing one is sentence
+  /// punctuation. That keeps `@st.allison.` a mention of `st.allison` and a
+  /// period, and leaves the 31-character cap intact.
   static final _combinedRegex = RegExp(
-    r'((?:(?<![a-zA-Z0-9._%+-])[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})|(?:https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w.-])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?))|#(\w+)|(?<![A-Za-z0-9])(?:nostr:)?((?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+)\b|(?<![A-Fa-f0-9])([A-Fa-f0-9]{64})(?![A-Fa-f0-9])|@([a-zA-Z][a-zA-Z0-9_]{0,30})',
+    r'((?:(?<![a-zA-Z0-9._%+-])[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})|(?:https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w.-])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?))|#(\w+)|(?<![A-Za-z0-9])(?:nostr:)?((?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+)\b|(?<![A-Fa-f0-9])([A-Fa-f0-9]{64})(?![A-Fa-f0-9])|@([a-zA-Z](?:[a-zA-Z0-9_]|[.-](?=[a-zA-Z0-9_])){0,30})',
     caseSensitive: false,
   );
 

--- a/mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart
@@ -6,6 +6,7 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/widgets.dart' show WidgetSpan;
 import 'package:nostr_sdk/nip19/nip19.dart';
 import 'package:nostr_sdk/nip19/nip19_tlv.dart';
+import 'package:openvine/constants/mention_pattern.dart';
 import 'package:openvine/utils/npub_hex.dart';
 import 'package:text_sanitizer/text_sanitizer.dart';
 
@@ -46,13 +47,13 @@ class LinkifiedTextSpanBuilder {
 
   /// Token precedence: URL/email, hashtag, bech32, bare hex, then `@mention`.
   ///
-  /// The mention alternative admits a dot or hyphen only when a word
-  /// character follows it, because Divine handles carry both — a NIP-05 local
-  /// part allows `.`, `-` and `_` — while a trailing one is sentence
-  /// punctuation. That keeps `@st.allison.` a mention of `st.allison` and a
-  /// period, and leaves the 31-character cap intact.
+  /// The trailing mention alternative is `mentionTokenPattern`, shared with
+  /// `MentionResolutionService` so the rendered span and the published `p`
+  /// tag always cover the same handle. The alternatives before it carry
+  /// lookbehinds the publish copy omits, and stay local.
   static final _combinedRegex = RegExp(
-    r'((?:(?<![a-zA-Z0-9._%+-])[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})|(?:https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w.-])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?))|#(\w+)|(?<![A-Za-z0-9])(?:nostr:)?((?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+)\b|(?<![A-Fa-f0-9])([A-Fa-f0-9]{64})(?![A-Fa-f0-9])|@([a-zA-Z](?:[a-zA-Z0-9_]|[.-](?=[a-zA-Z0-9_])){0,30})',
+    r'((?:(?<![a-zA-Z0-9._%+-])[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})|(?:https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w.-])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?))|#(\w+)|(?<![A-Za-z0-9])(?:nostr:)?((?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+)\b|(?<![A-Fa-f0-9])([A-Fa-f0-9]{64})(?![A-Fa-f0-9])|'
+    '$mentionTokenPattern',
     caseSensitive: false,
   );
 

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -85,7 +85,8 @@ final RegExp _npubIdentifierPattern = RegExp(
 /// protects. Groups 1 and 2 (URL/email, hashtag) are here only to consume
 /// their own text so a run buried inside them is not mistaken for one.
 ///
-/// The UI's trailing `@([a-zA-Z][a-zA-Z0-9_]{0,30})` alternative is the one
+/// The UI's trailing mention alternative,
+/// `@([a-zA-Z](?:[a-zA-Z0-9_]|[.-](?=[a-zA-Z0-9_])){0,30})`, is the one
 /// deliberate divergence, and it only fires when a letter follows the `@`.
 /// It therefore always wins for `@npub1…` — every bech32 prefix starts with
 /// `n` — and wins over hex only for a letter-initial `@<64-hex>`, capping

--- a/mobile/test/services/mention_resolution_service_test.dart
+++ b/mobile/test/services/mention_resolution_service_test.dart
@@ -372,6 +372,82 @@ void main() {
       expect(result.resolvedPubkeys, isEmpty);
       expect(result.unresolvedTokens, equals(['alice']));
     });
+
+    // A handle carrying a dot or a hyphen used to tokenize only up to the
+    // separator, so `@OG-AB` searched for `OG` and canonicalized to whoever
+    // owned that shorter handle — a p tag naming the wrong person.
+    group('handles containing dots and hyphens', () {
+      test('resolves the whole hyphenated handle, not its prefix', () async {
+        final bobNpub = NostrKeyUtils.encodePubKey(_bobPubkey);
+        when(
+          () => profileRepository.searchUsersLocally(
+            query: 'OG-AB',
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async => [_profile(_bobPubkey, name: 'OG-AB')]);
+
+        final result = await service.resolveTextMentions(
+          rawText: 'dedicated to my home-girl @OG-AB',
+        );
+
+        expect(
+          result.canonicalText,
+          equals('dedicated to my home-girl nostr:$bobNpub'),
+        );
+        expect(result.resolvedPubkeys, equals([_bobPubkey]));
+        expect(result.unresolvedTokens, isEmpty);
+        verifyNever(
+          () => profileRepository.searchUsersLocally(
+            query: 'OG',
+            limit: any(named: 'limit'),
+          ),
+        );
+      });
+
+      test(
+        'does not resolve a hyphenated handle to its prefix owner',
+        () async {
+          when(
+            () => profileRepository.searchUsersLocally(
+              query: any(named: 'query'),
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer((_) async => [_profile(_alicePubkey, name: 'OG')]);
+          when(
+            () => profileRepository.searchUsersFromApi(
+              query: any(named: 'query'),
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer((_) async => [_profile(_alicePubkey, name: 'OG')]);
+
+          final result = await service.resolveTextMentions(
+            rawText: 'hi @OG-AB',
+          );
+
+          expect(result.canonicalText, equals('hi @OG-AB'));
+          expect(result.resolvedPubkeys, isEmpty);
+        },
+      );
+
+      test('searches a dotted handle as typed', () async {
+        final carolNpub = NostrKeyUtils.encodePubKey(_carolPubkey);
+        when(
+          () => profileRepository.searchUsersLocally(
+            query: 'ickynicki.v2',
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer(
+          (_) async => [_profile(_carolPubkey, name: 'ickynicki.v2')],
+        );
+
+        final result = await service.resolveTextMentions(
+          rawText: 'inspired by @ickynicki.v2',
+        );
+
+        expect(result.canonicalText, equals('inspired by nostr:$carolNpub'));
+        expect(result.resolvedPubkeys, equals([_carolPubkey]));
+      });
+    });
   });
 
   group('buildGenericMentionPTags', () {

--- a/mobile/test/services/mention_resolution_service_test.dart
+++ b/mobile/test/services/mention_resolution_service_test.dart
@@ -447,6 +447,37 @@ void main() {
         expect(result.canonicalText, equals('inspired by nostr:$carolNpub'));
         expect(result.resolvedPubkeys, equals([_carolPubkey]));
       });
+
+      test(
+        'resolves handles that differ only by separators independently',
+        () async {
+          final aliceNpub = NostrKeyUtils.encodePubKey(_alicePubkey);
+          final bobNpub = NostrKeyUtils.encodePubKey(_bobPubkey);
+          when(
+            () => profileRepository.searchUsersLocally(
+              query: 'og-ab',
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer((_) async => [_profile(_bobPubkey, name: 'og-ab')]);
+          when(
+            () => profileRepository.searchUsersLocally(
+              query: 'ogab',
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer((_) async => [_profile(_alicePubkey, name: 'ogab')]);
+
+          final result = await service.resolveTextMentions(
+            rawText: 'shoutout @og-ab and @ogab',
+          );
+
+          expect(
+            result.canonicalText,
+            equals('shoutout nostr:$bobNpub and nostr:$aliceNpub'),
+          );
+          expect(result.resolvedPubkeys, equals([_bobPubkey, _alicePubkey]));
+          expect(result.unresolvedTokens, isEmpty);
+        },
+      );
     });
   });
 

--- a/mobile/test/widgets/linkified_text/linkified_text_span_builder_test.dart
+++ b/mobile/test/widgets/linkified_text/linkified_text_span_builder_test.dart
@@ -287,6 +287,99 @@ void main() {
       expect(spans.single.recognizer, isNull);
     });
 
+    // Divine handles routinely carry a dot or a hyphen — a NIP-05 local part
+    // allows both, and `ickynicki.v2` / `OG-AB` are real reported handles.
+    // The tokenizer stopped at the first one, so `@OG-AB` linked to whoever
+    // owns `OG` and left `-AB` as plain text.
+    group('handles containing dots and hyphens', () {
+      test('keeps a hyphenated handle in one mention span', () {
+        String? tappedMention;
+
+        final spans = LinkifiedTextSpanBuilder(
+          text: 'dedicated to my home-girl @OG-AB',
+          defaultStyle: defaultStyle,
+          linkStyle: linkStyle,
+          mentionStyle: mentionStyle,
+          onMentionTap: (username) => tappedMention = username,
+        ).build();
+
+        final mentionSpan = spans.tappableSpans.single;
+        expect(mentionSpan.text, equals('@OG-AB'));
+        mentionSpan.tap();
+        expect(tappedMention, equals('OG-AB'));
+      });
+
+      test('keeps a dotted handle in one mention span', () {
+        String? tappedMention;
+
+        final spans = LinkifiedTextSpanBuilder(
+          text: 'inspired by @ickynicki.v2',
+          defaultStyle: defaultStyle,
+          linkStyle: linkStyle,
+          mentionStyle: mentionStyle,
+          onMentionTap: (username) => tappedMention = username,
+        ).build();
+
+        final mentionSpan = spans.tappableSpans.single;
+        expect(mentionSpan.text, equals('@ickynicki.v2'));
+        mentionSpan.tap();
+        expect(tappedMention, equals('ickynicki.v2'));
+      });
+
+      test('leaves sentence punctuation after a handle outside the span', () {
+        final spans = LinkifiedTextSpanBuilder(
+          text: 'thanks @st.allison.',
+          defaultStyle: defaultStyle,
+          linkStyle: linkStyle,
+          mentionStyle: mentionStyle,
+          onMentionTap: (_) {},
+        ).build();
+
+        expect(spans.tappableSpans.single.text, equals('@st.allison'));
+        expect(
+          spans.map((span) => span.text).join(),
+          equals('thanks @st.allison.'),
+        );
+      });
+
+      test('leaves a trailing separator outside the span', () {
+        final spans = LinkifiedTextSpanBuilder(
+          text: '@trailing- and @trailing.',
+          defaultStyle: defaultStyle,
+          linkStyle: linkStyle,
+          mentionStyle: mentionStyle,
+          onMentionTap: (_) {},
+        ).build();
+
+        expect(
+          spans.tappableSpans.map((span) => span.text),
+          equals(['@trailing', '@trailing']),
+        );
+        expect(
+          spans.map((span) => span.text).join(),
+          equals('@trailing- and @trailing.'),
+        );
+      });
+
+      test('still leaves an email address unlinked as a mention', () {
+        final tappedUrls = <String>[];
+        final mentions = <String>[];
+
+        final spans = LinkifiedTextSpanBuilder(
+          text: 'write to bob@example.com',
+          defaultStyle: defaultStyle,
+          linkStyle: linkStyle,
+          mentionStyle: mentionStyle,
+          onMentionTap: mentions.add,
+          onUrlTap: (rawUrl) async => tappedUrls.add(rawUrl),
+        ).build();
+
+        spans.tappableSpans.single.tap();
+        expect(mentions, isEmpty);
+        expect(tappedUrls, equals(['bob@example.com']));
+      });
+    });
+
     // `@<64-hex>` resolves on the first character after the `@`. The trailing
     // mention alternative opens with `[a-zA-Z]`, so a letter-initial hex is
     // taken as a 31-character mention while a digit-initial one has no letter


### PR DESCRIPTION
Closes #8717

## Problem

A creator dedicated a video to `@OG-AB`. The caption linked `@OG` — a
different account — and left `-AB` sitting next to it as plain text.

It is not specific to that handle. Any username carrying a dot or a
hyphen truncated at the separator, including `@ickynicki.v2` and
`@st.allison`, both visible in the same reported screenshot. A NIP-05
local part explicitly allows `.`, `-` and `_`, so these are ordinary
handles, not edge cases.

The quiet half is worse than the visible one. The truncated token is
resolved again at publish time, and when an account really did own the
prefix, it resolved to *them*. The two writers differ in what that
costs:

- **Video captions** keep the text as typed but derive the `p` tags from
  the resolution, so the post tags and notifies a stranger while the
  intended person is never mentioned.
- **Comments** additionally take the canonicalized text, so the posted
  body itself became `nostr:npub1<someone-else>-AB`.

## Why this fix

Two independent causes sit on the same path, and the mention only lands
if both are fixed. Each was confirmed by reverting it alone and watching
the new tests fail.

**The token pattern.** It ended a mention at the first character outside
`[a-zA-Z0-9_]`, so `@OG-AB` yielded `OG`. It now admits `.` and `-` only
when a word character follows. The lookahead is what keeps sentence
punctuation out of the span — `thanks @st.allison.` is a mention of
`st.allison` plus a period — and the 31-character cap is unchanged, so
the existing `@npub1…` and `@<64-hex>` precedence tests still pin the
same behaviour.

**The lookup query.** Resolution searched on the *normalized* token,
which strips separators. Profile search is a substring match, so `ogab`
can never match `OG-AB`; widening the pattern alone would have left the
mention unresolved. It now searches the token as typed, keeping the
normalized form only as the dedupe and replacement key.

## What this deliberately leaves alone

- **The URL and email alternatives stay duplicated; the mention one no
  longer is.** Both tokenizers now compose `mentionTokenPattern` from
  `lib/constants/mention_pattern.dart`, so the rendered span and the
  published `p` tag cannot disagree about where a handle ends — the exact
  lockstep hazard this bug came from. The alternatives ahead of it are
  left alone: the render copy carries extra lookbehinds on the email and
  bare-domain cases, and merging those would change URL tokenization on
  the publish path, which is unrelated blast radius for a mention fix.
- **`notification_repository` keeps its deliberate divergence** and
  still omits the mention alternative. Only its doc comment, which
  quoted the old pattern verbatim, was updated.
- **No autocomplete.** Picking a user while typing a caption is a
  separate request from the same report, in progress on its own branch;
  the mention overlay today exists only in comments.

## Verification

- Failing-first: the three render tests and two of the three publish
  tests fail on `main`, for the reported reason.
- The shared-pattern refactor is behaviour-free by construction: both
  composed patterns are byte-identical to the ones reviewed at
  `5f52ee6d2c`, checked string-by-string, and the render and publish
  suites are what prove it.
- Reverting either half alone re-breaks the suite, so neither change is
  redundant.
- `flutter analyze lib test integration_test` clean; `dart format` clean.
- Suites run: `linkified_text`, `markdown`, `mention_resolution_service`,
  `blocs/comments`, `video_publish_provider`, `services/video_publish`,
  `profile_editor`, `screens/comments`, `widgets/video_feed_item`,
  hashtag widgets, and the `notification_repository` package — 1300+
  tests, all green.
- CI-only ratchets run locally: ungrouped tests, placeholder tests,
  unpinned unchanged assertions, shared setup stubs, skip ceiling, l10n
  delegates, untested services, test/unit structure, service god-file,
  empty catch, Nostr id truncation, pubkey log encoding, post-close
  emit, layer direction, orphaned ARB keys, production `Future.delayed`,
  uncancellable timer wait — all pass.
