### PR TITLE
refactor(profile): decide once whether a profile link is your own

### DIFF
--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -260,6 +260,22 @@ bool isOwnProfileLocation(String location, String currentUserHex) {
       routeIdentifiesUser(route.npub, currentUserHex);
 }
 
+/// Whether [context] is [currentUserHex]'s own profile *grid*.
+///
+/// Video mode keeps the shell's app bar even on your own profile, so a
+/// non-null `videoIndex` is deliberately not an own-profile grid.
+///
+/// One owner for a decision two layers make: the profile screen wraps the
+/// grid in its own scaffold, and the shell suppresses its app bar for it.
+/// When those two disagree, your own profile renders inside a stranger's
+/// chrome in the same frame — which is what `routeIdentifiesUser` exists to
+/// prevent, and why this predicate is not inlined at either site.
+bool isOwnProfileGridRoute(RouteContext? context, String? currentUserHex) =>
+    context != null &&
+    context.type == RouteType.profile &&
+    context.videoIndex == null &&
+    routeIdentifiesUser(context.npub, currentUserHex);
+
 /// Parse a URL path only when its route family is explicitly modeled.
 ///
 /// This is the route normalizer's fail-closed entry point: unknown or

--- a/mobile/lib/router/shell/shell_title_resolver.dart
+++ b/mobile/lib/router/shell/shell_title_resolver.dart
@@ -108,8 +108,5 @@ bool shellSuppressesAppBar({
   if (isExploreGrid) return true;
 
   // Video mode uses the app bar even on the viewer's own profile.
-  return context != null &&
-      context.type == RouteType.profile &&
-      context.videoIndex == null &&
-      routeIdentifiesUser(context.npub, currentUserHex);
+  return isOwnProfileGridRoute(context, currentUserHex);
 }

--- a/mobile/lib/router/shell/shell_title_resolver.dart
+++ b/mobile/lib/router/shell/shell_title_resolver.dart
@@ -72,16 +72,11 @@ bool shellShowsBackButton({
       context.type == RouteType.notifications &&
       context.videoIndex != null &&
       context.videoIndex != 0;
-  final isOtherUserProfile =
+  final isProfileWithShellAppBar =
       context.type == RouteType.profile &&
-      !routeIdentifiesUser(context.npub, currentUserHex);
-  final isProfileVideo =
-      context.type == RouteType.profile && context.videoIndex != null;
+      !isOwnProfileGridRoute(context, currentUserHex);
 
-  return isExploreVideo ||
-      isNotificationVideo ||
-      isOtherUserProfile ||
-      isProfileVideo;
+  return isExploreVideo || isNotificationVideo || isProfileWithShellAppBar;
 }
 
 /// Whether the shell suppresses its own app bar for [context].

--- a/mobile/lib/screens/profile_screen_router.dart
+++ b/mobile/lib/screens/profile_screen_router.dart
@@ -101,10 +101,10 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
 
     // Check if this is own profile grid view (needs own scaffold)
     final currentUserHex = ref.read(authServiceProvider).currentPublicKeyHex;
-    final isOwnProfileGrid =
-        routeContext.type == RouteType.profile &&
-        routeContext.videoIndex == null && // Video mode uses shell
-        routeIdentifiesUser(routeContext.npub, currentUserHex);
+    final isOwnProfileGrid = isOwnProfileGridRoute(
+      routeContext,
+      currentUserHex,
+    );
 
     final content = _ProfileContentView(
       routeContext: routeContext,
@@ -133,7 +133,7 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
         // stats, and video grid degrade to skeletons while MyProfileBloc is
         // absent — instead of a separate loading view. Once the identity
         // resolves, the BlocProvider below mounts and the layout fills in.
-        return _ProfileScaffold(body: content);
+        return ProfileScaffold(body: content);
       }
 
       return BlocProvider<MyProfileBloc>(
@@ -146,7 +146,7 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
               )
               ..add(const MyProfileSubscriptionRequested())
               ..add(const MyProfileFetchRequested()),
-        child: _ProfileScaffold(body: content),
+        child: ProfileScaffold(body: content),
       );
     }
 
@@ -268,9 +268,17 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
   }
 }
 
-class _ProfileScaffold extends StatelessWidget {
-  const _ProfileScaffold({required this.body});
+/// The scaffold the own-profile grid renders inside, and nothing else does.
+///
+/// Public only so a test can assert the screen took the own-profile branch by
+/// finding the real widget, rather than re-implementing the predicate and
+/// proving nothing about the screen.
+@visibleForTesting
+class ProfileScaffold extends StatelessWidget {
+  /// Creates the own-profile grid's scaffold around [body].
+  const ProfileScaffold({required this.body, super.key});
 
+  /// The profile content this scaffold wraps.
   final Widget body;
 
   @override

--- a/mobile/test/router/providers/page_context_provider_test.dart
+++ b/mobile/test/router/providers/page_context_provider_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: standing on their own profile.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:openvine/router/providers/page_context_provider.dart';
 import 'package:openvine/router/route_paths.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
@@ -13,6 +14,13 @@ const _otherHex =
 
 final String _npub = NostrKeyUtils.encodePubKey(_ownHex);
 final String _otherNpub = NostrKeyUtils.encodePubKey(_otherHex);
+
+/// Encoded rather than pasted: a bech32 literal that does not decode would
+/// make the negative cases pass because normalization returned null, not
+/// because the comparison rejected a different identity.
+final String _ownNprofile = NIP19Tlv.encodeNprofile(
+  Nprofile(pubkey: _ownHex, relays: const ['wss://relay.divine.video']),
+);
 
 void main() {
   group('isOwnProfileLocation', () {
@@ -76,6 +84,145 @@ void main() {
           _ownHex,
         ),
         isTrue,
+      );
+    });
+  });
+
+  group('isOwnProfileGridRoute', () {
+    // `/profile/<hex>` is a documented deep-link form
+    // (DEEP_LINK_URL_REFERENCE.md), and nothing normalizes the segment on the
+    // way in — the app itself only ever emits npub, so the other encodings
+    // arrive from shared links and are never dogfooded.
+    test('matches the signed-in user by npub', () {
+      expect(
+        isOwnProfileGridRoute(
+          RouteContext(type: RouteType.profile, npub: _npub),
+          _ownHex,
+        ),
+        isTrue,
+      );
+    });
+
+    test('matches a bare-hex deep link', () {
+      expect(
+        isOwnProfileGridRoute(
+          const RouteContext(type: RouteType.profile, npub: _ownHex),
+          _ownHex,
+        ),
+        isTrue,
+      );
+    });
+
+    test('matches an uppercase-hex deep link', () {
+      // The hex validator is case-insensitive, so an uppercase segment is a
+      // valid route that must not read as a different identity.
+      expect(
+        isOwnProfileGridRoute(
+          RouteContext(type: RouteType.profile, npub: _ownHex.toUpperCase()),
+          _ownHex,
+        ),
+        isTrue,
+      );
+    });
+
+    test('matches an nprofile deep link', () {
+      expect(
+        isOwnProfileGridRoute(
+          RouteContext(type: RouteType.profile, npub: _ownNprofile),
+          _ownHex,
+        ),
+        isTrue,
+      );
+    });
+
+    test("matches the relative 'me' route", () {
+      expect(
+        isOwnProfileGridRoute(
+          const RouteContext(type: RouteType.profile, npub: 'me'),
+          _ownHex,
+        ),
+        isTrue,
+      );
+    });
+
+    test("matches 'me' before the signed-in pubkey resolves", () {
+      // 'me' names the own-profile route structurally. Gating it on a
+      // resolved pubkey would flash a stranger's chrome during cold start.
+      expect(
+        isOwnProfileGridRoute(
+          const RouteContext(type: RouteType.profile, npub: 'me'),
+          null,
+        ),
+        isTrue,
+      );
+    });
+
+    test("does not match another user's npub", () {
+      expect(
+        isOwnProfileGridRoute(
+          RouteContext(type: RouteType.profile, npub: _otherNpub),
+          _ownHex,
+        ),
+        isFalse,
+      );
+    });
+
+    test("does not match another user's bare hex", () {
+      // The widening direction: normalizing the segment must not make every
+      // hex link read as yours. _otherHex is a real, decodable identity, so
+      // this fails for the right reason rather than because it did not decode.
+      expect(
+        isOwnProfileGridRoute(
+          const RouteContext(type: RouteType.profile, npub: _otherHex),
+          _ownHex,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not match your own profile in video mode', () {
+      // Index 0 is a real route, and video mode keeps the shell's app bar
+      // even on your own profile.
+      expect(
+        isOwnProfileGridRoute(
+          RouteContext(type: RouteType.profile, npub: _npub, videoIndex: 0),
+          _ownHex,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not match a non-profile route', () {
+      expect(
+        isOwnProfileGridRoute(
+          const RouteContext(type: RouteType.home, videoIndex: 0),
+          _ownHex,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not match before the route context resolves', () {
+      expect(isOwnProfileGridRoute(null, _ownHex), isFalse);
+    });
+
+    test('does not match an undecodable segment', () {
+      expect(
+        isOwnProfileGridRoute(
+          const RouteContext(type: RouteType.profile, npub: 'not-an-npub'),
+          _ownHex,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not match a real npub when nobody is signed in', () {
+      expect(
+        isOwnProfileGridRoute(
+          RouteContext(type: RouteType.profile, npub: _npub),
+          null,
+        ),
+        isFalse,
       );
     });
   });

--- a/mobile/test/screens/profile_screen_router_test.dart
+++ b/mobile/test/screens/profile_screen_router_test.dart
@@ -25,13 +25,16 @@ import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/services/video_publish/publish_error_kind.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/profile/blocked_user_screen.dart';
 import 'package:videos_repository/videos_repository.dart';
 
 import '../helpers/test_provider_overrides.dart';
+import '../helpers/test_pubkeys.dart';
 
 class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {}
@@ -100,6 +103,9 @@ const _npub = 'npub1424242424242424242424242424242424242424242424242424qamrcaj';
 /// does not match the profile's, so the two must describe one identity.
 const _authorPubkeyHex =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+/// A second real identity, for the "not yours" case.
+final String _otherNpub = NostrKeyUtils.encodePubKey(syntheticOtherTestPubkey);
 
 void main() {
   final now = DateTime.now();
@@ -450,6 +456,92 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('feed'), findsOneWidget);
+    });
+  });
+
+  // A sibling group, deliberately not nested inside the feed group above:
+  // that group's setUp registers 19 stubs, which stay uncounted by the
+  // shared-setUp ratchet only while it has no descendant groups.
+  group('own-profile grid detection', () {
+    late _MockContentBlocklistRepository blocklistRepository;
+
+    setUp(() {
+      blocklistRepository = _MockContentBlocklistRepository();
+      // The scaffold decision is made in ProfileScreenRouter.build, before and
+      // independently of the profile body. Reporting the subject as blocking
+      // the viewer stops the body at BlockedUserScreen, so these tests need
+      // none of the videos/profile provider stack the body would otherwise
+      // build — without touching the branch under test.
+      when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(true);
+      when(() => blocklistRepository.hasMutedUs(any())).thenReturn(false);
+    });
+
+    /// Pumps the grid route (no video index) for [segment], signed in as
+    /// [_authorPubkeyHex].
+    Future<void> pumpGridRoute(WidgetTester tester, String segment) async {
+      final location = ProfileScreenRouter.pathForNpub(segment);
+      final router = GoRouter(
+        initialLocation: location,
+        routes: [
+          GoRoute(
+            path: ProfileScreenRouter.pathWithNpub,
+            builder: (_, _) => const ProfileScreenRouter(),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        testProviderScope(
+          mockAuthService: createMockAuthService(
+            authState: AuthState.authenticated,
+            currentPublicKeyHex: _authorPubkeyHex,
+          ),
+          additionalOverrides: [
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              blocklistRepository,
+            ),
+            routerLocationStreamProvider.overrideWithValue(
+              Stream.value(location),
+            ),
+          ],
+          child: MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: router,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    // `/profile/<hex>` is a documented deep-link form, and the app only ever
+    // emits npub — so the hex form arrives from shared links and is never
+    // dogfooded. Before #6655 the screen compared the raw segment against the
+    // signed-in npub, and rendered your own profile without its scaffold.
+    testWidgets('a bare-hex link to your own profile is yours', (tester) async {
+      await pumpGridRoute(tester, _authorPubkeyHex);
+
+      expect(find.byType(BlockedUserScreen), findsOneWidget);
+      expect(find.byType(ProfileScaffold), findsOneWidget);
+    });
+
+    testWidgets('an npub link to your own profile is yours', (tester) async {
+      await pumpGridRoute(tester, _npub);
+
+      expect(find.byType(BlockedUserScreen), findsOneWidget);
+      expect(find.byType(ProfileScaffold), findsOneWidget);
+    });
+
+    testWidgets("another user's profile is not yours", (tester) async {
+      // A real, decodable identity: a malformed segment would pass this by
+      // failing to normalize rather than by being compared and rejected.
+      await pumpGridRoute(tester, _otherNpub);
+
+      // Positive control: the body really did render, so findsNothing below
+      // means the scaffold was not chosen — not that the tree failed to build.
+      expect(find.byType(BlockedUserScreen), findsOneWidget);
+      expect(find.byType(ProfileScaffold), findsNothing);
     });
   });
 }


### PR DESCRIPTION
Closes #7464.

## The problem

A profile URL's `:npub` segment can arrive in four forms — `npub1…`, bare hex, `nprofile1…`, or the literal `me` — and nothing normalizes it on the way in. `/profile/<hex>` is a **documented** deep-link form (`DEEP_LINK_URL_REFERENCE.md`: "hex pubkey also works"), but the app itself only ever *emits* npub, so the other forms arrive from links shared elsewhere and are never dogfooded.

Deciding "is this route my own profile grid?" is therefore easy to get wrong, and it has been wrong before: #6655 fixed the screen comparing the raw URL segment against the signed-in npub, which rendered your own profile without its scaffold whenever you opened it by a hex link.

Two things were still true after that fix:

1. **The decision was duplicated.** `profile_screen_router.dart` and `shell_title_resolver.dart` each carried a byte-identical copy of the same four-term expression. Nothing kept them in sync, and when they disagree the reader gets their own profile inside a stranger's chrome in the same frame — exactly what the shared helper exists to prevent.
2. **The screen's copy had no test at all** — not for hex, not for nprofile, not even for npub. #6655 shipped tests for the helper, for `AppShell`, and for account switching, but not for the screen it changed. Every existing test in that file opens the profile *feed* (`/profile/<npub>/<index>`), and a non-null video index short-circuits the predicate before the comparison is ever reached.

## Why this shape

The predicate is now named once, as `isOwnProfileGridRoute`, next to its existing sibling `isOwnProfileLocation` in the file that already owns `RouteContext` — and which both call sites already import. So there is no new file, no new import, and no new dependency direction; both copies become one call.

`ProfileScaffold` is public-for-testing so the widget test finds the real widget instead of re-implementing the decision and proving nothing about the screen. That follows `branchPage` in `router/routes/shell.dart`, made public for the same reason.

## What this deliberately leaves alone

- **No behaviour change.** The extracted expression is identical to both copies it replaces, and `shellSuppressesAppBar` keeps its earlier early-returns in their original order.
- `profile_screen_router.dart:334`'s separate `userIdHex == currentUserHex` compare. It is safe by construction — both sides are already normalized lowercase hex — and it decides the profile *body*, not the scaffold. Out of scope here.
- The followers/following comparison audit (#7463), and the deep-link parser's own asymmetry (the profile branch takes its segment verbatim while the sibling `/list/` branch normalizes).
- `profile_share_edit_buttons_test.dart`, whose skip is already adjudicated `delete` under #4836.

## What was already done elsewhere

The issue asks for four things; three were done by other work, which is why it stayed open unnoticed:

- The file it names, `test/router/profile_screen_router_test.dart`, has never existed — the real file is under `test/screens/`.
- Its skips were removed on 2026-08-21 by #7650, closing #7160 — a near-duplicate filed three days before this issue.
- The encoding coverage it asks for already exists for the helper (`npub_hex_test.dart`) and for three of the four call sites.

The one thing genuinely left was the screen's own call site, which is what this PR covers.

## How it was verified

- New unit tests: 13 cases over the predicate — npub, bare hex, uppercase hex, nprofile, `me`, and `me` before auth resolves; plus the two negative directions nothing covered before: **another user's bare hex** must still read as a stranger, and **your own profile in video mode** is not the grid. The nprofile fixture is encoded rather than pasted, so a negative case cannot pass merely by failing to decode.
- New widget tests: the grid route opened as yourself in hex and npub form, and as another user, asserting the own-profile scaffold appears only for the first two. Each carries a positive control, so "scaffold absent" cannot pass because the tree failed to build.
- **Mutation-proved.** Restoring the pre-#6655 raw npub compare turns the bare-hex widget test red while the npub and stranger tests stay green — the suite catches that specific regression rather than failing indiscriminately.
- `dart format` (0 changed), `flutter analyze lib test integration_test` → no issues, and the CI-only ratchets run locally: shared-setUp stubs, `Future.delayed`, l10n delegates, ungrouped tests, placeholder tests, unpinned-unchanged assertions, skip ceiling, test structure, layer direction.

One note for reviewers: the new widget tests report the subject as blocking the viewer, which stops the profile body at `BlockedUserScreen`. That is deliberate isolation, not an accident — the scaffold decision is made in `build` before and independently of the body, so this keeps the whole videos/profile provider stack out of a test that is about one boolean.
