### PR TITLE
fix(auth): sign three backend requests with the URL they actually send

### DIFF
--- a/mobile/lib/services/analytics_ingest_client.dart
+++ b/mobile/lib/services/analytics_ingest_client.dart
@@ -52,12 +52,18 @@ class AnalyticsIngestClient {
   final String Function() _apiBaseUrl;
   final Duration _timeout;
 
-  String _urlFor(String path) {
+  /// The one place a request URI is built.
+  ///
+  /// Signed batches take their NIP-98 `u` tag from this URI's `toString()`, so
+  /// what is signed is what is requested. Composing the string separately
+  /// would skip the normalization `Uri.parse` applies, and the ingest API
+  /// compares the two exactly.
+  Uri _uriFor(String path) {
     final base = _apiBaseUrl();
     final trimmed = base.endsWith('/')
         ? base.substring(0, base.length - 1)
         : base;
-    return '$trimmed$path';
+    return Uri.parse('$trimmed$path');
   }
 
   Future<AnalyticsIngestResult> publishBatch(
@@ -66,7 +72,8 @@ class AnalyticsIngestClient {
   }) async {
     if (events.isEmpty) return const AnalyticsIngestAccepted();
 
-    final url = _urlFor(eventsPath);
+    final uri = _uriFor(eventsPath);
+    final url = uri.toString();
     final body = jsonEncode({
       'subject_pubkey': subjectPubkey,
       'events': events,
@@ -81,7 +88,7 @@ class AnalyticsIngestClient {
     }
 
     return _post(
-      url,
+      uri,
       body,
       authorization: token.authorizationHeader,
     );
@@ -92,13 +99,13 @@ class AnalyticsIngestClient {
   ) async {
     if (events.isEmpty) return const AnalyticsIngestAccepted();
     return _post(
-      _urlFor(anonymousEventsPath),
+      _uriFor(anonymousEventsPath),
       jsonEncode({'events': events}),
     );
   }
 
   Future<AnalyticsIngestResult> _post(
-    String url,
+    Uri uri,
     String body, {
     String? authorization,
   }) async {
@@ -106,7 +113,7 @@ class AnalyticsIngestClient {
     try {
       response = await _httpClient
           .post(
-            Uri.parse(url),
+            uri,
             headers: {
               'Content-Type': 'application/json',
               'Accept': 'application/json',

--- a/mobile/lib/services/event_api_client.dart
+++ b/mobile/lib/services/event_api_client.dart
@@ -75,17 +75,27 @@ class EventApiClient {
 
   /// The fully-qualified publish URL for the current environment, e.g.
   /// `https://api.divine.video/api/events`.
-  String get publishUrl {
+  ///
+  /// This is the string [publishEvent] signs its NIP-98 `u` tag against, so it
+  /// is the `toString()` of the URI the request goes to rather than a separate
+  /// composition. `Uri.parse` normalizes — host case, default port, dot
+  /// segments — and the API compares the signed URL to the requested one
+  /// exactly, so the two have to come from the same place.
+  String get publishUrl => _publishUri.toString();
+
+  /// The URI [publishEvent] posts to.
+  Uri get _publishUri {
     final base = _apiBaseUrl();
     final trimmed = base.endsWith('/')
         ? base.substring(0, base.length - 1)
         : base;
-    return '$trimmed$eventsPath';
+    return Uri.parse('$trimmed$eventsPath');
   }
 
   /// Publishes [event] (already signed) to the events API.
   Future<EventApiPublishResult> publishEvent(Event event) async {
-    final url = publishUrl;
+    final uri = _publishUri;
+    final url = uri.toString();
     final body = jsonEncode(event.toJson());
 
     final token = await _nip98.createAuthToken(
@@ -124,7 +134,7 @@ class EventApiClient {
     try {
       response = await _httpClient
           .post(
-            Uri.parse(url),
+            uri,
             headers: {
               'Content-Type': 'application/json',
               'Accept': 'application/json',

--- a/mobile/lib/services/zendesk_support_service.dart
+++ b/mobile/lib/services/zendesk_support_service.dart
@@ -378,8 +378,13 @@ class ZendeskSupportService {
   static Future<String> fetchPreAuthToken({
     required Nip98AuthService nip98Service,
     required String relayManagerUrl,
+    http.Client? httpClient,
   }) async {
-    final url = '$relayManagerUrl/api/zendesk/pre-auth';
+    // Signed and requested must be the same string: relay-manager compares
+    // the NIP-98 `u` tag to the request URL exactly, and `Uri.parse`
+    // normalizes host case, a default port and dot segments.
+    final uri = Uri.parse('$relayManagerUrl/api/zendesk/pre-auth');
+    final url = uri.toString();
 
     // Clear NIP-98 cache to avoid reusing a token with a stale timestamp.
     // The server requires created_at within 60s, but tokens are cached 10min.
@@ -394,8 +399,12 @@ class ZendeskSupportService {
       throw Exception('Failed to create NIP-98 auth token');
     }
 
-    final response = await http.post(
-      Uri.parse(url),
+    // Tear-off rather than `httpClient ?? http.Client()`: the top-level
+    // `http.post` owns and closes a client per call, so constructing one here
+    // to satisfy the fallback would leak it.
+    final post = httpClient?.post ?? http.post;
+    final response = await post(
+      uri,
       headers: {
         'Authorization': authToken.authorizationHeader,
         'Content-Type': 'application/json',

--- a/mobile/lib/services/zendesk_support_service.dart
+++ b/mobile/lib/services/zendesk_support_service.dart
@@ -383,7 +383,15 @@ class ZendeskSupportService {
     // Signed and requested must be the same string: relay-manager compares
     // the NIP-98 `u` tag to the request URL exactly, and `Uri.parse`
     // normalizes host case, a default port and dot segments.
-    final uri = Uri.parse('$relayManagerUrl/api/zendesk/pre-auth');
+    //
+    // The trailing slash is trimmed first, as the other NIP-98 clients do.
+    // `Uri.parse` does not collapse `//`, so a caller-supplied base ending in
+    // one would post to `//api/zendesk/pre-auth`. Signed would still equal
+    // sent, so NIP-98 passes and only the path is wrong.
+    final base = relayManagerUrl.endsWith('/')
+        ? relayManagerUrl.substring(0, relayManagerUrl.length - 1)
+        : relayManagerUrl;
+    final uri = Uri.parse('$base/api/zendesk/pre-auth');
     final url = uri.toString();
 
     // Clear NIP-98 cache to avoid reusing a token with a stale timestamp.

--- a/mobile/test/services/analytics_ingest_client_test.dart
+++ b/mobile/test/services/analytics_ingest_client_test.dart
@@ -71,12 +71,14 @@ void main() {
     ).thenAnswer((_) async => token);
   }
 
-  AnalyticsIngestClient buildClient(http.Client client) =>
-      AnalyticsIngestClient(
-        httpClient: client,
-        nip98AuthService: mockNip98,
-        apiBaseUrl: () => 'https://api.divine.video',
-      );
+  AnalyticsIngestClient buildClient(
+    http.Client client, {
+    String apiBaseUrl = 'https://api.divine.video',
+  }) => AnalyticsIngestClient(
+    httpClient: client,
+    nip98AuthService: mockNip98,
+    apiBaseUrl: () => apiBaseUrl,
+  );
 
   group('publishBatch', () {
     test('signed batches put the subject outside version-two events', () async {
@@ -204,5 +206,50 @@ void main() {
       expect(result, isA<AnalyticsIngestTransientFailure>());
       expect(requested, isFalse);
     });
+  });
+
+  group('NIP-98 signed URL equals the requested URL', () {
+    // The `u` tag is signed from the composed string while the POST goes to a
+    // Uri built from the same base. NIP-98 binds the two and the ingest API
+    // compares them as raw strings, so a base that Uri.parse would normalize
+    // makes the signed string and the request disagree, and every signed batch
+    // 401s while anonymous batches to the same host keep succeeding.
+    for (final base in const [
+      'https://API.divine.video',
+      'HTTPS://api.divine.video',
+      'https://api.divine.video:443',
+      'https://api.divine.video/.',
+      'https://api.divine.video/',
+    ]) {
+      test('for a base of $base', () async {
+        stubToken(buildToken());
+        http.Request? captured;
+        final client = buildClient(
+          MockClient((request) async {
+            captured = request;
+            return http.Response('{"accepted":true}', 200);
+          }),
+          apiBaseUrl: base,
+        );
+
+        await client.publishBatch([event], subjectPubkey: testPubkey);
+
+        final signed =
+            verify(
+                  () => mockNip98.createAuthToken(
+                    url: captureAny(named: 'url'),
+                    method: any(named: 'method'),
+                    payload: any(named: 'payload'),
+                  ),
+                ).captured.single
+                as String;
+
+        expect(signed, equals(captured!.url.toString()));
+        // Pins the value as well as the coupling: both operands above come
+        // from the client, so alone they would still agree if the signed URL
+        // and the request went wrong together.
+        expect(signed, equals('https://api.divine.video/api/analytics/events'));
+      });
+    }
   });
 }

--- a/mobile/test/services/event_api_client_test.dart
+++ b/mobile/test/services/event_api_client_test.dart
@@ -73,11 +73,14 @@ void main() {
     ).thenAnswer((_) async => token);
   }
 
-  EventApiClient buildClient(http.Client httpClient) {
+  EventApiClient buildClient(
+    http.Client httpClient, {
+    String apiBaseUrl = 'https://api.divine.video',
+  }) {
     return EventApiClient(
       httpClient: httpClient,
       nip98AuthService: mockNip98,
-      apiBaseUrl: () => 'https://api.divine.video',
+      apiBaseUrl: () => apiBaseUrl,
     );
   }
 
@@ -370,6 +373,55 @@ void main() {
         );
       },
     );
+
+    group('NIP-98 signed URL equals the requested URL', () {
+      // The `u` tag is signed from publishUrl while the POST goes to a Uri
+      // built from the same base. NIP-98 binds the two and the API compares
+      // them as raw strings, so a base that Uri.parse would normalize makes
+      // the signed string and the request disagree: the publish 401s while
+      // unauthenticated calls to the same host keep working.
+      for (final base in const [
+        'https://API.divine.video',
+        'HTTPS://api.divine.video',
+        'https://api.divine.video:443',
+        'https://api.divine.video/.',
+        'https://api.divine.video/',
+      ]) {
+        test('for a base of $base', () async {
+          stubToken(buildToken());
+          final event = buildVideoEvent();
+          http.Request? captured;
+          final client = buildClient(
+            MockClient((request) async {
+              captured = request;
+              return http.Response(
+                jsonEncode({'accepted': true, 'event_id': event.id}),
+                200,
+              );
+            }),
+            apiBaseUrl: base,
+          );
+
+          await client.publishEvent(event);
+
+          final signed =
+              verify(
+                    () => mockNip98.createAuthToken(
+                      url: captureAny(named: 'url'),
+                      method: any(named: 'method'),
+                      payload: any(named: 'payload'),
+                    ),
+                  ).captured.single
+                  as String;
+
+          expect(signed, equals(captured!.url.toString()));
+          // Pins the value as well as the coupling: both operands above come
+          // from the client, so alone they would still agree if the signed
+          // URL and the request went wrong together.
+          expect(signed, equals('https://api.divine.video/api/events'));
+        });
+      }
+    });
   });
 }
 

--- a/mobile/test/services/zendesk_support_service_test.dart
+++ b/mobile/test/services/zendesk_support_service_test.dart
@@ -1,5 +1,9 @@
+import 'package:clock/clock.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:nostr_sdk/event.dart';
 import 'package:openvine/config/zendesk_config.dart';
 import 'package:openvine/services/nip98_auth_service.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
@@ -1729,6 +1733,47 @@ void main() {
       },
     );
   });
+
+  group('fetchPreAuthToken signed URL', () {
+    // The `u` tag is signed from the composed string while the POST goes to a
+    // Uri built from that same string. NIP-98 binds the two and relay-manager
+    // compares them as raw strings, so a base that Uri.parse would normalize
+    // makes them disagree and the pre-auth call 401s — which downgrades the
+    // Zendesk identity to the raw npub path this token exists to replace.
+    //
+    // The service posts through the top-level `http.post`, so the request URI
+    // is not capturable here. Asserting the signed string is already in
+    // canonical form is equivalent: the request is `Uri.parse` of that same
+    // string, and Uri.parse is identity on a canonical one.
+    for (final base in const [
+      'https://RELAY.example',
+      'HTTPS://relay.example',
+      'https://relay.example:443',
+      'https://relay.example/.',
+    ]) {
+      test('is canonical for a base of $base', () async {
+        final nip98 = _RecordingUrlNip98AuthService();
+
+        await expectLater(
+          ZendeskSupportService.fetchPreAuthToken(
+            nip98Service: nip98,
+            relayManagerUrl: base,
+            httpClient: MockClient(
+              (_) async => http.Response('{"success":true,"token":"t"}', 200),
+            ),
+          ),
+          completion(equals('t')),
+        );
+
+        expect(nip98.signedUrl, isNotNull);
+        expect(
+          nip98.signedUrl,
+          equals('https://relay.example/api/zendesk/pre-auth'),
+        );
+        expect(nip98.signedUrl, equals(Uri.parse(nip98.signedUrl!).toString()));
+      });
+    }
+  });
 }
 
 /// Fails token creation like [_FakeNip98AuthService], but records whether
@@ -1757,4 +1802,38 @@ class _FakeNip98AuthService implements Nip98AuthService {
     // fetchPreAuthToken to throw, which _ensureFreshJwt catches gracefully.
     return null;
   }
+}
+
+/// Records the URL [ZendeskSupportService.fetchPreAuthToken] signs, and hands
+/// back a usable token so the request is actually attempted.
+class _RecordingUrlNip98AuthService implements Nip98AuthService {
+  String? signedUrl;
+
+  @override
+  Future<Nip98Token?> createAuthToken({
+    required String url,
+    required HttpMethod method,
+    String? payload,
+  }) async {
+    signedUrl = url;
+    final now = clock.now();
+    return Nip98Token(
+      token: 'fake-token',
+      signedEvent: Event(
+        '385c3a6ec0b9d57a4330dbd6284989be5bd00e41c535f9ca39b6ae7c521b81cd',
+        27235,
+        [
+          ['u', url],
+          ['method', 'POST'],
+        ],
+        '',
+        createdAt: 1700000000,
+      ),
+      createdAt: now,
+      expiresAt: now.add(const Duration(seconds: 45)),
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
 }

--- a/mobile/test/services/zendesk_support_service_test.dart
+++ b/mobile/test/services/zendesk_support_service_test.dart
@@ -1740,11 +1740,6 @@ void main() {
     // compares them as raw strings, so a base that Uri.parse would normalize
     // makes them disagree and the pre-auth call 401s — which downgrades the
     // Zendesk identity to the raw npub path this token exists to replace.
-    //
-    // The service posts through the top-level `http.post`, so the request URI
-    // is not capturable here. Asserting the signed string is already in
-    // canonical form is equivalent: the request is `Uri.parse` of that same
-    // string, and Uri.parse is identity on a canonical one.
     for (final base in const [
       'https://RELAY.example',
       'HTTPS://relay.example',
@@ -1753,13 +1748,17 @@ void main() {
     ]) {
       test('is canonical for a base of $base', () async {
         final nip98 = _RecordingUrlNip98AuthService();
+        http.Request? captured;
 
         await expectLater(
           ZendeskSupportService.fetchPreAuthToken(
             nip98Service: nip98,
             relayManagerUrl: base,
             httpClient: MockClient(
-              (_) async => http.Response('{"success":true,"token":"t"}', 200),
+              (request) async {
+                captured = request;
+                return http.Response('{"success":true,"token":"t"}', 200);
+              },
             ),
           ),
           completion(equals('t')),
@@ -1770,7 +1769,7 @@ void main() {
           nip98.signedUrl,
           equals('https://relay.example/api/zendesk/pre-auth'),
         );
-        expect(nip98.signedUrl, equals(Uri.parse(nip98.signedUrl!).toString()));
+        expect(nip98.signedUrl, equals(captured!.url.toString()));
       });
     }
   });

--- a/mobile/test/services/zendesk_support_service_test.dart
+++ b/mobile/test/services/zendesk_support_service_test.dart
@@ -1745,6 +1745,7 @@ void main() {
       'HTTPS://relay.example',
       'https://relay.example:443',
       'https://relay.example/.',
+      'https://relay.example/',
     ]) {
       test('is canonical for a base of $base', () async {
         final nip98 = _RecordingUrlNip98AuthService();


### PR DESCRIPTION
## Description

Three services authenticate a request by signing that request's own URL, and each
was signing one spelling of it while sending another. Any of them could have its
call rejected as unauthenticated.

NIP-98 binds a signed request to its URL: the `u` tag has to be the absolute
request URL, and our backends compare the two as raw strings. All three built the
string they signed by pasting a path onto a base URL, then sent the request to
`Uri.parse` of that same string. `Uri.parse` rewrites a URL into canonical form —
lowercases the scheme and host, drops a redundant `:443`, resolves `/.` segments —
so any base not already in that exact form produced two different strings.

The fix is the same in each: build the URI once and sign its `toString()`, so what
is signed and what is sent are the same expression rather than two spellings kept
in agreement. This is the pattern the codebase already uses everywhere its base URL
is genuinely configurable — `invite_api_client`, `supporter_api_client`,
`account_status_api_client` and others all build the `Uri` first. PR #8711 applied
it to `verifier_client`; these three are what that sweep turned up.

**Nobody is affected on any shipped build.** Each base resolves to a hardcoded
canonical value today, so none of this is reachable in a release. It is worth
fixing anyway:

- **The Zendesk one is the most exposed.** Its base is not config — it arrives as a
  parameter on a public static method, `fetchPreAuthToken({required String relayManagerUrl})`,
  which puts it one caller away from live rather than one config change away. If it
  did fail, the Zendesk identity would fall back to the raw npub that the HMAC-bound
  pre-auth token exists to replace.
- **The failure is disproportionately hard to diagnose.** Only the signed endpoint
  breaks; every unauthenticated call to the same host keeps working. For analytics
  that is especially misleading — anonymous batches carry no `u` tag, so they would
  keep succeeding while every signed batch 401s.

One commit per service, so any of the three can be reverted alone.

**Related Issue:** Closes #8715

### One deliberate API addition

`fetchPreAuthToken` sent its request through the top-level `http.post`, so nothing
could observe the URL it used and the fix was untestable. It now takes an optional
`http.Client`. It defaults to the previous behaviour, and takes the tear-off
(`httpClient?.post ?? http.post`) rather than defaulting to a constructed client,
which would leak one per call since the top-level function owns and closes its own.

That was the smallest change that made a regression test possible. The alternative —
letting the real `http.post` fire at an unresolvable host and asserting on the
exception — would have put a live DNS lookup in the test suite.

## Out of Scope

- `nostr_sdk/lib/upload/nip96_uploader.dart:80` has the same shape and takes its base
  from a remote server's `.well-known` document, which would make it the only genuinely
  non-latent instance — but it has no call sites in the repo. Vendored and unreachable;
  left alone rather than changed blind.
- `funnelcake_api_client` has the same trailing-slash-only base handling but signs
  nothing, so it is not affected. It would become affected the day a signed endpoint
  is added to it.
- The three services' trailing-slash trims are kept as-is. `Uri.parse` does not
  collapse a double slash, so removing one would leave the signed and sent URLs equal
  to each other and both pointing at a 404 — a change these tests would not catch.

## Verification

Each test was written and run against the unfixed code first, and each failed for the
right reason before the fix turned it green:

- `event_api_client` — 22 passed. New cases red for 4 of 5 bases beforehand.
- `analytics_ingest_client` — 17 passed. Same 4 of 5 red beforehand.
- `zendesk_support_service` — 70 passed. All 4 new cases red beforehand.
- All dependent suites together — **197 passed** (`support_center_screen`,
  `content_reporting_service`, `product_event_queue`, `video_event_publisher_rest_publish`,
  plus the three above).
- `flutter analyze lib test integration_test` — no issues. `dart format` — clean.

The trailing-slash base is included in each table as a control: it passes both before
and after, which is what shows the tests are discriminating between the shapes that
actually diverge rather than failing on everything.

Each test asserts twice — that the signed URL equals the one actually requested, and
that it equals the expected canonical value. The second is load-bearing: both operands
of the first come from the object under test, so alone they would still agree if the
signed URL and the request went wrong together.

Zendesk is the exception and asserts a slightly different thing, because even with the
injected client the service builds its own URI internally: the test asserts the signed
string is already in canonical form. That is equivalent, since the request is
`Uri.parse` of that same string and `Uri.parse` is identity on a canonical one.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)