### PR TITLE
fix(repositories): stop a failed cache clear from half-clearing likes and reposts

### DIFF
--- a/mobile/packages/likes_repository/lib/src/likes_local_storage.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_local_storage.dart
@@ -58,8 +58,11 @@ abstract class LikesLocalStorage {
   /// Checks if an event is liked.
   Future<bool> isLiked(String targetEventId);
 
-  /// Clears all like records.
+  /// Clears all like records belonging to this storage's account.
   ///
-  /// Used when logging out or resetting local data.
+  /// Throws if the underlying store cannot be opened or the bulk delete
+  /// fails; callers decide whether that is recoverable. Note that erasing a
+  /// signed-out account's rows is done by the cleanup in
+  /// `social_providers.dart`, not through this method.
   Future<void> clearAll();
 }

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -2897,26 +2897,19 @@ class LikesRepository {
   Future<void> _ensureInitialized() async {
     if (_isInitialized) return;
 
+    // Degrade to an in-memory-only cache rather than failing the caller.
+    // Callers are publish paths: an unreadable cache costs a stale
+    // already-liked check, while throwing here costs the Kind 7.
     final localStorage = _localStorage;
     if (localStorage != null) {
-      try {
-        final records = await localStorage.getAllLikeRecords();
+      final records = await _bestEffortLocalStorage(
+        localStorage.getAllLikeRecords,
+        description: 'loading persisted reactions',
+        site: LikesRepositoryReportableSites.ensureInitializedLoadRecords,
+      );
+      if (records != null) {
         records.forEach(_indexLikeRecord);
         _emitLikedIds();
-      } on Object catch (e, stackTrace) {
-        // Degrade to an in-memory-only cache rather than failing the caller.
-        // Callers are publish paths: an unreadable cache costs a stale
-        // already-liked check, while throwing here costs the Kind 7.
-        _reportIfInvariantViolation(
-          e,
-          stackTrace,
-          site: LikesRepositoryReportableSites.ensureInitializedLoadRecords,
-        );
-        Log.warning(
-          'Like cache unavailable; continuing without persisted records: $e',
-          name: 'LikesRepository',
-          category: LogCategory.system,
-        );
       }
     }
     // Latched on both paths: an unreadable database stays unreadable for the

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -2845,14 +2845,24 @@ class LikesRepository {
     );
   }
 
-  /// Clear all local like data.
+  /// Clear all local like data. Does not affect data on relays.
   ///
-  /// Used when logging out or clearing user data.
-  /// Does not affect data on relays.
+  /// Clears the durable store first, so the clear is all-or-nothing: if
+  /// [LikesLocalStorage.clearAll] throws, the in-memory caches are left
+  /// intact, nothing is emitted, and the failure reaches the caller. A clear
+  /// that did not happen is therefore never reported as one.
+  ///
+  /// This is deliberately not routed through `_bestEffortLocalStorage`. That
+  /// helper exists so a dead cache cannot block a relay publish; clearing
+  /// publishes nothing, and the thing at risk here is the deletion itself.
+  /// Erasing a signed-out account's rows is handled by the cleanup in
+  /// `social_providers.dart`, which is likewise required to surface failures
+  /// rather than swallow them.
   ///
   /// Safe to call after [dispose] -- the cache is still cleared but no
   /// stream emission is attempted.
   Future<void> clearCache() async {
+    await _localStorage?.clearAll();
     _likeRecords.clear();
     _likeRecordsByAddressableId.clear();
     _inFlightLikePublishPlaceholders.clear();
@@ -2861,7 +2871,6 @@ class LikesRepository {
     _downvoteRecordsByAddressableId.clear();
     _likeCountCache.clear();
     _likeCountCacheByAddressableId.clear();
-    await _localStorage?.clearAll();
     _emitLikedIds();
     _emitDownvotedIds();
     _isInitialized = false;

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -2859,8 +2859,8 @@ class LikesRepository {
   /// `social_providers.dart`, which is likewise required to surface failures
   /// rather than swallow them.
   ///
-  /// Safe to call after [dispose] -- the cache is still cleared but no
-  /// stream emission is attempted.
+  /// Safe to call after [dispose] -- a successful clear still clears the
+  /// cache, but no stream emission is attempted.
   Future<void> clearCache() async {
     await _localStorage?.clearAll();
     _likeRecords.clear();

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -4506,6 +4506,20 @@ void main() {
       });
     });
 
+    group('_ensureInitialized', () {
+      test('an unreadable store degrades instead of throwing', () async {
+        when(
+          () => mockLocalStorage.getAllLikeRecords(),
+        ).thenThrow(StateError('database is dead'));
+        repository = createRepository();
+
+        // Callers are publish paths: the read is swallowed so a dead cache
+        // costs a stale already-liked check rather than the Kind 7.
+        await expectLater(repository.getLikedEventIds(), completion(isEmpty));
+        await expectLater(repository.isLiked(testEventId), completion(isFalse));
+      });
+    });
+
     group('watchLikedEventIds', () {
       test('seeds from local storage, then streams repository cache', () async {
         final mockEvent = MockEvent();

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -4504,6 +4504,35 @@ void main() {
         // after calling close" on the BehaviorSubject.
         await expectLater(repository.clearCache(), completes);
       });
+
+      test('a failing clearAll leaves the in-memory cache intact', () async {
+        // Stubbed here rather than in the shared setUp so the failure stays
+        // adjacent to the test that depends on it.
+        when(
+          () => mockLocalStorage.clearAll(),
+        ).thenThrow(StateError('database is dead'));
+        when(() => mockLocalStorage.getAllLikeRecords()).thenAnswer(
+          (_) async => [
+            LikeRecord(
+              targetEventId: testEventId,
+              reactionEventId: 'reaction_$testEventId',
+              createdAt: DateTime.utc(2026),
+            ),
+          ],
+        );
+        repository = createRepository();
+
+        // Pin the baseline: the record is genuinely loaded before we act, so
+        // the assertion after the throw cannot pass on an empty cache.
+        expect(await repository.getLikedEventIds(), {testEventId});
+
+        await expectLater(repository.clearCache(), throwsA(isA<StateError>()));
+
+        // All-or-nothing: the durable store rejected the clear, so the caches
+        // derived from it must still describe what is on disk.
+        expect(await repository.getLikedEventIds(), {testEventId});
+        expect(await repository.isLiked(testEventId), isTrue);
+      });
     });
 
     group('_ensureInitialized', () {

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -4535,20 +4535,6 @@ void main() {
       });
     });
 
-    group('_ensureInitialized', () {
-      test('an unreadable store degrades instead of throwing', () async {
-        when(
-          () => mockLocalStorage.getAllLikeRecords(),
-        ).thenThrow(StateError('database is dead'));
-        repository = createRepository();
-
-        // Callers are publish paths: the read is swallowed so a dead cache
-        // costs a stale already-liked check rather than the Kind 7.
-        await expectLater(repository.getLikedEventIds(), completion(isEmpty));
-        await expectLater(repository.isLiked(testEventId), completion(isFalse));
-      });
-    });
-
     group('watchLikedEventIds', () {
       test('seeds from local storage, then streams repository cache', () async {
         final mockEvent = MockEvent();

--- a/mobile/packages/reposts_repository/lib/src/reposts_local_storage.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_local_storage.dart
@@ -56,8 +56,11 @@ abstract class RepostsLocalStorage {
   /// Emits a new set whenever reposts change.
   Stream<Set<String>> watchRepostedAddressableIds();
 
-  /// Clears all repost records.
+  /// Clears all repost records belonging to this storage's account.
   ///
-  /// Used when logging out or resetting local data.
+  /// Throws if the underlying store cannot be opened or the bulk delete
+  /// fails; callers decide whether that is recoverable. Note that erasing a
+  /// signed-out account's rows is done by the cleanup in
+  /// `social_providers.dart`, not through this method.
   Future<void> clearAll();
 }

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -1163,28 +1163,21 @@ class RepostsRepository {
   Future<void> _ensureInitialized() async {
     if (_isInitialized) return;
 
+    // Degrade to an in-memory-only cache rather than failing the caller.
+    // Callers are publish paths: an unreadable cache costs a stale
+    // already-reposted check, while throwing here costs the Kind 16.
     final localStorage = _localStorage;
     if (localStorage != null) {
-      try {
-        final records = await localStorage.getAllRepostRecords();
+      final records = await _bestEffortLocalStorage(
+        localStorage.getAllRepostRecords,
+        description: 'loading persisted reposts',
+        site: RepostsRepositoryReportableSites.ensureInitializedLoadRecords,
+      );
+      if (records != null) {
         for (final record in records) {
           _repostRecords[record.addressableId] = record;
         }
         _emitRepostedIds();
-      } on Object catch (e, stackTrace) {
-        // Degrade to an in-memory-only cache rather than failing the caller.
-        // Callers are publish paths: an unreadable cache costs a stale
-        // already-reposted check, while throwing here costs the Kind 16.
-        _markStorageDegraded(
-          e,
-          stackTrace,
-          site: RepostsRepositoryReportableSites.ensureInitializedLoadRecords,
-        );
-        Log.warning(
-          'Repost cache unavailable; continuing without persisted records: $e',
-          name: 'RepostsRepository',
-          category: LogCategory.system,
-        );
       }
     }
     // Latched on both paths: an unreadable database stays unreadable for the

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -1122,17 +1122,26 @@ class RepostsRepository {
     _emitRepostedIds();
   }
 
-  /// Clear all local repost data.
+  /// Clear all local repost data. Does not affect data on relays.
   ///
-  /// Used when logging out or clearing user data.
-  /// Does not affect data on relays.
+  /// Clears the durable store first, so the clear is all-or-nothing: if
+  /// [RepostsLocalStorage.clearAll] throws, the in-memory caches are left
+  /// intact, nothing is emitted, and the failure reaches the caller. A clear
+  /// that did not happen is therefore never reported as one.
+  ///
+  /// This is deliberately not routed through `_bestEffortLocalStorage`. That
+  /// helper exists so a dead cache cannot block a relay publish; clearing
+  /// publishes nothing, and the thing at risk here is the deletion itself.
+  /// Erasing a signed-out account's rows is handled by the cleanup in
+  /// `social_providers.dart`, which is likewise required to surface failures
+  /// rather than swallow them.
   ///
   /// Safe to call after [dispose] -- the cache is still cleared but no
   /// stream emission is attempted.
   Future<void> clearCache() async {
+    await _localStorage?.clearAll();
     _repostRecords.clear();
     _localCountCache.clear();
-    await _localStorage?.clearAll();
     _emitRepostedIds();
     _isInitialized = false;
   }

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -1136,8 +1136,8 @@ class RepostsRepository {
   /// `social_providers.dart`, which is likewise required to surface failures
   /// rather than swallow them.
   ///
-  /// Safe to call after [dispose] -- the cache is still cleared but no
-  /// stream emission is attempted.
+  /// Safe to call after [dispose] -- a successful clear still clears the
+  /// cache, but no stream emission is attempted.
   Future<void> clearCache() async {
     await _localStorage?.clearAll();
     _repostRecords.clear();

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -2357,6 +2357,43 @@ void main() {
         // after calling close" on the BehaviorSubject.
         await expectLater(repository.clearCache(), completes);
       });
+
+      test('a failing clearAll leaves the in-memory cache intact', () async {
+        // The stub lives here rather than in the shared setUp so the failure
+        // it describes stays adjacent to the test that depends on it.
+        when(
+          () => mockLocalStorage.clearAll(),
+        ).thenThrow(StateError('database is dead'));
+        when(() => mockLocalStorage.getAllRepostRecords()).thenAnswer(
+          (_) async => [
+            RepostRecord(
+              addressableId: testAddressableId,
+              repostEventId: testEventId,
+              originalAuthorPubkey: testAuthorPubkey,
+              createdAt: DateTime.utc(2026),
+            ),
+          ],
+        );
+        final repository = RepostsRepository(
+          nostrClient: mockNostrClient,
+          localStorage: mockLocalStorage,
+        );
+
+        // Pin the baseline: the record is genuinely loaded before we act, so
+        // the assertion after the throw cannot pass on an empty cache.
+        expect(await repository.getRepostedAddressableIds(), {
+          testAddressableId,
+        });
+
+        await expectLater(repository.clearCache(), throwsA(isA<StateError>()));
+
+        // All-or-nothing: the durable store rejected the clear, so the caches
+        // derived from it must still describe what is on disk.
+        expect(repository.isRepostedSync(testAddressableId), isTrue);
+        expect(await repository.getRepostedAddressableIds(), {
+          testAddressableId,
+        });
+      });
     });
 
     group('_ensureInitialized', () {

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -2359,6 +2359,41 @@ void main() {
       });
     });
 
+    group('_ensureInitialized', () {
+      test(
+        'an unreadable store degrades to the in-memory stream instead of '
+        'throwing',
+        () async {
+          when(
+            () => mockLocalStorage.getAllRepostRecords(),
+          ).thenThrow(StateError('database is dead'));
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+          );
+
+          // The read is swallowed rather than propagated to the caller...
+          await expectLater(
+            repository.getRepostedAddressableIds(),
+            completion(isEmpty),
+          );
+
+          // ...and the failure latched _storageDegraded, so the watch falls
+          // back to the in-memory controller rather than storage's own query
+          // stream, which on a dead database would never emit.
+          await repository.repostVideo(
+            addressableId: testAddressableId,
+            originalAuthorPubkey: testAuthorPubkey,
+          );
+          await expectLater(
+            repository.watchRepostedAddressableIds().first,
+            completion(contains(testAddressableId)),
+          );
+          verifyNever(() => mockLocalStorage.watchRepostedAddressableIds());
+        },
+      );
+    });
+
     group('watchRepostedAddressableIds', () {
       test('returns internal stream when no local storage', () async {
         final repository = RepostsRepository(nostrClient: mockNostrClient);

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -2396,41 +2396,6 @@ void main() {
       });
     });
 
-    group('_ensureInitialized', () {
-      test(
-        'an unreadable store degrades to the in-memory stream instead of '
-        'throwing',
-        () async {
-          when(
-            () => mockLocalStorage.getAllRepostRecords(),
-          ).thenThrow(StateError('database is dead'));
-          final repository = RepostsRepository(
-            nostrClient: mockNostrClient,
-            localStorage: mockLocalStorage,
-          );
-
-          // The read is swallowed rather than propagated to the caller...
-          await expectLater(
-            repository.getRepostedAddressableIds(),
-            completion(isEmpty),
-          );
-
-          // ...and the failure latched _storageDegraded, so the watch falls
-          // back to the in-memory controller rather than storage's own query
-          // stream, which on a dead database would never emit.
-          await repository.repostVideo(
-            addressableId: testAddressableId,
-            originalAuthorPubkey: testAuthorPubkey,
-          );
-          await expectLater(
-            repository.watchRepostedAddressableIds().first,
-            completion(contains(testAddressableId)),
-          );
-          verifyNever(() => mockLocalStorage.watchRepostedAddressableIds());
-        },
-      );
-    });
-
     group('watchRepostedAddressableIds', () {
       test('returns internal stream when no local storage', () async {
         final repository = RepostsRepository(nostrClient: mockNostrClient);


### PR DESCRIPTION
## Description

Two repositories keep a local SQLite mirror of the signed-in account's likes and reposts. Both had a `clearCache()` that emptied its in-memory maps **before** asking the database to delete the rows:

```dart
_repostRecords.clear();
_localCountCache.clear();
await _localStorage?.clearAll();   // if this throws...
_emitRepostedIds();                // ...never runs
_isInitialized = false;            // ...never runs
```

When the delete fails, the repository ends up describing a world that does not exist: memory says "no likes, no reposts", the database still holds every row, the stream is never re-emitted so subscribers keep rendering the *pre-clear* set, and `_isInitialized` stays `true` so nothing ever reloads to correct it.

I measured this rather than reasoning about it, using a storage double whose `clearAll()` throws:

| Probe | Result |
|---|---|
| Does the call propagate? | yes, `StateError` |
| `getRepostedAddressableIds()` after the failure | `{}` — while storage still holds the record |
| `getAllRepostRecords()` reads afterwards | **1** — `_isInitialized` stayed true, so no reload |

**The fix is ordering.** Clearing the durable store first makes the operation all-or-nothing: if `clearAll()` throws, nothing is cleared anywhere, no stream claims otherwise, and the caller still sees the failure. If it succeeds, everything is cleared as before.

The PR also finishes a deduplication left over from #6867. `_ensureInitialized()` hand-rolled the same try/catch, log and degrade-latch that `_bestEffortLocalStorage()` already provides — the same helper `initialize()` and `syncUserReposts()` / `syncUserReactions()` were routed through in that PR. This is the site that was missed. Behaviour is unchanged; the helper calls the same degrade hook, and only the storage read can throw.

**Related Issue:** Closes #7729

### One deliberate deviation from the issue

#7729 asked for the `clearAll()` call to be wrapped in `_bestEffortLocalStorage()`, which logs and swallows. I did not do that, for three reasons:

1. **That helper's job is protecting relay publishes.** Its own doc says it exists so a dead cache "must never block a relay publish". `clearCache()` publishes nothing — the thing at risk is the deletion itself.
2. **It would contradict the policy already applied to these exact tables.** `social_providers.dart` deletes personal reactions and reposts through a `requiredDelete` helper that logs **and rethrows**, under an explicit `deleteUserData ? requiredCleanup : safeCleanup` split. Destructive deletes are loud here by design.
3. **`clearCache()` has no production callers at all** — every reference outside the two implementations is a test. Swallowing would have hardened a method nothing calls, in a direction the codebase rejects elsewhere.

No `clearCacheClearAll` reportable site is added, because nothing is being swallowed.

While confirming that, I found the doc comments on `clearCache()` **and** on both `clearAll()` interface methods all claimed "Used when logging out or clearing user data." None of them is — logout goes through `social_providers.dart` to the DAOs directly. That false pointer is what would lead someone to wire the wrong entry point into logout, so it is corrected at both levels.

## Out of Scope

- **#7730** (mid-session storage degradation not switching an already-open watch stream) — independent; different method, and this PR does not change when `_storageDegraded` is set.
- **Wiring `clearCache()` into the real logout path.** Architecturally tempting, but blocked: the provider builds `localStorage` only when a pubkey exists, so by cleanup time it is null and `clearCache()` would silently no-op.
- **Extracting the duplicated `_bestEffortLocalStorage`.** It exists in exactly these two packages and the copies have already diverged; consolidating them is a wider change.
- **A pre-existing concurrent double-init.** Several callers can pass `_ensureInitialized`'s guard at once. It is wasteful but harmless — every write is keyed map assignment — and this PR moves neither the guard nor the latch.

## Verification

- `flutter test` — reposts **147 pass**, likes **285 pass**
- `flutter test --coverage` — reposts **100.00% (438/438)**, which its CI gate requires (it sets no `min_coverage`, so it inherits VeryGood's default of 100); likes **96.97%** against a gate of 62
- `flutter analyze lib test integration_test` — **No issues found!**
- `dart format` — clean
- **Mutation-checked:** both new `clearCache` tests were run against the unfixed ordering and fail there, so they are real regression tests. The two `_ensureInitialized` tests pass either way by design — that half is behaviour-preserving, so they are characterization tests pinning the degrade contract (the reposts one asserts the in-memory fallback stream is used and storage's own watch is never subscribed).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
- [x] 📝 Documentation