### PR TITLE
fix(auth): fall back remotely without hiding local signer failures

### DIFF
--- a/mobile/lib/services/auth/nostr_identity.dart
+++ b/mobile/lib/services/auth/nostr_identity.dart
@@ -244,13 +244,11 @@ class KeycastNostrIdentity extends NostrIdentity
   Future<Event?> signEvent(Event event) async {
     // Try local signing first when a matching local key is available.
     if (_localSigner case final local?) {
-      final signed = await local.signEvent(event);
-      if (signed != null) return signed;
-      Log.warning(
-        'Local signing failed for Keycast identity, falling back to RPC',
-        name: 'KeycastNostrIdentity',
-        category: LogCategory.auth,
+      final signed = await _tryLocal(
+        () => local.signEvent(event),
+        operation: .signEvent,
       );
+      if (signed != null) return signed;
       // signsWithLocalKey is true for this identity, so the caller skips its
       // post-sign verify. This fallback result came from the remote RPC — a
       // trust boundary — so verify it here to honor that contract; otherwise a
@@ -276,7 +274,10 @@ class KeycastNostrIdentity extends NostrIdentity
     // BYOK setup or signed in with a recovery phrase.
     final local = _localSigner;
     if (local != null) {
-      final result = await local.signCanonicalPayload(payload);
+      final result = await _tryLocal(
+        () => local.signCanonicalPayload(payload),
+        operation: .signCanonicalPayload,
+      );
       if (result != null && result.isNotEmpty) return result;
     }
 
@@ -349,7 +350,10 @@ class KeycastNostrIdentity extends NostrIdentity
   @override
   Future<String?> encrypt(String pubkey, String plaintext) async {
     if (_localSigner case final local?) {
-      final result = await local.encrypt(pubkey, plaintext);
+      final result = await _tryLocal(
+        () => local.encrypt(pubkey, plaintext),
+        operation: .nip04Encrypt,
+      );
       if (result != null) return result;
     }
     return _rpcSigner.encrypt(pubkey, plaintext);
@@ -358,7 +362,10 @@ class KeycastNostrIdentity extends NostrIdentity
   @override
   Future<String?> decrypt(String pubkey, String ciphertext) async {
     if (_localSigner case final local?) {
-      final result = await local.decrypt(pubkey, ciphertext);
+      final result = await _tryLocal(
+        () => local.decrypt(pubkey, ciphertext),
+        operation: .nip04Decrypt,
+      );
       if (result != null) return result;
     }
     return _rpcSigner.decrypt(pubkey, ciphertext);
@@ -367,7 +374,10 @@ class KeycastNostrIdentity extends NostrIdentity
   @override
   Future<String?> nip44Encrypt(String pubkey, String plaintext) async {
     if (_localSigner case final local?) {
-      final result = await local.nip44Encrypt(pubkey, plaintext);
+      final result = await _tryLocal(
+        () => local.nip44Encrypt(pubkey, plaintext),
+        operation: .nip44Encrypt,
+      );
       if (result != null) return result;
     }
     return _rpcSigner.nip44Encrypt(pubkey, plaintext);
@@ -376,7 +386,10 @@ class KeycastNostrIdentity extends NostrIdentity
   @override
   Future<String?> nip44Decrypt(String pubkey, String ciphertext) async {
     if (_localSigner case final local?) {
-      final result = await local.nip44Decrypt(pubkey, ciphertext);
+      final result = await _tryLocal(
+        () => local.nip44Decrypt(pubkey, ciphertext),
+        operation: .nip44Decrypt,
+      );
       if (result != null) return result;
     }
     return _rpcSigner.nip44Decrypt(pubkey, ciphertext);
@@ -385,6 +398,24 @@ class KeycastNostrIdentity extends NostrIdentity
   @override
   void close() {
     // RPC signer lifecycle is managed by AuthService.
+  }
+
+  Future<T?> _tryLocal<T>(
+    Future<T?> Function() localCall, {
+    required LocalSignerOperation operation,
+  }) async {
+    try {
+      return await localCall();
+    } on LocalSignerOperationException catch (error, stackTrace) {
+      Log.warning(
+        'Local ${operation.name} failed for Keycast identity; falling back to RPC',
+        name: 'KeycastNostrIdentity',
+        category: LogCategory.auth,
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return null;
+    }
   }
 }
 

--- a/mobile/lib/services/auth/signer_factory.dart
+++ b/mobile/lib/services/auth/signer_factory.dart
@@ -307,20 +307,27 @@ class SignerFactory {
       return signedEvent;
     } catch (e, stackTrace) {
       Log.error(
-        'Failed to create or sign event: $e',
+        'Failed to create or sign event',
         name: 'SignerFactory',
         category: LogCategory.auth,
+        error: e,
+        stackTrace: stackTrace,
       );
       // An event signed for a different account is an invariant violation
       // (YES on the Reportable matrix), not an expected domain/network
       // failure — surface it to Crashlytics. Other errors keep the existing
       // log-only behavior to avoid flooding the dashboard.
-      if (e is EventSignerAccountMismatchException) {
+      if (e is EventSignerAccountMismatchException || e is Error) {
+        final isAccountMismatch = e is EventSignerAccountMismatchException;
         _reportError?.call(
           Reportable(e, context: 'createAndSignEvent'),
           stackTrace,
-          reason: 'Signer returned an event for a different account',
-          logMessage: 'Signer account mismatch during createAndSignEvent',
+          reason: isAccountMismatch
+              ? 'Signer returned an event for a different account'
+              : 'Unexpected signer invariant failure',
+          logMessage: isAccountMismatch
+              ? 'Signer account mismatch during createAndSignEvent'
+              : 'Unexpected signer invariant failure during createAndSignEvent',
         );
       }
       return null;

--- a/mobile/lib/services/local_key_signer.dart
+++ b/mobile/lib/services/local_key_signer.dart
@@ -63,7 +63,7 @@ class LocalKeySigner implements IsolateDecryptSigner {
       return _keyContainer.withPrivateKey<String>((privateKeyHex) {
         return schnorr.sign(privateKeyHex, digest, _canonicalPayloadAux);
       });
-    } on Exception catch (e) {
+    } on Object catch (e) {
       Log.error(
         'Failed to sign canonical payload: $e',
         name: 'LocalKeySigner',
@@ -80,7 +80,7 @@ class LocalKeySigner implements IsolateDecryptSigner {
         event.sign(privateKeyHex);
         return event;
       });
-    } on Exception catch (e) {
+    } on Object catch (e) {
       Log.error(
         'Failed to sign event: $e',
         name: 'LocalKeySigner',
@@ -100,7 +100,7 @@ class LocalKeySigner implements IsolateDecryptSigner {
         final agreement = NIP04.getAgreement(privateKeyHex);
         return NIP04.encrypt(plaintext, agreement, pubkey);
       });
-    } on Exception catch (e) {
+    } on Object catch (e) {
       Log.error(
         'NIP-04 encryption failed: $e',
         name: 'LocalKeySigner',
@@ -117,7 +117,7 @@ class LocalKeySigner implements IsolateDecryptSigner {
         final agreement = NIP04.getAgreement(privateKeyHex);
         return NIP04.decrypt(ciphertext, agreement, pubkey);
       });
-    } on Exception catch (e) {
+    } on Object catch (e) {
       Log.error(
         'NIP-04 decryption failed: $e',
         name: 'LocalKeySigner',

--- a/mobile/lib/services/local_key_signer.dart
+++ b/mobile/lib/services/local_key_signer.dart
@@ -13,6 +13,48 @@ const _canonicalPayloadAux =
     '00000000000000000000000000000000'
     '00000000000000000000000000000000';
 
+/// A local signer had the capability to perform an operation, attempted it,
+/// and failed.
+///
+/// This is distinct from a nullable signer result: `null` means the signer
+/// does not support the requested capability. Callers that compose local and
+/// remote signers may catch this exception to choose an explicit fallback.
+class LocalSignerOperationException implements Exception {
+  /// Creates a typed local-operation failure while preserving its [cause].
+  const LocalSignerOperationException(this.operation, this.cause);
+
+  /// The operation that failed, without any key or payload data.
+  final LocalSignerOperation operation;
+
+  /// The original failure.
+  final Object cause;
+
+  @override
+  String toString() =>
+      'LocalSignerOperationException(${operation.name}): ${cause.runtimeType}';
+}
+
+/// Operations that a [LocalKeySigner] can attempt and fail.
+enum LocalSignerOperation {
+  /// Deterministic signature over an arbitrary canonical payload.
+  signCanonicalPayload,
+
+  /// Nostr event signing.
+  signEvent,
+
+  /// NIP-04 encryption.
+  nip04Encrypt,
+
+  /// NIP-04 decryption.
+  nip04Decrypt,
+
+  /// NIP-44 encryption.
+  nip44Encrypt,
+
+  /// NIP-44 decryption.
+  nip44Decrypt,
+}
+
 /// NostrSigner implementation backed by a local [SecureKeyContainer].
 ///
 /// Used internally by [LocalNostrIdentity] and [KeycastNostrIdentity]'s
@@ -22,15 +64,10 @@ class LocalKeySigner implements IsolateDecryptSigner {
   ///
   /// The container is required. "No identity yet" is not this type's job —
   /// that state belongs to [UnauthenticatedSigner], which throws rather
-  /// than returning null. Keeping the container non-nullable is what lets
-  /// a `null` return from the methods below mean exactly one thing: a real
-  /// signing attempt failed.
-  ///
-  /// "Failed" covers `Error` as well as `Exception` — an off-curve peer
-  /// pubkey reaches ECDH as an `ArgumentError`, and NIP-04 surfaces one as a
-  /// `TypeError`. Both are failures of a real attempt, so both return `null`
-  /// rather than escaping to a caller that has no way to tell them apart from
-  /// the documented contract (#7332).
+  /// than returning null. Because this signer supports every operation it
+  /// exposes, an attempted operation either succeeds or throws
+  /// [LocalSignerOperationException]. Unexpected Dart [Error]s propagate so
+  /// programming-invariant failures remain visible and reportable.
   LocalKeySigner(this._keyContainer);
 
   final SecureKeyContainer _keyContainer;
@@ -55,7 +92,7 @@ class LocalKeySigner implements IsolateDecryptSigner {
   }
 
   @override
-  Future<String?> getPublicKey() async {
+  Future<String> getPublicKey() async {
     return _keyContainer.publicKeyHex;
   }
 
@@ -63,117 +100,147 @@ class LocalKeySigner implements IsolateDecryptSigner {
   ///
   /// Uses deterministic auxiliary data so repeated signing of the same payload
   /// produces the same signature, which keeps creator-binding assertions stable.
-  Future<String?> signCanonicalPayload(Uint8List payload) async {
+  ///
+  /// Throws [LocalSignerOperationException] if the signing attempt fails.
+  Future<String> signCanonicalPayload(Uint8List payload) async {
     try {
       final digest = sha256.convert(payload).toString();
       return _keyContainer.withPrivateKey<String>((privateKeyHex) {
         return schnorr.sign(privateKeyHex, digest, _canonicalPayloadAux);
       });
-    } on Object catch (e) {
-      Log.error(
-        'Failed to sign canonical payload: $e',
-        name: 'LocalKeySigner',
-        category: LogCategory.relay,
-      );
-      return null;
+    } on LocalSignerOperationException {
+      rethrow;
+    } on Exception catch (error, stackTrace) {
+      _throwOperationFailure(.signCanonicalPayload, error, stackTrace);
     }
   }
 
+  /// Throws [LocalSignerOperationException] if the signing attempt fails.
   @override
-  Future<Event?> signEvent(Event event) async {
+  Future<Event> signEvent(Event event) async {
     try {
       return _keyContainer.withPrivateKey<Event>((privateKeyHex) {
         event.sign(privateKeyHex);
         return event;
       });
-    } on Object catch (e) {
-      Log.error(
-        'Failed to sign event: $e',
-        name: 'LocalKeySigner',
-        category: LogCategory.relay,
-      );
-      return null;
+    } on LocalSignerOperationException {
+      rethrow;
+    } on Exception catch (error, stackTrace) {
+      _throwOperationFailure(.signEvent, error, stackTrace);
     }
   }
 
   @override
   Future<Map?> getRelays() async => null;
 
+  /// Throws [LocalSignerOperationException] if encryption fails.
   @override
-  Future<String?> encrypt(String pubkey, String plaintext) async {
+  Future<String> encrypt(String pubkey, String plaintext) async {
     try {
-      return _keyContainer.withPrivateKey<String?>((privateKeyHex) {
+      return _keyContainer.withPrivateKey<String>((privateKeyHex) {
+        _validatePeerPubkey(pubkey, operation: .nip04Encrypt);
         final agreement = NIP04.getAgreement(privateKeyHex);
         return NIP04.encrypt(plaintext, agreement, pubkey);
       });
-    } on Object catch (e) {
-      Log.error(
-        'NIP-04 encryption failed: $e',
-        name: 'LocalKeySigner',
-        category: LogCategory.relay,
-      );
-      return null;
+    } on LocalSignerOperationException {
+      rethrow;
+    } on Exception catch (error, stackTrace) {
+      _throwOperationFailure(.nip04Encrypt, error, stackTrace);
     }
   }
 
+  /// Throws [LocalSignerOperationException] if decryption fails.
   @override
-  Future<String?> decrypt(String pubkey, String ciphertext) async {
+  Future<String> decrypt(String pubkey, String ciphertext) async {
     try {
-      return _keyContainer.withPrivateKey<String?>((privateKeyHex) {
+      return _keyContainer.withPrivateKey<String>((privateKeyHex) {
+        _validatePeerPubkey(pubkey, operation: .nip04Decrypt);
         final agreement = NIP04.getAgreement(privateKeyHex);
         return NIP04.decrypt(ciphertext, agreement, pubkey);
       });
-    } on Object catch (e) {
-      Log.error(
-        'NIP-04 decryption failed: $e',
-        name: 'LocalKeySigner',
-        category: LogCategory.relay,
-      );
-      return null;
+    } on LocalSignerOperationException {
+      rethrow;
+    } on Exception catch (error, stackTrace) {
+      _throwOperationFailure(.nip04Decrypt, error, stackTrace);
     }
   }
 
+  /// Throws [LocalSignerOperationException] if encryption fails.
   @override
-  Future<String?> nip44Encrypt(String pubkey, String plaintext) async {
+  Future<String> nip44Encrypt(String pubkey, String plaintext) async {
     try {
-      // ECDH is synchronous, so the raw key hex is exposed only for this
-      // step; the cipher below runs on the derived conversation key. Keeping
-      // the await outside `withPrivateKey` is also what makes the handler
-      // reachable: `return`ing a future out of a `try` leaves the block
-      // before the future can reject.
+      // Keep the async cipher outside the private-key scope and await it inside
+      // this try so failures retain their typed boundary (#7332).
       final conversationKey = _keyContainer.withPrivateKey<Uint8List>(
-        (privateKeyHex) => NIP44V2.shareSecret(privateKeyHex, pubkey),
+        (privateKeyHex) {
+          _validatePeerPubkey(pubkey, operation: .nip44Encrypt);
+          return NIP44V2.shareSecret(privateKeyHex, pubkey);
+        },
       );
       return await NIP44V2.encrypt(plaintext, conversationKey);
-    } on Object catch (e) {
-      Log.error(
-        'NIP-44 encryption failed: $e',
-        name: 'LocalKeySigner',
-        category: LogCategory.relay,
-      );
-      return null;
+    } on LocalSignerOperationException {
+      rethrow;
+    } on Exception catch (error, stackTrace) {
+      _throwOperationFailure(.nip44Encrypt, error, stackTrace);
     }
   }
 
+  /// Throws [LocalSignerOperationException] if decryption fails.
   @override
-  Future<String?> nip44Decrypt(String pubkey, String ciphertext) async {
+  Future<String> nip44Decrypt(String pubkey, String ciphertext) async {
     try {
       final sealKey = _keyContainer.withPrivateKey<Uint8List>(
-        (privateKeyHex) => NIP44V2.shareSecret(privateKeyHex, pubkey),
+        (privateKeyHex) {
+          _validatePeerPubkey(pubkey, operation: .nip44Decrypt);
+          return NIP44V2.shareSecret(privateKeyHex, pubkey);
+        },
       );
       return await NIP44V2.decrypt(ciphertext, sealKey);
-    } on Object catch (e) {
-      Log.error(
-        'NIP-44 decryption failed: $e',
-        name: 'LocalKeySigner',
-        category: LogCategory.relay,
-      );
-      return null;
+    } on LocalSignerOperationException {
+      rethrow;
+    } on Exception catch (error, stackTrace) {
+      _throwOperationFailure(.nip44Decrypt, error, stackTrace);
     }
   }
 
   @override
   void close() {
     // Key container is managed by AuthService, not disposed here
+  }
+
+  void _validatePeerPubkey(
+    String pubkey, {
+    required LocalSignerOperation operation,
+  }) {
+    try {
+      if (!keyIsValid(pubkey)) {
+        throw const FormatException('Peer public key must be 32-byte hex');
+      }
+      NIP04.liftX(BigInt.parse(pubkey, radix: 16));
+    } on Object catch (error, stackTrace) {
+      // This catch is deliberately scoped to peer-key validation. The crypto
+      // package exposes an invalid curve point as a raw Dart Error; translate
+      // that untrusted-input outcome here without hiding Errors from the
+      // signing or cipher operations themselves.
+      _throwOperationFailure(operation, error, stackTrace);
+    }
+  }
+
+  Never _throwOperationFailure(
+    LocalSignerOperation operation,
+    Object error,
+    StackTrace stackTrace,
+  ) {
+    Log.error(
+      'Local signer operation failed',
+      name: 'LocalKeySigner',
+      category: LogCategory.relay,
+      error: error,
+      stackTrace: stackTrace,
+    );
+    Error.throwWithStackTrace(
+      LocalSignerOperationException(operation, error),
+      stackTrace,
+    );
   }
 }

--- a/mobile/lib/services/local_key_signer.dart
+++ b/mobile/lib/services/local_key_signer.dart
@@ -130,13 +130,16 @@ class LocalKeySigner implements IsolateDecryptSigner {
   @override
   Future<String?> nip44Encrypt(String pubkey, String plaintext) async {
     try {
-      return _keyContainer.withPrivateKey<Future<String?>>((
-        privateKeyHex,
-      ) async {
-        final conversationKey = NIP44V2.shareSecret(privateKeyHex, pubkey);
-        return NIP44V2.encrypt(plaintext, conversationKey);
-      });
-    } on Exception catch (e) {
+      // ECDH is synchronous, so the raw key hex is exposed only for this
+      // step; the cipher below runs on the derived conversation key. Keeping
+      // the await outside `withPrivateKey` is also what makes the handler
+      // reachable: `return`ing a future out of a `try` leaves the block
+      // before the future can reject.
+      final conversationKey = _keyContainer.withPrivateKey<Uint8List>(
+        (privateKeyHex) => NIP44V2.shareSecret(privateKeyHex, pubkey),
+      );
+      return await NIP44V2.encrypt(plaintext, conversationKey);
+    } on Object catch (e) {
       Log.error(
         'NIP-44 encryption failed: $e',
         name: 'LocalKeySigner',
@@ -149,13 +152,11 @@ class LocalKeySigner implements IsolateDecryptSigner {
   @override
   Future<String?> nip44Decrypt(String pubkey, String ciphertext) async {
     try {
-      return _keyContainer.withPrivateKey<Future<String?>>((
-        privateKeyHex,
-      ) async {
-        final sealKey = NIP44V2.shareSecret(privateKeyHex, pubkey);
-        return NIP44V2.decrypt(ciphertext, sealKey);
-      });
-    } on Exception catch (e) {
+      final sealKey = _keyContainer.withPrivateKey<Uint8List>(
+        (privateKeyHex) => NIP44V2.shareSecret(privateKeyHex, pubkey),
+      );
+      return await NIP44V2.decrypt(ciphertext, sealKey);
+    } on Object catch (e) {
       Log.error(
         'NIP-44 decryption failed: $e',
         name: 'LocalKeySigner',

--- a/mobile/lib/services/local_key_signer.dart
+++ b/mobile/lib/services/local_key_signer.dart
@@ -25,6 +25,12 @@ class LocalKeySigner implements IsolateDecryptSigner {
   /// than returning null. Keeping the container non-nullable is what lets
   /// a `null` return from the methods below mean exactly one thing: a real
   /// signing attempt failed.
+  ///
+  /// "Failed" covers `Error` as well as `Exception` — an off-curve peer
+  /// pubkey reaches ECDH as an `ArgumentError`, and NIP-04 surfaces one as a
+  /// `TypeError`. Both are failures of a real attempt, so both return `null`
+  /// rather than escaping to a caller that has no way to tell them apart from
+  /// the documented contract (#7332).
   LocalKeySigner(this._keyContainer);
 
   final SecureKeyContainer _keyContainer;

--- a/mobile/test/services/auth/nostr_identity_test.dart
+++ b/mobile/test/services/auth/nostr_identity_test.dart
@@ -104,6 +104,111 @@ void main() {
       mockRpc = _MockNostrSigner();
     });
 
+    // #7332: these four fallbacks were unreachable. The local signer threw
+    // instead of returning null, so `if (result != null)` never got a chance
+    // to fall through and the RPC signer was never consulted at all. A mocked
+    // local signer returning null cannot pin that — the identity always
+    // handled null correctly — so these drive a REAL LocalKeySigner into a
+    // genuine crypto failure with an off-curve peer pubkey.
+    group('crypto fallback to RPC when the local signer fails', () {
+      // Well-formed 32-byte hex that is not a point on secp256k1.
+      const offCurvePubkey =
+          '0000000000000000000000000000000000000000000000000000000000000000';
+
+      late KeycastNostrIdentity identity;
+      late _MockSecureKeyContainer container;
+
+      setUp(() {
+        container = _MockSecureKeyContainer();
+        when(() => container.publicKeyHex).thenReturn(testPublicKey);
+        when(() => container.isDisposed).thenReturn(false);
+        when(() => container.hasPrivateKey).thenReturn(true);
+        when(() => container.withPrivateKey<Uint8List>(any())).thenAnswer((
+          invocation,
+        ) {
+          final callback =
+              invocation.positionalArguments[0] as Uint8List Function(String);
+          return callback(testPrivateKey);
+        });
+        when(() => container.withPrivateKey<String?>(any())).thenAnswer((
+          invocation,
+        ) {
+          final callback =
+              invocation.positionalArguments[0] as String? Function(String);
+          return callback(testPrivateKey);
+        });
+
+        identity = KeycastNostrIdentity(
+          pubkey: testPublicKey,
+          rpcSigner: mockRpc,
+          localSigner: LocalKeySigner(container),
+        );
+      });
+
+      test('nip44Encrypt falls back to RPC', () async {
+        when(
+          () => mockRpc.nip44Encrypt(any(), any()),
+        ).thenAnswer((_) async => 'rpc-ciphertext');
+
+        expect(
+          await identity.nip44Encrypt(offCurvePubkey, 'hello'),
+          equals('rpc-ciphertext'),
+        );
+        verify(() => mockRpc.nip44Encrypt(any(), any())).called(1);
+        // Pins that the local signer really attempted the operation and
+        // returned null, rather than an unstubbed mock handing back null.
+        verify(() => container.withPrivateKey<Uint8List>(any())).called(1);
+      });
+
+      test('nip44Decrypt falls back to RPC', () async {
+        when(
+          () => mockRpc.nip44Decrypt(any(), any()),
+        ).thenAnswer((_) async => 'rpc-plaintext');
+
+        expect(
+          await identity.nip44Decrypt(offCurvePubkey, 'AgAB'),
+          equals('rpc-plaintext'),
+        );
+        verify(() => mockRpc.nip44Decrypt(any(), any())).called(1);
+        // Pins that the local signer really attempted the operation and
+        // returned null, rather than an unstubbed mock handing back null.
+        verify(() => container.withPrivateKey<Uint8List>(any())).called(1);
+      });
+
+      test('encrypt falls back to RPC', () async {
+        when(
+          () => mockRpc.encrypt(any(), any()),
+        ).thenAnswer((_) async => 'rpc-nip04-ciphertext');
+
+        expect(
+          await identity.encrypt(offCurvePubkey, 'hello'),
+          equals('rpc-nip04-ciphertext'),
+        );
+        verify(() => mockRpc.encrypt(any(), any())).called(1);
+        // Pins that the local signer really attempted the operation and
+        // returned null, rather than an unstubbed mock handing back null.
+        verify(() => container.withPrivateKey<String?>(any())).called(1);
+      });
+
+      test('decrypt falls back to RPC', () async {
+        when(
+          () => mockRpc.decrypt(any(), any()),
+        ).thenAnswer((_) async => 'rpc-nip04-plaintext');
+
+        expect(
+          await identity.decrypt(
+            offCurvePubkey,
+            'AA==?iv=AAAAAAAAAAAAAAAAAAAAAA==',
+          ),
+          equals('rpc-nip04-plaintext'),
+        );
+        verify(() => mockRpc.decrypt(any(), any())).called(1);
+        // Pins that the local signer really attempted the operation and
+        // returned null, rather than an unstubbed mock handing back null.
+        verify(() => container.withPrivateKey<String?>(any())).called(1);
+      });
+    });
+
     test('pubkey is set at construction', () {
       final identity = KeycastNostrIdentity(
         pubkey: testPublicKey,

--- a/mobile/test/services/auth/nostr_identity_test.dart
+++ b/mobile/test/services/auth/nostr_identity_test.dart
@@ -105,11 +105,10 @@ void main() {
     });
 
     // #7332: these four fallbacks were unreachable. The local signer threw
-    // instead of returning null, so `if (result != null)` never got a chance
-    // to fall through and the RPC signer was never consulted at all. A mocked
-    // local signer returning null cannot pin that — the identity always
-    // handled null correctly — so these drive a REAL LocalKeySigner into a
-    // genuine crypto failure with an off-curve peer pubkey.
+    // instead of producing a typed failure, so the identity had no explicit
+    // failure it could catch before consulting RPC. A mocked local signer
+    // cannot pin the LocalKeySigner boundary, so these drive a REAL signer
+    // into a genuine crypto failure with an off-curve peer pubkey.
     group('crypto fallback to RPC when the local signer fails', () {
       // Well-formed 32-byte hex that is not a point on secp256k1.
       const offCurvePubkey =
@@ -130,11 +129,11 @@ void main() {
               invocation.positionalArguments[0] as Uint8List Function(String);
           return callback(testPrivateKey);
         });
-        when(() => container.withPrivateKey<String?>(any())).thenAnswer((
+        when(() => container.withPrivateKey<String>(any())).thenAnswer((
           invocation,
         ) {
           final callback =
-              invocation.positionalArguments[0] as String? Function(String);
+              invocation.positionalArguments[0] as String Function(String);
           return callback(testPrivateKey);
         });
 
@@ -156,7 +155,7 @@ void main() {
         );
         verify(() => mockRpc.nip44Encrypt(any(), any())).called(1);
         // Pins that the local signer really attempted the operation and
-        // returned null, rather than an unstubbed mock handing back null.
+        // failed, rather than an unstubbed mock handing back null.
         verify(() => container.withPrivateKey<Uint8List>(any())).called(1);
       });
 
@@ -171,7 +170,7 @@ void main() {
         );
         verify(() => mockRpc.nip44Decrypt(any(), any())).called(1);
         // Pins that the local signer really attempted the operation and
-        // returned null, rather than an unstubbed mock handing back null.
+        // failed, rather than an unstubbed mock handing back null.
         verify(() => container.withPrivateKey<Uint8List>(any())).called(1);
       });
 
@@ -186,8 +185,8 @@ void main() {
         );
         verify(() => mockRpc.encrypt(any(), any())).called(1);
         // Pins that the local signer really attempted the operation and
-        // returned null, rather than an unstubbed mock handing back null.
-        verify(() => container.withPrivateKey<String?>(any())).called(1);
+        // failed, rather than an unstubbed mock handing back null.
+        verify(() => container.withPrivateKey<String>(any())).called(1);
       });
 
       test('decrypt falls back to RPC', () async {
@@ -204,8 +203,8 @@ void main() {
         );
         verify(() => mockRpc.decrypt(any(), any())).called(1);
         // Pins that the local signer really attempted the operation and
-        // returned null, rather than an unstubbed mock handing back null.
-        verify(() => container.withPrivateKey<String?>(any())).called(1);
+        // failed, rather than an unstubbed mock handing back null.
+        verify(() => container.withPrivateKey<String>(any())).called(1);
       });
     });
 
@@ -252,13 +251,18 @@ void main() {
     });
 
     test(
-      'signEvent falls back to RPC when local signer returns null and the '
+      'signEvent falls back to RPC when local signing fails and the '
       'RPC signature is valid',
       () async {
         final event = Event(testPublicKey, EventKind.textNote, [], 'test')
           ..sign(testPrivateKey);
         final mockLocal = _MockLocalKeySigner();
-        when(() => mockLocal.signEvent(any())).thenAnswer((_) async => null);
+        when(() => mockLocal.signEvent(any())).thenThrow(
+          const LocalSignerOperationException(
+            LocalSignerOperation.signEvent,
+            SecureKeyException('Local key unavailable'),
+          ),
+        );
         when(() => mockRpc.signEvent(any())).thenAnswer((_) async => event);
 
         final identity = KeycastNostrIdentity(
@@ -285,7 +289,12 @@ void main() {
         // returned, or the remote result would slip through unverified.
         final unsigned = Event(testPublicKey, EventKind.textNote, [], 'test');
         final mockLocal = _MockLocalKeySigner();
-        when(() => mockLocal.signEvent(any())).thenAnswer((_) async => null);
+        when(() => mockLocal.signEvent(any())).thenThrow(
+          const LocalSignerOperationException(
+            LocalSignerOperation.signEvent,
+            SecureKeyException('Local key unavailable'),
+          ),
+        );
         when(() => mockRpc.signEvent(any())).thenAnswer((_) async => unsigned);
 
         final identity = KeycastNostrIdentity(
@@ -470,14 +479,16 @@ void main() {
     );
 
     test(
-      'signCanonicalPayload falls back to KeycastRpc when local signer '
-      'returns null',
+      'signCanonicalPayload falls back to KeycastRpc when local signing fails',
       () async {
         final mockLocal = _MockLocalKeySigner();
         final mockKeycastRpc = _MockKeycastRpc();
-        when(
-          () => mockLocal.signCanonicalPayload(any()),
-        ).thenAnswer((_) async => null);
+        when(() => mockLocal.signCanonicalPayload(any())).thenThrow(
+          const LocalSignerOperationException(
+            LocalSignerOperation.signCanonicalPayload,
+            SecureKeyException('Local key unavailable'),
+          ),
+        );
         when(
           () => mockKeycastRpc.signCanonicalPayload(any()),
         ).thenAnswer((_) async => 'remote_sig_hex');
@@ -497,6 +508,25 @@ void main() {
         verify(() => mockKeycastRpc.signCanonicalPayload(any())).called(1);
       },
     );
+
+    test('does not hide unexpected local signer errors behind RPC', () async {
+      final mockLocal = _MockLocalKeySigner();
+      when(
+        () => mockLocal.nip44Encrypt(any(), any()),
+      ).thenThrow(StateError('broken signer invariant'));
+
+      final identity = KeycastNostrIdentity(
+        pubkey: testPublicKey,
+        rpcSigner: mockRpc,
+        localSigner: mockLocal,
+      );
+
+      await expectLater(
+        identity.nip44Encrypt(testPublicKey, 'hello'),
+        throwsStateError,
+      );
+      verifyNever(() => mockRpc.nip44Encrypt(any(), any()));
+    });
   });
 
   group(BunkerNostrIdentity, () {

--- a/mobile/test/services/auth/signer_factory_test.dart
+++ b/mobile/test/services/auth/signer_factory_test.dart
@@ -383,6 +383,39 @@ void main() {
         },
       );
 
+      test('reports unexpected signer errors as invariant failures', () async {
+        final remoteSigner = _MockNostrSigner();
+        when(
+          () => remoteSigner.signEvent(any()),
+        ).thenThrow(StateError('broken signer invariant'));
+        final identity = BunkerNostrIdentity(
+          pubkey: testPublicKey,
+          remoteSigner: remoteSigner,
+        );
+
+        final event = await factory.createAndSignEvent(
+          identity: identity,
+          authSource: AuthenticationSource.bunker,
+          kind: 1,
+          content: 'not signed',
+        );
+
+        expect(event, isNull);
+        expect(reported, hasLength(1));
+        expect(
+          reported.single.error,
+          isA<Reportable<Object>>().having(
+            (reportable) => reportable.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        );
+        expect(
+          reported.single.reason,
+          equals('Unexpected signer invariant failure'),
+        );
+      });
+
       test('returns null and reports when the signer answers for a '
           'different account', () async {
         final remoteSigner = _MockNostrSigner();

--- a/mobile/test/services/local_key_signer_test.dart
+++ b/mobile/test/services/local_key_signer_test.dart
@@ -123,6 +123,48 @@ void main() {
         expect(ciphertext, isNot(equals(plaintext)));
       });
 
+      // #7332: NIP-04 has no un-awaited-future bug — its callback is
+      // synchronous — but `on Exception` still let an `Error` through.
+      // `NIP04.getPubkey` catches the off-curve `Error` from `liftX`, leaves
+      // `y` null, then dereferences `y!`, so an off-curve pubkey raised a
+      // `TypeError` out of a method declared `Future<String?>`.
+      test('encrypt returns null for an off-curve pubkey', () async {
+        when(() => mockKeyContainer.withPrivateKey<String?>(any())).thenAnswer((
+          invocation,
+        ) {
+          final callback =
+              invocation.positionalArguments[0] as String? Function(String);
+          return callback(testPrivateKey);
+        });
+
+        final signer = LocalKeySigner(mockKeyContainer);
+
+        expect(await signer.encrypt(offCurvePubkey, 'Hello!'), isNull);
+      });
+
+      test('decrypt returns null for an off-curve pubkey', () async {
+        when(() => mockKeyContainer.withPrivateKey<String?>(any())).thenAnswer((
+          invocation,
+        ) {
+          final callback =
+              invocation.positionalArguments[0] as String? Function(String);
+          return callback(testPrivateKey);
+        });
+
+        final signer = LocalKeySigner(mockKeyContainer);
+
+        // The IV must be real base64, or `base64.decode` throws a
+        // FormatException — an Exception, which the old handler already
+        // caught — and we never reach the off-curve `Error` path.
+        expect(
+          await signer.decrypt(
+            offCurvePubkey,
+            'AA==?iv=AAAAAAAAAAAAAAAAAAAAAA==',
+          ),
+          isNull,
+        );
+      });
+
       test('decrypt decrypts ciphertext', () async {
         when(() => mockKeyContainer.withPrivateKey<String?>(any())).thenAnswer((
           invocation,

--- a/mobile/test/services/local_key_signer_test.dart
+++ b/mobile/test/services/local_key_signer_test.dart
@@ -70,12 +70,11 @@ void main() {
 
         final signedEvent = await signer.signEvent(event);
 
-        expect(signedEvent, isNotNull);
-        expect(signedEvent!.sig, isNotEmpty);
+        expect(signedEvent.sig, isNotEmpty);
         verify(() => mockKeyContainer.withPrivateKey<Event>(any())).called(1);
       });
 
-      test('returns null when signing fails', () async {
+      test('throws a typed failure when the key container refuses', () async {
         when(
           () => mockKeyContainer.withPrivateKey<Event>(any()),
         ).thenThrow(const SecureKeyException('Failed to sign'));
@@ -88,9 +87,66 @@ void main() {
           'Test content',
         );
 
-        final signedEvent = await signer.signEvent(event);
+        await expectLater(
+          signer.signEvent(event),
+          throwsA(
+            isA<LocalSignerOperationException>().having(
+              (error) => error.cause,
+              'cause',
+              isA<SecureKeyException>(),
+            ),
+          ),
+        );
+      });
 
-        expect(signedEvent, isNull);
+      test('does not hide programming errors', () async {
+        when(
+          () => mockKeyContainer.withPrivateKey<Event>(any()),
+        ).thenThrow(StateError('broken signing invariant'));
+
+        final signer = LocalKeySigner(mockKeyContainer);
+        final event = Event(
+          testPublicKey,
+          EventKind.textNote,
+          [],
+          'Test content',
+        );
+
+        await expectLater(signer.signEvent(event), throwsStateError);
+      });
+    });
+
+    group('signCanonicalPayload', () {
+      test('throws a typed failure when the key container refuses', () async {
+        when(
+          () => mockKeyContainer.withPrivateKey<String>(any()),
+        ).thenThrow(const SecureKeyException('Failed to sign'));
+
+        final signer = LocalKeySigner(mockKeyContainer);
+
+        await expectLater(
+          signer.signCanonicalPayload(Uint8List.fromList([1, 2, 3])),
+          throwsA(
+            isA<LocalSignerOperationException>().having(
+              (error) => error.operation,
+              'operation',
+              LocalSignerOperation.signCanonicalPayload,
+            ),
+          ),
+        );
+      });
+
+      test('does not hide programming errors', () async {
+        when(
+          () => mockKeyContainer.withPrivateKey<String>(any()),
+        ).thenThrow(StateError('broken canonical-signing invariant'));
+
+        final signer = LocalKeySigner(mockKeyContainer);
+
+        await expectLater(
+          signer.signCanonicalPayload(Uint8List.fromList([1, 2, 3])),
+          throwsStateError,
+        );
       });
     });
 
@@ -106,11 +162,11 @@ void main() {
 
     group('encrypt/decrypt (NIP-04)', () {
       test('encrypt encrypts plaintext', () async {
-        when(() => mockKeyContainer.withPrivateKey<String?>(any())).thenAnswer((
+        when(() => mockKeyContainer.withPrivateKey<String>(any())).thenAnswer((
           invocation,
         ) {
           final callback =
-              invocation.positionalArguments[0] as String? Function(String);
+              invocation.positionalArguments[0] as String Function(String);
           return callback(testPrivateKey);
         });
 
@@ -128,26 +184,29 @@ void main() {
       // `NIP04.getPubkey` catches the off-curve `Error` from `liftX`, leaves
       // `y` null, then dereferences `y!`, so an off-curve pubkey raised a
       // `TypeError` out of a method declared `Future<String?>`.
-      test('encrypt returns null for an off-curve pubkey', () async {
-        when(() => mockKeyContainer.withPrivateKey<String?>(any())).thenAnswer((
+      test('encrypt throws a typed failure for an off-curve pubkey', () async {
+        when(() => mockKeyContainer.withPrivateKey<String>(any())).thenAnswer((
           invocation,
         ) {
           final callback =
-              invocation.positionalArguments[0] as String? Function(String);
+              invocation.positionalArguments[0] as String Function(String);
           return callback(testPrivateKey);
         });
 
         final signer = LocalKeySigner(mockKeyContainer);
 
-        expect(await signer.encrypt(offCurvePubkey, 'Hello!'), isNull);
+        await expectLater(
+          signer.encrypt(offCurvePubkey, 'Hello!'),
+          throwsA(isA<LocalSignerOperationException>()),
+        );
       });
 
-      test('decrypt returns null for an off-curve pubkey', () async {
-        when(() => mockKeyContainer.withPrivateKey<String?>(any())).thenAnswer((
+      test('decrypt throws a typed failure for an off-curve pubkey', () async {
+        when(() => mockKeyContainer.withPrivateKey<String>(any())).thenAnswer((
           invocation,
         ) {
           final callback =
-              invocation.positionalArguments[0] as String? Function(String);
+              invocation.positionalArguments[0] as String Function(String);
           return callback(testPrivateKey);
         });
 
@@ -156,21 +215,18 @@ void main() {
         // The IV must be real base64, or `base64.decode` throws a
         // FormatException — an Exception, which the old handler already
         // caught — and we never reach the off-curve `Error` path.
-        expect(
-          await signer.decrypt(
-            offCurvePubkey,
-            'AA==?iv=AAAAAAAAAAAAAAAAAAAAAA==',
-          ),
-          isNull,
+        await expectLater(
+          signer.decrypt(offCurvePubkey, 'AA==?iv=AAAAAAAAAAAAAAAAAAAAAA=='),
+          throwsA(isA<LocalSignerOperationException>()),
         );
       });
 
       test('decrypt decrypts ciphertext', () async {
-        when(() => mockKeyContainer.withPrivateKey<String?>(any())).thenAnswer((
+        when(() => mockKeyContainer.withPrivateKey<String>(any())).thenAnswer((
           invocation,
         ) {
           final callback =
-              invocation.positionalArguments[0] as String? Function(String);
+              invocation.positionalArguments[0] as String Function(String);
           return callback(testPrivateKey);
         });
 
@@ -179,10 +235,8 @@ void main() {
 
         // First encrypt
         final ciphertext = await signer.encrypt(testPublicKey, plaintext);
-        expect(ciphertext, isNotNull);
-
         // Then decrypt
-        final decrypted = await signer.decrypt(testPublicKey, ciphertext!);
+        final decrypted = await signer.decrypt(testPublicKey, ciphertext);
 
         expect(decrypted, equals(plaintext));
       });
@@ -194,13 +248,11 @@ void main() {
       void stubConversationKeyDerivation() {
         when(
           () => mockKeyContainer.withPrivateKey<Uint8List>(any()),
-        ).thenAnswer(
-          (invocation) {
-            final callback =
-                invocation.positionalArguments[0] as Uint8List Function(String);
-            return callback(testPrivateKey);
-          },
-        );
+        ).thenAnswer((invocation) {
+          final callback =
+              invocation.positionalArguments[0] as Uint8List Function(String);
+          return callback(testPrivateKey);
+        });
       }
 
       test('nip44Encrypt encrypts plaintext', () async {
@@ -223,83 +275,98 @@ void main() {
 
         // First encrypt
         final ciphertext = await signer.nip44Encrypt(testPublicKey, plaintext);
-        expect(ciphertext, isNotNull);
-
         // Then decrypt
-        final decrypted = await signer.nip44Decrypt(testPublicKey, ciphertext!);
+        final decrypted = await signer.nip44Decrypt(testPublicKey, ciphertext);
 
         expect(decrypted, equals(plaintext));
       });
 
-      // #7332: these four methods returned a future out of the `try`, so the
-      // `on Exception` handler was unreachable and the declared
-      // `Future<String?>` null-on-failure contract was never honoured. Each
-      // case below threw before the fix.
-      test('nip44Decrypt returns null when the MAC does not verify', () async {
+      // #7332: these methods returned a future out of the `try`, so the
+      // `on Exception` handler was unreachable. The signer now exposes the
+      // failure as one typed exception, and Keycast decides explicitly whether
+      // to fall back to RPC.
+      test('nip44Decrypt throws a typed failure for an invalid MAC', () async {
         stubConversationKeyDerivation();
 
         final signer = LocalKeySigner(mockKeyContainer);
         final ciphertext = await signer.nip44Encrypt(testPublicKey, 'hello');
-        expect(ciphertext, isNotNull);
-
         // Flip the last byte of the payload so the HMAC check fails.
-        final bytes = List<int>.from(base64Decode(ciphertext!));
+        final bytes = List<int>.from(base64Decode(ciphertext));
         bytes[bytes.length - 1] ^= 0xFF;
 
-        final decrypted = await signer.nip44Decrypt(
-          testPublicKey,
-          base64Encode(bytes),
+        await expectLater(
+          signer.nip44Decrypt(testPublicKey, base64Encode(bytes)),
+          throwsA(isA<LocalSignerOperationException>()),
         );
-
-        expect(decrypted, isNull);
       });
 
-      test('nip44Decrypt returns null for a payload it cannot parse', () async {
-        stubConversationKeyDerivation();
+      test(
+        'nip44Decrypt throws a typed failure for an invalid payload',
+        () async {
+          stubConversationKeyDerivation();
 
-        final signer = LocalKeySigner(mockKeyContainer);
+          final signer = LocalKeySigner(mockKeyContainer);
 
-        final decrypted = await signer.nip44Decrypt(
-          testPublicKey,
-          'not-base64-!!!',
-        );
+          await expectLater(
+            signer.nip44Decrypt(testPublicKey, 'not-base64-!!!'),
+            throwsA(isA<LocalSignerOperationException>()),
+          );
+        },
+      );
 
-        expect(decrypted, isNull);
-      });
+      test(
+        'nip44Encrypt throws a typed failure for an off-curve pubkey',
+        () async {
+          stubConversationKeyDerivation();
 
-      test('nip44Encrypt returns null for an off-curve pubkey', () async {
-        stubConversationKeyDerivation();
+          final signer = LocalKeySigner(mockKeyContainer);
 
-        final signer = LocalKeySigner(mockKeyContainer);
+          // A Nostr pubkey is a secp256k1 x-coordinate and only about half of
+          // all 32-byte values have a matching y, so a well-formed hex string
+          // can still name nobody. ECDH raises ArgumentError — an Error, not an
+          // Exception, so `on Exception` would not have caught it either.
+          await expectLater(
+            signer.nip44Encrypt(offCurvePubkey, 'hello'),
+            throwsA(isA<LocalSignerOperationException>()),
+          );
+        },
+      );
 
-        // A Nostr pubkey is a secp256k1 x-coordinate and only about half of
-        // all 32-byte values have a matching y, so a well-formed hex string
-        // can still name nobody. ECDH raises ArgumentError — an Error, not an
-        // Exception, so `on Exception` would not have caught it either.
-        final ciphertext = await signer.nip44Encrypt(offCurvePubkey, 'hello');
+      test(
+        'nip44Decrypt throws a typed failure for an off-curve pubkey',
+        () async {
+          stubConversationKeyDerivation();
 
-        expect(ciphertext, isNull);
-      });
+          final signer = LocalKeySigner(mockKeyContainer);
 
-      test('nip44Decrypt returns null for an off-curve pubkey', () async {
-        stubConversationKeyDerivation();
+          await expectLater(
+            signer.nip44Decrypt(offCurvePubkey, 'AgAB'),
+            throwsA(isA<LocalSignerOperationException>()),
+          );
+        },
+      );
 
-        final signer = LocalKeySigner(mockKeyContainer);
+      test(
+        'nip44Encrypt throws a typed failure when the container refuses',
+        () async {
+          when(
+            () => mockKeyContainer.withPrivateKey<Uint8List>(any()),
+          ).thenThrow(const SecureKeyException('Container has been disposed'));
 
-        final plaintext = await signer.nip44Decrypt(offCurvePubkey, 'AgAB');
+          final signer = LocalKeySigner(mockKeyContainer);
 
-        expect(plaintext, isNull);
-      });
-
-      test('nip44Encrypt returns null when the container refuses', () async {
-        when(
-          () => mockKeyContainer.withPrivateKey<Uint8List>(any()),
-        ).thenThrow(const SecureKeyException('Container has been disposed'));
-
-        final signer = LocalKeySigner(mockKeyContainer);
-
-        expect(await signer.nip44Encrypt(testPublicKey, 'hello'), isNull);
-      });
+          await expectLater(
+            signer.nip44Encrypt(testPublicKey, 'hello'),
+            throwsA(
+              isA<LocalSignerOperationException>().having(
+                (error) => error.cause,
+                'cause',
+                isA<SecureKeyException>(),
+              ),
+            ),
+          );
+        },
+      );
     });
 
     group('close', () {

--- a/mobile/test/services/local_key_signer_test.dart
+++ b/mobile/test/services/local_key_signer_test.dart
@@ -1,6 +1,9 @@
 // ABOUTME: Tests for LocalKeySigner backed by a local SecureKeyContainer
 // ABOUTME: Validates event signing, encryption, and key access through secure container
 
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
@@ -16,6 +19,9 @@ void main() {
       '6b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e';
   const testPublicKey =
       '385c3a6ec0b9d57a4330dbd6284989be5bd00e41c535f9ca39b6ae7c521b81cd';
+  // Well-formed 32-byte hex that is not a point on secp256k1.
+  const offCurvePubkey =
+      '0000000000000000000000000000000000000000000000000000000000000000';
 
   setUpAll(() {
     registerFallbackValue(_MockSecureKeyContainer());
@@ -141,15 +147,22 @@ void main() {
     });
 
     group('nip44Encrypt/nip44Decrypt', () {
-      test('nip44Encrypt encrypts plaintext', () async {
+      // The conversation key is derived inside the synchronous
+      // `withPrivateKey` scope; the cipher call happens outside it.
+      void stubConversationKeyDerivation() {
         when(
-          () => mockKeyContainer.withPrivateKey<Future<String?>>(any()),
-        ).thenAnswer((invocation) {
-          final callback =
-              invocation.positionalArguments[0]
-                  as Future<String?> Function(String);
-          return callback(testPrivateKey);
-        });
+          () => mockKeyContainer.withPrivateKey<Uint8List>(any()),
+        ).thenAnswer(
+          (invocation) {
+            final callback =
+                invocation.positionalArguments[0] as Uint8List Function(String);
+            return callback(testPrivateKey);
+          },
+        );
+      }
+
+      test('nip44Encrypt encrypts plaintext', () async {
+        stubConversationKeyDerivation();
 
         final signer = LocalKeySigner(mockKeyContainer);
         const plaintext = 'Hello, NIP-44!';
@@ -161,14 +174,7 @@ void main() {
       });
 
       test('nip44Decrypt decrypts ciphertext', () async {
-        when(
-          () => mockKeyContainer.withPrivateKey<Future<String?>>(any()),
-        ).thenAnswer((invocation) {
-          final callback =
-              invocation.positionalArguments[0]
-                  as Future<String?> Function(String);
-          return callback(testPrivateKey);
-        });
+        stubConversationKeyDerivation();
 
         final signer = LocalKeySigner(mockKeyContainer);
         const plaintext = 'Hello, NIP-44!';
@@ -181,6 +187,76 @@ void main() {
         final decrypted = await signer.nip44Decrypt(testPublicKey, ciphertext!);
 
         expect(decrypted, equals(plaintext));
+      });
+
+      // #7332: these four methods returned a future out of the `try`, so the
+      // `on Exception` handler was unreachable and the declared
+      // `Future<String?>` null-on-failure contract was never honoured. Each
+      // case below threw before the fix.
+      test('nip44Decrypt returns null when the MAC does not verify', () async {
+        stubConversationKeyDerivation();
+
+        final signer = LocalKeySigner(mockKeyContainer);
+        final ciphertext = await signer.nip44Encrypt(testPublicKey, 'hello');
+        expect(ciphertext, isNotNull);
+
+        // Flip the last byte of the payload so the HMAC check fails.
+        final bytes = List<int>.from(base64Decode(ciphertext!));
+        bytes[bytes.length - 1] ^= 0xFF;
+
+        final decrypted = await signer.nip44Decrypt(
+          testPublicKey,
+          base64Encode(bytes),
+        );
+
+        expect(decrypted, isNull);
+      });
+
+      test('nip44Decrypt returns null for a payload it cannot parse', () async {
+        stubConversationKeyDerivation();
+
+        final signer = LocalKeySigner(mockKeyContainer);
+
+        final decrypted = await signer.nip44Decrypt(
+          testPublicKey,
+          'not-base64-!!!',
+        );
+
+        expect(decrypted, isNull);
+      });
+
+      test('nip44Encrypt returns null for an off-curve pubkey', () async {
+        stubConversationKeyDerivation();
+
+        final signer = LocalKeySigner(mockKeyContainer);
+
+        // A Nostr pubkey is a secp256k1 x-coordinate and only about half of
+        // all 32-byte values have a matching y, so a well-formed hex string
+        // can still name nobody. ECDH raises ArgumentError — an Error, not an
+        // Exception, so `on Exception` would not have caught it either.
+        final ciphertext = await signer.nip44Encrypt(offCurvePubkey, 'hello');
+
+        expect(ciphertext, isNull);
+      });
+
+      test('nip44Decrypt returns null for an off-curve pubkey', () async {
+        stubConversationKeyDerivation();
+
+        final signer = LocalKeySigner(mockKeyContainer);
+
+        final plaintext = await signer.nip44Decrypt(offCurvePubkey, 'AgAB');
+
+        expect(plaintext, isNull);
+      });
+
+      test('nip44Encrypt returns null when the container refuses', () async {
+        when(
+          () => mockKeyContainer.withPrivateKey<Uint8List>(any()),
+        ).thenThrow(const SecureKeyException('Container has been disposed'));
+
+        final signer = LocalKeySigner(mockKeyContainer);
+
+        expect(await signer.nip44Encrypt(testPublicKey, 'hello'), isNull);
       });
     });
 


### PR DESCRIPTION
Refs #7332

> **Description rewritten after review.** The first three commits made the local signer return `null` on failure, which is what #7332 asks for. The review commit (`5446e2f7ec`) took the opposite direction — a typed exception — and this description now describes what the code actually does. See "What changed in review" at the bottom, and the note on #7332's scope.

## The problem

`LocalKeySigner` signs and encrypts with a locally held key. Four of its six methods could not report failure in any way a caller could act on: they raised a raw `Exception` or `ArgumentError` out of methods declared `Future<String?>`, with a `try` block whose handler was unreachable.

The visible consequence is on Keycast accounts. `KeycastNostrIdentity` is documented to sign locally for speed and **fall back to the remote signer** when the local attempt fails. That fallback is written as "if the local result is not null, use it; otherwise ask the remote signer". Because the local signer raised instead of returning `null`, the remote signer was never asked — driving those methods into failure with a stubbed remote signer, it received **zero** calls.

## Why it happened

Two independent defects.

**1. The `try` was exited before the failure arrived.** `nip44Encrypt` / `nip44Decrypt` returned a future out of their `try` rather than awaiting it. `withPrivateKey` is synchronous and the callback was `async`, so errors went into that future and surfaced after the `try` had been left. The handler was unreachable and its `return null` was dead code.

**2. The handler was too narrow.** All six methods caught `on Exception`, which does not cover Dart's `Error` types. NIP-04 has a live path into one: `NIP04.getPubkey` catches the off-curve error from `liftX`, leaves `y` null, then dereferences `y!`, raising a `TypeError` — with no un-awaited-future bug involved.

An off-curve pubkey is reachable: a Nostr pubkey is a secp256k1 x-coordinate, only about half of all 32-byte values have a matching y, and the only validation in front of these methods (`keyIsValid`) checks hex and length.

## What this does now

Rather than making failure a `null`, the signer states its contract in the type system:

- **`LocalSignerOperationException`** — a new typed failure carrying a `LocalSignerOperation` enum and the underlying cause, with no key or payload data in `toString()`. Because this signer supports every operation it exposes, an attempted operation either succeeds or throws it.
- **Return types are now non-nullable** (`Future<String>`, `Future<Event>`), so `null` no longer has two meanings. `null` is reserved for "the signer does not support this capability".
- **Peer pubkeys are validated on-curve up front** (`_validatePeerPubkey`), which is what converts the raw `ArgumentError`/`TypeError` from ECDH into the typed failure.
- **Unexpected Dart `Error`s still propagate**, so programming-invariant violations stay loud rather than being flattened into a failure result. `SignerFactory.createAndSignEvent` now reports them to Crashlytics.
- **`KeycastNostrIdentity._tryLocal`** catches the typed exception and returns `null`, which is what re-arms the documented local→RPC fallback. That is the user-visible fix.

## What it deliberately leaves alone

- **`LocalNostrIdentity` still propagates the exception.** On a local-key-only account, `nip44Encrypt` / `nip44Decrypt` / `encrypt` / `decrypt` throw `LocalSignerOperationException` rather than returning `null`. Consumers written against the nullable contract — `gift_wrap_util.dart:119/:144/:209`, `curated_list_relay_gateway.dart:111`, `push_notification_service.dart:286/:370/:512` — therefore still never see `null`. That is the same shape #7332 reports, now typed and documented instead of raw. **This PR does not close that half**, which is why it says `Refs #7332` rather than `Closes`.
- **The interface contract.** `NostrSigner` still has no dartdoc and four implementations still give three different answers about failure. That belongs to #6917; evidence in #8713.
- **`KeycastRpc` still throws on every failure path**, so `KeycastNostrIdentity` is not fully null-on-failure. Pre-existing; #8713.
- **`NIP04.decrypt` returning `""` on malformed input** — #8712.
- **Prevention.** No lint catches the un-awaited-return shape; ratchet proposed in #8714.

## Honest note on severity

A blast-radius audit of all 20 call sites found **no user-visible divergence before this PR**: there are zero `on Exception catch` clauses in any consumer file, so every consumer that catches at all catches `Error` too. This is a contract fix, not an outage fix.

What makes it worth doing is how that safety was bought. #6431 fixed **permanently lost inbound DMs** caused by the same throw-vs-null gap — and patched the consumer while naming the *remote* signer as the source. Nobody noticed the local signer throws too, so the local-key variant of that path was never closed. Three fan-out loops (`sendInvites`, `_fanOutDeletion`, `_fanOutRumor`) carry no catch of their own and are safe only because one `on Object catch` in `sendRumor` stays broad.

## What changed in review

`5446e2f7ec` (by the reviewer) replaced the null-on-failure contract from commits 1–3 with the typed-exception contract described above, added the on-curve peer-key validation, made the return types non-nullable, wired `_tryLocal` into every `KeycastNostrIdentity` crypto path, and added `Error` reporting in `SignerFactory`. It aligns the signer with the Client-layer rule in `.claude/rules/error_handling.md` ("typed exception … no `null` 'and also it failed' returns") and keeps programming errors visible instead of swallowing them.

The regression tests from commits 1–3 were kept and inverted to assert the typed throw, plus two new cases asserting that programming errors are *not* hidden.

## Verification

- `flutter analyze lib test integration_test` — no issues
- 105 tests pass across `local_key_signer_test`, `nostr_identity_test`, `signer_factory_test`
- 19/19 GitHub checks green on `5446e2f7ec`
- Every regression case from commits 1–3 was verified to fail against `origin/main` before the review commit inverted their assertions

Not reproduced on a physical device; all evidence is from executing the real classes with real crypto.
