### PR TITLE
test(share-sheet): prevent unverified clip-import failures

### DIFF
--- a/mobile/test/services/video_clip_import_service_test.dart
+++ b/mobile/test/services/video_clip_import_service_test.dart
@@ -94,11 +94,12 @@ void main() {
     })?
     extractLastFrame,
     Future<VideoMetadata> Function(EditorVideo video)? readVideoMetadata,
+    DocumentsPathProvider? getDocumentsPath,
     DateTime? now,
   }) {
     return VideoClipImportService(
       clipLibraryService: clipLibraryService,
-      getDocumentsPath: () async => docsDir.path,
+      getDocumentsPath: getDocumentsPath ?? () async => docsDir.path,
       downloadVideo:
           downloadVideo ??
           ({required url, required cacheKey}) async => sourceVideo,
@@ -573,6 +574,91 @@ void main() {
             (result) => result.reason,
             'reason',
             VideoClipImportFailureReason.downloadFailed,
+          ),
+        );
+        verifyNever(() => clipLibraryService.saveClip(any()));
+      },
+    );
+
+    test('returns copyFailed when the video cannot be copied', () async {
+      final importedAt = DateTime.utc(2026, 4, 27, 12);
+      // Deliberately couple this collision to the generated clip ID: if the ID
+      // scheme changes, this regression test must choose a new failing target.
+      final target = Directory(
+        '${docsDir.path}/classic_vine_vine-123_'
+        '${importedAt.microsecondsSinceEpoch}.mp4',
+      )..createSync();
+      final service = buildService(now: importedAt);
+
+      final result = await service.importToLibrary(_video());
+
+      expect(
+        result,
+        isA<VideoClipImportFailure>().having(
+          (result) => result.reason,
+          'reason',
+          VideoClipImportFailureReason.copyFailed,
+        ),
+      );
+      verifyNever(() => clipLibraryService.saveClip(any()));
+      expect(target.existsSync(), isTrue);
+      expect(docsDir.listSync().whereType<File>(), isEmpty);
+    });
+
+    test(
+      'returns copyFailed when the documents directory cannot be created',
+      () async {
+        final service = buildService(
+          getDocumentsPath: () async => '${sourceVideo.path}/documents',
+        );
+
+        final result = await service.importToLibrary(_video());
+
+        expect(
+          result,
+          isA<VideoClipImportFailure>().having(
+            (result) => result.reason,
+            'reason',
+            VideoClipImportFailureReason.copyFailed,
+          ),
+        );
+        verifyNever(() => clipLibraryService.saveClip(any()));
+        expect(docsDir.listSync().whereType<File>(), isEmpty);
+      },
+    );
+
+    test('returns saveFailed when the clip cannot be saved', () async {
+      when(
+        () => clipLibraryService.saveClip(any()),
+      ).thenThrow(Exception('save failed'));
+      final service = buildService();
+
+      final result = await service.importToLibrary(_video());
+
+      expect(
+        result,
+        isA<VideoClipImportFailure>().having(
+          (result) => result.reason,
+          'reason',
+          VideoClipImportFailureReason.saveFailed,
+        ),
+      );
+      verify(() => clipLibraryService.saveClip(any())).called(1);
+    });
+
+    test(
+      'returns unsupportedPlatform when documents are unavailable',
+      () async {
+        final service = buildService(getDocumentsPath: () async => '');
+
+        final result = await service.importToLibrary(_video());
+
+        expect(
+          result,
+          isA<VideoClipImportFailure>().having(
+            (result) => result.reason,
+            'reason',
+            VideoClipImportFailureReason.unsupportedPlatform,
           ),
         );
         verifyNever(() => clipLibraryService.saveClip(any()));

--- a/mobile/test/services/video_clip_import_service_test.dart
+++ b/mobile/test/services/video_clip_import_service_test.dart
@@ -647,9 +647,16 @@ void main() {
     });
 
     test(
-      'returns unsupportedPlatform when documents are unavailable',
+      'returns unsupportedPlatform without downloading the video',
       () async {
-        final service = buildService(getDocumentsPath: () async => '');
+        var downloadAttempts = 0;
+        final service = buildService(
+          getDocumentsPath: () async => '',
+          downloadVideo: ({required url, required cacheKey}) async {
+            downloadAttempts++;
+            return sourceVideo;
+          },
+        );
 
         final result = await service.importToLibrary(_video());
 
@@ -661,6 +668,7 @@ void main() {
             VideoClipImportFailureReason.unsupportedPlatform,
           ),
         );
+        expect(downloadAttempts, isZero);
         verifyNever(() => clipLibraryService.saveClip(any()));
       },
     );


### PR DESCRIPTION
## Problem
Clip imports could fail while creating or copying into app documents without a regression test proving that no broken library entry was saved. The service also had untested save-failure and unsupported-platform outcomes.

## Why this change
These tests exercise both filesystem failure boundaries and assert that copy failures neither call the clip library nor leave a copied file behind. Separate tests prove that a library save exception remains a distinct failure and that an unavailable documents path exits before download or save work.

This is test-only. It does not change clip-import behavior, persistence, or user-facing copy.

## Verification
- `flutter test --no-pub test/services/video_clip_import_service_test.dart`
- `flutter analyze lib test integration_test`

Closes #3712