### PR TITLE
test(dm): verify bulk request actions close the sheet

### DIFF
--- a/mobile/test/screens/inbox/message_requests/widgets/request_bulk_actions_sheet_test.dart
+++ b/mobile/test/screens/inbox/message_requests/widgets/request_bulk_actions_sheet_test.dart
@@ -4,82 +4,102 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/screens/inbox/message_requests/widgets/request_bulk_actions_sheet.dart';
 
-import '../../../../helpers/go_router.dart';
 import '../../../../helpers/test_provider_overrides.dart';
 
 void main() {
   group(RequestBulkActionsSheet, () {
-    late MockGoRouter mockGoRouter;
-
-    setUp(() {
-      mockGoRouter = MockGoRouter();
-    });
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    const showSheetButtonKey = Key('show-sheet-button');
 
     Widget buildSubject({required ValueChanged<RequestBulkAction?> onResult}) {
-      return testMaterialApp(
-        additionalOverrides: [goRouterProvider.overrideWithValue(mockGoRouter)],
-        home: MockGoRouterProvider(
-          goRouter: mockGoRouter,
-          child: Builder(
-            builder: (context) {
-              return Scaffold(
-                body: ElevatedButton(
-                  onPressed: () async {
-                    final result = await RequestBulkActionsSheet.show(context);
-                    onResult(result);
-                  },
-                  child: const Text('Show sheet'),
+      final router = GoRouter(
+        initialLocation: '/sheet',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (_, _) => const Scaffold(),
+            routes: [
+              GoRoute(
+                path: 'sheet',
+                builder: (_, _) => Scaffold(
+                  body: Builder(
+                    builder: (context) {
+                      return ElevatedButton(
+                        key: showSheetButtonKey,
+                        onPressed: () async {
+                          final result = await RequestBulkActionsSheet.show(
+                            context,
+                          );
+                          onResult(result);
+                        },
+                        child: const Text('Show sheet'),
+                      );
+                    },
+                  ),
                 ),
-              );
-            },
+              ),
+            ],
           ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      return testProviderScope(
+        additionalOverrides: [goRouterProvider.overrideWithValue(router)],
+        child: MaterialApp.router(
+          routerConfig: router,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: ThemeData.dark(),
         ),
       );
+    }
+
+    Future<void> showSheet(WidgetTester tester) async {
+      await tester.tap(find.byKey(showSheetButtonKey));
+      await tester.pumpAndSettle();
     }
 
     testWidgets('renders both action tiles when shown', (tester) async {
       await tester.pumpWidget(buildSubject(onResult: (_) {}));
 
-      await tester.tap(find.text('Show sheet'));
-      await tester.pumpAndSettle();
+      await showSheet(tester);
 
-      expect(find.text('Mark all requests as read'), findsOneWidget);
-      expect(find.text('Remove all requests'), findsOneWidget);
+      expect(find.text(l10n.inboxRequestsMarkAllRead), findsOneWidget);
+      expect(find.text(l10n.inboxRequestsRemoveAll), findsOneWidget);
     });
 
     testWidgets('returns markAllRead when first tile tapped', (tester) async {
-      // Stub pop to use Navigator.pop with the value argument
-      when(() => mockGoRouter.pop(any())).thenAnswer((invocation) async {
-        // The value is passed as positional arg to GoRouter.pop
-      });
+      RequestBulkAction? capturedResult;
+      await tester.pumpWidget(
+        buildSubject(onResult: (result) => capturedResult = result),
+      );
 
-      await tester.pumpWidget(buildSubject(onResult: (_) {}));
-
-      await tester.tap(find.text('Show sheet'));
+      await showSheet(tester);
+      await tester.tap(find.text(l10n.inboxRequestsMarkAllRead));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Mark all requests as read'));
-      await tester.pumpAndSettle();
-
-      verify(() => mockGoRouter.pop(RequestBulkAction.markAllRead)).called(1);
+      expect(capturedResult, RequestBulkAction.markAllRead);
+      expect(find.text(l10n.inboxRequestsMarkAllRead), findsNothing);
     });
 
     testWidgets('returns removeAll when second tile tapped', (tester) async {
-      when(() => mockGoRouter.pop(any())).thenAnswer((invocation) async {});
+      RequestBulkAction? capturedResult;
+      await tester.pumpWidget(
+        buildSubject(onResult: (result) => capturedResult = result),
+      );
 
-      await tester.pumpWidget(buildSubject(onResult: (_) {}));
-
-      await tester.tap(find.text('Show sheet'));
+      await showSheet(tester);
+      await tester.tap(find.text(l10n.inboxRequestsRemoveAll));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Remove all requests'));
-      await tester.pumpAndSettle();
-
-      verify(() => mockGoRouter.pop(RequestBulkAction.removeAll)).called(1);
+      expect(capturedResult, RequestBulkAction.removeAll);
+      expect(find.text(l10n.inboxRequestsRemoveAll), findsNothing);
     });
   });
 }

--- a/mobile/test/screens/inbox/message_requests/widgets/request_bulk_actions_sheet_test.dart
+++ b/mobile/test/screens/inbox/message_requests/widgets/request_bulk_actions_sheet_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Widget tests for RequestBulkActionsSheet.
-// ABOUTME: Verifies that both action tiles render and return the correct
-// ABOUTME: RequestBulkAction when tapped.
+// ABOUTME: Verifies both tiles render, that tapping one closes the sheet and
+// ABOUTME: completes with the matching RequestBulkAction, and that dismissing
+// ABOUTME: it completes with null.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -19,6 +20,14 @@ void main() {
     setUp(() => VineThemeColors.debugFallbackCount = 0);
     tearDown(() => VineThemeColors.debugFallbackCount = 0);
 
+    // A real GoRouter, not the MockGoRouter the rest of the inbox tests use.
+    // The sheet dismisses through go_router's `context.pop(result)`, and a mock
+    // no-ops it, so `VineBottomSheet.show` never completes its future and every
+    // assertion about the result or the sheet closing is unreachable — with no
+    // error and no missed tap to explain why. The old `verify(pop(...))` passed
+    // anyway, which is what made this suite a false positive (#8409). Swapping
+    // back to `testMaterialApp(home: ...)` would read as a simplification and
+    // would silently restore that.
     Widget buildSubject({required ValueChanged<RequestBulkAction?> onResult}) {
       final router = GoRouter(
         routes: [

--- a/mobile/test/screens/inbox/message_requests/widgets/request_bulk_actions_sheet_test.dart
+++ b/mobile/test/screens/inbox/message_requests/widgets/request_bulk_actions_sheet_test.dart
@@ -6,10 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/l10n/l10n.dart';
-import 'package:openvine/router/app_router.dart';
 import 'package:openvine/screens/inbox/message_requests/widgets/request_bulk_actions_sheet.dart';
-
-import '../../../../helpers/test_provider_overrides.dart';
 
 void main() {
   group(RequestBulkActionsSheet, () {
@@ -49,14 +46,11 @@ void main() {
       );
       addTearDown(router.dispose);
 
-      return testProviderScope(
-        additionalOverrides: [goRouterProvider.overrideWithValue(router)],
-        child: MaterialApp.router(
-          routerConfig: router,
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          theme: ThemeData.dark(),
-        ),
+      return MaterialApp.router(
+        routerConfig: router,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        theme: ThemeData.dark(),
       );
     }
 

--- a/mobile/test/screens/inbox/message_requests/widgets/request_bulk_actions_sheet_test.dart
+++ b/mobile/test/screens/inbox/message_requests/widgets/request_bulk_actions_sheet_test.dart
@@ -102,5 +102,37 @@ void main() {
       expect(capturedResult, RequestBulkAction.removeAll);
       expect(find.text(l10n.inboxRequestsRemoveAll), findsNothing);
     });
+
+    // `show` promises "the chosen [RequestBulkAction] or `null` if dismissed",
+    // and the only caller leans on it: `message_requests_view.dart:60` returns
+    // early on null rather than sweeping the list. `VineBottomSheet.show` runs
+    // with the default `tapOutsideToDismiss: true`, so this is a live path —
+    // and it was unreachable under the old MockGoRouter, whose no-op `pop`
+    // meant the future never completed at all.
+    testWidgets('returns null when dismissed without choosing', (tester) async {
+      RequestBulkAction? capturedResult;
+      var didComplete = false;
+      await tester.pumpWidget(
+        buildSubject(
+          onResult: (result) {
+            capturedResult = result;
+            didComplete = true;
+          },
+        ),
+      );
+
+      await showSheet(tester);
+      expect(find.text(l10n.inboxRequestsMarkAllRead), findsOneWidget);
+
+      // Above the sheet, on the modal barrier.
+      await tester.tapAt(const Offset(10, 10));
+      await tester.pumpAndSettle();
+
+      // `didComplete` is the pin: without it a future that never resolved
+      // would leave `capturedResult` null and pass this test vacuously.
+      expect(didComplete, isTrue);
+      expect(capturedResult, isNull);
+      expect(find.text(l10n.inboxRequestsMarkAllRead), findsNothing);
+    });
   });
 }

--- a/mobile/test/screens/inbox/message_requests/widgets/request_bulk_actions_sheet_test.dart
+++ b/mobile/test/screens/inbox/message_requests/widgets/request_bulk_actions_sheet_test.dart
@@ -15,32 +15,25 @@ void main() {
 
     Widget buildSubject({required ValueChanged<RequestBulkAction?> onResult}) {
       final router = GoRouter(
-        initialLocation: '/sheet',
         routes: [
           GoRoute(
             path: '/',
-            builder: (_, _) => const Scaffold(),
-            routes: [
-              GoRoute(
-                path: 'sheet',
-                builder: (_, _) => Scaffold(
-                  body: Builder(
-                    builder: (context) {
-                      return ElevatedButton(
-                        key: showSheetButtonKey,
-                        onPressed: () async {
-                          final result = await RequestBulkActionsSheet.show(
-                            context,
-                          );
-                          onResult(result);
-                        },
-                        child: const Text('Show sheet'),
+            builder: (_, _) => Scaffold(
+              body: Builder(
+                builder: (context) {
+                  return ElevatedButton(
+                    key: showSheetButtonKey,
+                    onPressed: () async {
+                      final result = await RequestBulkActionsSheet.show(
+                        context,
                       );
+                      onResult(result);
                     },
-                  ),
-                ),
+                    child: const Text('Show sheet'),
+                  );
+                },
               ),
-            ],
+            ),
           ),
         ],
       );

--- a/mobile/test/screens/inbox/message_requests/widgets/request_bulk_actions_sheet_test.dart
+++ b/mobile/test/screens/inbox/message_requests/widgets/request_bulk_actions_sheet_test.dart
@@ -28,7 +28,10 @@ void main() {
     // anyway, which is what made this suite a false positive (#8409). Swapping
     // back to `testMaterialApp(home: ...)` would read as a simplification and
     // would silently restore that.
-    Widget buildSubject({required ValueChanged<RequestBulkAction?> onResult}) {
+    Widget buildSubject({
+      required ValueChanged<RequestBulkAction?> onResult,
+      Locale? locale,
+    }) {
       final router = GoRouter(
         routes: [
           GoRoute(
@@ -56,6 +59,7 @@ void main() {
 
       return MaterialApp.router(
         routerConfig: router,
+        locale: locale,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         theme: VineTheme.theme,
@@ -82,6 +86,23 @@ void main() {
             'missing, and _ActionTile reads context.vineColors for its label '
             'and divider colours.',
       );
+    });
+
+    // `find.text(l10n.inboxRequestsMarkAllRead)` resolves to the English
+    // literal, so on its own it passes whether the tile reads `context.l10n`
+    // or hardcodes the string. Pumping a non-English locale is what tells the
+    // two apart, which is the claim the assertions above are making.
+    testWidgets('renders both tiles in the active locale', (tester) async {
+      final filipino = lookupAppLocalizations(const Locale('fil'));
+      await tester.pumpWidget(
+        buildSubject(onResult: (_) {}, locale: const Locale('fil')),
+      );
+
+      await showSheet(tester);
+
+      expect(find.text(filipino.inboxRequestsMarkAllRead), findsOneWidget);
+      expect(find.text(filipino.inboxRequestsRemoveAll), findsOneWidget);
+      expect(find.text(l10n.inboxRequestsMarkAllRead), findsNothing);
     });
 
     testWidgets('returns markAllRead when first tile tapped', (tester) async {

--- a/mobile/test/screens/inbox/message_requests/widgets/request_bulk_actions_sheet_test.dart
+++ b/mobile/test/screens/inbox/message_requests/widgets/request_bulk_actions_sheet_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies that both action tiles render and return the correct
 // ABOUTME: RequestBulkAction when tapped.
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -12,6 +13,11 @@ void main() {
   group(RequestBulkActionsSheet, () {
     final l10n = lookupAppLocalizations(const Locale('en'));
     const showSheetButtonKey = Key('show-sheet-button');
+
+    // The dark fallback is silent by design, so a dropped theme extension is
+    // only observable through this counter — reset it around every pump.
+    setUp(() => VineThemeColors.debugFallbackCount = 0);
+    tearDown(() => VineThemeColors.debugFallbackCount = 0);
 
     Widget buildSubject({required ValueChanged<RequestBulkAction?> onResult}) {
       final router = GoRouter(
@@ -43,7 +49,7 @@ void main() {
         routerConfig: router,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        theme: ThemeData.dark(),
+        theme: VineTheme.theme,
       );
     }
 
@@ -59,6 +65,14 @@ void main() {
 
       expect(find.text(l10n.inboxRequestsMarkAllRead), findsOneWidget);
       expect(find.text(l10n.inboxRequestsRemoveAll), findsOneWidget);
+      expect(
+        VineThemeColors.debugFallbackCount,
+        0,
+        reason:
+            'A modal route is exactly where the VineThemeColors extension goes '
+            'missing, and _ActionTile reads context.vineColors for its label '
+            'and divider colours.',
+      );
     });
 
     testWidgets('returns markAllRead when first tile tapped', (tester) async {


### PR DESCRIPTION
## Problem

The bulk request action widget tests stubbed a generic `GoRouter.pop` call with a different reified type argument than production uses. Those stubs never matched, while interaction verifications still passed, so the tests did not prove that selecting an action closed the sheet or returned the chosen result.

## Why this fix

The tests now use a real `GoRouter`, matching the app behavior. Each action test captures the completed sheet result, asserts the selected `RequestBulkAction`, and verifies that the sheet closed. Visible copy assertions use the existing localized values instead of hardcoded English.

## Scope

Test-only. No production behavior, localization resources, generated code, or migrations changed.

## Verification

- `flutter test test/screens/inbox/message_requests/widgets/request_bulk_actions_sheet_test.dart`
- `flutter test test/screens/inbox/` (630 tests)
- `flutter analyze lib test integration_test`
- Mutation check: neutralizing the mark-all-read pop made its result assertion fail with `null`; restoring production made the focused suite pass
- Repository pre-push analyzer and changed-file test checks

Closes #8409