### PR TITLE
fix(divine_ui): hide drag handles when sheets cannot be dragged

### DIFF
--- a/mobile/lib/utils/pause_aware_modals.dart
+++ b/mobile/lib/utils/pause_aware_modals.dart
@@ -123,7 +123,10 @@ extension PauseAwareModals on BuildContext {
     Widget? bottomInput,
     bool expanded = true,
     bool showHeaderDivider = true,
-    bool showDragHandle = true,
+    // Nullable so the handle keeps following VineBottomSheet.show's
+    // enableDrag-derived default (#8462); a non-null default here would pin it
+    // on for every caller.
+    bool? showDragHandle,
     bool? isScrollControlled,
     double initialChildSize = 0.6,
     double minChildSize = 0.3,

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
@@ -187,6 +187,11 @@ class VineBottomSheet extends StatelessWidget {
   /// the sheet between sizes (e.g. expand to [maxChildSize] when a form
   /// field is revealed). Has no effect in fixed (`scrollable: false`)
   /// mode.
+  ///
+  /// When [showDragHandle] is omitted, the handle follows [enableDrag]. The
+  /// handle advertises the modal route's drag gesture, so a non-draggable
+  /// sheet does not show an inert affordance by default. Pass an explicit
+  /// value to override this behavior.
   static Future<T?> show<T>({
     required BuildContext context,
     List<Widget>? children,
@@ -204,7 +209,7 @@ class VineBottomSheet extends StatelessWidget {
     Widget? bottomInput,
     bool expanded = true,
     bool showHeaderDivider = true,
-    bool showDragHandle = true,
+    bool? showDragHandle,
     EdgeInsetsGeometry? headerPadding,
     DivineIconButton? headerLeadingAction,
     DivineIconButton? headerTrailingAction,
@@ -246,6 +251,7 @@ class VineBottomSheet extends StatelessWidget {
     // false` would still see the sheet dismissed by barrier taps above the
     // DraggableScrollableSheet's content area.
     final effectiveIsDismissible = isDismissible && tapOutsideToDismiss;
+    final effectiveShowDragHandle = showDragHandle ?? enableDrag;
 
     if (scrollable) {
       // Draggable/scrollable mode
@@ -274,7 +280,7 @@ class VineBottomSheet extends StatelessWidget {
               bottomInput: bottomInput,
               expanded: expanded,
               showHeaderDivider: showHeaderDivider,
-              showDragHandle: showDragHandle,
+              showDragHandle: effectiveShowDragHandle,
               headerPadding: headerPadding,
               headerLeadingAction: headerLeadingAction,
               headerTrailingAction: headerTrailingAction,
@@ -373,7 +379,7 @@ class VineBottomSheet extends StatelessWidget {
             bottomInput: bottomInput,
             expanded: expanded,
             showHeaderDivider: showHeaderDivider,
-            showDragHandle: showDragHandle,
+            showDragHandle: effectiveShowDragHandle,
             headerPadding: headerPadding,
             headerLeadingAction: headerLeadingAction,
             headerTrailingAction: headerTrailingAction,

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_prompt.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_prompt.dart
@@ -112,7 +112,9 @@ class VineBottomSheetPrompt extends StatelessWidget {
   /// Set both [isDismissible] and [enableDrag] to false for a prompt that
   /// must stay open until the user picks an action — [isDismissible] blocks
   /// barrier taps and [enableDrag] blocks drag-to-dismiss. Setting only one
-  /// leaves the other dismissal path active.
+  /// leaves the other dismissal path active. The drag handle follows
+  /// [enableDrag], so a prompt with dragging disabled does not advertise the
+  /// unavailable gesture.
   static Future<T?> show<T>({
     required BuildContext context,
     required DivineStickerName sticker,

--- a/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_prompt_test.dart
+++ b/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_prompt_test.dart
@@ -489,6 +489,14 @@ void main() {
           // a simulated fling inside the scroll body is gesture-arena-flaky.
           final sheet = tester.widget<BottomSheet>(find.byType(BottomSheet));
           expect(sheet.enableDrag, isFalse);
+          expect(
+            tester
+                .widget<VineBottomSheetHeader>(
+                  find.byType(VineBottomSheetHeader),
+                )
+                .showDragHandle,
+            isFalse,
+          );
         },
       );
     });

--- a/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_prompt_test.dart
+++ b/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_prompt_test.dart
@@ -43,6 +43,15 @@ class _TestAssetBundle extends CachingAssetBundle {
   }
 }
 
+// Matches the unkeyed 64x4 rounded Container the header paints as the drag
+// handle. Asserting the rendered tree, rather than the forwarded
+// showDragHandle flag, is what catches a header that stops honouring it.
+final Finder _dragHandle = find.byWidgetPredicate((widget) {
+  if (widget is! Container) return false;
+  final constraints = widget.constraints;
+  return constraints?.maxWidth == 64 && constraints?.maxHeight == 4;
+});
+
 void main() {
   late _TestAssetBundle bundle;
 
@@ -489,14 +498,7 @@ void main() {
           // a simulated fling inside the scroll body is gesture-arena-flaky.
           final sheet = tester.widget<BottomSheet>(find.byType(BottomSheet));
           expect(sheet.enableDrag, isFalse);
-          expect(
-            tester
-                .widget<VineBottomSheetHeader>(
-                  find.byType(VineBottomSheetHeader),
-                )
-                .showDragHandle,
-            isFalse,
-          );
+          expect(_dragHandle, findsNothing);
         },
       );
     });

--- a/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_test.dart
+++ b/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_test.dart
@@ -1321,6 +1321,145 @@ void main() {
           );
         },
       );
+
+      testWidgets(
+        'enableDrag: false hides the drag handle in fixed mode by default',
+        (tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: Builder(
+                  builder: (context) => ElevatedButton(
+                    onPressed: () => VineBottomSheet.show<void>(
+                      context: context,
+                      scrollable: false,
+                      enableDrag: false,
+                      children: const [Text('Body')],
+                    ),
+                    child: const Text('Open Fixed Without Handle'),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.tap(find.text('Open Fixed Without Handle'));
+          await tester.pumpAndSettle();
+
+          expect(
+            tester
+                .widget<VineBottomSheetHeader>(
+                  find.byType(VineBottomSheetHeader),
+                )
+                .showDragHandle,
+            isFalse,
+          );
+        },
+      );
+
+      testWidgets(
+        'enableDrag: false hides the drag handle in scrollable mode by default',
+        (tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: Builder(
+                  builder: (context) => ElevatedButton(
+                    onPressed: () => VineBottomSheet.show<void>(
+                      context: context,
+                      enableDrag: false,
+                      children: const [Text('Body')],
+                    ),
+                    child: const Text('Open Scrollable Without Handle'),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.tap(find.text('Open Scrollable Without Handle'));
+          await tester.pumpAndSettle();
+
+          expect(
+            tester
+                .widget<VineBottomSheetHeader>(
+                  find.byType(VineBottomSheetHeader),
+                )
+                .showDragHandle,
+            isFalse,
+          );
+        },
+      );
+
+      testWidgets(
+        'an explicit drag handle overrides enableDrag: false',
+        (tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: Builder(
+                  builder: (context) => ElevatedButton(
+                    onPressed: () => VineBottomSheet.show<void>(
+                      context: context,
+                      scrollable: false,
+                      enableDrag: false,
+                      showDragHandle: true,
+                      children: const [Text('Body')],
+                    ),
+                    child: const Text('Open With Handle'),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.tap(find.text('Open With Handle'));
+          await tester.pumpAndSettle();
+
+          expect(
+            tester
+                .widget<VineBottomSheetHeader>(
+                  find.byType(VineBottomSheetHeader),
+                )
+                .showDragHandle,
+            isTrue,
+          );
+        },
+      );
+
+      testWidgets(
+        'a draggable sheet shows the drag handle by default',
+        (tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: Builder(
+                  builder: (context) => ElevatedButton(
+                    onPressed: () => VineBottomSheet.show<void>(
+                      context: context,
+                      scrollable: false,
+                      children: const [Text('Body')],
+                    ),
+                    child: const Text('Open Draggable'),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.tap(find.text('Open Draggable'));
+          await tester.pumpAndSettle();
+
+          expect(
+            tester
+                .widget<VineBottomSheetHeader>(
+                  find.byType(VineBottomSheetHeader),
+                )
+                .showDragHandle,
+            isTrue,
+          );
+        },
+      );
     });
     group('onComplete', () {
       testWidgets(

--- a/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_test.dart
+++ b/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_test.dart
@@ -7,6 +7,15 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+// Matches the unkeyed 64x4 rounded Container the header paints as the drag
+// handle. Asserting the rendered tree, rather than the forwarded
+// showDragHandle flag, is what catches a header that stops honouring it.
+final Finder _dragHandle = find.byWidgetPredicate((widget) {
+  if (widget is! Container) return false;
+  final constraints = widget.constraints;
+  return constraints?.maxWidth == 64 && constraints?.maxHeight == 4;
+});
+
 void main() {
   group('VineBottomSheet', () {
     testWidgets('renders with required props', (tester) async {
@@ -1346,14 +1355,7 @@ void main() {
           await tester.tap(find.text('Open Fixed Without Handle'));
           await tester.pumpAndSettle();
 
-          expect(
-            tester
-                .widget<VineBottomSheetHeader>(
-                  find.byType(VineBottomSheetHeader),
-                )
-                .showDragHandle,
-            isFalse,
-          );
+          expect(_dragHandle, findsNothing);
         },
       );
 
@@ -1380,14 +1382,7 @@ void main() {
           await tester.tap(find.text('Open Scrollable Without Handle'));
           await tester.pumpAndSettle();
 
-          expect(
-            tester
-                .widget<VineBottomSheetHeader>(
-                  find.byType(VineBottomSheetHeader),
-                )
-                .showDragHandle,
-            isFalse,
-          );
+          expect(_dragHandle, findsNothing);
         },
       );
 
@@ -1416,14 +1411,7 @@ void main() {
           await tester.tap(find.text('Open With Handle'));
           await tester.pumpAndSettle();
 
-          expect(
-            tester
-                .widget<VineBottomSheetHeader>(
-                  find.byType(VineBottomSheetHeader),
-                )
-                .showDragHandle,
-            isTrue,
-          );
+          expect(_dragHandle, findsOneWidget);
         },
       );
 
@@ -1450,14 +1438,7 @@ void main() {
           await tester.tap(find.text('Open Draggable'));
           await tester.pumpAndSettle();
 
-          expect(
-            tester
-                .widget<VineBottomSheetHeader>(
-                  find.byType(VineBottomSheetHeader),
-                )
-                .showDragHandle,
-            isTrue,
-          );
+          expect(_dragHandle, findsOneWidget);
         },
       );
     });

--- a/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_test.dart
+++ b/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_test.dart
@@ -1359,6 +1359,10 @@ void main() {
         },
       );
 
+      // Not `enableDrag || scrollable`: the handle sits in the header, which
+      // in scrollable mode is a sibling of the scroll view, so with
+      // enableDrag: false no drag on it reaches DraggableScrollableSheet.
+      // Showing it would restore the #8462 false affordance — see below.
       testWidgets(
         'enableDrag: false hides the drag handle in scrollable mode by default',
         (tester) async {
@@ -1383,6 +1387,43 @@ void main() {
           await tester.pumpAndSettle();
 
           expect(_dragHandle, findsNothing);
+        },
+      );
+
+      // Evidence for the derivation above: force the handle on, then drag it.
+      testWidgets(
+        'a scrollable sheet with enableDrag: false ignores a header drag',
+        (tester) async {
+          var dismissed = false;
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: Builder(
+                  builder: (context) => ElevatedButton(
+                    onPressed: () => VineBottomSheet.show<void>(
+                      context: context,
+                      enableDrag: false,
+                      showDragHandle: true,
+                      title: const Text('Sheet Title'),
+                      onDismiss: () => dismissed = true,
+                      children: const [Text('Body')],
+                    ),
+                    child: const Text('Open Scrollable With Handle'),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.tap(find.text('Open Scrollable With Handle'));
+          await tester.pumpAndSettle();
+          expect(_dragHandle, findsOneWidget);
+
+          await tester.drag(find.text('Sheet Title'), const Offset(0, 500));
+          await tester.pumpAndSettle();
+
+          expect(dismissed, isFalse);
+          expect(find.text('Body'), findsOneWidget);
         },
       );
 

--- a/mobile/test/widgets/upload_failure_sheet_test.dart
+++ b/mobile/test/widgets/upload_failure_sheet_test.dart
@@ -88,6 +88,14 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text(l10n.uploadFailureSheetTitle), findsOneWidget);
+        expect(
+          tester
+              .widget<VineBottomSheetHeader>(
+                find.byType(VineBottomSheetHeader),
+              )
+              .showDragHandle,
+          isFalse,
+        );
       });
 
       testWidgets('localized error message from $PublishError kind', (

--- a/mobile/test/widgets/upload_failure_sheet_test.dart
+++ b/mobile/test/widgets/upload_failure_sheet_test.dart
@@ -29,6 +29,15 @@ class _MockBackgroundPublishBloc
     extends MockBloc<BackgroundPublishEvent, BackgroundPublishState>
     implements BackgroundPublishBloc {}
 
+// Matches the unkeyed 64x4 rounded Container the header paints as the drag
+// handle. Asserting the rendered tree, rather than the forwarded
+// showDragHandle flag, is what catches a header that stops honouring it.
+final Finder _dragHandle = find.byWidgetPredicate((widget) {
+  if (widget is! Container) return false;
+  final constraints = widget.constraints;
+  return constraints?.maxWidth == 64 && constraints?.maxHeight == 4;
+});
+
 void main() {
   final l10n = lookupAppLocalizations(const Locale('en'));
   late _MockDivineVideoDraft mockDraft;
@@ -88,14 +97,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text(l10n.uploadFailureSheetTitle), findsOneWidget);
-        expect(
-          tester
-              .widget<VineBottomSheetHeader>(
-                find.byType(VineBottomSheetHeader),
-              )
-              .showDragHandle,
-          isFalse,
-        );
+        expect(_dragHandle, findsNothing);
       });
 
       testWidgets('localized error message from $PublishError kind', (


### PR DESCRIPTION
Non-draggable bottom sheets currently show a grabber even though the route has disabled the gesture. This leaves the failed-send, upload-failure, and missing-content prompts advertising an interaction that cannot work.

The shared bottom-sheet API now derives its drag-handle default from whether route dragging is enabled. Callers can still explicitly override the handle, and direct widget construction keeps its existing default. This deliberately does not change whether any sheet can be dismissed.

Tests cover fixed and scrollable sheets, the explicit override, prompt forwarding, the common draggable path, and the upload-failure call site. Both the Divine UI package and app analyzers pass.

Closes #8462