### PR TITLE
refactor(video): remove misleading inactive home-feed expansion

### DIFF
--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -1759,8 +1759,6 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     nip50Sort, // NIP-50 search sorting (e.g., sort:hot, sort:top)
     bool force = false, // Force refresh even if parameters match
     bool scheduleOnlineRetry = true,
-    List<String>?
-    collaboratorPubkeys, // Legacy no-op until Funnelcake edge expansion exists
   }) async {
     // NostrService now handles subscription deduplication automatically via filter hashing
     // We still track subscription types for our own state management
@@ -2073,20 +2071,6 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         );
         Log.debug(
           '  - Video filter ($limit limit): ${videoFilter.toJson()}',
-          name: 'VideoEventService',
-          category: LogCategory.video,
-        );
-      }
-
-      // Do not expand feeds with raw collaborator p-tag filters. A p-tag can
-      // mean a pending invite or generic mention; confirmed collaborator feed
-      // expansion must come from Funnelcake collaborator edges once mobile has
-      // an endpoint/client for that feed path.
-      if (collaboratorPubkeys != null && collaboratorPubkeys.isNotEmpty) {
-        Log.debug(
-          'Skipping raw collaborator p-tag feed expansion for '
-          '${collaboratorPubkeys.length} pubkeys; waiting for Funnelcake '
-          'confirmed collaborator edges.',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
@@ -3503,7 +3487,6 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       includeReposts: true,
       sortBy: sortBy,
       force: force,
-      collaboratorPubkeys: followingPubkeys,
     );
 
     // After subscription, seed from relay to ensure we have ALL videos from

--- a/mobile/scripts/baseline/service_god_file_sizes.txt
+++ b/mobile/scripts/baseline/service_god_file_sizes.txt
@@ -11,4 +11,4 @@ lib/services/curated_list_service.dart	1847
 lib/services/upload_manager.dart	1958
 lib/services/video_editor/video_editor_render_service.dart	1539
 lib/services/video_event_publisher.dart	2295
-lib/services/video_event_service.dart	6517
+lib/services/video_event_service.dart	6500

--- a/mobile/test/unit/services/video_event_service_subscription_test.dart
+++ b/mobile/test/unit/services/video_event_service_subscription_test.dart
@@ -309,35 +309,31 @@ void main() {
       );
     });
 
-    test(
-      'does not add raw collaborator p-tag filters to feed subscriptions',
-      () async {
-        final subscriptionCalls = <List<Filter>>[];
-        when(
-          () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
-        ).thenAnswer((invocation) {
-          final filters = invocation.positionalArguments[0] as List<Filter>;
-          subscriptionCalls.add(filters);
-          return eventStreamController.stream;
-        });
+    test('does not add raw p-tag filters to home feed subscriptions', () async {
+      final subscriptionCalls = <List<Filter>>[];
+      when(
+        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+      ).thenAnswer((invocation) {
+        final filters = invocation.positionalArguments[0] as List<Filter>;
+        subscriptionCalls.add(filters);
+        return eventStreamController.stream;
+      });
 
-        await videoEventService.subscribeToVideoFeed(
-          subscriptionType: SubscriptionType.homeFeed,
-          authors: ['author1'],
-          limit: 50,
-          collaboratorPubkeys: ['author1'],
-        );
+      await videoEventService.subscribeToVideoFeed(
+        subscriptionType: SubscriptionType.homeFeed,
+        authors: ['author1'],
+        limit: 50,
+      );
 
-        expect(subscriptionCalls, hasLength(1));
-        expect(
-          subscriptionCalls.single.where((filter) => filter.p != null),
-          isEmpty,
-          reason:
-              'Confirmed collaborator expansion must come from Funnelcake '
-              'edges, not raw relay p-tags.',
-        );
-      },
-    );
+      expect(subscriptionCalls, hasLength(1));
+      expect(
+        subscriptionCalls.single.where((filter) => filter.p != null),
+        isEmpty,
+        reason:
+            'A p-tag can represent an unaccepted collaborator invite or a '
+            'generic mention, so the home feed must not expand raw p-tags.',
+      );
+    });
 
     test('should handle the classic vines -> open feed sequence correctly', () async {
       // This is the exact sequence that's failing in production


### PR DESCRIPTION
## Problem

The home-feed subscription path passed followed accounts through a collaborator-expansion parameter that had no behavior. The parameter only logged that raw Nostr p-tag expansion was skipped, which made the call graph imply that collaborator expansion was active.

## Why this fix

This removes the dead parameter, its home-feed argument, and the skip-only log. The existing subscription test now states the lasting behavior directly: home-feed filters must not expand raw p-tags, because those tags can represent unaccepted collaborator invites or generic mentions.

## Deliberately unchanged

This does not change live `VideoEvent.collaboratorPubkeys` model behavior or implement collaborator-based feed expansion. A future confirmed-collaborator feed source remains a separate product decision.

The service god-file ceiling is reduced from 6,517 to 6,500 lines to lock in the deletion.

## Verification

- `flutter test test/unit/services/video_event_service_subscription_test.dart test/unit/services/video_event_service_reset_resubscribe_test.dart test/services/video_event_service_deduplication_test.dart test/services/video_event_service_home_feed_streaming_test.dart`
- `flutter analyze lib test integration_test`
- `bash scripts/check_service_god_file_ceiling.sh`
- `git diff --check origin/main...HEAD`

Closes #6908