### PR TITLE
perf(feed): reduce repeated work during feed state comparisons

### DIFF
--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
@@ -61,7 +61,7 @@ final class FullscreenFeedTuningAction extends Equatable {
 
 /// State for the FullscreenFeedBloc.
 final class FullscreenFeedState extends Equatable {
-  const FullscreenFeedState({
+  FullscreenFeedState({
     this.status = FullscreenFeedStatus.initial,
     this.videos = const [],
     this.currentIndex = 0,
@@ -126,18 +126,21 @@ final class FullscreenFeedState extends Equatable {
 
   /// Metadata-sensitive signature for detecting updates to videos that keep
   /// the same IDs and order but change user-visible fields like loop counts.
-  List<String> get videoUpdateSignature => videos
-      .map(
-        (video) => [
-          video.id,
-          video.stableId,
-          video.videoUrl ?? '',
-          video.thumbnailUrl ?? '',
-          '${video.originalLoops ?? ''}',
-          video.rawTags['views'] ?? '',
-        ].join('|'),
-      )
-      .toList(growable: false);
+  ///
+  /// This is initialized lazily because computing it requires runtime video
+  /// data. Consequently, this state cannot have a const constructor.
+  late final List<String> videoUpdateSignature = List.unmodifiable(
+    videos.map(
+      (video) => [
+        video.id,
+        video.stableId,
+        video.videoUrl ?? '',
+        video.thumbnailUrl ?? '',
+        '${video.originalLoops ?? ''}',
+        video.rawTags['views'] ?? '',
+      ].join('|'),
+    ),
+  );
 
   /// Create a copy with updated values. [pendingSkipTarget] accepts
   /// `null` explicitly via [clearPendingSkipTarget] — the default

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
@@ -62,17 +62,48 @@ final class FullscreenFeedTuningAction extends Equatable {
 /// State for the FullscreenFeedBloc.
 final class FullscreenFeedState extends Equatable {
   FullscreenFeedState({
-    this.status = FullscreenFeedStatus.initial,
-    this.videos = const [],
-    this.currentIndex = 0,
-    this.isLoadingMore = false,
-    this.canLoadMore = false,
-    this.removedVideoIds = const <String>{},
-    this.pendingSkipTarget,
-    this.initialTargetResolved = false,
-    this.userChangedIndex = false,
-    this.lastTuningAction,
-  });
+    FullscreenFeedStatus status = FullscreenFeedStatus.initial,
+    List<VideoEvent> videos = const [],
+    int currentIndex = 0,
+    bool isLoadingMore = false,
+    bool canLoadMore = false,
+    Set<String> removedVideoIds = const <String>{},
+    int? pendingSkipTarget,
+    bool initialTargetResolved = false,
+    bool userChangedIndex = false,
+    FullscreenFeedTuningAction? lastTuningAction,
+  }) : this._(
+         status: status,
+         videos: videos,
+         currentIndex: currentIndex,
+         isLoadingMore: isLoadingMore,
+         canLoadMore: canLoadMore,
+         removedVideoIds: removedVideoIds,
+         pendingSkipTarget: pendingSkipTarget,
+         initialTargetResolved: initialTargetResolved,
+         userChangedIndex: userChangedIndex,
+         lastTuningAction: lastTuningAction,
+       );
+
+  /// Carries an already-materialized [videoUpdateSignature] into a copy whose
+  /// [videos] is the identical list instance, so the signature is built once
+  /// per list rather than once per state. See [copyWith].
+  FullscreenFeedState._({
+    required this.status,
+    required this.videos,
+    required this.currentIndex,
+    required this.isLoadingMore,
+    required this.canLoadMore,
+    required this.removedVideoIds,
+    required this.pendingSkipTarget,
+    required this.initialTargetResolved,
+    required this.userChangedIndex,
+    required this.lastTuningAction,
+    List<String>? signature,
+  }) : _inheritedSignature = signature;
+
+  /// Non-null only when [copyWith] proved [videos] unchanged by identity.
+  final List<String>? _inheritedSignature;
 
   /// The current status.
   final FullscreenFeedStatus status;
@@ -129,18 +160,20 @@ final class FullscreenFeedState extends Equatable {
   ///
   /// This is initialized lazily because computing it requires runtime video
   /// data. Consequently, this state cannot have a const constructor.
-  late final List<String> videoUpdateSignature = List.unmodifiable(
-    videos.map(
-      (video) => [
-        video.id,
-        video.stableId,
-        video.videoUrl ?? '',
-        video.thumbnailUrl ?? '',
-        '${video.originalLoops ?? ''}',
-        video.rawTags['views'] ?? '',
-      ].join('|'),
-    ),
-  );
+  late final List<String> videoUpdateSignature =
+      _inheritedSignature ??
+      List.unmodifiable(
+        videos.map(
+          (video) => [
+            video.id,
+            video.stableId,
+            video.videoUrl ?? '',
+            video.thumbnailUrl ?? '',
+            '${video.originalLoops ?? ''}',
+            video.rawTags['views'] ?? '',
+          ].join('|'),
+        ),
+      );
 
   /// Create a copy with updated values. [pendingSkipTarget] accepts
   /// `null` explicitly via [clearPendingSkipTarget] — the default
@@ -158,9 +191,10 @@ final class FullscreenFeedState extends Equatable {
     FullscreenFeedTuningAction? lastTuningAction,
     bool clearPendingSkipTarget = false,
   }) {
-    return FullscreenFeedState(
+    final nextVideos = videos ?? this.videos;
+    return FullscreenFeedState._(
       status: status ?? this.status,
-      videos: videos ?? this.videos,
+      videos: nextVideos,
       currentIndex: currentIndex ?? this.currentIndex,
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
       canLoadMore: canLoadMore ?? this.canLoadMore,
@@ -172,6 +206,9 @@ final class FullscreenFeedState extends Equatable {
           initialTargetResolved ?? this.initialTargetResolved,
       userChangedIndex: userChangedIndex ?? this.userChangedIndex,
       lastTuningAction: lastTuningAction ?? this.lastTuningAction,
+      signature: identical(nextVideos, this.videos)
+          ? videoUpdateSignature
+          : null,
     );
   }
 

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
@@ -212,10 +212,13 @@ final class FullscreenFeedState extends Equatable {
     );
   }
 
+  /// [videos] is deliberately absent: every [videoUpdateSignature] entry
+  /// starts with `video.id` and `VideoEvent ==` is id-only, so equal
+  /// signatures already imply equal length, ids and order. Listing both made
+  /// every `==` and `hashCode` walk the videos twice to answer one question.
   @override
   List<Object?> get props => [
     status,
-    videos,
     videoUpdateSignature,
     currentIndex,
     isLoadingMore,

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
@@ -85,9 +85,9 @@ final class FullscreenFeedState extends Equatable {
          lastTuningAction: lastTuningAction,
        );
 
-  /// Carries an already-materialized [videoUpdateSignature] into a copy whose
-  /// [videos] is the identical list instance, so the signature is built once
-  /// per list rather than once per state. See [copyWith].
+  /// Carries an already-materialized [videoUpdateSignature] into a copy when
+  /// [copyWith] leaves [videos] untouched, so the signature is built once per
+  /// list rather than once per state.
   FullscreenFeedState._({
     required this.status,
     required this.videos,
@@ -102,7 +102,7 @@ final class FullscreenFeedState extends Equatable {
     List<String>? signature,
   }) : _inheritedSignature = signature;
 
-  /// Non-null only when [copyWith] proved [videos] unchanged by identity.
+  /// Non-null only when [copyWith] was called without a [videos] argument.
   final List<String>? _inheritedSignature;
 
   /// The current status.
@@ -213,9 +213,7 @@ final class FullscreenFeedState extends Equatable {
           initialTargetResolved ?? this.initialTargetResolved,
       userChangedIndex: userChangedIndex ?? this.userChangedIndex,
       lastTuningAction: lastTuningAction ?? this.lastTuningAction,
-      signature: identical(nextVideos, this.videos)
-          ? videoUpdateSignature
-          : null,
+      signature: videos == null ? videoUpdateSignature : null,
     );
   }
 

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
@@ -158,8 +158,15 @@ final class FullscreenFeedState extends Equatable {
   /// Metadata-sensitive signature for detecting updates to videos that keep
   /// the same IDs and order but change user-visible fields like loop counts.
   ///
-  /// This is initialized lazily because computing it requires runtime video
-  /// data. Consequently, this state cannot have a const constructor.
+  /// A per-instance snapshot rather than a live view: it materializes once
+  /// from whatever [videos] holds at first access, so a later in-place
+  /// mutation of that same list is reported as a change instead of being
+  /// silently absorbed. The bloc's filter helpers do return the source list
+  /// by reference when no filter applies, so that case is reachable.
+  ///
+  /// The trade is memory for CPU — each live state retains one
+  /// `List<String>` (~130 KiB at 200 videos). Being `late` is also why this
+  /// class has no `const` constructor.
   late final List<String> videoUpdateSignature =
       _inheritedSignature ??
       List.unmodifiable(

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -177,7 +177,7 @@ void main() {
       });
 
       test('currentVideo returns null when videos empty', () {
-        const state = FullscreenFeedState(status: FullscreenFeedStatus.ready);
+        final state = FullscreenFeedState(status: FullscreenFeedStatus.ready);
 
         expect(state.currentVideo, isNull);
       });
@@ -193,13 +193,13 @@ void main() {
       });
 
       test('hasVideos returns false when videos empty', () {
-        const state = FullscreenFeedState(status: FullscreenFeedStatus.ready);
+        final state = FullscreenFeedState(status: FullscreenFeedStatus.ready);
 
         expect(state.hasVideos, isFalse);
       });
 
       test('copyWith creates copy with updated values', () {
-        const state = FullscreenFeedState();
+        final state = FullscreenFeedState();
         final video = createTestVideo('video1');
 
         final updated = state.copyWith(
@@ -421,6 +421,16 @@ void main() {
           isNot(updatedState.videoUpdateSignature),
         );
         expect(baseState, isNot(updatedState));
+      });
+
+      test('videoUpdateSignature is memoized and immutable', () {
+        final state = FullscreenFeedState(
+          videos: [createTestVideo('video1')],
+        );
+        final signature = state.videoUpdateSignature;
+
+        expect(identical(signature, state.videoUpdateSignature), isTrue);
+        expect(() => signature.add('changed'), throwsUnsupportedError);
       });
     });
 
@@ -667,7 +677,7 @@ void main() {
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'a later empty emission does not downgrade emptyAfterRemoval',
         build: createBloc,
-        seed: () => const FullscreenFeedState(
+        seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.emptyAfterRemoval,
         ),
         act: (bloc) async {
@@ -1198,7 +1208,7 @@ void main() {
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'does nothing when already loading more',
         build: () => createBloc(onLoadMore: () {}),
-        seed: () => const FullscreenFeedState(isLoadingMore: true),
+        seed: () => FullscreenFeedState(isLoadingMore: true),
         act: (bloc) => bloc.add(const FullscreenFeedLoadMoreRequested()),
         expect: () => <FullscreenFeedState>[],
       );
@@ -1288,7 +1298,7 @@ void main() {
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'sets index to 0 when videos are empty',
         build: createBloc,
-        seed: () => const FullscreenFeedState(
+        seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
           currentIndex: 5,
         ),
@@ -2075,7 +2085,7 @@ void main() {
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'clears pendingSkipTarget when acknowledged',
         build: createBloc,
-        seed: () => const FullscreenFeedState(
+        seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
           pendingSkipTarget: 2,
         ),
@@ -2092,8 +2102,7 @@ void main() {
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'no-ops when no pending skip',
         build: createBloc,
-        seed: () =>
-            const FullscreenFeedState(status: FullscreenFeedStatus.ready),
+        seed: () => FullscreenFeedState(status: FullscreenFeedStatus.ready),
         act: (bloc) => bloc.add(const FullscreenFeedSkipAcknowledged()),
         expect: () => <FullscreenFeedState>[],
       );
@@ -2142,29 +2151,29 @@ void main() {
 
     group('props and copyWith for new fields', () {
       test('removedVideoIds default is empty', () {
-        const state = FullscreenFeedState();
+        final state = FullscreenFeedState();
         expect(state.removedVideoIds, isEmpty);
       });
 
       test('pendingSkipTarget default is null', () {
-        const state = FullscreenFeedState();
+        final state = FullscreenFeedState();
         expect(state.pendingSkipTarget, isNull);
       });
 
       test('copyWith updates removedVideoIds', () {
-        const state = FullscreenFeedState();
+        final state = FullscreenFeedState();
         final updated = state.copyWith(removedVideoIds: {'a', 'b'});
         expect(updated.removedVideoIds, equals({'a', 'b'}));
       });
 
       test('copyWith updates pendingSkipTarget', () {
-        const state = FullscreenFeedState();
+        final state = FullscreenFeedState();
         final updated = state.copyWith(pendingSkipTarget: 5);
         expect(updated.pendingSkipTarget, equals(5));
       });
 
       test('copyWith clearPendingSkipTarget resets to null', () {
-        const state = FullscreenFeedState(pendingSkipTarget: 5);
+        final state = FullscreenFeedState(pendingSkipTarget: 5);
         final updated = state.copyWith(clearPendingSkipTarget: true);
         expect(updated.pendingSkipTarget, isNull);
       });

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -245,9 +245,10 @@ void main() {
           isLoadingMore: true,
         );
 
+        // `videos` is intentionally not a prop: the signature below already
+        // encodes each id, and VideoEvent equality is id-only.
         expect(state.props, [
           FullscreenFeedStatus.ready,
-          [video],
           [
             '${video.id}|${video.stableId}|${video.videoUrl ?? ''}|${video.thumbnailUrl ?? ''}|${video.originalLoops ?? ''}|${video.rawTags['views'] ?? ''}',
           ],

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -468,7 +468,7 @@ void main() {
           'video1',
           rawTags: const {'views': '42'},
         );
-        final after = FullscreenFeedState(videos: shared);
+        final after = before.copyWith(videos: shared);
 
         expect(after.videoUpdateSignature, isNot(equals(signature)));
         expect(before, isNot(equals(after)));

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -431,7 +431,47 @@ void main() {
         final signature = state.videoUpdateSignature;
 
         expect(identical(signature, state.videoUpdateSignature), isTrue);
-        expect(() => signature.add('changed'), throwsUnsupportedError);
+        // Index assignment, not `add`: a fixed-length list already rejects
+        // `add`, so asserting on it would pass against `.toList(growable:
+        // false)` too. Rejecting `[i] =` is what `List.unmodifiable` adds.
+        expect(() => signature[0] = 'changed', throwsUnsupportedError);
+      });
+
+      test('copyWith reuses the signature when videos is untouched', () {
+        final state = FullscreenFeedState(
+          videos: [createTestVideo('video1')],
+        );
+        final signature = state.videoUpdateSignature;
+
+        final sameVideos = state.copyWith(currentIndex: 1);
+        expect(identical(sameVideos.videoUpdateSignature, signature), isTrue);
+
+        final newVideos = state.copyWith(
+          videos: [createTestVideo('video2')],
+        );
+        expect(identical(newVideos.videoUpdateSignature, signature), isFalse);
+        expect(newVideos.videoUpdateSignature, isNot(equals(signature)));
+      });
+
+      test('a materialized signature is a snapshot, not a live view', () {
+        // The bloc's filter helpers return the source list by reference when
+        // no filter applies, so two states can share one list instance. Once
+        // a state has materialized its signature, a later in-place mutation
+        // of that shared list must still register as a change. A recomputing
+        // getter would report both states equal and drop the update.
+        final shared = [createTestVideo('video1')];
+        final before = FullscreenFeedState(videos: shared);
+        final signature = before.videoUpdateSignature;
+        expect(signature, hasLength(1));
+
+        shared[0] = createTestVideo(
+          'video1',
+          rawTags: const {'views': '42'},
+        );
+        final after = FullscreenFeedState(videos: shared);
+
+        expect(after.videoUpdateSignature, isNot(equals(signature)));
+        expect(before, isNot(equals(after)));
       });
     });
 

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -292,7 +292,7 @@ void main() {
       String? sourceDetail,
       VoidCallback? onBack,
     }) {
-      final effectiveState = state ?? const FullscreenFeedState();
+      final effectiveState = state ?? FullscreenFeedState();
       when(() => mockBloc.state).thenReturn(effectiveState);
 
       final content = buildContent(
@@ -584,7 +584,7 @@ void main() {
         tester,
       ) async {
         await tester.pumpWidget(
-          buildSubject(state: const FullscreenFeedState()),
+          buildSubject(state: FullscreenFeedState()),
         );
 
         expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
@@ -597,7 +597,7 @@ void main() {
       ) async {
         await tester.pumpWidget(
           buildSubject(
-            state: const FullscreenFeedState(
+            state: FullscreenFeedState(
               status: FullscreenFeedStatus.ready,
             ),
           ),
@@ -618,7 +618,7 @@ void main() {
         (tester) async {
           await tester.pumpWidget(
             buildSubject(
-              state: const FullscreenFeedState(
+              state: FullscreenFeedState(
                 status: FullscreenFeedStatus.empty,
               ),
               contextTitle: 'Liked',
@@ -641,7 +641,7 @@ void main() {
         tester,
       ) async {
         await tester.pumpWidget(
-          buildSubject(state: const FullscreenFeedState()),
+          buildSubject(state: FullscreenFeedState()),
         );
         expect(
           find.bySemanticsIdentifier(SemanticIds.fullscreenFeedLoading),
@@ -654,7 +654,7 @@ void main() {
 
         await tester.pumpWidget(
           buildSubject(
-            state: const FullscreenFeedState(
+            state: FullscreenFeedState(
               status: FullscreenFeedStatus.empty,
             ),
           ),
@@ -721,7 +721,7 @@ void main() {
         (tester) async {
           await tester.pumpWidget(
             buildSubject(
-              state: const FullscreenFeedState(
+              state: FullscreenFeedState(
                 status: FullscreenFeedStatus.emptyAfterRemoval,
               ),
               contextTitle: 'Saved',
@@ -746,7 +746,7 @@ void main() {
         'empty-state back button lands on the feed when route cannot pop',
         (tester) async {
           when(() => mockBloc.state).thenReturn(
-            const FullscreenFeedState(
+            FullscreenFeedState(
               status: FullscreenFeedStatus.emptyAfterRemoval,
             ),
           );
@@ -1868,7 +1868,7 @@ void main() {
           // Popping the feed while the receipt is visible, then tapping Undo,
           // called `context.read` on the unmounted State — a null-check on the
           // dead element.
-          const initialState = FullscreenFeedState();
+          final initialState = FullscreenFeedState();
           final controller = StreamController<FullscreenFeedState>();
           addTearDown(controller.close);
           when(() => mockBloc.state).thenReturn(initialState);

--- a/mobile/test/widgets/video_feed_item/inline_comment_composer_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/inline_comment_composer_bar_test.dart
@@ -431,7 +431,7 @@ void main() {
     ) async {
       when(
         () => fullscreenBloc.state,
-      ).thenReturn(const FullscreenFeedState());
+      ).thenReturn(FullscreenFeedState());
 
       await tester.pumpWidget(buildBar());
       await tester.enterText(


### PR DESCRIPTION
Fullscreen feed state comparisons repeatedly rebuilt a metadata signature for every video, allocating a new list and strings each time Equatable evaluated equality or a hash. On large feeds, that put avoidable O(videos) work on every state comparison.

This change computes the signature lazily once per video-list snapshot and exposes it as an unmodifiable list. Copies that leave `videos` untouched reuse the materialized signature, while an explicitly supplied video list always receives a fresh snapshot so an in-place source update cannot be hidden by stale memoized data.

Because runtime-derived lazy fields cannot coexist with a generative const constructor, the state constructor is now non-const and its test call sites have been updated. `videos` is also removed from Equatable's `props`: each signature entry already includes the video ID, and `VideoEvent` equality is ID-only, so comparing both lists walked the same identity and ordering information twice. Other equality fields retain their existing order.

Regression coverage verifies that repeated reads and copies without a video update reuse the same signature, callers cannot mutate it, and explicitly re-emitting a mutated shared list produces a new signature instead of dropping the state update.

This deliberately does not expand which video metadata fields participate in feed-state equality. Changes such as content-warning enrichment remain outside this performance fix.

Verification:
- `flutter test test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart test/widgets/video_feed_item/inline_comment_composer_bar_test.dart` (168 tests)
- `flutter analyze lib test integration_test`

Closes #3551
