### PR TITLE
fix(nostr): stop relay sends from retrying for minutes

### DIFF
--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -472,11 +472,10 @@ class RelayManager {
   /// Aggregate bound on one reconnect sweep.
   ///
   /// Parallelising already bounds a healthy sweep at roughly one connect
-  /// (a 10s handshake timeout plus a 2s orphan close), but nothing above the
-  /// socket layer guarantees a connect honours that: `_tryReconnect` with no
-  /// deadline retries with exponential backoff and can run for minutes. This
-  /// is the outer stop, so a wedged host cannot hold a DM send's inbox lookup
-  /// open indefinitely (#7091).
+  /// (a 10s handshake timeout plus a 2s orphan close). The socket layer also
+  /// bounds each send-path reconnect, while this shorter aggregate stop keeps
+  /// a sweep across multiple hosts from holding a DM send's inbox lookup open
+  /// indefinitely (#7091).
   @visibleForTesting
   static Duration reconnectSweepBudget = const Duration(seconds: 15);
 

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -469,13 +469,15 @@ class RelayManager {
   // Reconnection
   // ---------------------------------------------------------------------------
 
-  /// Aggregate bound on one reconnect sweep.
+  /// Aggregate bound on how long a caller waits for one reconnect sweep.
   ///
   /// Parallelising already bounds a healthy sweep at roughly one connect
-  /// (a 10s handshake timeout plus a 2s orphan close). The socket layer also
-  /// bounds each send-path reconnect, while this shorter aggregate stop keeps
-  /// a sweep across multiple hosts from holding a DM send's inbox lookup open
-  /// indefinitely (#7091).
+  /// (a 10s handshake timeout plus a 2s orphan close), but nothing below here
+  /// bounds an unhealthy one: this sweep dials through `relay.connect()`,
+  /// which passes no deadline and so never reaches the send-path reconnect
+  /// budget. This is the outer stop, so a wedged host cannot hold a DM send's
+  /// inbox lookup open indefinitely (#7091) — it releases the waiter only,
+  /// and late dials keep running.
   @visibleForTesting
   static Duration reconnectSweepBudget = const Duration(seconds: 15);
 

--- a/mobile/packages/nostr_sdk/lib/relay/relay.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay.dart
@@ -143,7 +143,11 @@ abstract class Relay {
       if (_isReqNaming(message, reissuedIds)) continue;
       if (dropQueuedCloses && _isClose(message)) continue;
       try {
-        final result = await send(message, queueIfFailed: false);
+        final result = await send(
+          message,
+          queueIfFailed: false,
+          skipReconnect: true,
+        );
         if (!result) {
           pendingMessages.add(message);
           log("message send fail onConnected");

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -601,7 +601,7 @@ class RelayPool {
           // relay.getSubscriptions() would return empty after AUTH success.
           relay.saveSubscription(subscription);
           log('🔄 autoSubscribe: sending ${subscription.id} to ${relay.url}');
-          await relay.send(subscription.toJson());
+          await relay.send(subscription.toJson(), skipReconnect: true);
         }
       }
       if (init) {

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -726,8 +726,9 @@ class RelayPool {
           !relay.relayStatus.authed) {
         log('🔐 Auth-required query - sending to trigger AUTH challenge');
         relay.saveQuery(subscription);
+        final deadline = DateTime.now().add(perRelaySendTimeout);
         final result = await relay
-            .send(message)
+            .send(message, queueIfFailed: false, deadline: deadline)
             .timeout(perRelaySendTimeout, onTimeout: () => false);
         if (!result) {
           log(
@@ -2034,8 +2035,9 @@ class RelayPool {
         log(
           '🔐 Auth-required subscription - sending to trigger AUTH challenge',
         );
+        final deadline = DateTime.now().add(perRelaySendTimeout);
         final result = await relay
-            .send(message)
+            .send(message, queueIfFailed: false, deadline: deadline)
             .timeout(perRelaySendTimeout, onTimeout: () => false);
         if (result) {
           return true;

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -590,6 +590,7 @@ class RelayPool {
 
     if (await relay.connect()) {
       if (autoSubscribe) {
+        var replayFailed = false;
         final msg =
             '🔄 autoSubscribe: re-sending ${_subscriptions.length} '
             'subscriptions to ${relay.url}';
@@ -601,7 +602,19 @@ class RelayPool {
           // relay.getSubscriptions() would return empty after AUTH success.
           relay.saveSubscription(subscription);
           log('🔄 autoSubscribe: sending ${subscription.id} to ${relay.url}');
-          await relay.send(subscription.toJson(), skipReconnect: true);
+          final sent = await relay.send(
+            subscription.toJson(),
+            skipReconnect: true,
+          );
+          replayFailed = replayFailed || !sent;
+        }
+        if (replayFailed) {
+          relay.relayStatus.onError();
+          log(
+            'autoSubscribe replay failed for ${relay.url}; '
+            'reconnecting once for saved-request replay',
+          );
+          if (!await relay.connect()) return false;
         }
       }
       if (init) {

--- a/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
@@ -12,14 +12,17 @@ enum ConnectionState { disconnected, connecting, connected }
 
 /// Configuration for WebSocket connection behavior
 class WebSocketConfig {
-  /// Maximum number of reconnection attempts before giving up
+  /// Maximum number of send-path reconnection attempts before giving up.
   final int maxReconnectAttempts;
 
-  /// Base delay for exponential backoff (doubles each attempt)
+  /// Base delay for send-path reconnect backoff (doubles each attempt).
   final Duration baseReconnectDelay;
 
-  /// Maximum delay between reconnection attempts
+  /// Maximum delay between send-path reconnection attempts.
   final Duration maxReconnectDelay;
+
+  /// Maximum time one send may spend reconnecting when it has no deadline.
+  final Duration reconnectBudget;
 
   /// Timeout for initial connection attempt
   final Duration connectionTimeout;
@@ -46,6 +49,7 @@ class WebSocketConfig {
     this.maxReconnectAttempts = 10,
     this.baseReconnectDelay = const Duration(seconds: 2),
     this.maxReconnectDelay = const Duration(minutes: 5),
+    this.reconnectBudget = const Duration(seconds: 30),
     this.connectionTimeout = const Duration(seconds: 10),
     this.closeTimeout = const Duration(seconds: 2),
     this.heartbeatInterval = const Duration(seconds: 30),
@@ -75,9 +79,9 @@ class DefaultWebSocketChannelFactory implements WebSocketChannelFactory {
 /// Manages a single WebSocket connection with on-demand reconnection and
 /// idle detection.
 ///
-/// Reconnects automatically when:
-/// - Sending a message while disconnected (triggers reconnect attempt)
-/// - Connection is lost while active (stream error/done)
+/// Reconnects on demand when a message is sent while disconnected. A stream
+/// error or closure marks the connection disconnected so the next send can
+/// start that bounded reconnect attempt.
 ///
 /// Idle Detection (heartbeat):
 /// - Tracks when the last message was received
@@ -193,11 +197,13 @@ class WebSocketConnectionManager {
     return _doConnect();
   }
 
-  Future<bool> _doConnect() async {
+  Future<bool> _doConnect({DateTime? deadline}) async {
     if (_disposed) {
       log('Connect refused: $url - manager is disposed');
       return false;
     }
+
+    if (_deadlineExpired(deadline)) return false;
 
     _setState(ConnectionState.connecting);
 
@@ -216,7 +222,9 @@ class WebSocketConnectionManager {
       // IOWebSocketChannel.connect() returns immediately and DNS/TLS
       // failures surface as unhandled async errors in the zone instead
       // of being caught here.
-      await channel.ready.timeout(config.connectionTimeout);
+      final handshakeTimeout = _remainingOr(config.connectionTimeout, deadline);
+      if (handshakeTimeout == Duration.zero) throw TimeoutException('deadline');
+      await channel.ready.timeout(handshakeTimeout);
 
       // A dispose, a disconnect, or a newer connect can all run inside the
       // handshake window, and each of them detaches this channel. Adopting it
@@ -255,7 +263,7 @@ class WebSocketConnectionManager {
       _setState(ConnectionState.disconnected);
       return false;
     } on TimeoutException {
-      log('Connection timed out after ${config.connectionTimeout}');
+      log('Connection timed out before its allowed deadline');
       _emitError('Connection timed out');
       // Clean up the channel that never finished connecting
       await _closeOrphanedChannel(channel);
@@ -458,8 +466,10 @@ class WebSocketConnectionManager {
   // --- Reconnection ---
 
   Future<bool> _tryReconnect({DateTime? deadline}) async {
+    final effectiveDeadline =
+        deadline ?? DateTime.now().add(config.reconnectBudget);
     while (_shouldReconnect && _state == ConnectionState.disconnected) {
-      if (_deadlineExpired(deadline)) return false;
+      if (_deadlineExpired(effectiveDeadline)) return false;
       if (_reconnectAttempts >= config.maxReconnectAttempts) {
         log('Max reconnect attempts reached for $url');
         _emitError('Max reconnect attempts reached');
@@ -478,13 +488,15 @@ class WebSocketConnectionManager {
         'Reconnecting in ${delay.inSeconds}s (attempt $_reconnectAttempts/${config.maxReconnectAttempts})',
       );
 
-      final wait = _remainingOr(delay, deadline);
+      final wait = _remainingOr(delay, effectiveDeadline);
       if (wait == Duration.zero) return false;
       await Future<void>.delayed(wait);
 
-      if (!_shouldReconnect || _deadlineExpired(deadline)) return false;
+      if (!_shouldReconnect || _deadlineExpired(effectiveDeadline)) {
+        return false;
+      }
 
-      final connected = await _doConnect();
+      final connected = await _doConnect(deadline: effectiveDeadline);
       if (connected) return true;
     }
 

--- a/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
@@ -214,6 +214,16 @@ class WebSocketConnectionManager {
         throw ArgumentError('Invalid WebSocket URL scheme: ${uri.scheme}');
       }
 
+      // Budget first: a socket created with no time left to await it leaves
+      // `channel.ready` unlistened, so its later failure escapes as an
+      // unhandled zone error — what the `await` below exists to prevent.
+      final handshakeTimeout = _remainingOr(config.connectionTimeout, deadline);
+      if (handshakeTimeout == Duration.zero) {
+        log('Connect abandoned: $url - no handshake time left');
+        _setState(ConnectionState.disconnected);
+        return false;
+      }
+
       log('Connecting to $url');
       channel = _channelFactory.create(uri);
       _channel = channel;
@@ -222,8 +232,6 @@ class WebSocketConnectionManager {
       // IOWebSocketChannel.connect() returns immediately and DNS/TLS
       // failures surface as unhandled async errors in the zone instead
       // of being caught here.
-      final handshakeTimeout = _remainingOr(config.connectionTimeout, deadline);
-      if (handshakeTimeout == Duration.zero) throw TimeoutException('deadline');
       await channel.ready.timeout(handshakeTimeout);
 
       // A dispose, a disconnect, or a newer connect can all run inside the

--- a/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
@@ -5,20 +5,51 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as developer;
 
+import 'package:clock/clock.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 /// Connection state for the WebSocket
 enum ConnectionState { disconnected, connecting, connected }
 
+class _ConnectionLimit {
+  _ConnectionLimit.wallClock(this._wallClockDeadline)
+    : _budget = null,
+      _stopwatch = null;
+
+  _ConnectionLimit.monotonic(this._budget)
+    : _wallClockDeadline = null,
+      _stopwatch = (Stopwatch()..start());
+
+  final DateTime? _wallClockDeadline;
+  final Duration? _budget;
+  final Stopwatch? _stopwatch;
+
+  bool get isMonotonic => _stopwatch != null;
+
+  bool get isExpired => remainingOr(Duration.zero) == Duration.zero;
+
+  Duration remainingOr(Duration fallback) {
+    final remaining = switch ((_wallClockDeadline, _budget, _stopwatch)) {
+      (final DateTime deadline, null, null) => deadline.difference(clock.now()),
+      (null, final Duration budget, final Stopwatch stopwatch) =>
+        budget - stopwatch.elapsed,
+      _ => Duration.zero,
+    };
+    if (remaining <= Duration.zero) return Duration.zero;
+    if (fallback == Duration.zero || remaining < fallback) return remaining;
+    return fallback;
+  }
+}
+
 /// Configuration for WebSocket connection behavior
 class WebSocketConfig {
-  /// Maximum number of send-path reconnection attempts before giving up.
+  /// Maximum number of reconnection attempts made for one send.
   final int maxReconnectAttempts;
 
   /// Base delay for send-path reconnect backoff (doubles each attempt).
   final Duration baseReconnectDelay;
 
-  /// Maximum delay between send-path reconnection attempts.
+  /// Maximum delay between reconnection attempts made for one send.
   final Duration maxReconnectDelay;
 
   /// Maximum time one send may spend reconnecting when it has no deadline.
@@ -46,9 +77,9 @@ class WebSocketConfig {
   final Duration idleTimeout;
 
   const WebSocketConfig({
-    this.maxReconnectAttempts = 10,
+    this.maxReconnectAttempts = 4,
     this.baseReconnectDelay = const Duration(seconds: 2),
-    this.maxReconnectDelay = const Duration(minutes: 5),
+    this.maxReconnectDelay = const Duration(seconds: 8),
     this.reconnectBudget = const Duration(seconds: 30),
     this.connectionTimeout = const Duration(seconds: 10),
     this.closeTimeout = const Duration(seconds: 2),
@@ -197,13 +228,13 @@ class WebSocketConnectionManager {
     return _doConnect();
   }
 
-  Future<bool> _doConnect({DateTime? deadline}) async {
+  Future<bool> _doConnect({_ConnectionLimit? limit}) async {
     if (_disposed) {
       log('Connect refused: $url - manager is disposed');
       return false;
     }
 
-    if (_deadlineExpired(deadline)) return false;
+    if (limit?.isExpired ?? false) return false;
 
     _setState(ConnectionState.connecting);
 
@@ -218,10 +249,12 @@ class WebSocketConnectionManager {
       // Budget first: a socket created with no time left to await it leaves
       // `channel.ready` unlistened, so its later failure escapes as an
       // unhandled zone error — what the `await` below exists to prevent.
-      handshakeTimeout = _remainingOr(config.connectionTimeout, deadline);
+      handshakeTimeout =
+          limit?.remainingOr(config.connectionTimeout) ??
+          config.connectionTimeout;
       if (handshakeTimeout == Duration.zero) {
         log('Connect abandoned: $url - no handshake time left');
-        _setState(ConnectionState.disconnected);
+        _markDisconnectedIfOwned(channel);
         return false;
       }
 
@@ -241,7 +274,7 @@ class WebSocketConnectionManager {
       // that no owner can reach — so nothing could ever close either (#7367).
       if (_disposed || !identical(_channel, channel)) {
         log('Discarding socket for $url: its owner went away mid-handshake');
-        await _closeOrphanedChannel(channel);
+        await _closeOrphanedChannel(channel, limit: limit);
         return false;
       }
 
@@ -280,7 +313,7 @@ class WebSocketConnectionManager {
         _emitError('Connection timed out');
       }
       // Clean up the channel that never finished connecting
-      await _closeOrphanedChannel(channel);
+      await _closeOrphanedChannel(channel, limit: limit);
       _markDisconnectedIfOwned(channel);
       return false;
     } catch (e) {
@@ -317,9 +350,12 @@ class WebSocketConnectionManager {
       channel == null ? _channel == null : identical(_channel, channel);
 
   /// Closes a socket that no longer has an owner.
-  Future<void> _closeOrphanedChannel(WebSocketChannel? channel) async {
+  Future<void> _closeOrphanedChannel(
+    WebSocketChannel? channel, {
+    _ConnectionLimit? limit,
+  }) async {
     if (channel == null) return;
-    await _closeSink(channel, description: 'orphaned channel');
+    await _closeSink(channel, description: 'orphaned channel', limit: limit);
   }
 
   /// Publishes to [errorStream] unless teardown already closed it.
@@ -391,11 +427,36 @@ class WebSocketConnectionManager {
   Future<void> _closeSink(
     WebSocketChannel channel, {
     required String description,
+    _ConnectionLimit? limit,
+  }) async {
+    final closeTimeout =
+        limit?.remainingOr(config.closeTimeout) ?? config.closeTimeout;
+    if (closeTimeout == Duration.zero) {
+      unawaited(
+        _closeSinkWithin(
+          channel,
+          description: description,
+          timeout: config.closeTimeout,
+        ),
+      );
+      return;
+    }
+    await _closeSinkWithin(
+      channel,
+      description: description,
+      timeout: closeTimeout,
+    );
+  }
+
+  Future<void> _closeSinkWithin(
+    WebSocketChannel channel, {
+    required String description,
+    required Duration timeout,
   }) async {
     try {
-      await channel.sink.close().timeout(config.closeTimeout);
+      await channel.sink.close().timeout(timeout);
     } on TimeoutException {
-      log('Timed out closing $description after ${config.closeTimeout}');
+      log('Timed out closing $description after $timeout');
     } catch (e) {
       log('Error closing $description: $e');
     }
@@ -412,7 +473,10 @@ class WebSocketConnectionManager {
     bool skipReconnect = false,
     DateTime? deadline,
   }) async {
-    if (_deadlineExpired(deadline)) return false;
+    final callerLimit = deadline == null
+        ? null
+        : _ConnectionLimit.wallClock(deadline);
+    if (callerLimit?.isExpired ?? false) return false;
 
     // Try to reconnect if disconnected
     if (_state == ConnectionState.disconnected) {
@@ -421,8 +485,8 @@ class WebSocketConnectionManager {
         return false;
       }
       log('Disconnected, attempting reconnect before send');
-      final connected = await _tryReconnect(deadline: deadline);
-      if (_deadlineExpired(deadline)) return false;
+      final connected = await _tryReconnect(callerLimit: callerLimit);
+      if (callerLimit?.isExpired ?? false) return false;
       if (!connected) {
         log('Reconnect failed, cannot send');
         return false;
@@ -432,20 +496,16 @@ class WebSocketConnectionManager {
     // Wait if currently connecting
     if (_state == ConnectionState.connecting) {
       log('Connecting, waiting before send');
-      final connected = await _waitForConnection(deadline: deadline);
-      if (_deadlineExpired(deadline)) return false;
+      final connected = await _waitForConnection(limit: callerLimit);
+      if (callerLimit?.isExpired ?? false) return false;
       if (!connected) {
         log('Connection failed, cannot send');
         return false;
       }
     }
 
-    if (_deadlineExpired(deadline)) return false;
+    if (callerLimit?.isExpired ?? false) return false;
     return _doSend(message);
-  }
-
-  bool _deadlineExpired(DateTime? deadline) {
-    return deadline != null && !DateTime.now().isBefore(deadline);
   }
 
   /// Send a message synchronously (no reconnection attempt).
@@ -472,7 +532,7 @@ class WebSocketConnectionManager {
     bool skipReconnect = false,
     DateTime? deadline,
   }) async {
-    if (_deadlineExpired(deadline)) return false;
+    if (deadline != null && !clock.now().isBefore(deadline)) return false;
 
     final String encoded;
     try {
@@ -493,12 +553,14 @@ class WebSocketConnectionManager {
 
   // --- Reconnection ---
 
-  Future<bool> _tryReconnect({DateTime? deadline}) async {
-    final effectiveDeadline =
-        deadline ?? DateTime.now().add(config.reconnectBudget);
+  Future<bool> _tryReconnect({_ConnectionLimit? callerLimit}) async {
+    final limit =
+        callerLimit ?? _ConnectionLimit.monotonic(config.reconnectBudget);
+    var attempts = 0;
+    _reconnectAttempts = 0;
     while (_shouldReconnect && _state == ConnectionState.disconnected) {
-      if (_deadlineExpired(effectiveDeadline)) return false;
-      if (_reconnectAttempts >= config.maxReconnectAttempts) {
+      if (limit.isExpired) return _stopAtReconnectLimit(limit);
+      if (attempts >= config.maxReconnectAttempts) {
         log('Max reconnect attempts reached for $url');
         _emitError('Max reconnect attempts reached');
         return false;
@@ -507,18 +569,18 @@ class WebSocketConnectionManager {
       // Exponential backoff: base * 2^attempts, capped at max
       final delayMs =
           (config.baseReconnectDelay.inMilliseconds *
-                  (1 << _reconnectAttempts.clamp(0, 8)))
+                  (1 << attempts.clamp(0, 8)))
               .clamp(0, config.maxReconnectDelay.inMilliseconds);
       final delay = Duration(milliseconds: delayMs);
 
-      final attempt = _reconnectAttempts + 1;
-      final wait = _remainingOr(delay, effectiveDeadline);
+      final attempt = attempts + 1;
+      final wait = limit.remainingOr(delay);
       if (wait < delay) {
         log(
           'Reconnect budget cannot fit the next backoff for $url; '
           'stopping before attempt $attempt',
         );
-        return false;
+        return _stopAtReconnectLimit(limit);
       }
       log(
         'Reconnecting in ${delay.inSeconds}s '
@@ -526,37 +588,36 @@ class WebSocketConnectionManager {
       );
       await Future<void>.delayed(wait);
 
-      if (!_shouldReconnect || _deadlineExpired(effectiveDeadline)) {
-        return false;
+      if (!_shouldReconnect) return false;
+      if (limit.isExpired) {
+        return _stopAtReconnectLimit(limit);
       }
 
       // Another sender may have started or completed a handshake during the
       // backoff. Join that connection instead of creating a competing socket.
       if (_state == ConnectionState.connected) return true;
       if (_state == ConnectionState.connecting) {
-        return _waitForConnection(deadline: effectiveDeadline);
+        return _waitForConnection(limit: limit);
       }
 
+      attempts = attempt;
       _reconnectAttempts = attempt;
-      final connected = await _doConnect(deadline: effectiveDeadline);
+      final connected = await _doConnect(limit: limit);
       if (connected) return true;
     }
 
     return _state == ConnectionState.connected;
   }
 
-  Duration _remainingOr(Duration fallback, DateTime? deadline) {
-    if (deadline == null) return fallback;
-    final remaining = deadline.difference(DateTime.now());
-    if (remaining.isNegative || remaining == Duration.zero) {
-      return Duration.zero;
-    }
-    if (remaining < fallback) return remaining;
-    return fallback;
+  bool _stopAtReconnectLimit(_ConnectionLimit limit) {
+    if (limit.isMonotonic) _emitError('Reconnect budget exhausted');
+    return false;
   }
 
-  Future<bool> _waitForConnection({DateTime? deadline}) async {
-    final waitTimeout = _connectionWaitTimeout(deadline);
+  Future<bool> _waitForConnection({_ConnectionLimit? limit}) async {
+    final waitTimeout =
+        limit?.remainingOr(config.connectionTimeout) ??
+        config.connectionTimeout;
     if (waitTimeout == Duration.zero) return false;
 
     // Wait up to connectionTimeout for connection to complete
@@ -592,16 +653,6 @@ class WebSocketConnectionManager {
     );
 
     return result;
-  }
-
-  Duration _connectionWaitTimeout(DateTime? deadline) {
-    if (deadline == null) return config.connectionTimeout;
-    final remaining = deadline.difference(DateTime.now());
-    if (remaining.isNegative || remaining == Duration.zero) {
-      return Duration.zero;
-    }
-    if (remaining < config.connectionTimeout) return remaining;
-    return config.connectionTimeout;
   }
 
   /// Reset reconnection state, allowing fresh attempts

--- a/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
@@ -266,26 +266,29 @@ class WebSocketConnectionManager {
 
       return true;
     } on WebSocketChannelException catch (e) {
-      log('Connection failed (WebSocket): $e');
-      _emitError('Connection failed: $e');
-      _detachChannel(channel);
-      _setState(ConnectionState.disconnected);
+      if (_ownsChannel(channel)) {
+        log('Connection failed (WebSocket): $e');
+        _emitError('Connection failed: $e');
+      }
+      _markDisconnectedIfOwned(channel);
       return false;
     } on TimeoutException {
-      // Name the budget: it is now min(connectionTimeout, time left), so a
-      // stall and a spent deadline would otherwise log identically.
-      log('Connection timed out after $handshakeTimeout');
-      _emitError('Connection timed out');
+      if (_ownsChannel(channel)) {
+        // Name the budget: it is now min(connectionTimeout, time left), so a
+        // stall and a spent deadline would otherwise log identically.
+        log('Connection timed out after $handshakeTimeout');
+        _emitError('Connection timed out');
+      }
       // Clean up the channel that never finished connecting
       await _closeOrphanedChannel(channel);
-      _detachChannel(channel);
-      _setState(ConnectionState.disconnected);
+      _markDisconnectedIfOwned(channel);
       return false;
     } catch (e) {
-      log('Connection failed: $e');
-      _emitError('Connection failed: $e');
-      _detachChannel(channel);
-      _setState(ConnectionState.disconnected);
+      if (_ownsChannel(channel)) {
+        log('Connection failed: $e');
+        _emitError('Connection failed: $e');
+      }
+      _markDisconnectedIfOwned(channel);
       return false;
     }
   }
@@ -298,6 +301,20 @@ class WebSocketConnectionManager {
   void _detachChannel(WebSocketChannel? channel) {
     if (channel == null || identical(_channel, channel)) _channel = null;
   }
+
+  /// Marks a failed connect disconnected only while it still owns the socket.
+  ///
+  /// An explicit reconnect can replace [_channel] while an older handshake is
+  /// waiting or cleaning up. That older attempt must not disconnect the newer
+  /// owner when it eventually fails.
+  void _markDisconnectedIfOwned(WebSocketChannel? channel) {
+    if (!_ownsChannel(channel)) return;
+    _detachChannel(channel);
+    _setState(ConnectionState.disconnected);
+  }
+
+  bool _ownsChannel(WebSocketChannel? channel) =>
+      channel == null ? _channel == null : identical(_channel, channel);
 
   /// Closes a socket that no longer has an owner.
   Future<void> _closeOrphanedChannel(WebSocketChannel? channel) async {
@@ -494,19 +511,33 @@ class WebSocketConnectionManager {
               .clamp(0, config.maxReconnectDelay.inMilliseconds);
       final delay = Duration(milliseconds: delayMs);
 
-      _reconnectAttempts++;
-      log(
-        'Reconnecting in ${delay.inSeconds}s (attempt $_reconnectAttempts/${config.maxReconnectAttempts})',
-      );
-
+      final attempt = _reconnectAttempts + 1;
       final wait = _remainingOr(delay, effectiveDeadline);
-      if (wait == Duration.zero) return false;
+      if (wait < delay) {
+        log(
+          'Reconnect budget cannot fit the next backoff for $url; '
+          'stopping before attempt $attempt',
+        );
+        return false;
+      }
+      log(
+        'Reconnecting in ${delay.inSeconds}s '
+        '(attempt $attempt/${config.maxReconnectAttempts})',
+      );
       await Future<void>.delayed(wait);
 
       if (!_shouldReconnect || _deadlineExpired(effectiveDeadline)) {
         return false;
       }
 
+      // Another sender may have started or completed a handshake during the
+      // backoff. Join that connection instead of creating a competing socket.
+      if (_state == ConnectionState.connected) return true;
+      if (_state == ConnectionState.connecting) {
+        return _waitForConnection(deadline: effectiveDeadline);
+      }
+
+      _reconnectAttempts = attempt;
       final connected = await _doConnect(deadline: effectiveDeadline);
       if (connected) return true;
     }
@@ -546,6 +577,10 @@ class WebSocketConnectionManager {
     if (_state == ConnectionState.connected) {
       sub.cancel();
       return true;
+    }
+    if (_state == ConnectionState.disconnected) {
+      sub.cancel();
+      return false;
     }
 
     final result = await completer.future.timeout(

--- a/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
@@ -208,6 +208,7 @@ class WebSocketConnectionManager {
     _setState(ConnectionState.connecting);
 
     WebSocketChannel? channel;
+    Duration? handshakeTimeout;
     try {
       final uri = Uri.parse(url);
       if (uri.scheme != 'ws' && uri.scheme != 'wss') {
@@ -217,7 +218,7 @@ class WebSocketConnectionManager {
       // Budget first: a socket created with no time left to await it leaves
       // `channel.ready` unlistened, so its later failure escapes as an
       // unhandled zone error — what the `await` below exists to prevent.
-      final handshakeTimeout = _remainingOr(config.connectionTimeout, deadline);
+      handshakeTimeout = _remainingOr(config.connectionTimeout, deadline);
       if (handshakeTimeout == Duration.zero) {
         log('Connect abandoned: $url - no handshake time left');
         _setState(ConnectionState.disconnected);
@@ -271,7 +272,9 @@ class WebSocketConnectionManager {
       _setState(ConnectionState.disconnected);
       return false;
     } on TimeoutException {
-      log('Connection timed out before its allowed deadline');
+      // Name the budget: it is now min(connectionTimeout, time left), so a
+      // stall and a spent deadline would otherwise log identically.
+      log('Connection timed out after $handshakeTimeout');
       _emitError('Connection timed out');
       // Clean up the channel that never finished connecting
       await _closeOrphanedChannel(channel);

--- a/mobile/packages/nostr_sdk/test/unit/relay_pending_messages_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pending_messages_test.dart
@@ -13,6 +13,7 @@ class _RequeueingRelay extends Relay {
 
   final List<dynamic> failedMessage;
   final List<List<dynamic>> sentMessages = [];
+  final List<bool> skipReconnectValues = [];
 
   @override
   final bool connectionIsFresh;
@@ -31,6 +32,7 @@ class _RequeueingRelay extends Relay {
     DateTime? deadline,
   }) async {
     sentMessages.add(List<dynamic>.from(message));
+    skipReconnectValues.add(skipReconnect);
 
     if (_messagesEqual(message, failedMessage)) {
       if (queueIfFailed) {
@@ -83,6 +85,7 @@ void main() {
           failedMessage,
         ]);
         expect(relay.pendingMessages, [failedMessage]);
+        expect(relay.skipReconnectValues, everyElement(isTrue));
       },
     );
   });

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
@@ -46,6 +46,8 @@ class _AuthFakeRelay extends Relay {
   /// When true, [send] records the frame but reports transport failure, so the
   /// failing post-auth resend path can be exercised.
   bool failSends = false;
+  bool? lastQueueIfFailed;
+  DateTime? lastDeadline;
 
   @override
   Future<bool> doConnect() async {
@@ -66,6 +68,8 @@ class _AuthFakeRelay extends Relay {
     DateTime? deadline,
   }) async {
     sentMessages.add(message);
+    lastQueueIfFailed = queueIfFailed;
+    lastDeadline = deadline;
     return !failSends;
   }
 
@@ -260,8 +264,29 @@ void main() {
         expect(result, isTrue);
         expect(relay.checkQuery(subscription.id), isTrue);
         expect(sentMessagesOfType(relay, 'REQ'), hasLength(1));
+        expect(relay.lastQueueIfFailed, isFalse);
+        expect(relay.lastDeadline, isNotNull);
       },
     );
+
+    test('bounds an auth-required subscription trigger at the send', () async {
+      relay.relayStatus.alwaysAuth = true;
+      relay.failSends = true;
+      final subscription = Subscription([
+        Filter(kinds: [EventKind.textNote]).toJson(),
+      ], (_) {});
+
+      final result = await nostr.relayPool.relayDoSubscribe(
+        relay,
+        subscription,
+        false,
+      );
+
+      expect(result, isFalse);
+      expect(relay.getSubscriptions(), contains(subscription));
+      expect(relay.lastQueueIfFailed, isFalse);
+      expect(relay.lastDeadline, isNotNull);
+    });
 
     test('republishes when AUTH OK arrives before EVENT rejection', () async {
       const eventId =

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
@@ -44,6 +44,36 @@ class _MutatingRelay extends Relay {
   }
 }
 
+class _DisconnectingAutoSubscribeRelay extends Relay {
+  _DisconnectingAutoSubscribeRelay(String url) : super(url, RelayStatus(url));
+
+  bool? receivedSkipReconnect;
+
+  @override
+  Future<bool> doConnect() async {
+    relayStatus.connected = ClientConnected.connected;
+    return true;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    relayStatus.connected = ClientConnected.disconnect;
+  }
+
+  @override
+  Future<bool> send(
+    List<dynamic> message, {
+    bool queueIfFailed = true,
+    bool skipReconnect = false,
+    DateTime? deadline,
+  }) async {
+    relayStatus.connected = ClientConnected.disconnect;
+    receivedSkipReconnect = skipReconnect;
+    if (!skipReconnect) return Completer<bool>().future;
+    return false;
+  }
+}
+
 /// A relay that succeeds on send and immediately responds with EOSE.
 class _SucceedingRelay extends Relay {
   _SucceedingRelay(String url) : super(url, RelayStatus(url));
@@ -459,6 +489,24 @@ void main() {
           relay.sentMessages.where((message) => message.first == 'REQ').length,
           greaterThanOrEqualTo(1),
         );
+      },
+    );
+
+    test(
+      'add(autoSubscribe: true) does not reconnect a socket lost after connect',
+      () async {
+        nostr.relayPool.subscribe([
+          Filter(kinds: const [1], limit: 1).toJson(),
+        ], (_) {});
+        final relay = _DisconnectingAutoSubscribeRelay(
+          'wss://disconnected-auto-subscribe.relay',
+        );
+
+        final add = nostr.relayPool.add(relay, autoSubscribe: true);
+        await pumpEventQueue();
+        expect(relay.receivedSkipReconnect, isTrue);
+        expect(await add, isTrue);
+        expect(relay.getSubscriptions(), hasLength(1));
       },
     );
 

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
@@ -48,9 +48,12 @@ class _DisconnectingAutoSubscribeRelay extends Relay {
   _DisconnectingAutoSubscribeRelay(String url) : super(url, RelayStatus(url));
 
   bool? receivedSkipReconnect;
+  int connectCount = 0;
+  int sendCount = 0;
 
   @override
   Future<bool> doConnect() async {
+    connectCount++;
     relayStatus.connected = ClientConnected.connected;
     return true;
   }
@@ -67,6 +70,8 @@ class _DisconnectingAutoSubscribeRelay extends Relay {
     bool skipReconnect = false,
     DateTime? deadline,
   }) async {
+    sendCount++;
+    if (sendCount > 1) return true;
     relayStatus.connected = ClientConnected.disconnect;
     receivedSkipReconnect = skipReconnect;
     if (!skipReconnect) return Completer<bool>().future;
@@ -493,7 +498,7 @@ void main() {
     );
 
     test(
-      'add(autoSubscribe: true) does not reconnect a socket lost after connect',
+      'add(autoSubscribe: true) reconnects a socket lost during replay',
       () async {
         nostr.relayPool.subscribe([
           Filter(kinds: const [1], limit: 1).toJson(),
@@ -506,6 +511,9 @@ void main() {
         await pumpEventQueue();
         expect(relay.receivedSkipReconnect, isTrue);
         expect(await add, isTrue);
+        await pumpEventQueue();
+        expect(relay.connectCount, 2);
+        expect(relay.sendCount, greaterThan(1));
         expect(relay.getSubscriptions(), hasLength(1));
       },
     );

--- a/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
@@ -607,6 +607,79 @@ void main() {
     });
 
     group('on-demand reconnection', () {
+      test('send without a deadline stops at the reconnect budget', () async {
+        mockFactory.shouldFail = true;
+        final boundedManager = WebSocketConnectionManager(
+          url: 'wss://test.relay.com',
+          channelFactory: mockFactory,
+          logger: logMessages.add,
+          config: const WebSocketConfig(
+            maxReconnectAttempts: 10,
+            baseReconnectDelay: Duration(milliseconds: 10),
+            maxReconnectDelay: Duration(milliseconds: 100),
+            connectionTimeout: Duration(milliseconds: 500),
+            reconnectBudget: Duration(milliseconds: 25),
+          ),
+        );
+        addTearDown(boundedManager.dispose);
+
+        expect(await boundedManager.send('test'), isFalse);
+        expect(boundedManager.reconnectAttempts, lessThan(10));
+      });
+
+      test('an explicit deadline overrides the reconnect budget', () async {
+        mockFactory.shouldFail = true;
+        final boundedManager = WebSocketConnectionManager(
+          url: 'wss://test.relay.com',
+          channelFactory: mockFactory,
+          logger: logMessages.add,
+          config: const WebSocketConfig(
+            maxReconnectAttempts: 10,
+            baseReconnectDelay: Duration(milliseconds: 10),
+            maxReconnectDelay: Duration(milliseconds: 100),
+            connectionTimeout: Duration(milliseconds: 500),
+            reconnectBudget: Duration(seconds: 1),
+          ),
+        );
+        addTearDown(boundedManager.dispose);
+
+        expect(
+          await boundedManager.send(
+            'test',
+            deadline: DateTime.now().add(const Duration(milliseconds: 25)),
+          ),
+          isFalse,
+        );
+        expect(boundedManager.reconnectAttempts, lessThan(10));
+      });
+
+      test('reconnect budget bounds a pending handshake', () async {
+        final readyGate = Completer<void>();
+        mockFactory.readyGate = readyGate;
+        final boundedManager = WebSocketConnectionManager(
+          url: 'wss://test.relay.com',
+          channelFactory: mockFactory,
+          logger: logMessages.add,
+          config: const WebSocketConfig(
+            maxReconnectAttempts: 10,
+            baseReconnectDelay: Duration(milliseconds: 1),
+            maxReconnectDelay: Duration(milliseconds: 1),
+            connectionTimeout: Duration(seconds: 1),
+            closeTimeout: Duration(milliseconds: 5),
+            reconnectBudget: Duration(milliseconds: 20),
+          ),
+        );
+        addTearDown(boundedManager.dispose);
+
+        expect(await boundedManager.send('test'), isFalse);
+        expect(boundedManager.state, ConnectionState.disconnected);
+
+        readyGate.complete();
+        await Future<void>.delayed(Duration.zero);
+        expect(boundedManager.state, ConnectionState.disconnected);
+        expect(mockFactory.lastChannel!.isClosed, isTrue);
+      });
+
       test('send reconnects when disconnected', () async {
         // Start disconnected
         expect(manager.state, equals(ConnectionState.disconnected));

--- a/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
@@ -337,6 +337,15 @@ void main() {
         expect(slowManager.state, equals(ConnectionState.disconnected));
         expect(errors, isNotEmpty);
         expect(errors.first, contains('timed out'));
+        // Without the duration, a stalled host and a caller out of budget
+        // log the same line.
+        expect(
+          logMessages,
+          contains(
+            'Connection timed out after '
+            '${const Duration(milliseconds: 100)}',
+          ),
+        );
 
         await slowManager.dispose();
       });

--- a/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
@@ -675,13 +675,16 @@ void main() {
             maxReconnectDelay: Duration(milliseconds: 1),
             connectionTimeout: Duration(seconds: 1),
             closeTimeout: Duration(milliseconds: 5),
-            reconnectBudget: Duration(milliseconds: 20),
+            // Must outlast the 1ms backoff before the only dial: an overshoot
+            // there exits the loop without dialling at all.
+            reconnectBudget: Duration(milliseconds: 200),
           ),
         );
         addTearDown(boundedManager.dispose);
 
         expect(await boundedManager.send('test'), isFalse);
         expect(boundedManager.state, ConnectionState.disconnected);
+        expect(mockFactory.createdChannels, isNotEmpty);
 
         readyGate.complete();
         await Future<void>.delayed(Duration.zero);

--- a/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
@@ -123,6 +123,7 @@ class MockWebSocketChannelFactory implements WebSocketChannelFactory {
   final List<MockWebSocketChannel> createdChannels = [];
   bool shouldFail = false;
   String? failureMessage;
+  Completer<void>? createdSignal;
 
   /// When set, the channel's `ready` future completes with this error
   /// instead of succeeding. Simulates DNS/TLS handshake failures.
@@ -143,6 +144,8 @@ class MockWebSocketChannelFactory implements WebSocketChannelFactory {
           : (readyGate?.future ?? Future.value()),
     );
     createdChannels.add(channel);
+    final signal = createdSignal;
+    if (signal != null && !signal.isCompleted) signal.complete();
     return channel;
   }
 
@@ -155,6 +158,7 @@ class MockWebSocketChannelFactory implements WebSocketChannelFactory {
     failureMessage = null;
     readyError = null;
     readyGate = null;
+    createdSignal = null;
   }
 }
 
@@ -636,6 +640,35 @@ void main() {
         expect(boundedManager.reconnectAttempts, lessThan(10));
       });
 
+      test(
+        'an unaffordable backoff neither waits nor consumes an attempt',
+        () async {
+          final boundedManager = WebSocketConnectionManager(
+            url: 'wss://test.relay.com',
+            channelFactory: mockFactory,
+            logger: logMessages.add,
+            config: const WebSocketConfig(
+              maxReconnectAttempts: 10,
+              baseReconnectDelay: Duration(seconds: 1),
+              reconnectBudget: Duration(milliseconds: 20),
+            ),
+          );
+          addTearDown(boundedManager.dispose);
+
+          expect(await boundedManager.send('test'), isFalse);
+
+          expect(boundedManager.reconnectAttempts, isZero);
+          expect(mockFactory.createdChannels, isEmpty);
+          expect(
+            logMessages,
+            contains(
+              'Reconnect budget cannot fit the next backoff for '
+              'wss://test.relay.com; stopping before attempt 1',
+            ),
+          );
+        },
+      );
+
       test('an explicit deadline overrides the reconnect budget', () async {
         mockFactory.shouldFail = true;
         final boundedManager = WebSocketConnectionManager(
@@ -764,6 +797,34 @@ void main() {
 
         expect(result, isTrue);
         expect(manager.state, equals(ConnectionState.connected));
+      });
+
+      test('concurrent sends do not start competing handshakes', () async {
+        final readyGate = Completer<void>();
+        final createdSignal = Completer<void>();
+        mockFactory.readyGate = readyGate;
+        mockFactory.createdSignal = createdSignal;
+        final reconnecting = WebSocketConnectionManager(
+          url: 'wss://test.relay.com',
+          channelFactory: mockFactory,
+          logger: logMessages.add,
+          config: const WebSocketConfig(
+            baseReconnectDelay: Duration(milliseconds: 1),
+            connectionTimeout: Duration(milliseconds: 100),
+            reconnectBudget: Duration(milliseconds: 200),
+          ),
+        );
+        addTearDown(reconnecting.dispose);
+
+        final first = reconnecting.send('first');
+        final second = reconnecting.send('second');
+        await createdSignal.future;
+        await Future<void>.delayed(Duration.zero);
+
+        expect(mockFactory.createdChannels, hasLength(1));
+        readyGate.complete();
+        expect(await first, isTrue);
+        expect(await second, isTrue);
       });
 
       test('resetReconnection clears attempt counter', () async {
@@ -934,6 +995,40 @@ void main() {
 
           expect(received, equals(['still listening to the live socket']));
           expect(supersededChannel.isClosed, isTrue);
+        },
+      );
+
+      test(
+        'a superseded handshake timeout does not disconnect its replacement',
+        () async {
+          final gate = Completer<void>();
+          mockFactory.readyGate = gate;
+          final racing = WebSocketConnectionManager(
+            url: 'wss://test.relay.com',
+            channelFactory: mockFactory,
+            logger: logMessages.add,
+            config: const WebSocketConfig(
+              connectionTimeout: Duration(milliseconds: 30),
+            ),
+          );
+          addTearDown(racing.dispose);
+          final errors = <String>[];
+          racing.errorStream.listen(errors.add);
+
+          final superseded = racing.connect();
+          await Future<void>.delayed(Duration.zero);
+          final oldChannel = mockFactory.lastChannel!;
+
+          mockFactory.readyGate = null;
+          expect(await racing.reconnect(), isTrue);
+          final replacement = mockFactory.lastChannel!;
+          expect(replacement, isNot(same(oldChannel)));
+
+          expect(await superseded, isFalse);
+          expect(racing.state, ConnectionState.connected);
+          expect(racing.isConnected, isTrue);
+          expect(replacement.isClosed, isFalse);
+          expect(errors, isEmpty);
         },
       );
 

--- a/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:nostr_sdk/relay/web_socket_connection_manager.dart';
 import 'package:test/test.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -621,7 +622,7 @@ void main() {
 
     group('on-demand reconnection', () {
       test('send without a deadline stops at the reconnect budget', () async {
-        mockFactory.shouldFail = true;
+        mockFactory.readyError = Exception('Connection failed');
         final boundedManager = WebSocketConnectionManager(
           url: 'wss://test.relay.com',
           channelFactory: mockFactory,
@@ -636,8 +637,112 @@ void main() {
         );
         addTearDown(boundedManager.dispose);
 
+        final stopwatch = Stopwatch()..start();
         expect(await boundedManager.send('test'), isFalse);
+        stopwatch.stop();
+
         expect(boundedManager.reconnectAttempts, lessThan(10));
+        expect(mockFactory.createdChannels, hasLength(1));
+        expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 250)));
+      });
+
+      test('each send gets a fresh reconnect schedule', () async {
+        mockFactory.readyError = Exception('Connection failed');
+        final boundedManager = WebSocketConnectionManager(
+          url: 'wss://test.relay.com',
+          channelFactory: mockFactory,
+          logger: logMessages.add,
+          config: const WebSocketConfig(
+            maxReconnectAttempts: 4,
+            baseReconnectDelay: Duration(milliseconds: 1),
+            maxReconnectDelay: Duration(milliseconds: 4),
+            reconnectBudget: Duration(milliseconds: 5),
+          ),
+        );
+        addTearDown(boundedManager.dispose);
+
+        expect(await boundedManager.send('first'), isFalse);
+        final firstSendAttempts = boundedManager.reconnectAttempts;
+        expect(firstSendAttempts, greaterThan(0));
+
+        expect(await boundedManager.send('second'), isFalse);
+
+        expect(boundedManager.reconnectAttempts, firstSendAttempts);
+      });
+
+      test('manager budget expiry reaches the error stream', () async {
+        final errors = <String>[];
+        final boundedManager = WebSocketConnectionManager(
+          url: 'wss://test.relay.com',
+          channelFactory: mockFactory,
+          logger: logMessages.add,
+          config: const WebSocketConfig(
+            baseReconnectDelay: Duration(seconds: 1),
+            reconnectBudget: Duration(milliseconds: 20),
+          ),
+        );
+        addTearDown(boundedManager.dispose);
+        final subscription = boundedManager.errorStream.listen(errors.add);
+        addTearDown(subscription.cancel);
+
+        expect(await boundedManager.send('test'), isFalse);
+        await pumpEventQueue();
+
+        expect(errors, ['Reconnect budget exhausted']);
+      });
+
+      test('caller deadline expiry does not report a relay error', () async {
+        final errors = <String>[];
+        final boundedManager = WebSocketConnectionManager(
+          url: 'wss://test.relay.com',
+          channelFactory: mockFactory,
+          logger: logMessages.add,
+          config: const WebSocketConfig(
+            baseReconnectDelay: Duration(seconds: 1),
+          ),
+        );
+        addTearDown(boundedManager.dispose);
+        final subscription = boundedManager.errorStream.listen(errors.add);
+        addTearDown(subscription.cancel);
+
+        expect(
+          await boundedManager.send(
+            'test',
+            deadline: clock.now().add(const Duration(milliseconds: 20)),
+          ),
+          isFalse,
+        );
+        await pumpEventQueue();
+
+        expect(errors, isEmpty);
+      });
+
+      test('synthesized reconnect budget ignores wall-clock jumps', () async {
+        mockFactory.readyError = Exception('Connection failed');
+        var wallClock = DateTime(2026);
+        final boundedManager = WebSocketConnectionManager(
+          url: 'wss://test.relay.com',
+          channelFactory: mockFactory,
+          logger: (message) {
+            logMessages.add(message);
+            if (message.startsWith('Connection failed:')) {
+              wallClock = wallClock.subtract(const Duration(days: 1));
+            }
+          },
+          config: const WebSocketConfig(
+            maxReconnectAttempts: 10,
+            baseReconnectDelay: Duration(milliseconds: 10),
+            maxReconnectDelay: Duration(milliseconds: 100),
+            reconnectBudget: Duration(milliseconds: 25),
+          ),
+        );
+        addTearDown(boundedManager.dispose);
+
+        await withClock(Clock(() => wallClock), () async {
+          expect(await boundedManager.send('test'), isFalse);
+        });
+
+        expect(mockFactory.createdChannels, hasLength(1));
       });
 
       test(
@@ -717,7 +822,7 @@ void main() {
 
         expect(await boundedManager.send('test'), isFalse);
         expect(boundedManager.state, ConnectionState.disconnected);
-        expect(mockFactory.createdChannels, isNotEmpty);
+        expect(mockFactory.createdChannels, hasLength(1));
 
         readyGate.complete();
         await Future<void>.delayed(Duration.zero);


### PR DESCRIPTION
## Problem

A send on a disconnected relay could enter a ten-attempt exponential reconnect schedule and remain pending for minutes. A first bounded implementation also allowed retry state to survive across sends, eventually preventing that relay from dialing again while other relays remained healthy.

## Why this fix

This gives every reconnecting send a fresh bounded retry schedule. Sends without a caller deadline use a 30-second monotonic budget; explicit caller deadlines stay wall-clock limits. Remaining time clamps backoff, handshake, connection waits, and synchronous cleanup. Cleanup continues safely in the background when public time is gone.

Defaults now describe one bounded schedule: four attempts, a 2-second exponential base, an 8-second cap, and a 30-second budget. Manager-owned budget exhaustion reaches relay error diagnostics; expected caller deadline expiry does not.

Concurrent sends join active handshakes. Superseded handshakes cannot mutate replacement channels. AUTH paths forward deadlines and disable failed-send queuing.

Queued-frame and saved-request replay never recursively enter the reconnect schedule. If auto-subscription replay loses its socket, the pool reports the failure and owns one reconnect so saved requests can replay on the fresh connection.

## Deliberately unchanged

The relay manager's separate 15-second aggregate sweep budget remains because it bounds a multi-relay operation. Explicit caller deadlines remain wall-clock API values. The change does not make expected caller cancellation a relay error.

## Verification

- `flutter analyze packages/nostr_sdk packages/nostr_client`
- `flutter test packages/nostr_sdk/test` (682 tests after rebase)
- `flutter test packages/nostr_client/test` (361 tests after rebase)
- Pre-push analyzer and changed-test checks (99 tests)
- Full GitHub check matrix, including service integration

Closes #8450
