### PR TITLE
fix(blocklist): make unblock clear every copy of a hidden account

### DIFF
--- a/mobile/integration_test/e2e/block_leaves_kind3_follow_test.dart
+++ b/mobile/integration_test/e2e/block_leaves_kind3_follow_test.dart
@@ -89,8 +89,15 @@ class _LocalBlockListSigner implements BlockListSigner {
     required int kind,
     required String content,
     List<List<String>>? tags,
+    int? createdAt,
   }) async {
-    final event = Event(_pubkey, kind, tags ?? const [], content);
+    final event = Event(
+      _pubkey,
+      kind,
+      tags ?? const [],
+      content,
+      createdAt: createdAt,
+    );
     return _signer.signEvent(event);
   }
 }

--- a/mobile/lib/blocs/other_profile/other_profile_bloc.dart
+++ b/mobile/lib/blocs/other_profile/other_profile_bloc.dart
@@ -85,7 +85,16 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
   /// pubkeys, and it matches the kind 3 we publish (#6903). The profile ⋯
   /// sheet gates its `Unfollow <name>` row on this, so without the check it
   /// offers to unfollow an account the rest of the app says is not followed.
-  bool get isFollowing => !isBlocked && _followRepository.isFollowing(pubkey);
+  ///
+  /// This reads the repository's block predicate rather than [isBlocked]:
+  /// a mute imported from another client severs nothing, so `MyFollowingBloc`
+  /// still lists the account and `blockedPubkeysForAccount` still publishes
+  /// the follow. Widening it here would hide the `Unfollow` row for an
+  /// account the viewer does follow -- the same disagreement this getter
+  /// exists to prevent, with the sign flipped.
+  bool get isFollowing =>
+      !_blocklistRepository.isBlocked(pubkey) &&
+      _followRepository.isFollowing(pubkey);
 
   Future<void> _onLoadRequested(
     OtherProfileLoadRequested event,

--- a/mobile/lib/blocs/other_profile/other_profile_bloc.dart
+++ b/mobile/lib/blocs/other_profile/other_profile_bloc.dart
@@ -72,8 +72,11 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
   /// The pubkey of the profile being viewed.
   final String pubkey;
 
-  /// Current block status for the viewed profile.
-  bool get isBlocked => _blocklistRepository.isBlocked(pubkey);
+  /// Whether the viewer can stop hiding the viewed profile.
+  ///
+  /// Includes both Divine blocks and mutes imported from another Nostr
+  /// client, so either source reaches the existing Unblock action.
+  bool get isBlocked => _blocklistRepository.canUnblock(pubkey);
 
   /// Whether the current user is following the viewed profile.
   ///

--- a/mobile/lib/widgets/profile/profile_action_buttons_widget.dart
+++ b/mobile/lib/widgets/profile/profile_action_buttons_widget.dart
@@ -82,7 +82,7 @@ class ProfileActionButtons extends ConsumerWidget {
     // Watch blocklist version to trigger rebuilds when block/unblock occurs
     ref.watch(blocklistVersionProvider);
 
-    final isBlocked = contentBlocklistRepository.isBlocked(userIdHex);
+    final isBlocked = contentBlocklistRepository.canUnblock(userIdHex);
     final canTargetUser = ref.watch(canTargetUserProvider(userIdHex));
 
     // Create MyFollowingBloc at this level so both the follow button

--- a/mobile/lib/widgets/profile/unavailable_profile_actions.dart
+++ b/mobile/lib/widgets/profile/unavailable_profile_actions.dart
@@ -58,7 +58,7 @@ class UnavailableProfileActions extends ConsumerWidget {
         // the same generic fallback the conversation header uses.
         displayName: context.l10n.profileUserFallback,
         isFollowing: followRepository.isFollowing(userIdHex),
-        isBlocked: blocklistRepository.isBlocked(userIdHex),
+        isBlocked: blocklistRepository.canUnblock(userIdHex),
         showReport: true,
       ),
       children: const [],

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -744,7 +744,9 @@ class ContentBlocklistRepository {
   /// the latest own kind 10000 event.
   ///
   /// Returns `true` when the event was accepted by at least one relay.
-  Future<bool> _publishMuteListToNostr() async {
+  Future<bool> _publishMuteListToNostr({
+    Set<String> protectedUnblocks = const <String>{},
+  }) async {
     // Keep every unsuccessful attempt retryable. This is set before the
     // dependency guards too, because block/unblock actions can race startup.
     _muteListPublishPending = true;
@@ -770,7 +772,10 @@ class ContentBlocklistRepository {
     }
 
     try {
-      if (!await _refreshLatestOwnMuteList(nostrClient)) {
+      if (!await _refreshLatestOwnMuteList(
+        nostrClient,
+        protectedUnblocks: protectedUnblocks,
+      )) {
         // Kind 10000 is replaceable: publishing now would replace a list we
         // could not read. Everything only the unread event holds would go
         // with it -- the encrypted private section, every t/word/e mute, and
@@ -784,6 +789,18 @@ class ContentBlocklistRepository {
         );
         return false;
       }
+      var pendingTimestampChanged = false;
+      final latestOwnCreatedAt = _latestOwnMuteListEvent?.createdAt;
+      if (latestOwnCreatedAt != null) {
+        for (final pubkey in protectedUnblocks) {
+          final pendingAt = _pendingUnblocks[pubkey];
+          if (pendingAt != null && pendingAt < latestOwnCreatedAt) {
+            _pendingUnblocks[pubkey] = latestOwnCreatedAt;
+            pendingTimestampChanged = true;
+          }
+        }
+      }
+      if (pendingTimestampChanged) await _savePendingUnblocks();
       final publishShape = _buildMuteListPublishShape();
 
       final event = await signer.createAndSignEvent(
@@ -841,7 +858,10 @@ class ContentBlocklistRepository {
   /// `noRelays` -- which is why the detailed form is used here, with
   /// `requireAllRelaysSettled` so a relay abandoned by the settle window
   /// arrives as a timeout rather than as an empty answer.
-  Future<bool> _refreshLatestOwnMuteList(NostrClient nostrClient) async {
+  Future<bool> _refreshLatestOwnMuteList(
+    NostrClient nostrClient, {
+    Set<String> protectedUnblocks = const <String>{},
+  }) async {
     final ourPubkey = _ourPubkey;
     if (ourPubkey == null) return false;
 
@@ -861,7 +881,10 @@ class ContentBlocklistRepository {
     }
 
     if (newest != null && newest != _latestOwnMuteListEvent) {
-      _applyOwnMuteListEvent(newest);
+      _applyOwnMuteListEvent(
+        newest,
+        protectedUnblocks: protectedUnblocks,
+      );
     }
 
     return !result.timedOut && !result.noRelays;
@@ -918,6 +941,14 @@ class ContentBlocklistRepository {
     _runtimeBlocklist.forEach(addPubkey);
 
     return _MuteListPublishShape(tags: tags, content: source?.content ?? '');
+  }
+
+  bool _latestOwnMuteListCarries(String pubkey) {
+    final source = _latestOwnMuteListEvent;
+    if (source == null) return false;
+    return source.tags.any(
+      (tag) => tag.length >= 2 && tag[0] == 'p' && tag[1] == pubkey,
+    );
   }
 
   /// Whether [pubkey] is still the session identity.
@@ -1198,10 +1229,12 @@ class ContentBlocklistRepository {
   /// Persists to SharedPreferences and publishes the user's kind 10000 mute
   /// list once no matter how many new pubkeys are added. Emits one
   /// [BlocklistChange] per newly-blocked pubkey because downstream feed
-  /// cleanup reacts per author.
+  /// cleanup reacts per author. An idempotent re-block also flushes a pending
+  /// mute-list publish without producing another local change event.
   Future<void> blockUsers(Iterable<String> pubkeys, {String? ourPubkey}) async {
     final selfPubkey = ourPubkey ?? _ourPubkey;
     var skippedSelf = false;
+    var hasEligibleTarget = false;
     final newlyBlocked = <String>[];
     final newlySeveredFollowers = <String>[];
     var retiredPendingUnblock = false;
@@ -1212,11 +1245,12 @@ class ContentBlocklistRepository {
         skippedSelf = true;
         continue;
       }
+      hasEligibleTarget = true;
       if (_runtimeBlocklist.add(pubkey)) {
         newlyBlocked.add(pubkey);
-        retiredPendingUnblock =
-            _pendingUnblocks.remove(pubkey) != null || retiredPendingUnblock;
       }
+      retiredPendingUnblock =
+          _pendingUnblocks.remove(pubkey) != null || retiredPendingUnblock;
       if (!_severedFollowers.contains(pubkey) &&
           !newlySeveredFollowers.contains(pubkey)) {
         newlySeveredFollowers.add(pubkey);
@@ -1231,9 +1265,9 @@ class ContentBlocklistRepository {
       );
     }
 
+    if (retiredPendingUnblock) await _savePendingUnblocks();
     if (newlyBlocked.isNotEmpty) {
       await _saveBlockedUsers();
-      if (retiredPendingUnblock) await _savePendingUnblocks();
       for (final pubkey in newlyBlocked) {
         _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.blocked));
       }
@@ -1246,6 +1280,9 @@ class ContentBlocklistRepository {
         category: LogCategory.system,
       );
     }
+    if (newlyBlocked.isEmpty && hasEligibleTarget) {
+      await retryPendingMuteListPublish();
+    }
 
     // Track as severed follower so they stay hidden from our followers
     // list even after unblocking (until they explicitly re-follow).
@@ -1255,34 +1292,15 @@ class ContentBlocklistRepository {
     }
   }
 
-  /// Remove a public key from the runtime blocklist
+  /// Stop hiding a public key through this account's own mute list.
   ///
-  /// Persists to SharedPreferences and republishes the updated kind 10000
-  /// mute list to Nostr.
+  /// Removes both Divine-authored blocks and mutes imported from another
+  /// client, then republishes the updated kind 10000 mute list to Nostr.
   /// Awaits the local write so the change survives an immediate app kill.
   /// Note: Cannot remove users from internal blocklist.
   Future<void> unblockUser(String pubkey) async {
-    if (_runtimeBlocklist.contains(pubkey)) {
-      _runtimeBlocklist.remove(pubkey);
-      await _saveBlockedUsers();
-      // Recorded BEFORE the publish, so a withheld or failed publish still
-      // leaves the intent behind for the next launch to act on (#8263).
-      _pendingUnblocks[pubkey] = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-      await _savePendingUnblocks();
-      _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.unblocked));
-      _notifyChanged();
-      // Retirement is not repeated here: a successful publish routes its own
-      // event through [_applyOwnMuteListEvent], which drops the intent
-      // because the list it just wrote no longer carries the tag.
-      await _publishMuteListToNostr();
-
-      Log.info(
-        'Removed user from blocklist: ${pubkeyForLogs(pubkey)}',
-        name: 'ContentBlocklistRepository',
-        category: LogCategory.system,
-      );
-      // coverage:ignore-start
-    } else if (_internalBlocklist.contains(pubkey)) {
+    // coverage:ignore-start
+    if (_internalBlocklist.contains(pubkey)) {
       // Internal blocklist is intentionally empty; this branch is
       // unreachable in production. Retained as a guard in case hardcoded
       // moderation blocks are re-introduced.
@@ -1291,8 +1309,53 @@ class ContentBlocklistRepository {
         name: 'ContentBlocklistRepository',
         category: LogCategory.system,
       );
-      // coverage:ignore-end
+      return;
     }
+    // coverage:ignore-end
+
+    final removedBlock = _runtimeBlocklist.remove(pubkey);
+    final removedMute = _mutedPubkeys.remove(pubkey);
+    final hadPendingUnblock = _pendingUnblocks.containsKey(pubkey);
+    final publishedListCarries = _latestOwnMuteListCarries(pubkey);
+    final hasExplicitUnblock =
+        removedBlock ||
+        removedMute ||
+        hadPendingUnblock ||
+        publishedListCarries;
+
+    if (removedBlock) {
+      await _saveBlockedUsers();
+      _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.unblocked));
+    }
+    if (removedMute) {
+      await _saveMutedUsers();
+      _emitChange(
+        BlocklistChange(pubkey: pubkey, op: BlocklistOp.unmutedByUs),
+      );
+    }
+    if (removedBlock || removedMute) {
+      _notifyChanged();
+    }
+
+    if (!hasExplicitUnblock) {
+      await retryPendingMuteListPublish();
+      return;
+    }
+
+    // Recorded BEFORE the publish, so a withheld or failed publish still
+    // leaves the intent behind for the next launch to act on (#8263).
+    _pendingUnblocks[pubkey] = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    await _savePendingUnblocks();
+    // Protect this explicit action from a clock-skewed source event fetched
+    // during the mandatory pre-publish refresh. Ordinary later reconciliation
+    // still honours a genuinely newer mute authored by another client.
+    await _publishMuteListToNostr(protectedUnblocks: {pubkey});
+
+    Log.info(
+      'Stopped hiding user: ${pubkeyForLogs(pubkey)}',
+      name: 'ContentBlocklistRepository',
+      category: LogCategory.system,
+    );
   }
 
   /// Get all blocked public keys (for debugging)
@@ -1792,6 +1855,7 @@ class ContentBlocklistRepository {
     bool notify = true,
     bool persist = true,
     bool reconcile = false,
+    Set<String> protectedUnblocks = const <String>{},
   }) {
     final ourPubkey = event.pubkey;
     final createdAt = event.createdAt;
@@ -1829,6 +1893,10 @@ class ContentBlocklistRepository {
     if (_pendingUnblocks.isNotEmpty) {
       final retired = <String>[];
       for (final entry in _pendingUnblocks.entries) {
+        if (protectedUnblocks.contains(entry.key)) {
+          relayMuted.remove(entry.key);
+          continue;
+        }
         if (!relayMuted.contains(entry.key) || entry.value < createdAt) {
           // Either the tag is gone, so the unblock landed, or this list is
           // newer than the unblock and the tag is a fresh mute from another

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -1353,10 +1353,10 @@ class ContentBlocklistRepository {
     // with nothing to stop the relay's surviving `p` tag from being
     // re-adopted as a mute (#8263).
     //
-    // The watermark only ever advances. The stored second is what a later
-    // reconciliation compares a relay list's `created_at` against, so
-    // lowering it on a repeat attempt hands back protection an earlier
-    // attempt already earned.
+    // The recorded second no longer decides retirement -- whether the own
+    // list still carries the `p` tag does -- so it survives as a diagnostic
+    // and as the tiebreak in the legacy-key merge above, which keeps the
+    // later of two copies. Keep it monotonic so both stay meaningful.
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     final recordedAt = _pendingUnblocks[pubkey];
     if (recordedAt == null || recordedAt < now) {

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -1921,7 +1921,14 @@ class ContentBlocklistRepository {
     if (_pendingUnblocks.isNotEmpty) {
       final retired = <String>[];
       for (final entry in _pendingUnblocks.entries) {
-        if (protectedUnblocks.contains(entry.key)) {
+        // Protection only ever means "do not re-adopt a tag that is still
+        // there". Once the list has dropped it the unblock landed, and the
+        // intent has to retire like any other -- an entry that can never
+        // retire re-arms `_muteListPublishPending` from `_loadPendingUnblocks`
+        // on every cold start, so the device signs and publishes a kind 10000
+        // on every launch for the life of the install.
+        if (protectedUnblocks.contains(entry.key) &&
+            relayMuted.contains(entry.key)) {
           relayMuted.remove(entry.key);
           continue;
         }

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -945,7 +945,11 @@ class ContentBlocklistRepository {
 
   bool _latestOwnMuteListCarries(String pubkey) {
     final source = _latestOwnMuteListEvent;
-    if (source == null) return false;
+    // A self `p` tag is malformed and is filtered out of the mute set in
+    // [_applyOwnMuteListEvent], so it must not make us look muted here
+    // either -- an intent keyed on our own pubkey could never be satisfied
+    // and would re-arm the publish on every launch (#2192).
+    if (source == null || pubkey == _ourPubkey) return false;
     return source.tags.any(
       (tag) => tag.length >= 2 && tag[0] == 'p' && tag[1] == pubkey,
     );
@@ -1299,6 +1303,9 @@ class ContentBlocklistRepository {
   /// Awaits the local write so the change survives an immediate app kill.
   /// Note: Cannot remove users from internal blocklist.
   Future<void> unblockUser(String pubkey) async {
+    // DM surfaces fall back to an empty counterparty when a conversation
+    // carries no participants; [blockUsers] already skips it.
+    if (pubkey.isEmpty) return;
     // coverage:ignore-start
     if (_internalBlocklist.contains(pubkey)) {
       // Internal blocklist is intentionally empty; this branch is

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -1344,11 +1344,12 @@ class ContentBlocklistRepository {
 
     // Recorded BEFORE the local removals are persisted, and so before the
     // publish. A kill anywhere after this leaves an account that is still
-    // hidden plus the intent to unhide it, which the next launch acts on. In
+    // hidden plus the intent to unhide it, which the next launch acts on; in
     // the other order a kill between the two writes left it unhidden locally
     // with nothing to stop the relay's surviving `p` tag from being
-    // re-adopted as a mute on the next launch (#8263).
-    // Only ever advance the watermark. The stored second is what a later
+    // re-adopted as a mute (#8263).
+    //
+    // The watermark only ever advances. The stored second is what a later
     // reconciliation compares a relay list's `created_at` against, so
     // lowering it on a repeat attempt hands back protection an earlier
     // attempt already earned.

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -12,6 +12,7 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
 import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
+import 'package:nostr_sdk/utils/nostr_timestamp.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -25,14 +26,14 @@ const _mutedUsersPrefsKey = 'muted_users_list';
 const _severedFollowersPrefsKey = 'severed_followers_list';
 
 /// SharedPreferences key for unblocks whose kind 10000 publish has not been
-/// confirmed, as `pubkey -> unblocked-at` in Unix seconds.
+/// confirmed, as `pubkey -> intent-recorded-at` in Unix seconds.
 ///
 /// A block that never reached the relay is derivable after a restart -- it is
 /// in `_blockedUsersPrefsKey` and absent from the list the relay serves back.
 /// An unblock is not: once the pubkey leaves the block set, "the user
 /// unblocked them" and "another client muted them" are the same state. The
-/// timestamp is what separates the two, against the list's `created_at`
-/// (#8263).
+/// durable intent is what separates the two until a list without the tag is
+/// observed (#8263).
 const _pendingUnblocksPrefsKey = 'pending_unblocks';
 
 /// SharedPreferences key recording which account's per-account state the
@@ -144,8 +145,8 @@ class ContentBlocklistRepository {
   bool _muteListPublishPending = false;
 
   // Unblocks whose removal from the published kind 10000 is not yet
-  // confirmed, as pubkey -> unblocked-at in Unix seconds. Persisted, because
-  // the whole point is to survive the restart that loses
+  // confirmed, as pubkey -> intent-recorded-at in Unix seconds. The map is
+  // persisted because the whole point is to survive the restart that loses
   // [_muteListPublishPending].
   final Map<String, int> _pendingUnblocks = <String, int>{};
 
@@ -477,9 +478,7 @@ class ContentBlocklistRepository {
     final scopedKey = '$_pendingUnblocksPrefsKey.$pubkey';
     final scoped = prefs.getString(scopedKey);
     if (scoped != null &&
-        (_scopedBasesPresentAtConstruction.contains(
-              _pendingUnblocksPrefsKey,
-            ) ||
+        (_scopedBasesPresentAtConstruction.contains(_pendingUnblocksPrefsKey) ||
             _activeAccountPubkey == null)) {
       try {
         final decoded = jsonDecode(scoped) as Map<String, dynamic>;
@@ -744,9 +743,7 @@ class ContentBlocklistRepository {
   /// the latest own kind 10000 event.
   ///
   /// Returns `true` when the event was accepted by at least one relay.
-  Future<bool> _publishMuteListToNostr({
-    Set<String> protectedUnblocks = const <String>{},
-  }) async {
+  Future<bool> _publishMuteListToNostr() async {
     // Keep every unsuccessful attempt retryable. This is set before the
     // dependency guards too, because block/unblock actions can race startup.
     _muteListPublishPending = true;
@@ -772,10 +769,7 @@ class ContentBlocklistRepository {
     }
 
     try {
-      if (!await _refreshLatestOwnMuteList(
-        nostrClient,
-        protectedUnblocks: protectedUnblocks,
-      )) {
+      if (!await _refreshLatestOwnMuteList(nostrClient)) {
         // Kind 10000 is replaceable: publishing now would replace a list we
         // could not read. Everything only the unread event holds would go
         // with it -- the encrypted private section, every t/word/e mute, and
@@ -789,25 +783,37 @@ class ContentBlocklistRepository {
         );
         return false;
       }
-      var pendingTimestampChanged = false;
-      final latestOwnCreatedAt = _latestOwnMuteListEvent?.createdAt;
-      if (latestOwnCreatedAt != null) {
-        for (final pubkey in protectedUnblocks) {
-          final pendingAt = _pendingUnblocks[pubkey];
-          if (pendingAt != null && pendingAt < latestOwnCreatedAt) {
-            _pendingUnblocks[pubkey] = latestOwnCreatedAt;
-            pendingTimestampChanged = true;
-          }
-        }
-      }
-      if (pendingTimestampChanged) await _savePendingUnblocks();
       final publishShape = _buildMuteListPublishShape();
+      final now = NostrTimestamp.now(driftTolerance: 0);
+      final latestCreatedAt = _latestOwnMuteListEvent?.createdAt;
+      final replacementCreatedAt =
+          latestCreatedAt != null && latestCreatedAt > now
+          ? latestCreatedAt + 1
+          : null;
+      if (replacementCreatedAt != null &&
+          !NostrTimestamp.isValid(replacementCreatedAt)) {
+        Log.warning(
+          'Withholding mute list publish - latest own kind 10000 timestamp '
+          'is outside the accepted clock window '
+          '(latestCreatedAt=$latestCreatedAt, now=$now)',
+          name: 'ContentBlocklistRepository',
+          category: LogCategory.system,
+        );
+        return false;
+      }
 
-      final event = await signer.createAndSignEvent(
-        kind: 10000,
-        content: publishShape.content,
-        tags: publishShape.tags,
-      );
+      final event = replacementCreatedAt == null
+          ? await signer.createAndSignEvent(
+              kind: 10000,
+              content: publishShape.content,
+              tags: publishShape.tags,
+            )
+          : await signer.createAndSignEvent(
+              kind: 10000,
+              content: publishShape.content,
+              tags: publishShape.tags,
+              createdAt: replacementCreatedAt,
+            );
 
       if (event == null) return false;
 
@@ -858,19 +864,13 @@ class ContentBlocklistRepository {
   /// `noRelays` -- which is why the detailed form is used here, with
   /// `requireAllRelaysSettled` so a relay abandoned by the settle window
   /// arrives as a timeout rather than as an empty answer.
-  Future<bool> _refreshLatestOwnMuteList(
-    NostrClient nostrClient, {
-    Set<String> protectedUnblocks = const <String>{},
-  }) async {
+  Future<bool> _refreshLatestOwnMuteList(NostrClient nostrClient) async {
     final ourPubkey = _ourPubkey;
     if (ourPubkey == null) return false;
 
-    final result = await nostrClient.queryEventsDetailed(
-      [
-        Filter(authors: [ourPubkey], kinds: const [10000]),
-      ],
-      requireAllRelaysSettled: true,
-    );
+    final result = await nostrClient.queryEventsDetailed([
+      Filter(authors: [ourPubkey], kinds: const [10000]),
+    ], requireAllRelaysSettled: true);
 
     var newest = _latestOwnMuteListEvent;
     for (final event in result.events) {
@@ -881,10 +881,7 @@ class ContentBlocklistRepository {
     }
 
     if (newest != null && newest != _latestOwnMuteListEvent) {
-      _applyOwnMuteListEvent(
-        newest,
-        protectedUnblocks: protectedUnblocks,
-      );
+      _applyOwnMuteListEvent(newest);
     }
 
     return !result.timedOut && !result.noRelays;
@@ -1110,6 +1107,13 @@ class ContentBlocklistRepository {
     return _internalBlocklist.contains(pubkey) ||
         _runtimeBlocklist.contains(pubkey);
   }
+
+  /// Whether this account can stop hiding [pubkey] through its own list.
+  ///
+  /// Unlike [isBlocked], this includes mutes imported from another Nostr
+  /// client. Internal moderation blocks remain intentionally non-removable.
+  bool canUnblock(String pubkey) =>
+      _runtimeBlocklist.contains(pubkey) || _mutedPubkeys.contains(pubkey);
 
   /// The buckets recording a hide **this account chose**: the operator list,
   /// our own blocks, and the mutes we authored on our own kind 10000 list
@@ -1366,18 +1370,13 @@ class ContentBlocklistRepository {
     }
     if (removedMute) {
       await _saveMutedUsers();
-      _emitChange(
-        BlocklistChange(pubkey: pubkey, op: BlocklistOp.unmutedByUs),
-      );
+      _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.unmutedByUs));
     }
     if (removedBlock || removedMute) {
       _notifyChanged();
     }
 
-    // Protect this explicit action from a clock-skewed source event fetched
-    // during the mandatory pre-publish refresh. Ordinary later reconciliation
-    // still honours a genuinely newer mute authored by another client.
-    await _publishMuteListToNostr(protectedUnblocks: {pubkey});
+    await _publishMuteListToNostr();
 
     Log.info(
       'Stopped hiding user: ${pubkeyForLogs(pubkey)}',
@@ -1699,12 +1698,9 @@ class ContentBlocklistRepository {
       //    list we could not see -- step 4 republishes the whole event, and
       //    the completion flag below stays unset so the next launch retries
       //    (#6750).
-      final muteRead = await nostrClient.queryEventsDetailed(
-        [
-          Filter(authors: [ourPubkey], kinds: const [10000]),
-        ],
-        requireAllRelaysSettled: true,
-      );
+      final muteRead = await nostrClient.queryEventsDetailed([
+        Filter(authors: [ourPubkey], kinds: const [10000]),
+      ], requireAllRelaysSettled: true);
       if (muteRead.timedOut || muteRead.noRelays) {
         Log.warning(
           'Deferring legacy block-list migration - could not confirm the '
@@ -1883,7 +1879,6 @@ class ContentBlocklistRepository {
     bool notify = true,
     bool persist = true,
     bool reconcile = false,
-    Set<String> protectedUnblocks = const <String>{},
   }) {
     final ourPubkey = event.pubkey;
     final createdAt = event.createdAt;
@@ -1912,35 +1907,19 @@ class ContentBlocklistRepository {
       }
     }
     var needsRepublish = false;
-    // An unblock this list predates never reached the relay, so its `p` tag
-    // is stale and must not be re-adopted as a mute from another client
-    // (#8263). A tag on a list NEWER than the unblock is the opposite case --
-    // someone muted them again after we unblocked -- so it is honoured and
-    // the intent retired. `created_at` is what separates the two; without it
-    // a legitimate later re-mute would be suppressed forever.
+    // Pending unblocks are durable user intent. Until an own list arrives
+    // without the tag, no relay echo may re-adopt it as a mute. Deriving the
+    // protection here covers refreshes, retries, live subscriptions,
+    // migrations, and our own successful publish uniformly.
     if (_pendingUnblocks.isNotEmpty) {
       final retired = <String>[];
       for (final entry in _pendingUnblocks.entries) {
-        // Protection only ever means "do not re-adopt a tag that is still
-        // there". Once the list has dropped it the unblock landed, and the
-        // intent has to retire like any other -- an entry that can never
-        // retire re-arms `_muteListPublishPending` from `_loadPendingUnblocks`
-        // on every cold start, so the device signs and publishes a kind 10000
-        // on every launch for the life of the install.
-        if (protectedUnblocks.contains(entry.key) &&
-            relayMuted.contains(entry.key)) {
+        if (relayMuted.contains(entry.key)) {
           relayMuted.remove(entry.key);
           continue;
         }
-        if (!relayMuted.contains(entry.key) || entry.value < createdAt) {
-          // Either the tag is gone, so the unblock landed, or this list is
-          // newer than the unblock and the tag is a fresh mute from another
-          // client. Both retire the intent; the second also lets the mute
-          // through, which is the point of comparing against `created_at`.
-          retired.add(entry.key);
-        } else {
-          relayMuted.remove(entry.key);
-        }
+        // The tag is gone, so the unblock landed.
+        retired.add(entry.key);
       }
       if (retired.isNotEmpty) {
         retired.forEach(_pendingUnblocks.remove);

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -1341,7 +1341,15 @@ class ContentBlocklistRepository {
     // the other order a kill between the two writes left it unhidden locally
     // with nothing to stop the relay's surviving `p` tag from being
     // re-adopted as a mute on the next launch (#8263).
-    _pendingUnblocks[pubkey] = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    // Only ever advance the watermark. The stored second is what a later
+    // reconciliation compares a relay list's `created_at` against, so
+    // lowering it on a repeat attempt hands back protection an earlier
+    // attempt already earned.
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final recordedAt = _pendingUnblocks[pubkey];
+    if (recordedAt == null || recordedAt < now) {
+      _pendingUnblocks[pubkey] = now;
+    }
     await _savePendingUnblocks();
 
     if (removedBlock) {

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -1269,13 +1269,20 @@ class ContentBlocklistRepository {
       );
     }
 
-    if (retiredPendingUnblock) await _savePendingUnblocks();
     if (newlyBlocked.isNotEmpty) {
       await _saveBlockedUsers();
       for (final pubkey in newlyBlocked) {
         _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.blocked));
       }
       _notifyChanged();
+    }
+    // Dropped only once the block that contradicts it is durable. A kill in
+    // the other order persists "no pending unblock" against a block that
+    // never landed, so the relay's surviving `p` tag comes back as a foreign
+    // mute rather than a block -- a weaker state, and one no unblock
+    // affordance in the app can reach.
+    if (retiredPendingUnblock) await _savePendingUnblocks();
+    if (newlyBlocked.isNotEmpty) {
       await _publishMuteListToNostr();
 
       Log.debug(

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -1323,6 +1323,20 @@ class ContentBlocklistRepository {
         hadPendingUnblock ||
         publishedListCarries;
 
+    if (!hasExplicitUnblock) {
+      await retryPendingMuteListPublish();
+      return;
+    }
+
+    // Recorded BEFORE the local removals are persisted, and so before the
+    // publish. A kill anywhere after this leaves an account that is still
+    // hidden plus the intent to unhide it, which the next launch acts on. In
+    // the other order a kill between the two writes left it unhidden locally
+    // with nothing to stop the relay's surviving `p` tag from being
+    // re-adopted as a mute on the next launch (#8263).
+    _pendingUnblocks[pubkey] = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    await _savePendingUnblocks();
+
     if (removedBlock) {
       await _saveBlockedUsers();
       _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.unblocked));
@@ -1337,15 +1351,6 @@ class ContentBlocklistRepository {
       _notifyChanged();
     }
 
-    if (!hasExplicitUnblock) {
-      await retryPendingMuteListPublish();
-      return;
-    }
-
-    // Recorded BEFORE the publish, so a withheld or failed publish still
-    // leaves the intent behind for the next launch to act on (#8263).
-    _pendingUnblocks[pubkey] = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    await _savePendingUnblocks();
     // Protect this explicit action from a clock-skewed source event fetched
     // during the mandatory pre-publish refresh. Ordinary later reconciliation
     // still honours a genuinely newer mute authored by another client.

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -4131,6 +4131,245 @@ void main() {
 
         expect(restarted.isMutedByUs(target), isTrue);
       });
+
+      group('explicit unblock intent (#6438)', () {
+        Future<ContentBlocklistRepository> serviceWithOwnMute({
+          required SharedPreferences prefs,
+          required Event ownMute,
+        }) async {
+          await prefs.setBool(
+            'block_list_migrated_to_mute_list.$ourPubkey',
+            true,
+          );
+          await prefs.setBool('block_list_retired.$ourPubkey', true);
+          final ownList = StreamController<Event>.broadcast();
+          addTearDown(ownList.close);
+          when(() => mockClient.subscribe(any())).thenAnswer(
+            (_) => ownList.stream,
+          );
+          stubHealthy();
+          stubReadSettled();
+
+          final service = ContentBlocklistRepository(prefs: prefs);
+          await service.syncBlockListsInBackground(
+            mockClient,
+            mockSigner,
+            ourPubkey,
+          );
+          await service.syncMuteListsInBackground(mockClient, ourPubkey);
+          ownList.add(ownMute);
+          await pumpEventQueue();
+          clearInteractions(mockSigner);
+          return service;
+        }
+
+        test(
+          'removes and publishes a mute that is not a runtime block',
+          () async {
+            SharedPreferences.setMockInitialValues(<String, Object>{});
+            final prefs = await SharedPreferences.getInstance();
+            final service = await serviceWithOwnMute(
+              prefs: prefs,
+              ownMute: buildEvent(
+                kind: 10000,
+                tags: const [
+                  ['p', target],
+                ],
+                createdAt: 1000,
+              ),
+            );
+            final changes = <BlocklistChange>[];
+            final subscription = service.changes.listen(changes.add);
+            addTearDown(subscription.cancel);
+
+            await service.unblockUser(target);
+
+            expect(service.isMutedByUs(target), isFalse);
+            expect(service.shouldFilterFromFeeds(target), isFalse);
+            expect(
+              changes,
+              contains(
+                const BlocklistChange(
+                  pubkey: target,
+                  op: BlocklistOp.unmutedByUs,
+                ),
+              ),
+            );
+            final tags =
+                verify(
+                      () => mockSigner.createAndSignEvent(
+                        kind: 10000,
+                        content: any(named: 'content'),
+                        tags: captureAny(named: 'tags'),
+                      ),
+                    ).captured.last
+                    as List<List<String>>;
+            expect(tags, isNot(contains(equals(['p', target]))));
+          },
+        );
+
+        test(
+          'protects the unblock from a clock-skewed publish refresh',
+          () async {
+            SharedPreferences.setMockInitialValues(<String, Object>{});
+            final prefs = await SharedPreferences.getInstance();
+            final service = await serviceWithOwnMute(
+              prefs: prefs,
+              ownMute: buildEvent(
+                kind: 10000,
+                tags: const [
+                  ['p', target],
+                ],
+                createdAt: 1000,
+              ),
+            );
+            final clockSkewedList = buildEvent(
+              kind: 10000,
+              tags: const [
+                ['p', target],
+              ],
+              createdAt: 99999999999,
+            )..id = 'clock-skewed-event';
+            when(
+              () => mockClient.queryEventsDetailed(
+                any(),
+                requireAllRelaysSettled: any(
+                  named: 'requireAllRelaysSettled',
+                ),
+              ),
+            ).thenAnswer(
+              (_) async => (
+                events: [clockSkewedList],
+                timedOut: false,
+                noRelays: false,
+              ),
+            );
+            when(
+              () => mockClient.publishEvent(any()),
+            ).thenAnswer((_) async => const PublishFailed());
+
+            await service.unblockUser(target);
+
+            expect(service.isMutedByUs(target), isFalse);
+            final pending =
+                jsonDecode(prefs.getString('pending_unblocks.$ourPubkey')!)
+                    as Map<String, dynamic>;
+            expect(pending[target], clockSkewedList.createdAt);
+            final tags =
+                verify(
+                      () => mockSigner.createAndSignEvent(
+                        kind: 10000,
+                        content: any(named: 'content'),
+                        tags: captureAny(named: 'tags'),
+                      ),
+                    ).captured.last
+                    as List<List<String>>;
+            expect(tags, isNot(contains(equals(['p', target]))));
+          },
+        );
+
+        test(
+          'is a true no-op when no local or published state carries it',
+          () async {
+            SharedPreferences.setMockInitialValues(<String, Object>{});
+            final prefs = await SharedPreferences.getInstance();
+            stubHealthy();
+            stubReadSettled();
+            final service = ContentBlocklistRepository(prefs: prefs);
+            await service.syncBlockListsInBackground(
+              mockClient,
+              mockSigner,
+              ourPubkey,
+            );
+            clearInteractions(mockSigner);
+
+            await service.unblockUser(target);
+
+            verifyNever(
+              () => mockSigner.createAndSignEvent(
+                kind: any(named: 'kind'),
+                content: any(named: 'content'),
+                tags: any(named: 'tags'),
+              ),
+            );
+            expect(
+              jsonDecode(
+                prefs.getString('pending_unblocks.$ourPubkey') ?? '{}',
+              ),
+              isNot(contains(target)),
+            );
+          },
+        );
+
+        test(
+          're-blocking retires contradictory pending intent and republishes',
+          () async {
+            SharedPreferences.setMockInitialValues(<String, Object>{
+              'blocklist_active_pubkey': ourPubkey,
+              'blocked_users_list.$ourPubkey': jsonEncode([target]),
+              'pending_unblocks.$ourPubkey': jsonEncode({target: 1000}),
+              'block_list_migrated_to_mute_list.$ourPubkey': true,
+              'block_list_retired.$ourPubkey': true,
+            });
+            final prefs = await SharedPreferences.getInstance();
+            stubHealthy();
+            stubReadSettled();
+            final service = ContentBlocklistRepository(prefs: prefs);
+            await service.syncBlockListsInBackground(
+              mockClient,
+              mockSigner,
+              ourPubkey,
+            );
+            clearInteractions(mockSigner);
+
+            await service.blockUser(target);
+
+            final pending =
+                jsonDecode(prefs.getString('pending_unblocks.$ourPubkey')!)
+                    as Map<String, dynamic>;
+            expect(pending, isNot(contains(target)));
+            final tags =
+                verify(
+                      () => mockSigner.createAndSignEvent(
+                        kind: 10000,
+                        content: any(named: 'content'),
+                        tags: captureAny(named: 'tags'),
+                      ),
+                    ).captured.last
+                    as List<List<String>>;
+            expect(tags, contains(equals(['p', target])));
+          },
+        );
+
+        test('re-blocking is a no-op when no publish is pending', () async {
+          SharedPreferences.setMockInitialValues(<String, Object>{
+            'blocklist_active_pubkey': ourPubkey,
+            'blocked_users_list.$ourPubkey': jsonEncode([target]),
+            'block_list_migrated_to_mute_list.$ourPubkey': true,
+            'block_list_retired.$ourPubkey': true,
+          });
+          final prefs = await SharedPreferences.getInstance();
+          stubHealthy();
+          stubReadSettled();
+          final service = ContentBlocklistRepository(prefs: prefs);
+          await service.syncBlockListsInBackground(
+            mockClient,
+            mockSigner,
+            ourPubkey,
+          );
+          clearInteractions(mockSigner);
+
+          await service.blockUser(target);
+
+          verifyNever(
+            () => mockSigner.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          );
+        });
+      });
     });
   });
 

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -2866,6 +2866,7 @@ void main() {
         kind: invocation.namedArguments[#kind] as int,
         content: invocation.namedArguments[#content] as String,
         tags: invocation.namedArguments[#tags] as List<List<String>>,
+        createdAt: invocation.namedArguments[#createdAt] as int?,
       );
     }
 
@@ -3702,6 +3703,16 @@ void main() {
         ).thenAnswer(
           (invocation) async => signedEventFromInvocation(invocation),
         );
+        when(
+          () => mockSigner.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+            createdAt: any(named: 'createdAt'),
+          ),
+        ).thenAnswer(
+          (invocation) async => signedEventFromInvocation(invocation),
+        );
         when(() => mockClient.publishEvent(any())).thenAnswer(
           (invocation) async => PublishSuccess(
             event: invocation.positionalArguments.first as Event,
@@ -3783,31 +3794,33 @@ void main() {
         },
       );
 
-      test('IS honoured when the list is newer than the unblock, because that '
-          'is another client muting them again', () async {
-        final prefs = await prefsAfterAWithheldUnblock();
-        final ownList = StreamController<Event>.broadcast();
-        addTearDown(ownList.close);
-        when(
-          () => mockClient.subscribe(any()),
-        ).thenAnswer((_) => ownList.stream);
+      test(
+        'does not let a later relay echo override outstanding intent',
+        () async {
+          final prefs = await prefsAfterAWithheldUnblock();
+          final ownList = StreamController<Event>.broadcast();
+          addTearDown(ownList.close);
+          when(
+            () => mockClient.subscribe(any()),
+          ).thenAnswer((_) => ownList.stream);
 
-        final restarted = ContentBlocklistRepository(prefs: prefs);
-        await restarted.syncMuteListsInBackground(mockClient, ourPubkey);
-        ownList.add(
-          buildEvent(
-            kind: 10000,
-            tags: const [
-              ['p', target],
-            ],
-            // Comfortably after the unblock we just recorded.
-            createdAt: 99999999999,
-          ),
-        );
-        await Future<void>.delayed(Duration.zero);
+          final restarted = ContentBlocklistRepository(prefs: prefs);
+          await restarted.syncMuteListsInBackground(mockClient, ourPubkey);
+          ownList.add(
+            buildEvent(
+              kind: 10000,
+              tags: const [
+                ['p', target],
+              ],
+              // A client-controlled timestamp cannot prove our removal landed.
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 60,
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
 
-        expect(restarted.isMutedByUs(target), isTrue);
-      });
+          expect(restarted.isMutedByUs(target), isFalse);
+        },
+      );
 
       test('is not re-adopted from a stale list in the same second', () async {
         final prefs = await prefsAfterAWithheldUnblock();
@@ -4228,9 +4241,13 @@ void main() {
             final subscription = service.changes.listen(changes.add);
             addTearDown(subscription.cancel);
 
+            expect(service.isBlocked(target), isFalse);
+            expect(service.canUnblock(target), isTrue);
+
             await service.unblockUser(target);
 
             expect(service.isMutedByUs(target), isFalse);
+            expect(service.canUnblock(target), isFalse);
             expect(service.shouldFilterFromFeeds(target), isFalse);
             expect(
               changes,
@@ -4274,7 +4291,7 @@ void main() {
               tags: const [
                 ['p', target],
               ],
-              createdAt: 99999999999,
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 60,
             )..id = 'clock-skewed-event';
             when(
               () => mockClient.queryEventsDetailed(
@@ -4300,17 +4317,66 @@ void main() {
             final pending =
                 jsonDecode(prefs.getString('pending_unblocks.$ourPubkey')!)
                     as Map<String, dynamic>;
-            expect(pending[target], clockSkewedList.createdAt);
+            expect(pending, contains(target));
             final tags =
                 verify(
                       () => mockSigner.createAndSignEvent(
                         kind: 10000,
                         content: any(named: 'content'),
                         tags: captureAny(named: 'tags'),
+                        createdAt: any(named: 'createdAt'),
                       ),
                     ).captured.single
                     as List<List<String>>;
             expect(tags, isNot(contains(equals(['p', target]))));
+          },
+        );
+
+        test(
+          'retires a clock-skew-protected intent after publish succeeds',
+          () async {
+            SharedPreferences.setMockInitialValues(<String, Object>{});
+            final prefs = await SharedPreferences.getInstance();
+            final service = await serviceWithOwnMute(
+              prefs: prefs,
+              ownMute: buildEvent(
+                kind: 10000,
+                tags: const [
+                  ['p', target],
+                ],
+                createdAt: 1000,
+              ),
+            );
+            final clockSkewedList = buildEvent(
+              kind: 10000,
+              tags: const [
+                ['p', target],
+              ],
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 60,
+            )..id = 'clock-skewed-event';
+            when(
+              () => mockClient.queryEventsDetailed(
+                any(),
+                requireAllRelaysSettled: any(
+                  named: 'requireAllRelaysSettled',
+                ),
+              ),
+            ).thenAnswer(
+              (_) async => (
+                events: [clockSkewedList],
+                timedOut: false,
+                noRelays: false,
+              ),
+            );
+
+            await service.unblockUser(target);
+            await pumpEventQueue();
+
+            final pending =
+                jsonDecode(prefs.getString('pending_unblocks.$ourPubkey')!)
+                    as Map<String, dynamic>;
+            expect(pending, isNot(contains(target)));
+            expect(service.isMutedByUs(target), isFalse);
           },
         );
 
@@ -4329,9 +4395,6 @@ void main() {
                 createdAt: 1000,
               ),
             );
-            // Newer than the seeded list and no longer carrying the tag: the
-            // unblock already landed, from another device or an earlier
-            // attempt.
             final landedList = buildEvent(
               kind: 10000,
               createdAt: 2000,
@@ -4350,20 +4413,13 @@ void main() {
                 noRelays: false,
               ),
             );
-            // Withheld, so only the refresh can retire the intent here.
             when(
               () => mockClient.publishEvent(any()),
             ).thenAnswer((_) async => const PublishFailed());
 
             await service.unblockUser(target);
-            // The retire persists fire-and-forget, matching `_saveMutedUsers`
-            // in the same method.
             await pumpEventQueue();
 
-            // Protection is only ever about refusing a surviving `p` tag. An
-            // intent that outlives the tag can never retire, and
-            // `_loadPendingUnblocks` re-arms the publish from it on every cold
-            // start -- a signing prompt on every launch for a remote signer.
             final stored = prefs.getString('pending_unblocks.$ourPubkey');
             expect(stored, isNotNull);
             expect(
@@ -4372,6 +4428,126 @@ void main() {
             );
           },
         );
+
+        test(
+          'does not ask the signer to supersede an invalid future list',
+          () async {
+            SharedPreferences.setMockInitialValues(<String, Object>{});
+            final prefs = await SharedPreferences.getInstance();
+            final service = await serviceWithOwnMute(
+              prefs: prefs,
+              ownMute: buildEvent(
+                kind: 10000,
+                tags: const [
+                  ['p', target],
+                ],
+                createdAt: 1000,
+              ),
+            );
+            final invalidFutureList = buildEvent(
+              kind: 10000,
+              tags: const [
+                ['p', target],
+              ],
+              createdAt: 99999999999,
+            )..id = 'invalid-future-event';
+            when(
+              () => mockClient.queryEventsDetailed(
+                any(),
+                requireAllRelaysSettled: any(
+                  named: 'requireAllRelaysSettled',
+                ),
+              ),
+            ).thenAnswer(
+              (_) async => (
+                events: [invalidFutureList],
+                timedOut: false,
+                noRelays: false,
+              ),
+            );
+
+            await service.unblockUser(target);
+
+            verifyNever(
+              () => mockSigner.createAndSignEvent(
+                kind: any(named: 'kind'),
+                content: any(named: 'content'),
+                tags: any(named: 'tags'),
+                createdAt: any(named: 'createdAt'),
+              ),
+            );
+            verifyNever(
+              () => mockSigner.createAndSignEvent(
+                kind: any(named: 'kind'),
+                content: any(named: 'content'),
+                tags: any(named: 'tags'),
+              ),
+            );
+            final pending =
+                jsonDecode(prefs.getString('pending_unblocks.$ourPubkey')!)
+                    as Map<String, dynamic>;
+            expect(pending, contains(target));
+            expect(service.isMutedByUs(target), isFalse);
+          },
+        );
+
+        test('protects every outstanding unblock during a refresh', () async {
+          const other =
+              '00000000000000000000000000000000'
+              '000000000000000000000000000000ee';
+          SharedPreferences.setMockInitialValues(<String, Object>{
+            'blocklist_active_pubkey': ourPubkey,
+            'pending_unblocks.$ourPubkey': jsonEncode({
+              target: 1000,
+              other: 1000,
+            }),
+            'block_list_migrated_to_mute_list.$ourPubkey': true,
+            'block_list_retired.$ourPubkey': true,
+          });
+          final prefs = await SharedPreferences.getInstance();
+          stubHealthy();
+          final clockSkewedList = buildEvent(
+            kind: 10000,
+            tags: const [
+              ['p', target],
+              ['p', other],
+            ],
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 60,
+          )..id = 'clock-skewed-event';
+          when(
+            () => mockClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(
+                named: 'requireAllRelaysSettled',
+              ),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              events: [clockSkewedList],
+              timedOut: false,
+              noRelays: false,
+            ),
+          );
+          when(
+            () => mockClient.publishEvent(any()),
+          ).thenAnswer((_) async => const PublishFailed());
+          final service = ContentBlocklistRepository(prefs: prefs);
+          addTearDown(service.dispose);
+          await service.syncBlockListsInBackground(
+            mockClient,
+            mockSigner,
+            ourPubkey,
+          );
+
+          expect(await service.retryPendingMuteListPublish(), isFalse);
+
+          expect(service.isMutedByUs(target), isFalse);
+          expect(service.isMutedByUs(other), isFalse);
+          final pending =
+              jsonDecode(prefs.getString('pending_unblocks.$ourPubkey')!)
+                  as Map<String, dynamic>;
+          expect(pending.keys, containsAll([target, other]));
+        });
 
         test(
           'ignores a self `p` tag on our own malformed mute list',
@@ -4442,7 +4618,6 @@ void main() {
             stubHealthy();
             stubReadSettled();
             final service = ContentBlocklistRepository(prefs: prefs);
-            addTearDown(service.dispose);
             await service.syncBlockListsInBackground(
               mockClient,
               mockSigner,
@@ -4514,7 +4689,6 @@ void main() {
             stubHealthy();
             stubReadSettled();
             final service = ContentBlocklistRepository(prefs: prefs);
-            addTearDown(service.dispose);
             await service.syncBlockListsInBackground(
               mockClient,
               mockSigner,
@@ -4609,7 +4783,6 @@ void main() {
           stubHealthy();
           stubReadSettled();
           final service = ContentBlocklistRepository(prefs: prefs);
-          addTearDown(service.dispose);
           await service.syncBlockListsInBackground(
             mockClient,
             mockSigner,

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -4665,9 +4665,9 @@ void main() {
 
             await service.unblockUser(target);
 
-            // The stored second is what a later reconciliation compares a
-            // relay list's `created_at` against. Rewriting it down to `now`
-            // hands back protection the earlier attempt already earned.
+            // The recorded second is monotonic so the diagnostic and the
+            // legacy-key merge tiebreak stay meaningful; a repeat attempt
+            // must not rewrite it down to `now`.
             final pending =
                 jsonDecode(prefs.getString('pending_unblocks.$ourPubkey')!)
                     as Map<String, dynamic>;

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -4151,6 +4151,7 @@ void main() {
           stubReadSettled();
 
           final service = ContentBlocklistRepository(prefs: prefs);
+          addTearDown(service.dispose);
           await service.syncBlockListsInBackground(
             mockClient,
             mockSigner,
@@ -4202,7 +4203,7 @@ void main() {
                         content: any(named: 'content'),
                         tags: captureAny(named: 'tags'),
                       ),
-                    ).captured.last
+                    ).captured.single
                     as List<List<String>>;
             expect(tags, isNot(contains(equals(['p', target]))));
           },
@@ -4262,7 +4263,7 @@ void main() {
                         content: any(named: 'content'),
                         tags: captureAny(named: 'tags'),
                       ),
-                    ).captured.last
+                    ).captured.single
                     as List<List<String>>;
             expect(tags, isNot(contains(equals(['p', target]))));
           },
@@ -4292,12 +4293,8 @@ void main() {
                 tags: any(named: 'tags'),
               ),
             );
-            expect(
-              jsonDecode(
-                prefs.getString('pending_unblocks.$ourPubkey') ?? '{}',
-              ),
-              isNot(contains(target)),
-            );
+            expect(prefs.getString('pending_unblocks.$ourPubkey'), isNull);
+            expect(prefs.getString('pending_unblocks'), isNull);
           },
         );
 
@@ -4335,7 +4332,7 @@ void main() {
                         content: any(named: 'content'),
                         tags: captureAny(named: 'tags'),
                       ),
-                    ).captured.last
+                    ).captured.single
                     as List<List<String>>;
             expect(tags, contains(equals(['p', target])));
           },

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -4334,7 +4334,6 @@ void main() {
             // attempt.
             final landedList = buildEvent(
               kind: 10000,
-              tags: const [],
               createdAt: 2000,
             )..id = 'unblock-already-landed';
             when(
@@ -4443,6 +4442,7 @@ void main() {
             stubHealthy();
             stubReadSettled();
             final service = ContentBlocklistRepository(prefs: prefs);
+            addTearDown(service.dispose);
             await service.syncBlockListsInBackground(
               mockClient,
               mockSigner,
@@ -4514,6 +4514,7 @@ void main() {
             stubHealthy();
             stubReadSettled();
             final service = ContentBlocklistRepository(prefs: prefs);
+            addTearDown(service.dispose);
             await service.syncBlockListsInBackground(
               mockClient,
               mockSigner,
@@ -4608,6 +4609,7 @@ void main() {
           stubHealthy();
           stubReadSettled();
           final service = ContentBlocklistRepository(prefs: prefs);
+          addTearDown(service.dispose);
           await service.syncBlockListsInBackground(
             mockClient,
             mockSigner,

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -4405,6 +4405,42 @@ void main() {
         );
 
         test(
+          'does not lower a watermark an earlier attempt already advanced',
+          () async {
+            SharedPreferences.setMockInitialValues(<String, Object>{
+              'blocklist_active_pubkey': ourPubkey,
+              'pending_unblocks.$ourPubkey': jsonEncode({
+                target: 99999999999,
+              }),
+              'block_list_migrated_to_mute_list.$ourPubkey': true,
+              'block_list_retired.$ourPubkey': true,
+            });
+            final prefs = await SharedPreferences.getInstance();
+            stubHealthy();
+            // Every read stays inconclusive, so the publish is withheld and
+            // the intent is still outstanding when the user tries again.
+            stubReadInconclusive();
+            final service = ContentBlocklistRepository(prefs: prefs);
+            addTearDown(service.dispose);
+            await service.syncBlockListsInBackground(
+              mockClient,
+              mockSigner,
+              ourPubkey,
+            );
+
+            await service.unblockUser(target);
+
+            // The stored second is what a later reconciliation compares a
+            // relay list's `created_at` against. Rewriting it down to `now`
+            // hands back protection the earlier attempt already earned.
+            final pending =
+                jsonDecode(prefs.getString('pending_unblocks.$ourPubkey')!)
+                    as Map<String, dynamic>;
+            expect(pending[target], 99999999999);
+          },
+        );
+
+        test(
           're-blocking retires contradictory pending intent and republishes',
           () async {
             SharedPreferences.setMockInitialValues(<String, Object>{

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -4315,6 +4315,66 @@ void main() {
         );
 
         test(
+          'retires the intent when the refreshed list no longer carries it',
+          () async {
+            SharedPreferences.setMockInitialValues(<String, Object>{});
+            final prefs = await SharedPreferences.getInstance();
+            final service = await serviceWithOwnMute(
+              prefs: prefs,
+              ownMute: buildEvent(
+                kind: 10000,
+                tags: const [
+                  ['p', target],
+                ],
+                createdAt: 1000,
+              ),
+            );
+            // Newer than the seeded list and no longer carrying the tag: the
+            // unblock already landed, from another device or an earlier
+            // attempt.
+            final landedList = buildEvent(
+              kind: 10000,
+              tags: const [],
+              createdAt: 2000,
+            )..id = 'unblock-already-landed';
+            when(
+              () => mockClient.queryEventsDetailed(
+                any(),
+                requireAllRelaysSettled: any(
+                  named: 'requireAllRelaysSettled',
+                ),
+              ),
+            ).thenAnswer(
+              (_) async => (
+                events: [landedList],
+                timedOut: false,
+                noRelays: false,
+              ),
+            );
+            // Withheld, so only the refresh can retire the intent here.
+            when(
+              () => mockClient.publishEvent(any()),
+            ).thenAnswer((_) async => const PublishFailed());
+
+            await service.unblockUser(target);
+            // The retire persists fire-and-forget, matching `_saveMutedUsers`
+            // in the same method.
+            await pumpEventQueue();
+
+            // Protection is only ever about refusing a surviving `p` tag. An
+            // intent that outlives the tag can never retire, and
+            // `_loadPendingUnblocks` re-arms the publish from it on every cold
+            // start -- a signing prompt on every launch for a remote signer.
+            final stored = prefs.getString('pending_unblocks.$ourPubkey');
+            expect(stored, isNotNull);
+            expect(
+              jsonDecode(stored!) as Map<String, dynamic>,
+              isNot(contains(target)),
+            );
+          },
+        );
+
+        test(
           'ignores a self `p` tag on our own malformed mute list',
           () async {
             SharedPreferences.setMockInitialValues(<String, Object>{});

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -3805,6 +3805,7 @@ void main() {
           ).thenAnswer((_) => ownList.stream);
 
           final restarted = ContentBlocklistRepository(prefs: prefs);
+          addTearDown(restarted.dispose);
           await restarted.syncMuteListsInBackground(mockClient, ourPubkey);
           ownList.add(
             buildEvent(
@@ -4386,7 +4387,7 @@ void main() {
             // relay serving the list we are trying to replace, and no other
             // assertion in this file would notice.
             expect(publishedAt, isNotNull);
-            expect(publishedAt!, greaterThan(clockSkewedList.createdAt));
+            expect(publishedAt, greaterThan(clockSkewedList.createdAt));
           },
         );
 
@@ -4443,6 +4444,12 @@ void main() {
           () async {
             SharedPreferences.setMockInitialValues(<String, Object>{});
             final prefs = await SharedPreferences.getInstance();
+            // Sampled synchronously at the removal, before the publish's
+            // refresh runs. Without it the closing assertion cannot tell
+            // "the intent was retired" from "no intent was ever recorded":
+            // the test survives a mutation that stops recording it at all.
+            final pendingWhenAnnounced = <String?>[];
+            var sampling = false;
             final service = await serviceWithOwnMute(
               prefs: prefs,
               ownMute: buildEvent(
@@ -4452,7 +4459,14 @@ void main() {
                 ],
                 createdAt: 1000,
               ),
+              onChanged: () {
+                if (!sampling) return;
+                pendingWhenAnnounced.add(
+                  prefs.getString('pending_unblocks.$ourPubkey'),
+                );
+              },
             );
+            sampling = true;
             final landedList = buildEvent(
               kind: 10000,
               createdAt: 2000,
@@ -4478,6 +4492,11 @@ void main() {
             await service.unblockUser(target);
             await pumpEventQueue();
 
+            expect(pendingWhenAnnounced, isNotEmpty);
+            expect(
+              jsonDecode(pendingWhenAnnounced.first!) as Map<String, dynamic>,
+              contains(target),
+            );
             final stored = prefs.getString('pending_unblocks.$ourPubkey');
             expect(stored, isNotNull);
             expect(
@@ -4526,19 +4545,14 @@ void main() {
 
             await service.unblockUser(target);
 
+            // `any(named: 'createdAt')` matches a null stamp too, so this
+            // also covers a call that omits the argument.
             verifyNever(
               () => mockSigner.createAndSignEvent(
                 kind: any(named: 'kind'),
                 content: any(named: 'content'),
                 tags: any(named: 'tags'),
                 createdAt: any(named: 'createdAt'),
-              ),
-            );
-            verifyNever(
-              () => mockSigner.createAndSignEvent(
-                kind: any(named: 'kind'),
-                content: any(named: 'content'),
-                tags: any(named: 'tags'),
               ),
             );
             final pending =

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -4315,6 +4315,67 @@ void main() {
         );
 
         test(
+          'ignores a self `p` tag on our own malformed mute list',
+          () async {
+            SharedPreferences.setMockInitialValues(<String, Object>{});
+            final prefs = await SharedPreferences.getInstance();
+            final service = await serviceWithOwnMute(
+              prefs: prefs,
+              ownMute: buildEvent(
+                kind: 10000,
+                tags: const [
+                  ['p', ourPubkey],
+                ],
+                createdAt: 1000,
+              ),
+            );
+
+            await service.unblockUser(ourPubkey);
+
+            // Our own pubkey can never be in a hide bucket, so there is
+            // nothing to unblock and nothing to record. A pending entry
+            // keyed on self would also re-arm the publish on every launch.
+            verifyNever(
+              () => mockSigner.createAndSignEvent(
+                kind: any(named: 'kind'),
+                content: any(named: 'content'),
+                tags: any(named: 'tags'),
+              ),
+            );
+            expect(prefs.getString('pending_unblocks.$ourPubkey'), isNull);
+          },
+        );
+
+        test('ignores an empty pubkey', () async {
+          SharedPreferences.setMockInitialValues(<String, Object>{});
+          final prefs = await SharedPreferences.getInstance();
+          final service = await serviceWithOwnMute(
+            prefs: prefs,
+            ownMute: buildEvent(
+              kind: 10000,
+              tags: const [
+                ['p', ''],
+              ],
+              createdAt: 1000,
+            ),
+          );
+
+          // DM surfaces derive the counterparty as
+          // `participants.isNotEmpty ? participants.first : ''`, so an empty
+          // string reaches this method. `blockUsers` already skips it.
+          await service.unblockUser('');
+
+          verifyNever(
+            () => mockSigner.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          );
+          expect(prefs.getString('pending_unblocks.$ourPubkey'), isNull);
+        });
+
+        test(
           'is a true no-op when no local or published state carries it',
           () async {
             SharedPreferences.setMockInitialValues(<String, Object>{});

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -4136,6 +4136,7 @@ void main() {
         Future<ContentBlocklistRepository> serviceWithOwnMute({
           required SharedPreferences prefs,
           required Event ownMute,
+          void Function()? onChanged,
         }) async {
           await prefs.setBool(
             'block_list_migrated_to_mute_list.$ourPubkey',
@@ -4150,7 +4151,10 @@ void main() {
           stubHealthy();
           stubReadSettled();
 
-          final service = ContentBlocklistRepository(prefs: prefs);
+          final service = ContentBlocklistRepository(
+            prefs: prefs,
+            onChanged: onChanged,
+          );
           addTearDown(service.dispose);
           await service.syncBlockListsInBackground(
             mockClient,
@@ -4163,6 +4167,47 @@ void main() {
           clearInteractions(mockSigner);
           return service;
         }
+
+        test(
+          'records the unblock intent before it persists the mute removal',
+          () async {
+            SharedPreferences.setMockInitialValues(<String, Object>{});
+            final prefs = await SharedPreferences.getInstance();
+            // Sampled synchronously, the moment the removal is announced.
+            final pendingWhenAnnounced = <String?>[];
+            var sampling = false;
+            final service = await serviceWithOwnMute(
+              prefs: prefs,
+              ownMute: buildEvent(
+                kind: 10000,
+                tags: const [
+                  ['p', target],
+                ],
+                createdAt: 1000,
+              ),
+              onChanged: () {
+                if (!sampling) return;
+                pendingWhenAnnounced.add(
+                  prefs.getString('pending_unblocks.$ourPubkey'),
+                );
+              },
+            );
+            sampling = true;
+
+            await service.unblockUser(target);
+
+            // A kill in the window between the removal write and the intent
+            // write leaves the mute gone locally with nothing to defend that
+            // against the relay's surviving `p` tag, so the next launch
+            // re-adopts it -- the exact revert the intent prevents (#8263).
+            expect(pendingWhenAnnounced, isNotEmpty);
+            expect(pendingWhenAnnounced.first, isNotNull);
+            expect(
+              jsonDecode(pendingWhenAnnounced.first!) as Map<String, dynamic>,
+              contains(target),
+            );
+          },
+        );
 
         test(
           'removes and publishes a mute that is not a runtime block',

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -4333,6 +4333,64 @@ void main() {
         );
 
         test(
+          'supersedes a future-dated own list with a strictly newer stamp',
+          () async {
+            SharedPreferences.setMockInitialValues(<String, Object>{});
+            final prefs = await SharedPreferences.getInstance();
+            final service = await serviceWithOwnMute(
+              prefs: prefs,
+              ownMute: buildEvent(
+                kind: 10000,
+                tags: const [
+                  ['p', target],
+                ],
+                createdAt: 1000,
+              ),
+            );
+            final clockSkewedList = buildEvent(
+              kind: 10000,
+              tags: const [
+                ['p', target],
+              ],
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 60,
+            )..id = 'clock-skewed-event';
+            when(
+              () => mockClient.queryEventsDetailed(
+                any(),
+                requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              ),
+            ).thenAnswer(
+              (_) async => (
+                events: [clockSkewedList],
+                timedOut: false,
+                noRelays: false,
+              ),
+            );
+
+            await service.unblockUser(target);
+
+            final publishedAt =
+                verify(
+                      () => mockSigner.createAndSignEvent(
+                        kind: 10000,
+                        content: any(named: 'content'),
+                        tags: any(named: 'tags'),
+                        createdAt: captureAny(named: 'createdAt'),
+                      ),
+                    ).captured.single
+                    as int?;
+
+            // Kind 10000 is replaceable, and an equal `created_at` does not
+            // win the tie by rule -- relays keep the lower id. Stamping the
+            // replacement at the skewed list's own second would leave the
+            // relay serving the list we are trying to replace, and no other
+            // assertion in this file would notice.
+            expect(publishedAt, isNotNull);
+            expect(publishedAt!, greaterThan(clockSkewedList.createdAt));
+          },
+        );
+
+        test(
           'retires a clock-skew-protected intent after publish succeeds',
           () async {
             SharedPreferences.setMockInitialValues(<String, Object>{});

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -4480,6 +4480,63 @@ void main() {
           },
         );
 
+        test(
+          'persists the block before dropping the intent it contradicts',
+          () async {
+            SharedPreferences.setMockInitialValues(<String, Object>{
+              'blocklist_active_pubkey': ourPubkey,
+              'pending_unblocks.$ourPubkey': jsonEncode({target: 1000}),
+              'block_list_migrated_to_mute_list.$ourPubkey': true,
+              'block_list_retired.$ourPubkey': true,
+            });
+            final prefs = await SharedPreferences.getInstance();
+            stubHealthy();
+            // Withheld throughout, so the seeded intent survives the sync
+            // and is still outstanding when the block arrives.
+            stubReadInconclusive();
+            // Sampled synchronously, the moment the block is announced.
+            final blockedWhenAnnounced = <String?>[];
+            final pendingWhenAnnounced = <String?>[];
+            var sampling = false;
+            final service = ContentBlocklistRepository(
+              prefs: prefs,
+              onChanged: () {
+                if (!sampling) return;
+                blockedWhenAnnounced.add(
+                  prefs.getString('blocked_users_list.$ourPubkey'),
+                );
+                pendingWhenAnnounced.add(
+                  prefs.getString('pending_unblocks.$ourPubkey'),
+                );
+              },
+            );
+            addTearDown(service.dispose);
+            await service.syncBlockListsInBackground(
+              mockClient,
+              mockSigner,
+              ourPubkey,
+            );
+            sampling = true;
+
+            await service.blockUser(target);
+
+            // A kill between the two writes must not leave "no pending
+            // unblock" recorded against a block that never landed: the
+            // relay's surviving `p` tag would then come back as a foreign
+            // mute instead of a block, which no affordance can lift.
+            expect(blockedWhenAnnounced.first, isNotNull);
+            expect(
+              jsonDecode(blockedWhenAnnounced.first!) as List<dynamic>,
+              contains(target),
+            );
+            expect(pendingWhenAnnounced.first, isNotNull);
+            expect(
+              jsonDecode(pendingWhenAnnounced.first!) as Map<String, dynamic>,
+              contains(target),
+            );
+          },
+        );
+
         test('re-blocking is a no-op when no publish is pending', () async {
           SharedPreferences.setMockInitialValues(<String, Object>{
             'blocklist_active_pubkey': ourPubkey,

--- a/mobile/packages/nostr_client/lib/src/block_list_signer.dart
+++ b/mobile/packages/nostr_client/lib/src/block_list_signer.dart
@@ -20,5 +20,6 @@ abstract class BlockListSigner {
     required int kind,
     required String content,
     List<List<String>>? tags,
+    int? createdAt,
   });
 }

--- a/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
+++ b/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
@@ -70,6 +70,8 @@ void main() {
       mockBlocklistRepository = _MockContentBlocklistRepository();
       mockFollowRepository = _MockFollowRepository();
 
+      when(() => mockBlocklistRepository.canUnblock(any())).thenReturn(false);
+
       when(() => mockFollowRepository.isFollowing(any())).thenReturn(false);
       when(
         () => mockFollowRepository.toggleFollow(any()),
@@ -95,7 +97,7 @@ void main() {
     test('reports a blocked account as not followed', () {
       when(() => mockFollowRepository.isFollowing(testPubkey)).thenReturn(true);
       when(
-        () => mockBlocklistRepository.isBlocked(testPubkey),
+        () => mockBlocklistRepository.canUnblock(testPubkey),
       ).thenReturn(true);
 
       final bloc = createBloc();
@@ -107,11 +109,21 @@ void main() {
     test('reports an unblocked account as followed', () {
       when(() => mockFollowRepository.isFollowing(testPubkey)).thenReturn(true);
       when(
-        () => mockBlocklistRepository.isBlocked(testPubkey),
+        () => mockBlocklistRepository.canUnblock(testPubkey),
       ).thenReturn(false);
 
       final bloc = createBloc();
       expect(bloc.isFollowing, isTrue);
+      bloc.close();
+    });
+
+    test('offers Unblock for an imported mute', () {
+      when(
+        () => mockBlocklistRepository.canUnblock(testPubkey),
+      ).thenReturn(true);
+
+      final bloc = createBloc();
+      expect(bloc.isBlocked, isTrue);
       bloc.close();
     });
 
@@ -747,7 +759,7 @@ void main() {
             () => mockFollowRepository.isFollowing(testPubkey),
           ).thenReturn(true);
           when(
-            () => mockBlocklistRepository.isBlocked(testPubkey),
+            () => mockBlocklistRepository.canUnblock(testPubkey),
           ).thenReturn(true);
         },
         build: createBloc,

--- a/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
+++ b/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
@@ -70,8 +70,6 @@ void main() {
       mockBlocklistRepository = _MockContentBlocklistRepository();
       mockFollowRepository = _MockFollowRepository();
 
-      when(() => mockBlocklistRepository.canUnblock(any())).thenReturn(false);
-
       when(() => mockFollowRepository.isFollowing(any())).thenReturn(false);
       when(
         () => mockFollowRepository.toggleFollow(any()),

--- a/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
+++ b/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
@@ -97,6 +97,9 @@ void main() {
       when(
         () => mockBlocklistRepository.canUnblock(testPubkey),
       ).thenReturn(true);
+      when(
+        () => mockBlocklistRepository.isBlocked(testPubkey),
+      ).thenReturn(true);
 
       final bloc = createBloc();
       expect(bloc.isBlocked, isTrue);
@@ -108,6 +111,9 @@ void main() {
       when(() => mockFollowRepository.isFollowing(testPubkey)).thenReturn(true);
       when(
         () => mockBlocklistRepository.canUnblock(testPubkey),
+      ).thenReturn(false);
+      when(
+        () => mockBlocklistRepository.isBlocked(testPubkey),
       ).thenReturn(false);
 
       final bloc = createBloc();
@@ -122,6 +128,24 @@ void main() {
 
       final bloc = createBloc();
       expect(bloc.isBlocked, isTrue);
+      bloc.close();
+    });
+
+    test('still reports an imported mute as followed', () {
+      when(() => mockFollowRepository.isFollowing(testPubkey)).thenReturn(true);
+      when(
+        () => mockBlocklistRepository.canUnblock(testPubkey),
+      ).thenReturn(true);
+      when(
+        () => mockBlocklistRepository.isBlocked(testPubkey),
+      ).thenReturn(false);
+
+      final bloc = createBloc();
+      // A mute severs nothing: MyFollowingBloc still lists the account and
+      // the kind 3 we publish still carries it, so the profile sheet has to
+      // keep offering `Unfollow` rather than hiding the row.
+      expect(bloc.isBlocked, isTrue);
+      expect(bloc.isFollowing, isTrue);
       bloc.close();
     });
 

--- a/mobile/test/screens/other_profile_screen_test.dart
+++ b/mobile/test/screens/other_profile_screen_test.dart
@@ -45,7 +45,13 @@ class _MockPeopleListsBloc extends MockBloc<PeopleListsEvent, PeopleListsState>
     implements PeopleListsBloc {}
 
 class _MockContentBlocklistRepository extends Mock
-    implements ContentBlocklistRepository {}
+    implements ContentBlocklistRepository {
+  @override
+  bool isBlocked(String pubkey) => false;
+
+  @override
+  bool canUnblock(String pubkey) => false;
+}
 
 class _MockLikesRepository extends Mock implements LikesRepository {}
 
@@ -137,7 +143,6 @@ void main() {
     );
     when(() => peopleListsBloc.state).thenReturn(const PeopleListsState());
 
-    when(() => blocklistRepository.isBlocked(any())).thenReturn(false);
     when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(false);
     when(() => blocklistRepository.hasMutedUs(any())).thenReturn(false);
     when(

--- a/mobile/test/screens/profile_screen_router_test.dart
+++ b/mobile/test/screens/profile_screen_router_test.dart
@@ -37,7 +37,13 @@ import '../helpers/test_provider_overrides.dart';
 import '../helpers/test_pubkeys.dart';
 
 class _MockContentBlocklistRepository extends Mock
-    implements ContentBlocklistRepository {}
+    implements ContentBlocklistRepository {
+  @override
+  bool isBlocked(String pubkey) => false;
+
+  @override
+  bool canUnblock(String pubkey) => false;
+}
 
 class _MockVideosRepository extends Mock implements VideosRepository {}
 
@@ -208,7 +214,6 @@ void main() {
       when(
         () => blocklistRepository.shouldFilterFromFeeds(any()),
       ).thenReturn(false);
-      when(() => blocklistRepository.isBlocked(any())).thenReturn(false);
       when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(false);
       when(() => blocklistRepository.hasMutedUs(any())).thenReturn(false);
       when(

--- a/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
@@ -24,11 +24,17 @@ import '../../helpers/test_provider_overrides.dart';
 
 class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {
-  @override
-  bool isBlocked(String pubkey) => false;
+  /// Answers for the two hide predicates the row reads. Plain fields keep
+  /// them out of the shared `setUp`, but settable ones let a test make the
+  /// two disagree -- the only way to pin which predicate the row calls.
+  bool blocked = false;
+  bool unblockable = false;
 
   @override
-  bool canUnblock(String pubkey) => false;
+  bool isBlocked(String pubkey) => blocked;
+
+  @override
+  bool canUnblock(String pubkey) => unblockable;
 }
 
 class _MockNotifySubscriptionsRepository extends Mock
@@ -242,6 +248,35 @@ void main() {
     });
   });
 
+  group('blocked state', () {
+    testWidgets('shows the blocked pill for a mute imported elsewhere', (
+      tester,
+    ) async {
+      // The two predicates disagree only for a mute the viewer authored on
+      // another Nostr client: not a Divine block, but still hidden and still
+      // liftable. Reading `isBlocked` here would miss it.
+      blocklistRepository
+        ..unblockable = true
+        ..blocked = false;
+
+      await tester.pumpWidget(buildWidget());
+      await tester.pump();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.profileBlockedLabel), findsOneWidget);
+    });
+
+    testWidgets('shows no blocked pill when the viewer hides nothing', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pump();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.profileBlockedLabel), findsNothing);
+    });
+  });
+
   group('notification bell', () {
     late StreamController<List<String>> followingStream;
 
@@ -287,24 +322,23 @@ void main() {
       expect(find.byType(ProfileNotifyBellButton), findsOneWidget);
     });
 
-    testWidgets(
-      'stays hidden behind the flag, and reads no subscriptions',
-      (tester) async {
-        followingTarget();
+    testWidgets('stays hidden behind the flag, and reads no subscriptions', (
+      tester,
+    ) async {
+      followingTarget();
 
-        await tester.pumpWidget(buildWidget(newPostNotifications: false));
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(buildWidget(newPostNotifications: false));
+      await tester.pumpAndSettle();
 
-        expect(find.byType(ProfileNotifyBellButton), findsNothing);
-        // The cubit must not be constructed either — otherwise a flagged-off
-        // build still hits the relay for a list it can never show.
-        verifyNever(
-          () => notifyRepository.watchSubscriptions(
-            ownerPubkey: any(named: 'ownerPubkey'),
-          ),
-        );
-      },
-    );
+      expect(find.byType(ProfileNotifyBellButton), findsNothing);
+      // The cubit must not be constructed either — otherwise a flagged-off
+      // build still hits the relay for a list it can never show.
+      verifyNever(
+        () => notifyRepository.watchSubscriptions(
+          ownerPubkey: any(named: 'ownerPubkey'),
+        ),
+      );
+    });
 
     testWidgets('tapping it subscribes the viewer to the target', (
       tester,

--- a/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
@@ -73,7 +73,6 @@ void main() {
 
     when(() => nostrClient.publicKey).thenReturn(viewerPubkey);
 
-    when(() => blocklistRepository.isBlocked(any())).thenReturn(false);
     when(() => blocklistRepository.canUnblock(any())).thenReturn(false);
     when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(false);
     when(

--- a/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
@@ -74,6 +74,7 @@ void main() {
     when(() => nostrClient.publicKey).thenReturn(viewerPubkey);
 
     when(() => blocklistRepository.isBlocked(any())).thenReturn(false);
+    when(() => blocklistRepository.canUnblock(any())).thenReturn(false);
     when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(false);
     when(
       () => blocklistRepository.currentState,

--- a/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
@@ -23,7 +23,13 @@ import '../../helpers/accessibility_guidelines.dart';
 import '../../helpers/test_provider_overrides.dart';
 
 class _MockContentBlocklistRepository extends Mock
-    implements ContentBlocklistRepository {}
+    implements ContentBlocklistRepository {
+  @override
+  bool isBlocked(String pubkey) => false;
+
+  @override
+  bool canUnblock(String pubkey) => false;
+}
 
 class _MockNotifySubscriptionsRepository extends Mock
     implements NotifySubscriptionsRepository {}
@@ -73,7 +79,6 @@ void main() {
 
     when(() => nostrClient.publicKey).thenReturn(viewerPubkey);
 
-    when(() => blocklistRepository.canUnblock(any())).thenReturn(false);
     when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(false);
     when(
       () => blocklistRepository.currentState,

--- a/mobile/test/widgets/profile/profile_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_grid_test.dart
@@ -39,7 +39,13 @@ class _MockVideosRepository extends Mock implements VideosRepository {}
 class _MockCommentsRepository extends Mock implements CommentsRepository {}
 
 class _MockContentBlocklistRepository extends Mock
-    implements ContentBlocklistRepository {}
+    implements ContentBlocklistRepository {
+  @override
+  bool isBlocked(String pubkey) => false;
+
+  @override
+  bool canUnblock(String pubkey) => false;
+}
 
 /// In-memory [CacheDao] whose writes can be parked, so a test can hold a tab
 /// BLoC in the post-emit snapshot write the way a real disk write does.
@@ -163,7 +169,6 @@ void main() {
       when(
         () => videosRepository.isVideoKnownDeleted(any()),
       ).thenReturn(false);
-      when(() => blocklistRepository.isBlocked(any())).thenReturn(false);
       when(() => blocklistRepository.hasMutedUs(any())).thenReturn(false);
       when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(false);
       whenListen(

--- a/mobile/test/widgets/profile/unavailable_profile_actions_test.dart
+++ b/mobile/test/widgets/profile/unavailable_profile_actions_test.dart
@@ -39,7 +39,7 @@ void main() {
         () => followRepository.isFollowing(_userIdHex),
       ).thenReturn(isFollowing);
       when(
-        () => blocklistRepository.isBlocked(_userIdHex),
+        () => blocklistRepository.canUnblock(_userIdHex),
       ).thenReturn(isBlocked);
 
       return ProviderScope(


### PR DESCRIPTION
## Description

Unblocking could report success while leaving an account hidden when the local block set and the user's published Nostr mute list disagreed. It also gave users no way to clear a mute imported from another Nostr client.

This change treats unblock as durable intent to remove the account from both local hide buckets and the complete published mute list. Pending intent is applied centrally whenever an own mute-list event is reconciled, so refreshes, retries, live subscriptions, migration, and successful publish echoes cannot re-adopt a stale `p` tag. A realistically clock-skewed replaceable event is superseded with a newer valid timestamp; an invalid future timestamp is withheld before asking the signer.

Profile actions now expose the existing Unblock flow for mutes imported from another Nostr client. Re-blocking retires contradictory pending intent, and pending intent retires only after an own list without the tag is observed.

This deliberately makes the pending unblock authoritative until a published list without the account is observed. That prevents stale relay echoes from undoing the user's unblock, but it also temporarily suppresses a legitimate re-mute made by another client while the unblock remains pending.

The change does not add a separate mute UI, change internal moderation blocks, or publish for stray unblock calls when neither local nor known published state contains the account. Caller-visible relay publish feedback remains tracked by #6436.

## Verification

- `very_good test --coverage` in `mobile/packages/content_blocklist_repository` (178 tests)
- Affected profile action, BLoC, screen, grid, and router tests
- `flutter test test/l10n/arb_consistency_test.dart` (11 tests)
- `python3 .agents/skills/check-l10n/scan_strings.py`
- `flutter analyze` in `mobile`
- Repository pre-push checks (268 changed-file tests)

Closes #6438

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
