### PR TITLE
fix(nostr-sdk): keep private keys out of diagnostics

### DIFF
--- a/mobile/lib/utils/nostr_key_utils.dart
+++ b/mobile/lib/utils/nostr_key_utils.dart
@@ -34,17 +34,11 @@ class NostrKeyUtils {
     return keyIsValid(key);
   }
 
-  /// Check if nsec is valid by attempting to decode it
+  /// Check if nsec has the private-key prefix and decodes to a 32-byte key
   ///
   /// Returns true if the nsec can be successfully decoded, false otherwise
-  static bool isValidNsec(String nsec) {
-    try {
-      Nip19.decode(nsec);
-      return true;
-    } catch (_) {
-      return false;
-    }
-  }
+  static bool isValidNsec(String nsec) =>
+      Nip19.isPrivateKey(nsec) && Nip19.decode(nsec).length == 64;
 
   /// The full npub for [hexPubkey], or the hex itself when it cannot be
   /// encoded.

--- a/mobile/lib/utils/nostr_key_utils.dart
+++ b/mobile/lib/utils/nostr_key_utils.dart
@@ -3,6 +3,7 @@
 // ABOUTME: shortening them for UI display (never for logs — see AGENTS.md)
 
 import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/nip19/hrps.dart';
 import 'package:nostr_sdk/nip19/nip19.dart';
 
 /// Utility class for Nostr key operations.
@@ -34,11 +35,13 @@ class NostrKeyUtils {
     return keyIsValid(key);
   }
 
-  /// Check if nsec has the private-key prefix and decodes to a 32-byte key
+  /// Whether [nsec] is a bech32 `nsec1…` string carrying a 32-byte key.
   ///
-  /// Returns true if the nsec can be successfully decoded, false otherwise
+  /// False when the prefix is absent or belongs to another HRP that merely
+  /// starts with `nsec`, when the bech32 is malformed, or when the decoded
+  /// payload is not a 32-byte hex key.
   static bool isValidNsec(String nsec) =>
-      Nip19.isPrivateKey(nsec) && Nip19.decode(nsec).length == 64;
+      nsec.startsWith('${Hrps.privateKey}1') && isValidKey(Nip19.decode(nsec));
 
   /// The full npub for [hexPubkey], or the hex itself when it cannot be
   /// encoded.

--- a/mobile/lib/utils/nostr_key_utils.dart
+++ b/mobile/lib/utils/nostr_key_utils.dart
@@ -3,7 +3,6 @@
 // ABOUTME: shortening them for UI display (never for logs — see AGENTS.md)
 
 import 'package:nostr_sdk/client_utils/keys.dart';
-import 'package:nostr_sdk/nip19/hrps.dart';
 import 'package:nostr_sdk/nip19/nip19.dart';
 
 /// Utility class for Nostr key operations.
@@ -35,13 +34,11 @@ class NostrKeyUtils {
     return keyIsValid(key);
   }
 
-  /// Whether [nsec] is a bech32 `nsec1…` string carrying a 32-byte key.
+  /// Whether [nsec] has the `nsec` HRP and carries a 32-byte key.
   ///
-  /// False when the prefix is absent or belongs to another HRP that merely
-  /// starts with `nsec`, when the bech32 is malformed, or when the decoded
-  /// payload is not a 32-byte hex key.
-  static bool isValidNsec(String nsec) =>
-      nsec.startsWith('${Hrps.privateKey}1') && isValidKey(Nip19.decode(nsec));
+  /// Uniformly uppercase bech32 is valid. Mixed case, another HRP, malformed
+  /// bech32, and payloads other than 32 bytes are invalid.
+  static bool isValidNsec(String nsec) => Nip19.isPrivateKey(nsec);
 
   /// The full npub for [hexPubkey], or the hex itself when it cannot be
   /// encoded.

--- a/mobile/packages/keycast_flutter/test/key_utils_test.dart
+++ b/mobile/packages/keycast_flutter/test/key_utils_test.dart
@@ -27,6 +27,20 @@ void main() {
             'npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6';
         expect(KeyUtils.parseNsec(npub), isNull);
       });
+
+      test('returns null for a forged nsec HRP', () {
+        const forgedNsec =
+            'nsec1abc1vankwem8vankwem8vankwem8vankwem8vankwem8vankwem8vanspqs76t';
+
+        expect(KeyUtils.parseNsec(forgedNsec), isNull);
+      });
+
+      test('decodes a uniformly uppercase nsec', () {
+        const uppercaseNsec =
+            'NSEC1VL029MGPSPEDVA04G90VLTKH6FVH240ZQTV9K0T9AF8935KE9LAQSNLFE5';
+
+        expect(KeyUtils.parseNsec(uppercaseNsec), isNotNull);
+      });
     });
 
     group('derivePublicKey', () {

--- a/mobile/packages/nostr_key_manager/test/src/secure_key_storage_integration_test.dart
+++ b/mobile/packages/nostr_key_manager/test/src/secure_key_storage_integration_test.dart
@@ -76,6 +76,28 @@ void main() {
       );
     });
 
+    test('importFromNsec rejects a forged nsec HRP', () async {
+      await storageService.initialize();
+      const forgedNsec =
+          'nsec1abc1vankwem8vankwem8vankwem8vankwem8vankwem8vankwem8vanspqs76t';
+
+      expect(
+        () => storageService.importFromNsec(forgedNsec),
+        throwsA(isA<SecureKeyStorageException>()),
+      );
+    });
+
+    test('importFromNsec accepts a uniformly uppercase nsec', () async {
+      await storageService.initialize();
+      const uppercaseNsec =
+          'NSEC1VL029MGPSPEDVA04G90VLTKH6FVH240ZQTV9K0T9AF8935KE9LAQSNLFE5';
+
+      final imported = await storageService.importFromNsec(uppercaseNsec);
+
+      expect(imported.publicKeyHex, isNotEmpty);
+      imported.dispose();
+    });
+
     test('should delete keys securely', () async {
       // Arrange
       await storageService.initialize();

--- a/mobile/packages/nostr_sdk/lib/client_utils/keys.dart
+++ b/mobile/packages/nostr_sdk/lib/client_utils/keys.dart
@@ -9,10 +9,10 @@ String generatePrivateKey() => getRandomHexString();
 
 /// Returns the BIP340 public key derived from [privateKey].
 ///
-/// An [ArgumentError] is thrown if [privateKey] is invalid.
+/// An [ArgumentError] is thrown without including [privateKey] if it is invalid.
 String getPublicKey(String privateKey) {
   if (!keyIsValid(privateKey)) {
-    throw ArgumentError.value(privateKey, 'privateKey', 'Invalid key');
+    throw ArgumentError('privateKey: Invalid key (expected 64 hex characters)');
   }
   return schnorr.getPublicKey(privateKey);
 }

--- a/mobile/packages/nostr_sdk/lib/client_utils/keys.dart
+++ b/mobile/packages/nostr_sdk/lib/client_utils/keys.dart
@@ -9,10 +9,14 @@ String generatePrivateKey() => getRandomHexString();
 
 /// Returns the BIP340 public key derived from [privateKey].
 ///
-/// An [ArgumentError] is thrown without including [privateKey] if it is invalid.
+/// Throws an [ArgumentError] when [privateKey] is not 64 hex characters.
+/// The error never carries [privateKey], so it is safe to log.
 String getPublicKey(String privateKey) {
   if (!keyIsValid(privateKey)) {
-    throw ArgumentError('privateKey: Invalid key (expected 64 hex characters)');
+    throw ArgumentError(
+      'Invalid key (expected 64 hex characters)',
+      'privateKey',
+    );
   }
   return schnorr.getPublicKey(privateKey);
 }

--- a/mobile/packages/nostr_sdk/lib/nip19/nip19.dart
+++ b/mobile/packages/nostr_sdk/lib/nip19/nip19.dart
@@ -2,10 +2,17 @@ import 'dart:developer';
 
 import 'package:bech32/bech32.dart';
 import 'package:hex/hex.dart';
+import 'package:meta/meta.dart';
 
 import 'hrps.dart';
 
 class Nip19 {
+  /// Captures decode diagnostics in tests when set.
+  ///
+  /// Production leaves this null and writes through [log].
+  @visibleForTesting
+  static void Function(String)? debugLogSink;
+
   // static String encodePubKey(String pubkey) {
   //   var data = hex.decode(pubkey);
   //   data = Bech32.convertBits(data, 8, 5, true);
@@ -83,7 +90,8 @@ class Nip19 {
       var data = convertBits(bech32Result.data, 5, 8, false);
       return HEX.encode(data);
     } catch (e) {
-      log("Nip19 decode error ${e.toString()}");
+      // Exception messages may contain sensitive input.
+      (debugLogSink ?? log)('Nip19 decode error: ${e.runtimeType}');
       return "";
     }
   }

--- a/mobile/packages/nostr_sdk/lib/nip19/nip19.dart
+++ b/mobile/packages/nostr_sdk/lib/nip19/nip19.dart
@@ -112,7 +112,14 @@ class Nip19 {
   }
 
   static bool isPrivateKey(String str) {
-    return isKey(Hrps.privateKey, str);
+    try {
+      final bech32Result = Bech32Decoder().convert(str);
+      if (bech32Result.hrp != Hrps.privateKey) return false;
+
+      return convertBits(bech32Result.data, 5, 8, false).length == 32;
+    } catch (_) {
+      return false;
+    }
   }
 
   static String encodePrivateKey(String privateKey) {

--- a/mobile/packages/nostr_sdk/lib/nip19/nip19.dart
+++ b/mobile/packages/nostr_sdk/lib/nip19/nip19.dart
@@ -91,7 +91,13 @@ class Nip19 {
       return HEX.encode(data);
     } catch (e) {
       // Exception messages may contain sensitive input.
-      (debugLogSink ?? log)('Nip19 decode error: ${e.runtimeType}');
+      final message = 'Nip19 decode error: ${e.runtimeType}';
+      final sink = debugLogSink;
+      if (sink != null) {
+        sink(message);
+      } else {
+        log(message);
+      }
       return "";
     }
   }

--- a/mobile/packages/nostr_sdk/test/unit/keys_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/keys_test.dart
@@ -1,0 +1,25 @@
+// ABOUTME: Tests private-key validation errors do not disclose key material.
+// ABOUTME: Invalid inputs must remain absent from diagnostic representations.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+
+void main() {
+  group('getPublicKey', () {
+    test('does not include an invalid private key in ArgumentError', () {
+      const invalidPrivateKey =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+      expect(
+        () => getPublicKey(invalidPrivateKey),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.toString(),
+            'diagnostic',
+            isNot(contains(invalidPrivateKey)),
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/mobile/packages/nostr_sdk/test/unit/keys_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/keys_test.dart
@@ -6,42 +6,29 @@ import 'package:nostr_sdk/client_utils/keys.dart';
 
 void main() {
   group('getPublicKey', () {
-    test('does not include a too-short private key in ArgumentError', () {
-      const tooShort =
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const invalidPrivateKeys = <String, String>{
+      'too-short':
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      'non-hex':
+          'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz',
+    };
 
-      expect(
-        () => getPublicKey(tooShort),
-        throwsA(
-          isA<ArgumentError>()
-              .having((error) => error.name, 'name', 'privateKey')
-              .having((error) => error.invalidValue, 'invalidValue', isNull)
-              .having(
-                (error) => error.toString(),
-                'diagnostic',
-                isNot(contains(tooShort)),
-              ),
-        ),
-      );
-    });
-
-    test('does not include a non-hex private key in ArgumentError', () {
-      const nonHex =
-          'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz';
-
-      expect(
-        () => getPublicKey(nonHex),
-        throwsA(
-          isA<ArgumentError>()
-              .having((error) => error.name, 'name', 'privateKey')
-              .having((error) => error.invalidValue, 'invalidValue', isNull)
-              .having(
-                (error) => error.toString(),
-                'diagnostic',
-                isNot(contains(nonHex)),
-              ),
-        ),
-      );
+    invalidPrivateKeys.forEach((kind, invalidPrivateKey) {
+      test('does not include a $kind private key in ArgumentError', () {
+        expect(
+          () => getPublicKey(invalidPrivateKey),
+          throwsA(
+            isA<ArgumentError>()
+                .having((error) => error.name, 'name', 'privateKey')
+                .having((error) => error.invalidValue, 'invalidValue', isNull)
+                .having(
+                  (error) => error.toString(),
+                  'diagnostic',
+                  isNot(contains(invalidPrivateKey)),
+                ),
+          ),
+        );
+      });
     });
   });
 }

--- a/mobile/packages/nostr_sdk/test/unit/keys_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/keys_test.dart
@@ -6,18 +6,40 @@ import 'package:nostr_sdk/client_utils/keys.dart';
 
 void main() {
   group('getPublicKey', () {
-    test('does not include an invalid private key in ArgumentError', () {
-      const invalidPrivateKey =
+    test('does not include a too-short private key in ArgumentError', () {
+      const tooShort =
           'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
       expect(
-        () => getPublicKey(invalidPrivateKey),
+        () => getPublicKey(tooShort),
         throwsA(
-          isA<ArgumentError>().having(
-            (error) => error.toString(),
-            'diagnostic',
-            isNot(contains(invalidPrivateKey)),
-          ),
+          isA<ArgumentError>()
+              .having((error) => error.name, 'name', 'privateKey')
+              .having((error) => error.invalidValue, 'invalidValue', isNull)
+              .having(
+                (error) => error.toString(),
+                'diagnostic',
+                isNot(contains(tooShort)),
+              ),
+        ),
+      );
+    });
+
+    test('does not include a non-hex private key in ArgumentError', () {
+      const nonHex =
+          'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz';
+
+      expect(
+        () => getPublicKey(nonHex),
+        throwsA(
+          isA<ArgumentError>()
+              .having((error) => error.name, 'name', 'privateKey')
+              .having((error) => error.invalidValue, 'invalidValue', isNull)
+              .having(
+                (error) => error.toString(),
+                'diagnostic',
+                isNot(contains(nonHex)),
+              ),
         ),
       );
     });

--- a/mobile/packages/nostr_sdk/test/unit/nip19_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nip19_test.dart
@@ -5,6 +5,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 
 void main() {
+  tearDown(() {
+    Nip19.debugLogSink = null;
+  });
+
   group('NIP-19 Bech32 Encoding Tests', () {
     const testHexPubkey =
         '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
@@ -131,6 +135,28 @@ void main() {
       // decode should handle invalid input gracefully
       final result = Nip19.decode('invalid_bech32');
       expect(result, equals('')); // Should return empty string on error
+    });
+
+    test('does not include mixed-case secret input in decode diagnostics', () {
+      final nsec = Nip19.encodePrivateKey(testHexPrivateKey);
+      final mixedCaseCharacters = nsec.split('');
+      final lowercasePayloadIndex = mixedCaseCharacters.indexWhere(
+        (character) => RegExp('[a-z]').hasMatch(character),
+        5,
+      );
+      mixedCaseCharacters[lowercasePayloadIndex] =
+          mixedCaseCharacters[lowercasePayloadIndex].toUpperCase();
+      final mixedCaseNsec = mixedCaseCharacters.join();
+      final diagnostics = <String>[];
+      Nip19.debugLogSink = diagnostics.add;
+
+      expect(Nip19.decode(mixedCaseNsec), isEmpty);
+      expect(diagnostics, hasLength(1));
+      for (var start = 0; start <= mixedCaseCharacters.length - 20; start++) {
+        final inputFragment = mixedCaseCharacters.skip(start).take(20).join();
+        expect(diagnostics.single, isNot(contains(inputFragment)));
+      }
+      expect(diagnostics.single, contains('MixedCase'));
     });
 
     test('Bech32 end checking functionality', () {

--- a/mobile/packages/nostr_sdk/test/unit/nip19_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nip19_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for NIP-19 bech32 encoding and decoding functionality
 // ABOUTME: Validates npub, nsec, and note encoding/decoding works correctly
 
+import 'package:bech32/bech32.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 
@@ -38,6 +39,21 @@ void main() {
       expect(nsec, startsWith('nsec1'));
       expect(nsec.length, greaterThan(50));
       expect(Nip19.isPrivateKey(nsec), isTrue);
+    });
+
+    test('accepts a uniformly uppercase nsec', () {
+      final uppercaseNsec = Nip19.encodePrivateKey(
+        testHexPrivateKey,
+      ).toUpperCase();
+
+      expect(Nip19.isPrivateKey(uppercaseNsec), isTrue);
+    });
+
+    test('rejects a valid payload encoded under a forged nsec HRP', () {
+      final words = Nip19.convertBits(List<int>.filled(32, 0x67), 8, 5, true);
+      final forgedNsec = Bech32Encoder().convert(Bech32('nsec1abc', words));
+
+      expect(Nip19.isPrivateKey(forgedNsec), isFalse);
     });
 
     test('Decode nsec back to hex', () {
@@ -83,6 +99,7 @@ void main() {
 
       expect(Nip19.isPubkey('nsec1...'), isFalse); // Wrong prefix
       expect(Nip19.isPrivateKey('npub1...'), isFalse); // Wrong prefix
+      expect(Nip19.isPrivateKey('nsec1...'), isFalse); // Invalid bech32
     });
 
     test('Encoding different hex strings produces different results', () {

--- a/mobile/packages/nostr_sdk/test/unit/nip19_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nip19_test.dart
@@ -157,11 +157,13 @@ void main() {
       expect(diagnostics.single, isNot(contains(mixedCaseNsec)));
       expect(diagnostics.single, isNot(contains('nsec1')));
       expect(diagnostics.single, isNot(contains(testHexPrivateKey)));
-      expect(mixedCaseCharacters.length, greaterThanOrEqualTo(20));
+      var comparedFragments = 0;
       for (var start = 0; start <= mixedCaseCharacters.length - 20; start++) {
         final inputFragment = mixedCaseCharacters.skip(start).take(20).join();
         expect(diagnostics.single, isNot(contains(inputFragment)));
+        comparedFragments++;
       }
+      expect(comparedFragments, greaterThan(0));
       expect(diagnostics.single, contains('MixedCase'));
     });
 

--- a/mobile/packages/nostr_sdk/test/unit/nip19_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nip19_test.dart
@@ -154,6 +154,9 @@ void main() {
 
       expect(Nip19.decode(mixedCaseNsec), isEmpty);
       expect(diagnostics, hasLength(1));
+      expect(diagnostics.single, isNot(contains(mixedCaseNsec)));
+      expect(diagnostics.single, isNot(contains('nsec1')));
+      expect(diagnostics.single, isNot(contains(testHexPrivateKey)));
       expect(mixedCaseCharacters.length, greaterThanOrEqualTo(20));
       for (var start = 0; start <= mixedCaseCharacters.length - 20; start++) {
         final inputFragment = mixedCaseCharacters.skip(start).take(20).join();

--- a/mobile/packages/nostr_sdk/test/unit/nip19_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nip19_test.dart
@@ -140,10 +140,12 @@ void main() {
     test('does not include mixed-case secret input in decode diagnostics', () {
       final nsec = Nip19.encodePrivateKey(testHexPrivateKey);
       final mixedCaseCharacters = nsec.split('');
+      final lowercaseLetter = RegExp('[a-z]');
       final lowercasePayloadIndex = mixedCaseCharacters.indexWhere(
-        (character) => RegExp('[a-z]').hasMatch(character),
+        lowercaseLetter.hasMatch,
         5,
       );
+      expect(lowercasePayloadIndex, isNonNegative);
       mixedCaseCharacters[lowercasePayloadIndex] =
           mixedCaseCharacters[lowercasePayloadIndex].toUpperCase();
       final mixedCaseNsec = mixedCaseCharacters.join();
@@ -152,6 +154,7 @@ void main() {
 
       expect(Nip19.decode(mixedCaseNsec), isEmpty);
       expect(diagnostics, hasLength(1));
+      expect(mixedCaseCharacters.length, greaterThanOrEqualTo(20));
       for (var start = 0; start <= mixedCaseCharacters.length - 20; start++) {
         final inputFragment = mixedCaseCharacters.skip(start).take(20).join();
         expect(diagnostics.single, isNot(contains(inputFragment)));

--- a/mobile/scripts/check_process_global_mutations.sh
+++ b/mobile/scripts/check_process_global_mutations.sh
@@ -119,6 +119,7 @@ RESET_TO_DEFAULT_GLOBALS=(
   'NativeProofModeService\.proofFileOverride:null'
   'NativeProofModeService\.c2paSigningServiceFactoryOverride:null'
   'InfiniteVideoFeed\.debugIsSupportedOverride:null'
+  'Nip19\.debugLogSink:null'
 )
 
 # SCAN_DIR remains a single-root override for the synthetic self-tests.

--- a/mobile/test/utils/nostr_key_utils_test.dart
+++ b/mobile/test/utils/nostr_key_utils_test.dart
@@ -1,0 +1,37 @@
+// ABOUTME: Tests Nostr secret-key validation against complete NIP-19 input.
+// ABOUTME: Prefix-only and malformed values must not pass the import gate.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nip19/nip19.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
+
+void main() {
+  group('NostrKeyUtils.isValidNsec', () {
+    const privateKey =
+        '67dea2ed018072d675f5415ecfaed7d2597555e202d85b3d65ea4e58d2d92ffa';
+    const publicKey =
+        '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+
+    test('accepts a valid nsec', () {
+      expect(
+        NostrKeyUtils.isValidNsec(Nip19.encodePrivateKey(privateKey)),
+        isTrue,
+      );
+    });
+
+    test('rejects malformed text', () {
+      expect(NostrKeyUtils.isValidNsec('not-a-secret-key'), isFalse);
+    });
+
+    test('rejects a valid npub', () {
+      expect(NostrKeyUtils.isValidNsec(Nip19.encodePubKey(publicKey)), isFalse);
+    });
+
+    test('rejects an nsec with an invalid checksum', () {
+      final characters = Nip19.encodePrivateKey(privateKey).split('');
+      characters[characters.length - 1] = characters.last == 'q' ? 'p' : 'q';
+
+      expect(NostrKeyUtils.isValidNsec(characters.join()), isFalse);
+    });
+  });
+}

--- a/mobile/test/utils/nostr_key_utils_test.dart
+++ b/mobile/test/utils/nostr_key_utils_test.dart
@@ -35,11 +35,17 @@ void main() {
       expect(NostrKeyUtils.isValidNsec(characters.join()), isFalse);
     });
 
-    test('rejects a foreign HRP that starts with nsec', () {
+    test('rejects a foreign HRP whose text starts with nsec1', () {
       final words = Nip19.convertBits(List<int>.filled(32, 0x67), 8, 5, true);
-      final foreignHrpKey = Bech32Encoder().convert(Bech32('nsecx', words));
+      final foreignHrpKey = Bech32Encoder().convert(Bech32('nsec1abc', words));
 
       expect(NostrKeyUtils.isValidNsec(foreignHrpKey), isFalse);
+    });
+
+    test('accepts a uniformly uppercase nsec', () {
+      final uppercaseNsec = Nip19.encodePrivateKey(privateKey).toUpperCase();
+
+      expect(NostrKeyUtils.isValidNsec(uppercaseNsec), isTrue);
     });
   });
 }

--- a/mobile/test/utils/nostr_key_utils_test.dart
+++ b/mobile/test/utils/nostr_key_utils_test.dart
@@ -1,7 +1,9 @@
 // ABOUTME: Tests Nostr secret-key validation against complete NIP-19 input.
 // ABOUTME: Prefix-only and malformed values must not pass the import gate.
 
+import 'package:bech32/bech32.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hex/hex.dart';
 import 'package:nostr_sdk/nip19/nip19.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 
@@ -32,6 +34,13 @@ void main() {
       characters[characters.length - 1] = characters.last == 'q' ? 'p' : 'q';
 
       expect(NostrKeyUtils.isValidNsec(characters.join()), isFalse);
+    });
+
+    test('rejects a foreign HRP that starts with nsec', () {
+      final words = Nip19.convertBits(HEX.decode(privateKey), 8, 5, true);
+      final foreignHrpKey = Bech32Encoder().convert(Bech32('nsecx', words));
+
+      expect(NostrKeyUtils.isValidNsec(foreignHrpKey), isFalse);
     });
   });
 }

--- a/mobile/test/utils/nostr_key_utils_test.dart
+++ b/mobile/test/utils/nostr_key_utils_test.dart
@@ -3,7 +3,6 @@
 
 import 'package:bech32/bech32.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hex/hex.dart';
 import 'package:nostr_sdk/nip19/nip19.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 
@@ -37,7 +36,7 @@ void main() {
     });
 
     test('rejects a foreign HRP that starts with nsec', () {
-      final words = Nip19.convertBits(HEX.decode(privateKey), 8, 5, true);
+      final words = Nip19.convertBits(List<int>.filled(32, 0x67), 8, 5, true);
       final foreignHrpKey = Bech32Encoder().convert(Bech32('nsecx', words));
 
       expect(NostrKeyUtils.isValidNsec(foreignHrpKey), isFalse);


### PR DESCRIPTION
Malformed secret-key input could be copied into local diagnostics while decoding or validating a key. The nsec import guard also treated malformed values as valid because it expected the decoder to throw, although the decoder returns an empty value on failure.

This change records only the decode exception type, omits invalid private-key values from `ArgumentError`, and validates nsec inputs using the parsed bech32 HRP plus an exact 32-byte payload. The shared NIP-19 validator now rejects forged HRPs across app import, Keycast BYOK, and secure storage while continuing to accept uniformly uppercase bech32 keys. Existing successful NIP-19 decoding and key derivation behavior is unchanged.

Verification:
- `flutter analyze lib test integration_test tools`
- `flutter test packages/nostr_sdk/test packages/keycast_flutter/test packages/nostr_key_manager/test test/utils/nostr_key_utils_test.dart` (1,060 tests)
- Focused forged-HRP and uppercase coverage in nostr_sdk, app utilities, Keycast, and secure storage
- Process-global mutation, Nostr ID logging, pubkey encoding, placeholder test, grouped test, test structure, pinned assertion, and empty-catch ratchets

Closes #8311
