### PR TITLE
fix(test): stop shared Hive boxes leaking rows between test suites

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -794,6 +794,7 @@ dead letter — the `vgv-tag-gate` CI job enforces this.
 | An irreversible initializer (`loadAppFonts()`) | Not allowed in a suite. The root `flutter_test_config.dart` loads app fonts once before `testMain`, so every merged test measures the same glyphs. There is no inverse, so no teardown can undo a suite-local call — `test/goldens/` is the only other allowed home (`check_process_global_mutations.sh` enforces, hard zero). |
 | `HttpOverrides.global` | Not allowed in a merged test — tag the file `['skip_very_good_optimization', 'integration']` (`check_http_overrides_isolation.sh` enforces). |
 | View config (`tester.view.physicalSize` / `devicePixelRatio` / `setSurfaceSize`) | Pair every override with an `addTearDown` reset (`resetPhysicalSize`, `resetDevicePixelRatio`, `setSurfaceSize(null)`). |
+| Any Hive box in `HiveBoxNames.all` (they are registered process-globally by name) | `await TestHelpers.cleanupHiveBox(name)` in **both** `setUp` and `tearDown`. Never `Hive.box(name).close()` — see the harness below. A root `tearDown` heals any box left **open** and blames under `DIVINE_STRICT_HIVE_BOXES`; the rest of the row is convention, not a check. |
 | A service you registered with `BackgroundActivityManager` (`AuthService`, `UploadManager`, `AnalyticsService`) | Dispose the service. All three unregister in `dispose()`. If a test drives a manager directly, keep that exact instance and call `addTearDown(manager.resetForTesting)`. Each provider container owns a separate manager, so constructing a new manager cannot reset the instance under test. |
 
 ### Heal-and-blame harness (the 5 shared channels)
@@ -810,3 +811,51 @@ rather than being healed into someone else's suite; a bare
 `flutter test <file>` leaves it off and heals silently. A static
 `check_shared_channel_overrides.sh` ratchet additionally freezes the set of
 files that raw-install a shared channel, so new ones must use the helper.
+
+### Heal-and-blame harness (shared Hive boxes)
+
+Hive registers a box **process-globally by name**, so the box one suite leaves
+open is the box the next suite gets back from `openBox` — rows and backing
+directory included, regardless of the path it asked for. More than a dozen
+suites open `pending_uploads`, which is why a curated-lists PR that touches no
+upload code could fail on `upload_manager_get_by_path` seeing a row it never
+wrote (#6748).
+
+`flutter_test_config.dart` registers a root `tearDown` that closes and deletes
+every box in `sharedHiveBoxNames` (`test/helpers/shared_hive_box_guard.dart`,
+which is `HiveBoxNames.all`) that a test left open. Under
+`DIVINE_STRICT_HIVE_BOXES=true`, it then `fail()`s that test.
+The hazard is a property of the name being process-global, not of which box it
+is, so the guard covers every box the app owns rather than only the one that
+surfaced it. Blame is gated while the harness soaks because Hive does not
+expose an `openBox` still pending in its private `_openingBoxes` registry. Such
+an open can become visible during the following test, so unconditional blame
+could identify the wrong owner.
+
+**Clean up with `TestHelpers.cleanupHiveBox(name)`, never `Hive.box(name)`.**
+`Hive.box(name)` is `Hive.box<dynamic>`, and hive_ce throws
+``HiveError: The box "pending_uploads" is already open and of type
+Box<PendingUpload>`` for any box opened with a concrete value type. Swallowed
+by a bare `catch`, that throw made the shared cleanup helper a silent no-op on
+every open typed box — both the close and the `deleteBoxFromDisk` after it were
+skipped. Measured over the seventeen suites that touch `pending_uploads`, seven
+of them were handing 64 rows forward to whichever suite ran next.
+`cleanupHiveBox` routes through `deleteBoxFromDisk`, which resolves the box by
+name with no type check, and asserts its own postcondition rather than
+swallowing a failure.
+
+**Scope: `mobile/test` only.** `flutter_test_config.dart` is a per-directory
+hook and the repo has exactly one, under `mobile/test/`. `mobile/integration_test/`
+and `mobile/packages/*/test` get no guard, no heal and no signal — nothing there
+opens a shared box today, so this is a gap to know about rather than a live one.
+
+**What the guard can and cannot see.** It observes one thing: whether a box in
+`HiveBoxNames.all` is still open when a test ends. So `await Hive.close()`
+satisfies it too — twelve suites clean up that way — and an `openBox` still
+in flight is invisible to `Hive.isBoxOpen`, which reads `HiveImpl._boxes` while
+a pending open sits in `_openingBoxes`. Neither is enforcement of the row above:
+"clean up with `cleanupHiveBox`, in both `setUp` and `tearDown`" is the
+convention, and only the open-box half is mechanically checked. The
+MethodChannel harness pairs its runtime guard with a static
+`check_shared_channel_overrides.sh` ratchet for exactly this reason; there is
+no Hive equivalent yet.

--- a/mobile/test/flutter_test_config.dart
+++ b/mobile/test/flutter_test_config.dart
@@ -12,9 +12,13 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:openvine/widgets/avatar_failure_cache.dart';
 
 import 'helpers/shared_channel_override.dart';
+import 'helpers/shared_hive_box_guard.dart';
 import 'test_setup.dart';
 
 const _runGoldenSetup = bool.fromEnvironment('DIVINE_GOLDEN_TESTS');
+// Heal during the initial soak; opt into blame once pending-open behavior has
+// been observed across the merged suite.
+const _strictHiveBoxes = bool.fromEnvironment('DIVINE_STRICT_HIVE_BOXES');
 
 /// When set (via `--dart-define=DIVINE_STRICT_CHANNELS=true`), the
 /// heal-and-blame tearDown also `fail()`s the test that leaked a shared
@@ -59,6 +63,13 @@ Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   // from its canonical handler, and — under DIVINE_STRICT_CHANNELS — blames
   // the perpetrating test. Compliant tests never trip it.
   tearDown(() => healAndBlameSharedChannels(strict: _strictChannels));
+
+  // Hive registers boxes process-globally by name, so a box one suite leaves
+  // open is the same box the next suite gets back from openBox — rows and
+  // backing directory included (#6748). This root tearDown closes and deletes
+  // any shared box a test left open. Blame is gated while the guard soaks,
+  // because Hive does not expose opens still pending in `_openingBoxes`.
+  tearDown(() => healAndBlameSharedHiveBoxes(strict: _strictHiveBoxes));
 
   // UserAvatar records broken image URLs in a process-global negative cache.
   // In the merged optimizer isolate that state would otherwise leak a failed

--- a/mobile/test/helpers/shared_hive_box_guard.dart
+++ b/mobile/test/helpers/shared_hive_box_guard.dart
@@ -1,0 +1,75 @@
+// ABOUTME: Heal-and-blame for the process-global Hive box registry in tests.
+// ABOUTME: Guards the #6748 merged-isolate leak class where a suite leaves a
+// ABOUTME: box open by name and the next suite inherits its rows.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:openvine/constants/hive_box_names.dart';
+
+import 'test_helpers.dart';
+
+/// Every Hive box name the app owns.
+///
+/// A Hive box is registered process-globally by name, so under
+/// `very_good test --optimization` — where the whole unit suite runs in one
+/// isolate — a box one suite leaves open is the same box the next suite gets
+/// back from `openBox`, rows and backing directory included. That hazard is a
+/// property of the name being shared, not of which box it is, so the guard
+/// covers the whole set rather than only the box that surfaced it (#6748).
+const Set<String> sharedHiveBoxNames = HiveBoxNames.all;
+
+/// How the guard closes and deletes one leaked box. Exists so the guard's own
+/// tests can drive the failure path; production callers take the default.
+typedef HiveBoxCleanup = Future<void> Function(String boxName);
+
+/// Shared Hive boxes still open at the moment this is called — i.e. a test
+/// finished without closing one. Pure: no side effects.
+List<String> findSharedHiveBoxViolations() => [
+  for (final name in sharedHiveBoxNames)
+    if (Hive.isBoxOpen(name)) name,
+];
+
+/// After every test (wired as a root `tearDown` in `flutter_test_config.dart`):
+/// close and delete every shared Hive box the test left open, so the next suite
+/// in the merged isolate starts from an empty one. When [strict] is true, also
+/// `fail()` the test that left it.
+///
+/// During the soak period cleanup always runs but blame is gated by [strict].
+/// Hive does not expose opens still pending in its private `_openingBoxes`
+/// registry, so unconditional blame could attribute a late open to the test
+/// after the actual owner.
+Future<void> healAndBlameSharedHiveBoxes({
+  required bool strict,
+  HiveBoxCleanup cleanup = TestHelpers.cleanupHiveBox,
+}) async {
+  final violations = findSharedHiveBoxViolations();
+  if (violations.isEmpty) return;
+
+  // Heal each box independently. An unguarded `await` here would let the first
+  // failing cleanup abandon every box after it — leaking the exact rows this
+  // guard exists to purge — and skip the `fail()` below, so the perpetrating
+  // test would die with a bare error carrying none of the diagnostic and the
+  // next suite would be blamed for the survivor.
+  final healFailures = <String>[];
+  for (final name in violations) {
+    try {
+      await cleanup(name);
+    } on Object catch (error) {
+      healFailures.add('$name ($error)');
+    }
+  }
+
+  if (!strict) return;
+
+  fail(
+    'This test left shared Hive box(es) ${violations.join(', ')} open. Under '
+    'very_good --optimization every suite shares one isolate and Hive '
+    'registers boxes by name, so the next suite opening the same name gets '
+    "this test's box back — rows and backing directory included (#6748). Add "
+    'await TestHelpers.cleanupHiveBox(<name>) to the suite tearDown. '
+    'See .claude/rules/testing.md (VGV merged isolate).'
+    '${healFailures.isEmpty ? '' : ' Cleanup itself then failed for '
+              '${healFailures.join('; ')}, so those boxes are still open and the '
+              'next suite will inherit them.'}',
+  );
+}

--- a/mobile/test/helpers/shared_hive_box_guard_test.dart
+++ b/mobile/test/helpers/shared_hive_box_guard_test.dart
@@ -1,0 +1,157 @@
+// ABOUTME: Tests the heal-and-blame harness for shared process-wide Hive boxes.
+// ABOUTME: Each test heals within itself so the root tearDown sees no leak.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:openvine/constants/hive_box_names.dart';
+import 'package:openvine/services/upload_initialization_helper.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import '../mocks/mock_path_provider_platform.dart';
+import 'shared_hive_box_guard.dart';
+import 'test_helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('shared Hive box guard', () {
+    late Directory tempDir;
+    late PathProviderPlatform originalPathProvider;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('hive_box_guard_test_');
+      originalPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = MockPathProviderPlatform()
+        ..setTemporaryPath(tempDir.path)
+        ..setApplicationDocumentsPath('${tempDir.path}/documents')
+        ..setApplicationSupportPath('${tempDir.path}/support');
+      await TestHelpers.initHiveHome();
+      // The tearDown half alone cannot protect this suite from a box an
+      // earlier suite left registered; the documented contract is both.
+      await TestHelpers.cleanupHiveBox(HiveBoxNames.pendingUploads);
+    });
+
+    tearDown(() async {
+      PathProviderPlatform.instance = originalPathProvider;
+      try {
+        await TestHelpers.cleanupHiveBox(HiveBoxNames.pendingUploads);
+      } finally {
+        // initHiveHome pointed Hive's process-global home path inside tempDir,
+        // and HiveStorageService.resetForTesting only clears that service's own
+        // latch -- it never touches HiveImpl.homePath. Left set, the next suite
+        // to open a box without re-pointing Hive has BackendManagerVm silently
+        // recreate the directory deleted below and write there.
+        Hive.init(null);
+        if (tempDir.existsSync()) {
+          await tempDir.delete(recursive: true);
+        }
+      }
+    });
+
+    group('findSharedHiveBoxViolations', () {
+      test('is empty while no shared box is open', () {
+        expect(sharedHiveBoxNames, contains(HiveBoxNames.pendingUploads));
+        expect(findSharedHiveBoxViolations(), isEmpty);
+      });
+
+      test('reports a shared box left open', () async {
+        await UploadInitializationHelper.initializeUploadsBox();
+
+        expect(
+          findSharedHiveBoxViolations(),
+          contains(HiveBoxNames.pendingUploads),
+        );
+      });
+    });
+
+    group('healAndBlameSharedHiveBoxes', () {
+      test('does nothing when every shared box is closed', () async {
+        await expectLater(
+          healAndBlameSharedHiveBoxes(strict: true),
+          completes,
+        );
+      });
+
+      test('closes the leaked box and fails in strict mode', () async {
+        await UploadInitializationHelper.initializeUploadsBox();
+
+        await expectLater(
+          healAndBlameSharedHiveBoxes(strict: true),
+          throwsA(isA<TestFailure>()),
+        );
+
+        expect(Hive.isBoxOpen(HiveBoxNames.pendingUploads), isFalse);
+        expect(findSharedHiveBoxViolations(), isEmpty);
+      });
+
+      test('closes the leaked box without failing during soak mode', () async {
+        await UploadInitializationHelper.initializeUploadsBox();
+
+        await expectLater(
+          healAndBlameSharedHiveBoxes(strict: false),
+          completes,
+        );
+
+        expect(findSharedHiveBoxViolations(), isEmpty);
+      });
+
+      // One box whose cleanup throws must not abandon the boxes after it.
+      // Unguarded, the first throw escaped the loop, left every later box
+      // registered for the next suite to inherit, and skipped the fail()
+      // below — so the leak survived and the diagnostic never printed.
+      test('heals the remaining boxes when one cleanup throws', () async {
+        await UploadInitializationHelper.initializeUploadsBox();
+        await Hive.openBox<dynamic>(HiveBoxNames.notifications);
+        expect(
+          findSharedHiveBoxViolations(),
+          containsAll([
+            HiveBoxNames.pendingUploads,
+            HiveBoxNames.notifications,
+          ]),
+          reason: 'both boxes must leak for the loop to have a second pass',
+        );
+
+        final attempted = <String>[];
+        await expectLater(
+          healAndBlameSharedHiveBoxes(
+            strict: true,
+            cleanup: (name) async {
+              attempted.add(name);
+              if (name == HiveBoxNames.pendingUploads) {
+                throw StateError('cleanup blew up on $name');
+              }
+              await TestHelpers.cleanupHiveBox(name);
+            },
+          ),
+          throwsA(
+            isA<TestFailure>().having(
+              (failure) => failure.message,
+              'message',
+              allOf(
+                contains(HiveBoxNames.pendingUploads),
+                contains('Cleanup itself then failed'),
+                contains('cleanup blew up'),
+              ),
+            ),
+          ),
+        );
+
+        expect(
+          attempted,
+          containsAll([
+            HiveBoxNames.pendingUploads,
+            HiveBoxNames.notifications,
+          ]),
+          reason: 'the throw must not abandon the boxes after it',
+        );
+        expect(Hive.isBoxOpen(HiveBoxNames.notifications), isFalse);
+
+        // The injected cleanup deliberately left this one open; heal it here
+        // so the root tearDown does not blame this test for it.
+        await TestHelpers.cleanupHiveBox(HiveBoxNames.pendingUploads);
+      });
+    });
+  });
+}

--- a/mobile/test/helpers/test_helpers.dart
+++ b/mobile/test/helpers/test_helpers.dart
@@ -1,12 +1,15 @@
 // ABOUTME: Test helper utilities for creating mock data and testing video system
 // ABOUTME: Provides consistent test data generation and common testing patterns
 
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:models/models.dart' hide LogCategory, LogLevel;
+import 'package:openvine/constants/hive_box_names.dart';
 import 'package:openvine/services/hive_storage_service.dart';
 import 'package:openvine/services/upload_initialization_helper.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -185,14 +188,26 @@ class TestHelpers {
     return events;
   }
 
-  /// Clean up Hive box to ensure test isolation
-  /// Call this in setUp() BEFORE initializing your manager
+  /// Close and delete a Hive box so the next test starts from an empty one.
   ///
-  /// This ensures proper unit test isolation by:
-  /// - Resetting static state in UploadInitializationHelper
-  /// - Closing any open Hive boxes
-  /// - Deleting the box from disk
-  /// - Clearing ALL data from the box after reopen
+  /// Hive boxes are process-global and several suites share the same name, so
+  /// under `very_good test --optimization` — where the whole suite runs in one
+  /// isolate — a box left behind by one suite is inherited by the next. Call
+  /// this in both `setUp` and `tearDown` for every shared box a suite touches.
+  ///
+  /// Deliberately routed through [HiveInterface.deleteBoxFromDisk], which looks
+  /// the box up by name with **no type check**, closes it, unregisters it from
+  /// `HiveImpl._boxes` — the registry `Hive.isBoxOpen` and `openBox` read, and
+  /// so the one this leak class is about — and deletes the files. Note it does
+  /// not also call `HiveConnect.unregisterBox`, which `close()` does, so the
+  /// first box object opened under each name stays reachable from that static
+  /// for the life of the isolate. Retention is bounded by the ~7 shared names.
+  /// The obvious `Hive.box(boxName).close()` cannot be used: it is
+  /// `Hive.box<dynamic>`, and hive_ce throws
+  /// ``HiveError: The box "x" is already open and of type Box<PendingUpload>``
+  /// for any box opened with a concrete value type. That throw — swallowed by
+  /// a bare `catch` — is what made this helper a silent no-op on every open
+  /// typed box for months (#6748).
   ///
   /// Example usage:
   /// ```dart
@@ -200,21 +215,46 @@ class TestHelpers {
   ///   await TestHelpers.cleanupHiveBox('pending_uploads');
   ///   manager = UploadManager(...);
   ///   await manager.initialize(); // This will create a fresh empty box
-  ///   await TestHelpers.ensureBoxEmpty('pending_uploads'); // Verify it's really empty
   /// });
+  ///
+  /// tearDown(() => TestHelpers.cleanupHiveBox('pending_uploads'));
   /// ```
   static Future<void> cleanupHiveBox(String boxName) async {
-    // Reset static state
-    UploadInitializationHelper.reset();
+    // Only the uploads box has an owner holding cached static state, and only
+    // it may be reset here. reset() runs AsyncScope.cancelAll(), which
+    // completes every in-flight initializeUploadsBox() waiter with
+    // AsyncCancelledException and clears the failure/backoff counters -- so
+    // firing it for an unrelated name (the guard heals any of
+    // HiveBoxNames.all) rejects a concurrent uploads initialization and
+    // discards state a retry test may have deliberately established.
+    if (boxName == HiveBoxNames.pendingUploads) {
+      UploadInitializationHelper.reset();
+    }
 
-    // Close and delete the box
     try {
-      if (Hive.isBoxOpen(boxName)) {
-        await Hive.box(boxName).close();
-      }
       await Hive.deleteBoxFromDisk(boxName);
-    } catch (e) {
-      // Box might not exist, that's fine
+    } on Object catch (error) {
+      // Some suites call cleanup before installing their per-test Hive home.
+      // There cannot be an on-disk box to remove when the backend path is
+      // uninitialized; preserve that valid pre-init no-op without skipping
+      // closed-box deletion once a home exists.
+      final isUninitializedHome =
+          error is ArgumentError &&
+          error.name == 'path' &&
+          error.invalidValue == null;
+      if (isUninitializedHome) return;
+
+      // The suite's temp directory can already be gone. `deleteFromDisk`
+      // unregisters the box before it touches the file, so the box is closed
+      // either way and the postcondition below still holds.
+      if (error is! FileSystemException) rethrow;
+    }
+
+    if (Hive.isBoxOpen(boxName)) {
+      throw StateError(
+        'cleanupHiveBox("$boxName") left the box open. Every later suite in '
+        'the merged isolate now inherits its rows. See #6748.',
+      );
     }
   }
 
@@ -227,16 +267,6 @@ class TestHelpers {
     HiveStorageService.resetForTesting();
     addTearDown(HiveStorageService.resetForTesting);
     await HiveStorageService.initialize();
-  }
-
-  /// Ensure a Hive box is completely empty
-  /// Call this AFTER initialization to verify the box is truly empty
-  static Future<void> ensureBoxEmpty<T>(String boxName) async {
-    if (Hive.isBoxOpen(boxName)) {
-      final box = Hive.box<T>(boxName);
-      // Clear all keys
-      await box.clear();
-    }
   }
 
   /// Generate test data for performance testing

--- a/mobile/test/helpers/test_helpers_test.dart
+++ b/mobile/test/helpers/test_helpers_test.dart
@@ -1,0 +1,136 @@
+// ABOUTME: Tests TestHelpers' shared-Hive-box cleanup contract.
+// ABOUTME: Pins #6748 — cleanupHiveBox silently no-opped on an open typed box.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:openvine/constants/hive_box_names.dart';
+import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/upload_initialization_helper.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import '../mocks/mock_path_provider_platform.dart';
+import 'test_helpers.dart';
+
+const _pubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TestHelpers.cleanupHiveBox', () {
+    late Directory tempDir;
+    late PathProviderPlatform originalPathProvider;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('cleanup_hive_box_test_');
+      originalPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = MockPathProviderPlatform()
+        ..setTemporaryPath(tempDir.path)
+        ..setApplicationDocumentsPath('${tempDir.path}/documents')
+        ..setApplicationSupportPath('${tempDir.path}/support');
+      await TestHelpers.initHiveHome();
+      // The tearDown half alone cannot protect this suite from a box an
+      // earlier suite left registered; the documented contract is both.
+      await TestHelpers.cleanupHiveBox(HiveBoxNames.pendingUploads);
+    });
+
+    tearDown(() async {
+      PathProviderPlatform.instance = originalPathProvider;
+      try {
+        await TestHelpers.cleanupHiveBox(HiveBoxNames.pendingUploads);
+      } finally {
+        // initHiveHome pointed Hive's process-global home path inside tempDir,
+        // and HiveStorageService.resetForTesting only clears that service's own
+        // latch -- it never touches HiveImpl.homePath. Left set, the next suite
+        // to open a box without re-pointing Hive has BackendManagerVm silently
+        // recreate the directory deleted below and write there.
+        Hive.init(null);
+        if (tempDir.existsSync()) {
+          await tempDir.delete(recursive: true);
+        }
+      }
+    });
+
+    Future<Box<PendingUpload>> openBoxWithOneRow() async {
+      final box = await UploadInitializationHelper.initializeUploadsBox();
+      await box.put(
+        'row',
+        PendingUpload.create(
+          localVideoPath: '${tempDir.path}/video.mp4',
+          nostrPubkey: _pubkey,
+        ),
+      );
+      return box;
+    }
+
+    // The box is opened as Box<PendingUpload>, which is the case the old
+    // implementation could not handle: it reached for Hive.box(name) —
+    // Hive.box<dynamic> — and hive_ce threw before the delete ever ran.
+    test('closes a box that is open with a concrete value type', () async {
+      final box = await openBoxWithOneRow();
+      expect(box.length, 1, reason: 'the box must have a row to leak');
+      expect(Hive.isBoxOpen(HiveBoxNames.pendingUploads), isTrue);
+
+      await TestHelpers.cleanupHiveBox(HiveBoxNames.pendingUploads);
+
+      expect(Hive.isBoxOpen(HiveBoxNames.pendingUploads), isFalse);
+    });
+
+    test('deletes the rows, so the next open sees an empty box', () async {
+      await openBoxWithOneRow();
+
+      await TestHelpers.cleanupHiveBox(HiveBoxNames.pendingUploads);
+      final reopened = await UploadInitializationHelper.initializeUploadsBox();
+
+      expect(reopened.length, isZero);
+    });
+
+    test('deletes rows from disk after the box was already closed', () async {
+      final box = await openBoxWithOneRow();
+      await box.close();
+      expect(Hive.isBoxOpen(HiveBoxNames.pendingUploads), isFalse);
+
+      await TestHelpers.cleanupHiveBox(HiveBoxNames.pendingUploads);
+      final reopened = await UploadInitializationHelper.initializeUploadsBox();
+
+      expect(reopened.length, isZero);
+    });
+
+    test('is a no-op when the box was never opened', () async {
+      expect(Hive.isBoxOpen(HiveBoxNames.pendingUploads), isFalse);
+
+      await expectLater(
+        TestHelpers.cleanupHiveBox(HiveBoxNames.pendingUploads),
+        completes,
+      );
+      expect(Hive.isBoxOpen(HiveBoxNames.pendingUploads), isFalse);
+    });
+
+    // The guard heals any name in HiveBoxNames.all, so this helper is called
+    // with box names the uploads owner knows nothing about. Resetting it for
+    // those runs AsyncScope.cancelAll(), which rejects an in-flight
+    // initializeUploadsBox() waiter and clears the backoff counters.
+    test(
+      'leaves the uploads owner alone when cleaning an unrelated box',
+      () async {
+        await UploadInitializationHelper.initializeUploadsBox();
+        expect(
+          UploadInitializationHelper.getDebugState()['hasCachedBox'],
+          isTrue,
+          reason: 'the uploads owner must hold cached state to lose',
+        );
+
+        await TestHelpers.cleanupHiveBox(HiveBoxNames.notifications);
+
+        expect(
+          UploadInitializationHelper.getDebugState()['hasCachedBox'],
+          isTrue,
+          reason: 'cleaning notifications must not reset the uploads owner',
+        );
+        expect(Hive.isBoxOpen(HiveBoxNames.pendingUploads), isTrue);
+      },
+    );
+  });
+}

--- a/mobile/test/models/thumbnail_url_preservation_test.dart
+++ b/mobile/test/models/thumbnail_url_preservation_test.dart
@@ -7,6 +7,7 @@ import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/providers/app_providers.dart';
 
 import '../helpers/real_integration_test_helper.dart';
+import '../helpers/test_helpers.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -26,16 +27,10 @@ void main() {
     tearDown(() async {
       container.dispose();
 
-      // Clean up Hive boxes
-      try {
-        if (Hive.isBoxOpen('pending_uploads')) {
-          final box = Hive.box('pending_uploads');
-          await box.clear();
-          await box.close();
-        }
-      } catch (e) {
-        // Ignore errors - box might not exist
-      }
+      // Hive.box(name) is Hive.box<dynamic> and throws on a box opened as
+      // Box<PendingUpload>; swallowed by the bare catch this replaces, that
+      // throw made the whole block a silent no-op and leaked the box (#6748).
+      await TestHelpers.cleanupHiveBox('pending_uploads');
     });
 
     test('thumbnail URL should be preserved after upload success', () async {

--- a/mobile/test/providers/social_providers_cleanup_test.dart
+++ b/mobile/test/providers/social_providers_cleanup_test.dart
@@ -93,6 +93,11 @@ void main() {
         ..setApplicationCachePath('${tempDir.path}/cache');
       PathProviderPlatform.instance = mockPathProvider;
       await TestHelpers.initHiveHome();
+      // Without this, UploadInitializationHelper's static _cachedBox short-
+      // circuits initialize() past Hive.openBox entirely, so this suite can
+      // inherit a previous suite's box -- and the non-destructive test below
+      // then asserts on rows it never wrote.
+      await TestHelpers.cleanupHiveBox('pending_uploads');
 
       uploadManager = UploadManager(
         backgroundActivityManager: BackgroundActivityManager(),
@@ -101,8 +106,10 @@ void main() {
         scopeUploadsToCurrentUser: true,
       );
       await uploadManager.initialize();
-      await TestHelpers.ensureBoxEmpty<hive_model.PendingUpload>(
-        'pending_uploads',
+      expect(
+        uploadManager.pendingUploads,
+        isEmpty,
+        reason: 'setUp must hand each test an empty pending_uploads box',
       );
 
       container = ProviderContainer(
@@ -120,10 +127,13 @@ void main() {
       container.dispose();
       uploadManager.dispose();
       await db.close();
-      await TestHelpers.cleanupHiveBox('pending_uploads');
       PathProviderPlatform.instance = originalPathProviderInstance;
-      if (tempDir.existsSync()) {
-        await tempDir.delete(recursive: true);
+      try {
+        await TestHelpers.cleanupHiveBox('pending_uploads');
+      } finally {
+        if (tempDir.existsSync()) {
+          await tempDir.delete(recursive: true);
+        }
       }
     });
 

--- a/mobile/test/services/cache_recovery_service_test.dart
+++ b/mobile/test/services/cache_recovery_service_test.dart
@@ -43,13 +43,16 @@ void main() {
       });
 
       tearDown(() async {
-        await TestHelpers.cleanupHiveBox(HiveBoxNames.notifications);
-        await TestHelpers.cleanupHiveBox(
-          HiveBoxNames.pushNotificationPreferencesDirty,
-        );
-        await TestHelpers.cleanupHiveBox(HiveBoxNames.pendingUploads);
-        await TestHelpers.cleanupHiveBox(HiveBoxNames.hashtagStats);
-        if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+        try {
+          await TestHelpers.cleanupHiveBox(HiveBoxNames.notifications);
+          await TestHelpers.cleanupHiveBox(
+            HiveBoxNames.pushNotificationPreferencesDirty,
+          );
+          await TestHelpers.cleanupHiveBox(HiveBoxNames.pendingUploads);
+          await TestHelpers.cleanupHiveBox(HiveBoxNames.hashtagStats);
+        } finally {
+          if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+        }
       });
 
       test('classifies every known Hive box exactly once', () {

--- a/mobile/test/services/upload/pending_upload_store_test.dart
+++ b/mobile/test/services/upload/pending_upload_store_test.dart
@@ -35,9 +35,6 @@ Future<PendingUploadStore> _openStore({
     currentNostrPubkey: currentNostrPubkey,
   );
   await store.open();
-  // Guarantee a clean slate even if a prior test left records in the shared
-  // 'pending_uploads' box (mirrors upload_manager_owner_scope_test.dart).
-  await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
   return store;
 }
 
@@ -110,10 +107,13 @@ void main() {
     });
 
     tearDown(() async {
-      await TestHelpers.cleanupHiveBox('pending_uploads');
       PathProviderPlatform.instance = originalPathProvider;
-      if (tempDir.existsSync()) {
-        await tempDir.delete(recursive: true);
+      try {
+        await TestHelpers.cleanupHiveBox('pending_uploads');
+      } finally {
+        if (tempDir.existsSync()) {
+          await tempDir.delete(recursive: true);
+        }
       }
     });
 
@@ -543,7 +543,6 @@ void main() {
         () async {
           final store = await _openStore();
           addTearDown(store.disposeStore);
-          await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
           await seedTwoAccounts(store);
 
           expect(store.pendingUploads, hasLength(2));
@@ -558,7 +557,6 @@ void main() {
             currentNostrPubkey: _pubkeyA,
           );
           addTearDown(store.disposeStore);
-          await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
           final uploads = await seedTwoAccounts(store);
 
           final visible = store.pendingUploads;
@@ -578,7 +576,6 @@ void main() {
             scopeUploadsToCurrentUser: true,
           );
           addTearDown(store.disposeStore);
-          await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
           await seedTwoAccounts(store);
 
           expect(store.pendingUploads, isEmpty);
@@ -591,7 +588,6 @@ void main() {
           currentNostrPubkey: _pubkeyA,
         );
         addTearDown(store.disposeStore);
-        await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
         await seedTwoAccounts(store);
 
         expect(
@@ -610,7 +606,6 @@ void main() {
           currentNostrPubkey: _pubkeyA,
         );
         addTearDown(store.disposeStore);
-        await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
         await seedTwoAccounts(store);
 
         final stats = store.uploadStats;
@@ -623,7 +618,6 @@ void main() {
           currentNostrPubkey: _pubkeyA,
         );
         addTearDown(store.disposeStore);
-        await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
         final uploads = await seedTwoAccounts(store);
 
         final deleted = await store.deleteAllForOwner(_pubkeyA);

--- a/mobile/test/services/upload_manager_owner_scope_test.dart
+++ b/mobile/test/services/upload_manager_owner_scope_test.dart
@@ -55,10 +55,13 @@ void main() {
     });
 
     tearDown(() async {
-      await TestHelpers.cleanupHiveBox('pending_uploads');
       PathProviderPlatform.instance = originalPathProviderInstance;
-      if (tempDir.existsSync()) {
-        await tempDir.delete(recursive: true);
+      try {
+        await TestHelpers.cleanupHiveBox('pending_uploads');
+      } finally {
+        if (tempDir.existsSync()) {
+          await tempDir.delete(recursive: true);
+        }
       }
     });
 
@@ -73,7 +76,6 @@ void main() {
         scopeUploadsToCurrentUser: scopeUploadsToCurrentUser,
       );
       await manager.initialize();
-      await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
       return manager;
     }
 

--- a/mobile/test/services/upload_manager_recovery_test.dart
+++ b/mobile/test/services/upload_manager_recovery_test.dart
@@ -93,18 +93,20 @@ void main() {
         ),
       );
       await uploadManager.initialize();
-      await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
     });
 
     tearDown(() async {
       uploadManager.dispose();
       // dispose() nulls the store's reference without closing the box, so
       // close and delete it before the directory underneath it goes away.
-      await TestHelpers.cleanupHiveBox('pending_uploads');
-      Hive.init(null);
-      PathProviderPlatform.instance = originalPathProviderInstance;
-      if (tempDir.existsSync()) {
-        await tempDir.delete(recursive: true);
+      try {
+        await TestHelpers.cleanupHiveBox('pending_uploads');
+      } finally {
+        Hive.init(null);
+        PathProviderPlatform.instance = originalPathProviderInstance;
+        if (tempDir.existsSync()) {
+          await tempDir.delete(recursive: true);
+        }
       }
     });
 
@@ -167,7 +169,6 @@ void main() {
         ),
       );
       await uploadManager.initialize();
-      await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
 
       var uploadAttempts = 0;
       final firstAttemptFailed = Completer<void>();
@@ -428,11 +429,14 @@ void main() {
 
       addTearDown(() async {
         manager.dispose();
-        await TestHelpers.cleanupHiveBox('pending_uploads');
-        Hive.init(null);
-        PathProviderPlatform.instance = originalPathProvider;
-        if (tempDir.existsSync()) {
-          await tempDir.delete(recursive: true);
+        try {
+          await TestHelpers.cleanupHiveBox('pending_uploads');
+        } finally {
+          Hive.init(null);
+          PathProviderPlatform.instance = originalPathProvider;
+          if (tempDir.existsSync()) {
+            await tempDir.delete(recursive: true);
+          }
         }
       });
 

--- a/mobile/test/services/upload_manager_resumable_upload_test.dart
+++ b/mobile/test/services/upload_manager_resumable_upload_test.dart
@@ -86,18 +86,20 @@ void main() {
         ),
       );
       await uploadManager.initialize();
-      await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
     });
 
     tearDown(() async {
       uploadManager.dispose();
       // dispose() nulls the store's reference without closing the box, so
       // close and delete it before the directory underneath it goes away.
-      await TestHelpers.cleanupHiveBox('pending_uploads');
-      Hive.init(null);
-      PathProviderPlatform.instance = originalPathProviderInstance;
-      if (tempDir.existsSync()) {
-        await tempDir.delete(recursive: true);
+      try {
+        await TestHelpers.cleanupHiveBox('pending_uploads');
+      } finally {
+        Hive.init(null);
+        PathProviderPlatform.instance = originalPathProviderInstance;
+        if (tempDir.existsSync()) {
+          await tempDir.delete(recursive: true);
+        }
       }
     });
 
@@ -812,18 +814,20 @@ void main() {
         blossomService: mockBlossomService,
       );
       await uploadManager.initialize();
-      await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
     });
 
     tearDown(() async {
       uploadManager.dispose();
       // dispose() nulls the store's reference without closing the box, so
       // close and delete it before the directory underneath it goes away.
-      await TestHelpers.cleanupHiveBox('pending_uploads');
-      Hive.init(null);
-      PathProviderPlatform.instance = originalPathProviderInstance;
-      if (tempDir.existsSync()) {
-        await tempDir.delete(recursive: true);
+      try {
+        await TestHelpers.cleanupHiveBox('pending_uploads');
+      } finally {
+        Hive.init(null);
+        PathProviderPlatform.instance = originalPathProviderInstance;
+        if (tempDir.existsSync()) {
+          await tempDir.delete(recursive: true);
+        }
       }
     });
 

--- a/mobile/test/services/upload_manager_sandbox_test.dart
+++ b/mobile/test/services/upload_manager_sandbox_test.dart
@@ -14,6 +14,8 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+import '../helpers/test_helpers.dart';
+
 // Mock PathProviderPlatform for testing
 class MockPathProviderPlatform extends Fake
     with MockPlatformInterfaceMixin
@@ -64,28 +66,33 @@ void main() {
     ).create(recursive: true);
     Hive.init(p.join(testDir.path, 'app_support'));
 
-    // Reset helper state
-    UploadInitializationHelper.reset();
+    // Reset helper state. cleanupHiveBox resets UploadInitializationHelper's
+    // cache too, and additionally clears any box an earlier suite registered
+    // under this name -- the setUp half of the documented contract.
+    await TestHelpers.cleanupHiveBox('pending_uploads');
   });
 
   tearDown(() async {
-    // Clean up
+    PathProviderPlatform.instance = originalPathProviderInstance;
+    // `Hive.box('pending_uploads')` is `Hive.box<dynamic>` and throws on this
+    // box, which is opened as Box<PendingUpload> — swallowed, that throw left
+    // the box open for every later test (#6748). cleanupHiveBox resolves the
+    // box by name instead, and resets UploadInitializationHelper's cache.
     try {
-      PathProviderPlatform.instance = originalPathProviderInstance;
-      // Close all boxes
-      if (Hive.isBoxOpen('pending_uploads')) {
-        await Hive.box('pending_uploads').close();
+      await TestHelpers.cleanupHiveBox('pending_uploads');
+      try {
+        await Hive.close();
+      } on PathNotFoundException catch (_) {
+        // close() ends in a lock-file delete that races a temp directory
+        // already gone. Three sibling suites catch this for the same reason.
       }
-      await Hive.close();
-
-      // Reset helper state
-      UploadInitializationHelper.reset();
-
+    } finally {
+      // close() leaves Hive's process-global home path pointing at the
+      // directory deleted below.
+      Hive.init(null);
       if (testDir.existsSync()) {
         await testDir.delete(recursive: true);
       }
-    } catch (e) {
-      // Ignore cleanup errors
     }
   });
 

--- a/mobile/test/services/video_publish/draft_upload_materializer_test.dart
+++ b/mobile/test/services/video_publish/draft_upload_materializer_test.dart
@@ -129,10 +129,13 @@ void main() {
       // box before deleting tempDir, so neither leaks into the merged VGV
       // optimizer isolate (#5159).
       uploadManager.dispose();
-      await TestHelpers.cleanupHiveBox('pending_uploads');
       PathProviderPlatform.instance = originalPathProviderInstance;
-      if (tempDir.existsSync()) {
-        await tempDir.delete(recursive: true);
+      try {
+        await TestHelpers.cleanupHiveBox('pending_uploads');
+      } finally {
+        if (tempDir.existsSync()) {
+          await tempDir.delete(recursive: true);
+        }
       }
     });
 

--- a/mobile/test/unit/services/upload_manager_get_by_path_test.dart
+++ b/mobile/test/unit/services/upload_manager_get_by_path_test.dart
@@ -10,9 +10,7 @@ import 'dart:io';
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/background_activity_manager.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
@@ -82,18 +80,6 @@ void main() {
         thumbnailUrl: 'https://media.divine.video/test-video-id-thumb.jpg',
       ),
     );
-    // cleanupHiveBox swallows a failed deleteBoxFromDisk, and initialize()
-    // loads the box into an in-memory list that ensureBoxEmpty does not touch —
-    // so clearing after initialize leaves stale uploads visible through
-    // pendingUploads. Open and clear with a throwaway manager first, then read
-    // the empty box with the one under test so memory matches disk.
-    final boxOpener = UploadManager(
-      backgroundActivityManager: BackgroundActivityManager(),
-      blossomService: mockUploadService,
-    );
-    await boxOpener.initialize();
-    await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
-    boxOpener.dispose();
 
     uploadManager = UploadManager(
       backgroundActivityManager: BackgroundActivityManager(),
@@ -108,28 +94,25 @@ void main() {
   });
 
   tearDown(() async {
-    // Clean up after each test using proper async coordination
+    // Restore the process-global mock first. cleanupHiveBox and the temp-dir
+    // delete below can both throw, and this restore used to sit in a finally;
+    // without one, a throw would strand a MockPathProviderPlatform pointing at
+    // a just-deleted directory for every later test in the merged isolate.
+    // cleanupHiveBox resolves the box through Hive's own home path, not
+    // PathProvider, so restoring ahead of it is safe.
+    PathProviderPlatform.instance = originalPathProviderInstance;
+    reset(mockUploadService);
+
+    // Detach the manager from the box first, then close and delete the box so
+    // the next suite in the merged isolate does not inherit these rows (#6748).
+    uploadManager.dispose();
     try {
-      // Dispose the upload manager and wait for completion
-      uploadManager.dispose();
-
-      // Use proper async coordination instead of arbitrary delays
-      await Future.microtask(() {});
-
-      // Close the box if it's still open
-      if (Hive.isBoxOpen('pending_uploads')) {
-        final box = Hive.box('pending_uploads');
-        await box.close();
-      }
+      await TestHelpers.cleanupHiveBox('pending_uploads');
+    } finally {
       if (tempDir.existsSync()) {
         await tempDir.delete(recursive: true);
       }
-    } catch (e) {
-      // Manager or box might already be disposed/closed
-    } finally {
-      PathProviderPlatform.instance = originalPathProviderInstance;
     }
-    reset(mockUploadService);
   });
 
   File createVideoFile(String relativePath, List<int> bytes) {


### PR DESCRIPTION
## Description

Tests that claimed to clean up shared Hive boxes could leave both open boxes and persisted rows behind. Hive registers boxes process-globally by name, so a later suite could receive another suite's box, data, and backing directory. That made unrelated changes fail depending on merged-isolate ordering.

This change makes `TestHelpers.cleanupHiveBox` delete boxes through Hive's type-agnostic path, including boxes that are already closed but still have data on disk. It still treats cleanup before Hive initialization as a safe no-op, but otherwise verifies that the box is no longer open.

The root Hive guard now always heals leaked boxes. Blame is enabled only when `DIVINE_STRICT_HIVE_BOXES=true`, so the guard can soak without misattributing an in-flight asynchronous `openBox` operation. New tests prove both soak and strict behavior, and prove that cleanup removes persisted rows from a closed box.

Affected upload/cache teardowns now restore process-global PathProvider and Hive state and delete temporary directories even when box cleanup fails. Two hand-written cleanup paths use the shared helper, and the obsolete throwaway-manager workaround is removed.

**Related issue:** Closes #6748

## Out of Scope

- `upload_manager_get_by_path_test.dart` keeps its existing `skip_very_good_optimization` tag because its documented constraint also covers shared platform-channel state.
- This PR does not add a new static ratchet for direct `Hive.init(...)` calls. The runtime guard and failure-safe teardowns address the demonstrated leak; a repository-wide source-policy check would be a separate change.

## Verification

- The closed-box regression test failed against the previous helper (`Actual: <1>` persisted row) and passes with this fix.
- Changed test suites on the rebuilt current-`main` branch: **135 passed, 1 skipped, 0 failed**.
- Targeted Hive/upload/cache suites: **133 passed, 0 failed**.
- Full merged-isolate suite on the equivalent pre-rebuild diff: **19,354 passed, 254 skipped, 0 failed**.
- `flutter analyze lib test integration_test` — clean.
- Process-global mutation and ungrouped-test ratchets — clean.
- Test infrastructure and documentation only; no app runtime code changed.

## Type of Change

- [x] Bug fix
- [x] Documentation
