### PR TITLE
test(async): make provider synchronization explicit

### DIFF
--- a/mobile/scripts/baseline/future_delayed_test_counts.txt
+++ b/mobile/scripts/baseline/future_delayed_test_counts.txt
@@ -91,9 +91,7 @@ test/providers/invite_status_auth_sessions_test.dart	2
 test/providers/list_providers_test.dart	17
 test/providers/moderation_label_provider_session_test.dart	3
 test/providers/moderation_providers_blocked_follow_reconciler_test.dart	19
-test/providers/nostr_service_identity_source_test.dart	116
 test/providers/provider_identity_stream_test.dart	10
-test/providers/push_notification_sync_test.dart	85
 test/providers/seen_videos_notifier_test.dart	8
 test/providers/sounds_providers_test.dart	2
 test/providers/supporter_providers_test.dart	1

--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -220,8 +220,7 @@ void main() {
       expect(container.read(nostrInitializationInProgressProvider), isTrue);
 
       initialize.complete();
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 2);
 
       expect(container.read(nostrInitializationInProgressProvider), isFalse);
     });
@@ -309,8 +308,7 @@ void main() {
       addTearDown(container.dispose);
 
       container.read(nostrServiceProvider);
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 2);
 
       expect(factory.callCount, equals(1));
       expect(factory.signers.single, isNull);
@@ -449,8 +447,7 @@ void main() {
         );
 
         bInitialize.complete();
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         expect(factory.callCount, equals(3));
         expect(factory.clients.last.publicKey, equals(pubkeyC));
@@ -476,8 +473,7 @@ void main() {
         addTearDown(container.dispose);
 
         final oldClient = container.read(nostrServiceProvider);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         final bInitialize = Completer<void>();
         factory.initializeCompleters[pubkeyB] = bInitialize;
@@ -485,8 +481,7 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(identityB);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
         authStream.add(AuthState.authenticated);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         expect(factory.callCount, equals(2));
         expect(
@@ -510,8 +505,7 @@ void main() {
         );
 
         bInitialize.complete();
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         expect(
           container.read(nostrServiceProvider),
@@ -548,8 +542,7 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(identityB);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
         authStream.add(AuthState.authenticated);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         expect(
           container.read(nostrSessionProvider),
@@ -566,8 +559,7 @@ void main() {
         );
 
         bInitialize.complete();
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         final readyClient = container.read(nostrServiceProvider);
         expect(
@@ -589,8 +581,7 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(null);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(null);
         authStream.add(AuthState.unauthenticated);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         expect(
           observedReadiness.map((readiness) => readiness.phase),
@@ -618,8 +609,7 @@ void main() {
         addTearDown(container.dispose);
 
         container.read(nostrServiceProvider);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         final bInitialize = Completer<void>();
         factory.initializeCompleters[pubkeyB] = bInitialize;
@@ -633,9 +623,7 @@ void main() {
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyC);
         authStream.add(AuthState.authenticated);
         bInitialize.completeError(StateError('B initialize failed'));
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 3);
 
         expect(factory.callCount, equals(3));
         expect(factory.clients.last.publicKey, equals(pubkeyC));
@@ -669,8 +657,7 @@ void main() {
       addTearDown(container.dispose);
 
       container.read(nostrServiceProvider);
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 2);
       expect(factory.callCount, equals(1));
 
       final failedBInitialize = Completer<void>();
@@ -684,14 +671,11 @@ void main() {
       expect(factory.callCount, equals(2));
 
       failedBInitialize.completeError(StateError('B initialize failed'));
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 2);
 
       factory.initializeCompleters.remove(pubkeyB);
       authStream.add(AuthState.authenticated);
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 3);
 
       expect(
         factory.callCount,
@@ -735,8 +719,7 @@ void main() {
       failedInitialAInitialize.completeError(
         StateError('initial A initialize failed'),
       );
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 2);
 
       expect(
         container.read(nostrSessionProvider),
@@ -754,9 +737,7 @@ void main() {
 
       factory.initializeCompleters.remove(pubkeyA);
       authStream.add(AuthState.authenticated);
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 3);
 
       expect(
         factory.callCount,
@@ -825,8 +806,7 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(identityA);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
         authStream.add(AuthState.authenticated);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         expect(
           factory.callCount,
@@ -845,8 +825,7 @@ void main() {
         // RPC-upgrade nudge: same pubkey re-emitted after the background
         // Keycast upgrade resolves (auth_service.dart:733, unconditional add).
         authStream.add(AuthState.authenticated);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         expect(
           factory.callCount,
@@ -901,8 +880,7 @@ void main() {
         // RPC-upgrade nudge: same pubkey re-emitted while relay connect is
         // still running.
         authStream.add(AuthState.authenticated);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         expect(
           factory.callCount,
@@ -914,8 +892,7 @@ void main() {
 
         // Completing the gated init lets the ORIGINAL client reach ready.
         gate.complete();
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
         expect(factory.callCount, equals(1));
         expect(
           container.read(nostrSessionProvider).phase,
@@ -946,8 +923,7 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(identityB);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
         authStream.add(AuthState.authenticated);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         expect(
           factory.callCount,
@@ -1154,16 +1130,13 @@ void main() {
       failedInitialAInitialize.completeError(
         StateError('initial A initialize failed'),
       );
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 2);
 
       factory.initializeCompleters.remove(pubkeyA);
       when(() => mockAuth.currentIdentity).thenReturn(identityB);
       when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
       authStream.add(AuthState.authenticated);
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 3);
 
       expect(factory.callCount, equals(2));
       expect(factory.signers.last, same(identityB));
@@ -1193,8 +1166,7 @@ void main() {
       failedInitialAInitialize.completeError(
         StateError('initial A initialize failed'),
       );
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 2);
 
       container.dispose();
       await pumpEventQueue(times: 1);
@@ -1220,16 +1192,13 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(null);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(null);
         authStream.add(AuthState.unauthenticated);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         factory.initializeCompleters.remove(pubkeyA);
         when(() => mockAuth.currentIdentity).thenReturn(identityA);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
         authStream.add(AuthState.authenticated);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 3);
 
         final currentAClient = container.read(nostrServiceProvider);
         expect(currentAClient, isNot(same(firstAClient)));
@@ -1239,8 +1208,7 @@ void main() {
         );
 
         firstAInitialize.complete();
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         expect(
           container.read(nostrSessionProvider),
@@ -1281,9 +1249,7 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(identityA);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
         authStream.add(AuthState.authenticated);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 3);
 
         final readyClient = container.read(nostrServiceProvider);
         expect(
@@ -1303,8 +1269,7 @@ void main() {
         );
 
         initialPlaceholderInitialize.complete();
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         expect(
           container.read(nostrSessionProvider),
@@ -1346,22 +1311,19 @@ void main() {
         addTearDown(container.dispose);
 
         final oldClient = container.read(nostrServiceProvider);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
         final staleRelayCallback = latestRelayCallback!;
 
         when(() => mockAuth.currentIdentity).thenReturn(identityB);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
         authStream.add(AuthState.authenticated);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         expect(container.read(nostrServiceProvider), isNot(same(oldClient)));
 
         const staleRelays = ['wss://stale-relay.example'];
         staleRelayCallback(pubkeyA, staleRelays);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         verifyNever(() => oldClient.addRelays(staleRelays));
       },
@@ -1377,8 +1339,7 @@ void main() {
         addTearDown(container.dispose);
 
         final client = container.read(nostrServiceProvider);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         expect(
           container.read(nostrSessionProvider),

--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:db_client/db_client.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -1123,65 +1124,79 @@ void main() {
       },
     );
 
-    test('auth change cancels pending initialization retry', () async {
-      final failedInitialAInitialize = Completer<void>();
-      factory.initializeCompleters[pubkeyA] = failedInitialAInitialize;
-      when(() => mockAuth.currentIdentity).thenReturn(identityA);
-      when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
+    test('auth change cancels pending initialization retry', () {
+      fakeAsync((async) {
+        final failedInitialAInitialize = Completer<void>();
+        factory.initializeCompleters[pubkeyA] = failedInitialAInitialize;
+        when(() => mockAuth.currentIdentity).thenReturn(identityA);
+        when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
 
-      final container = createRetryContainer(
-        retryDelay: (_) => const Duration(hours: 1),
-      );
-      addTearDown(container.dispose);
+        final container = createRetryContainer(
+          retryDelay: (_) => const Duration(hours: 1),
+        );
+        addTearDown(container.dispose);
 
-      container.read(nostrServiceProvider);
-      await pumpEventQueue(times: 1);
-      failedInitialAInitialize.completeError(
-        StateError('initial A initialize failed'),
-      );
-      await pumpEventQueue(times: 2);
+        container.read(nostrServiceProvider);
+        async.elapse(const Duration(milliseconds: 1));
+        failedInitialAInitialize.completeError(
+          StateError('initial A initialize failed'),
+        );
+        async.elapse(const Duration(milliseconds: 1));
 
-      factory.initializeCompleters.remove(pubkeyA);
-      when(() => mockAuth.currentIdentity).thenReturn(identityB);
-      when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
-      authStream.add(AuthState.authenticated);
-      await pumpEventQueue(times: 3);
+        factory.initializeCompleters.remove(pubkeyA);
+        when(() => mockAuth.currentIdentity).thenReturn(identityB);
+        when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
+        authStream.add(AuthState.authenticated);
+        async.elapse(const Duration(milliseconds: 1));
 
-      expect(factory.callCount, equals(2));
-      expect(factory.signers.last, same(identityB));
-      expect(container.read(nostrServiceProvider), same(factory.clients.last));
-      expect(
-        container.read(nostrSessionProvider).pubkey,
-        equals(pubkeyB),
-      );
-      expect(
-        container.read(nostrSessionProvider).phase,
-        equals(NostrSessionPhase.nostrReady),
-      );
+        expect(factory.callCount, equals(2));
+        expect(factory.signers.last, same(identityB));
+        expect(
+          container.read(nostrServiceProvider),
+          same(factory.clients.last),
+        );
+        expect(container.read(nostrSessionProvider).pubkey, equals(pubkeyB));
+        expect(
+          container.read(nostrSessionProvider).phase,
+          equals(NostrSessionPhase.nostrReady),
+        );
+
+        // Teeth: identity A's pending retry must have been cancelled.
+        // callCount cannot see this -- when the retry fires it bails on the
+        // changed identity anyway -- so assert on the timer itself. Removing
+        // the cancel in _handleIdentityChange leaves one timer pending here.
+        expect(async.pendingTimers, isEmpty);
+      });
     });
 
-    test('dispose cancels pending initialization retry', () async {
-      final failedInitialAInitialize = Completer<void>();
-      factory.initializeCompleters[pubkeyA] = failedInitialAInitialize;
-      when(() => mockAuth.currentIdentity).thenReturn(identityA);
-      when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
+    test('dispose cancels pending initialization retry', () {
+      fakeAsync((async) {
+        final failedInitialAInitialize = Completer<void>();
+        factory.initializeCompleters[pubkeyA] = failedInitialAInitialize;
+        when(() => mockAuth.currentIdentity).thenReturn(identityA);
+        when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
 
-      final container = createRetryContainer(
-        retryDelay: (_) => const Duration(hours: 1),
-      );
+        final container = createRetryContainer(
+          retryDelay: (_) => const Duration(hours: 1),
+        );
 
-      final failedClient = container.read(nostrServiceProvider);
-      await pumpEventQueue(times: 1);
-      failedInitialAInitialize.completeError(
-        StateError('initial A initialize failed'),
-      );
-      await pumpEventQueue(times: 2);
+        final failedClient = container.read(nostrServiceProvider);
+        async.elapse(const Duration(milliseconds: 1));
+        failedInitialAInitialize.completeError(
+          StateError('initial A initialize failed'),
+        );
+        async.elapse(const Duration(milliseconds: 1));
 
-      container.dispose();
-      await pumpEventQueue(times: 1);
+        container.dispose();
+        async.elapse(const Duration(milliseconds: 1));
 
-      expect(factory.callCount, equals(1));
-      verify(failedClient.dispose).called(1);
+        expect(factory.callCount, equals(1));
+        verify(failedClient.dispose).called(1);
+
+        // Teeth, as above: removing the cancel in ref.onDispose leaves one
+        // timer pending here, which no callCount assertion can observe.
+        expect(async.pendingTimers, isEmpty);
+      });
     });
 
     test(

--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -220,7 +220,7 @@ void main() {
       expect(container.read(nostrInitializationInProgressProvider), isTrue);
 
       initialize.complete();
-      await pumpEventQueue(times: 2);
+      await pumpEventQueue();
 
       expect(container.read(nostrInitializationInProgressProvider), isFalse);
     });
@@ -447,7 +447,7 @@ void main() {
         );
 
         bInitialize.complete();
-        await pumpEventQueue(times: 2);
+        await pumpEventQueue();
 
         expect(factory.callCount, equals(3));
         expect(factory.clients.last.publicKey, equals(pubkeyC));
@@ -505,7 +505,7 @@ void main() {
         );
 
         bInitialize.complete();
-        await pumpEventQueue(times: 2);
+        await pumpEventQueue();
 
         expect(
           container.read(nostrServiceProvider),
@@ -559,7 +559,7 @@ void main() {
         );
 
         bInitialize.complete();
-        await pumpEventQueue(times: 2);
+        await pumpEventQueue();
 
         final readyClient = container.read(nostrServiceProvider);
         expect(
@@ -892,7 +892,7 @@ void main() {
 
         // Completing the gated init lets the ORIGINAL client reach ready.
         gate.complete();
-        await pumpEventQueue(times: 2);
+        await pumpEventQueue();
         expect(factory.callCount, equals(1));
         expect(
           container.read(nostrSessionProvider).phase,
@@ -936,7 +936,7 @@ void main() {
 
         // Drain the abandoned A init cleanly.
         gate.complete();
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue();
       },
     );
 
@@ -1208,7 +1208,7 @@ void main() {
         );
 
         firstAInitialize.complete();
-        await pumpEventQueue(times: 2);
+        await pumpEventQueue();
 
         expect(
           container.read(nostrSessionProvider),
@@ -1269,7 +1269,7 @@ void main() {
         );
 
         initialPlaceholderInitialize.complete();
-        await pumpEventQueue(times: 2);
+        await pumpEventQueue();
 
         expect(
           container.read(nostrSessionProvider),

--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -983,9 +983,9 @@ void main() {
           StateError('initial A initialize failed'),
         );
         factory.initializeCompleters.remove(pubkeyA);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        // Load-bearing count: the retry runs on a real zero-delay Timer, and
+        // three turns is the measured minimum -- two leaves callCount behind.
+        await pumpEventQueue(times: 3);
 
         expect(
           factory.callCount,
@@ -1038,9 +1038,9 @@ void main() {
 
         final timedOutClient = container.read(nostrServiceProvider);
         factory.addRelaysCompleters.remove(pubkeyA);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        // Load-bearing count: the retry runs on a real zero-delay Timer, and
+        // three turns is the measured minimum -- two leaves callCount behind.
+        await pumpEventQueue(times: 3);
 
         expect(factory.callCount, equals(2));
         expect(factory.addRelaysPubkeys, equals([pubkeyA, pubkeyA]));
@@ -1106,9 +1106,9 @@ void main() {
         expect(factory.callCount, equals(1));
 
         firstFailure.completeError(StateError('first initialize failed'));
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        // Load-bearing count: the retry runs on a real zero-delay Timer, and
+        // three turns is the measured minimum -- two leaves callCount behind.
+        await pumpEventQueue(times: 3);
 
         expect(factory.callCount, equals(2));
         expect(
@@ -1119,9 +1119,9 @@ void main() {
         );
 
         secondFailure.completeError(StateError('second initialize failed'));
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        // Load-bearing count: the retry runs on a real zero-delay Timer, and
+        // three turns is the measured minimum -- two leaves callCount behind.
+        await pumpEventQueue(times: 3);
 
         expect(factory.callCount, equals(3));
         expect(retryAttempts, equals([1, 2]));

--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -962,8 +962,9 @@ void main() {
           StateError('initial A initialize failed'),
         );
         factory.initializeCompleters.remove(pubkeyA);
-        // Load-bearing count: the retry runs on a real zero-delay Timer, and
-        // three turns is the measured minimum -- two leaves callCount behind.
+        // Load-bearing count: the retry runs on a real zero-delay Timer, so
+        // the wait must outlast it. Two turns is the measured minimum at
+        // this site; three keeps a turn of margin.
         await pumpEventQueue(times: 3);
 
         expect(
@@ -1017,8 +1018,11 @@ void main() {
 
         final timedOutClient = container.read(nostrServiceProvider);
         factory.addRelaysCompleters.remove(pubkeyA);
-        // Load-bearing count: the retry runs on a real zero-delay Timer, and
-        // three turns is the measured minimum -- two leaves callCount behind.
+        // Load-bearing count: the retry runs on a real zero-delay Timer and
+        // this container adds a second one via createRetryContainer(
+        // initializationTimeout: Duration.zero), so three turns is the
+        // measured minimum here and two leaves callCount behind. The
+        // completeError-driven sibling sites settle in two.
         await pumpEventQueue(times: 3);
 
         expect(factory.callCount, equals(2));
@@ -1085,8 +1089,9 @@ void main() {
         expect(factory.callCount, equals(1));
 
         firstFailure.completeError(StateError('first initialize failed'));
-        // Load-bearing count: the retry runs on a real zero-delay Timer, and
-        // three turns is the measured minimum -- two leaves callCount behind.
+        // Load-bearing count: the retry runs on a real zero-delay Timer, so
+        // the wait must outlast it. Two turns is the measured minimum at
+        // this site; three keeps a turn of margin.
         await pumpEventQueue(times: 3);
 
         expect(factory.callCount, equals(2));
@@ -1098,8 +1103,9 @@ void main() {
         );
 
         secondFailure.completeError(StateError('second initialize failed'));
-        // Load-bearing count: the retry runs on a real zero-delay Timer, and
-        // three turns is the measured minimum -- two leaves callCount behind.
+        // Load-bearing count: the retry runs on a real zero-delay Timer, so
+        // the wait must outlast it. Two turns is the measured minimum at
+        // this site; three keeps a turn of margin.
         await pumpEventQueue(times: 3);
 
         expect(factory.callCount, equals(3));

--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -1426,8 +1426,9 @@ void main() {
             container.read(nostrServiceProvider);
             container.dispose();
 
-            await pumpEventQueue(times: 1);
-            await pumpEventQueue(times: 1);
+            // Drain the queue fully: a leak that surfaces on a later turn must
+            // still reach the zone handler before the isEmpty assertion runs.
+            await pumpEventQueue();
           },
           (error, _) => errors.add(error),
         );
@@ -1473,8 +1474,9 @@ void main() {
           // Dispose mid-init, then let init resume past the await.
           container.dispose();
           factory.initializeCompleters[pubkeyA]!.complete();
-          await pumpEventQueue(times: 1);
-          await pumpEventQueue(times: 1);
+          // Drain the queue fully: a leak that surfaces on a later turn must
+          // still reach the zone handler before the isEmpty assertion runs.
+          await pumpEventQueue();
         },
         (error, _) => errors.add(error),
       );
@@ -1512,8 +1514,9 @@ void main() {
           factory.initializeCompleters[pubkeyA]!.completeError(
             StateError('init failed'),
           );
-          await pumpEventQueue(times: 1);
-          await pumpEventQueue(times: 1);
+          // Drain the queue fully: a leak that surfaces on a later turn must
+          // still reach the zone handler before the isEmpty assertion runs.
+          await pumpEventQueue();
         },
         (error, _) => errors.add(error),
       );

--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -308,7 +308,10 @@ void main() {
       addTearDown(container.dispose);
 
       container.read(nostrServiceProvider);
-      await pumpEventQueue(times: 2);
+      // Drain fully: every assertion here is a negative -- that nothing
+      // was initialized yet -- so a deferred bootstrap behind any timer
+      // would still look absent at a fixed turn budget.
+      await pumpEventQueue();
 
       expect(factory.callCount, equals(1));
       expect(factory.signers.single, isNull);

--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -215,13 +215,13 @@ void main() {
       addTearDown(container.dispose);
 
       container.read(nostrServiceProvider);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
 
       expect(container.read(nostrInitializationInProgressProvider), isTrue);
 
       initialize.complete();
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
 
       expect(container.read(nostrInitializationInProgressProvider), isFalse);
     });
@@ -274,7 +274,7 @@ void main() {
 
       authStream.add(AuthState.authenticating);
       // Let the async listener run.
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
 
       expect(
         factory.callCount,
@@ -290,7 +290,7 @@ void main() {
       when(() => mockAuth.currentIdentity).thenReturn(identityA);
 
       authStream.add(AuthState.authenticated);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
 
       expect(
         factory.callCount,
@@ -309,8 +309,8 @@ void main() {
       addTearDown(container.dispose);
 
       container.read(nostrServiceProvider);
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
 
       expect(factory.callCount, equals(1));
       expect(factory.signers.single, isNull);
@@ -342,7 +342,7 @@ void main() {
       when(() => mockAuth.currentIdentity).thenReturn(null);
       when(() => mockAuth.currentPublicKeyHex).thenReturn(null);
       authStream.add(AuthState.unauthenticated);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
 
       expect(
         factory.callCount,
@@ -374,7 +374,7 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(null);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(null);
         authStream.add(AuthState.unauthenticated);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
         expect(factory.callCount, equals(2));
         expect(factory.clients.last.hasKeys, isFalse);
 
@@ -384,7 +384,7 @@ void main() {
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
         // currentIdentity stays null intentionally.
         authStream.add(AuthState.authenticating);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
 
         expect(
           factory.callCount,
@@ -398,7 +398,7 @@ void main() {
         // Step 3: authenticated with real identity for B.
         when(() => mockAuth.currentIdentity).thenReturn(identityB);
         authStream.add(AuthState.authenticated);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
 
         expect(factory.callCount, equals(3));
         expect(factory.signers.last, same(identityB));
@@ -426,7 +426,7 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(identityB);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
         authStream.add(AuthState.authenticated);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
 
         expect(factory.callCount, equals(2));
         expect(
@@ -439,7 +439,7 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(identityC);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyC);
         authStream.add(AuthState.authenticated);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
 
         expect(
           factory.callCount,
@@ -449,8 +449,8 @@ void main() {
         );
 
         bInitialize.complete();
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(factory.callCount, equals(3));
         expect(factory.clients.last.publicKey, equals(pubkeyC));
@@ -476,8 +476,8 @@ void main() {
         addTearDown(container.dispose);
 
         final oldClient = container.read(nostrServiceProvider);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         final bInitialize = Completer<void>();
         factory.initializeCompleters[pubkeyB] = bInitialize;
@@ -485,8 +485,8 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(identityB);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
         authStream.add(AuthState.authenticated);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(factory.callCount, equals(2));
         expect(
@@ -510,8 +510,8 @@ void main() {
         );
 
         bInitialize.complete();
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(
           container.read(nostrServiceProvider),
@@ -548,8 +548,8 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(identityB);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
         authStream.add(AuthState.authenticated);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(
           container.read(nostrSessionProvider),
@@ -566,8 +566,8 @@ void main() {
         );
 
         bInitialize.complete();
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         final readyClient = container.read(nostrServiceProvider);
         expect(
@@ -589,8 +589,8 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(null);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(null);
         authStream.add(AuthState.unauthenticated);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(
           observedReadiness.map((readiness) => readiness.phase),
@@ -618,8 +618,8 @@ void main() {
         addTearDown(container.dispose);
 
         container.read(nostrServiceProvider);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         final bInitialize = Completer<void>();
         factory.initializeCompleters[pubkeyB] = bInitialize;
@@ -627,15 +627,15 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(identityB);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
         authStream.add(AuthState.authenticated);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
 
         when(() => mockAuth.currentIdentity).thenReturn(identityC);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyC);
         authStream.add(AuthState.authenticated);
         bInitialize.completeError(StateError('B initialize failed'));
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(factory.callCount, equals(3));
         expect(factory.clients.last.publicKey, equals(pubkeyC));
@@ -669,8 +669,8 @@ void main() {
       addTearDown(container.dispose);
 
       container.read(nostrServiceProvider);
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
       expect(factory.callCount, equals(1));
 
       final failedBInitialize = Completer<void>();
@@ -679,19 +679,19 @@ void main() {
       when(() => mockAuth.currentIdentity).thenReturn(identityB);
       when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
       authStream.add(AuthState.authenticated);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
 
       expect(factory.callCount, equals(2));
 
       failedBInitialize.completeError(StateError('B initialize failed'));
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
 
       factory.initializeCompleters.remove(pubkeyB);
       authStream.add(AuthState.authenticated);
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
 
       expect(
         factory.callCount,
@@ -729,14 +729,14 @@ void main() {
       addTearDown(container.dispose);
 
       container.read(nostrServiceProvider);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
       expect(factory.callCount, equals(1));
 
       failedInitialAInitialize.completeError(
         StateError('initial A initialize failed'),
       );
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
 
       expect(
         container.read(nostrSessionProvider),
@@ -754,9 +754,9 @@ void main() {
 
       factory.initializeCompleters.remove(pubkeyA);
       authStream.add(AuthState.authenticated);
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
 
       expect(
         factory.callCount,
@@ -811,7 +811,7 @@ void main() {
         addTearDown(container.dispose);
 
         container.read(nostrServiceProvider);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
         expect(
           factory.callCount,
           equals(1),
@@ -825,8 +825,8 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(identityA);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
         authStream.add(AuthState.authenticated);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(
           factory.callCount,
@@ -845,8 +845,8 @@ void main() {
         // RPC-upgrade nudge: same pubkey re-emitted after the background
         // Keycast upgrade resolves (auth_service.dart:733, unconditional add).
         authStream.add(AuthState.authenticated);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(
           factory.callCount,
@@ -886,7 +886,7 @@ void main() {
         addTearDown(container.dispose);
 
         container.read(nostrServiceProvider);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
         expect(
           factory.callCount,
           equals(1),
@@ -901,8 +901,8 @@ void main() {
         // RPC-upgrade nudge: same pubkey re-emitted while relay connect is
         // still running.
         authStream.add(AuthState.authenticated);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(
           factory.callCount,
@@ -914,8 +914,8 @@ void main() {
 
         // Completing the gated init lets the ORIGINAL client reach ready.
         gate.complete();
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
         expect(factory.callCount, equals(1));
         expect(
           container.read(nostrSessionProvider).phase,
@@ -938,7 +938,7 @@ void main() {
         addTearDown(container.dispose);
 
         container.read(nostrServiceProvider);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
         expect(factory.callCount, equals(1));
 
         // A genuine account switch to B while A's build init is in flight must
@@ -946,8 +946,8 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(identityB);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
         authStream.add(AuthState.authenticated);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(
           factory.callCount,
@@ -960,7 +960,7 @@ void main() {
 
         // Drain the abandoned A init cleanly.
         gate.complete();
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
       },
     );
 
@@ -976,16 +976,16 @@ void main() {
         addTearDown(container.dispose);
 
         final failedClient = container.read(nostrServiceProvider);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
         expect(factory.callCount, equals(1));
 
         failedInitialAInitialize.completeError(
           StateError('initial A initialize failed'),
         );
         factory.initializeCompleters.remove(pubkeyA);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(
           factory.callCount,
@@ -1038,9 +1038,9 @@ void main() {
 
         final timedOutClient = container.read(nostrServiceProvider);
         factory.addRelaysCompleters.remove(pubkeyA);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(factory.callCount, equals(2));
         expect(factory.addRelaysPubkeys, equals([pubkeyA, pubkeyA]));
@@ -1102,13 +1102,13 @@ void main() {
         addTearDown(container.dispose);
 
         final initialClient = container.read(nostrServiceProvider);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
         expect(factory.callCount, equals(1));
 
         firstFailure.completeError(StateError('first initialize failed'));
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(factory.callCount, equals(2));
         expect(
@@ -1119,9 +1119,9 @@ void main() {
         );
 
         secondFailure.completeError(StateError('second initialize failed'));
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(factory.callCount, equals(3));
         expect(retryAttempts, equals([1, 2]));
@@ -1150,20 +1150,20 @@ void main() {
       addTearDown(container.dispose);
 
       container.read(nostrServiceProvider);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
       failedInitialAInitialize.completeError(
         StateError('initial A initialize failed'),
       );
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
 
       factory.initializeCompleters.remove(pubkeyA);
       when(() => mockAuth.currentIdentity).thenReturn(identityB);
       when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
       authStream.add(AuthState.authenticated);
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
 
       expect(factory.callCount, equals(2));
       expect(factory.signers.last, same(identityB));
@@ -1189,15 +1189,15 @@ void main() {
       );
 
       final failedClient = container.read(nostrServiceProvider);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
       failedInitialAInitialize.completeError(
         StateError('initial A initialize failed'),
       );
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
 
       container.dispose();
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
 
       expect(factory.callCount, equals(1));
       verify(failedClient.dispose).called(1);
@@ -1215,21 +1215,21 @@ void main() {
         addTearDown(container.dispose);
 
         final firstAClient = container.read(nostrServiceProvider);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
 
         when(() => mockAuth.currentIdentity).thenReturn(null);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(null);
         authStream.add(AuthState.unauthenticated);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         factory.initializeCompleters.remove(pubkeyA);
         when(() => mockAuth.currentIdentity).thenReturn(identityA);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
         authStream.add(AuthState.authenticated);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         final currentAClient = container.read(nostrServiceProvider);
         expect(currentAClient, isNot(same(firstAClient)));
@@ -1239,8 +1239,8 @@ void main() {
         );
 
         firstAInitialize.complete();
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(
           container.read(nostrSessionProvider),
@@ -1273,7 +1273,7 @@ void main() {
         addTearDown(container.dispose);
 
         container.read(nostrServiceProvider);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
         expect(factory.callCount, equals(1));
         expect(factory.signers.single, isNull);
 
@@ -1281,9 +1281,9 @@ void main() {
         when(() => mockAuth.currentIdentity).thenReturn(identityA);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
         authStream.add(AuthState.authenticated);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         final readyClient = container.read(nostrServiceProvider);
         expect(
@@ -1303,8 +1303,8 @@ void main() {
         );
 
         initialPlaceholderInitialize.complete();
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(
           container.read(nostrSessionProvider),
@@ -1346,22 +1346,22 @@ void main() {
         addTearDown(container.dispose);
 
         final oldClient = container.read(nostrServiceProvider);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
         final staleRelayCallback = latestRelayCallback!;
 
         when(() => mockAuth.currentIdentity).thenReturn(identityB);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
         authStream.add(AuthState.authenticated);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(container.read(nostrServiceProvider), isNot(same(oldClient)));
 
         const staleRelays = ['wss://stale-relay.example'];
         staleRelayCallback(pubkeyA, staleRelays);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         verifyNever(() => oldClient.addRelays(staleRelays));
       },
@@ -1377,8 +1377,8 @@ void main() {
         addTearDown(container.dispose);
 
         final client = container.read(nostrServiceProvider);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(
           container.read(nostrSessionProvider),
@@ -1393,7 +1393,7 @@ void main() {
         );
 
         container.invalidate(nostrSessionProvider);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
 
         expect(
           container.read(nostrSessionProvider),
@@ -1426,8 +1426,8 @@ void main() {
             container.read(nostrServiceProvider);
             container.dispose();
 
-            await Future<void>.delayed(Duration.zero);
-            await Future<void>.delayed(Duration.zero);
+            await pumpEventQueue(times: 1);
+            await pumpEventQueue(times: 1);
           },
           (error, _) => errors.add(error),
         );
@@ -1462,7 +1462,7 @@ void main() {
           container.read(nostrServiceProvider); // schedules _initializeClient
 
           // Let the scheduled microtask reach `await client.initialize()`.
-          await Future<void>.delayed(Duration.zero);
+          await pumpEventQueue(times: 1);
           expect(
             factory.initializePubkeys,
             contains(pubkeyA),
@@ -1473,8 +1473,8 @@ void main() {
           // Dispose mid-init, then let init resume past the await.
           container.dispose();
           factory.initializeCompleters[pubkeyA]!.complete();
-          await Future<void>.delayed(Duration.zero);
-          await Future<void>.delayed(Duration.zero);
+          await pumpEventQueue(times: 1);
+          await pumpEventQueue(times: 1);
         },
         (error, _) => errors.add(error),
       );
@@ -1505,15 +1505,15 @@ void main() {
           final container = createContainer();
           container.read(nostrServiceProvider);
 
-          await Future<void>.delayed(Duration.zero);
+          await pumpEventQueue(times: 1);
           expect(factory.initializePubkeys, contains(pubkeyA));
 
           container.dispose();
           factory.initializeCompleters[pubkeyA]!.completeError(
             StateError('init failed'),
           );
-          await Future<void>.delayed(Duration.zero);
-          await Future<void>.delayed(Duration.zero);
+          await pumpEventQueue(times: 1);
+          await pumpEventQueue(times: 1);
         },
         (error, _) => errors.add(error),
       );

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -214,6 +214,7 @@ void main() {
     preferenceStore = _FakeNotificationPreferencesStore();
     authStateController = StreamController<AuthState>.broadcast();
     defaultTokenRefreshController = StreamController<String>.broadcast();
+    beforeSessionTeardownCallback = null;
 
     when(
       () => authService.authStateStream,

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -1020,6 +1020,7 @@ void main() {
 
         publishCompleter.complete();
         await pumpEventQueue(times: 1);
+        expect(registerCalls, equals(1));
       },
     );
 

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -2881,9 +2881,8 @@ void main() {
         await container
             .read(notificationPreferencesServiceProvider)
             .updatePreferences(publishedPrefs);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        expect(preferenceStore.dirtyPreferencesByPubkey, contains(pubkeyA));
+        await preferenceStore.waitForClear(pubkeyA);
 
         verify(() => pushService.updatePreferences(publishedPrefs)).called(1);
         verify(() => pushService.updatePreferences(newerPrefs)).called(1);
@@ -2922,9 +2921,8 @@ void main() {
       await container
           .read(notificationPreferencesServiceProvider)
           .updatePreferences(prefs);
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
+      expect(preferenceStore.dirtyPreferencesByPubkey, contains(pubkeyA));
+      await preferenceStore.waitForClear(pubkeyA);
 
       expect(attempts, equals(2));
       expect(
@@ -2958,9 +2956,8 @@ void main() {
           ),
         );
         container.read(pushNotificationSyncProvider);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        expect(preferenceStore.dirtyPreferencesByPubkey, contains(pubkeyA));
+        await preferenceStore.waitForClear(pubkeyA);
 
         expect(attempts, equals(2));
         expect(

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -1520,9 +1520,9 @@ void main() {
               client: nostrClient,
             ),
           );
-          await pumpEventQueue(times: 1);
-          await pumpEventQueue(times: 1);
-          await pumpEventQueue(times: 1);
+          // Drain the queue fully: a leak that surfaces on a later turn must
+          // still reach the zone handler before the isEmpty assertion runs.
+          await pumpEventQueue();
         }, (error, stack) => unhandled.add(error));
 
         expect(
@@ -1563,8 +1563,9 @@ void main() {
             client: nostrClient,
           ),
         );
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        // Drain the queue fully: a leak that surfaces on a later turn must
+        // still reach the zone handler before the isEmpty assertion runs.
+        await pumpEventQueue();
       }, (error, stack) => unhandled.add(error));
 
       expect(unhandled, isEmpty);
@@ -1607,8 +1608,9 @@ void main() {
 
           // Then start sign-out teardown — publishing deregistration throws.
           await beforeSessionTeardownCallback!();
-          await pumpEventQueue(times: 1);
-          await pumpEventQueue(times: 1);
+          // Drain the queue fully: a leak that surfaces on a later turn must
+          // still reach the zone handler before the isEmpty assertion runs.
+          await pumpEventQueue();
         }, (error, stack) => unhandled.add(error));
 
         expect(unhandled, isEmpty);

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -1561,6 +1561,9 @@ void main() {
       }, (error, stack) => unhandled.add(error));
 
       expect(unhandled, isEmpty);
+      verify(
+        () => pushService.register(pubkeyA, isCurrent: any(named: 'isCurrent')),
+      ).called(1);
     });
 
     test(

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -952,9 +952,7 @@ void main() {
 
         await emitReady(nostrSession, pubkeyA);
 
-        final teardownFuture = beforeSessionTeardownCallback!().timeout(
-          const Duration(milliseconds: 100),
-        );
+        final teardownFuture = beforeSessionTeardownCallback!();
         await pumpEventQueue(times: 2);
 
         await teardownFuture;
@@ -2658,7 +2656,7 @@ void main() {
         nostrSession.setReadiness(
           const NostrSessionReadiness.identityKnown(pubkey: pubkeyB),
         );
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue();
         expect(preferenceStore.dirtyPreferencesByPubkey[pubkeyA], prefs);
 
         when(() => authService.currentIdentity).thenReturn(_identity(pubkeyA));
@@ -2719,7 +2717,7 @@ void main() {
             .updatePreferences(prefs);
 
         nostrSession.setReadiness(const NostrSessionReadiness.signedOut());
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue();
         expect(preferenceStore.dirtyPreferencesByPubkey[pubkeyA], prefs);
 
         nostrSession.setReadiness(

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -192,9 +192,11 @@ void main() {
     environment: AppEnvironment.staging,
     configuredPushServicePubkey: pushServicePubkey,
   );
+  const switchedPushServicePubkey =
+      'fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321';
   const stagingEnvironment = _ConfiguredEnvironmentConfig(
     environment: AppEnvironment.staging,
-    configuredPushServicePubkey: pushServicePubkey,
+    configuredPushServicePubkey: switchedPushServicePubkey,
   );
 
   setUpAll(() {

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -329,8 +329,7 @@ void main() {
     nostrSession.setReadiness(
       NostrSessionReadiness.nostrReady(pubkey: pubkey, client: nostrClient),
     );
-    await pumpEventQueue(times: 1);
-    await pumpEventQueue(times: 1);
+    await pumpEventQueue(times: 2);
   }
 
   void recordMockDeregistration(
@@ -477,8 +476,7 @@ void main() {
         await pumpEventQueue(times: 1);
 
         tokenCompleter.complete('fcm-token-for-stale-session');
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         verifyNever(
           () => nostrClient.publishEventAwaitOk(
@@ -504,8 +502,7 @@ void main() {
       when(() => authService.currentIdentity).thenReturn(_identity(pubkeyA));
       when(() => authService.currentPublicKeyHex).thenReturn(pubkeyA);
       authStateController.add(AuthState.authenticated);
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 2);
 
       verifyNever(
         () => pushService.register(any(), isCurrent: any(named: 'isCurrent')),
@@ -846,8 +843,7 @@ void main() {
       nostrSession.setReadiness(
         NostrSessionReadiness.nostrReady(pubkey: pubkeyA, client: nostrClient),
       );
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 2);
 
       verifyNever(
         () => pushService.register(any(), isCurrent: any(named: 'isCurrent')),
@@ -888,8 +884,7 @@ void main() {
             client: nostrClient,
           ),
         );
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         await beforeSessionTeardownCallback!();
 
@@ -926,8 +921,7 @@ void main() {
       nostrSession.setReadiness(const NostrSessionReadiness.signedOut());
 
       settingsCompleter.complete(_settings(AuthorizationStatus.authorized));
-      await pumpEventQueue(times: 1);
-      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 2);
 
       verifyNever(
         () => pushService.register(any(), isCurrent: any(named: 'isCurrent')),
@@ -961,8 +955,7 @@ void main() {
         final teardownFuture = beforeSessionTeardownCallback!().timeout(
           const Duration(milliseconds: 100),
         );
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         await teardownFuture;
         when(() => authService.currentIdentity).thenReturn(null);
@@ -970,8 +963,7 @@ void main() {
         expect(events, ['deregister $pubkeyA']);
 
         settingsCompleter.complete(_settings(AuthorizationStatus.authorized));
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         expect(events, ['deregister $pubkeyA']);
         verifyNever(
@@ -1022,8 +1014,7 @@ void main() {
         await pumpEventQueue(times: 1);
 
         settingsCompleter.complete(_settings(AuthorizationStatus.authorized));
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
         expect(registerCalls, equals(1));
 
         publishCompleter.complete();
@@ -1603,8 +1594,7 @@ void main() {
               client: nostrClient,
             ),
           );
-          await pumpEventQueue(times: 1);
-          await pumpEventQueue(times: 1);
+          await pumpEventQueue(times: 2);
 
           // Then start sign-out teardown — publishing deregistration throws.
           await beforeSessionTeardownCallback!();
@@ -1783,8 +1773,7 @@ void main() {
             client: nostrClient,
           ),
         );
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         nostrSession.setReadiness(
           const NostrSessionReadiness.identityKnown(pubkey: pubkeyA),
@@ -1874,8 +1863,7 @@ void main() {
             client: nostrClient,
           ),
         );
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         when(() => authService.currentIdentity).thenReturn(null);
         when(() => authService.currentPublicKeyHex).thenReturn(null);
@@ -1979,8 +1967,7 @@ void main() {
             client: nostrClient,
           ),
         );
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         currentEnvironment = stagingEnvironment;
         container.invalidate(currentEnvironmentProvider);
@@ -1990,13 +1977,11 @@ void main() {
             client: nostrClient,
           ),
         );
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         final teardownFuture = coordinator
             .deregisterLastReadyPubkeyAfterAccountSwitch();
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         verify(() => messaging.getToken()).called(1);
         verifyNever(cleanupClient.initialize);
@@ -2010,8 +1995,7 @@ void main() {
 
         container.dispose();
         tokenCompleter.complete('fcm-token');
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         verify(() => signer.signEvent(any())).called(1);
         verify(cleanupClient.initialize).called(1);
@@ -2125,13 +2109,11 @@ void main() {
             client: nostrClient,
           ),
         );
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         await beforeSessionTeardownCallback!();
         tokenRefreshController.add('refreshed-token-during-teardown');
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         verifyNever(
           () => authService.createAndSignEvent(
@@ -2259,12 +2241,10 @@ void main() {
             client: nostrClient,
           ),
         );
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         tokenRefreshController.add('refreshed-token-during-session');
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
         expect(events, ['registration publish started']);
 
         // The refresh delivered a token, so getToken() now returns it and the
@@ -2272,8 +2252,7 @@ void main() {
         sessionToken = 'refreshed-token-during-session';
 
         final teardownFuture = beforeSessionTeardownCallback!();
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
         expect(events, ['registration publish started']);
 
         registrationPublishCompleter.complete(
@@ -2806,9 +2785,7 @@ void main() {
               client: nostrClient,
             ),
           );
-          await pumpEventQueue(times: 1);
-          await pumpEventQueue(times: 1);
-          await pumpEventQueue(times: 1);
+          await pumpEventQueue(times: 3);
         }, (error, stack) => unhandled.add(error));
 
         expect(unhandled, isEmpty);
@@ -2842,11 +2819,7 @@ void main() {
               .updatePreferences(prefs),
           completes,
         );
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 5);
 
         verify(() => pushService.updatePreferences(prefs)).called(5);
         expect(preferenceStore.dirtyPreferencesByPubkey[pubkeyA], prefs);
@@ -3102,13 +3075,10 @@ void main() {
             client: nostrClient,
           ),
         );
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 2);
 
         permissionCompleter.complete(_settings(AuthorizationStatus.authorized));
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
-        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 3);
 
         expect(requestCount, 1);
         expect(events, ['register $pubkeyB']);

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -1605,6 +1605,12 @@ void main() {
         }, (error, stack) => unhandled.add(error));
 
         expect(unhandled, isEmpty);
+        verify(
+          () => pushService.publishDeregistrationEvent(
+            any(),
+            publishClient: any(named: 'publishClient'),
+          ),
+        ).called(1);
       },
     );
 

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -955,7 +955,13 @@ void main() {
 
         await emitReady(nostrSession, pubkeyA);
 
-        final teardownFuture = beforeSessionTeardownCallback!();
+        // Bounded deliberately: teardown must not serialize behind the
+        // blocked permission check. Without this, a widened operations
+        // filter stalls four real seconds and then fails on the event list,
+        // instead of failing here in 100ms naming the blocked future.
+        final teardownFuture = beforeSessionTeardownCallback!().timeout(
+          const Duration(milliseconds: 100),
+        );
         await pumpEventQueue(times: 2);
 
         await teardownFuture;

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -2820,7 +2820,9 @@ void main() {
               .updatePreferences(prefs),
           completes,
         );
-        await pumpEventQueue(times: 5);
+        // Drain fully: the retry ladder is microtasks bounded by
+        // maxDirtySyncRetries, so the assertion pins the retry cap.
+        await pumpEventQueue();
 
         verify(() => pushService.updatePreferences(prefs)).called(5);
         expect(preferenceStore.dirtyPreferencesByPubkey[pubkeyA], prefs);

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -2334,6 +2334,10 @@ void main() {
         );
         addTearDown(container.dispose);
 
+        // Build the subject: the token-refresh subscription lives in the
+        // coordinator, which only pushNotificationSyncProvider constructs.
+        container.read(pushNotificationSyncProvider);
+
         expect(container.read(pushNotificationServiceProvider), isNull);
 
         tokenRefreshController.add('refreshed-token');

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -329,8 +329,8 @@ void main() {
     nostrSession.setReadiness(
       NostrSessionReadiness.nostrReady(pubkey: pubkey, client: nostrClient),
     );
-    await Future<void>.delayed(Duration.zero);
-    await Future<void>.delayed(Duration.zero);
+    await pumpEventQueue(times: 1);
+    await pumpEventQueue(times: 1);
   }
 
   void recordMockDeregistration(
@@ -393,7 +393,7 @@ void main() {
             data: {'title': 'New like', 'body': 'Someone'},
           ),
         );
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
 
         verify(
           () => pushService.handleForegroundMessage(const {
@@ -468,17 +468,17 @@ void main() {
         container.read(pushNotificationSyncProvider);
 
         await emitReady(nostrSession, pubkeyA);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
         verify(() => messaging.getToken()).called(1);
 
         when(() => authService.currentIdentity).thenReturn(_identity(pubkeyB));
         when(() => authService.currentPublicKeyHex).thenReturn(pubkeyB);
         authStateController.add(AuthState.authenticated);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
 
         tokenCompleter.complete('fcm-token-for-stale-session');
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         verifyNever(
           () => nostrClient.publishEventAwaitOk(
@@ -504,8 +504,8 @@ void main() {
       when(() => authService.currentIdentity).thenReturn(_identity(pubkeyA));
       when(() => authService.currentPublicKeyHex).thenReturn(pubkeyA);
       authStateController.add(AuthState.authenticated);
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
 
       verifyNever(
         () => pushService.register(any(), isCurrent: any(named: 'isCurrent')),
@@ -846,8 +846,8 @@ void main() {
       nostrSession.setReadiness(
         NostrSessionReadiness.nostrReady(pubkey: pubkeyA, client: nostrClient),
       );
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
 
       verifyNever(
         () => pushService.register(any(), isCurrent: any(named: 'isCurrent')),
@@ -888,8 +888,8 @@ void main() {
             client: nostrClient,
           ),
         );
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         await beforeSessionTeardownCallback!();
 
@@ -919,15 +919,15 @@ void main() {
       nostrSession.setReadiness(
         NostrSessionReadiness.nostrReady(pubkey: pubkeyA, client: nostrClient),
       );
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
 
       when(() => authService.currentIdentity).thenReturn(null);
       when(() => authService.currentPublicKeyHex).thenReturn(null);
       nostrSession.setReadiness(const NostrSessionReadiness.signedOut());
 
       settingsCompleter.complete(_settings(AuthorizationStatus.authorized));
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
 
       verifyNever(
         () => pushService.register(any(), isCurrent: any(named: 'isCurrent')),
@@ -961,8 +961,8 @@ void main() {
         final teardownFuture = beforeSessionTeardownCallback!().timeout(
           const Duration(milliseconds: 100),
         );
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         await teardownFuture;
         when(() => authService.currentIdentity).thenReturn(null);
@@ -970,8 +970,8 @@ void main() {
         expect(events, ['deregister $pubkeyA']);
 
         settingsCompleter.complete(_settings(AuthorizationStatus.authorized));
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(events, ['deregister $pubkeyA']);
         verifyNever(
@@ -1019,15 +1019,15 @@ void main() {
             .updatePreferences(prefs);
 
         await emitReady(nostrSession, pubkeyA);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
 
         settingsCompleter.complete(_settings(AuthorizationStatus.authorized));
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
         expect(registerCalls, equals(1));
 
         publishCompleter.complete();
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
       },
     );
 
@@ -1055,11 +1055,11 @@ void main() {
         container.read(pushNotificationSyncProvider);
 
         await emitReady(nostrSession, pubkeyA);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
         expect(events, ['register $pubkeyA']);
 
         final teardownFuture = beforeSessionTeardownCallback!();
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
 
         expect(events, ['register $pubkeyA']);
 
@@ -1520,9 +1520,9 @@ void main() {
               client: nostrClient,
             ),
           );
-          await Future<void>.delayed(Duration.zero);
-          await Future<void>.delayed(Duration.zero);
-          await Future<void>.delayed(Duration.zero);
+          await pumpEventQueue(times: 1);
+          await pumpEventQueue(times: 1);
+          await pumpEventQueue(times: 1);
         }, (error, stack) => unhandled.add(error));
 
         expect(
@@ -1563,8 +1563,8 @@ void main() {
             client: nostrClient,
           ),
         );
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
       }, (error, stack) => unhandled.add(error));
 
       expect(unhandled, isEmpty);
@@ -1602,13 +1602,13 @@ void main() {
               client: nostrClient,
             ),
           );
-          await Future<void>.delayed(Duration.zero);
-          await Future<void>.delayed(Duration.zero);
+          await pumpEventQueue(times: 1);
+          await pumpEventQueue(times: 1);
 
           // Then start sign-out teardown — publishing deregistration throws.
           await beforeSessionTeardownCallback!();
-          await Future<void>.delayed(Duration.zero);
-          await Future<void>.delayed(Duration.zero);
+          await pumpEventQueue(times: 1);
+          await pumpEventQueue(times: 1);
         }, (error, stack) => unhandled.add(error));
 
         expect(unhandled, isEmpty);
@@ -1664,7 +1664,7 @@ void main() {
       when(() => authService.currentIdentity).thenReturn(null);
       when(() => authService.currentPublicKeyHex).thenReturn(null);
       nostrSession.setReadiness(const NostrSessionReadiness.signedOut());
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
 
       await beforeSessionTeardownCallback!();
 
@@ -1694,7 +1694,7 @@ void main() {
         nostrSession.setReadiness(
           const NostrSessionReadiness.identityKnown(pubkey: pubkeyA),
         );
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
 
         await beforeSessionTeardownCallback!();
 
@@ -1781,13 +1781,13 @@ void main() {
             client: nostrClient,
           ),
         );
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         nostrSession.setReadiness(
           const NostrSessionReadiness.identityKnown(pubkey: pubkeyA),
         );
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
 
         await beforeSessionTeardownCallback!();
 
@@ -1872,8 +1872,8 @@ void main() {
             client: nostrClient,
           ),
         );
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         when(() => authService.currentIdentity).thenReturn(null);
         when(() => authService.currentPublicKeyHex).thenReturn(null);
@@ -1977,8 +1977,8 @@ void main() {
             client: nostrClient,
           ),
         );
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         currentEnvironment = stagingEnvironment;
         container.invalidate(currentEnvironmentProvider);
@@ -1988,13 +1988,13 @@ void main() {
             client: nostrClient,
           ),
         );
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         final teardownFuture = coordinator
             .deregisterLastReadyPubkeyAfterAccountSwitch();
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         verify(() => messaging.getToken()).called(1);
         verifyNever(cleanupClient.initialize);
@@ -2008,8 +2008,8 @@ void main() {
 
         container.dispose();
         tokenCompleter.complete('fcm-token');
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         verify(() => signer.signEvent(any())).called(1);
         verify(cleanupClient.initialize).called(1);
@@ -2123,13 +2123,13 @@ void main() {
             client: nostrClient,
           ),
         );
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         await beforeSessionTeardownCallback!();
         tokenRefreshController.add('refreshed-token-during-teardown');
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         verifyNever(
           () => authService.createAndSignEvent(
@@ -2257,12 +2257,12 @@ void main() {
             client: nostrClient,
           ),
         );
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         tokenRefreshController.add('refreshed-token-during-session');
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
         expect(events, ['registration publish started']);
 
         // The refresh delivered a token, so getToken() now returns it and the
@@ -2270,8 +2270,8 @@ void main() {
         sessionToken = 'refreshed-token-during-session';
 
         final teardownFuture = beforeSessionTeardownCallback!();
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
         expect(events, ['registration publish started']);
 
         registrationPublishCompleter.complete(
@@ -2355,7 +2355,7 @@ void main() {
         expect(container.read(pushNotificationServiceProvider), isNull);
 
         tokenRefreshController.add('refreshed-token');
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
 
         verifyNever(() => nostrClient.signer);
       },
@@ -2677,7 +2677,7 @@ void main() {
         nostrSession.setReadiness(
           const NostrSessionReadiness.identityKnown(pubkey: pubkeyB),
         );
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
         expect(preferenceStore.dirtyPreferencesByPubkey[pubkeyA], prefs);
 
         when(() => authService.currentIdentity).thenReturn(_identity(pubkeyA));
@@ -2738,7 +2738,7 @@ void main() {
             .updatePreferences(prefs);
 
         nostrSession.setReadiness(const NostrSessionReadiness.signedOut());
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
         expect(preferenceStore.dirtyPreferencesByPubkey[pubkeyA], prefs);
 
         nostrSession.setReadiness(
@@ -2804,9 +2804,9 @@ void main() {
               client: nostrClient,
             ),
           );
-          await Future<void>.delayed(Duration.zero);
-          await Future<void>.delayed(Duration.zero);
-          await Future<void>.delayed(Duration.zero);
+          await pumpEventQueue(times: 1);
+          await pumpEventQueue(times: 1);
+          await pumpEventQueue(times: 1);
         }, (error, stack) => unhandled.add(error));
 
         expect(unhandled, isEmpty);
@@ -2840,11 +2840,11 @@ void main() {
               .updatePreferences(prefs),
           completes,
         );
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         verify(() => pushService.updatePreferences(prefs)).called(5);
         expect(preferenceStore.dirtyPreferencesByPubkey[pubkeyA], prefs);
@@ -2881,9 +2881,9 @@ void main() {
         await container
             .read(notificationPreferencesServiceProvider)
             .updatePreferences(publishedPrefs);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         verify(() => pushService.updatePreferences(publishedPrefs)).called(1);
         verify(() => pushService.updatePreferences(newerPrefs)).called(1);
@@ -2922,9 +2922,9 @@ void main() {
       await container
           .read(notificationPreferencesServiceProvider)
           .updatePreferences(prefs);
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
+      await pumpEventQueue(times: 1);
 
       expect(attempts, equals(2));
       expect(
@@ -2958,9 +2958,9 @@ void main() {
           ),
         );
         container.read(pushNotificationSyncProvider);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(attempts, equals(2));
         expect(
@@ -3103,13 +3103,13 @@ void main() {
             client: nostrClient,
           ),
         );
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         permissionCompleter.complete(_settings(AuthorizationStatus.authorized));
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
+        await pumpEventQueue(times: 1);
 
         expect(requestCount, 1);
         expect(events, ['register $pubkeyB']);

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -2786,7 +2786,9 @@ void main() {
               client: nostrClient,
             ),
           );
-          await pumpEventQueue(times: 3);
+          // Drain the queue fully: a leak that surfaces on a later turn must
+          // still reach the zone handler before the isEmpty assertion runs.
+          await pumpEventQueue();
         }, (error, stack) => unhandled.add(error));
 
         expect(unhandled, isEmpty);


### PR DESCRIPTION
Two provider test suites used 201 `Future.delayed(Duration.zero)` calls to advance asynchronous work. The repeated calls obscured whether a test needed one event-loop turn, full settling, or an observable completion boundary.

This replaces those calls with synchronization that states the intended ordering:

- exact `pumpEventQueue(times: n)` counts remain only where intermediate ordering or retry progression is part of the assertion;
- completion-adjacent and negative assertions drain the event queue fully;
- dirty-preference retries wait for the store clear boundary; and
- the 100 ms teardown deadline remains as an intentional guard against serialization behind a blocked permission check.

This is test-only and does not change application behavior. It deliberately leaves the mixed zero-duration and timed waits in the fullscreen feed suite, along with all other directories, for later focused slices.

The numeric baseline drops both migrated files, reducing the frozen debt from 1,120 calls across 175 files to 919 calls across 173 files.

Verification:

- `flutter test test/providers/nostr_service_identity_source_test.dart test/providers/push_notification_sync_test.dart` — 76 tests passed
- `bash scripts/check_future_delayed_ceiling.sh` — 173 keys tracked, none grew
- `flutter analyze lib test integration_test` — no issues
- pre-push analyzer and focused test checks — passed

Part of #4837
