### PR TITLE
chore(analyzer): require direct dependency declarations

### DIFF
--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -32,7 +32,6 @@ analyzer:
 linter:
   rules:
     avoid_dynamic_calls: false
-    depend_on_referenced_packages: false
     # Requires `TODO(username)`; a `#` in the parentheses fails the rule. The
     # repo mandates `TODO(#issue)` instead (`.claude/rules/code_style.md`), so
     # the two conventions are mutually exclusive.

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -129,7 +129,7 @@ packages:
     source: hosted
     version: "2.7.0"
   async:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: async
       sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
@@ -161,7 +161,7 @@ packages:
     source: hosted
     version: "0.2.2"
   bip340:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: bip340
       sha256: b7bcd70a860e605046006adaa72bc4f7453f4d31d7ba74a4ad9d5de387a0fc0b
@@ -169,7 +169,7 @@ packages:
     source: hosted
     version: "0.3.0"
   bloc:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: bloc
       sha256: e03b235924e4f509c27b5d6b2f949200e0a91149a9818b4f65eeb56662b75413
@@ -338,7 +338,7 @@ packages:
     source: hosted
     version: "4.11.0"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
@@ -570,7 +570,7 @@ packages:
     source: hosted
     version: "2.1.5"
   file:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: file
       sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
@@ -682,7 +682,7 @@ packages:
     source: hosted
     version: "4.4.0"
   firebase_core_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: firebase_core_platform_interface
       sha256: cccb4f572325dc14904c02fcc7db6323ad62ba02536833dddb5c02cac7341c64
@@ -1589,7 +1589,7 @@ packages:
     source: hosted
     version: "3.2.1"
   path:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
@@ -1637,7 +1637,7 @@ packages:
     source: hosted
     version: "2.2.1"
   path_provider_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: path_provider_platform_interface
       sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
@@ -1741,7 +1741,7 @@ packages:
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
@@ -1861,7 +1861,7 @@ packages:
     source: hosted
     version: "2.0.0"
   provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: provider
       sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
@@ -1989,7 +1989,7 @@ packages:
     source: hosted
     version: "2.2.0"
   riverpod:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: riverpod
       sha256: "17100416c51db7810c71a7bb2c34d1f881faa0074fd452afb0c4db6f8f126c76"
@@ -2141,7 +2141,7 @@ packages:
     source: hosted
     version: "2.4.1"
   shared_preferences_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: shared_preferences_platform_interface
       sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
@@ -2402,7 +2402,7 @@ packages:
     source: hosted
     version: "1.2.2"
   test:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: test
       sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
@@ -2514,7 +2514,7 @@ packages:
     source: hosted
     version: "3.2.5"
   url_launcher_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: url_launcher_platform_interface
       sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
@@ -2618,7 +2618,7 @@ packages:
     source: hosted
     version: "1.5.2"
   wakelock_plus_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: wakelock_plus_platform_interface
       sha256: "14b2e5b9e35c2631e656913c47adecdd71633ae92896a27a64c8f1fcfabc21cc"
@@ -2690,7 +2690,7 @@ packages:
     source: hosted
     version: "4.10.13"
   webview_flutter_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: webview_flutter_platform_interface
       sha256: "63d26ee3aca7256a83ccb576a50272edd7cfc80573a4305caa98985feb493ee0"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -114,7 +114,9 @@ dependencies:
   characters: ^1.4.1
 
   # State management
+  bloc: ^9.2.1
   flutter_riverpod: ^3.0.0
+  riverpod: ^3.3.2
   riverpod_annotation: ^4.0.3
   flutter_bloc: ^9.0.0
   bloc_concurrency: ^0.3.0
@@ -123,6 +125,7 @@ dependencies:
   rxdart: ^0.28.0
 
   # Networking
+  async: ^2.13.0
   http: ^1.5.0
   web_socket_channel: ^3.0.3
   connectivity_plus: ^7.3.0
@@ -183,16 +186,19 @@ dependencies:
   hive_ce_flutter: ^2.1.0
 
   # Storage
+  path: ^1.9.1
   shared_preferences: ^2.2.3
   sqflite: ^2.3.3+1
   path_provider: ^2.1.4
   flutter_secure_storage: ^9.0.0
 
   # Crypto (needed for Nostr)
+  bip340: ^0.3.0
   crypto: ^3.0.7
   bech32: ^0.2.2
 
   # UI/UX
+  collection: ^1.19.1
   flutter_cache_manager: ^3.3.1
   share_plus: ^12.0.0 # Cross-platform sharing
   google_fonts: ^6.3.2 # For using Google Fonts including Pacifico
@@ -251,6 +257,7 @@ dependencies:
 
   # Nostr SDK - Local package for comprehensive Nostr support
   nostr_app_bridge_repository:
+  nostr_client:
   nostr_sdk:
 
   # Nostr Key Manager - Secure key management with hardware-backed storage
@@ -278,6 +285,14 @@ dependencies:
 
   # Models - Shared Nostr/data model definitions
   models:
+
+  # Direct workspace dependencies used by app-layer repositories and blocs.
+  app_update_repository:
+  app_version_client:
+  db_client:
+  likes_repository:
+  media_cache:
+  reposts_repository:
 
   # Text Sanitizer - display-safe user text (zalgo caps, UTF-16 well-formed)
   text_sanitizer:
@@ -365,6 +380,7 @@ dependencies:
   pointer_interceptor: ^0.10.1+2
   volume_controller: ^3.4.4
   meta: ^1.18.0
+  provider: ^6.1.5+1
 
 dependency_overrides:
   # TODO(#3638): Keep device_info_plus on 10.x until the app is ready for the
@@ -400,9 +416,18 @@ dev_dependencies:
   analyzer: ^12.1.0
 
   # Testing
+  file: ^7.0.1
+  firebase_core_platform_interface: ^6.0.2
   fake_async: ^1.3.3
   mocktail: ^1.0.3
   bloc_test: ^10.0.0
+  path_provider_platform_interface: ^2.1.2
+  plugin_platform_interface: ^2.1.8
+  shared_preferences_platform_interface: ^2.4.1
+  test: ^1.31.0
+  url_launcher_platform_interface: ^2.3.2
+  wakelock_plus_platform_interface: ^1.5.0
+  webview_flutter_platform_interface: ^2.14.0
 
   # Code generation
   build_runner: ^2.15.0
@@ -418,11 +443,9 @@ dev_dependencies:
   # riverpod_lint: ^2.3.10  # Depends on custom_lint
   freezed: ^3.0.0
   json_serializable: ^6.8.0
-  path: any
   yaml: any
   golden_toolkit: ^0.15.0
   alchemist: ^0.12.1
-  async: ^2.13.0
   drift_dev: ^2.34.0
   melos: ^7.3.0
 

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -113,6 +113,10 @@ dependencies:
   # Unicode grapheme segmentation for user-entered category names.
   characters: ^1.4.1
 
+  # Dart core utilities
+  async: ^2.13.0
+  collection: ^1.19.1
+
   # State management
   bloc: ^9.2.1
   flutter_riverpod: ^3.0.0
@@ -120,12 +124,12 @@ dependencies:
   riverpod_annotation: ^4.0.3
   flutter_bloc: ^9.0.0
   bloc_concurrency: ^0.3.0
+  provider: ^6.1.5+1
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
   rxdart: ^0.28.0
 
   # Networking
-  async: ^2.13.0
   http: ^1.5.0
   web_socket_channel: ^3.0.3
   connectivity_plus: ^7.3.0
@@ -198,7 +202,6 @@ dependencies:
   bech32: ^0.2.2
 
   # UI/UX
-  collection: ^1.19.1
   flutter_cache_manager: ^3.3.1
   share_plus: ^12.0.0 # Cross-platform sharing
   google_fonts: ^6.3.2 # For using Google Fonts including Pacifico
@@ -380,7 +383,6 @@ dependencies:
   pointer_interceptor: ^0.10.1+2
   volume_controller: ^3.4.4
   meta: ^1.18.0
-  provider: ^6.1.5+1
 
 dependency_overrides:
   # TODO(#3638): Keep device_info_plus on 10.x until the app is ready for the


### PR DESCRIPTION
## Problem

The app directly imports workspace packages, hosted packages, and test platform interfaces that it does not declare. Those imports currently work only because the monorepo workspace or another dependency happens to make the packages available, so dependency changes can break unrelated app code without an analyzer warning.

## Why this fix

Declare every package imported directly by the app as a production dependency and every test-only platform interface as a development dependency, then enable `depend_on_referenced_packages`. Existing resolved versions are retained; the lockfile changes only reclassify those hosted packages as direct dependencies.

The dependency-provenance baseline remains unchanged and shrink-only. Workspace dependencies do not add new provenance exceptions.

## Deliberately unchanged

This PR does not enable the remaining collection-type, async-safety, or ignore-documentation rules tracked by #3342. Those require separate measurement and remediation.

## Verification

- `flutter pub get`
- `flutter analyze lib test integration_test tools`
- `bash mobile/scripts/check_dependency_provenance.sh`
- `bash mobile/scripts/check_package_ci_floor.sh`
- `git diff origin/main...HEAD --check`

Part of #3342.
