### PR TITLE
ci(testing): run service tests for affected app changes

### DIFF
--- a/.agents/skills/e2e-test/SKILL.md
+++ b/.agents/skills/e2e-test/SKILL.md
@@ -38,9 +38,9 @@ Not every suite is a patrol suite. `profile.sh` recursively greps the
 target for `patrolTest` and dispatches: patrol suites go to
 `patrol test`, plain `integration_test` suites go to
 `flutter test --device-id`. Everything under `integration_test/e2e/`
-is now the plain kind — those four converted off patrol in #7005
-because none of them used the native automator for anything
-load-bearing. The plain path pre-grants `POST_NOTIFICATIONS`, since
+is now the plain kind. The original four converted off patrol in #7005 because
+none used the native automator for anything load-bearing, and new suites should
+follow that pattern. The plain path pre-grants `POST_NOTIFICATIONS`, since
 without an automator nothing can dismiss that dialog.
 
 ## Version pair

--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -38,9 +38,9 @@ Not every suite is a patrol suite. `profile.sh` recursively greps the
 target for `patrolTest` and dispatches: patrol suites go to
 `patrol test`, plain `integration_test` suites go to
 `flutter test --device-id`. Everything under `integration_test/e2e/`
-is now the plain kind — those four converted off patrol in #7005
-because none of them used the native automator for anything
-load-bearing. The plain path pre-grants `POST_NOTIFICATIONS`, since
+is now the plain kind. The original four converted off patrol in #7005 because
+none used the native automator for anything load-bearing, and new suites should
+follow that pattern. The plain path pre-grants `POST_NOTIFICATIONS`, since
 without an automator nothing can dismiss that dialog.
 
 ## Version pair

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -161,6 +161,8 @@ jobs:
         run: bash scripts/check_process_global_mutations.sh
       - name: 🧯 Verify integration_test error-handler restores are exception-safe
         run: bash scripts/check_integration_test_error_restore_safety.sh
+      - name: 🧾 Verify every E2E service suite is accounted for
+        run: bash scripts/check_service_suite_coverage.sh
       - name: 🔌 Verify no new raw shared-channel installs (heal-and-blame ratchet)
         run: |
           # LIST ratchet vs origin/main (fails closed if the base baseline can't

--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -4,23 +4,46 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
-    paths:
-      - "mobile/integration_test/e2e/**"
-      - "mobile/integration_test/helpers/**"
-      - "mobile/lib/services/relay_discovery_service.dart"
-      - "mobile/packages/nostr_sdk/**"
-      - "mobile/packages/nostr_client/**"
-      - "mobile/packages/dm_repository/**"
-      - "mobile/packages/db_client/**"
-      - ".github/workflows/mobile_service_integration_tests.yaml"
+
+# The 13 Linux-runnable suites have two dependency shapes. Eleven have a
+# focused closure across ten packages and five app files. Two widget-level
+# suites import the provider/router graph, which reaches nearly all mobile/lib
+# and mobile/packages production code. A 60-PR sample found those scopes on
+# 37% and 77% of changes respectively; running every suite costs about 14
+# minutes. The changes job therefore selects either suite group (or both), and
+# one service-tests job pays setup cost once. Keep the detector and its tests in
+# sync when suite dependencies change.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Service Suite Scope
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      focused: ${{ steps.scope.outputs.focused }}
+      app: ${{ steps.scope.outputs.app }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: mobile/scripts/ci/detect_service_suite_scope.sh
+          sparse-checkout-cone-mode: false
+      - name: Detect affected service suites
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: bash mobile/scripts/ci/detect_service_suite_scope.sh
+
   service-tests:
     name: Integration Tests (services)
+    needs: changes
+    if: ${{ needs.changes.outputs.focused == 'true' || needs.changes.outputs.app == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     defaults:
@@ -61,22 +84,10 @@ jobs:
       # launch never gets a debug connection ("The log reader stopped
       # unexpectedly, or never started"). Each suite passes on its own.
       #
-      # The list is explicit rather than a glob over integration_test/e2e/,
+      # The lists are explicit rather than a glob over integration_test/e2e/,
       # because `service` and "runnable on a Linux CI runner" are different
-      # axes. Every suite in that directory is tagged `service`; these eleven
-      # are the ones this runner can actually execute. The remaining five are
-      # excluded for reasons no workflow change can fix:
-      #
-      #   c2pa_init                         — c2pa_flutter ships android/ and
-      #                                       ios/ only, no desktop impl.
-      #   video_creation_flow               — needs the invite service.
-      #   deleted_video_visible_to_others   — needs the full stack.
-      #   dm_optimistic_survives_watch_race — needs the full stack.
-      #   contact_list_freshness_docker     — needs the full stack. It is the
-      #                                       real-relay twin of
-      #                                       contact_list_freshness, which is
-      #                                       in the list above; run it locally
-      #                                       against local_stack.
+      # axes. The generated-files guard accounts for every suite against these
+      # lists or service_suite_exclusions.txt.
       #
       # local_stack cannot start on a GitHub runner at all:
       # divine-invite-darshan:e2e is a private GHCR package, compose resolves
@@ -84,21 +95,37 @@ jobs:
       # suites below need none of it — they stand up their own in-process relay
       # (integration_test/helpers/fake_relay.dart).
       - name: 🚀 Run service integration tests
+        env:
+          RUN_FOCUSED_SUITES: ${{ needs.changes.outputs.focused }}
+          RUN_APP_SUITES: ${{ needs.changes.outputs.app }}
         run: |
-          for suite in \
-            integration_test/e2e/relay_list_admission_test.dart \
-            integration_test/e2e/dm_inbox_relay_admission_test.dart \
-            integration_test/e2e/dm_self_wrap_inbox_relays_test.dart \
-            integration_test/e2e/reel_reply_retry_double_send_test.dart \
-            integration_test/e2e/block_leaves_kind3_follow_test.dart \
-            integration_test/e2e/contact_list_freshness_test.dart \
-            integration_test/e2e/dm_group_delete_for_everyone_test.dart \
-            integration_test/e2e/dm_reaction_unreadable_inbox_test.dart \
-            integration_test/e2e/dm_deletion_unreadable_inbox_test.dart \
-            integration_test/e2e/dm_group_send_unreadable_inbox_test.dart \
-            integration_test/e2e/dm_group_send_joined_recovery_retry_test.dart \
-            integration_test/e2e/dm_oneway_latch_unlatch_test.dart \
-            integration_test/e2e/dm_history_drain_idle_pool_test.dart; do
+          # SERVICE_SUITE_LIST_START — parsed by check_service_suite_coverage.sh.
+          focused_suites=(
+            integration_test/e2e/relay_list_admission_test.dart
+            integration_test/e2e/dm_inbox_relay_admission_test.dart
+            integration_test/e2e/dm_self_wrap_inbox_relays_test.dart
+            integration_test/e2e/contact_list_freshness_test.dart
+            integration_test/e2e/dm_group_delete_for_everyone_test.dart
+            integration_test/e2e/dm_reaction_unreadable_inbox_test.dart
+            integration_test/e2e/dm_deletion_unreadable_inbox_test.dart
+            integration_test/e2e/dm_group_send_unreadable_inbox_test.dart
+            integration_test/e2e/dm_group_send_joined_recovery_retry_test.dart
+            integration_test/e2e/dm_oneway_latch_unlatch_test.dart
+            integration_test/e2e/dm_history_drain_idle_pool_test.dart
+          )
+          app_suites=(
+            integration_test/e2e/reel_reply_retry_double_send_test.dart
+            integration_test/e2e/block_leaves_kind3_follow_test.dart
+          )
+          # SERVICE_SUITE_LIST_END
+          suites=()
+          if [[ "$RUN_FOCUSED_SUITES" == "true" ]]; then
+            suites+=("${focused_suites[@]}")
+          fi
+          if [[ "$RUN_APP_SUITES" == "true" ]]; then
+            suites+=("${app_suites[@]}")
+          fi
+          for suite in "${suites[@]}"; do
             echo "── $suite"
             xvfb-run -a flutter test "$suite" --tags service -d linux
           done

--- a/mobile/integration_test/e2e/service_suite_exclusions.txt
+++ b/mobile/integration_test/e2e/service_suite_exclusions.txt
@@ -1,0 +1,8 @@
+# Headless service-suite exclusions. Format: suite path | reason
+# Entries may be removed when a suite becomes runnable; the CI guard prevents
+# this debt list from growing relative to origin/main.
+integration_test/e2e/c2pa_init_test.dart | c2pa_flutter has no Linux desktop implementation
+integration_test/e2e/contact_list_freshness_docker_test.dart | requires the Docker service stack, including a private runner image
+integration_test/e2e/deleted_video_visible_to_other_users_test.dart | requires the full Docker service stack
+integration_test/e2e/dm_optimistic_survives_watch_race_test.dart | requires the full Docker service stack
+integration_test/e2e/video_creation_flow_test.dart | requires the invite service

--- a/mobile/scripts/check_service_suite_coverage.sh
+++ b/mobile/scripts/check_service_suite_coverage.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# ABOUTME: Accounts for every E2E suite in the headless service workflow.
+# ABOUTME: Rejects missing, duplicate, stale, reasonless, or newly excluded suites.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOBILE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_DIR="$(cd "$MOBILE_DIR/.." && pwd)"
+WORKFLOW_FILE="${SERVICE_SUITE_WORKFLOW_FILE:-$REPO_DIR/.github/workflows/mobile_service_integration_tests.yaml}"
+E2E_DIR="${SERVICE_SUITE_E2E_DIR:-$MOBILE_DIR/integration_test/e2e}"
+SUITE_PATH_ROOT="${SERVICE_SUITE_PATH_ROOT:-$MOBILE_DIR}"
+MANIFEST_FILE="${SERVICE_SUITE_MANIFEST_FILE:-$E2E_DIR/service_suite_exclusions.txt}"
+MANIFEST_REPO_PATH="mobile/integration_test/e2e/service_suite_exclusions.txt"
+BASE_REF="${SERVICE_SUITE_BASE_REF:-origin/main}"
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+parse_manifest() {
+  awk '
+    /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
+    {
+      separator = index($0, "|")
+      if (separator == 0) {
+        printf "Invalid exclusion on line %d: expected suite path | reason\n", FNR > "/dev/stderr"
+        invalid = 1
+        next
+      }
+      path = substr($0, 1, separator - 1)
+      reason = substr($0, separator + 1)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", path)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", reason)
+      if (path == "" || reason == "") {
+        printf "Invalid exclusion on line %d: suite path and reason are required\n", FNR > "/dev/stderr"
+        invalid = 1
+        next
+      }
+      print path
+    }
+    END { exit invalid }
+  ' "$1"
+}
+
+find "$E2E_DIR" -maxdepth 1 -type f -name '*_test.dart' -print \
+  | sed "s|^$SUITE_PATH_ROOT/||" \
+  | sort > "$scratch/all"
+
+start_markers="$(grep -c 'SERVICE_SUITE_LIST_START' "$WORKFLOW_FILE" || true)"
+end_markers="$(grep -c 'SERVICE_SUITE_LIST_END' "$WORKFLOW_FILE" || true)"
+if [ "$start_markers" -ne 1 ] || [ "$end_markers" -ne 1 ]; then
+  echo "FAIL [service_suite_coverage]: workflow must contain exactly one service-suite list marker pair."
+  exit 1
+fi
+
+awk '
+  /SERVICE_SUITE_LIST_START/ { capture = 1; next }
+  /SERVICE_SUITE_LIST_END/ { capture = 0 }
+  capture
+' "$WORKFLOW_FILE" \
+  | grep -Eo 'integration_test/e2e/[[:alnum:]_./-]+_test\.dart' \
+  | sort > "$scratch/included"
+
+parse_manifest "$MANIFEST_FILE" | sort > "$scratch/excluded"
+
+failed=false
+for population in included excluded; do
+  duplicates="$(uniq -d "$scratch/$population")"
+  if [ -n "$duplicates" ]; then
+    echo "FAIL [service_suite_coverage]: duplicate $population suites:"
+    echo "$duplicates"
+    failed=true
+  fi
+done
+
+sort -u "$scratch/included" > "$scratch/included_unique"
+sort -u "$scratch/excluded" > "$scratch/excluded_unique"
+cat "$scratch/included_unique" "$scratch/excluded_unique" | sort -u > "$scratch/accounted"
+
+overlap="$(comm -12 "$scratch/included_unique" "$scratch/excluded_unique")"
+if [ -n "$overlap" ]; then
+  echo "FAIL [service_suite_coverage]: suites cannot be both included and excluded:"
+  echo "$overlap"
+  failed=true
+fi
+
+unaccounted="$(comm -23 "$scratch/all" "$scratch/accounted")"
+if [ -n "$unaccounted" ]; then
+  echo "FAIL [service_suite_coverage]: E2E suites missing from the workflow and exclusion manifest:"
+  echo "$unaccounted"
+  failed=true
+fi
+
+unknown="$(comm -13 "$scratch/all" "$scratch/accounted")"
+if [ -n "$unknown" ]; then
+  echo "FAIL [service_suite_coverage]: accounted suites that do not exist:"
+  echo "$unknown"
+  failed=true
+fi
+
+base_manifest="${SERVICE_SUITE_BASE_MANIFEST:-}"
+if [ -z "$base_manifest" ]; then
+  if ! git -C "$REPO_DIR" rev-parse --verify "$BASE_REF^{commit}" >/dev/null 2>&1; then
+    echo "FAIL [service_suite_coverage]: cannot resolve base ref $BASE_REF."
+    exit 1
+  fi
+  if git -C "$REPO_DIR" cat-file -e "$BASE_REF:$MANIFEST_REPO_PATH" 2>/dev/null; then
+    base_manifest="$scratch/base_manifest"
+    git -C "$REPO_DIR" show "$BASE_REF:$MANIFEST_REPO_PATH" > "$base_manifest"
+  fi
+fi
+
+if [ -n "$base_manifest" ]; then
+  parse_manifest "$base_manifest" | sort -u > "$scratch/base_excluded"
+  growth="$(comm -13 "$scratch/base_excluded" "$scratch/excluded_unique")"
+  if [ -n "$growth" ]; then
+    echo "FAIL [service_suite_coverage]: exclusion debt grew relative to $BASE_REF:"
+    echo "$growth"
+    failed=true
+  fi
+else
+  echo "NOTE [service_suite_coverage]: introducing the exclusion manifest; skipping the no-growth comparison."
+fi
+
+if [ "$failed" = "true" ]; then
+  exit 1
+fi
+
+included_count="$(wc -l < "$scratch/included_unique" | tr -d '[:space:]')"
+excluded_count="$(wc -l < "$scratch/excluded_unique" | tr -d '[:space:]')"
+echo "OK: all E2E suites accounted for ($included_count included, $excluded_count excluded); exclusion debt did not grow."

--- a/mobile/scripts/check_service_suite_coverage.sh
+++ b/mobile/scripts/check_service_suite_coverage.sh
@@ -4,6 +4,9 @@
 
 set -euo pipefail
 
+# sort/comm/uniq must agree regardless of the runner's locale.
+export LC_ALL=C
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MOBILE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_DIR="$(cd "$MOBILE_DIR/.." && pwd)"
@@ -69,7 +72,7 @@ parse_workflow_suites() {
   ' "$1"
 }
 
-find "$E2E_DIR" -maxdepth 1 -type f -name '*_test.dart' -print \
+find "$E2E_DIR" -type f -name '*_test.dart' -print \
   | sed "s|^$SUITE_PATH_ROOT/||" \
   | sort > "$scratch/all"
 

--- a/mobile/scripts/check_service_suite_coverage.sh
+++ b/mobile/scripts/check_service_suite_coverage.sh
@@ -11,7 +11,7 @@ WORKFLOW_FILE="${SERVICE_SUITE_WORKFLOW_FILE:-$REPO_DIR/.github/workflows/mobile
 E2E_DIR="${SERVICE_SUITE_E2E_DIR:-$MOBILE_DIR/integration_test/e2e}"
 SUITE_PATH_ROOT="${SERVICE_SUITE_PATH_ROOT:-$MOBILE_DIR}"
 MANIFEST_FILE="${SERVICE_SUITE_MANIFEST_FILE:-$E2E_DIR/service_suite_exclusions.txt}"
-MANIFEST_REPO_PATH="mobile/integration_test/e2e/service_suite_exclusions.txt"
+MANIFEST_REPO_PATH="${MANIFEST_FILE#"$REPO_DIR"/}"
 BASE_REF="${SERVICE_SUITE_BASE_REF:-origin/main}"
 
 scratch="$(mktemp -d)"
@@ -42,6 +42,33 @@ parse_manifest() {
   ' "$1"
 }
 
+parse_workflow_suites() {
+  awk '
+    /SERVICE_SUITE_LIST_START/ { capture = 1; next }
+    /SERVICE_SUITE_LIST_END/ { capture = 0; next }
+    !capture { next }
+    /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
+    /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=\([[:space:]]*$/ { inside = 1; next }
+    /^[[:space:]]*\)[[:space:]]*$/ { inside = 0; next }
+    {
+      entry = $0
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", entry)
+      if (!inside) {
+        printf "Unexpected line %d between the suite-list markers: %s\n", FNR, entry > "/dev/stderr"
+        invalid = 1
+        next
+      }
+      if (entry !~ /^integration_test\/e2e\/[[:alnum:]_.\/-]+_test\.dart$/) {
+        printf "Unrecognized suite-array entry on line %d: %s\n", FNR, entry > "/dev/stderr"
+        invalid = 1
+        next
+      }
+      print entry
+    }
+    END { exit invalid }
+  ' "$1"
+}
+
 find "$E2E_DIR" -maxdepth 1 -type f -name '*_test.dart' -print \
   | sed "s|^$SUITE_PATH_ROOT/||" \
   | sort > "$scratch/all"
@@ -53,13 +80,7 @@ if [ "$start_markers" -ne 1 ] || [ "$end_markers" -ne 1 ]; then
   exit 1
 fi
 
-awk '
-  /SERVICE_SUITE_LIST_START/ { capture = 1; next }
-  /SERVICE_SUITE_LIST_END/ { capture = 0 }
-  capture
-' "$WORKFLOW_FILE" \
-  | grep -Eo 'integration_test/e2e/[[:alnum:]_./-]+_test\.dart' \
-  | sort > "$scratch/included"
+parse_workflow_suites "$WORKFLOW_FILE" | sort > "$scratch/included"
 
 parse_manifest "$MANIFEST_FILE" | sort > "$scratch/excluded"
 
@@ -99,14 +120,29 @@ if [ -n "$unknown" ]; then
 fi
 
 base_manifest="${SERVICE_SUITE_BASE_MANIFEST:-}"
+skipped_growth=false
 if [ -z "$base_manifest" ]; then
-  if ! git -C "$REPO_DIR" rev-parse --verify "$BASE_REF^{commit}" >/dev/null 2>&1; then
-    echo "FAIL [service_suite_coverage]: cannot resolve base ref $BASE_REF."
-    exit 1
+  if ! git -C "$REPO_DIR" rev-parse --verify --quiet "$BASE_REF^{commit}" >/dev/null 2>&1; then
+    git -C "$REPO_DIR" fetch --quiet --depth=1 origin main 2>/dev/null || true
   fi
-  if git -C "$REPO_DIR" cat-file -e "$BASE_REF:$MANIFEST_REPO_PATH" 2>/dev/null; then
+  if ! git -C "$REPO_DIR" rev-parse --verify --quiet "$BASE_REF^{commit}" >/dev/null 2>&1; then
+    if [ "${SERVICE_SUITE_ALLOW_NO_BASE:-0}" = "1" ]; then
+      echo "NOTE [service_suite_coverage]: $BASE_REF unavailable; skipping the no-growth comparison (SERVICE_SUITE_ALLOW_NO_BASE=1, local opt-out)."
+      skipped_growth=true
+    else
+      echo "FAIL [service_suite_coverage]: cannot resolve base ref $BASE_REF, so the"
+      echo "  no-growth ratchet cannot be verified - failing closed. Ensure $BASE_REF is"
+      echo "  fetched (CI fetches it before this guard); for a local run without a base"
+      echo "  ref, set SERVICE_SUITE_ALLOW_NO_BASE=1."
+      exit 1
+    fi
+  elif git -C "$REPO_DIR" cat-file -e "$BASE_REF:$MANIFEST_REPO_PATH" 2>/dev/null; then
     base_manifest="$scratch/base_manifest"
-    git -C "$REPO_DIR" show "$BASE_REF:$MANIFEST_REPO_PATH" > "$base_manifest"
+    if ! git -C "$REPO_DIR" show "$BASE_REF:$MANIFEST_REPO_PATH" > "$base_manifest" 2>/dev/null; then
+      echo "FAIL [service_suite_coverage]: $MANIFEST_REPO_PATH exists on $BASE_REF but could"
+      echo "  not be read, so the no-growth ratchet cannot be verified - failing closed."
+      exit 1
+    fi
   fi
 fi
 
@@ -118,8 +154,8 @@ if [ -n "$base_manifest" ]; then
     echo "$growth"
     failed=true
   fi
-else
-  echo "NOTE [service_suite_coverage]: introducing the exclusion manifest; skipping the no-growth comparison."
+elif [ "$skipped_growth" != "true" ]; then
+  echo "NOTE [service_suite_coverage]: no exclusion manifest on $BASE_REF yet (introducing the guard); skipping the no-growth comparison."
 fi
 
 if [ "$failed" = "true" ]; then
@@ -128,4 +164,8 @@ fi
 
 included_count="$(wc -l < "$scratch/included_unique" | tr -d '[:space:]')"
 excluded_count="$(wc -l < "$scratch/excluded_unique" | tr -d '[:space:]')"
-echo "OK: all E2E suites accounted for ($included_count included, $excluded_count excluded); exclusion debt did not grow."
+if [ -n "$base_manifest" ]; then
+  echo "OK: all E2E suites accounted for ($included_count included, $excluded_count excluded); exclusion debt did not grow."
+else
+  echo "OK: all E2E suites accounted for ($included_count included, $excluded_count excluded); no-growth comparison skipped."
+fi

--- a/mobile/scripts/ci/detect_service_suite_scope.sh
+++ b/mobile/scripts/ci/detect_service_suite_scope.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# ABOUTME: Classifies changed files for the headless service integration suites.
+# ABOUTME: Separates focused service dependencies from app-connected dependencies.
+
+set -euo pipefail
+
+changed_files="$(mktemp)"
+trap 'rm -f "$changed_files"' EXIT
+
+emit_scope() {
+  echo "focused=$1" >> "$GITHUB_OUTPUT"
+  echo "app=$2" >> "$GITHUB_OUTPUT"
+}
+
+fall_open() {
+  emit_scope true true
+  echo "$1"
+  exit 0
+}
+
+if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+  fall_open "Non-PR event; running every headless service integration suite."
+fi
+
+# The files endpoint caps at 3000 entries. A PR that large is not a scoped
+# change, so run every suite rather than trusting a truncated response.
+changed_total=$(gh api "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.changed_files')
+if [ "$changed_total" -gt 3000 ]; then
+  fall_open "PR touches $changed_total files (> 3000 API cap); running every suite."
+fi
+
+gh api --method GET --paginate -F per_page=100 \
+  "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+  --jq '.[].filename' > "$changed_files"
+
+file_count=$(( $(wc -l < "$changed_files") ))
+if [ "$file_count" -eq 0 ] || [ "$file_count" -ne "$changed_total" ]; then
+  fall_open "PR returned $file_count files but reported $changed_total changed files; running every suite."
+fi
+
+echo "Changed files:"
+cat "$changed_files"
+
+focused=false
+app=false
+while IFS= read -r path; do
+  # These inputs affect the runner or the suites as a population, so changes
+  # run both dependency groups.
+  case "$path" in
+    .github/workflows/mobile_service_integration_tests.yaml|\
+    mobile/scripts/ci/detect_service_suite_scope.sh|\
+    mobile/scripts/check_service_suite_coverage.sh|\
+    mobile/integration_test/e2e/service_suite_exclusions.txt|\
+    mobile/integration_test/e2e/*|\
+    mobile/integration_test/helpers/*|\
+    mobile/pubspec.yaml|\
+    mobile/pubspec.lock|\
+    mobile/dart_test.yaml|\
+    mobile/linux/*)
+      focused=true
+      app=true
+      ;;
+  esac
+
+  # Eleven suites have this maintainable production dependency closure.
+  case "$path" in
+    mobile/packages/cache_sync/*|\
+    mobile/packages/db_client/*|\
+    mobile/packages/dm_repository/*|\
+    mobile/packages/follow_repository/*|\
+    mobile/packages/funnelcake_api_client/*|\
+    mobile/packages/models/*|\
+    mobile/packages/nostr_client/*|\
+    mobile/packages/nostr_sdk/*|\
+    mobile/packages/text_sanitizer/*|\
+    mobile/packages/unified_logger/*|\
+    mobile/lib/observability/crash_reporter.dart|\
+    mobile/lib/services/outgoing_dm_retry_service.dart|\
+    mobile/lib/services/outgoing_dm_retry_service_reportable_sites.dart|\
+    mobile/lib/services/relay_discovery_service.dart|\
+    mobile/lib/utils/relay_url_utils.dart)
+      focused=true
+      ;;
+  esac
+
+  # Two widget-level suites import the app's provider/router graph. That graph
+  # reaches nearly all app and workspace-package production code, so a narrower
+  # rule would silently miss real dependencies.
+  case "$path" in
+    mobile/lib/*|mobile/packages/*)
+      app=true
+      ;;
+  esac
+done < "$changed_files"
+
+emit_scope "$focused" "$app"
+echo "Focused service suites required: $focused"
+echo "App-connected service suites required: $app"

--- a/mobile/test/tools/detect_service_suite_scope_test.dart
+++ b/mobile/test/tools/detect_service_suite_scope_test.dart
@@ -1,0 +1,214 @@
+// ABOUTME: Tests changed-path classification for service integration suites.
+// ABOUTME: Pins focused/app scopes and every pull-request API fall-open guard.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('detect_service_suite_scope.sh', () {
+    late Directory sandbox;
+    late String scriptPath;
+    late String outputPath;
+
+    setUp(() {
+      sandbox = Directory.systemTemp.createTempSync('service_suite_scope_');
+      scriptPath = File(
+        p.join(
+          Directory.current.path,
+          'scripts',
+          'ci',
+          'detect_service_suite_scope.sh',
+        ),
+      ).absolute.path;
+      outputPath = p.join(sandbox.path, 'github-output');
+
+      final fakeGh = File(p.join(sandbox.path, 'bin', 'gh'))
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync(
+          '#!/usr/bin/env bash\n'
+          r'''
+set -euo pipefail
+
+if [[ "$*" == *"/files"* ]]; then
+  if [ -n "${FAKE_CHANGED_FILES:-}" ]; then
+    printf '%s\n' "$FAKE_CHANGED_FILES"
+  fi
+elif [[ "$*" == *".changed_files"* ]]; then
+  printf '%s\n' "${FAKE_CHANGED_TOTAL:-0}"
+else
+  echo "Unexpected gh invocation: $*" >&2
+  exit 2
+fi
+''',
+        );
+      Process.runSync('chmod', ['+x', fakeGh.path]);
+    });
+
+    tearDown(() {
+      if (sandbox.existsSync()) sandbox.deleteSync(recursive: true);
+    });
+
+    ({ProcessResult result, Map<String, String> outputs}) runDetector({
+      String event = 'pull_request',
+      List<String> changedFiles = const [],
+      int? changedTotal,
+    }) {
+      final result = Process.runSync(
+        'bash',
+        [scriptPath],
+        environment: {
+          'PATH':
+              '${p.join(sandbox.path, 'bin')}:${Platform.environment['PATH']}',
+          'GITHUB_EVENT_NAME': event,
+          'GITHUB_REPOSITORY': 'divinevideo/divine-mobile',
+          'GITHUB_OUTPUT': outputPath,
+          'PR_NUMBER': '8756',
+          'FAKE_CHANGED_FILES': changedFiles.join('\n'),
+          'FAKE_CHANGED_TOTAL': '${changedTotal ?? changedFiles.length}',
+        },
+      );
+
+      final outputs = <String, String>{};
+      final outputFile = File(outputPath);
+      if (outputFile.existsSync()) {
+        for (final line in outputFile.readAsLinesSync()) {
+          final separator = line.indexOf('=');
+          if (separator > 0) {
+            outputs[line.substring(0, separator)] = line.substring(
+              separator + 1,
+            );
+          }
+        }
+      }
+      return (result: result, outputs: outputs);
+    }
+
+    void expectScope(
+      ({ProcessResult result, Map<String, String> outputs}) run, {
+      required bool focused,
+      required bool app,
+    }) {
+      expect(run.result.exitCode, 0, reason: run.result.stderr.toString());
+      expect(run.outputs, {'focused': '$focused', 'app': '$app'});
+    }
+
+    test('runs both groups for every focused package dependency', () {
+      const packages = [
+        'cache_sync',
+        'db_client',
+        'dm_repository',
+        'follow_repository',
+        'funnelcake_api_client',
+        'models',
+        'nostr_client',
+        'nostr_sdk',
+        'text_sanitizer',
+        'unified_logger',
+      ];
+
+      for (final package in packages) {
+        expectScope(
+          runDetector(
+            changedFiles: ['mobile/packages/$package/lib/change.dart'],
+          ),
+          focused: true,
+          app: true,
+        );
+      }
+    });
+
+    test('runs both groups for every focused app dependency', () {
+      const paths = [
+        'mobile/lib/observability/crash_reporter.dart',
+        'mobile/lib/services/outgoing_dm_retry_service.dart',
+        'mobile/lib/services/outgoing_dm_retry_service_reportable_sites.dart',
+        'mobile/lib/services/relay_discovery_service.dart',
+        'mobile/lib/utils/relay_url_utils.dart',
+      ];
+
+      for (final path in paths) {
+        expectScope(
+          runDetector(changedFiles: [path]),
+          focused: true,
+          app: true,
+        );
+      }
+    });
+
+    test('runs only app-connected suites for other app and package code', () {
+      for (final path in [
+        'mobile/lib/widgets/video_grid.dart',
+        'mobile/packages/feed_repository/lib/src/feed_repository.dart',
+      ]) {
+        expectScope(
+          runDetector(changedFiles: [path]),
+          focused: false,
+          app: true,
+        );
+      }
+    });
+
+    test('runs both groups for shared test and runner inputs', () {
+      for (final path in [
+        'mobile/integration_test/e2e/new_test.dart',
+        'mobile/integration_test/helpers/fake_relay.dart',
+        'mobile/integration_test/e2e/service_suite_exclusions.txt',
+        'mobile/pubspec.yaml',
+        'mobile/pubspec.lock',
+        'mobile/dart_test.yaml',
+        'mobile/linux/CMakeLists.txt',
+        '.github/workflows/mobile_service_integration_tests.yaml',
+        'mobile/scripts/ci/detect_service_suite_scope.sh',
+        'mobile/scripts/check_service_suite_coverage.sh',
+      ]) {
+        expectScope(
+          runDetector(changedFiles: [path]),
+          focused: true,
+          app: true,
+        );
+      }
+    });
+
+    test('skips both groups for docs-only changes', () {
+      expectScope(
+        runDetector(changedFiles: ['docs/testing.md']),
+        focused: false,
+        app: false,
+      );
+    });
+
+    test('falls open above the pull-request file cap', () {
+      final run = runDetector(
+        changedFiles: ['docs/only.md'],
+        changedTotal: 3001,
+      );
+
+      expectScope(run, focused: true, app: true);
+      expect(run.result.stdout, contains('touches 3001 files'));
+    });
+
+    test('falls open when the file response is empty', () {
+      final run = runDetector(changedTotal: 1);
+
+      expectScope(run, focused: true, app: true);
+      expect(run.result.stdout, contains('returned 0 files but reported 1'));
+    });
+
+    test('falls open when the file response is truncated', () {
+      final run = runDetector(changedFiles: ['docs/only.md'], changedTotal: 2);
+
+      expectScope(run, focused: true, app: true);
+      expect(run.result.stdout, contains('returned 1 files but reported 2'));
+    });
+
+    test('workflow dispatch falls open without calling the API', () {
+      expectScope(
+        runDetector(event: 'workflow_dispatch'),
+        focused: true,
+        app: true,
+      );
+    });
+  });
+}

--- a/mobile/test/tools/service_suite_coverage_test.dart
+++ b/mobile/test/tools/service_suite_coverage_test.dart
@@ -1,0 +1,196 @@
+// ABOUTME: Tests complete accounting of headless service integration suites.
+// ABOUTME: Pins duplicate, stale, reason, and exclusion-debt failure modes.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('check_service_suite_coverage.sh', () {
+    late Directory sandbox;
+    late String scriptPath;
+    late File workflow;
+    late Directory e2eDirectory;
+    late File manifest;
+    late File baseManifest;
+
+    setUp(() {
+      sandbox = Directory.systemTemp.createTempSync('service_suite_coverage_');
+      scriptPath = File(
+        p.join(
+          Directory.current.path,
+          'scripts',
+          'check_service_suite_coverage.sh',
+        ),
+      ).absolute.path;
+      workflow = File(p.join(sandbox.path, 'workflow.yaml'));
+      e2eDirectory = Directory(
+        p.join(sandbox.path, 'integration_test', 'e2e'),
+      )..createSync(recursive: true);
+      manifest = File(p.join(sandbox.path, 'exclusions.txt'));
+      baseManifest = File(p.join(sandbox.path, 'base-exclusions.txt'));
+
+      _writeSuite(e2eDirectory, 'focused_test.dart');
+      _writeSuite(e2eDirectory, 'app_test.dart');
+      _writeSuite(e2eDirectory, 'excluded_test.dart');
+      workflow.writeAsStringSync(
+        '# SERVICE_SUITE_LIST_START\n'
+        'integration_test/e2e/focused_test.dart\n'
+        'integration_test/e2e/app_test.dart\n'
+        '# SERVICE_SUITE_LIST_END\n',
+      );
+      _writeManifest(manifest, const {
+        'excluded_test.dart': 'requires unavailable service',
+      });
+      _writeManifest(baseManifest, const {
+        'excluded_test.dart': 'requires unavailable service',
+      });
+    });
+
+    tearDown(() {
+      if (sandbox.existsSync()) sandbox.deleteSync(recursive: true);
+    });
+
+    ProcessResult runGuard() => Process.runSync(
+      'bash',
+      [scriptPath],
+      environment: {
+        ...Platform.environment,
+        'SERVICE_SUITE_WORKFLOW_FILE': workflow.path,
+        'SERVICE_SUITE_E2E_DIR': e2eDirectory.path,
+        'SERVICE_SUITE_PATH_ROOT': sandbox.path,
+        'SERVICE_SUITE_MANIFEST_FILE': manifest.path,
+        'SERVICE_SUITE_BASE_MANIFEST': baseManifest.path,
+        'SERVICE_SUITE_BASE_REF': 'test-base',
+      },
+    );
+
+    test('accepts suites accounted for exactly once', () {
+      final result = runGuard();
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('2 included, 1 excluded'));
+    });
+
+    test('rejects an unaccounted suite', () {
+      _writeSuite(e2eDirectory, 'new_test.dart');
+
+      final result = runGuard();
+
+      expect(result.exitCode, 1);
+      expect(result.stdout, contains('missing from the workflow'));
+      expect(result.stdout, contains('new_test.dart'));
+    });
+
+    test('rejects a suite included more than once', () {
+      workflow.writeAsStringSync(
+        '# SERVICE_SUITE_LIST_START\n'
+        'integration_test/e2e/focused_test.dart\n'
+        'integration_test/e2e/app_test.dart\n'
+        'integration_test/e2e/focused_test.dart\n'
+        '# SERVICE_SUITE_LIST_END\n',
+      );
+
+      final result = runGuard();
+
+      expect(result.exitCode, 1);
+      expect(result.stdout, contains('duplicate included suites'));
+    });
+
+    test('rejects a workflow without the suite-list markers', () {
+      workflow.writeAsStringSync(
+        'integration_test/e2e/focused_test.dart\n'
+        'integration_test/e2e/app_test.dart\n',
+      );
+
+      final result = runGuard();
+
+      expect(result.exitCode, 1);
+      expect(result.stdout, contains('exactly one service-suite list marker'));
+    });
+
+    test('rejects an exclusion without a reason', () {
+      manifest.writeAsStringSync(
+        'integration_test/e2e/excluded_test.dart |   \n',
+      );
+
+      final result = runGuard();
+
+      expect(result.exitCode, 1);
+      expect(result.stderr, contains('suite path and reason are required'));
+    });
+
+    test('rejects a suite that is both included and excluded', () {
+      workflow.writeAsStringSync(
+        '# SERVICE_SUITE_LIST_START\n'
+        'integration_test/e2e/focused_test.dart\n'
+        'integration_test/e2e/app_test.dart\n'
+        'integration_test/e2e/excluded_test.dart\n'
+        '# SERVICE_SUITE_LIST_END\n',
+      );
+
+      final result = runGuard();
+
+      expect(result.exitCode, 1);
+      expect(result.stdout, contains('both included and excluded'));
+    });
+
+    test('rejects an exclusion for a suite that does not exist', () {
+      _writeManifest(manifest, const {
+        'excluded_test.dart': 'requires unavailable service',
+        'missing_test.dart': 'not actually present',
+      });
+      _writeManifest(baseManifest, const {
+        'excluded_test.dart': 'requires unavailable service',
+        'missing_test.dart': 'not actually present',
+      });
+
+      final result = runGuard();
+
+      expect(result.exitCode, 1);
+      expect(result.stdout, contains('accounted suites that do not exist'));
+    });
+
+    test('rejects growth in exclusion debt', () {
+      _writeSuite(e2eDirectory, 'new_excluded_test.dart');
+      _writeManifest(manifest, const {
+        'excluded_test.dart': 'requires unavailable service',
+        'new_excluded_test.dart': 'new debt',
+      });
+
+      final result = runGuard();
+
+      expect(result.exitCode, 1);
+      expect(result.stdout, contains('exclusion debt grew'));
+      expect(result.stdout, contains('new_excluded_test.dart'));
+    });
+
+    test('allows exclusion debt to shrink', () {
+      workflow.writeAsStringSync(
+        '# SERVICE_SUITE_LIST_START\n'
+        'integration_test/e2e/focused_test.dart\n'
+        'integration_test/e2e/app_test.dart\n'
+        'integration_test/e2e/excluded_test.dart\n'
+        '# SERVICE_SUITE_LIST_END\n',
+      );
+      manifest.writeAsStringSync('# No exclusions remain.\n');
+
+      final result = runGuard();
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+    });
+  });
+}
+
+void _writeSuite(Directory directory, String name) {
+  File(p.join(directory.path, name)).writeAsStringSync('// test fixture\n');
+}
+
+void _writeManifest(File file, Map<String, String> entries) {
+  file.writeAsStringSync(
+    entries.entries
+        .map((entry) => 'integration_test/e2e/${entry.key} | ${entry.value}\n')
+        .join(),
+  );
+}

--- a/mobile/test/tools/service_suite_coverage_test.dart
+++ b/mobile/test/tools/service_suite_coverage_test.dart
@@ -25,20 +25,18 @@ void main() {
         ),
       ).absolute.path;
       workflow = File(p.join(sandbox.path, 'workflow.yaml'));
-      e2eDirectory = Directory(
-        p.join(sandbox.path, 'integration_test', 'e2e'),
-      )..createSync(recursive: true);
+      e2eDirectory = Directory(p.join(sandbox.path, 'integration_test', 'e2e'))
+        ..createSync(recursive: true);
       manifest = File(p.join(sandbox.path, 'exclusions.txt'));
       baseManifest = File(p.join(sandbox.path, 'base-exclusions.txt'));
 
       _writeSuite(e2eDirectory, 'focused_test.dart');
       _writeSuite(e2eDirectory, 'app_test.dart');
       _writeSuite(e2eDirectory, 'excluded_test.dart');
-      workflow.writeAsStringSync(
-        '# SERVICE_SUITE_LIST_START\n'
-        'integration_test/e2e/focused_test.dart\n'
-        'integration_test/e2e/app_test.dart\n'
-        '# SERVICE_SUITE_LIST_END\n',
+      _writeWorkflow(
+        workflow,
+        focused: const ['focused_test.dart'],
+        app: const ['app_test.dart'],
       );
       _writeManifest(manifest, const {
         'excluded_test.dart': 'requires unavailable service',
@@ -84,12 +82,10 @@ void main() {
     });
 
     test('rejects a suite included more than once', () {
-      workflow.writeAsStringSync(
-        '# SERVICE_SUITE_LIST_START\n'
-        'integration_test/e2e/focused_test.dart\n'
-        'integration_test/e2e/app_test.dart\n'
-        'integration_test/e2e/focused_test.dart\n'
-        '# SERVICE_SUITE_LIST_END\n',
+      _writeWorkflow(
+        workflow,
+        focused: const ['focused_test.dart', 'focused_test.dart'],
+        app: const ['app_test.dart'],
       );
 
       final result = runGuard();
@@ -122,12 +118,10 @@ void main() {
     });
 
     test('rejects a suite that is both included and excluded', () {
-      workflow.writeAsStringSync(
-        '# SERVICE_SUITE_LIST_START\n'
-        'integration_test/e2e/focused_test.dart\n'
-        'integration_test/e2e/app_test.dart\n'
-        'integration_test/e2e/excluded_test.dart\n'
-        '# SERVICE_SUITE_LIST_END\n',
+      _writeWorkflow(
+        workflow,
+        focused: const ['focused_test.dart', 'excluded_test.dart'],
+        app: const ['app_test.dart'],
       );
 
       final result = runGuard();
@@ -167,18 +161,189 @@ void main() {
     });
 
     test('allows exclusion debt to shrink', () {
-      workflow.writeAsStringSync(
-        '# SERVICE_SUITE_LIST_START\n'
-        'integration_test/e2e/focused_test.dart\n'
-        'integration_test/e2e/app_test.dart\n'
-        'integration_test/e2e/excluded_test.dart\n'
-        '# SERVICE_SUITE_LIST_END\n',
+      _writeWorkflow(
+        workflow,
+        focused: const ['focused_test.dart', 'excluded_test.dart'],
+        app: const ['app_test.dart'],
       );
       manifest.writeAsStringSync('# No exclusions remain.\n');
 
       final result = runGuard();
 
       expect(result.exitCode, 0, reason: result.stderr.toString());
+    });
+
+    test('does not count a commented-out suite as included', () {
+      _writeSuite(e2eDirectory, 'commented_test.dart');
+      workflow.writeAsStringSync(
+        '# SERVICE_SUITE_LIST_START\n'
+        'focused_suites=(\n'
+        '  integration_test/e2e/focused_test.dart\n'
+        '  # FLAKY: integration_test/e2e/commented_test.dart\n'
+        ')\n'
+        'app_suites=(\n'
+        '  integration_test/e2e/app_test.dart\n'
+        ')\n'
+        '# SERVICE_SUITE_LIST_END\n',
+      );
+
+      final result = runGuard();
+
+      expect(result.exitCode, 1);
+      expect(result.stdout, contains('missing from the workflow'));
+      expect(result.stdout, contains('commented_test.dart'));
+    });
+
+    test('rejects suite paths outside the declared arrays', () {
+      workflow.writeAsStringSync(
+        '# SERVICE_SUITE_LIST_START\n'
+        'focused_suites=(\n'
+        '  integration_test/e2e/focused_test.dart\n'
+        ')\n'
+        'integration_test/e2e/app_test.dart\n'
+        '# SERVICE_SUITE_LIST_END\n',
+      );
+
+      final result = runGuard();
+
+      expect(result.exitCode, 1);
+      expect(result.stderr, contains('Unexpected line'));
+    });
+  });
+
+  group('check_service_suite_coverage.sh base-ref handling', () {
+    late Directory repo;
+    late Directory e2eDirectory;
+    late File workflow;
+    late File manifest;
+    late String scriptPath;
+    late String defaultPath;
+
+    ProcessResult git(List<String> arguments) =>
+        Process.runSync('git', arguments, workingDirectory: repo.path);
+
+    void commitBase() {
+      expect(git(['add', '-A']).exitCode, 0);
+      final result = git([
+        '-c',
+        'user.name=Service Suite Test',
+        '-c',
+        'user.email=service-suite-test@example.invalid',
+        'commit',
+        '-q',
+        '-m',
+        'base',
+      ]);
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(git(['branch', '-f', 'base', 'HEAD']).exitCode, 0);
+    }
+
+    ProcessResult runGuard({
+      String baseRef = 'base',
+      bool allowNoBase = false,
+      bool makeBaseBlobUnreadable = false,
+    }) => Process.runSync(
+      'bash',
+      [scriptPath],
+      environment: {
+        ...Platform.environment,
+        'PATH': makeBaseBlobUnreadable
+            ? '${p.join(repo.path, 'fake-bin')}:$defaultPath'
+            : defaultPath,
+        'SERVICE_SUITE_WORKFLOW_FILE': workflow.path,
+        'SERVICE_SUITE_E2E_DIR': e2eDirectory.path,
+        'SERVICE_SUITE_PATH_ROOT': p.join(repo.path, 'mobile'),
+        'SERVICE_SUITE_MANIFEST_FILE': manifest.path,
+        'SERVICE_SUITE_BASE_REF': baseRef,
+        if (allowNoBase) 'SERVICE_SUITE_ALLOW_NO_BASE': '1',
+      },
+    );
+
+    setUp(() {
+      repo = Directory.systemTemp.createTempSync('service_suite_base_ref_');
+      expect(git(['init', '-q']).exitCode, 0);
+      defaultPath = Platform.environment['PATH']!;
+      final scripts = Directory(p.join(repo.path, 'mobile', 'scripts'))
+        ..createSync(recursive: true);
+      final sourceScript = File(
+        p.join(
+          Directory.current.path,
+          'scripts',
+          'check_service_suite_coverage.sh',
+        ),
+      );
+      final copiedScript = File(
+        p.join(scripts.path, sourceScript.uri.pathSegments.last),
+      )..writeAsBytesSync(sourceScript.readAsBytesSync());
+      scriptPath = copiedScript.path;
+      workflow = File(p.join(repo.path, 'workflow.yaml'));
+      e2eDirectory = Directory(
+        p.join(repo.path, 'mobile', 'integration_test', 'e2e'),
+      )..createSync(recursive: true);
+      manifest = File(p.join(e2eDirectory.path, 'moved_exclusions.txt'));
+      _writeSuite(e2eDirectory, 'focused_test.dart');
+      _writeSuite(e2eDirectory, 'app_test.dart');
+      _writeWorkflow(
+        workflow,
+        focused: const ['focused_test.dart'],
+        app: const ['app_test.dart'],
+      );
+      _writeManifest(manifest, const {});
+    });
+
+    tearDown(() {
+      if (repo.existsSync()) repo.deleteSync(recursive: true);
+    });
+
+    test('derives the base manifest path when the manifest moves', () {
+      _writeSuite(e2eDirectory, 'excluded_test.dart');
+      _writeManifest(manifest, const {});
+      commitBase();
+      _writeManifest(manifest, const {'excluded_test.dart': 'new debt'});
+
+      final result = runGuard();
+
+      expect(result.exitCode, 1);
+      expect(result.stdout, contains('exclusion debt grew'));
+      expect(result.stdout, contains('excluded_test.dart'));
+    });
+
+    test('fails closed when the base ref cannot be resolved', () {
+      final result = runGuard(baseRef: 'missing-base');
+
+      expect(result.exitCode, 1);
+      expect(result.stdout, contains('cannot resolve base ref missing-base'));
+      expect(result.stdout, contains('failing closed'));
+    });
+
+    test('fails closed when the base manifest blob cannot be read', () {
+      commitBase();
+      final realGit = Process.runSync('which', [
+        'git',
+      ]).stdout.toString().trim();
+      final fakeGit = File(p.join(repo.path, 'fake-bin', 'git'))
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync(
+          '#!/usr/bin/env bash\n'
+          'if [[ "\$*" == *" show "* ]]; then exit 1; fi\n'
+          'exec "$realGit" "\$@"\n',
+        );
+      expect(Process.runSync('chmod', ['+x', fakeGit.path]).exitCode, 0);
+
+      final result = runGuard(makeBaseBlobUnreadable: true);
+
+      expect(result.exitCode, 1);
+      expect(result.stdout, contains('not be read'));
+      expect(result.stdout, contains('failing closed'));
+    });
+
+    test('allows an explicit local opt-out when the base is unavailable', () {
+      final result = runGuard(baseRef: 'missing-base', allowNoBase: true);
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('local opt-out'));
+      expect(result.stdout, contains('no-growth comparison skipped'));
+      expect(result.stdout, isNot(contains('exclusion debt did not grow')));
     });
   });
 }
@@ -192,5 +357,22 @@ void _writeManifest(File file, Map<String, String> entries) {
     entries.entries
         .map((entry) => 'integration_test/e2e/${entry.key} | ${entry.value}\n')
         .join(),
+  );
+}
+
+void _writeWorkflow(
+  File file, {
+  required List<String> focused,
+  required List<String> app,
+}) {
+  file.writeAsStringSync(
+    '# SERVICE_SUITE_LIST_START\n'
+    'focused_suites=(\n'
+    '${focused.map((name) => '  integration_test/e2e/$name').join('\n')}\n'
+    ')\n'
+    'app_suites=(\n'
+    '${app.map((name) => '  integration_test/e2e/$name').join('\n')}\n'
+    ')\n'
+    '# SERVICE_SUITE_LIST_END\n',
   );
 }

--- a/mobile/test/tools/service_suite_coverage_test.dart
+++ b/mobile/test/tools/service_suite_coverage_test.dart
@@ -81,6 +81,18 @@ void main() {
       expect(result.stdout, contains('new_test.dart'));
     });
 
+    test('rejects an unaccounted suite in a nested directory', () {
+      final nestedDirectory = Directory(p.join(e2eDirectory.path, 'dm'))
+        ..createSync();
+      _writeSuite(nestedDirectory, 'nested_test.dart');
+
+      final result = runGuard();
+
+      expect(result.exitCode, 1);
+      expect(result.stdout, contains('missing from the workflow'));
+      expect(result.stdout, contains('dm/nested_test.dart'));
+    });
+
     test('rejects a suite included more than once', () {
       _writeWorkflow(
         workflow,


### PR DESCRIPTION
## Problem

The headless service integration workflow watched only four packages and one app file even though its 13 executed suites depend on substantially more production code. Ordinary app and package changes could therefore merge without exercising service behavior they affect. The workflow also had no guard ensuring that every E2E service suite was either executed or deliberately excluded.

## Why this fix

The executed suites have two dependency shapes:

- Eleven focused suites depend on a maintainable closure of ten packages and five app files.
- Two widget-level suites import the provider/router graph, which reaches nearly all `mobile/lib/**` and `mobile/packages/**` production code.

This replaces the workflow-level path filter with a tested, fall-open scope detector. One prepared test job conditionally runs the focused 11-suite group, the app-connected 2-suite group, or both, so overlapping changes pay checkout and Linux setup cost once. A 60-PR sample found the focused and app scopes on 37% and 77% of changes respectively; the existing all-suite path takes about 14 minutes.

The same PR adds a reasoned exclusion manifest and a Generated Files guard. The guard accounts for every `integration_test/e2e/*_test.dart` file exactly once, rejects missing or duplicate entries, and prevents exclusion debt from growing relative to `origin/main`.

## Consolidation

This is the canonical resolution of the overlap with #8763. Its compatible hardening is included here: locale-independent comparisons, recursive nested-suite discovery, regression coverage for nested unaccounted suites, and corrected E2E guidance. Its unconditional-loop assertions were not copied because this PR intentionally selects separate focused and app-connected suite groups.

## Deliberately unchanged

- The 13 currently executed suites and five runner-incompatible suites are unchanged.
- Each suite still runs in its own `flutter test -d linux` invocation.
- The workflow remains advisory and is not added to the merge queue.
- Docker/local-stack and Patrol runner limitations are unchanged.

## Verification

- `flutter analyze`
- `flutter test test/tools/detect_service_suite_scope_test.dart test/tools/service_suite_coverage_test.dart`
- `bash mobile/scripts/check_service_suite_coverage.sh`
- `bash mobile/scripts/check_ungrouped_tests.sh`
- `bash mobile/scripts/check_placeholder_tests.sh`
- `shellcheck mobile/scripts/ci/detect_service_suite_scope.sh mobile/scripts/check_service_suite_coverage.sh`
- `actionlint .github/workflows/mobile_service_integration_tests.yaml .github/workflows/mobile_ci.yaml`
- Repository pre-push checks
- All GitHub checks, including the service integration suite

Closes #8755.
Closes #8756.
Relates to #4239; this completes its remaining pull-request trigger requirement without changing its Patrol or full-stack scope.
