### PR TITLE
fix(dm): stop group messages addressed only to yourself, and hide the ones already sent

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -6171,6 +6171,9 @@ class DmRepository {
   /// a 64-character hex string, if [content] is empty, or if
   /// [recipientPubkeys] is empty.
   ///
+  /// Returns failure results, publishing nothing, when every recipient is the
+  /// sender. One result is returned for each supplied recipient.
+  ///
   /// When an [OutgoingDmsDao] is injected, each per-recipient send
   /// goes through the durable queue with the same atomicity contract
   /// as [sendMessage]: enqueue a `pending`/`pending` row keyed by a
@@ -7634,8 +7637,9 @@ class DmRepository {
     ).map(
       (conversations) => conversations
           .where(
-            (conversation) => conversation.participantPubkeys.any(
-              (pubkey) => !pubkeysEqual(pubkey, owner),
+            (conversation) => !_containsOnlyPubkey(
+              conversation.participantPubkeys,
+              owner,
             ),
           )
           .toList(),
@@ -8407,32 +8411,38 @@ class DmRepository {
   // Helpers
   // -------------------------------------------------------------------------
 
-  /// Removes phantom self-conversations created by the self-wrap bug where
-  /// `_resolveConversationParticipants` produced `[self, self]`.
+  /// Removes phantom self-conversations created by legacy self-wrap bugs or
+  /// malformed participant lists.
   ///
   /// Idempotent — safe to call on every init.
   Future<void> _cleanupSelfConversations() async {
     try {
-      final selfConvId = computeConversationId([_userPubkey, _userPubkey]);
-      final existing = await _conversationsDao.getConversation(
-        selfConvId,
+      final rows = await _conversationsDao.getAllConversations(
         ownerPubkey: _ownerPubkey,
       );
-      if (existing == null) return;
+      final selfConversations = rows.where(
+        (row) => _containsOnlyPubkey(
+          _conversationFromRow(row).participantPubkeys,
+          _userPubkey,
+        ),
+      );
+      if (selfConversations.isEmpty) return;
 
       await _conversationsDao.runInTransaction(() async {
-        await _directMessagesDao.deleteConversationMessages(
-          selfConvId,
-          ownerPubkey: _ownerPubkey,
-        );
-        await _conversationsDao.deleteConversation(
-          selfConvId,
-          ownerPubkey: _ownerPubkey,
-        );
+        for (final conversation in selfConversations) {
+          await _directMessagesDao.deleteConversationMessages(
+            conversation.id,
+            ownerPubkey: _ownerPubkey,
+          );
+          await _conversationsDao.deleteConversation(
+            conversation.id,
+            ownerPubkey: _ownerPubkey,
+          );
+        }
       });
 
       Log.info(
-        'Cleaned up phantom self-conversation',
+        'Cleaned up ${selfConversations.length} phantom self-conversation(s)',
         category: LogCategory.system,
       );
     } on Object catch (e, stackTrace) {
@@ -8444,6 +8454,15 @@ class DmRepository {
       );
     }
   }
+
+  static bool _containsOnlyPubkey(
+    Iterable<String> participantPubkeys,
+    String pubkey,
+  ) =>
+      participantPubkeys.isNotEmpty &&
+      participantPubkeys.every(
+        (participantPubkey) => pubkeysEqual(participantPubkey, pubkey),
+      );
 
   /// Runs post-auth cleanup and migration tasks sequentially so each step
   /// operates on the final state of the previous one.

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -6208,6 +6208,31 @@ class DmRepository {
       throw ArgumentError.value(content, 'content', 'must not be empty');
     }
 
+    // Divine does not support a self-addressed conversation (#8351, decided on
+    // #8261). [sendMessage] and the file path already refuse one; this path did
+    // not, so a group whose only recipient was the sender still published a
+    // wrap the app cannot read back — the receive path drops a participant list
+    // that collapses to one pubkey (#2824) — and that nobody can delete, since
+    // funnelcake matches a kind-5 against the wrap's throwaway ephemeral author
+    // rather than the real sender (#8699).
+    //
+    // Returned rather than thrown, and one result per recipient, matching the
+    // send gate below: callers branch on `success` per recipient.
+    //
+    // Only the self-ONLY case is refused. Whether a group send keeps its sender
+    // in the recipient list is an open product decision (#8359), so a group
+    // that also carries real recipients is left exactly as it was. Note
+    // `recipientPubkeys` is non-empty by the guard above, so `every` cannot be
+    // vacuously true here.
+    if (recipientPubkeys.every(_isSelf)) {
+      return [
+        for (final _ in recipientPubkeys)
+          const NIP17SendResult.failure(
+            'refused: a message cannot be addressed to its own sender',
+          ),
+      ];
+    }
+
     // Send gate (#176) — group all-or-nothing: a restricted sender (protected
     // minor) may only message a group where EVERY recipient is approved.
     // Per-recipient gating in sendRumor alone would still deliver to the

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -7620,12 +7620,10 @@ class DmRepository {
   /// Report, Block and Mute all addressing the viewer's own account.
   ///
   /// [classifyPotentialRequests] already drops the same shape, but it only
-  /// ever sees conversations the user has NOT sent to. A row the user HAS
-  /// sent to arrives here instead, which is exactly what a group send
-  /// addressed only to the sender produced before #8699 refused it. Refusing
-  /// the send stops new ones; this stops the ones already on disk from
-  /// rendering. Filtered here rather than in each consumer so the Messages
-  /// list and the unread badge cannot disagree about what exists (#4976).
+  /// ever sees conversations the user has NOT sent to. Legacy self-wrap bugs
+  /// and malformed data can leave an already-sent row on this stream instead.
+  /// Startup maintenance removes known rows; this filter remains as defense in
+  /// depth so the Messages list and unread badge cannot disagree (#4976).
   Stream<List<DmConversation>> watchAcceptedConversations({int? limit}) {
     final owner = _ownerPubkey;
     if (owner == null) return Stream.value(const <DmConversation>[]);

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -7609,6 +7609,20 @@ class DmRepository {
   ///
   /// Supports pagination via [limit]. These conversations are never
   /// message requests.
+  ///
+  /// A conversation whose participants collapse to the viewer alone is
+  /// omitted. Divine does not support a conversation with only yourself
+  /// (#8261), and the row is unusable: every caller resolves the counterparty
+  /// by dropping the viewer, so it renders as a chat with yourself, with
+  /// Report, Block and Mute all addressing the viewer's own account.
+  ///
+  /// [classifyPotentialRequests] already drops the same shape, but it only
+  /// ever sees conversations the user has NOT sent to. A row the user HAS
+  /// sent to arrives here instead, which is exactly what a group send
+  /// addressed only to the sender produced before #8699 refused it. Refusing
+  /// the send stops new ones; this stops the ones already on disk from
+  /// rendering. Filtered here rather than in each consumer so the Messages
+  /// list and the unread badge cannot disagree about what exists (#4976).
   Stream<List<DmConversation>> watchAcceptedConversations({int? limit}) {
     final owner = _ownerPubkey;
     if (owner == null) return Stream.value(const <DmConversation>[]);
@@ -7617,6 +7631,14 @@ class DmRepository {
         limit: limit,
         ownerPubkey: owner,
       ),
+    ).map(
+      (conversations) => conversations
+          .where(
+            (conversation) => conversation.participantPubkeys.any(
+              (pubkey) => !pubkeysEqual(pubkey, owner),
+            ),
+          )
+          .toList(),
     );
   }
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -7635,10 +7635,8 @@ class DmRepository {
     ).map(
       (conversations) => conversations
           .where(
-            (conversation) => !_containsOnlyPubkey(
-              conversation.participantPubkeys,
-              owner,
-            ),
+            (conversation) =>
+                _hasCounterparty(conversation.participantPubkeys, owner),
           )
           .toList(),
     );
@@ -8453,6 +8451,13 @@ class DmRepository {
     }
   }
 
+  /// Whether [participantPubkeys] is exactly [pubkey], repeated or not.
+  ///
+  /// Requires at least one entry: an empty list is a shape this cannot
+  /// identify, and [_cleanupSelfConversations] deletes what this matches, so
+  /// it must not match a row whose participants failed to parse. The display
+  /// side asks [_hasCounterparty] instead, which is not destructive and can
+  /// hide the empty shape safely.
   static bool _containsOnlyPubkey(
     Iterable<String> participantPubkeys,
     String pubkey,
@@ -8461,6 +8466,20 @@ class DmRepository {
       participantPubkeys.every(
         (participantPubkey) => pubkeysEqual(participantPubkey, pubkey),
       );
+
+  /// Whether the conversation has someone in it other than [viewer].
+  ///
+  /// False for a self-only list AND for an empty one. The empty case is the
+  /// reason this is not `!_containsOnlyPubkey(...)`: a row with no
+  /// participants does not merely render as a chat with yourself, it throws —
+  /// every caller resolves the counterparty through `dmConversationFirstPeer`,
+  /// which falls back to `participantPubkeys.first`.
+  static bool _hasCounterparty(
+    Iterable<String> participantPubkeys,
+    String viewer,
+  ) => participantPubkeys.any(
+    (participantPubkey) => !pubkeysEqual(participantPubkey, viewer),
+  );
 
   /// Runs post-auth cleanup and migration tasks sequentially so each step
   /// operates on the final state of the previous one.

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -19824,40 +19824,67 @@ void main() {
 
     group('_cleanupSelfConversations', () {
       test(
-        'deletes self-conversation when it exists',
+        'deletes every self-only participant shape case-insensitively',
         () async {
-          final selfConvId = DmRepository.computeConversationId(
+          final participantLists = [
+            [_validPubkeyA],
             [_validPubkeyA, _validPubkeyA],
+            [
+              _validPubkeyA,
+              _validPubkeyA.toUpperCase(),
+              _validPubkeyA,
+            ],
+          ];
+          final selfConversationIds = [
+            for (final participants in participantLists)
+              DmRepository.computeConversationId(participants),
+          ];
+          final peerParticipants = [_validPubkeyA, _validPubkeyB]..sort();
+          final peerConversationId = DmRepository.computeConversationId(
+            peerParticipants,
           );
+          var conversationReads = 0;
 
-          // Stub: self-conversation exists
           when(
-            () => mockConversationsDao.getConversation(
-              selfConvId,
+            () => mockConversationsDao.getAllConversations(
               ownerPubkey: any(named: 'ownerPubkey'),
             ),
           ).thenAnswer(
-            (_) async => ConversationRow(
-              ownerPubkey: '',
-              id: selfConvId,
-              participantPubkeys: jsonEncode([_validPubkeyA, _validPubkeyA]),
-              isGroup: false,
-              isRead: true,
-              currentUserHasSent: false,
-              createdAt: 1700000000,
-            ),
+            (_) async => conversationReads++ == 0
+                ? [
+                    for (var i = 0; i < participantLists.length; i++)
+                      ConversationRow(
+                        ownerPubkey: '',
+                        id: selfConversationIds[i],
+                        participantPubkeys: jsonEncode(participantLists[i]),
+                        isGroup: false,
+                        isRead: true,
+                        currentUserHasSent: false,
+                        createdAt: 1700000000,
+                      ),
+                    ConversationRow(
+                      ownerPubkey: '',
+                      id: peerConversationId,
+                      participantPubkeys: jsonEncode(peerParticipants),
+                      isGroup: false,
+                      isRead: true,
+                      currentUserHasSent: false,
+                      createdAt: 1700000000,
+                    ),
+                  ]
+                : [],
           );
 
           when(
             () => mockDirectMessagesDao.deleteConversationMessages(
-              selfConvId,
+              any(),
               ownerPubkey: any(named: 'ownerPubkey'),
             ),
           ).thenAnswer((_) async => 0);
 
           when(
             () => mockConversationsDao.deleteConversation(
-              selfConvId,
+              any(),
               ownerPubkey: any(named: 'ownerPubkey'),
             ),
           ).thenAnswer((_) async => 1);
@@ -19866,70 +19893,71 @@ void main() {
             () => mockNostrClient.unsubscribe(any()),
           ).thenAnswer((_) async {});
 
-          // Create repo then setCredentials to trigger post-auth
-          // maintenance including _cleanupSelfConversations.
-          DmRepository(
-            nostrClient: mockNostrClient,
-            directMessagesDao: mockDirectMessagesDao,
-            conversationsDao: mockConversationsDao,
-          ).setCredentials(
-            userPubkey: _validPubkeyA,
-            signer: LocalNostrSigner(_validPrivateKey),
-            messageService: mockMessageService,
-          );
+          final repository =
+              DmRepository(
+                nostrClient: mockNostrClient,
+                directMessagesDao: mockDirectMessagesDao,
+                conversationsDao: mockConversationsDao,
+              )..setCredentials(
+                userPubkey: _validPubkeyA,
+                signer: LocalNostrSigner(_validPrivateKey),
+                messageService: mockMessageService,
+              );
 
-          // Give post-auth maintenance time to complete.
-          await Future<void>.delayed(const Duration(milliseconds: 50));
+          await repository.getConversations();
 
-          verify(
-            () => mockDirectMessagesDao.deleteConversationMessages(
-              selfConvId,
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          ).called(1);
-
-          verify(
+          for (final conversationId in selfConversationIds) {
+            verify(
+              () => mockDirectMessagesDao.deleteConversationMessages(
+                conversationId,
+                ownerPubkey: _validPubkeyA,
+              ),
+            ).called(1);
+            verify(
+              () => mockConversationsDao.deleteConversation(
+                conversationId,
+                ownerPubkey: _validPubkeyA,
+              ),
+            ).called(1);
+          }
+          verifyNever(
             () => mockConversationsDao.deleteConversation(
-              selfConvId,
+              peerConversationId,
               ownerPubkey: any(named: 'ownerPubkey'),
             ),
-          ).called(1);
+          );
         },
       );
 
       test(
         'no-op when self-conversation does not exist',
         () async {
-          final selfConvId = DmRepository.computeConversationId(
-            [_validPubkeyA, _validPubkeyA],
-          );
-
           when(
-            () => mockConversationsDao.getConversation(
-              selfConvId,
+            () => mockConversationsDao.getAllConversations(
               ownerPubkey: any(named: 'ownerPubkey'),
             ),
-          ).thenAnswer((_) async => null);
+          ).thenAnswer((_) async => []);
 
           when(
             () => mockNostrClient.unsubscribe(any()),
           ).thenAnswer((_) async {});
 
-          DmRepository(
-            nostrClient: mockNostrClient,
-            directMessagesDao: mockDirectMessagesDao,
-            conversationsDao: mockConversationsDao,
-          ).setCredentials(
-            userPubkey: _validPubkeyA,
-            signer: LocalNostrSigner(_validPrivateKey),
-            messageService: mockMessageService,
-          );
+          final repository =
+              DmRepository(
+                nostrClient: mockNostrClient,
+                directMessagesDao: mockDirectMessagesDao,
+                conversationsDao: mockConversationsDao,
+              )..setCredentials(
+                userPubkey: _validPubkeyA,
+                signer: LocalNostrSigner(_validPrivateKey),
+                messageService: mockMessageService,
+              );
 
-          await Future<void>.delayed(const Duration(milliseconds: 50));
+          await repository.getConversations();
 
           verifyNever(
             () => mockDirectMessagesDao.deleteConversationMessages(
-              selfConvId,
+              any(),
               ownerPubkey: any(named: 'ownerPubkey'),
             ),
           );

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -17360,6 +17360,89 @@ void main() {
         expect(conversations.first.currentUserHasSent, isTrue);
       });
 
+      // A conversation that contains only the viewer is unusable: every caller
+      // resolves the counterparty by dropping the viewer, so the row renders
+      // as a chat with yourself. #8694 hid these from the request-derived
+      // lists, but an ALREADY-SENT one arrives on this stream instead and was
+      // still shown. A group send addressed only to the sender is what created
+      // them (#8699) — refusing that send stops new ones, and this stops the
+      // ones already on disk from rendering.
+      test('omits a conversation that contains only the viewer', () async {
+        final peerParticipants = [_validPubkeyA, _validPubkeyB]..sort();
+        final peerId = DmRepository.computeConversationId(peerParticipants);
+        final selfId = DmRepository.computeConversationId([
+          _validPubkeyA,
+          _validPubkeyA,
+        ]);
+
+        when(
+          () => mockConversationsDao.watchAcceptedConversations(
+            limit: any(named: 'limit'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer(
+          (_) => Stream.value([
+            ConversationRow(
+              ownerPubkey: '',
+              id: selfId,
+              participantPubkeys: jsonEncode([_validPubkeyA, _validPubkeyA]),
+              isGroup: false,
+              isRead: true,
+              currentUserHasSent: true,
+              createdAt: 1700000000,
+            ),
+            ConversationRow(
+              ownerPubkey: '',
+              id: peerId,
+              participantPubkeys: jsonEncode(peerParticipants),
+              isGroup: false,
+              isRead: true,
+              currentUserHasSent: true,
+              createdAt: 1700000000,
+            ),
+          ]),
+        );
+
+        final repository = createRepository();
+        final conversations = await repository
+            .watchAcceptedConversations()
+            .first;
+
+        expect(conversations, hasLength(1));
+        expect(conversations.single.id, equals(peerId));
+      });
+
+      // Same row shape, viewer stored under a different casing.
+      test('omits a self-only conversation whatever the casing', () async {
+        final selfId = DmRepository.computeConversationId([_validPubkeyA]);
+
+        when(
+          () => mockConversationsDao.watchAcceptedConversations(
+            limit: any(named: 'limit'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer(
+          (_) => Stream.value([
+            ConversationRow(
+              ownerPubkey: '',
+              id: selfId,
+              participantPubkeys: jsonEncode([_validPubkeyA.toUpperCase()]),
+              isGroup: false,
+              isRead: true,
+              currentUserHasSent: true,
+              createdAt: 1700000000,
+            ),
+          ]),
+        );
+
+        final repository = createRepository();
+        final conversations = await repository
+            .watchAcceptedConversations()
+            .first;
+
+        expect(conversations, isEmpty);
+      });
+
       test(
         'uses the conversation row preview as the source of truth',
         () async {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -1849,6 +1849,71 @@ void main() {
         );
       });
 
+      // The one-to-one and file send paths refuse a self-addressed message
+      // (#8351, decided on #8261); the group path did not, so a group whose
+      // only recipient is the sender still published (#8699).
+      test('refuses a group addressed only to the sender (#8699)', () async {
+        final repository = createRepository(); // viewer is _validPubkeyA
+
+        final results = await repository.sendGroupMessage(
+          recipientPubkeys: [_validPubkeyA],
+          content: 'note to self',
+        );
+
+        expect(results, hasLength(1));
+        expect(results.every((r) => !r.success), isTrue);
+        expect(results.first.error, contains('refused'));
+        verifyNever(
+          () => mockMessageService.sendRumor(
+            rumorEvent: any(named: 'rumorEvent'),
+            recipientPubkey: any(named: 'recipientPubkey'),
+            targetRelays: any(named: 'targetRelays'),
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
+            selfWrapOnSoftUnconfirmed: any(named: 'selfWrapOnSoftUnconfirmed'),
+          ),
+        );
+      });
+
+      // Matches on the sender's own key regardless of casing, like [_isSelf].
+      test('refuses a self-only group whatever the pubkey casing', () async {
+        final repository = createRepository();
+
+        final results = await repository.sendGroupMessage(
+          recipientPubkeys: [_validPubkeyA.toUpperCase()],
+          content: 'note to self',
+        );
+
+        expect(results.every((r) => !r.success), isTrue);
+        expect(results.first.error, contains('refused'));
+      });
+
+      // A group containing the sender AND real recipients is deliberately NOT
+      // refused: whether a group send keeps its sender in the recipient list is
+      // an open product decision (#8359). Only the self-ONLY case is settled,
+      // so this pins the boundary rather than letting the guard widen silently.
+      test('does not refuse a group that also has a real recipient', () async {
+        // The sender passes the gate, the real recipient does not, so the send
+        // stops at the #176 gate rather than the self-only refusal. Stopping
+        // there is the proof: the guard under test would have returned before
+        // any gate call at all.
+        when(
+          () => mockMessageService.canSendTo(_validPubkeyA),
+        ).thenAnswer((_) async => true);
+        when(
+          () => mockMessageService.canSendTo(_validPubkeyB),
+        ).thenAnswer((_) async => false);
+
+        final repository = createRepository();
+
+        final results = await repository.sendGroupMessage(
+          recipientPubkeys: [_validPubkeyA, _validPubkeyB],
+          content: 'group including me',
+        );
+
+        expect(results.first.error, contains('blocked'));
+        verify(() => mockMessageService.canSendTo(_validPubkeyB)).called(1);
+      });
+
       test(
         'all-or-nothing: any non-approved participant blocks the whole '
         'group send (#176)',

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -17363,10 +17363,9 @@ void main() {
       // A conversation that contains only the viewer is unusable: every caller
       // resolves the counterparty by dropping the viewer, so the row renders
       // as a chat with yourself. #8694 hid these from the request-derived
-      // lists, but an ALREADY-SENT one arrives on this stream instead and was
-      // still shown. A group send addressed only to the sender is what created
-      // them (#8699) — refusing that send stops new ones, and this stops the
-      // ones already on disk from rendering.
+      // lists, but an ALREADY-SENT legacy or malformed row arrives on this
+      // stream instead. Startup maintenance removes known rows; this remains
+      // as defense in depth for rows that reach the stream later.
       test('omits a conversation that contains only the viewer', () async {
         final peerParticipants = [_validPubkeyA, _validPubkeyB]..sort();
         final peerId = DmRepository.computeConversationId(peerParticipants);

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -17411,6 +17411,39 @@ void main() {
         expect(conversations.single.id, equals(peerId));
       });
 
+      // A row with no participants at all is not merely unusable, it
+      // crashes: every caller resolves the counterparty through
+      // `dmConversationFirstPeer`, which falls back to
+      // `participantPubkeys.first` and throws `StateError` on an empty
+      // list. It must not reach the list either.
+      test('omits a conversation with no participants at all', () async {
+        when(
+          () => mockConversationsDao.watchAcceptedConversations(
+            limit: any(named: 'limit'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer(
+          (_) => Stream.value([
+            ConversationRow(
+              ownerPubkey: '',
+              id: 'empty-participants',
+              participantPubkeys: jsonEncode(const <String>[]),
+              isGroup: false,
+              isRead: true,
+              currentUserHasSent: true,
+              createdAt: 1700000000,
+            ),
+          ]),
+        );
+
+        final repository = createRepository();
+        final conversations = await repository
+            .watchAcceptedConversations()
+            .first;
+
+        expect(conversations, isEmpty);
+      });
+
       // Same row shape, viewer stored under a different casing.
       test('omits a self-only conversation whatever the casing', () async {
         final selfId = DmRepository.computeConversationId([_validPubkeyA]);


### PR DESCRIPTION
## The problem

Divine does not support conversations addressed only to yourself. One-to-one text and file messages already refused those sends, but the group-send repository entry point did not have the same defensive check. Although the current recipient picker excludes the viewer and normal conversation routing strips the viewer from recipient lists, another caller or malformed state could still invoke that repository method with only the sender.

Older and malformed local data can also contain conversations whose participant list contains only the viewer. The canonical duplicated-self row came from an earlier self-wrap participant bug, while other legacy shapes can contain one or several copies of the same key with different casing. Those conversations have no counterparty and should neither appear in Messages nor remain stored locally.

## Why this fix

The group send now refuses the self-only case at the repository boundary before building, queuing, or publishing anything. It returns one documented failure result per supplied recipient, matching the method's existing per-recipient contract.

Startup maintenance now scans the viewer's conversations and atomically removes every non-empty participant list that collapses case-insensitively to the viewer, including the messages beneath those rows. The accepted-conversation stream keeps its repository-level filter as defense in depth so the Messages list and unread badge cannot briefly disagree if malformed data appears after startup.

The same private predicate identifies self-only participant lists in both maintenance and the accepted-stream filter.

## What this deliberately leaves alone

- A group containing the sender and at least one real recipient is unchanged. Whether group sends should retain or remove the sender remains the separate product decision in #8359.
- No UI behavior or routing changes. Current UI paths already prevent selecting yourself; the send guard protects the repository boundary and future callers.
- The existing potential-request classification remains defensive for malformed rows that reach that path.

## How this was verified

- `flutter test packages/dm_repository/test/src/dm_repository_test.dart` — 495 tests passed.
- `flutter analyze` — no issues.
- Cleanup coverage includes one self participant, duplicated self participants, repeated mixed-case self participants, and a real peer conversation that must remain untouched.
- The send tests cover exact-case self, mixed-case self, and a mixed group with a real recipient.
- The branch was rebased onto fresh `origin/main` before publishing.

Closes #8699
