### PR TITLE
fix(tooling): stop the prune report recommending a worktree that is still in use

### DIFF
--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -61,7 +61,7 @@ report-only classifier for likely stale local branches and worktrees. It
 does not delete anything; prune the reported rows manually after reviewing
 the output.
 
-Do **not** improvise the classification. Three things that look like they
+Do **not** improvise the classification. Four things that look like they
 work do not:
 
 - `git branch --merged main` reports 5 of 1185 branches here. This repo
@@ -73,16 +73,26 @@ work do not:
 - Matching branch names against an issue number deletes live work.
   `fix/7606-semantic-tokens` was destroyed exactly this way: unpushed
   local work on a parallel attempt at the same task.
+- `git merge-base --is-ancestor` cannot tell you a tip is already on
+  `main`. This checkout is **shallow**, and a shallow clone's ancestry
+  walk stops at the graft boundary, so it answers "not an ancestor" for a
+  commit that is one — exit 1, silently, with the ref still resolving and
+  no error to catch. A worktree you are still working in reads as
+  prunable.
 
-The useful signals are GitHub reporting a same-repo merged PR to `main` with
-that head ref, or a worktree tip that belongs to a merged PR but is not already
-an ancestor of `main`. The latter identifies review worktrees whose scratch
-branch name never matched the reviewed PR while excluding fresh worktrees
-created at `origin/main`. Two vetoes apply on top: the local branch tip must
-exist in GitHub's repository object database, and the worktree must have no
-uncommitted, untracked, or non-regenerable ignored files. Ignored toolchain
-output such as `build/`, `.dart_tool/`, and generated plugin registrants does
-not veto because tracked inputs can recreate it. This keeps branch-name reuse,
+The useful signals are GitHub reporting a same-repo merged PR to `main`
+with that head ref, or a worktree tip that belongs to a merged PR and is
+not already contained in `main`. The second identifies review worktrees
+whose scratch branch name never matched the reviewed PR, while excluding
+worktrees that hold no commits of their own. **Containment is asked of
+GitHub, for the reason above** — nothing in the classifier walks local
+history.
+
+Two vetoes apply on top: the local branch tip must exist in GitHub's
+repository object database, and the worktree must have no uncommitted,
+untracked, or non-regenerable ignored files. Ignored toolchain output such
+as `build/`, `.dart_tool/`, and generated plugin registrants does not veto
+because tracked inputs can recreate it. This keeps branch-name reuse,
 unpushed commits, and local-only worktree files out of the prunable set.
 
 ### Optional: warn on concurrent sessions in one worktree

--- a/mobile/scripts/ci/detect_mobile_ci_scope.sh
+++ b/mobile/scripts/ci/detect_mobile_ci_scope.sh
@@ -72,6 +72,13 @@ while IFS= read -r path; do
     *.md|docs/*|brand-guidelines/*|mobile/docs/*)
       # Docs-only changes do not need the full app test matrix.
       ;;
+    scripts/*)
+      # Repo-root scripts are covered by tests under mobile/test/tools/, so a
+      # change here must run the matrix that owns those tests. Without this,
+      # a scripts-only PR skips the tests job and the script ships untested:
+      # nothing else covers them, as there is no shellcheck or bash -n job.
+      app=true
+      ;;
     mobile/lib/*|mobile/test/*|mobile/integration_test/*|mobile/scripts/*)
       app=true
       ;;

--- a/mobile/test/tools/detect_mobile_ci_scope_test.dart
+++ b/mobile/test/tools/detect_mobile_ci_scope_test.dart
@@ -163,6 +163,34 @@ esac
           );
         });
 
+        test('runs app CI for a repo-root scripts change', () {
+          // mobile/test/tools/ owns the tests for these scripts, and there is
+          // no shellcheck or bash -n job, so skipping the matrix would ship
+          // them with no coverage at all.
+          expectScope(
+            runDetector(
+              event: event,
+              changedFiles: ['scripts/prune-merged-branches.sh'],
+              changedTotal: 1,
+            ),
+            app: true,
+            native: false,
+          );
+        });
+
+        test('still skips app CI for docs under scripts/', () {
+          // The docs arm is matched first on purpose; pins that ordering.
+          expectScope(
+            runDetector(
+              event: event,
+              changedFiles: ['scripts/lnav/README.md'],
+              changedTotal: 1,
+            ),
+            app: false,
+            native: false,
+          );
+        });
+
         test('runs app and native checks for native configuration', () {
           expectScope(
             runDetector(

--- a/mobile/test/tools/prune_merged_branches_test.dart
+++ b/mobile/test/tools/prune_merged_branches_test.dart
@@ -64,6 +64,7 @@ void main() {
       required List<String> mergedHeadRefs,
       required List<String> githubCommitShas,
       List<String> mergedTipShas = const [],
+      List<String> containedShas = const [],
       List<String> args = const [],
     }) {
       return Process.runSync(
@@ -79,6 +80,7 @@ void main() {
           'FAKE_MERGED_HEAD_REFS': mergedHeadRefs.join('\n'),
           'FAKE_GITHUB_COMMIT_SHAS': githubCommitShas.join('\n'),
           'FAKE_MERGED_TIP_SHAS': mergedTipShas.join('\n'),
+          'FAKE_CONTAINED_SHAS': containedShas.join('\n'),
           'FAKE_GH_ARGS': ghArgs.path,
         },
       );
@@ -109,6 +111,19 @@ printf '%s\n' "$*" >> "${FAKE_GH_ARGS:?}"
 if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
   if [ -n "${FAKE_MERGED_HEAD_REFS:-}" ]; then
     printf '%s\n' "$FAKE_MERGED_HEAD_REFS"
+  fi
+  exit 0
+fi
+
+if [ "$1" = "api" ] && [ "${2:-}" = "graphql" ]; then
+  head=""
+  for arg in "$@"; do
+    case "$arg" in h=*) head="${arg#h=}" ;; esac
+  done
+  if printf '%s\n' "${FAKE_CONTAINED_SHAS:-}" | grep -qxF -- "$head"; then
+    printf 'BEHIND\n'
+  else
+    printf 'DIVERGED\n'
   fi
   exit 0
 fi
@@ -307,10 +322,51 @@ exit 2
         mergedHeadRefs: const [],
         githubCommitShas: [tip],
         mergedTipShas: [tip],
+        containedShas: [tip],
       );
 
       expect(result.exitCode, 0, reason: result.stderr.toString());
       expect(result.stdout, contains('KEEP           fresh-worktree'));
+      expect(result.stdout, contains('0 likely prunable'));
+    });
+
+    test('keeps a worktree already on main when the clone is shallow', () {
+      // The containment question is asked of GitHub rather than answered from
+      // local history, because this repository is cloned shallow. A shallow
+      // clone's ancestry walk stops at the graft boundary and reports "not an
+      // ancestor" for a commit that is one -- silently, exit 1, with the ref
+      // still resolving, so there is no error for the script to notice. That
+      // wrong negative used to score a live worktree MERGED-TIP.
+      write('second.txt', 'advance main\n');
+      commit('advance main');
+      git(['push', 'origin', 'main']);
+
+      final tip = branchTip('main~1');
+      git(['branch', 'stale-worktree', 'main~1']);
+      final worktree = Directory(p.join(sandbox.path, 'stale-worktree'));
+      git(['worktree', 'add', worktree.path, 'stale-worktree']);
+
+      // Severs the local path from the tip back to origin/main without
+      // removing the object, which is what makes the walk answer wrongly.
+      git(['fetch', '--depth=1', 'origin', 'main']);
+      expect(
+        Process.runSync('git', [
+          'rev-parse',
+          '--is-shallow-repository',
+        ], workingDirectory: repo.path).stdout.toString().trim(),
+        'true',
+        reason: 'the fixture must be shallow for this to exercise anything',
+      );
+
+      final result = runScript(
+        mergedHeadRefs: const [],
+        githubCommitShas: [tip],
+        mergedTipShas: [tip],
+        containedShas: [tip],
+      );
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('KEEP           stale-worktree'));
       expect(result.stdout, contains('0 likely prunable'));
     });
 

--- a/scripts/prune-merged-branches.sh
+++ b/scripts/prune-merged-branches.sh
@@ -24,6 +24,10 @@
 #    whose name is the head ref of no PR at all, so the name lookup scores it
 #    KEEP forever. For those, ask GitHub which PRs contain the worktree's tip
 #    COMMIT — an exact SHA, so it needs no name inference. That is MERGED-TIP.
+#    A tip already contained in main is excluded: it belongs to a worktree that
+#    has no commits of its own, not to a squashed-away PR head. Ask GitHub that
+#    too. `git merge-base --is-ancestor` looks like the obvious way to decide
+#    it and is not — see tip_contained_in_base.
 #
 # 5. Vetoing on any ignored file makes the script report nothing, ever. Every
 #    Flutter worktree carries build/, .dart_tool/ and a pile of generated
@@ -58,6 +62,7 @@ done
 
 GH="${GH:-gh}"
 BASE="${BASE:-origin/main}"
+BASE_BRANCH="${BASE##*/}"
 REPO="${REPO:-${GITHUB_REPOSITORY:-divinevideo/divine-mobile}}"
 MERGED_PR_LIMIT="${MERGED_PR_LIMIT:-100000}"
 
@@ -70,8 +75,9 @@ git rev-parse --verify --quiet "$BASE" >/dev/null || {
   echo "$BASE not found" >&2; exit 2
 }
 
-# Shallow is fine for the signals used here: the GitHub lookups need no local
-# history, and the worktree checks inspect only the current checkout state.
+# Shallow is fine for the signals used here, and stays fine only because every
+# merged-ness question below is answered by GitHub: nothing walks local history.
+# See tip_contained_in_base for why that is load-bearing rather than incidental.
 if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
   echo "Note: shallow repository. Classification is unaffected."
 fi
@@ -107,6 +113,26 @@ merged_pr_contains_commit() {
   "$GH" api -X GET "repos/$REPO/commits/$1/pulls" \
     --jq '[.[] | select(.merged_at != null) | select(.base.ref == "main")] | length' \
     2>/dev/null | grep -qxE '[1-9][0-9]*'
+}
+
+# Is this commit already contained in $BASE? GitHub answers, not local git.
+# `git merge-base --is-ancestor` walks local history, and in a shallow clone
+# that walk stops at the graft boundary and reports "not an ancestor" for a
+# commit that is one — exit 1, silently, with no error to catch, since the ref
+# still resolves. A worktree holding no commits of its own would then be scored
+# MERGED-TIP and recommended for deletion. Any unclear answer reports contained,
+# which lands on KEEP.
+tip_contained_in_base() {
+  # shellcheck disable=SC2016  # $o/$n/$r/$h are GraphQL variables, bound by -F
+  case "$("$GH" api graphql -f query='
+    query($o:String!,$n:String!,$r:String!,$h:String!){repository(owner:$o,name:$n){
+      ref(qualifiedName:$r){compare(headRef:$h){status}}}}' \
+    -F o="${REPO%%/*}" -F n="${REPO##*/}" -F r="refs/heads/$BASE_BRANCH" \
+    -F h="$1" --jq '.data.repository.ref.compare.status' 2>/dev/null)" in
+    IDENTICAL|BEHIND) return 0 ;;
+    AHEAD|DIVERGED)   return 1 ;;
+    *)                return 0 ;;
+  esac
 }
 
 # Ignored paths any Flutter toolchain step recreates from tracked sources.
@@ -150,11 +176,13 @@ while IFS= read -r branch; do
   if grep -qxF -- "$branch" "$MERGED_REFS"; then
     verdict="MERGED-PR"
   elif [ -n "$wt" ] && [ -d "$wt" ] \
-    && ! git merge-base --is-ancestor "$tip" "$BASE" \
-    && merged_pr_contains_commit "$tip"; then
+    && merged_pr_contains_commit "$tip" \
+    && ! tip_contained_in_base "$tip"; then
     # Only worktree branches get this lookup: it is one API call per branch,
     # and a branch with no worktree costs a ref, not 4GB of build output. Tips
     # already on main belong to fresh worktrees, not squashed-away PR heads.
+    # The containment check runs second so it costs a call only for the few
+    # branches a merged PR already claims, rather than for every worktree.
     verdict="MERGED-TIP"
   else
     verdict="KEEP"


### PR DESCRIPTION
Closes #8761

## Problem

`scripts/prune-merged-branches.sh` tells you which local branches and worktrees look safe to delete. It can currently recommend a worktree you are still working in.

PR #8682 added a guard so a worktree holding no commits of its own is never recommended, and decided that with `git merge-base --is-ancestor`. That is the script's only use of local git history, three lines below a comment promising there is none.

**This checkout is shallow** — `git rev-parse --is-shallow-repository` is `true`, with 13 commits reachable from `origin/main`. In a shallow clone the ancestry walk stops at the graft boundary and returns exit 1, "not an ancestor", for a commit that genuinely is one. Nothing errors: the ref resolves, the object is present, and exit 1 is indistinguishable from a true negative, so no exit-code handling can catch it. The leading `!` reads that wrong negative as "proceed" and lands the branch on the prunable side — inverting the script's own stated bias, *"A false KEEP costs disk. A false DELETE costs work that exists nowhere else."*

Same repository, same script, same branch, same stubbed `gh`; only the clone depth differs:

| clone | verdict |
| --- | --- |
| full | `KEEP` — `0 likely prunable` |
| shallow | `MERGED-TIP` — `1 likely prunable` |

The shallow run prints `Note: shallow repository. Classification is unaffected.` in the same output where the classification flipped.

**Nothing is mis-ranked today.** All 28 live worktree branches here were checked against GitHub's compare API and the local answer agrees in every case. But the failing shape is the starting state of every worktree — `git worktree add -b x origin/main` leaves a tip with no commits of its own. That is safe only while the tip is still `origin/main`'s exact tip, because `--is-ancestor X X` needs no walk. Once `main` moves past the shallow boundary, an untouched worktree silently becomes eligible for a delete recommendation.

## Why this fix

Ask GitHub for containment instead of walking local history. That restores the property the header comment already claims, and matches the script's own thesis — its opening three numbered points all argue that local git signals are unreliable in a squash-merge repo.

GraphQL `Ref.compare` rather than the REST compare endpoint: REST ships its `files` array, measured at 130–256 KB per call here, against 89 bytes for the GraphQL query. It is ordered after `merged_pr_contains_commit` so the extra call is made only for the few branches a merged PR already claims. Any unclear answer — network failure, rate limit, unexpected status — reports contained, which lands on `KEEP`.

| repo | worktree | want | before | after |
| --- | --- | --- | --- | --- |
| shallow | tip already on `main` | `KEEP` | **`MERGED-TIP`** | `KEEP` |
| shallow | genuine review worktree | `MERGED-TIP` | `MERGED-TIP` | `MERGED-TIP` |
| full | tip already on `main` | `KEEP` | `KEEP` | `KEEP` |
| full | genuine review worktree | `MERGED-TIP` | `MERGED-TIP` | `MERGED-TIP` |

Row two is why the approach was chosen. Disabling `MERGED-TIP` in shallow clones is the tempting one-line fix and is wrong: review-worktree detection works correctly here today, and that would silently revert #8682 in the one checkout that runs this script.

## Second fix in this PR

`mobile/scripts/ci/detect_mobile_ci_scope.sh` had no arm for the repo-root `scripts/` directory, so a PR touching only `scripts/prune-merged-branches.sh` set `app=false`, skipped the `tests` job, and never ran that script's own test. Nothing else covers those scripts — no shellcheck job, no `bash -n` step — so the effective coverage was zero.

Found while fixing the above. This PR edits a file under `mobile/test/`, so it runs the matrix regardless; the next scripts-only change would not have. Kept as its own commit (`d54c9b3`), and both directions are pinned: `scripts/*` runs the matrix, `scripts/lnav/README.md` still counts as docs.

## What this deliberately leaves alone

- **Still report-only.** No deletion, no `--execute`.
- **Detached worktrees stay invisible**, as before — the script iterates `refs/heads/`.
- **The full-clone path is unchanged in behaviour**, only in mechanism.
- **No new ratchet.** The two shell scripts remain covered by their Dart tests alone.

## Verification

- `flutter test test/tools/prune_merged_branches_test.dart test/tools/detect_mobile_ci_scope_test.dart` — 35 passed.
- **Red/green on both fixes.** Reverting only the guard swap fails the new shallow test and no other (11 others still green). Removing only the `scripts/*` arm fails the two new scope tests and no other.
- `flutter analyze lib test integration_test` — no issues.
- `dart format` clean; `bash -n` and `shellcheck` clean on both scripts.
- Ratchets covering the test tree all pass: ungrouped-tests, placeholder-tests, unpinned-unchanged-assertions, test-unit-structure, skip-ceiling, shared-setup-stubs, l10n-delegates.
- `tip_contained_in_base` checked against the live API: real ancestor → `BEHIND`, diverged branch → `DIVERGED`, `origin/main` itself → `IDENTICAL`. Both failure modes fail safe to `KEEP` (bogus SHA, missing/erroring `gh`), and the failing command substitution does not trip `set -euo pipefail`.
