### PR TITLE
docs(ci): preserve historical test-performance measurements

### DIFF
--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -164,15 +164,18 @@ setting has nothing to schedule.
 
 ### Existing test-hygiene ratchets (already in place, not regressions)
 
+Counts below are as of the capture commit; the baseline files themselves are
+authoritative for current ceilings.
+
 The repo already freezes several of the things a perf audit would normally
 flag, so these are *not* available wins:
 
 - `scripts/baseline/future_delayed_test_counts.txt` — 1,119 executable
   `Future.delayed` call sites across 178 files under `test/`, frozen as
   shrink-only per-file numeric ceilings (epic #4337).
-- `scripts/baseline/skip_tests.txt` — skipped-test count, shrink-only.
+- `scripts/baseline/skip_test_ceilings.txt` — skipped-test count, shrink-only.
 - `test/vgv_tag_baseline.txt` — 18 `skip_very_good_optimization` files,
-  count may not increase.
+  count may not increase (18 at capture; ratcheted to 15 in #8354).
 - `scripts/baseline/test_unit_files.txt` — `test/unit/` frozen per-file.
 
 Total explicit real-time sleep across `test/**` is **21.4s over 105

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -175,7 +175,7 @@ flag, so these are *not* available wins:
   shrink-only per-file numeric ceilings (epic #4337).
 - `scripts/baseline/skip_test_ceilings.txt` — skipped-test count, shrink-only.
 - `test/vgv_tag_baseline.txt` — 18 `skip_very_good_optimization` files,
-  count may not increase (18 at capture; ratcheted to 15 in #8354).
+  count may not increase.
 - `scripts/baseline/test_unit_files.txt` — `test/unit/` frozen per-file.
 
 Total explicit real-time sleep across `test/**` is **21.4s over 105

--- a/mobile/scripts/ci/select_test_shard.sh
+++ b/mobile/scripts/ci/select_test_shard.sh
@@ -5,8 +5,9 @@
 # Mobile CI's `Tests` job is the workflow's critical path. `very_good test
 # --optimization` collapses every untagged test file into a single
 # .test_optimizer.dart suite — one process — so `--concurrency=4` has nothing
-# left to schedule once the 18 skip_very_good_optimization files are done, and
-# the bulk of the run is single-core on a 4-vCPU runner.
+# left to schedule once the skip_very_good_optimization files are done (the
+# count is tracked in test/vgv_tag_baseline.txt), and the bulk of the run is
+# single-core on a 4-vCPU runner.
 #
 # very_good has no "run this subset" flag, so the shard is selected by removing
 # the other shards' *_test.dart files from the checkout before very_good scans


### PR DESCRIPTION
## Problem

The test-sharding script presented a historical optimization-tag count as current, while the performance baseline did not clearly distinguish capture-time ratchet values from today’s ceilings. The same baseline section also linked to a file that has since been renamed.

## Why this fix

The live script now points readers to `test/vgv_tag_baseline.txt` instead of duplicating its changing count. The dated performance snapshot explicitly scopes its ratchet counts to the capture commit and uses the current skipped-test baseline path.

## Deliberately unchanged

The capture-time references to 18 tagged suites remain intact because those suites produced the documented timing measurements.

## Verification

- `git diff --check origin/main...HEAD`
- `bash -n mobile/scripts/ci/select_test_shard.sh`
- verified `mobile/scripts/baseline/skip_test_ceilings.txt` exists
- verified `mobile/test/vgv_tag_baseline.txt` contains the value 15
- pre-push hook: no merge conflicts; no Dart files changed

Closes #8767