### PR TITLE
test(editor): stop cleanup tests racing editor teardown

### DIFF
--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -131,6 +131,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// run from `onDispose` without reading providers after disposal.
   DraftsDao? _deferredCleanupDraftsDao;
   ClipsDao? _deferredCleanupClipsDao;
+  final Set<Future<void>> _pendingDeferredCleanup = {};
 
   /// Get clip manager notifier.
   ClipManagerNotifier get _clipManager =>
@@ -167,7 +168,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       // session end). Best-effort and fire-and-forget: the container is tearing
       // down. On mobile this often never fires (OS kill), which is why [reset]
       // is the primary reaper.
-      unawaited(_flushDeferredFileCleanup());
+      _startDeferredFileCleanup();
       Log.debug(
         '🧹 VideoEditorNotifier disposed',
         name: 'VideoEditorNotifier',
@@ -277,7 +278,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         .isAudioSharingEnabled;
     state = VideoEditorProviderState(allowAudioReuse: audioSharingEnabled);
     _autosaveTimer?.cancel();
-    unawaited(_flushDeferredFileCleanup());
+    _startDeferredFileCleanup();
     draftId = null;
     if (!keepAutosavedDraft) {
       await removeAutosavedDraft();
@@ -841,6 +842,24 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     );
   }
 
+  /// Starts a best-effort cleanup without blocking the editor lifecycle.
+  ///
+  /// Every active operation remains tracked independently so a cleanup
+  /// started by [reset] cannot be hidden by a later no-op cleanup from
+  /// [build]'s `onDispose` callback.
+  void _startDeferredFileCleanup() {
+    late final Future<void> operation;
+    operation = () async {
+      try {
+        await _flushDeferredFileCleanup();
+      } finally {
+        _pendingDeferredCleanup.remove(operation);
+      }
+    }();
+    _pendingDeferredCleanup.add(operation);
+    unawaited(operation);
+  }
+
   /// Queue clip-owned files that became unreachable in the live editor state.
   ///
   /// The actual delete waits for [_flushDeferredFileCleanup] so undo/redo and
@@ -858,6 +877,12 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// Test hook: the set of files awaiting cleanup.
   @visibleForTesting
   Set<String> get deferredFileCleanupForTest => _deferredFileCleanup;
+
+  /// Completes when every deferred cleanup currently in flight completes.
+  @visibleForTesting
+  Future<void> get pendingDeferredCleanupForTest async {
+    await Future.wait(_pendingDeferredCleanup.toList());
+  }
 
   /// Save the current video project as a draft.
   ///

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -849,13 +849,9 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// [build]'s `onDispose` callback.
   void _startDeferredFileCleanup() {
     late final Future<void> operation;
-    operation = () async {
-      try {
-        await _flushDeferredFileCleanup();
-      } finally {
-        _pendingDeferredCleanup.remove(operation);
-      }
-    }();
+    operation = _flushDeferredFileCleanup().whenComplete(() {
+      _pendingDeferredCleanup.remove(operation);
+    });
     _pendingDeferredCleanup.add(operation);
     unawaited(operation);
   }

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -121,7 +121,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// the pre-split source clip after a split), so deleting them mid-session
   /// breaks undo/redo — it lands on a clip whose source file is gone. We hold
   /// them here and reap them at editor-session end via
-  /// [_flushDeferredFileCleanup] ([reset], with [build]'s `onDispose` as a
+  /// [_startDeferredFileCleanup] ([reset], with [build]'s `onDispose` as a
   /// teardown safety net), once the history that could resurrect them no longer
   /// exists. The reaper still runs each path through the reference check, so a
   /// file the user restored (and a later autosave re-referenced) is kept.
@@ -131,6 +131,10 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// run from `onDispose` without reading providers after disposal.
   DraftsDao? _deferredCleanupDraftsDao;
   ClipsDao? _deferredCleanupClipsDao;
+
+  /// In-flight [_startDeferredFileCleanup] operations, held only so
+  /// [pendingDeferredCleanupForTest] can await them. Production never reads
+  /// this back; the cleanup calls stay fire-and-forget.
   final Set<Future<void>> _pendingDeferredCleanup = {};
 
   /// Get clip manager notifier.
@@ -822,11 +826,15 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   }
 
   /// Reap the clip/thumbnail files deferred during this session (see
-  /// [_deferredFileCleanup]). Runs at editor-session end ([reset]) and as a
-  /// teardown safety net ([build]'s `onDispose`); both call it, and it clears
-  /// the set so a second call is a no-op. Each path still goes through the
-  /// draft/library reference check, so anything a surviving draft (or the
-  /// library) references is kept — only genuinely-orphaned files are removed.
+  /// [_deferredFileCleanup]). Reached through [_startDeferredFileCleanup] at
+  /// editor-session end ([reset]) and as a teardown safety net ([build]'s
+  /// `onDispose`); it clears the set, so a second call is a no-op. Each path
+  /// still goes through the draft/library reference check, so anything a
+  /// surviving draft (or the library) references is kept — only
+  /// genuinely-orphaned files are removed.
+  ///
+  /// Reach it through [_startDeferredFileCleanup] rather than calling it
+  /// directly: a direct call is invisible to [pendingDeferredCleanupForTest].
   Future<void> _flushDeferredFileCleanup() async {
     if (_deferredFileCleanup.isEmpty) return;
     final draftsDao = _deferredCleanupDraftsDao;
@@ -844,9 +852,10 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
 
   /// Starts a best-effort cleanup without blocking the editor lifecycle.
   ///
-  /// Every active operation remains tracked independently so a cleanup
-  /// started by [reset] cannot be hidden by a later no-op cleanup from
-  /// [build]'s `onDispose` callback.
+  /// The handle goes into [_pendingDeferredCleanup] so tests can await it;
+  /// that set is the only reason this is not a bare `unawaited(...)`. It is a
+  /// set rather than one slot because [reset] and [build]'s `onDispose` can
+  /// each have an operation running, and a single slot would drop the first.
   void _startDeferredFileCleanup() {
     late final Future<void> operation;
     operation = _flushDeferredFileCleanup().whenComplete(() {
@@ -874,7 +883,14 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   @visibleForTesting
   Set<String> get deferredFileCleanupForTest => _deferredFileCleanup;
 
-  /// Completes when every deferred cleanup currently in flight completes.
+  /// Completes when the cleanups in flight *at the moment it is read*
+  /// complete.
+  ///
+  /// A snapshot, not a barrier: it ignores anything started afterwards and
+  /// resolves immediately when nothing is in flight, so read it after the
+  /// call whose cleanup you mean to await. It also covers only
+  /// [_startDeferredFileCleanup] — other fire-and-forget work on this
+  /// notifier and on [ClipManagerNotifier] settles on its own schedule.
   @visibleForTesting
   Future<void> get pendingDeferredCleanupForTest async {
     await Future.wait(_pendingDeferredCleanup.toList());

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -3546,10 +3546,11 @@ void main() {
     });
 
     tearDown(() async {
-      disposeContainer();
-      // Let any fire-and-forget onDispose flush finish querying the DB before
-      // we close it, so a still-deferred file doesn't race a closed database.
-      await pumpEventQueue();
+      if (!containerDisposed) {
+        final notifier = container.read(videoEditorProvider.notifier);
+        disposeContainer();
+        await notifier.pendingDeferredCleanupForTest;
+      }
       await database.close();
       if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
     });
@@ -3588,21 +3589,12 @@ void main() {
           );
     }
 
-    Future<void> expectFileReaped(File file, {required String reason}) async {
-      for (var attempt = 0; attempt < 20; attempt++) {
-        await pumpEventQueue();
-        if (!file.existsSync()) return;
-      }
-
-      expect(file.existsSync(), isFalse, reason: reason);
-    }
-
     test('an autosave keeps its orphaned files alive', () async {
       final orphan = stubDeferringAutosave();
       addTimelineClip();
       final notifier = container.read(videoEditorProvider.notifier);
 
-      await notifier.autosaveChanges();
+      expect(await notifier.autosaveChanges(), isTrue);
 
       expect(
         orphan.existsSync(),
@@ -3618,31 +3610,52 @@ void main() {
       final orphan = stubDeferringAutosave();
       addTimelineClip();
       final notifier = container.read(videoEditorProvider.notifier);
-      await notifier.autosaveChanges();
+      expect(await notifier.autosaveChanges(), isTrue);
+      expect(notifier.deferredFileCleanupForTest, contains(orphan.path));
 
-      // reset() is the real session-end hook (publish / discard / start-over),
-      // not the @visibleForTesting flush — this exercises the wiring an app
-      // actually hits when the editor closes.
       await notifier.reset(keepAutosavedDraft: true);
+      await notifier.pendingDeferredCleanupForTest;
 
-      await expectFileReaped(
-        orphan,
+      expect(
+        orphan.existsSync(),
+        isFalse,
         reason: 'session end reaps a deferred file once nothing references it',
       );
       expect(notifier.deferredFileCleanupForTest, isEmpty);
     });
 
+    test('reset cleanup remains awaitable during container teardown', () async {
+      final orphan = stubDeferringAutosave();
+      addTimelineClip();
+      final notifier = container.read(videoEditorProvider.notifier);
+      expect(await notifier.autosaveChanges(), isTrue);
+      expect(notifier.deferredFileCleanupForTest, contains(orphan.path));
+
+      await notifier.reset(keepAutosavedDraft: true);
+      disposeContainer();
+      await notifier.pendingDeferredCleanupForTest;
+
+      expect(
+        orphan.existsSync(),
+        isFalse,
+        reason: 'onDispose must not hide cleanup that reset already started',
+      );
+    });
+
     test('container teardown reaps deferred files as a safety net', () async {
       final orphan = stubDeferringAutosave();
       addTimelineClip();
-      await container.read(videoEditorProvider.notifier).autosaveChanges();
+      final notifier = container.read(videoEditorProvider.notifier);
+      expect(await notifier.autosaveChanges(), isTrue);
+      expect(notifier.deferredFileCleanupForTest, contains(orphan.path));
       expect(orphan.existsSync(), isTrue);
 
-      // Drives the real ref.onDispose wiring, not the @visibleForTesting flush.
       disposeContainer();
+      await notifier.pendingDeferredCleanupForTest;
 
-      await expectFileReaped(
-        orphan,
+      expect(
+        orphan.existsSync(),
+        isFalse,
         reason: 'onDispose reaps deferred files left when reset never ran',
       );
     });
@@ -3729,14 +3742,16 @@ void main() {
         finalRenderedClip: renderedClip('new-rendered', newRendered),
       );
 
-      await notifier.autosaveChanges();
+      expect(await notifier.autosaveChanges(), isTrue);
       expect(oldRendered.existsSync(), isTrue);
       expect(notifier.deferredFileCleanupForTest, contains(oldRendered.path));
 
       disposeContainer();
+      await notifier.pendingDeferredCleanupForTest;
 
-      await expectFileReaped(
-        oldRendered,
+      expect(
+        oldRendered.existsSync(),
+        isFalse,
         reason:
             'onDispose must reap a replaced rendered export once the new '
             'draft row no longer references it',

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -3655,6 +3655,11 @@ void main() {
       expect(notifier.deferredFileCleanupForTest, contains(orphan.path));
 
       await notifier.reset(keepAutosavedDraft: true);
+      // The precondition this test exists for: reset's flush is still in
+      // flight here, so the reap below is the one reset started rather than
+      // one onDispose ran. reset(keepAutosavedDraft: true) has no await after
+      // it starts the flush, so it cannot have finished.
+      expect(orphan.existsSync(), isTrue);
       disposeContainer();
       await drainDeferredCleanup(notifier);
 

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -3642,7 +3642,9 @@ void main() {
       expect(
         orphan.existsSync(),
         isFalse,
-        reason: 'session end reaps a deferred file once nothing references it',
+        reason:
+            'session end reaps a deferred file without waiting for container '
+            'teardown',
       );
       expect(notifier.deferredFileCleanupForTest, isEmpty);
     });

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -3514,6 +3514,16 @@ void main() {
       container.dispose();
     }
 
+    // Bounds every drain. The 20x pumpEventQueue poll this replaced bounded
+    // itself and failed with its own reason string; a bare await on a wedged
+    // cleanup instead hangs to the suite timeout with nothing naming deferred
+    // cleanup as the stuck party.
+    Future<void> drainDeferredCleanup(VideoEditorNotifier notifier) =>
+        notifier.pendingDeferredCleanupForTest.timeout(
+          const Duration(seconds: 10),
+          onTimeout: () => fail('deferred file cleanup did not settle'),
+        );
+
     setUpAll(() {
       registerFallbackValue(
         DivineVideoDraft.create(
@@ -3557,7 +3567,7 @@ void main() {
         // `if (!containerDisposed)` guard skipped the drain entirely for the
         // three tests that dispose the container themselves.
         disposeContainer();
-        await editorNotifier.pendingDeferredCleanupForTest;
+        await drainDeferredCleanup(editorNotifier);
       } finally {
         // The drain can throw — the reference check inside
         // `deleteFilesIfUnreferenced` is unguarded — and an open database or
@@ -3627,7 +3637,7 @@ void main() {
       expect(notifier.deferredFileCleanupForTest, contains(orphan.path));
 
       await notifier.reset(keepAutosavedDraft: true);
-      await notifier.pendingDeferredCleanupForTest;
+      await drainDeferredCleanup(notifier);
 
       expect(
         orphan.existsSync(),
@@ -3646,7 +3656,7 @@ void main() {
 
       await notifier.reset(keepAutosavedDraft: true);
       disposeContainer();
-      await notifier.pendingDeferredCleanupForTest;
+      await drainDeferredCleanup(notifier);
 
       expect(
         orphan.existsSync(),
@@ -3664,7 +3674,7 @@ void main() {
       expect(orphan.existsSync(), isTrue);
 
       disposeContainer();
-      await notifier.pendingDeferredCleanupForTest;
+      await drainDeferredCleanup(notifier);
 
       expect(
         orphan.existsSync(),
@@ -3760,7 +3770,7 @@ void main() {
       expect(notifier.deferredFileCleanupForTest, contains(oldRendered.path));
 
       disposeContainer();
-      await notifier.pendingDeferredCleanupForTest;
+      await drainDeferredCleanup(notifier);
 
       expect(
         oldRendered.existsSync(),

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -3505,6 +3505,7 @@ void main() {
     late AppDatabase database;
     late ProviderContainer container;
     late Directory tempDir;
+    late VideoEditorNotifier editorNotifier;
     var containerDisposed = false;
 
     void disposeContainer() {
@@ -3543,16 +3544,28 @@ void main() {
           databaseProvider.overrideWithValue(database),
         ],
       );
+      // Captured here, not in tearDown: a test that disposes the container
+      // itself must still get the drain, and `container.read` throws once the
+      // container is gone.
+      editorNotifier = container.read(videoEditorProvider.notifier);
     });
 
     tearDown(() async {
-      if (!containerDisposed) {
-        final notifier = container.read(videoEditorProvider.notifier);
+      try {
+        // Unconditional: every test needs the deferred cleanup to stop
+        // querying the DAOs before the database closes under it. The old
+        // `if (!containerDisposed)` guard skipped the drain entirely for the
+        // three tests that dispose the container themselves.
         disposeContainer();
-        await notifier.pendingDeferredCleanupForTest;
+        await editorNotifier.pendingDeferredCleanupForTest;
+      } finally {
+        // The drain can throw — the reference check inside
+        // `deleteFilesIfUnreferenced` is unguarded — and an open database or
+        // a leftover temp dir would then outlive this suite in the merged
+        // test isolate.
+        await database.close();
+        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
       }
-      await database.close();
-      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
     });
 
     // Stubs the next autosave to hand [orphan] to the deferral sink instead of


### PR DESCRIPTION
## Problem

The video editor cleanup tests waited for asynchronous file deletion by spinning the event queue a fixed number of times. On busy merged CI runs, that gave teardown no reliable completion boundary and could leave the orphaned file present when the assertion ran. The tests also ignored whether autosave had actually deferred the file, so the failure could not distinguish a broken precondition from incomplete cleanup.

## Why this fix

Deferred cleanup operations are now tracked for their full lifetime while remaining fire-and-forget in production. Tests can await every cleanup already in flight, including the overlap where `reset` starts deletion and provider disposal immediately triggers a second no-op cleanup. Each cleanup test also verifies that autosave succeeded and queued the expected file before asserting deletion.

## Deliberately unchanged

Editor session reset and provider disposal still do not block the app on file deletion. File reference checks and deletion behavior are unchanged; this adds an observable lifecycle boundary for tests and teardown.

## Verification

- `flutter test test/providers/video_editor_provider_test.dart`
- `flutter analyze`
- Five repeated optimized merged-file runs with `very_good test --optimization --concurrency=4 --exclude-tags integration test/providers/video_editor_provider_test.dart`
- `bash scripts/check_future_delayed_ceiling.sh`
- `bash scripts/check_future_delayed_production_ceiling.sh`
- Red/green proof: disabling the completion boundary makes the reset/dispose overlap regression fail with the orphan still present; restoring it passes.

Closes #8771
