### PR TITLE
fix(e2e): restore the key-backup journey through Nostr Settings

### DIFF
--- a/mobile/e2e/maestro/asserts/assertNostrKeys.yaml
+++ b/mobile/e2e/maestro/asserts/assertNostrKeys.yaml
@@ -21,4 +21,5 @@ appId: co.openvine.app.staging
     Backup Your Key
     Save your private key (nsec) to use your account in other Nostr apps.
     Never share your nsec with anyone!
-- assertVisible: Copy My Private Key (nsec)
+- assertVisible:
+    id: "copy_nsec_button"

--- a/mobile/e2e/maestro/asserts/assertPrivKeyCopied.yaml
+++ b/mobile/e2e/maestro/asserts/assertPrivKeyCopied.yaml
@@ -1,3 +1,8 @@
 appId: co.openvine.app.staging
 ---
-- assertVisible: Private key copied to the clipboard!
+- extendedWaitUntil:
+    visible: |-
+      Private key copied to clipboard!
+
+      Store it somewhere safe.
+    timeout: 30000

--- a/mobile/e2e/maestro/tests/backupYourKey.yaml
+++ b/mobile/e2e/maestro/tests/backupYourKey.yaml
@@ -1,22 +1,33 @@
 appId: co.openvine.app.staging
 ---
-#TC to follow a user,
-# given the user is logged in in the app,
-# by opening the settings, nostr keys menu, and copying the private key
+# Verify that a signed-in user can reach key management and back up their
+# private key to the clipboard.
 #Steps:
-# 1. Given an already logged in user, Menu and Settings: Settings screen is presented
-# 2. Tap on a Key management. Expected: Nostr Keys screen is presented
-# 3. Backup Your Key by tapping on the button: VIDEO_USER videos are displayed validated thru username
+# 1. Open Settings, then Nostr Settings
+# 2. Open Key Management and verify the Nostr Keys screen
+# 3. Copy the private key and verify the confirmation
 
-# 1. Given an already logged in user, Menu and Settings: Settings screen is presented
+# 1. Settings -> Nostr Settings
 - runFlow: ../utils/openSettings.yaml
+- tapOn:
+    id: "nostr_settings_tile"
 
-# 2. Tap on a Key management. Expected: Nostr Keys screen is presented
-- scroll
-- tapOn: |-
-    Key Management
-    Export, backup, and restore your Nostr keys
+# 2. Targeted by id because this row moved off the Settings root and its copy
+# is localized and expected to evolve independently of the journey.
+- extendedWaitUntil:
+    visible:
+      id: "key_management_tile"
+    timeout: 30000
+- tapOn:
+    id: "key_management_tile"
 - runFlow: ../asserts/assertNostrKeys.yaml
-# 3. Backup Your Key by tapping on the button: VIDEO_USER videos are displayed validated thru username
-- tapOn: Copy My Private Key (nsec)
+
+# 3. Targeted by id so edits to the warning-sensitive button label do not
+# strand account recovery coverage.
+- extendedWaitUntil:
+    visible:
+      id: "copy_nsec_button"
+    timeout: 30000
+- tapOn:
+    id: "copy_nsec_button"
 - runFlow: ../asserts/assertPrivKeyCopied.yaml

--- a/mobile/lib/constants/semantic_ids.dart
+++ b/mobile/lib/constants/semantic_ids.dart
@@ -112,10 +112,14 @@ abstract class SemanticIds {
   static const String authInviteCodeField = 'invite_code_field';
   static const String authInviteSubmitButton = 'invite_submit_button';
 
-  /// Settings rows on the path to signing the device out. removeKeys is the
-  /// teardown of every E2E flow, so this route has to stay addressable.
+  /// Settings rows on the path to managing local account keys. These journeys
+  /// have to stay addressable after settings information-architecture moves.
   static const String settingsNostrRow = 'nostr_settings_tile';
+  static const String settingsKeyManagementRow = 'key_management_tile';
   static const String settingsRemoveKeysRow = 'remove_keys_tile';
+
+  /// Key backup action. Copy changes should not strand the recovery journey.
+  static const String keyManagementCopyNsecButton = 'copy_nsec_button';
 
   /// Account portability. The row leaves the app for the hosted Divine Exit
   /// flow, so an E2E flow can only assert the handoff by addressing the row.

--- a/mobile/lib/screens/key_management_screen.dart
+++ b/mobile/lib/screens/key_management_screen.dart
@@ -5,6 +5,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/authentication_source.dart';
@@ -187,6 +188,7 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
             label: context.l10n.keyManagementCopyNsec,
             leadingIcon: DivineIconName.copy,
             expanded: true,
+            semanticIdentifier: SemanticIds.keyManagementCopyNsecButton,
             onPressed: _isProcessing ? null : () => _exportKey(context),
           ),
         ] else if (showKeycastRemoteSigningInfo)

--- a/mobile/lib/screens/settings/nostr_settings_screen.dart
+++ b/mobile/lib/screens/settings/nostr_settings_screen.dart
@@ -113,6 +113,7 @@ class NostrSettingsScreen extends ConsumerWidget {
                   iconColor: context.vineColors.accentPositive,
                   title: context.l10n.nostrSettingsKeyManagement,
                   subtitle: context.l10n.nostrSettingsKeyManagementSubtitle,
+                  semanticIdentifier: SemanticIds.settingsKeyManagementRow,
                   onTap: () => context.push(KeyManagementScreen.path),
                 ),
                 const _ClientAttributionToggle(),

--- a/mobile/scripts/baseline/maestro_copy_manifest.txt
+++ b/mobile/scripts/baseline/maestro_copy_manifest.txt
@@ -66,9 +66,8 @@ feedExploreVideos	e2e/maestro/asserts/assertFreshHome.yaml	bound:Explore Videos
 followingTitle	e2e/maestro/asserts/assertUsersFollowing.yaml	bound:Following
 keyManagementBackupSubtitle	e2e/maestro/asserts/assertNostrKeys.yaml	bound:Save your private key (nsec) to use your account in other Nostr apps.
 keyManagementBackupTitle	e2e/maestro/asserts/assertNostrKeys.yaml	bound:Backup Your Key
-keyManagementCopyNsec	e2e/maestro/asserts/assertNostrKeys.yaml	bound:Copy My Private Key (nsec)
-keyManagementCopyNsec	e2e/maestro/tests/backupYourKey.yaml	bound:Copy My Private Key (nsec)
 keyManagementExplanation	e2e/maestro/asserts/assertNostrKeys.yaml	bound:Your Nostr identity is a cryptographic key pair: • Your public key (npub) is like your username - share it freely • Your private key (nsec) is like your password - keep it secret! Your nsec lets you access your account on any Nostr app.
+keyManagementExportSuccess	e2e/maestro/asserts/assertPrivKeyCopied.yaml	bound:Private key copied to clipboard! Store it somewhere safe.
 keyManagementImportButton	e2e/maestro/asserts/assertNostrKeys.yaml	bound:Import Key
 keyManagementImportSubtitle	e2e/maestro/asserts/assertNostrKeys.yaml	bound:Already have a Nostr account? Paste your private key (nsec) to access it here.
 keyManagementImportTitle	e2e/maestro/asserts/assertNostrKeys.yaml	bound:Import Existing Key
@@ -91,8 +90,6 @@ navOpenCamera	e2e/maestro/asserts/assertExplore.yaml	bound:Open camera
 navOpenCamera	e2e/maestro/asserts/assertHome.yaml	bound:Open camera
 nostrInfoGotIt	e2e/maestro/utils/openRecorder.yaml	bound:Got it!
 nostrSettingsDeleteAccount	e2e/maestro/tests/deleteAccountData.yaml	bound:Delete Account and Data
-nostrSettingsKeyManagement	e2e/maestro/tests/backupYourKey.yaml	bound:Key Management
-nostrSettingsKeyManagementSubtitle	e2e/maestro/tests/backupYourKey.yaml	bound:Export, backup, and restore your Nostr keys
 profileCompletePrimaryButton	e2e/maestro/asserts/assertEditYourProfile.yaml	bound:Update Your Profile
 profileCompleteSubtitle	e2e/maestro/asserts/assertProfileFresh.yaml	bound:Add your name, bio, and picture to get started
 profileCompleteYourProfile	e2e/maestro/asserts/assertProfileFresh.yaml	bound:Complete Your Profile

--- a/mobile/test/screens/key_management_screen_test.dart
+++ b/mobile/test/screens/key_management_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/legacy.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/protected_minor_providers.dart';
 import 'package:openvine/screens/key_management_screen.dart';
@@ -164,6 +165,13 @@ void main() {
 
         expect(
           find.text(l10n.keyManagementCopyNsec, skipOffstage: false),
+          findsOneWidget,
+        );
+        expect(
+          find.bySemanticsIdentifier(
+            SemanticIds.keyManagementCopyNsecButton,
+            skipOffstage: false,
+          ),
           findsOneWidget,
         );
         expect(

--- a/mobile/test/widgets/nostr_settings_screen_test.dart
+++ b/mobile/test/widgets/nostr_settings_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:models/models.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart'
     show SecureKeyStorageException;
 import 'package:openvine/constants/app_constants.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
@@ -131,6 +132,17 @@ void main() {
 
       expect(find.text(l10n.nostrSettingsMoveAccount), findsOneWidget);
       expect(find.text(l10n.nostrSettingsMoveAccountSubtitle), findsOneWidget);
+    });
+
+    testWidgets('exposes a stable key management row identifier', (
+      tester,
+    ) async {
+      await pumpSubject(tester);
+
+      expect(
+        find.bySemanticsIdentifier(SemanticIds.settingsKeyManagementRow),
+        findsOneWidget,
+      );
     });
 
     testWidgets('hides account portability tile when signed out', (


### PR DESCRIPTION
## Problem

The key-backup Maestro journey still looked for Key Management on the Settings root after that row moved under Nostr Settings. It also waited for obsolete clipboard confirmation copy, so the manual full-regression path could no longer complete.

## Why this fix

The journey now follows Settings → Nostr Settings → Key Management and uses stable semantic identifiers for the moved row and local private-key copy action. The confirmation assertion uses the current localized success message and waits for the asynchronous clipboard operation. Focused widget tests pin both new identifiers, and the Maestro copy manifest now binds the corrected success copy.

## Deliberately unchanged

- The app’s local-key versus Keycast export behavior is unchanged; this journey still requires a local-nsec `USER_KEYS` fixture.
- Existing prose assertions in `assertNostrKeys.yaml` remain copy-bound. Escaping their regex metacharacters would erase valid copy-manifest bindings under the current guard, and a device run was unavailable to prove that static concern.
- `fullRegression.yaml` is untouched to avoid colliding with the complementary regression-suite work.

## Verification

- `bash e2e/maestro/scripts/check_refs.sh`
- `bash scripts/check_maestro_copy_drift.sh`
- `flutter test test/widgets/nostr_settings_screen_test.dart test/screens/key_management_screen_test.dart` (35 tests)
- `flutter analyze lib test`
- Pre-push analyzer and changed-file tests

Device verification was not run: Maestro and ADB are not installed in this environment, and `USER_KEYS` is unset.

Closes #8775