### PR TITLE
fix(people-lists): keep other clients' list data when membership changes

### DIFF
--- a/mobile/packages/people_lists_repository/lib/src/local_people_lists_cache.dart
+++ b/mobile/packages/people_lists_repository/lib/src/local_people_lists_cache.dart
@@ -16,11 +16,39 @@ abstract class _CacheKeys {
   static const String ownerPubkey = 'ownerPubkey';
   static const String list = 'list';
   static const String receivedAtMillis = 'receivedAtMillis';
+  static const String sourceTags = 'sourceTags';
+  static const String sourceContent = 'sourceContent';
   static const String deletedAtMillis = 'deletedAtMillis';
 }
 
 /// Logger name used for cache-level diagnostic log entries.
 const String _logName = 'people_lists_repository.local_cache';
+
+/// A cached display model and, when available, its complete publish source.
+///
+/// Rows written before source preservation have no [sourceTags] or
+/// [sourceContent]. They remain readable for display but must not be used as
+/// the base of a replaceable-event publish.
+class CachedPeopleListRecord {
+  /// Creates a decoded cache record.
+  const CachedPeopleListRecord({
+    required this.list,
+    this.sourceTags,
+    this.sourceContent,
+  });
+
+  /// The display model consumed by repository clients.
+  final UserList list;
+
+  /// Exact ordered tags of the event represented by [list].
+  final List<List<String>>? sourceTags;
+
+  /// Exact content of the event represented by [list].
+  final String? sourceContent;
+
+  /// Whether this record can safely drive a complete replacement publish.
+  bool get hasPublishSource => sourceTags != null && sourceContent != null;
+}
 
 /// Local cache for kind 30000 people lists, scoped by owner pubkey.
 ///
@@ -66,6 +94,24 @@ class LocalPeopleListsCache {
   Future<List<UserList>> readLists({required String ownerPubkey}) async {
     final box = await _box();
     return _collectLists(box, ownerPubkey);
+  }
+
+  /// Returns one non-tombstoned cache record, including its publish source.
+  Future<CachedPeopleListRecord?> readRecord({
+    required String ownerPubkey,
+    required String listId,
+  }) async {
+    final box = await _box();
+    final raw = box.get(_listKey(ownerPubkey, listId));
+    if (raw is! Map) return null;
+    final record = _decodeRecord(raw);
+    if (record == null) return null;
+    final tombstoneMillis = _tombstoneMillis(box, ownerPubkey, listId);
+    if (tombstoneMillis != null &&
+        tombstoneMillis >= record.list.updatedAt.millisecondsSinceEpoch) {
+      return null;
+    }
+    return record;
   }
 
   /// Emits the current lists for [ownerPubkey] immediately, then re-emits on
@@ -119,7 +165,14 @@ class LocalPeopleListsCache {
     required String ownerPubkey,
     required UserList list,
     required DateTime receivedAt,
+    List<List<String>>? sourceTags,
+    String? sourceContent,
   }) async {
+    if ((sourceTags == null) != (sourceContent == null)) {
+      throw ArgumentError(
+        'sourceTags and sourceContent must both be present or both be absent',
+      );
+    }
     final box = await _box();
     final tombstoneMillis = _tombstoneMillis(box, ownerPubkey, list.id);
     if (tombstoneMillis != null &&
@@ -130,6 +183,11 @@ class LocalPeopleListsCache {
       _CacheKeys.ownerPubkey: ownerPubkey,
       _CacheKeys.list: list.toJson(),
       _CacheKeys.receivedAtMillis: receivedAt.millisecondsSinceEpoch,
+      if (sourceTags != null)
+        _CacheKeys.sourceTags: [
+          for (final tag in sourceTags) List<String>.of(tag),
+        ],
+      _CacheKeys.sourceContent: ?sourceContent,
     });
   }
 
@@ -174,9 +232,9 @@ class LocalPeopleListsCache {
     final listKey = _listKey(ownerPubkey, listId);
     final existing = box.get(listKey);
     if (existing is Map) {
-      final list = _decodeList(existing);
-      if (list != null &&
-          list.updatedAt.millisecondsSinceEpoch <= deletedMillis) {
+      final record = _decodeRecord(existing);
+      if (record != null &&
+          record.list.updatedAt.millisecondsSinceEpoch <= deletedMillis) {
         await box.delete(listKey);
       }
     }
@@ -219,8 +277,9 @@ class LocalPeopleListsCache {
       if (!_isListKey(key, ownerPubkey)) continue;
       final raw = box.get(key);
       if (raw is! Map) continue;
-      final list = _decodeList(raw);
-      if (list == null) continue;
+      final record = _decodeRecord(raw);
+      if (record == null) continue;
+      final list = record.list;
       final tombstoneMillis = tombstones[list.id];
       if (tombstoneMillis != null &&
           tombstoneMillis >= list.updatedAt.millisecondsSinceEpoch) {
@@ -238,14 +297,15 @@ class LocalPeopleListsCache {
   /// Returns `null` and logs a warning when the record is shaped unexpectedly
   /// or when [UserList.fromJson] throws. A single malformed row must not
   /// poison the whole `readLists`/`watchLists` result.
-  UserList? _decodeList(Map<dynamic, dynamic> record) {
+  CachedPeopleListRecord? _decodeRecord(Map<dynamic, dynamic> record) {
     final raw = record[_CacheKeys.list];
     if (raw is! Map) return null;
+    final UserList list;
     try {
       final json = Map<String, dynamic>.from(
         raw.map((key, value) => MapEntry(key.toString(), value)),
       );
-      return UserList.fromJson(json);
+      list = UserList.fromJson(json);
     } on Object catch (error, stackTrace) {
       Log.error(
         'Dropped malformed people-list record during decode',
@@ -256,6 +316,58 @@ class LocalPeopleListsCache {
       );
       return null;
     }
+
+    try {
+      final rawTags = record[_CacheKeys.sourceTags];
+      final rawContent = record[_CacheKeys.sourceContent];
+      if (rawTags == null && rawContent == null) {
+        return CachedPeopleListRecord(list: list);
+      }
+      if (rawTags is! List || rawContent is! String) {
+        throw const FormatException('Incomplete cached people-list source');
+      }
+      final tags = <List<String>>[];
+      for (final rawTag in rawTags) {
+        if (rawTag is! List || rawTag.any((value) => value is! String)) {
+          throw const FormatException('Invalid cached people-list source tag');
+        }
+        tags.add([for (final value in rawTag) value as String]);
+      }
+      final sourceDTag = _firstNonEmptyTagValue(tags, 'd');
+      if (sourceDTag != list.id) {
+        throw const FormatException(
+          'Cached people-list source does not match its list',
+        );
+      }
+      return CachedPeopleListRecord(
+        list: list,
+        sourceTags: List<List<String>>.unmodifiable(
+          tags.map(List<String>.unmodifiable),
+        ),
+        sourceContent: rawContent,
+      );
+    } on Object catch (error, stackTrace) {
+      Log.error(
+        'Ignored malformed people-list publish source during decode',
+        name: _logName,
+        category: LogCategory.storage,
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return CachedPeopleListRecord(list: list);
+    }
+  }
+
+  static String? _firstNonEmptyTagValue(
+    List<List<String>> tags,
+    String name,
+  ) {
+    for (final tag in tags) {
+      if (tag.length >= 2 && tag[0] == name && tag[1].isNotEmpty) {
+        return tag[1];
+      }
+    }
+    return null;
   }
 
   int? _tombstoneMillis(Box<dynamic> box, String ownerPubkey, String listId) {

--- a/mobile/packages/people_lists_repository/lib/src/nip51_people_list_codec.dart
+++ b/mobile/packages/people_lists_repository/lib/src/nip51_people_list_codec.dart
@@ -20,11 +20,15 @@ class PeopleListEventPayload extends Equatable {
   /// Nostr event kind. Always [Nip51PeopleListCodec.kind] for people lists.
   final int kind;
 
-  /// Ordered tags for the event, including the `d`, `title`, optional
-  /// `description` and `image`, and one `p` tag per member pubkey.
+  /// Ordered tags for the event.
+  ///
+  /// For an existing list this preserves every untouched source tag and all
+  /// of its positions. A new member receives a minimal `p` tag.
   final List<List<String>> tags;
 
-  /// Event content. Always an empty string for NIP-51 follow sets.
+  /// Event content, preserved verbatim from an existing list.
+  ///
+  /// NIP-51 clients may store private list items here as ciphertext.
   final String content;
 
   @override
@@ -61,11 +65,61 @@ abstract final class Nip51PeopleListCodec {
 
   /// Encodes [list] into a [PeopleListEventPayload].
   ///
-  /// The payload always includes `d` and `title` tags. `description` and
-  /// `image` are only added when non-empty after trimming. One `p` tag is
-  /// emitted per non-empty pubkey in [UserList.pubkeys]; pubkeys are never
-  /// truncated.
-  static PeopleListEventPayload encode(UserList list) {
+  /// When [sourceTags] is supplied, the payload is a membership edit over the
+  /// complete source event: non-member tags and surviving `p` tags are kept
+  /// verbatim, removed members lose every matching tag, and new members are
+  /// appended as minimal `p` tags. [sourceContent] is carried through without
+  /// interpretation so private items written by another client survive.
+  ///
+  /// With no source, this creates a new list with `d`, `title`, optional
+  /// metadata, and minimal `p` tags. The source arguments must either both be
+  /// present or both be absent.
+  static PeopleListEventPayload encode(
+    UserList list, {
+    List<List<String>>? sourceTags,
+    String? sourceContent,
+  }) {
+    if ((sourceTags == null) != (sourceContent == null)) {
+      throw ArgumentError(
+        'sourceTags and sourceContent must both be present or both be absent',
+      );
+    }
+    if (sourceTags != null) {
+      if (_firstTagValue(sourceTags, 'd') != list.id) {
+        throw ArgumentError.value(
+          sourceTags,
+          'sourceTags',
+          'must contain the d tag represented by the list',
+        );
+      }
+      final wanted = list.pubkeys.where((pubkey) => pubkey.isNotEmpty).toSet();
+      final sourced = <String>{};
+      final tags = <List<String>>[];
+
+      for (final tag in sourceTags) {
+        if (tag.length < 2 || tag[0] != 'p' || tag[1].isEmpty) {
+          tags.add(List<String>.of(tag));
+          continue;
+        }
+        final pubkey = tag[1];
+        if (wanted.contains(pubkey)) {
+          tags.add(List<String>.of(tag));
+          sourced.add(pubkey);
+        }
+      }
+
+      for (final pubkey in list.pubkeys) {
+        if (pubkey.isNotEmpty && sourced.add(pubkey)) {
+          tags.add(['p', pubkey]);
+        }
+      }
+      return PeopleListEventPayload(
+        kind: kind,
+        tags: tags,
+        content: sourceContent!,
+      );
+    }
+
     final tags = <List<String>>[
       ['d', list.id],
       ['title', list.name],

--- a/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
+++ b/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
@@ -112,10 +112,21 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
       for (final list in existing) list.id: list,
     };
 
-    final receivedAt = DateTime.now().toUtc();
+    final newestByListId = <String, ({Event event, UserList list})>{};
     for (final event in events) {
       final list = Nip51PeopleListCodec.decode(event);
       if (list == null) continue;
+      final candidate = (event: event, list: list);
+      final selected = newestByListId[list.id];
+      if (selected == null || _isNewerRevision(candidate, selected)) {
+        newestByListId[list.id] = candidate;
+      }
+    }
+
+    final receivedAt = DateTime.now().toUtc();
+    for (final candidate in newestByListId.values) {
+      final event = candidate.event;
+      final list = candidate.list;
       final current = existingById[list.id];
       // list.updatedAt is derived from the relay event's created_at by
       // Nip51PeopleListCodec, so comparing it against the cached list's
@@ -124,10 +135,19 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
       if (current != null && current.updatedAt.isAfter(list.updatedAt)) {
         continue;
       }
+      if (current != null &&
+          current.updatedAt == list.updatedAt &&
+          current.nostrEventId != null &&
+          current.nostrEventId != list.nostrEventId &&
+          current.nostrEventId!.compareTo(list.nostrEventId ?? '') < 0) {
+        continue;
+      }
       await _cache.putList(
         ownerPubkey: ownerPubkey,
         list: list,
         receivedAt: receivedAt,
+        sourceTags: event.tags,
+        sourceContent: event.content,
       );
     }
     return conclusive;
@@ -164,18 +184,27 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
     if (!await _reconcileOwner(ownerPubkey)) {
       return const PeopleListPublishResult.failed();
     }
-    final existing = await _findList(ownerPubkey: ownerPubkey, listId: listId);
-    if (existing == null) {
+    final record = await _findList(ownerPubkey: ownerPubkey, listId: listId);
+    if (record == null) {
       return const PeopleListPublishResult.failed();
     }
+    final existing = record.list;
     if (existing.pubkeys.contains(pubkey)) {
       return const PeopleListPublishResult.noop();
+    }
+    if (!record.hasPublishSource) {
+      return const PeopleListPublishResult.failed();
     }
     final updated = existing.copyWith(
       pubkeys: [...existing.pubkeys, pubkey],
       updatedAt: DateTime.now().toUtc(),
     );
-    return _publishListReplacement(ownerPubkey: ownerPubkey, list: updated);
+    return _publishListReplacement(
+      ownerPubkey: ownerPubkey,
+      list: updated,
+      sourceTags: record.sourceTags,
+      sourceContent: record.sourceContent,
+    );
   }
 
   @override
@@ -188,18 +217,27 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
     if (!await _reconcileOwner(ownerPubkey)) {
       return const PeopleListPublishResult.failed();
     }
-    final existing = await _findList(ownerPubkey: ownerPubkey, listId: listId);
-    if (existing == null) {
+    final record = await _findList(ownerPubkey: ownerPubkey, listId: listId);
+    if (record == null) {
       return const PeopleListPublishResult.failed();
     }
+    final existing = record.list;
     if (!existing.pubkeys.contains(pubkey)) {
       return const PeopleListPublishResult.noop();
+    }
+    if (!record.hasPublishSource) {
+      return const PeopleListPublishResult.failed();
     }
     final updated = existing.copyWith(
       pubkeys: existing.pubkeys.where((p) => p != pubkey).toList(),
       updatedAt: DateTime.now().toUtc(),
     );
-    return _publishListReplacement(ownerPubkey: ownerPubkey, list: updated);
+    return _publishListReplacement(
+      ownerPubkey: ownerPubkey,
+      list: updated,
+      sourceTags: record.sourceTags,
+      sourceContent: record.sourceContent,
+    );
   }
 
   @override
@@ -301,8 +339,14 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
   Future<PeopleListPublishResult> _publishListReplacement({
     required String ownerPubkey,
     required UserList list,
+    List<List<String>>? sourceTags,
+    String? sourceContent,
   }) async {
-    final payload = Nip51PeopleListCodec.encode(list);
+    final payload = Nip51PeopleListCodec.encode(
+      list,
+      sourceTags: sourceTags,
+      sourceContent: sourceContent,
+    );
     final event = Event(
       ownerPubkey,
       payload.kind,
@@ -320,6 +364,8 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
         ownerPubkey: ownerPubkey,
         list: persisted,
         receivedAt: DateTime.now().toUtc(),
+        sourceTags: payload.tags,
+        sourceContent: payload.content,
       );
       return PeopleListPublishResult.submitted(eventId: sent.event.id);
     } on Object catch (error, stackTrace) {
@@ -334,15 +380,20 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
     }
   }
 
-  Future<UserList?> _findList({
+  Future<CachedPeopleListRecord?> _findList({
     required String ownerPubkey,
     required String listId,
-  }) async {
-    final lists = await _cache.readLists(ownerPubkey: ownerPubkey);
-    for (final list in lists) {
-      if (list.id == listId) return list;
-    }
-    return null;
+  }) => _cache.readRecord(ownerPubkey: ownerPubkey, listId: listId);
+
+  static bool _isNewerRevision(
+    ({Event event, UserList list}) candidate,
+    ({Event event, UserList list}) selected,
+  ) {
+    final createdAtComparison = candidate.event.createdAt.compareTo(
+      selected.event.createdAt,
+    );
+    if (createdAtComparison != 0) return createdAtComparison > 0;
+    return candidate.event.id.compareTo(selected.event.id) < 0;
   }
 
   /// Generates a NIP-33 `d`-tag list identifier from [instant].

--- a/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
+++ b/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
@@ -103,15 +103,6 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
     final events = result.events;
     if (events.isEmpty) return conclusive;
 
-    // Index existing lists by id so we can skip stale relay echoes whose
-    // createdAt is older than the locally-stored updatedAt. The cache alone
-    // cannot make this decision because it compares against tombstones, not
-    // against the current list's updatedAt.
-    final existing = await _cache.readLists(ownerPubkey: ownerPubkey);
-    final existingById = <String, UserList>{
-      for (final list in existing) list.id: list,
-    };
-
     final newestByListId = <String, ({Event event, UserList list})>{};
     for (final event in events) {
       final list = Nip51PeopleListCodec.decode(event);
@@ -127,19 +118,13 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
     for (final candidate in newestByListId.values) {
       final event = candidate.event;
       final list = candidate.list;
-      final current = existingById[list.id];
-      // list.updatedAt is derived from the relay event's created_at by
-      // Nip51PeopleListCodec, so comparing it against the cached list's
-      // updatedAt correctly detects stale relay echoes. If the codec ever
-      // stops sourcing updatedAt from created_at, revisit this guard.
-      if (current != null && current.updatedAt.isAfter(list.updatedAt)) {
-        continue;
-      }
-      if (current != null &&
-          current.updatedAt == list.updatedAt &&
-          current.nostrEventId != null &&
-          current.nostrEventId != list.nostrEventId &&
-          current.nostrEventId!.compareTo(list.nostrEventId ?? '') < 0) {
+      // Read the record rather than the list: whether the cached row carries a
+      // publish source decides whether a relay revision may replace it.
+      final current = await _cache.readRecord(
+        ownerPubkey: ownerPubkey,
+        listId: list.id,
+      );
+      if (current != null && !_shouldReplaceCached(current, list)) {
         continue;
       }
       await _cache.putList(
@@ -384,6 +369,39 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
     required String ownerPubkey,
     required String listId,
   }) => _cache.readRecord(ownerPubkey: ownerPubkey, listId: listId);
+
+  /// Whether relay revision [incoming] should replace cached record [current].
+  ///
+  /// [UserList.updatedAt] is derived from the relay event's `created_at` by
+  /// [Nip51PeopleListCodec], so comparing the two normally detects a stale
+  /// relay echo. If the codec ever stops sourcing `updatedAt` from
+  /// `created_at`, revisit this guard.
+  ///
+  /// A row written before this repository preserved publish sources is the
+  /// exception. Its `updatedAt` is the millisecond `DateTime.now()` the
+  /// publish stamped, so it always reads as newer than the second-resolution
+  /// `created_at` of the very event it came from — and with no source tags it
+  /// can never drive another membership edit. A matching `nostrEventId` proves
+  /// the relay holds that same event, so adopting it loses nothing and is what
+  /// keeps the list editable.
+  static bool _shouldReplaceCached(
+    CachedPeopleListRecord current,
+    UserList incoming,
+  ) {
+    final cached = current.list;
+    if (cached.updatedAt.isAfter(incoming.updatedAt)) {
+      return !current.hasPublishSource &&
+          cached.nostrEventId != null &&
+          cached.nostrEventId == incoming.nostrEventId;
+    }
+    if (cached.updatedAt == incoming.updatedAt &&
+        cached.nostrEventId != null &&
+        cached.nostrEventId != incoming.nostrEventId &&
+        cached.nostrEventId!.compareTo(incoming.nostrEventId ?? '') < 0) {
+      return false;
+    }
+    return true;
+  }
 
   static bool _isNewerRevision(
     ({Event event, UserList list}) candidate,

--- a/mobile/packages/people_lists_repository/test/local_people_lists_cache_test.dart
+++ b/mobile/packages/people_lists_repository/test/local_people_lists_cache_test.dart
@@ -199,6 +199,92 @@ void main() {
     });
 
     group('putList', () {
+      test('round-trips the complete publish source', () async {
+        final cache = LocalPeopleListsCache(openBox: makeOpener());
+        final list = _list(
+          id: 'source-list',
+          updatedAt: DateTime.utc(2026, 4, 1),
+        );
+        const sourceTags = [
+          ['d', 'source-list'],
+          ['alt', 'Written elsewhere'],
+          ['p', _memberA, 'wss://relay.example'],
+        ];
+
+        await cache.putList(
+          ownerPubkey: _ownerA,
+          list: list,
+          receivedAt: DateTime.utc(2026, 4, 20),
+          sourceTags: sourceTags,
+          sourceContent: 'encrypted-private-items',
+        );
+
+        final record = await cache.readRecord(
+          ownerPubkey: _ownerA,
+          listId: list.id,
+        );
+        expect(record, isNotNull);
+        expect(record!.list, list);
+        expect(record.sourceTags, sourceTags);
+        expect(record.sourceContent, 'encrypted-private-items');
+        expect(record.hasPublishSource, isTrue);
+      });
+
+      test(
+        'loads a legacy row without treating it as a publish source',
+        () async {
+          final cache = LocalPeopleListsCache(openBox: makeOpener());
+          final list = _list(
+            id: 'legacy-list',
+            updatedAt: DateTime.utc(2026, 4, 1),
+          );
+
+          await cache.putList(
+            ownerPubkey: _ownerA,
+            list: list,
+            receivedAt: DateTime.utc(2026, 4, 20),
+          );
+
+          final record = await cache.readRecord(
+            ownerPubkey: _ownerA,
+            listId: list.id,
+          );
+          expect(record, isNotNull);
+          expect(record!.list, list);
+          expect(record.hasPublishSource, isFalse);
+        },
+      );
+
+      test('keeps a list readable but rejects its malformed source', () async {
+        final box = await Hive.openBox<dynamic>(
+          'malformed_source_${boxCounter++}',
+          path: tempDir.path,
+        );
+        final list = _list(
+          id: 'malformed-source',
+          updatedAt: DateTime.utc(2026, 4, 1),
+        );
+        await box.put('list:$_ownerA:${list.id}', <String, dynamic>{
+          'ownerPubkey': _ownerA,
+          'list': list.toJson(),
+          'receivedAtMillis': DateTime.utc(2026, 4, 20).millisecondsSinceEpoch,
+          'sourceTags': [
+            ['d', null],
+          ],
+          'sourceContent': '',
+        });
+        final cache = LocalPeopleListsCache(openBox: () async => box);
+
+        expect(await cache.readLists(ownerPubkey: _ownerA), [list]);
+        final record = await cache.readRecord(
+          ownerPubkey: _ownerA,
+          listId: list.id,
+        );
+        expect(record, isNotNull);
+        expect(record!.list, list);
+        expect(record.hasPublishSource, isFalse);
+      });
+
       test('ignores events older than a tombstone', () async {
         final cache = LocalPeopleListsCache(openBox: makeOpener());
 

--- a/mobile/packages/people_lists_repository/test/nip51_people_list_codec_test.dart
+++ b/mobile/packages/people_lists_repository/test/nip51_people_list_codec_test.dart
@@ -16,6 +16,87 @@ void main() {
         'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
 
     group('encode', () {
+      test('edits members over the complete source event', () {
+        final list = UserList(
+          id: 'punk-friends',
+          name: 'Punk Friends',
+          pubkeys: const [memberPubkeyA, memberPubkeyB],
+          createdAt: DateTime.fromMillisecondsSinceEpoch(1710000000000),
+          updatedAt: DateTime.fromMillisecondsSinceEpoch(1710000000000),
+        );
+        const ciphertext = 'nip44-ciphertext-written-by-another-client';
+
+        final payload = Nip51PeopleListCodec.encode(
+          list,
+          sourceTags: const [
+            ['d', 'punk-friends', 'extra-position'],
+            ['alt', 'Follow set'],
+            ['p', memberPubkeyA, 'wss://relay.example', 'friend'],
+            ['p', memberPubkeyA, 'wss://backup.example'],
+            ['t', 'nostr'],
+          ],
+          sourceContent: ciphertext,
+        );
+
+        expect(payload.tags, const [
+          ['d', 'punk-friends', 'extra-position'],
+          ['alt', 'Follow set'],
+          ['p', memberPubkeyA, 'wss://relay.example', 'friend'],
+          ['p', memberPubkeyA, 'wss://backup.example'],
+          ['t', 'nostr'],
+          ['p', memberPubkeyB],
+        ]);
+        expect(payload.content, ciphertext);
+      });
+
+      test('removes every source tag for a removed member', () {
+        final list = UserList(
+          id: 'punk-friends',
+          name: 'Punk Friends',
+          pubkeys: const [memberPubkeyB],
+          createdAt: DateTime.fromMillisecondsSinceEpoch(1710000000000),
+          updatedAt: DateTime.fromMillisecondsSinceEpoch(1710000000000),
+        );
+
+        final payload = Nip51PeopleListCodec.encode(
+          list,
+          sourceTags: const [
+            ['d', 'punk-friends'],
+            ['p', memberPubkeyA, 'wss://relay.example'],
+            ['p', memberPubkeyA, 'wss://backup.example'],
+            ['p', memberPubkeyB, 'wss://relay.example'],
+          ],
+          sourceContent: '',
+        );
+
+        expect(payload.tags, const [
+          ['d', 'punk-friends'],
+          ['p', memberPubkeyB, 'wss://relay.example'],
+        ]);
+      });
+
+      test('rejects a source for a different addressable list', () {
+        final list = UserList(
+          id: 'punk-friends',
+          name: 'Punk Friends',
+          pubkeys: const [memberPubkeyA],
+          createdAt: DateTime.fromMillisecondsSinceEpoch(1710000000000),
+          updatedAt: DateTime.fromMillisecondsSinceEpoch(1710000000000),
+        );
+
+        expect(
+          () => Nip51PeopleListCodec.encode(
+            list,
+            sourceTags: const [
+              ['d', 'some-other-list'],
+              ['p', memberPubkeyA],
+            ],
+            sourceContent: '',
+          ),
+          throwsArgumentError,
+        );
+      });
+
       test('creates a kind 30000 follow set with all optional tags', () {
         final list = UserList(
           id: 'punk-friends',

--- a/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
@@ -50,6 +50,8 @@ const _memberA =
     '2222222222222222222222222222222222222222222222222222222222222222';
 const _memberB =
     '3333333333333333333333333333333333333333333333333333333333333333';
+const _memberC =
+    '5555555555555555555555555555555555555555555555555555555555555555';
 const _blockedOwnerPubkey =
     '4444444444444444444444444444444444444444444444444444444444444444';
 
@@ -225,6 +227,121 @@ void main() {
     });
 
     group('addPubkey', () {
+      test('preserves foreign tags, p-tag positions, and content', () async {
+        final client = _MockNostrClient();
+        when(() => client.publicKey).thenReturn(_ownerPubkey);
+        final remote = signedEvent(
+          kind: _peopleListKind,
+          tags: const [
+            ['d', 'shared-list'],
+            ['alt', 'Written by another client'],
+            ['p', _memberA, 'wss://relay.example', 'friend'],
+            ['expiration', '2000000000'],
+          ],
+          content: 'nip44-encrypted-private-members',
+          createdAt: 1000,
+        );
+        when(
+          () => client.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: true,
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => (events: [remote], timedOut: false, noRelays: false),
+        );
+        when(() => client.publishEvent(any())).thenAnswer((invocation) async {
+          final event = invocation.positionalArguments.first as Event;
+          return PublishSuccess(event: event);
+        });
+        final repository = buildRepository(nostrClient: client);
+
+        final result = await repository.addPubkey(
+          ownerPubkey: _ownerPubkey,
+          listId: 'shared-list',
+          pubkey: _memberB,
+        );
+
+        expect(result.status, PeopleListPublishStatus.submitted);
+        final published =
+            verify(() => client.publishEvent(captureAny())).captured.single
+                as Event;
+        expect(published.tags, const [
+          ['d', 'shared-list'],
+          ['alt', 'Written by another client'],
+          ['p', _memberA, 'wss://relay.example', 'friend'],
+          ['expiration', '2000000000'],
+          ['p', _memberB],
+        ]);
+        expect(published.content, 'nip44-encrypted-private-members');
+      });
+
+      test(
+        'a second edit uses the complete source published by the first',
+        () async {
+          final client = _MockNostrClient();
+          when(() => client.publicKey).thenReturn(_ownerPubkey);
+          final staleRemote = signedEvent(
+            kind: _peopleListKind,
+            tags: const [
+              ['d', 'shared-list'],
+              ['alt', 'Keep me'],
+              ['p', _memberA, 'wss://relay.example'],
+            ],
+            content: 'ciphertext',
+            createdAt: 1000,
+          );
+          when(
+            () => client.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: true,
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              events: [staleRemote],
+              timedOut: false,
+              noRelays: false,
+            ),
+          );
+          when(() => client.publishEvent(any())).thenAnswer((invocation) async {
+            return PublishSuccess(
+              event: invocation.positionalArguments.first as Event,
+            );
+          });
+          final repository = buildRepository(nostrClient: client);
+
+          expect(
+            (await repository.addPubkey(
+              ownerPubkey: _ownerPubkey,
+              listId: 'shared-list',
+              pubkey: _memberB,
+            )).submitted,
+            isTrue,
+          );
+          expect(
+            (await repository.addPubkey(
+              ownerPubkey: _ownerPubkey,
+              listId: 'shared-list',
+              pubkey: _memberC,
+            )).submitted,
+            isTrue,
+          );
+
+          final published = verify(
+            () => client.publishEvent(captureAny()),
+          ).captured.cast<Event>();
+          expect(published.last.tags, const [
+            ['d', 'shared-list'],
+            ['alt', 'Keep me'],
+            ['p', _memberA, 'wss://relay.example'],
+            ['p', _memberB],
+            ['p', _memberC],
+          ]);
+          expect(published.last.content, 'ciphertext');
+        },
+      );
+
       test(
         'publishes a kind 30000 event with a full p tag for new pubkey',
         () async {
@@ -586,6 +703,52 @@ void main() {
           );
         },
       );
+
+      test(
+        'a legacy cached list without a complete source fails closed',
+        () async {
+          final client = publishingClient();
+          final cache = LocalPeopleListsCache(openBox: makeOpener());
+          final legacyEvent = signedEvent(
+            kind: _peopleListKind,
+            tags: const [
+              ['d', 'legacy-list'],
+              ['title', 'Legacy'],
+              ['p', _memberA],
+            ],
+            createdAt: 2000,
+          );
+          await cache.putList(
+            ownerPubkey: _ownerPubkey,
+            list: Nip51PeopleListCodec.decode(legacyEvent)!,
+            receivedAt: DateTime.now().toUtc(),
+          );
+          stubReconcile(
+            client,
+            events: [
+              signedEvent(
+                kind: _peopleListKind,
+                tags: const [
+                  ['d', 'legacy-list'],
+                  ['title', 'Older'],
+                  ['p', _memberA],
+                ],
+                createdAt: 1000,
+              ),
+            ],
+          );
+          final repository = buildRepository(nostrClient: client, cache: cache);
+
+          final result = await repository.addPubkey(
+            ownerPubkey: _ownerPubkey,
+            listId: 'legacy-list',
+            pubkey: _memberB,
+          );
+
+          expect(result.status, PeopleListPublishStatus.failed);
+          verifyNever(() => client.publishEvent(any()));
+        },
+      );
     });
 
     group('deleteList', () {
@@ -690,6 +853,104 @@ void main() {
     });
 
     group('syncOwner', () {
+      test(
+        'stores the newest revision regardless of relay result order',
+        () async {
+          final client = _MockNostrClient();
+          when(() => client.publicKey).thenReturn(_ownerPubkey);
+          final newer = signedEvent(
+            kind: _peopleListKind,
+            tags: const [
+              ['d', 'Crew'],
+              ['title', 'Newer'],
+              ['p', _memberA],
+              ['p', _memberB],
+            ],
+            createdAt: 2000,
+          );
+          final older = signedEvent(
+            kind: _peopleListKind,
+            tags: const [
+              ['d', 'Crew'],
+              ['title', 'Older'],
+              ['p', _memberA],
+            ],
+            createdAt: 1000,
+          );
+          when(
+            () => client.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: true,
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              events: [newer, older],
+              timedOut: false,
+              noRelays: false,
+            ),
+          );
+          final repository = buildRepository(nostrClient: client);
+
+          await repository.syncOwner(ownerPubkey: _ownerPubkey);
+
+          final stored = await repository.readLists(ownerPubkey: _ownerPubkey);
+          expect(stored.single.name, 'Newer');
+          expect(stored.single.pubkeys, const [_memberA, _memberB]);
+        },
+      );
+
+      test('uses the lowest event id when revision timestamps tie', () async {
+        final client = _MockNostrClient();
+        when(() => client.publicKey).thenReturn(_ownerPubkey);
+        final higherId =
+            signedEvent(
+                kind: _peopleListKind,
+                tags: const [
+                  ['d', 'Crew'],
+                  ['title', 'Higher id'],
+                  ['p', _memberA],
+                ],
+                createdAt: 2000,
+              )
+              ..id =
+                  'ffffffffffffffffffffffffffffffff'
+                  'ffffffffffffffffffffffffffffffff';
+        final lowerId =
+            signedEvent(
+                kind: _peopleListKind,
+                tags: const [
+                  ['d', 'Crew'],
+                  ['title', 'Lower id'],
+                  ['p', _memberB],
+                ],
+                createdAt: 2000,
+              )
+              ..id =
+                  '00000000000000000000000000000000'
+                  '00000000000000000000000000000000';
+        when(
+          () => client.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: true,
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: [higherId, lowerId],
+            timedOut: false,
+            noRelays: false,
+          ),
+        );
+        final repository = buildRepository(nostrClient: client);
+
+        await repository.syncOwner(ownerPubkey: _ownerPubkey);
+
+        final stored = await repository.readLists(ownerPubkey: _ownerPubkey);
+        expect(stored.single.name, 'Lower id');
+        expect(stored.single.pubkeys, const [_memberB]);
+      });
+
       test(
         'queries kind 30000 by author and writes decoded lists to cache',
         () async {

--- a/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
@@ -749,6 +749,60 @@ void main() {
           verifyNever(() => client.publishEvent(any()));
         },
       );
+
+      test(
+        'a pre-source row adopts the source of the event it already holds',
+        () async {
+          final client = publishingClient();
+          final cache = LocalPeopleListsCache(openBox: makeOpener());
+          final publishedEvent = signedEvent(
+            kind: _peopleListKind,
+            tags: const [
+              ['d', 'legacy-list'],
+              ['title', 'Legacy'],
+              ['alt', 'Written by another client'],
+              ['p', _memberA, 'wss://relay.example'],
+            ],
+            content: 'ciphertext',
+            createdAt: 1700000000,
+          );
+          // The row a publish left behind before source preservation: the
+          // same event, stamped with the millisecond `DateTime.now()` of the
+          // publish, which always reads as newer than that event's
+          // second-resolution created_at.
+          await cache.putList(
+            ownerPubkey: _ownerPubkey,
+            list: Nip51PeopleListCodec.decode(publishedEvent)!.copyWith(
+              updatedAt: DateTime.fromMillisecondsSinceEpoch(
+                1700000000 * 1000 + 250,
+                isUtc: true,
+              ),
+            ),
+            receivedAt: DateTime.now().toUtc(),
+          );
+          stubReconcile(client, events: [publishedEvent]);
+          final repository = buildRepository(nostrClient: client, cache: cache);
+
+          final result = await repository.addPubkey(
+            ownerPubkey: _ownerPubkey,
+            listId: 'legacy-list',
+            pubkey: _memberB,
+          );
+
+          expect(result.status, PeopleListPublishStatus.submitted);
+          final published =
+              verify(() => client.publishEvent(captureAny())).captured.single
+                  as Event;
+          expect(published.tags, const [
+            ['d', 'legacy-list'],
+            ['title', 'Legacy'],
+            ['alt', 'Written by another client'],
+            ['p', _memberA, 'wss://relay.example'],
+            ['p', _memberB],
+          ]);
+          expect(published.content, 'ciphertext');
+        },
+      );
     });
 
     group('deleteList', () {


### PR DESCRIPTION
## Problem

Adding or removing someone from a people list replaced the whole Nostr event with only the fields Divine understands. That silently deleted metadata, relay hints, and encrypted private members written by other clients.

## Why this fix

The relay event is now retained as the complete publish source alongside the display-only `UserList`. Membership edits walk that source once: untouched tags and surviving member tags remain byte-for-byte equivalent, removed members lose every matching tag, new members receive a minimal `p` tag, and encrypted content passes through unchanged.

The cache distinguishes a complete source from legacy or malformed rows and fails closed when it cannot safely construct a replacement. Reconciliation also selects the newest addressable-event revision deterministically before persisting its model and source together.

## Deliberately unchanged

The app-managed `d=notify` list uses a separate in-memory snapshot and remains outside this PR. #8783 tracks applying the same preservation contract there.

This does not add private-member editing or change the public `UserList` model.

## Verification

- `flutter analyze lib test`
- `very_good test --coverage --min-coverage 95` — 105 tests passed
- repository pre-push analyzer and focused tests

Closes #8729