### PR TITLE
build(seed-media): keep screenshot fixtures out of release builds

### DIFF
--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -573,10 +573,12 @@ cd <patch-worktree>/mobile && ruby <main-checkout>/mobile/scripts/shorebird_patc
 
 It reads `refs/remotes/origin/main`, so fetch `main` first.
 
-**`shorebird init` invents a `divineuitests` flavor.** Its iOS detection treats
-every shared Xcode scheme that is not `Runner` as a product flavor, and picks up
-the `DivineUITests` test target. The app has no product flavors — if a re-init
-ever writes a `flavors:` block into `shorebird.yaml`, delete it.
+**`shorebird init` invents a `divineuitests` release flavor.** Its iOS detection
+treats every shared Xcode scheme that is not `Runner` as a product flavor, and
+picks up the `DivineUITests` test target. That scheme now intentionally has a
+matching `Debug-DivineUITests` configuration solely to include screenshot asset
+fixtures. It is not a shipping flavor. If a re-init ever writes a `flavors:`
+block into `shorebird.yaml`, delete it.
 
 ## Reference
 

--- a/mobile/ios/Podfile
+++ b/mobile/ios/Podfile
@@ -12,6 +12,7 @@ install! 'cocoapods', :warn_for_unused_master_specs_repo => false
 
 project 'Runner', {
   'Debug' => :debug,
+  'Debug-DivineUITests' => :debug,
   'Profile' => :release,
   'Release' => :release,
 }

--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -88,8 +88,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		029BDD854485FA62BC5A9C26 /* Pods-RunnerTests.debug-divineuitests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug-divineuitests.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug-divineuitests.xcconfig"; sourceTree = "<group>"; };
 		037A7FC0D83198C29E787FD1 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		06671AD11C80317FA3B1799D /* NostrBridgeAttestationPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NostrBridgeAttestationPlugin.swift; sourceTree = "<group>"; };
+		0E3A100F5AEE1456DCC23B03 /* Pods-Runner.debug-divineuitests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug-divineuitests.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug-divineuitests.xcconfig"; sourceTree = "<group>"; };
 		0F9089E8B21DD51EA95A008F /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
@@ -111,7 +113,6 @@
 		7B0F1A2B3C4D5E6F708192A3 /* Profile.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Profile.xcconfig; path = Flutter/Profile.xcconfig; sourceTree = "<group>"; };
 		82B841000000000000334401 /* AppVersion.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = AppVersion.xcconfig; path = Flutter/AppVersion.xcconfig; sourceTree = "<group>"; };
 		8CE07D4A15ABF6932C18302C /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
-		F17EBA5E0000000000000001 /* GoogleService-Info-Debug.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Debug.plist"; sourceTree = "<group>"; };
 		8E202EC5FED8AC0BD1454DD8 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -147,6 +148,7 @@
 		D1A000000000000000000018 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/Localizable.strings; sourceTree = "<group>"; };
 		D1A000000000000000000019 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
 		D1A00000000000000000001A /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F17EBA5E0000000000000001 /* GoogleService-Info-Debug.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Debug.plist"; sourceTree = "<group>"; };
 		FFDB7ACB68DA1546A0CCA26A /* SnapshotHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -302,6 +304,8 @@
 				8E202EC5FED8AC0BD1454DD8 /* Pods-RunnerTests.release.xcconfig */,
 				7724038FFA9E1FC6C1CB27D0 /* Pods-Runner.profile.xcconfig */,
 				0F9089E8B21DD51EA95A008F /* Pods-RunnerTests.profile.xcconfig */,
+				0E3A100F5AEE1456DCC23B03 /* Pods-Runner.debug-divineuitests.xcconfig */,
+				029BDD854485FA62BC5A9C26 /* Pods-RunnerTests.debug-divineuitests.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -546,23 +550,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		F17EBA5E0000000000000002 /* Use staging Firebase config */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PROJECT_DIR}/Runner/GoogleService-Info-Debug.plist",
-			);
-			name = "Use staging Firebase config";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ \"$CONFIGURATION\" = \"Debug\" ]; then\n  cp \"$PROJECT_DIR/Runner/GoogleService-Info-Debug.plist\" \"$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/GoogleService-Info.plist\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
 		0439C9E33AA6B9E50AD033CE /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -670,6 +657,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F17EBA5E0000000000000002 /* Use staging Firebase config */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PROJECT_DIR}/Runner/GoogleService-Info-Debug.plist",
+			);
+			name = "Use staging Firebase config";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"$CONFIGURATION\" = \"Debug\" ] || [ \"$CONFIGURATION\" = \"Debug-DivineUITests\" ]; then\n  cp \"$PROJECT_DIR/Runner/GoogleService-Info-Debug.plist\" \"$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/GoogleService-Info.plist\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -791,6 +795,42 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		08212E517D79FA4E7FC6B005 /* Debug-DivineUITests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = Runner;
+			};
+			name = "Debug-DivineUITests";
+		};
+		0834E00E905A4759B34181D5 /* Debug-DivineUITests */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 029BDD854485FA62BC5A9C26 /* Pods-RunnerTests.debug-divineuitests.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = GZCZBKH7MY;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.RunnerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
+			};
+			name = "Debug-DivineUITests";
+		};
 		0BC0507D5E3CE82900357116 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -807,6 +847,34 @@
 				TEST_TARGET_NAME = Runner;
 			};
 			name = Debug;
+		};
+		1920DEB43254CC0788B0574D /* Debug-DivineUITests */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 82B841000000000000334401 /* AppVersion.xcconfig */;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = CameraQuickActionWidget/CameraQuickActionWidgetDebug.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = GZCZBKH7MY;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = CameraQuickActionWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.staging.CameraQuickActionWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Debug-DivineUITests";
 		};
 		249021D3217E4FDB00AE95B9 /* Profile */ = {
 			isa = XCBuildConfiguration;
@@ -970,6 +1038,37 @@
 			};
 			name = Debug;
 		};
+		690C290FFEC18D56B5A4AB45 /* Debug-DivineUITests */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
+			buildSettings = {
+				APP_DISPLAY_NAME = "Divine Staging";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/RunnerDebug.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = GZCZBKH7MY;
+				ENABLE_BITCODE = NO;
+				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.staging;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Debug-DivineUITests";
+		};
 		6F25D99821DC9953797A6C8C /* Profile */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 82B841000000000000334401 /* AppVersion.xcconfig */;
@@ -996,6 +1095,91 @@
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Profile;
+		};
+		771A927547845EF5964CF7CD /* Debug-DivineUITests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Debug-DivineUITests";
+		};
+		80594D3D7487E2719C71B428 /* Debug-DivineUITests */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 82B841000000000000334401 /* AppVersion.xcconfig */;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = NotificationServiceExtension/NotificationServiceExtensionDebug.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = GZCZBKH7MY;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = NotificationServiceExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.staging.NotificationServiceExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = "Debug-DivineUITests";
 		};
 		97C147031CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1328,6 +1512,7 @@
 				9AC55D875DA6372D557DFD73 /* Release */,
 				65ADA09C553354C7668EF9F4 /* Debug */,
 				6F25D99821DC9953797A6C8C /* Profile */,
+				80594D3D7487E2719C71B428 /* Debug-DivineUITests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1338,6 +1523,7 @@
 				331C8088294A63A400263BE5 /* Debug */,
 				331C8089294A63A400263BE5 /* Release */,
 				331C808A294A63A400263BE5 /* Profile */,
+				0834E00E905A4759B34181D5 /* Debug-DivineUITests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1348,6 +1534,7 @@
 				D5C99739AAD4B4594BA82E2F /* Release */,
 				0BC0507D5E3CE82900357116 /* Debug */,
 				CF7F20E6143507C66B284ADD /* Profile */,
+				08212E517D79FA4E7FC6B005 /* Debug-DivineUITests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1358,6 +1545,7 @@
 				97C147031CF9000F007C117D /* Debug */,
 				97C147041CF9000F007C117D /* Release */,
 				249021D3217E4FDB00AE95B9 /* Profile */,
+				771A927547845EF5964CF7CD /* Debug-DivineUITests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1368,6 +1556,7 @@
 				97C147061CF9000F007C117D /* Debug */,
 				97C147071CF9000F007C117D /* Release */,
 				249021D4217E4FDB00AE95B9 /* Profile */,
+				690C290FFEC18D56B5A4AB45 /* Debug-DivineUITests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1378,6 +1567,7 @@
 				D1A000000000000000000024 /* Release */,
 				D1A000000000000000000023 /* Debug */,
 				D1A000000000000000000025 /* Profile */,
+				1920DEB43254CC0788B0574D /* Debug-DivineUITests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/mobile/ios/Runner.xcodeproj/xcshareddata/xcschemes/DivineUITests.xcscheme
+++ b/mobile/ios/Runner.xcodeproj/xcshareddata/xcschemes/DivineUITests.xcscheme
@@ -41,7 +41,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Debug-DivineUITests"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -76,7 +76,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Debug-DivineUITests"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -114,7 +114,7 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Debug">
+      buildConfiguration = "Debug-DivineUITests">
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Release"

--- a/mobile/ios/fastlane/README_SCREENSHOTS.md
+++ b/mobile/ios/fastlane/README_SCREENSHOTS.md
@@ -27,6 +27,13 @@ recapturing (e.g. after editing caption copy), run
 
 The `screenshots` lane verifies step 1 ran (it checks `Generated.xcconfig`
 for the `SCREENSHOT_MODE` define) and fails fast with instructions if not.
+The `DivineUITests` scheme uses the `Debug-DivineUITests` build configuration,
+which is also the Flutter asset flavor that bundles the screenshot-only videos
+and thumbnails.
+
+A flavorless `flutter run --dart-define=SCREENSHOT_MODE=true` does not bundle
+those fixtures. For manual screenshot-mode debugging, select the
+`DivineUITests` scheme in Xcode so the app is built with its fixture flavor.
 
 Output lands in `mobile/ios/fastlane/screenshots/<locale>/` - raw captures
 as `<device>-<name>.png`, framed + captioned versions as
@@ -49,6 +56,9 @@ bundle exec fastlane frame     # re-frame existing captures (fast)
   `lib/config/screenshot_mode.dart`) is compile-time false outside debug
   builds; the Fastfile verifies the define is present before capture, and
   no screenshot affordance ships in Release.
+- The `Debug-DivineUITests` configuration lets Flutter infer the
+  `DivineUITests` asset flavor from the scheme build. Production and ordinary
+  debug builds therefore omit the screenshot-only videos and thumbnails.
 - On launch, screenshot mode creates a **throwaway Nostr account**
   (fresh key, terms auto-accepted) and follows a fixed set of well-known
   creators (see `ScreenshotModeService.creatorPubkeysHex`) so the share

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -452,12 +452,18 @@ flutter:
     - assets/loading-brand-sprite.png
     - assets/seed_data/seed_events.json
     - assets/seed_data/classic_viner_profiles.json
-    - assets/seed_media/videos/0cfc8ec503ae05856ec43165bebb7d0d2a3759b2900e38f509b8d08154ef6dc2.mp4
-    - assets/seed_media/videos/606486ed7079b4b2614e9ca3e0f46c1c9a4a39d52c90dd25a9e51d1b7cf96b33.mp4
-    - assets/seed_media/videos/6c7bf42367895238e3bd20b12e95a171e9a37a41e2b9b18b89f228de38e9f827.mp4
-    - assets/seed_media/thumbnails/0cfc8ec503ae05856ec43165bebb7d0d2a3759b2900e38f509b8d08154ef6dc2.jpg
-    - assets/seed_media/thumbnails/606486ed7079b4b2614e9ca3e0f46c1c9a4a39d52c90dd25a9e51d1b7cf96b33.jpg
-    - assets/seed_media/thumbnails/6c7bf42367895238e3bd20b12e95a171e9a37a41e2b9b18b89f228de38e9f827.jpg
+    - path: assets/seed_media/videos/0cfc8ec503ae05856ec43165bebb7d0d2a3759b2900e38f509b8d08154ef6dc2.mp4
+      flavors: [DivineUITests]
+    - path: assets/seed_media/videos/606486ed7079b4b2614e9ca3e0f46c1c9a4a39d52c90dd25a9e51d1b7cf96b33.mp4
+      flavors: [DivineUITests]
+    - path: assets/seed_media/videos/6c7bf42367895238e3bd20b12e95a171e9a37a41e2b9b18b89f228de38e9f827.mp4
+      flavors: [DivineUITests]
+    - path: assets/seed_media/thumbnails/0cfc8ec503ae05856ec43165bebb7d0d2a3759b2900e38f509b8d08154ef6dc2.jpg
+      flavors: [DivineUITests]
+    - path: assets/seed_media/thumbnails/606486ed7079b4b2614e9ca3e0f46c1c9a4a39d52c90dd25a9e51d1b7cf96b33.jpg
+      flavors: [DivineUITests]
+    - path: assets/seed_media/thumbnails/6c7bf42367895238e3bd20b12e95a171e9a37a41e2b9b18b89f228de38e9f827.jpg
+      flavors: [DivineUITests]
     - assets/seed_media/classic_viner_avatars/brittany-furlan.png
     - assets/seed_media/classic_viner_avatars/jerome-jarre.png
     - assets/stickers/

--- a/mobile/test/services/screenshot_mode_service_test.dart
+++ b/mobile/test/services/screenshot_mode_service_test.dart
@@ -14,6 +14,8 @@ import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/screenshot_mode_service.dart';
 import 'package:yaml/yaml.dart';
 
+const _classicVinerAvatarDirectory = 'assets/seed_media/classic_viner_avatars';
+
 class _MockAuthService extends Mock implements AuthService {}
 
 /// Files under [dir] that could legitimately be declared as bundled assets.
@@ -28,6 +30,27 @@ Set<String> bundleCandidatesIn(Directory dir) => dir
     .map((file) => file.path.replaceAll(Platform.pathSeparator, '/'))
     .where((path) => !path.split('/').last.startsWith('.'))
     .toSet();
+
+Map<String, Set<String>> declaredFlutterAssets() {
+  final pubspec = loadYaml(File('pubspec.yaml').readAsStringSync()) as YamlMap;
+  final assets = (pubspec['flutter'] as YamlMap)['assets'] as YamlList;
+  final declarations = <String, Set<String>>{};
+
+  for (final asset in assets) {
+    switch (asset) {
+      case final String path:
+        declarations[path] = {};
+      case final YamlMap entry:
+        declarations[entry['path'] as String] = {
+          for (final flavor in entry['flavors'] as YamlList) flavor as String,
+        };
+      default:
+        throw FormatException('Unsupported Flutter asset declaration: $asset');
+    }
+  }
+
+  return declarations;
+}
 
 void main() {
   group(ScreenshotModeService, () {
@@ -220,13 +243,8 @@ void main() {
           }
         });
 
-        test('every seed-media file is bundled explicitly', () {
-          final pubspec =
-              loadYaml(File('pubspec.yaml').readAsStringSync()) as YamlMap;
-          final flutterAssets =
-              (pubspec['flutter'] as YamlMap)['assets'] as YamlList;
-          final declaredSeedMedia = flutterAssets
-              .cast<String>()
+        test('every seed-media file is declared explicitly', () {
+          final declaredSeedMedia = declaredFlutterAssets().keys
               .where((asset) => asset.startsWith('assets/seed_media/'))
               .toSet();
           final seedMediaOnDisk = bundleCandidatesIn(
@@ -241,6 +259,57 @@ void main() {
                 'removals cannot silently change the app bundle',
           );
         });
+
+        test('production bundles contain only classic-profile avatars', () {
+          final productionSeedMedia = declaredFlutterAssets().entries
+              .where(
+                (entry) =>
+                    entry.key.startsWith('assets/seed_media/') &&
+                    entry.value.isEmpty,
+              )
+              .map((entry) => entry.key)
+              .toSet();
+
+          expect(
+            productionSeedMedia,
+            equals({
+              '$_classicVinerAvatarDirectory/brittany-furlan.png',
+              '$_classicVinerAvatarDirectory/jerome-jarre.png',
+            }),
+          );
+        });
+
+        test('screenshot fixtures are bundled only for DivineUITests', () {
+          final declarations = declaredFlutterAssets();
+
+          for (final asset in screenshotMediaAssets()) {
+            expect(
+              declarations[asset],
+              equals({'DivineUITests'}),
+              reason: '$asset must be exclusive to screenshot capture builds',
+            );
+          }
+        });
+
+        test(
+          'DivineUITests scheme selects its fixture build configuration',
+          () {
+            final scheme = File(
+              'ios/Runner.xcodeproj/xcshareddata/xcschemes/'
+              'DivineUITests.xcscheme',
+            ).readAsStringSync();
+
+            expect(
+              RegExp(
+                'buildConfiguration = "Debug-DivineUITests"',
+              ).allMatches(scheme),
+              hasLength(3),
+              reason:
+                  'the test, launch, and analyze actions must select the '
+                  'Flutter asset flavor that includes screenshot fixtures',
+            );
+          },
+        );
       });
     });
   });


### PR DESCRIPTION
## Description

Flutter packages every declared asset, so six screenshot-only videos and thumbnails were adding 3.09 MiB to every release even though their consumers are disabled outside screenshot mode. This change assigns those fixtures to the existing `DivineUITests` asset flavor and wires that scheme to `Debug-DivineUITests`, preserving deterministic App Store capture builds while ordinary and release bundles retain only the two production avatar assets.

**Related Issue:** Closes #8782

## Out of Scope

The existing classic-profile avatar files and the one-shot cleanup for assets shipped by earlier versions are unchanged. This does not add a shipping product flavor; the Shorebird documentation now calls out that distinction.

## Verification

- `flutter test test/services/screenshot_mode_service_test.dart` (16 tests passed)
- `flutter analyze` (no issues)
- `flutter build bundle --debug` (2 seed-media manifest entries: production avatars only)
- `flutter build ios --simulator --debug --config-only --dart-define=SCREENSHOT_MODE=true`, followed by `xcodebuild -workspace ios/Runner.xcworkspace -scheme DivineUITests -configuration Debug-DivineUITests -sdk iphonesimulator -destination "generic/platform=iOS Simulator" -derivedDataPath build/issue8782-derived-data build-for-testing CODE_SIGNING_ALLOWED=NO` (test build succeeded; 8 seed-media manifest entries)
- `scripts/check_ios_extension_signing_contract.sh`
- `scripts/check_ios_shipping_versions.sh`
- `.codex/scripts/test-config.sh`

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore