### PR TITLE
fix(tooling): stop the stale-branch report recommending worktrees still in use

### DIFF
--- a/mobile/scripts/ci/detect_mobile_ci_scope.sh
+++ b/mobile/scripts/ci/detect_mobile_ci_scope.sh
@@ -78,6 +78,13 @@ while IFS= read -r path; do
     mobile/lib/*|mobile/test/*|mobile/integration_test/*|mobile/scripts/*)
       app=true
       ;;
+    scripts/*)
+      # Repo-root tooling is covered by mobile/test/tools/, which only runs in
+      # the app matrix. Without this arm a scripts/-only PR skips the one job
+      # that tests it, and there is no shellcheck or `bash -n` step to catch it
+      # instead (#8761).
+      app=true
+      ;;
     mobile/android/*|mobile/ios/*|mobile/macos/*|mobile/web/*|mobile/assets/*|mobile/fonts/*|mobile/overrides/*|mobile/l10n/*)
       app=true
       ;;

--- a/mobile/test/tools/detect_mobile_ci_scope_test.dart
+++ b/mobile/test/tools/detect_mobile_ci_scope_test.dart
@@ -229,6 +229,20 @@ esac
       );
     });
 
+    test('repo-root script changes run app CI', () {
+      // mobile/test/tools/ only runs in the app matrix, so a scripts/-only PR
+      // must not skip the one job that tests it (#8761).
+      expectScope(
+        runDetector(
+          event: 'pull_request',
+          changedFiles: ['scripts/prune-merged-branches.sh'],
+          changedTotal: 1,
+        ),
+        app: true,
+        native: false,
+      );
+    });
+
     test('detector changes run native checks', () {
       expectScope(
         runDetector(

--- a/mobile/test/tools/prune_merged_branches_test.dart
+++ b/mobile/test/tools/prune_merged_branches_test.dart
@@ -64,6 +64,8 @@ void main() {
       required List<String> mergedHeadRefs,
       required List<String> githubCommitShas,
       List<String> mergedTipShas = const [],
+      List<String> containedShas = const [],
+      bool compareFails = false,
       List<String> args = const [],
     }) {
       return Process.runSync(
@@ -79,6 +81,8 @@ void main() {
           'FAKE_MERGED_HEAD_REFS': mergedHeadRefs.join('\n'),
           'FAKE_GITHUB_COMMIT_SHAS': githubCommitShas.join('\n'),
           'FAKE_MERGED_TIP_SHAS': mergedTipShas.join('\n'),
+          'FAKE_CONTAINED_SHAS': containedShas.join('\n'),
+          if (compareFails) 'FAKE_COMPARE_FAILS': '1',
           'FAKE_GH_ARGS': ghArgs.path,
         },
       );
@@ -109,6 +113,23 @@ printf '%s\n' "$*" >> "${FAKE_GH_ARGS:?}"
 if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
   if [ -n "${FAKE_MERGED_HEAD_REFS:-}" ]; then
     printf '%s\n' "$FAKE_MERGED_HEAD_REFS"
+  fi
+  exit 0
+fi
+
+if [ "$1" = "api" ] && [ "${2:-}" = "graphql" ]; then
+  if [ "${FAKE_COMPARE_FAILS:-}" = "1" ]; then
+    echo "simulated compare failure" >&2
+    exit 1
+  fi
+  head=""
+  for arg in "$@"; do
+    case "$arg" in head=*) head="${arg#head=}" ;; esac
+  done
+  if printf '%s\n' "${FAKE_CONTAINED_SHAS:-}" | grep -qxF -- "$head"; then
+    printf 'BEHIND\n'
+  else
+    printf 'DIVERGED\n'
   fi
   exit 0
 fi
@@ -307,6 +328,7 @@ exit 2
         mergedHeadRefs: const [],
         githubCommitShas: [tip],
         mergedTipShas: [tip],
+        containedShas: [tip],
       );
 
       expect(result.exitCode, 0, reason: result.stderr.toString());
@@ -342,7 +364,114 @@ exit 2
 
       expect(result.exitCode, 0, reason: result.stderr.toString());
       expect(result.stdout, contains('KEEP           no-worktree-branch'));
-      expect(ghArgs.readAsStringSync(), isNot(contains('/pulls')));
+      final args = ghArgs.readAsStringSync();
+      expect(args, isNot(contains('/pulls')));
+      expect(args, isNot(contains('graphql')));
+    });
+
+    test('keeps a worktree tip GitHub reports as already on the base', () {
+      makeBranch('tip-on-base', 'no commits of its own');
+      final tip = branchTip('tip-on-base');
+      final worktree = Directory(p.join(sandbox.path, 'tip-on-base'));
+      git(['worktree', 'add', worktree.path, 'tip-on-base']);
+
+      final result = runScript(
+        mergedHeadRefs: const [],
+        githubCommitShas: [tip],
+        mergedTipShas: [tip],
+        containedShas: [tip],
+      );
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('KEEP           tip-on-base'));
+      expect(result.stdout, contains('0 likely prunable'));
+    });
+
+    test('keeps a shallow-clone worktree whose tip is an ancestor of main', () {
+      // #8761: `git merge-base --is-ancestor` returns "not an ancestor" for a
+      // commit that is one once the walk hits the graft boundary, which put
+      // untouched worktrees on the prunable side.
+      for (var i = 0; i < 3; i++) {
+        write('main-$i.txt', 'advance $i');
+        commit('advance main $i');
+      }
+      git(['push', 'origin', 'main']);
+
+      final older = branchTip('main~3');
+      git(['branch', 'stale-worktree', older]);
+      final worktree = Directory(p.join(sandbox.path, 'stale-worktree'));
+      git(['worktree', 'add', worktree.path, 'stale-worktree']);
+
+      git(['fetch', '--depth', '1', 'origin', 'main']);
+      expect(
+        Process.runSync('git', [
+          'rev-parse',
+          '--is-shallow-repository',
+        ], workingDirectory: repo.path).stdout.toString().trim(),
+        'true',
+        reason: 'fixture must be shallow for this regression to apply',
+      );
+      // The local signal the old implementation trusted is wrong here.
+      expect(
+        Process.runSync('git', [
+          'merge-base',
+          '--is-ancestor',
+          older,
+          'origin/main',
+        ], workingDirectory: repo.path).exitCode,
+        isNot(0),
+        reason: 'precondition: local ancestry must be unanswerable',
+      );
+
+      final result = runScript(
+        mergedHeadRefs: const [],
+        githubCommitShas: [older],
+        mergedTipShas: [older],
+        containedShas: [older],
+      );
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('KEEP           stale-worktree'));
+      expect(result.stdout, contains('0 likely prunable'));
+      expect(
+        result.stdout,
+        contains('Containment is resolved by GitHub, not locally'),
+      );
+    });
+
+    test('keeps a worktree when the containment check cannot be answered', () {
+      makeBranch('pr-8888', 'review checkout');
+      final tip = branchTip('pr-8888');
+      final worktree = Directory(p.join(sandbox.path, 'pr-8888'));
+      git(['worktree', 'add', worktree.path, 'pr-8888']);
+
+      final result = runScript(
+        mergedHeadRefs: const [],
+        githubCommitShas: [tip],
+        mergedTipShas: [tip],
+        compareFails: true,
+      );
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('KEEP           pr-8888'));
+      expect(result.stdout, contains('0 likely prunable'));
+    });
+
+    test('asks about containment only after a merged PR contains the tip', () {
+      makeBranch('pr-7777', 'review checkout');
+      final tip = branchTip('pr-7777');
+      final worktree = Directory(p.join(sandbox.path, 'pr-7777'));
+      git(['worktree', 'add', worktree.path, 'pr-7777']);
+
+      // No merged PR contains this tip, so the containment call must not fire.
+      final result = runScript(
+        mergedHeadRefs: const [],
+        githubCommitShas: [tip],
+      );
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('KEEP           pr-7777'));
+      expect(ghArgs.readAsStringSync(), isNot(contains('graphql')));
     });
 
     test('--execute is rejected while deletion lives outside this PR', () {

--- a/mobile/test/tools/prune_merged_branches_test.dart
+++ b/mobile/test/tools/prune_merged_branches_test.dart
@@ -66,6 +66,7 @@ void main() {
       List<String> mergedTipShas = const [],
       List<String> containedShas = const [],
       bool compareFails = false,
+      String? compareStatus,
       List<String> args = const [],
     }) {
       return Process.runSync(
@@ -83,6 +84,7 @@ void main() {
           'FAKE_MERGED_TIP_SHAS': mergedTipShas.join('\n'),
           'FAKE_CONTAINED_SHAS': containedShas.join('\n'),
           if (compareFails) 'FAKE_COMPARE_FAILS': '1',
+          'FAKE_COMPARE_STATUS': ?compareStatus,
           'FAKE_GH_ARGS': ghArgs.path,
         },
       );
@@ -121,6 +123,10 @@ if [ "$1" = "api" ] && [ "${2:-}" = "graphql" ]; then
   if [ "${FAKE_COMPARE_FAILS:-}" = "1" ]; then
     echo "simulated compare failure" >&2
     exit 1
+  fi
+  if [ -n "${FAKE_COMPARE_STATUS+x}" ]; then
+    printf '%s\n' "$FAKE_COMPARE_STATUS"
+    exit 0
   fi
   head=""
   for arg in "$@"; do
@@ -455,6 +461,32 @@ exit 2
       expect(result.exitCode, 0, reason: result.stderr.toString());
       expect(result.stdout, contains('KEEP           pr-8888'));
       expect(result.stdout, contains('0 likely prunable'));
+      expect(
+        result.stderr,
+        contains('could not verify whether $tip is contained in main'),
+      );
+    });
+
+    test('warns and keeps a worktree for an unknown containment status', () {
+      makeBranch('pr-8889', 'review checkout');
+      final tip = branchTip('pr-8889');
+      final worktree = Directory(p.join(sandbox.path, 'pr-8889'));
+      git(['worktree', 'add', worktree.path, 'pr-8889']);
+
+      final result = runScript(
+        mergedHeadRefs: const [],
+        githubCommitShas: [tip],
+        mergedTipShas: [tip],
+        compareStatus: '',
+      );
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('KEEP           pr-8889'));
+      expect(result.stdout, contains('0 likely prunable'));
+      expect(
+        result.stderr,
+        contains('GitHub returned no recognized containment status for $tip'),
+      );
     });
 
     test('asks about containment only after a merged PR contains the tip', () {

--- a/scripts/prune-merged-branches.sh
+++ b/scripts/prune-merged-branches.sh
@@ -32,6 +32,14 @@
 #    recreates from tracked sources are not work; ignored paths it does not
 #    (a .env, a scratch note, a patch) still are. Only the latter veto.
 #
+# 6. `git merge-base --is-ancestor` cannot answer "is this tip already on main"
+#    here. The main checkout is a shallow clone, and the ancestry walk stops at
+#    the graft boundary: it returns exit 1 — "not an ancestor" — for a commit
+#    that is one, indistinguishable from a true negative. That wrong negative
+#    put fresh worktrees on the prunable side (#8761). Ask GitHub for
+#    containment instead, which is what points 1-4 already do for every other
+#    signal. Any unclear answer reports contained, landing on KEEP.
+#
 # The bias is deliberate. A false KEEP costs disk. A false DELETE costs work
 # that exists nowhere else — an unpushed branch has no backup. Both additions
 # above keep that asymmetry: MERGED-TIP still needs Veto 1 to pass, and an
@@ -58,6 +66,8 @@ done
 
 GH="${GH:-gh}"
 BASE="${BASE:-origin/main}"
+# GitHub names the branch without the remote: origin/main -> main.
+BASE_BRANCH="${BASE#*/}"
 REPO="${REPO:-${GITHUB_REPOSITORY:-divinevideo/divine-mobile}}"
 MERGED_PR_LIMIT="${MERGED_PR_LIMIT:-100000}"
 
@@ -70,10 +80,11 @@ git rev-parse --verify --quiet "$BASE" >/dev/null || {
   echo "$BASE not found" >&2; exit 2
 }
 
-# Shallow is fine for the signals used here: the GitHub lookups need no local
-# history, and the worktree checks inspect only the current checkout state.
+# Shallow is fine for the signals used here: every containment question goes to
+# GitHub (see point 6 above), and the worktree checks inspect only the current
+# checkout state. No classification walks local history.
 if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
-  echo "Note: shallow repository. Classification is unaffected."
+  echo "Note: shallow repository. Containment is resolved by GitHub, not locally."
 fi
 
 echo "Loading merged PR head refs from GitHub..."
@@ -107,6 +118,33 @@ merged_pr_contains_commit() {
   "$GH" api -X GET "repos/$REPO/commits/$1/pulls" \
     --jq '[.[] | select(.merged_at != null) | select(.base.ref == "main")] | length' \
     2>/dev/null | grep -qxE '[1-9][0-9]*'
+}
+
+# Is this tip already contained in the base branch on GitHub? IDENTICAL and
+# BEHIND mean yes; AHEAD and DIVERGED mean the tip carries its own commits.
+#
+# GraphQL rather than REST compare: the REST endpoint ships a `files` array and
+# returns 130-256 KB per call on this repo, against ~90 bytes here.
+#
+# `-f` rather than `-F` for every variable: `-F` type-infers, and an all-digit
+# SHA is coerced to a number, which the API rejects as a String! violation.
+#
+# Fails toward contained, which lands on KEEP. A network failure, a rate limit,
+# an unpushed tip, or any unrecognized status must not become a delete
+# recommendation.
+tip_contained_in_base() {
+  local compare_status
+  compare_status="$(
+    "$GH" api graphql \
+      -f query='query($owner:String!,$name:String!,$base:String!,$head:String!){repository(owner:$owner,name:$name){ref(qualifiedName:$base){compare(headRef:$head){status}}}}' \
+      -f owner="${REPO%%/*}" -f name="${REPO#*/}" \
+      -f base="$BASE_BRANCH" -f head="$1" \
+      --jq '.data.repository.ref.compare.status' 2>/dev/null
+  )" || return 0
+  case "$compare_status" in
+    AHEAD|DIVERGED) return 1 ;;
+    *) return 0 ;;
+  esac
 }
 
 # Ignored paths any Flutter toolchain step recreates from tracked sources.
@@ -150,11 +188,13 @@ while IFS= read -r branch; do
   if grep -qxF -- "$branch" "$MERGED_REFS"; then
     verdict="MERGED-PR"
   elif [ -n "$wt" ] && [ -d "$wt" ] \
-    && ! git merge-base --is-ancestor "$tip" "$BASE" \
-    && merged_pr_contains_commit "$tip"; then
+    && merged_pr_contains_commit "$tip" \
+    && ! tip_contained_in_base "$tip"; then
     # Only worktree branches get this lookup: it is one API call per branch,
     # and a branch with no worktree costs a ref, not 4GB of build output. Tips
-    # already on main belong to fresh worktrees, not squashed-away PR heads.
+    # already on main belong to fresh worktrees, not squashed-away PR heads, so
+    # the containment check runs last — only for branches this would otherwise
+    # call MERGED-TIP.
     verdict="MERGED-TIP"
   else
     verdict="KEEP"

--- a/scripts/prune-merged-branches.sh
+++ b/scripts/prune-merged-branches.sh
@@ -134,16 +134,23 @@ merged_pr_contains_commit() {
 # recommendation.
 tip_contained_in_base() {
   local compare_status
-  compare_status="$(
+  if ! compare_status="$(
     "$GH" api graphql \
       -f query='query($owner:String!,$name:String!,$base:String!,$head:String!){repository(owner:$owner,name:$name){ref(qualifiedName:$base){compare(headRef:$head){status}}}}' \
       -f owner="${REPO%%/*}" -f name="${REPO#*/}" \
       -f base="$BASE_BRANCH" -f head="$1" \
       --jq '.data.repository.ref.compare.status' 2>/dev/null
-  )" || return 0
+  )"; then
+    echo "Warning: could not verify whether $1 is contained in $BASE_BRANCH; keeping it." >&2
+    return 0
+  fi
   case "$compare_status" in
+    IDENTICAL|BEHIND) return 0 ;;
     AHEAD|DIVERGED) return 1 ;;
-    *) return 0 ;;
+    *)
+      echo "Warning: GitHub returned no recognized containment status for $1; keeping it." >&2
+      return 0
+      ;;
   esac
 }
 
@@ -190,11 +197,11 @@ while IFS= read -r branch; do
   elif [ -n "$wt" ] && [ -d "$wt" ] \
     && merged_pr_contains_commit "$tip" \
     && ! tip_contained_in_base "$tip"; then
-    # Only worktree branches get this lookup: it is one API call per branch,
-    # and a branch with no worktree costs a ref, not 4GB of build output. Tips
-    # already on main belong to fresh worktrees, not squashed-away PR heads, so
-    # the containment check runs last — only for branches this would otherwise
-    # call MERGED-TIP.
+    # Only worktree branches get these lookups: every candidate checks for a
+    # merged PR, then candidates with one check containment. A branch with no
+    # worktree costs a ref, not 4GB of build output. Tips already on main belong
+    # to fresh worktrees, not squashed-away PR heads, so containment runs last —
+    # only for branches this would otherwise call MERGED-TIP.
     verdict="MERGED-TIP"
   else
     verdict="KEEP"


### PR DESCRIPTION
## The problem

`scripts/prune-merged-branches.sh` tells you which local branches and worktrees look safe to delete. It could put a worktree on the "safe to delete" side when that worktree held no work at all — the exact mistake the script has a guard against.

The guard asked local git whether the worktree's tip was already contained in `main`. Our main checkout is a **shallow clone**, and that question has no reliable local answer: `git merge-base --is-ancestor` stops walking at the graft boundary and returns exit 1 — "not an ancestor" — for a commit that *is* one. Exit 1 is indistinguishable from a true negative, so no error handling could have caught it. The leading `!` turned that wrong negative into "proceed".

That inverts the bias the script's own header states: *a false KEEP costs disk, a false DELETE costs work that exists nowhere else.*

Nothing is mis-ranked in the checkout today — this fires once `main` advances past the shallow boundary, which here is 13 commits and well under a day. The failing shape is the **starting state of every worktree**: `git worktree add -b x origin/main` leaves a tip with no commits of its own.

## Why this fix

Ask GitHub for containment instead of walking local history.

That is not a new idea in this script — it is what the other four signals already do. The header's opening argument is that local git signals are untrustworthy in a squash-merge repo, and this one call was the last place still relying on one.

- **Ordered last.** The new containment call runs only for branches this would otherwise call `MERGED-TIP`. The existing commit-to-PR lookup still runs for each worktree branch whose name does not match a merged PR.
- **Fails toward KEEP.** Network failure, rate limit, unpushed tip, unrecognized status — every unclear answer reports "contained", which lands on KEEP. Nothing ambiguous can become a delete recommendation.
- **GraphQL, not REST compare.** REST ships a `files` array and returns 130–256 KB per call on this repo; the GraphQL query is ~90 bytes.
- **`-f`, not `-F`.** `-F` type-infers, and an all-digit SHA gets coerced to a number the API rejects as a `String!` violation. Found by testing it.

## What this deliberately leaves alone

Disabling `MERGED-TIP` in shallow clones is the tempting one-liner and is wrong — it would silently revert the review-worktree detection that is currently working correctly in the one checkout that runs this script.

| repo | worktree | want | before | after |
| --- | --- | --- | --- | --- |
| shallow | tip already on `main` | `KEEP` | **`MERGED-TIP`** | `KEEP` |
| shallow | genuine review worktree | `MERGED-TIP` | `MERGED-TIP` | `MERGED-TIP` |
| full | tip already on `main` | `KEEP` | `KEEP` | `KEEP` |
| full | genuine review worktree | `MERGED-TIP` | `MERGED-TIP` | `MERGED-TIP` |

## Second commit: this script had no CI

The scope detector had an arm for `mobile/scripts/*` but none for the repo-root `scripts/` directory. A PR touching only `scripts/prune-merged-branches.sh` set `app=false`, skipped the `tests` job, and so never ran `mobile/test/tools/prune_merged_branches_test.dart` — the only coverage this script has. There is no shellcheck job and no `bash -n` step to catch it instead.

This PR would have shipped with zero CI without that fix.

## Verification

- **The regression test builds a genuinely shallow fixture** and asserts `merge-base --is-ancestor` is unanswerable *before* asserting the script still reports `KEEP`, so it fails if the fixture ever stops reproducing the condition.
- **The three new behavioural tests were confirmed red against the unfixed script**, not just green against the fixed one.
- **The helper was exercised against the live API in the real shallow main checkout**: tip of `main` → contained, `main~5` → contained, unknown SHA → contained (fail-safe).
- 37 tests pass across both affected suites; `flutter analyze lib test integration_test` clean.

Closes #8761