### PR TITLE
docs(metrics): correct how many videos actually show a loop count

### DIFF
--- a/docs/superpowers/specs/2026-08-08-video-card-view-count-display-design.md
+++ b/docs/superpowers/specs/2026-08-08-video-card-view-count-display-design.md
@@ -39,7 +39,7 @@ The live site is `mobile/lib/widgets/video_feed_item/video_feed_item.dart:394`,
 inside `VideoOverlayActions.build`. It renders `videoFeedLoopCountLine` directly
 under the author name, unconditionally — so `0 loops` on a fresh post is real.
 
-`VideoEvent.totalLoops` (`mobile/packages/models/lib/src/video_event.dart:1084`)
+`VideoEvent.totalLoops` (`mobile/packages/models/lib/src/video_event.dart:1187-1188`)
 is:
 
 ```dart

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
@@ -218,13 +218,14 @@ Caveats, stated so the number is not over-read:
 ## 5. The display floor, restated on current numbers
 
 **This section is the measurement record behind the design doc's corrected
-display-floor section.** `mobile/lib/widgets/video_feed_item/video_card_meta.dart:70`
-defines the gated quantity as `video.isOriginalVine ? video.originalLoops ?? 0 :
-video.totalLoops` — i.e. the archival `loops` tag for classic Vines (about 98%
-of the `nostr.videos` catalogue; derived by the appendix query), and
-`originalLoops + views` for native ones. The design doc's table originally
+display-floor section.** The gated quantity is defined at
+`mobile/lib/widgets/video_feed_item/video_card_meta.dart:70` as
+`video.isOriginalVine ? video.originalLoops ?? 0 : video.totalLoops` — i.e. the
+archival `loops` tag for classic Vines (about 98% of the `nostr.videos`
+catalogue; derived by the appendix query), and `originalLoops + views` for
+native ones. The design doc's table originally
 measured `video_total_views_data.total_views`, which the floor is never applied
-to, and landed three orders of magnitude off; #7471 replaced it with the figures
+to, and landed three orders of magnitude off; #7218 replaced it with the figures
 below.
 
 `publicLoopCountFloor` = 1000, measured against the quantity the code
@@ -262,17 +263,16 @@ itself (`mobile/lib/widgets/video_feed_item/video_card_meta.dart:9`): a number
 below the floor "tells a viewer not to bother", and a wall of small counts on
 *other people's* videos discourages posting. On the real distribution, the
 floor shows visitors a count on ~52% of videos, every one of them ≥1000, and a
-date on the rest instead of a discouraging two-digit count. Creators are never
-gated:
-`_resolveLoopCount` returns
-`video.totalLoops` unconditionally when `isOwnVideo`, and `totalLoops` is
-additive (`mobile/packages/models/lib/src/video_event.dart:1187-1188`), so a
-creator sees the larger number.
+date on the rest instead of a discouraging sub-1000 count. Creators are never
+gated: `_resolveLoopCount` returns `video.totalLoops` unconditionally when
+`isOwnVideo`, and `totalLoops` is additive
+(`mobile/packages/models/lib/src/video_event.dart:1187-1188`), so a creator sees
+the larger number.
 
 One unreconciled discrepancy, stated rather than smoothed over: the
 constant's own doc comment reports "roughly 64% of the archive" hidden
 with "p50 is 298 loops", measured against a 1,000-Vine sample. The
-full-catalogue measurement above gives 47.7% hidden at p50 1,417. Both are
+full-catalogue measurement above gives 47.70% hidden at p50 1,417. Both are
 the same order of magnitude and both contradict the withdrawn 0.044%,
 but the sample and the census disagree by enough that the sample was
 probably not representative. Re-tuning the floor should use the census.

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
@@ -217,14 +217,15 @@ Caveats, stated so the number is not over-read:
 
 ## 5. The display floor, restated on current numbers
 
-**This section corrects the design doc, which measures the wrong column.**
-`mobile/lib/widgets/video_feed_item/video_card_meta.dart:70` defines the gated
-quantity as `video.isOriginalVine ? video.originalLoops ?? 0 :
+**This section is the measurement record behind the design doc's corrected
+display-floor section.** `mobile/lib/widgets/video_feed_item/video_card_meta.dart:70`
+defines the gated quantity as `video.isOriginalVine ? video.originalLoops ?? 0 :
 video.totalLoops` — i.e. the archival `loops` tag for classic Vines (about 98%
 of the `nostr.videos` catalogue; derived by the appendix query), and
-`originalLoops + views` for native ones. The design doc's table measures
-`video_total_views_data.total_views`, which the floor is never applied to, and
-lands three orders of magnitude off.
+`originalLoops + views` for native ones. The design doc's table originally
+measured `video_total_views_data.total_views`, which the floor is never applied
+to, and landed three orders of magnitude off; #7471 replaced it with the figures
+below.
 
 `publicLoopCountFloor` = 1000, measured against the quantity the code
 actually gates:
@@ -271,7 +272,7 @@ One unreconciled discrepancy, stated rather than smoothed over: the
 constant's own doc comment reports "roughly 64% of the archive" hidden
 with "p50 is 298 loops", measured against a 1,000-Vine sample. The
 full-catalogue measurement above gives 47.7% hidden at p50 1,417. Both are
-the same order of magnitude and both contradict the design doc's 0.044%,
+the same order of magnitude and both contradict the withdrawn 0.044%,
 but the sample and the census disagree by enough that the sample was
 probably not representative. Re-tuning the floor should use the census.
 

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
@@ -262,10 +262,11 @@ itself (`mobile/lib/widgets/video_feed_item/video_card_meta.dart:9`): a number
 below the floor "tells a viewer not to bother", and a wall of small counts on
 *other people's* videos discourages posting. On the real distribution, the
 floor shows visitors a count on ~52% of videos, every one of them ≥1000, and a
-date on the rest instead of a discouraging 47. Creators are never gated:
+date on the rest instead of a discouraging two-digit count. Creators are never
+gated:
 `_resolveLoopCount` returns
 `video.totalLoops` unconditionally when `isOwnVideo`, and `totalLoops` is
-additive (`mobile/packages/models/lib/src/video_event.dart:1181-1183`), so a
+additive (`mobile/packages/models/lib/src/video_event.dart:1187-1188`), so a
 creator sees the larger number.
 
 One unreconciled discrepancy, stated rather than smoothed over: the

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -302,7 +302,14 @@ Treat every figure here as the least the number should move, not the most.
 
 ### The display floor
 
-`publicLoopCountFloor` is 1000. It gates `_publicCount` in `mobile/lib/widgets/video_feed_item/video_card_meta.dart` — the archival `loops` tag for classic Vines (about 98% of the catalogue), and `originalLoops + views` for everything else. It is never applied to `video_total_views_data.total_views`, which is the column an earlier revision of this section measured; that mistake put the section three orders of magnitude off.
+`publicLoopCountFloor` is 1000. It gates `_publicCount` in
+`mobile/lib/widgets/video_feed_item/video_card_meta.dart` — the archival
+`loops` tag for classic Vines (about 98% of the catalogue), and
+`originalLoops + views` for everything else. It is never applied to
+`video_total_views_data.total_views`, which is the column an earlier revision
+of this section measured; that mistake put the section three orders of
+magnitude off, and #7218 corrected it in the baseline before this section
+caught up.
 
 Measured against the quantity the code actually gates:
 
@@ -312,26 +319,73 @@ Measured against the quantity the code actually gates:
 | 333 (floor reached at ×3) | 1,375,711 | 62.42% |
 | 100 (floor reached at ×10) | 1,621,923 | 73.60% |
 
-Median public count: 1,417. A public count renders on about half the catalogue, not on 0.044% of it.
+Median public count: 1,417. A public count renders on about half the
+catalogue, not on 0.044% of it.
 
-Every figure above comes from one query over `nostr.videos` that reproduces `_publicCount`'s branch in SQL: [the pre-change baseline](2026-08-13-view-and-loop-metrics-baseline.md#appendix-exact-queries), appendix block **§5 — display floor distribution**. The column mapping the whole correction rests on was checked rather than assumed: `nostr.videos.loops` is the client's `loops` tag, verified over a 200,000-row Vine sample in which 198,061 rows carry the tag and the column equals it in all 198,061, with zero mismatches. §5 of that document is the measurement record; this section states what it means for the design.
+Every figure above comes from one query over `nostr.videos` that reproduces
+`_publicCount`'s branch in SQL:
+[the pre-change baseline](2026-08-13-view-and-loop-metrics-baseline.md#appendix-exact-queries),
+appendix block **§5 — display floor distribution**. The column mapping the
+whole correction rests on was checked rather than assumed:
+`nostr.videos.loops` is the client's `loops` tag, verified over a 200,000-row
+Vine sample in which 198,061 rows carry the tag and the column equals it in
+all 198,061, with zero mismatches. §5 of that document is the measurement
+record; this section states what it means for the design.
 
-**This is live for everyone.** `FeatureFlag.videoCardPostDate` originally gated the rule as a kill switch, but it defaulted off and nothing ever set `FF_VIDEO_CARD_POST_DATE`, so it never reached a normal build. #7452 (merged 2026-08-15) deleted the dead flag, and `_resolveLoopCount` now applies the floor unconditionally for anyone who is not the video's owner. Earlier drafts of this section — including the one this replaces — describe the floor as feature-gated; that stopped being true before those words merged.
+**This is live for everyone.** `FeatureFlag.videoCardPostDate` originally
+gated the rule as a kill switch, but it defaulted off and nothing ever set
+`FF_VIDEO_CARD_POST_DATE`, so it never reached a normal build. #7452 (merged
+2026-08-15) deleted the dead flag, and `_resolveLoopCount` now applies the
+floor unconditionally for anyone who is not the video's owner. Earlier drafts
+of this section — including the one this replaces — describe the floor as
+feature-gated; that stopped being true before those words merged.
 
-This is Flutter-client behavior. Divine Web currently diverges: its card renders any positive playback count and `formatLoopCount` applies only K/M abbreviation, not a display floor.
+This is Flutter-client behavior. Divine Web currently diverges: its card
+renders any positive playback count and `formatLoopCount` applies only K/M
+abbreviation, not a display floor.
 
-**The floor decision survives the correction. Two of the arguments this document made for it do not, and are withdrawn.** Both were artifacts of the wrong column:
+**The floor decision survives the correction. Two of the arguments this
+document made for it do not, and are withdrawn.** Both were artifacts of the
+wrong column:
 
-- "The public count is effectively never shown — 9,996 videos in 10,000 render a date instead." It is shown on roughly half of them.
-- "A date is the better default for this catalogue." The archival-artifact reading — that "Apr 22, 2014" reframes a clip as an artifact — assumed a date is what almost every card renders. It is not, so the argument no longer reaches the conclusion it was offered for. Whether a date reads better than a count on a given card is untested in either direction; nothing here settles it, and no decision in this document should be read as resting on it.
+- "The public count is effectively never shown — 9,996 videos in 10,000
+  render a date instead." It is shown on roughly half of them.
+- "A date is the better default for this catalogue." The archival-artifact
+  reading — that "Apr 22, 2014" reframes a clip as an artifact — assumed a
+  date is what almost every card renders. It is not, so the argument no
+  longer reaches the conclusion it was offered for. Whether a date reads
+  better than a count on a given card is untested in either direction;
+  nothing here settles it, and no decision in this document should be read as
+  resting on it.
 
-What holds the floor up instead is the argument the constant's own doc comment gives: a number below the floor tells a viewer not to bother, and a wall of small counts on *other people's* videos discourages a visitor from posting. On the real distribution the floor does exactly that — a count on ~52% of videos, every one of them at or above 1000, and a date on the rest instead of a discouraging two-digit count.
+What holds the floor up instead is the argument the constant's own doc
+comment gives: a number below the floor tells a viewer not to bother, and a
+wall of small counts on *other people's* videos discourages a visitor from
+posting. On the real distribution the floor does exactly that — a count on
+~52% of videos, every one of them at or above 1000, and a date on the rest
+instead of a discouraging two-digit count.
 
-Creator retention is untouched by any of this and was never gated by the floor. `_resolveLoopCount` returns `video.totalLoops` unconditionally when `isOwnVideo`, and `totalLoops` is additive, so a creator who claimed a Vine account sees archival loops plus live views. The retention effect the video-card spec cites — crossing ~100 views roughly doubling the chance a new creator keeps posting — operates on the creator's own number, which has no floor.
+Creator retention is untouched by any of this and was never gated by the
+floor. `_resolveLoopCount` returns `video.totalLoops` unconditionally when
+`isOwnVideo`, and `totalLoops` is additive, so a creator who claimed a Vine
+account sees archival loops plus live views. The retention effect the
+video-card spec cites — crossing ~100 views roughly doubling the chance a new
+creator keeps posting — operates on the creator's own number, which has no
+floor.
 
-**Open, not resolved: the constant's doc comment disagrees with the census.** The doc comment on `publicLoopCountFloor` reports "roughly 64% of the archive" hidden at "p50 is 298 loops", measured against a 1,000-Vine sample; the full-catalogue census above gives 47.70% hidden at p50 1,417. Both are the same order of magnitude and both contradict the withdrawn 0.044%, but they disagree with each other by more than sampling noise allows, and the sample's provenance is unexplained. The census is the better basis and this section uses it; the comment is deliberately left standing rather than overwritten by assertion. Reconciling the two is open work.
+**Open, not resolved: the constant's doc comment disagrees with the census.**
+The doc comment on `publicLoopCountFloor` reports "roughly 64% of the archive"
+hidden at "p50 is 298 loops", measured against a 1,000-Vine sample; the
+full-catalogue census above gives 47.70% hidden at p50 1,417. Both are the
+same order of magnitude and both contradict the withdrawn 0.044%, but they
+disagree with each other by more than sampling noise allows, and the sample's
+provenance is unexplained. The census is the better basis and this section
+uses it; the comment is deliberately left standing rather than overwritten by
+assertion. Reconciling the two is open work.
 
-Re-tuning the floor value stays out of scope here. The constant is deliberately one line and the number is a product call, to be made on the census rather than as a side effect of correcting the evidence behind it.
+Re-tuning the floor value stays out of scope here. The constant is
+deliberately one line and the number is a product call, to be made on the
+census rather than as a side effect of correcting the evidence behind it.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -138,7 +138,7 @@ direction that decides it.
 
 **The card does not render this metric today, despite the label.**
 `VideoEvent.totalLoops`
-(`mobile/packages/models/lib/src/video_event.dart:1149`) is:
+(`mobile/packages/models/lib/src/video_event.dart:1187-1188`) is:
 
 ```dart
 int get totalLoops =>
@@ -325,7 +325,7 @@ This is Flutter-client behavior. Divine Web currently diverges: its card renders
 - "The public count is effectively never shown — 9,996 videos in 10,000 render a date instead." It is shown on roughly half of them.
 - "A date is the better default for this catalogue." The archival-artifact reading — that "Apr 22, 2014" reframes a clip as an artifact — assumed a date is what almost every card renders. It is not, so the argument no longer reaches the conclusion it was offered for. Whether a date reads better than a count on a given card is untested in either direction; nothing here settles it, and no decision in this document should be read as resting on it.
 
-What holds the floor up instead is the argument the constant's own doc comment gives: a number below the floor tells a viewer not to bother, and a wall of small counts on *other people's* videos discourages a visitor from posting. On the real distribution the floor does exactly that — a count on ~52% of videos, every one of them at or above 1000, and a date on the rest instead of a discouraging 47.
+What holds the floor up instead is the argument the constant's own doc comment gives: a number below the floor tells a viewer not to bother, and a wall of small counts on *other people's* videos discourages a visitor from posting. On the real distribution the floor does exactly that — a count on ~52% of videos, every one of them at or above 1000, and a date on the rest instead of a discouraging two-digit count.
 
 Creator retention is untouched by any of this and was never gated by the floor. `_resolveLoopCount` returns `video.totalLoops` unconditionally when `isOwnVideo`, and `totalLoops` is additive, so a creator who claimed a Vine account sees archival loops plus live views. The retention effect the video-card spec cites — crossing ~100 views roughly doubling the chance a new creator keeps posting — operates on the creator's own number, which has no floor.
 

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -363,7 +363,7 @@ comment gives: a number below the floor tells a viewer not to bother, and a
 wall of small counts on *other people's* videos discourages a visitor from
 posting. On the real distribution the floor does exactly that — a count on
 ~52% of videos, every one of them at or above 1000, and a date on the rest
-instead of a discouraging two-digit count.
+instead of a discouraging sub-1000 count.
 
 Creator retention is untouched by any of this and was never gated by the
 floor. `_resolveLoopCount` returns `video.totalLoops` unconditionally when

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -302,11 +302,9 @@ Treat every figure here as the least the number should move, not the most.
 
 ### The display floor
 
-`publicLoopCountFloor` is 1000. The pre-change baseline corrected this section:
-the floor applies to
-`mobile/lib/widgets/video_feed_item/video_card_meta.dart`'s public count
-(`loops` for classic Vines, `originalLoops + views` otherwise), not to
-`video_total_views_data.total_views`. Measured against the gated quantity:
+`publicLoopCountFloor` is 1000. It gates `_publicCount` in `mobile/lib/widgets/video_feed_item/video_card_meta.dart` — the archival `loops` tag for classic Vines (about 98% of the catalogue), and `originalLoops + views` for everything else. It is never applied to `video_total_views_data.total_views`, which is the column an earlier revision of this section measured; that mistake put the section three orders of magnitude off.
+
+Measured against the quantity the code actually gates:
 
 | Threshold | Videos at or above | Share of 2,203,822 |
 |---|---|---|
@@ -314,45 +312,26 @@ the floor applies to
 | 333 (floor reached at ×3) | 1,375,711 | 62.42% |
 | 100 (floor reached at ×10) | 1,621,923 | 73.60% |
 
-Median public count: 1,417. A public count renders on about half the
-catalogue, not on 0.04% of it.
+Median public count: 1,417. A public count renders on about half the catalogue, not on 0.044% of it.
 
-**This is live for everyone.** `FeatureFlag.videoCardPostDate` originally
-gated the rule as a kill switch, but it defaulted off and nothing ever set
-`FF_VIDEO_CARD_POST_DATE`, so it never reached a normal build. #7452 (merged
-2026-08-15) deleted the dead flag, and `_resolveLoopCount` now applies the
-floor unconditionally for anyone who is not the video's owner. Earlier drafts
-of this section — including the one this replaces — describe the floor as
-feature-gated; that stopped being true before those words merged.
+Every figure above comes from one query over `nostr.videos` that reproduces `_publicCount`'s branch in SQL: [the pre-change baseline](2026-08-13-view-and-loop-metrics-baseline.md#appendix-exact-queries), appendix block **§5 — display floor distribution**. The column mapping the whole correction rests on was checked rather than assumed: `nostr.videos.loops` is the client's `loops` tag, verified over a 200,000-row Vine sample in which 198,061 rows carry the tag and the column equals it in all 198,061, with zero mismatches. §5 of that document is the measurement record; this section states what it means for the design.
 
-This is Flutter-client behavior. Divine Web currently diverges: its card
-renders any positive playback count and `formatLoopCount` applies only K/M
-abbreviation, not a display floor.
+**This is live for everyone.** `FeatureFlag.videoCardPostDate` originally gated the rule as a kill switch, but it defaulted off and nothing ever set `FF_VIDEO_CARD_POST_DATE`, so it never reached a normal build. #7452 (merged 2026-08-15) deleted the dead flag, and `_resolveLoopCount` now applies the floor unconditionally for anyone who is not the video's owner. Earlier drafts of this section — including the one this replaces — describe the floor as feature-gated; that stopped being true before those words merged.
 
-The floor still matters after the metric correction, but the reason is not
-that the count is effectively never shown; it is that the counts which do
-appear are all large enough to read as social proof rather than a warning.
+This is Flutter-client behavior. Divine Web currently diverges: its card renders any positive playback count and `formatLoopCount` applies only K/M abbreviation, not a display floor.
 
-**This is intended, and it is not a defect.** Two reasons it holds:
+**The floor decision survives the correction. Two of the arguments this document made for it do not, and are withdrawn.** Both were artifacts of the wrong column:
 
-- **Creator retention does not run through the public count.** The video-card
-  spec's `isOwnVideo` case shows a creator their own number *always, however
-  small*. The retention effect it cites — crossing ~100 views roughly doubling
-  the chance a new creator keeps posting — operates on the creator's own view,
-  which has no floor. The public floor never gated it.
-- **A date is the better default for this catalogue.** With ~2.2M archived
-  vines from 2013–16, "Apr 22, 2014" reframes a clip as an artifact in a way a
-  view count does not. Suppression is not a fallback here; it is often the
-  stronger presentation.
+- "The public count is effectively never shown — 9,996 videos in 10,000 render a date instead." It is shown on roughly half of them.
+- "A date is the better default for this catalogue." The archival-artifact reading — that "Apr 22, 2014" reframes a clip as an artifact — assumed a date is what almost every card renders. It is not, so the argument no longer reaches the conclusion it was offered for. Whether a date reads better than a count on a given card is untested in either direction; nothing here settles it, and no decision in this document should be read as resting on it.
 
-Earlier drafts of this document got the measurement wrong in opposite
-directions: first claiming the correction would lift "a large share of the
-catalogue" above the floor, then claiming the floor was mis-set by two orders of
-magnitude and was starving creators of encouragement. The corrected census says
-the public floor governs a real slice of the catalogue, but it still governs
-public display only, the constant is deliberately one line, and re-tuning it is
-a product call to make on its own evidence rather than a consequence of this
-work.
+What holds the floor up instead is the argument the constant's own doc comment gives: a number below the floor tells a viewer not to bother, and a wall of small counts on *other people's* videos discourages a visitor from posting. On the real distribution the floor does exactly that — a count on ~52% of videos, every one of them at or above 1000, and a date on the rest instead of a discouraging 47.
+
+Creator retention is untouched by any of this and was never gated by the floor. `_resolveLoopCount` returns `video.totalLoops` unconditionally when `isOwnVideo`, and `totalLoops` is additive, so a creator who claimed a Vine account sees archival loops plus live views. The retention effect the video-card spec cites — crossing ~100 views roughly doubling the chance a new creator keeps posting — operates on the creator's own number, which has no floor.
+
+**Open, not resolved: the constant's doc comment disagrees with the census.** The doc comment on `publicLoopCountFloor` reports "roughly 64% of the archive" hidden at "p50 is 298 loops", measured against a 1,000-Vine sample; the full-catalogue census above gives 47.70% hidden at p50 1,417. Both are the same order of magnitude and both contradict the withdrawn 0.044%, but they disagree with each other by more than sampling noise allows, and the sample's provenance is unexplained. The census is the better basis and this section uses it; the comment is deliberately left standing rather than overwritten by assertion. Reconciling the two is open work.
+
+Re-tuning the floor value stays out of scope here. The constant is deliberately one line and the number is a product call, to be made on the census rather than as a side effect of correcting the evidence behind it.
 
 ## Testing
 


### PR DESCRIPTION
## Description

The design docs display-floor section contradicted itself. Its measurement table had already been corrected by the #7218 baseline to say the loop-count floor hides about 48% of the catalogue, but the arguments underneath were still the ones written for the original figure of 0.044%. So the section said the count is shown on roughly half of all videos, and two paragraphs later still reasoned from the premise that virtually every card renders a date instead.

The original error was that the doc measured `video_total_views_data.total_views`, a column the floor is never applied to. `publicLoopCountFloor` gates `video.isOriginalVine ? video.originalLoops ?? 0 : video.totalLoops` — the archival `loops` tag for classic Vines, which are about 98% of the catalogue. That is a different quantity, and it is roughly three orders of magnitude larger.

Two supporting claims no longer follow from the corrected data, and this PR marks them **withdrawn, quoted verbatim**, rather than deleting them:

- "The public count is effectively never shown — 9,996 videos in 10,000 render a date instead."
- "A date is the better default for this catalogue."

The second one matters: with the real distribution, whether a date beats a count is untested **in either direction**. Retracting it without asserting its opposite is deliberate — the point is to stop an unsupported claim from being replaced by its mirror image.

The overall conclusion (keep the floor) survives, but it is now grounded on the argument the constant itself gives, which the real distribution supports directly: a count on about 52% of videos, all at or above 1000, and a date on the rest instead of a discouraging sub-1000 count.

## Out of Scope

- The floor value itself is untouched. That is a product decision, not a docs fix.
- The constants own doc comment still claims 64% hidden at p50 298, from a 1,000-Vine sample, against 47.70% at p50 1,417 measured here. That discrepancy is recorded as **open** in the doc rather than overwritten by assertion.

## Verification

No Dart changed, so no analyze run applies. Verified the code still matches the issues description before editing: `video_card_meta.dart:70` still gates `_publicCount` as described, `originalLoops` still parses the `loops` tag, `totalLoops` is still `(originalLoops ?? 0) + views`. No test asserts on these figures.

Checked the other docs for the same wrong number: `2026-08-13-view-and-loop-findings.md` already uses 52.30%, and the view-count design doc carries no distribution figure. The baseline doc now attributes the corrected figures to #7218, matches the design docs precision, and keeps the creator-facing explanation readable.

Nothing here is device-observable.

## Type of Change

- [x] 📝 Documentation

**Related Issue:** Closes #7471