### PR TITLE
fix(relay): stop sending teardown frames to a relay that is not connected

### DIFF
--- a/mobile/packages/nostr_sdk/lib/relay/relay.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay.dart
@@ -330,7 +330,11 @@ abstract class Relay {
   /// Used when the relay itself ended the subscription (a `CLOSED` frame), so
   /// echoing a `CLOSE` back would name a subscription the relay has already
   /// forgotten. Returns whether [id] named a pending query.
-  bool discardQuery(String id) => _queries.remove(id) != null;
+  bool discardQuery(String id) {
+    final discarded = _queries.remove(id) != null;
+    if (discarded) _discardQueuedReq(id);
+    return discarded;
+  }
 
   /// Drops a live subscription without sending `CLOSE`.
   ///
@@ -338,7 +342,24 @@ abstract class Relay {
   /// `CLOSE` naming it would reach nothing: either the relay ended it itself
   /// (a `CLOSED` frame), or the socket it lived on is gone. Returns whether
   /// [id] named a live subscription.
-  bool discardSubscription(String id) => _subscriptions.remove(id) != null;
+  bool discardSubscription(String id) {
+    final discarded = _subscriptions.remove(id) != null;
+    if (discarded) _discardQueuedReq(id);
+    return discarded;
+  }
+
+  /// Drops a `REQ` that failed before its saved subscription was discarded.
+  ///
+  /// A fresh socket would otherwise replay the abandoned request without any
+  /// local subscription left to receive its events or send its eventual
+  /// `CLOSE`. Only callers that actually removed a saved request invoke this,
+  /// so deliberately queued, unsaved requests remain eligible for replay.
+  void _discardQueuedReq(String id) {
+    pendingMessages.removeWhere(
+      (message) =>
+          message.length > 1 && message[0] == 'REQ' && message[1] == id,
+    );
+  }
 
   bool checkQuery(String id) {
     return _queries[id] != null;

--- a/mobile/packages/nostr_sdk/lib/relay/relay.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay.dart
@@ -92,10 +92,13 @@ abstract class Relay {
   /// to a timeout. Mirrors the post-AUTH replay and the zombie reconnect in
   /// `RelayPool`.
   Future onConnected({String? source}) async {
-    final saved = connectionIsFresh
+    final isFresh = connectionIsFresh;
+    final saved = isFresh
         ? [..._subscriptions.values, ..._queries.values]
         : const <Subscription>[];
-    await _flushPendingMessages(source, {for (final s in saved) s.id});
+    await _flushPendingMessages(source, {
+      for (final s in saved) s.id,
+    }, dropQueuedCloses: isFresh);
     await _reissueSavedRequests(source, saved);
   }
 
@@ -104,10 +107,26 @@ abstract class Relay {
   /// REQ frames naming one of [reissuedIds] are dropped instead of sent: the
   /// saved subscription carries the same REQ and is re-issued right after, and
   /// sending both makes the relay replay its whole stored window twice.
+  ///
+  /// [dropQueuedCloses] drops queued `CLOSE` frames for the same class of
+  /// reason, and is set exactly when this socket is a new one. A relay forgets
+  /// every subscription when its socket dies, so a `CLOSE` queued against the
+  /// previous connection can only name something the fresh socket has never
+  /// heard of. At best that is a wasted frame. At worst it is destructive:
+  /// `RelayPool` re-issues saved subscriptions from its own post-AUTH replay
+  /// and zombie reconnect, off this await chain, so a caller that tore down a
+  /// subscription and later re-subscribed under the same explicit id can have
+  /// the replayed REQ land first — and then this stale `CLOSE` tears down the
+  /// live subscription, which goes silent with no terminal frame.
+  ///
+  /// A reused connection is the opposite case and is left alone: nothing
+  /// cycled, so a queued `CLOSE` may still name a subscription this very
+  /// socket is holding.
   Future<void> _flushPendingMessages(
     String? source,
-    Set<String> reissuedIds,
-  ) async {
+    Set<String> reissuedIds, {
+    required bool dropQueuedCloses,
+  }) async {
     log(
       '[Relay] onConnected[${source ?? "unknown"}]: ${relayStatus.addr} - sending ${pendingMessages.length} pending messages',
     );
@@ -122,6 +141,7 @@ abstract class Relay {
 
     for (var message in messagesToSend) {
       if (_isReqNaming(message, reissuedIds)) continue;
+      if (dropQueuedCloses && _isClose(message)) continue;
       try {
         final result = await send(message, queueIfFailed: false);
         if (!result) {
@@ -145,6 +165,9 @@ abstract class Relay {
 
   bool _isReqNaming(List<dynamic> message, Set<String> ids) =>
       message.length > 1 && message[0] == 'REQ' && ids.contains(message[1]);
+
+  bool _isClose(List<dynamic> message) =>
+      message.isNotEmpty && message[0] == 'CLOSE';
 
   /// Re-sends every REQ this relay is still holding on the fresh socket.
   ///
@@ -311,9 +334,10 @@ abstract class Relay {
 
   /// Drops a live subscription without sending `CLOSE`.
   ///
-  /// Used when the relay itself closed the subscription (a `CLOSED` frame), so
-  /// echoing a `CLOSE` back would name a subscription the relay has already
-  /// forgotten. Returns whether [id] named a live subscription.
+  /// Used whenever the relay has already forgotten the subscription, so a
+  /// `CLOSE` naming it would reach nothing: either the relay ended it itself
+  /// (a `CLOSED` frame), or the socket it lived on is gone. Returns whether
+  /// [id] named a live subscription.
   bool discardSubscription(String id) => _subscriptions.remove(id) != null;
 
   bool checkQuery(String id) {

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1159,6 +1159,28 @@ class RelayPool {
     }
   }
 
+  /// Tears down the live subscription [subId] on every relay holding it.
+  ///
+  /// The subscription half of [_releaseQuery], and it makes the same
+  /// connected-state decision for the same reason. `CLOSE` is a statement
+  /// about the current socket: sending it on a disconnected relay drives a
+  /// reconnect purely to deliver a teardown frame, and when that fails the
+  /// frame is queued into `pendingMessages` — where it names a subscription
+  /// that only ever existed on the connection that already died.
+  void _releaseSubscription(String subId) {
+    for (final relay in [
+      ..._relaysSnapshot(),
+      ..._tempRelaysSnapshot(),
+      ..._cacheRelaysSnapshot(),
+    ]) {
+      if (relay.relayStatus.connected == ClientConnected.connected) {
+        relay.checkAndCompleteSubscription(subId);
+      } else {
+        relay.discardSubscription(subId);
+      }
+    }
+  }
+
   /// Whether a query saved on [relay] can still produce a terminal frame, and
   /// therefore deserves to hold [_fireQueryCompleteIfSettled] back.
   ///
@@ -2047,23 +2069,9 @@ class RelayPool {
     _subscriptionEoseRelays.remove(id);
     if (subscription != null) {
       // A relay that still holds this REQ never served it, so offer it to the
-      // zombie repair before the CLOSE sweep below drops that evidence.
+      // zombie repair before the teardown sweep below drops that evidence.
       _repairRelaysThatNeverServedSubscription(id);
-      // check query and send close
-      var it = _relaysSnapshot();
-      for (var relay in it) {
-        relay.checkAndCompleteSubscription(id);
-      }
-
-      it = _tempRelaysSnapshot();
-      for (var relay in it) {
-        relay.checkAndCompleteSubscription(id);
-      }
-
-      it = _cacheRelaysSnapshot();
-      for (var relay in it) {
-        relay.checkAndCompleteSubscription(id);
-      }
+      _releaseSubscription(id);
     } else {
       // No matching subscription — treat [id] as a one-shot query. Drop its
       // completion callback so a query cancelled before EOSE doesn't leak a

--- a/mobile/packages/nostr_sdk/test/unit/relay_pending_messages_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pending_messages_test.dart
@@ -191,4 +191,59 @@ void main() {
       expect(relay.sentMessages.map((m) => m.first), ['REQ']);
     });
   });
+
+  group('Relay queued-CLOSE replay', () {
+    test('drops a queued CLOSE on a fresh socket — the subscription it names '
+        'died with the previous connection', () async {
+      final relay = _RequeueingRelay('wss://relay.example', failedMessage: [])
+        ..pendingMessages.addAll([
+          ['CLOSE', 'feed'],
+          [
+            'EVENT',
+            {'id': 'queued-while-down'},
+          ],
+        ]);
+
+      await relay.onConnected(source: 'stateStream-reconnect');
+
+      expect(relay.sentMessages.map((m) => m.first), ['EVENT']);
+      expect(relay.pendingMessages, isEmpty);
+    });
+
+    test('drops it even when the same id is re-issued — the replayed REQ can '
+        'land first and the stale CLOSE would tear it down', () async {
+      final relay = _RequeueingRelay('wss://relay.example', failedMessage: [])
+        ..saveSubscription(
+          Subscription(
+            [
+              {
+                'kinds': [34236],
+              },
+            ],
+            (_) {},
+            id: 'feed',
+          ),
+        )
+        ..pendingMessages.add(['CLOSE', 'feed']);
+
+      await relay.onConnected(source: 'stateStream-reconnect');
+
+      expect(relay.sentMessages.map((m) => m.first), ['REQ']);
+    });
+
+    test('replays a queued CLOSE when the connection was only reused — that '
+        'socket may still be holding the subscription', () async {
+      final relay = _RequeueingRelay(
+        'wss://relay.example',
+        failedMessage: [],
+        connectionIsFresh: false,
+      )..pendingMessages.add(['CLOSE', 'feed']);
+
+      await relay.onConnected(source: 'connect()');
+
+      expect(relay.sentMessages, [
+        ['CLOSE', 'feed'],
+      ]);
+    });
+  });
 }

--- a/mobile/packages/nostr_sdk/test/unit/relay_pending_messages_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pending_messages_test.dart
@@ -192,6 +192,55 @@ void main() {
     });
   });
 
+  group('Relay queued-REQ discard', () {
+    Subscription subscriptionWith(String id) => Subscription(
+      [
+        {
+          'kinds': [34236],
+        },
+      ],
+      (_) {},
+      id: id,
+    );
+
+    test('discardSubscription purges its queued REQ only', () {
+      final discarded = subscriptionWith('feed');
+      final deliberatelyUnsaved = subscriptionWith('discovery');
+      final relay = _RequeueingRelay('wss://relay.example', failedMessage: [])
+        ..saveSubscription(discarded)
+        ..pendingMessages.addAll([
+          discarded.toJson(),
+          deliberatelyUnsaved.toJson(),
+        ]);
+
+      expect(relay.discardSubscription(discarded.id), isTrue);
+
+      expect(relay.pendingMessages, [deliberatelyUnsaved.toJson()]);
+    });
+
+    test('discardQuery purges its queued REQ', () {
+      final discarded = subscriptionWith('author-page');
+      final relay = _RequeueingRelay('wss://relay.example', failedMessage: [])
+        ..saveQuery(discarded)
+        ..pendingMessages.add(discarded.toJson());
+
+      expect(relay.discardQuery(discarded.id), isTrue);
+
+      expect(relay.pendingMessages, isEmpty);
+    });
+
+    test('an unsaved queued REQ remains eligible for replay', () async {
+      final deliberatelyUnsaved = subscriptionWith('discovery');
+      final relay = _RequeueingRelay('wss://relay.example', failedMessage: [])
+        ..pendingMessages.add(deliberatelyUnsaved.toJson());
+
+      expect(relay.discardSubscription(deliberatelyUnsaved.id), isFalse);
+      await relay.onConnected(source: 'stateStream-reconnect');
+
+      expect(relay.sentMessages, [deliberatelyUnsaved.toJson()]);
+    });
+  });
+
   group('Relay queued-CLOSE replay', () {
     test('drops a queued CLOSE on a fresh socket — the subscription it names '
         'died with the previous connection', () async {

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_unsubscribe_close_guard_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_unsubscribe_close_guard_test.dart
@@ -1,0 +1,134 @@
+// ABOUTME: Regression tests for RelayPool.unsubscribe's connected-state guard.
+// ABOUTME: A disconnected relay must be torn down locally, not sent a CLOSE.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:nostr_sdk/relay/client_connected.dart';
+
+/// Relay whose connection state the test drives directly, recording every
+/// frame the pool asks it to write.
+class _StateControlledRelay extends Relay {
+  _StateControlledRelay(String url) : super(url, RelayStatus(url));
+
+  final List<List<dynamic>> sentMessages = [];
+
+  List<List<dynamic>> get closeFrames =>
+      sentMessages.where((m) => m.isNotEmpty && m[0] == 'CLOSE').toList();
+
+  @override
+  Future<bool> doConnect() async {
+    relayStatus.connected = ClientConnected.connected;
+    return true;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    relayStatus.connected = ClientConnected.disconnect;
+  }
+
+  /// The socket died under a live subscription. The pool learns this from the
+  /// status alone; the saved subscription stays behind for the reconnect.
+  void dropSocket() => relayStatus.connected = ClientConnected.disconnect;
+
+  @override
+  Future<bool> send(
+    List<dynamic> message, {
+    bool queueIfFailed = true,
+    bool skipReconnect = false,
+    DateTime? deadline,
+  }) async {
+    sentMessages.add(List<dynamic>.from(message));
+    return relayStatus.connected == ClientConnected.connected;
+  }
+}
+
+void main() {
+  group('RelayPool.unsubscribe connected-state guard', () {
+    const relayUrl = 'wss://relay.divine.video';
+    const tempRelayUrl = 'wss://temp.divine.video';
+
+    late Nostr nostr;
+    late _StateControlledRelay relay;
+    late _StateControlledRelay tempRelay;
+
+    setUp(() async {
+      final signer = LocalNostrSigner(
+        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+      );
+      tempRelay = _StateControlledRelay(tempRelayUrl);
+      nostr = Nostr(signer, [], (url) => tempRelay);
+      await nostr.refreshPublicKey();
+      relay = _StateControlledRelay(relayUrl);
+      await nostr.relayPool.add(relay);
+    });
+
+    Future<String> subscribeToFeed() async {
+      final subId = nostr.subscribe(
+        [
+          {
+            'kinds': [34236],
+          },
+        ],
+        (_) {},
+        tempRelays: [tempRelayUrl],
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        relay.hasSubscriptionById(subId),
+        isTrue,
+        reason: 'the pool must have saved the subscription on the relay',
+      );
+      expect(tempRelay.hasSubscriptionById(subId), isTrue);
+      return subId;
+    }
+
+    test('sends CLOSE while the socket is up', () async {
+      final subId = await subscribeToFeed();
+
+      nostr.unsubscribe(subId);
+
+      expect(relay.closeFrames, [
+        ['CLOSE', subId],
+      ]);
+      expect(relay.hasSubscriptionById(subId), isFalse);
+    });
+
+    test('drops the subscription locally when the socket is gone instead of '
+        'writing a CLOSE it has nowhere to send', () async {
+      final subId = await subscribeToFeed();
+      relay.dropSocket();
+
+      nostr.unsubscribe(subId);
+
+      expect(
+        relay.closeFrames,
+        isEmpty,
+        reason:
+            'a CLOSE on a disconnected relay either drives a reconnect purely '
+            'to deliver a teardown frame, or is queued for a replay where the '
+            'id names a subscription only the dead socket ever had',
+      );
+      expect(
+        relay.hasSubscriptionById(subId),
+        isFalse,
+        reason:
+            'skipping the CLOSE must not leave the subscription saved — '
+            'the reconnect would re-issue a REQ nobody is listening to',
+      );
+    });
+
+    test('applies the same guard to temp relays', () async {
+      final subId = await subscribeToFeed();
+      tempRelay.dropSocket();
+
+      nostr.unsubscribe(subId);
+
+      expect(tempRelay.closeFrames, isEmpty);
+      expect(tempRelay.hasSubscriptionById(subId), isFalse);
+      // The healthy relay in the same sweep is unaffected.
+      expect(relay.closeFrames, [
+        ['CLOSE', subId],
+      ]);
+    });
+  });
+}

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_unsubscribe_close_guard_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_unsubscribe_close_guard_test.dart
@@ -30,6 +30,8 @@ class _StateControlledRelay extends Relay {
   /// status alone; the saved subscription stays behind for the reconnect.
   void dropSocket() => relayStatus.connected = ClientConnected.disconnect;
 
+  void beginConnecting() => relayStatus.connected = ClientConnected.connecting;
+
   @override
   Future<bool> send(
     List<dynamic> message, {
@@ -37,8 +39,13 @@ class _StateControlledRelay extends Relay {
     bool skipReconnect = false,
     DateTime? deadline,
   }) async {
-    sentMessages.add(List<dynamic>.from(message));
-    return relayStatus.connected == ClientConnected.connected;
+    final copiedMessage = List<dynamic>.from(message);
+    sentMessages.add(copiedMessage);
+    final sent = relayStatus.connected == ClientConnected.connected;
+    if (!sent && queueIfFailed) {
+      pendingMessages.add(copiedMessage);
+    }
+    return sent;
   }
 }
 
@@ -115,6 +122,45 @@ void main() {
             'skipping the CLOSE must not leave the subscription saved — '
             'the reconnect would re-issue a REQ nobody is listening to',
       );
+    });
+
+    test(
+      'does not replay a REQ queued before a disconnected unsubscribe',
+      () async {
+        relay.dropSocket();
+        final subId = await subscribeToFeed();
+        expect(
+          relay.pendingMessages.where(
+            (message) =>
+                message.length > 1 &&
+                message[0] == 'REQ' &&
+                message[1] == subId,
+          ),
+          hasLength(1),
+        );
+
+        nostr.unsubscribe(subId);
+        relay.sentMessages.clear();
+        await relay.onConnected(source: 'stateStream-reconnect');
+
+        expect(
+          relay.sentMessages.where(
+            (message) => message.length > 1 && message[1] == subId,
+          ),
+          isEmpty,
+        );
+        expect(relay.pendingMessages, isEmpty);
+      },
+    );
+
+    test('discards locally while a replacement socket is connecting', () async {
+      final subId = await subscribeToFeed();
+      relay.beginConnecting();
+
+      nostr.unsubscribe(subId);
+
+      expect(relay.closeFrames, isEmpty);
+      expect(relay.hasSubscriptionById(subId), isFalse);
     });
 
     test('applies the same guard to temp relays', () async {


### PR DESCRIPTION
## Problem

Tearing down a Nostr subscription while its relay was disconnected could reconnect solely to send a `CLOSE` frame, or queue that teardown frame for a socket where the subscription never existed.

A related replay edge case made the first fix incomplete: when the original `REQ` had also been queued, discarding only the saved subscription left that request eligible for replay. The fresh relay socket could then open a subscription the client no longer tracked or ever closed.

## Fix

`RelayPool.unsubscribe` now makes the teardown decision from the relay's connection state:

- connected relays receive `CLOSE`;
- disconnected or connecting relays discard the saved subscription locally.

Discarding a saved subscription or one-shot query also removes queued `REQ` frames with that ID. Cleanup happens only when a saved request was actually removed, so callers that deliberately queue an unsaved `REQ` still replay normally.

Fresh connections discard queued `CLOSE` frames because relays forget subscriptions when a socket dies. Reused live connections retain those frames because the current socket may still hold the named subscription.

## Scope

This completes #7358 and also covers the directly adjacent pending-message replay path required to make disconnected teardown safe. It does not change relay selection, subscription IDs, event filtering, or intentionally unsaved queued requests.

## Verification

- `flutter analyze lib test` from `mobile/packages/nostr_sdk`: no issues
- `flutter test` from `mobile/packages/nostr_sdk`: 670 tests passed
- `flutter analyze lib test` from `mobile`: no issues
- regression test reproduced the stale queued-`REQ` replay before the fix and passes after it
- tests cover connected, disconnected, and connecting teardown; saved subscription and query cleanup; fresh versus reused sockets; and preservation of deliberately unsaved `REQ` frames

Closes #7358
