### PR TITLE
docs(video-editor): explain why exports do not trim to the common track end

### DIFF
--- a/mobile/docs/VIDEO_TRACK_END_MISMATCH.md
+++ b/mobile/docs/VIDEO_TRACK_END_MISMATCH.md
@@ -1,0 +1,55 @@
+# Audio/video track-end mismatch
+
+An mp4's container duration is its *longest* track. Capture and export pipelines stop the audio and video writers independently, so the two tracks routinely end tens of milliseconds apart, and the file declares the longer one. Playing or exporting to that declared length ends on a stretch where one track has already run out — picture with no sound, or a frozen last frame. On a looping player that stretch is the loop seam (#6386).
+
+Two independent mechanisms correct for this, at two different layers. They are easy to confuse because they are named after the same idea, and issues #7787, #7788 and #7789 all conflate them. This document is the map.
+
+| | Export / render path | Playback path |
+|---|---|---|
+| Mechanism | `commonTrackEnd` shortens the *recorded clip's stored length* | `VideoClip.trimToCommonTrackEnd` clamps the *clip end the native player uses* |
+| Lives in | `mobile/lib/services/video_editor/clip_media_duration.dart` | `mobile/packages/divine_video_player/lib/src/video_clip.dart` |
+| Applied at | recording time, once, during the recorder's metadata enrichment pass | every `setSource`, per playback surface |
+| Landed in | #6439 | #6430 |
+| Tolerance | at most 500 ms shortfall, audio track at least `minCommonTrackEnd` | at most 500 ms and at most 10% of playable duration |
+
+## The export path does not use `trimToCommonTrackEnd`
+
+`VideoRenderData.trimToCommonTrackEnd` exists in `pro_video_editor` (2.11.3, `lib/core/models/video/video_render_data_model.dart:243`) and defaults to `false`. **No render task in this repo sets it.** All eleven `VideoRenderData(...)` constructions under `mobile/lib` leave it at the default, as does the `copyWith` in `renderWithEncoderFallback`.
+
+That covers every render entry point, since they all funnel through the same builder:
+
+| Entry point | Caller | Reaches |
+|---|---|---|
+| `renderVideoToClip` (final export) | `lib/providers/video_editor_provider.dart:1254`, `lib/providers/video_publish_provider.dart:494` | `_concatenateSegments` |
+| `renderVideo` (seam preview) | `lib/services/video_editor/transition_seam_render_service.dart:163` | `_concatenateSegments` |
+| `renderVideo` (merge clips) | `lib/services/video_editor/video_editor_merge_service.dart:35` | `_concatenateSegments` |
+| `renderVideo` (save clip to library) | `lib/services/video_editor/video_editor_clip_library_save_service.dart:68` | `_concatenateSegments` |
+| per-clip aspect-ratio normalization | `_normalizeClipsToAspectRatio` → `_renderNormalizedClip` | its own `VideoRenderData` |
+
+This is deliberate, and #6439 measured both reasons for it:
+
+- **It fixes the symptom a layer too late.** The trim happens in the native renderer, after the whole editor has already authored trims, layer windows, transitions and filter windows against the un-trimmed length. On a two-clip export with a 300 ms gap per clip, the native trim moved clip 2's start from 3.00 s to 2.70 s while an overlay anchored to clip 2 still fired at 3.00 s — 300 ms late, accumulating across clips. That drift is what #7787 describes.
+- **It was Apple-only.** The flag had no Android counterpart in `pro_video_editor` 2.10.0; on a Galaxy S25 a 300 ms gap rendered to the same 284 ms with and without it.
+
+Correcting the recorded clip's length instead is platform-independent and keeps the editor timeline and the export in step, so the export follows from the existing per-segment `endTime` with no special-casing.
+
+## Where `trimToCommonTrackEnd` is actually set
+
+Every site below is playback. Sites not listed take the constructor default, `false`.
+
+| Site | Value | Intended? |
+|---|---|---|
+| `packages/infinite_video_feed/lib/src/utils/source_loader.dart:58` (`setSourceWithFallbacks` parameter default), forwarded at `:82` and `:133` | `true` | Yes. Its two callers are the feed, which wants it, and the subtitle editor, which opts out explicitly. Note the sharp edge: a *new* caller of this helper opts in silently. |
+| `packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart:1185` (cached file), `:1447` (failover source), `:1543` (retry after processing) | `true` | Yes. Looping single-clip feed playback is exactly the case the flag is documented for, and hiding the loop seam on already-published video is why #6430 exists. |
+| `lib/widgets/subtitle_editor/subtitle_editor_stage.dart:62` | `false` | Yes, and the rationale is inline: the caption timeline is drawn from the container duration, so a clamp would put the last half-second of the axis out of the preview's reach. |
+| `lib/extensions/divine_video_clip_player_mapping.dart:16` (`toPlayerVideoClip`, editor preview) and `lib/services/video_editor/transition_seam_render_service.dart:747-760` (seam preview clips) | default `false` | Yes. These are segments of a multi-clip timeline, where the field's own dartdoc says the clamp would cut content rather than a seam. |
+| `lib/screens/comments/widgets/video_comment_player.dart:99` and `lib/widgets/video_clip/video_clip_preview.dart:87` | default `false` | **Unclear.** Both are looping single-clip playback of a finished video, which is the shape the flag was written for, yet neither opts in. Whether #6430 scoped itself to the feed on purpose is not answerable from the code. |
+| `lib/screens/video_editor/video_clip_chroma_key_screen.dart:128`, `lib/screens/video_editor/video_clip_transform_screen.dart:73`, `lib/widgets/video_editor/main_editor/video_editor_canvas.dart:2268` (single-clip trim-drag preview) | default `false` | **Unclear.** Looping single-clip editor previews. The subtitle editor's reasoning plausibly applies — the canvas one sets `end: clip.duration`, so its axis really is the container duration — but unlike the subtitle editor none of them says so. |
+
+Platform support is per-backend and documented on the field: Apple and Android honour it for local and remote sources, web and Linux ignore it, and Android skips the probe entirely for HLS.
+
+## What the record says, and what the code says
+
+PR #6439's description frames its first, abandoned revision — which did pass `trimToCommonTrackEnd` into the native renderer — and then explains under "Why not fix this at export time" that the merged version does not. The merged diff touches five files (`video_recorder_bloc.dart`, `clip_manager_provider.dart`, `clip_media_duration.dart`, and their two tests) and contains no occurrence of `trimToCommonTrackEnd`.
+
+So the premise shared by #7787, #7788 and #7789 — that `_concatenateSegments` passes the flag to its render callers — does not hold against `main`. `_concatenateSegments` has never passed it, and the flag those issues name belongs to the player, from #6430.

--- a/mobile/docs/VIDEO_TRACK_END_MISMATCH.md
+++ b/mobile/docs/VIDEO_TRACK_END_MISMATCH.md
@@ -21,7 +21,7 @@ single-purpose direct renderers. The complete inventory is:
 
 | Render task | Construction | Reaches |
 |---|---|---|
-| final export, seam preview, merge clips, and save clip to library | `lib/services/video_editor/video_editor_render_service.dart:1219` | `_concatenateSegments` |
+| final export, seam preview, merge clips, and save clip to library | `lib/services/video_editor/video_editor_render_service.dart:1215` | `_concatenateSegments` |
 | per-clip aspect-ratio normalization | `lib/services/video_editor/video_editor_render_service.dart:1111` | `renderWithEncoderFallback` |
 | limit clip duration and crop to aspect ratio | `lib/services/video_editor/video_editor_render_service.dart:855`, `:942` | `_cancelAndRender` |
 | bake chroma key | `lib/services/video_editor/chroma_key_bake_service.dart:172`, `:194` | `renderNativeVideoToFile` |

--- a/mobile/docs/VIDEO_TRACK_END_MISMATCH.md
+++ b/mobile/docs/VIDEO_TRACK_END_MISMATCH.md
@@ -8,7 +8,7 @@ Two independent mechanisms correct for this, at two different layers. They are e
 |---|---|---|
 | Mechanism | `commonTrackEnd` shortens the *recorded clip's stored length* | `VideoClip.trimToCommonTrackEnd` clamps the *clip end the native player uses* |
 | Lives in | `mobile/lib/services/video_editor/clip_media_duration.dart` | `mobile/packages/divine_video_player/lib/src/video_clip.dart` |
-| Applied at | recording time, once, during the recorder's metadata enrichment pass | every `setSource`, per playback surface |
+| Applied at | recording time, once, during the recorder's metadata enrichment pass | when a `VideoClip` is loaded, per playback surface |
 | Landed in | #6439 | #6430 |
 | Tolerance | at most 500 ms shortfall, audio track at least `minCommonTrackEnd` | at most 500 ms and at most 10% of playable duration |
 
@@ -16,20 +16,25 @@ Two independent mechanisms correct for this, at two different layers. They are e
 
 `VideoRenderData.trimToCommonTrackEnd` exists in `pro_video_editor` (2.11.3, `lib/core/models/video/video_render_data_model.dart:243`) and defaults to `false`. **No render task in this repo sets it.** All eleven `VideoRenderData(...)` constructions under `mobile/lib` leave it at the default, as does the `copyWith` in `renderWithEncoderFallback`.
 
-That covers every render entry point, since they all funnel through the same builder:
+The constructions are spread across the final-export builder and several
+single-purpose direct renderers. The complete inventory is:
 
-| Entry point | Caller | Reaches |
+| Render task | Construction | Reaches |
 |---|---|---|
-| `renderVideoToClip` (final export) | `lib/providers/video_editor_provider.dart:1254`, `lib/providers/video_publish_provider.dart:494` | `_concatenateSegments` |
-| `renderVideo` (seam preview) | `lib/services/video_editor/transition_seam_render_service.dart:163` | `_concatenateSegments` |
-| `renderVideo` (merge clips) | `lib/services/video_editor/video_editor_merge_service.dart:35` | `_concatenateSegments` |
-| `renderVideo` (save clip to library) | `lib/services/video_editor/video_editor_clip_library_save_service.dart:68` | `_concatenateSegments` |
-| per-clip aspect-ratio normalization | `_normalizeClipsToAspectRatio` → `_renderNormalizedClip` | its own `VideoRenderData` |
+| final export, seam preview, merge clips, and save clip to library | `lib/services/video_editor/video_editor_render_service.dart:1219` | `_concatenateSegments` |
+| per-clip aspect-ratio normalization | `lib/services/video_editor/video_editor_render_service.dart:1111` | `renderWithEncoderFallback` |
+| limit clip duration and crop to aspect ratio | `lib/services/video_editor/video_editor_render_service.dart:855`, `:942` | `_cancelAndRender` |
+| bake chroma key | `lib/services/video_editor/chroma_key_bake_service.dart:172`, `:194` | `renderNativeVideoToFile` |
+| bake playback speed | `lib/services/video_editor/clip_speed_render_service.dart:172` | `renderNativeVideoToFile` |
+| reverse clip | `lib/services/video_editor/video_editor_reverse_service.dart:64` | `renderNativeVideoToFile` |
+| transform clip | `lib/services/video_editor/video_editor_transform_service.dart:68` | `renderNativeVideoToFile` |
+| materialize a multi-clip draft for upload | `lib/services/video_publish/draft_upload_materializer.dart:126` | `renderNativeVideoToFile` |
+| add a download watermark | `lib/services/watermark_download_service.dart:417` | `renderNativeVideoToFile` |
 
 This is deliberate, and #6439 measured both reasons for it:
 
 - **It fixes the symptom a layer too late.** The trim happens in the native renderer, after the whole editor has already authored trims, layer windows, transitions and filter windows against the un-trimmed length. On a two-clip export with a 300 ms gap per clip, the native trim moved clip 2's start from 3.00 s to 2.70 s while an overlay anchored to clip 2 still fired at 3.00 s — 300 ms late, accumulating across clips. That drift is what #7787 describes.
-- **It was Apple-only.** The flag had no Android counterpart in `pro_video_editor` 2.10.0; on a Galaxy S25 a 300 ms gap rendered to the same 284 ms with and without it.
+- **It is Apple-only.** The shipped `pro_video_editor` 2.11.3 still says Android has no equivalent clamp and that compositions ignore the flag. On a Galaxy S25 a 300 ms gap rendered to the same 284 ms with and without it.
 
 Correcting the recorded clip's length instead is platform-independent and keeps the editor timeline and the export in step, so the export follows from the existing per-segment `endTime` with no special-casing.
 
@@ -45,6 +50,13 @@ Every site below is playback. Sites not listed take the constructor default, `fa
 | `lib/extensions/divine_video_clip_player_mapping.dart:16` (`toPlayerVideoClip`, editor preview) and `lib/services/video_editor/transition_seam_render_service.dart:747-760` (seam preview clips) | default `false` | Yes. These are segments of a multi-clip timeline, where the field's own dartdoc says the clamp would cut content rather than a seam. |
 | `lib/screens/comments/widgets/video_comment_player.dart:99` and `lib/widgets/video_clip/video_clip_preview.dart:87` | default `false` | **Unclear.** Both are looping single-clip playback of a finished video, which is the shape the flag was written for, yet neither opts in. Whether #6430 scoped itself to the feed on purpose is not answerable from the code. |
 | `lib/screens/video_editor/video_clip_chroma_key_screen.dart:128`, `lib/screens/video_editor/video_clip_transform_screen.dart:73`, `lib/widgets/video_editor/main_editor/video_editor_canvas.dart:2268` (single-clip trim-drag preview) | default `false` | **Unclear.** Looping single-clip editor previews. The subtitle editor's reasoning plausibly applies — the canvas one sets `end: clip.duration`, so its axis really is the container duration — but unlike the subtitle editor none of them says so. |
+| `lib/screens/video_metadata/video_metadata_preview_screen.dart:130` and `lib/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail.dart:91` | default `false` | **Unclear.** Looping single-clip previews of the finished video, the same shape as the comment player and clip preview above. |
+| `lib/widgets/video_editor/chroma_key/chroma_key_backdrop.dart:195` | default `false` | **Unclear.** A looping, muted single-clip backdrop. It is re-anchored to the foreground clip on every foreground loop, but nothing explains whether its own track-end seam should be clamped. |
+| `lib/screens/video_metadata/video_metadata_cover_screen.dart:124` | default `false` | Yes. The cover picker scrubs against the container duration returned by `getMetadata`, so clamping the player would make the end of that axis unreachable. |
+| `lib/blocs/video_recorder/video_recorder_bloc.dart:1118`, `:1123` | default `false` | Yes. These calls only preload metadata and initial buffer data into the native cache; they do not create a looping playback surface. |
+
+Issue #8804 tracks the unresolved policy for looping finished-video previews
+and backdrops.
 
 Platform support is per-backend and documented on the field: Apple and Android honour it for local and remote sources, web and Linux ignore it, and Android skips the probe entirely for HLS.
 

--- a/mobile/lib/services/video_editor/clip_media_duration.dart
+++ b/mobile/lib/services/video_editor/clip_media_duration.dart
@@ -29,6 +29,11 @@ const Duration minCommonTrackEnd = VideoEditorSplitService.minClipDuration;
 ///
 /// Returns `null` when there is nothing to correct — no audio track, tracks
 /// already ending together, or a shortfall beyond [clipTrackEndTolerance].
+///
+/// This is the only place the mismatch is corrected for export. The native
+/// renderer's own `trimToCommonTrackEnd` is deliberately left off, because it
+/// trims after the editor has authored every time anchor against the
+/// un-trimmed length. See `docs/VIDEO_TRACK_END_MISMATCH.md`.
 Duration? commonTrackEnd(VideoMetadata metadata) {
   final audioDuration = metadata.audioDuration;
   if (audioDuration == null) return null;

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -1150,14 +1150,10 @@ class VideoEditorRenderService {
   // Video Concatenation
   // ─────────────────────────────────────────────────────────────────────────
 
-  /// Concatenates all video segments into a final output file.
+  /// Concatenates all segments; [globalTransform] applies in one pass.
   ///
-  /// If [globalTransform] is provided, applies it to all segments in a single
-  /// pass.
-  ///
-  /// The native renderer's `trimToCommonTrackEnd` stays disabled here because
-  /// it would shorten clips after editor time anchors were authored. See
-  /// `docs/VIDEO_TRACK_END_MISMATCH.md` for the export/playback distinction.
+  /// `trimToCommonTrackEnd` stays off because it would shift authored anchors;
+  /// see `docs/VIDEO_TRACK_END_MISMATCH.md` for the export/playback distinction.
   static Future<String> _concatenateSegments({
     required List<DivineVideoClip> clips,
     required List<VideoSegment> segments,

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -1154,6 +1154,10 @@ class VideoEditorRenderService {
   ///
   /// If [globalTransform] is provided, applies it to all segments in a single
   /// pass.
+  ///
+  /// The native renderer's `trimToCommonTrackEnd` stays disabled here because
+  /// it would shorten clips after editor time anchors were authored. See
+  /// `docs/VIDEO_TRACK_END_MISMATCH.md` for the export/playback distinction.
   static Future<String> _concatenateSegments({
     required List<DivineVideoClip> clips,
     required List<VideoSegment> segments,


### PR DESCRIPTION
## Description

#7789 reported that PR #6439's description claimed a narrow scope while its implementation passed `trimToCommonTrackEnd` to every `renderVideo` caller. Investigating it produced the opposite answer, and the answer is worth writing down.

**No render path passes that flag, and none ever has.** PR #6439 touched five files — `video_recorder_bloc.dart`, `clip_manager_provider.dart`, `clip_media_duration.dart` and two tests. None is a render service, and `gh pr diff 6439 | grep trimToCommonTrackEnd` returns nothing. `git log -S"trimToCommonTrackEnd" -- mobile/lib/services mobile/lib/providers` is empty across all of main's history.

PR #6439's own description explains why: the render-flag approach was the **abandoned first revision**, dropped for two measured reasons — overlay drift, and being Apple-only. The issue read the discarded design as the shipped one. The flag itself is real, but it belongs to the player, introduced by #6430.

So the thing that needed recording was not "which paths get the flag" but "why the export deliberately does not use it, and what does the job instead" — because the next person to chase an export seam will land on the same fork and, without this written down, may re-derive the abandoned design.

Adds `mobile/docs/VIDEO_TRACK_END_MISMATCH.md`: the two mechanisms and the layers they live in, all eleven render-task constructions (all at the default `false`), and the complete playback construction/helper inventory with an intent verdict for each group. Sites whose intent is not established by the code are marked **unclear** rather than given an invented rationale.

Also adds dartdoc on `commonTrackEnd` — the #6439 fix — and an inline pointer at `_concatenateSegments`, where #7789 requires the export/playback distinction to be discoverable.

## Out of Scope

- **#7787 was closed as moot.** Its stated root cause does not match the code; the 300 ms drift it describes is the measurement from the abandoned revision, quoted in #6439 as the reason not to ship it.
- **#7788's literal criterion is unsatisfiable.** It asks for a test asserting `trimToCommonTrackEnd == true` on the export task; the value is `false` everywhere. PR #8790 pins the inverse instead.
- **#8804 tracks the remaining product decision** for five looping finished-video preview/backdrop surfaces whose intent cannot be established from code history.
- No pointer was added to `divine_video_player`'s public dartdoc — that would put app-specific export knowledge into a reusable package's API docs, inverting the layer direction.

## Verification

- `mise exec -- dart format lib test integration_test --output=none --set-exit-if-changed`
- `flutter analyze lib test` → `No issues found!`
- Every documented render and playback citation was checked against the pushed head.

No behavior changed, so nothing requires device verification.

## Type of Change

- [x] 📝 Documentation

**Related Issue:** Closes #7789
