### PR TITLE
fix(video-editor): let cancel actually stop an export that is still normalizing clips

### DIFF
--- a/mobile/lib/services/video_editor/clip_normalization_models.dart
+++ b/mobile/lib/services/video_editor/clip_normalization_models.dart
@@ -1,0 +1,153 @@
+// ABOUTME: Value types for the video editor's clip normalization pass
+// ABOUTME: Crop geometry, per-clip analysis, and the pass's rendered result
+
+import 'package:flutter/widgets.dart' show Size;
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+/// Result of normalizing clips to a target aspect ratio.
+class NormalizationResult {
+  const NormalizationResult({
+    required this.segments,
+    required this.tempFilePaths,
+    this.globalTransform,
+  });
+
+  /// The video segments ready for concatenation.
+  final List<VideoSegment> segments;
+
+  /// Paths to temporary files that should be cleaned up after rendering.
+  final List<String> tempFilePaths;
+
+  /// Global crop transform to apply during concatenation (if all clips match).
+  final CropParameters? globalTransform;
+}
+
+/// Analysis result for a single clip.
+class ClipAnalysisEntry {
+  const ClipAnalysisEntry({
+    required this.clip,
+    required this.resolution,
+    required this.cropParams,
+  });
+
+  final DivineVideoClip clip;
+  final Size resolution;
+  final CropParameters cropParams;
+}
+
+/// Analysis of all clips for optimal rendering strategy.
+class ClipAnalysis {
+  const ClipAnalysis({required this.entries});
+
+  final List<ClipAnalysisEntry> entries;
+
+  /// True if all clips have identical crop parameters.
+  bool get allSameCropParams {
+    if (entries.isEmpty) return true;
+    final first = entries.first.cropParams;
+    return entries.every(
+      (e) =>
+          e.cropParams.x == first.x &&
+          e.cropParams.y == first.y &&
+          e.cropParams.width == first.width &&
+          e.cropParams.height == first.height,
+    );
+  }
+}
+
+/// Crop parameters for aspect ratio transformation.
+class CropParameters {
+  const CropParameters({
+    required this.x,
+    required this.y,
+    required this.width,
+    required this.height,
+  });
+
+  /// Creates crop parameters for the given aspect ratio.
+  factory CropParameters.forAspectRatio({
+    required Size resolution,
+    required model.AspectRatio aspectRatio,
+  }) {
+    return switch (aspectRatio) {
+      model.AspectRatio.square => CropParameters.squareCrop(resolution),
+      model.AspectRatio.vertical => CropParameters.verticalCrop(resolution),
+    };
+  }
+
+  /// Creates crop parameters from a resolution for a centered square crop.
+  factory CropParameters.squareCrop(Size resolution) {
+    final minDimension = resolution.width < resolution.height
+        ? resolution.width
+        : resolution.height;
+
+    return CropParameters(
+      x: ((resolution.width - minDimension) / 2).round(),
+      y: ((resolution.height - minDimension) / 2).round(),
+      width: minDimension.round(),
+      height: minDimension.round(),
+    );
+  }
+
+  /// Creates crop parameters from a resolution for a centered 9:16 vertical crop.
+  factory CropParameters.verticalCrop(Size resolution) {
+    final inputAspectRatio = resolution.width / resolution.height;
+    const targetRatio = 9.0 / 16.0;
+
+    final double cropX;
+    final double cropY;
+    final double cropWidth;
+    final double cropHeight;
+
+    if (inputAspectRatio > targetRatio) {
+      // Input is wider than 9:16 - crop width, keep height
+      cropHeight = resolution.height;
+      cropWidth = cropHeight * targetRatio;
+      cropX = (resolution.width - cropWidth) / 2;
+      cropY = 0;
+    } else {
+      // Input is taller than 9:16 - keep width, crop height
+      cropWidth = resolution.width;
+      cropHeight = cropWidth / targetRatio;
+      cropX = 0;
+      cropY = (resolution.height - cropHeight) / 2;
+    }
+
+    return CropParameters(
+      x: cropX.round(),
+      y: cropY.round(),
+      width: cropWidth.round(),
+      height: cropHeight.round(),
+    );
+  }
+
+  /// Horizontal offset for cropping.
+  final int x;
+
+  /// Vertical offset for cropping.
+  final int y;
+
+  /// Width of the cropped area.
+  final int width;
+
+  /// Height of the cropped area.
+  final int height;
+
+  /// Whether cropping is needed based on the original resolution.
+  bool needsCropping(Size resolution) {
+    return x != 0 ||
+        y != 0 ||
+        width != resolution.width.round() ||
+        height != resolution.height.round();
+  }
+
+  /// Converts to [ExportTransform] for video rendering.
+  ExportTransform toExportTransform() {
+    return ExportTransform(x: x, y: y, width: width, height: height);
+  }
+
+  @override
+  String toString() => '($x, $y, ${width}x$height)';
+}

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -15,6 +15,7 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/observability/crash_reporter.dart';
 import 'package:openvine/services/native_proofmode_service.dart';
+import 'package:openvine/services/video_editor/clip_normalization_models.dart';
 import 'package:openvine/services/video_editor/native_render_task_registry.dart';
 import 'package:openvine/services/video_editor/render_cancellation_registry.dart';
 import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
@@ -29,152 +30,6 @@ import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 export 'package:openvine/services/video_editor/video_render_failures.dart';
-
-/// Result of normalizing clips to a target aspect ratio.
-class _NormalizationResult {
-  const _NormalizationResult({
-    required this.segments,
-    required this.tempFilePaths,
-    this.globalTransform,
-  });
-
-  /// The video segments ready for concatenation.
-  final List<VideoSegment> segments;
-
-  /// Paths to temporary files that should be cleaned up after rendering.
-  final List<String> tempFilePaths;
-
-  /// Global crop transform to apply during concatenation (if all clips match).
-  final _CropParameters? globalTransform;
-}
-
-/// Analysis result for a single clip.
-class _ClipAnalysisEntry {
-  const _ClipAnalysisEntry({
-    required this.clip,
-    required this.resolution,
-    required this.cropParams,
-  });
-
-  final DivineVideoClip clip;
-  final Size resolution;
-  final _CropParameters cropParams;
-}
-
-/// Analysis of all clips for optimal rendering strategy.
-class _ClipAnalysis {
-  const _ClipAnalysis({required this.entries});
-
-  final List<_ClipAnalysisEntry> entries;
-
-  /// True if all clips have identical crop parameters.
-  bool get allSameCropParams {
-    if (entries.isEmpty) return true;
-    final first = entries.first.cropParams;
-    return entries.every(
-      (e) =>
-          e.cropParams.x == first.x &&
-          e.cropParams.y == first.y &&
-          e.cropParams.width == first.width &&
-          e.cropParams.height == first.height,
-    );
-  }
-}
-
-/// Crop parameters for aspect ratio transformation.
-class _CropParameters {
-  const _CropParameters({
-    required this.x,
-    required this.y,
-    required this.width,
-    required this.height,
-  });
-
-  /// Creates crop parameters for the given aspect ratio.
-  factory _CropParameters.forAspectRatio({
-    required Size resolution,
-    required model.AspectRatio aspectRatio,
-  }) {
-    return switch (aspectRatio) {
-      model.AspectRatio.square => _CropParameters.squareCrop(resolution),
-      model.AspectRatio.vertical => _CropParameters.verticalCrop(resolution),
-    };
-  }
-
-  /// Creates crop parameters from a resolution for a centered square crop.
-  factory _CropParameters.squareCrop(Size resolution) {
-    final minDimension = resolution.width < resolution.height
-        ? resolution.width
-        : resolution.height;
-
-    return _CropParameters(
-      x: ((resolution.width - minDimension) / 2).round(),
-      y: ((resolution.height - minDimension) / 2).round(),
-      width: minDimension.round(),
-      height: minDimension.round(),
-    );
-  }
-
-  /// Creates crop parameters from a resolution for a centered 9:16 vertical crop.
-  factory _CropParameters.verticalCrop(Size resolution) {
-    final inputAspectRatio = resolution.width / resolution.height;
-    const targetRatio = 9.0 / 16.0;
-
-    final double cropX;
-    final double cropY;
-    final double cropWidth;
-    final double cropHeight;
-
-    if (inputAspectRatio > targetRatio) {
-      // Input is wider than 9:16 - crop width, keep height
-      cropHeight = resolution.height;
-      cropWidth = cropHeight * targetRatio;
-      cropX = (resolution.width - cropWidth) / 2;
-      cropY = 0;
-    } else {
-      // Input is taller than 9:16 - keep width, crop height
-      cropWidth = resolution.width;
-      cropHeight = cropWidth / targetRatio;
-      cropX = 0;
-      cropY = (resolution.height - cropHeight) / 2;
-    }
-
-    return _CropParameters(
-      x: cropX.round(),
-      y: cropY.round(),
-      width: cropWidth.round(),
-      height: cropHeight.round(),
-    );
-  }
-
-  /// Horizontal offset for cropping.
-  final int x;
-
-  /// Vertical offset for cropping.
-  final int y;
-
-  /// Width of the cropped area.
-  final int width;
-
-  /// Height of the cropped area.
-  final int height;
-
-  /// Whether cropping is needed based on the original resolution.
-  bool needsCropping(Size resolution) {
-    return x != 0 ||
-        y != 0 ||
-        width != resolution.width.round() ||
-        height != resolution.height.round();
-  }
-
-  /// Converts to [ExportTransform] for video rendering.
-  ExportTransform toExportTransform() {
-    return ExportTransform(x: x, y: y, width: width, height: height);
-  }
-
-  @override
-  String toString() => '($x, $y, ${width}x$height)';
-}
 
 class _RenderProgressTracker {
   _RenderProgressTracker({
@@ -772,19 +627,22 @@ class VideoEditorRenderService {
         await clip.processingCompleter?.future;
       }
 
+      final effectiveTaskId = taskId ?? clips.first.id;
+
       // Intermediate normalized clips always go to cache (they get deleted)
       final result = await _normalizeClipsToAspectRatio(
         clips: clips,
         aspectRatio: aspectRatio ?? clips.first.targetAspectRatio,
         cacheDir: cacheDir,
         parameters: parameters,
+        taskId: effectiveTaskId,
       );
       tempFilePaths = result.tempFilePaths;
 
       final outputPath = await _concatenateSegments(
         clips: clips,
         segments: result.segments,
-        taskId: taskId ?? clips.first.id,
+        taskId: effectiveTaskId,
         outputDir: outputDir,
         globalTransform: result.globalTransform,
         aspectRatio: aspectRatio ?? clips.first.targetAspectRatio,
@@ -911,7 +769,7 @@ class VideoEditorRenderService {
   }) async {
     metadata ??= await ProVideoEditor.instance.getMetadata(video);
     final resolution = metadata.resolution;
-    final cropParams = _CropParameters.forAspectRatio(
+    final cropParams = CropParameters.forAspectRatio(
       resolution: resolution,
       aspectRatio: aspectRatio,
     );
@@ -964,11 +822,15 @@ class VideoEditorRenderService {
   /// - Only pre-rendering clips that differ from the majority
   ///
   /// Returns video segments ready for concatenation and temp file paths for cleanup.
-  static Future<_NormalizationResult> _normalizeClipsToAspectRatio({
+  ///
+  /// [taskId] is the export's own id — the one a user cancel targets — so this
+  /// pass can stop between clips instead of rendering the whole set (#7833).
+  static Future<NormalizationResult> _normalizeClipsToAspectRatio({
     required List<DivineVideoClip> clips,
     required model.AspectRatio aspectRatio,
     required Directory cacheDir,
     required CompleteParameters? parameters,
+    required String taskId,
   }) async {
     // Analyze all clips first to determine the optimal rendering strategy
     final clipAnalysis = await _analyzeClips(clips, aspectRatio);
@@ -986,7 +848,7 @@ class VideoEditorRenderService {
         name: _logName,
         category: .video,
       );
-      return _NormalizationResult(
+      return NormalizationResult(
         segments: clips
             .map(
               (c) => VideoSegment(
@@ -1020,6 +882,7 @@ class VideoEditorRenderService {
     final tempFilePaths = <String>[];
 
     for (int i = 0; i < clips.length; i++) {
+      _throwIfCancellationRequested(taskId);
       final entry = clipAnalysis.entries[i];
       final needsCrop = entry.cropParams.needsCropping(entry.resolution);
 
@@ -1050,6 +913,7 @@ class VideoEditorRenderService {
           cropParams: entry.cropParams,
           tempDir: cacheDir,
           parameters: parameters,
+          ownerTaskId: taskId,
         );
         tempFilePaths.add(normalizedPath);
         segments.add(
@@ -1061,30 +925,30 @@ class VideoEditorRenderService {
       }
     }
 
-    return _NormalizationResult(
+    return NormalizationResult(
       segments: segments,
       tempFilePaths: tempFilePaths,
     );
   }
 
   /// Analyzes all clips to determine their crop parameters.
-  static Future<_ClipAnalysis> _analyzeClips(
+  static Future<ClipAnalysis> _analyzeClips(
     List<DivineVideoClip> clips,
     model.AspectRatio aspectRatio,
   ) async {
-    final entries = <_ClipAnalysisEntry>[];
+    final entries = <ClipAnalysisEntry>[];
 
     for (final clip in clips) {
       final metaData = await ProVideoEditor.instance.getMetadata(
         clip.requireVideo,
       );
       final resolution = metaData.resolution;
-      final cropParams = _CropParameters.forAspectRatio(
+      final cropParams = CropParameters.forAspectRatio(
         resolution: resolution,
         aspectRatio: aspectRatio,
       );
       entries.add(
-        _ClipAnalysisEntry(
+        ClipAnalysisEntry(
           clip: clip,
           resolution: resolution,
           cropParams: cropParams,
@@ -1092,16 +956,17 @@ class VideoEditorRenderService {
       );
     }
 
-    return _ClipAnalysis(entries: entries);
+    return ClipAnalysis(entries: entries);
   }
 
   /// Renders a single clip with crop transform to normalize its aspect ratio.
   static Future<String> _renderNormalizedClip({
     required DivineVideoClip clip,
     required int index,
-    required _CropParameters cropParams,
+    required CropParameters cropParams,
     required Directory tempDir,
     required CompleteParameters? parameters,
+    required String ownerTaskId,
   }) async {
     final outputPath = path.join(
       tempDir.path,
@@ -1135,6 +1000,7 @@ class VideoEditorRenderService {
     await renderWithEncoderFallback(
       baseTask: task,
       encode: (attemptTask) => _cancelAndRender(outputPath, attemptTask),
+      ownerTaskId: ownerTaskId,
     );
 
     Log.debug(
@@ -1162,7 +1028,7 @@ class VideoEditorRenderService {
     required CompleteParameters? parameters,
     required model.AspectRatio aspectRatio,
     required Duration? maxOutputDuration,
-    _CropParameters? globalTransform,
+    CropParameters? globalTransform,
   }) async {
     final outputPath = path.join(
       outputDir.path,
@@ -1279,11 +1145,17 @@ class VideoEditorRenderService {
   ///
   /// The happy path pays no extra latency: the first attempt runs immediately
   /// and only failures incur a settle.
+  ///
+  /// [ownerTaskId] names the export this render belongs to, for passes that
+  /// render under an id of their own. A user cancel targets the export's id,
+  /// so without it a retry fires after the settle and finishes work nobody is
+  /// waiting for any more (#7833).
   @visibleForTesting
   static Future<void> renderWithEncoderFallback({
     required VideoRenderData baseTask,
     required Future<void> Function(VideoRenderData task) encode,
     model.AspectRatio? fallbackAspectRatio,
+    String? ownerTaskId,
     Duration settleDelay = VideoEditorConstants.encoderRetrySettleDelay,
   }) async {
     const fallbackQuality = VideoEditorConstants.encoderFallbackQuality;
@@ -1314,10 +1186,10 @@ class VideoEditorRenderService {
         if (attempt.settle > Duration.zero) {
           await Future<void>.delayed(attempt.settle);
         }
-        _throwIfCancellationRequested(baseTask.id);
+        _throwIfCancellationRequested(baseTask.id, ownerTaskId);
         try {
           await encode(attempt.task);
-          _throwIfCancellationRequested(baseTask.id);
+          _throwIfCancellationRequested(baseTask.id, ownerTaskId);
           return;
         } on RenderEncoderException catch (e) {
           final isLast = i == attempts.length - 1;
@@ -1338,8 +1210,22 @@ class VideoEditorRenderService {
     }
   }
 
-  static void _throwIfCancellationRequested(String taskId) {
-    if (RenderCancellationRegistry.consumeCancellation(taskId)) {
+  /// Throws [RenderCanceledException] when a cancel is pending for [taskId]
+  /// or for [ownerTaskId], consuming the request.
+  ///
+  /// Intermediate passes render under their own ids, so a user cancel — which
+  /// targets the export's id — is invisible to them unless they also consult
+  /// the owner.
+  static void _throwIfCancellationRequested(
+    String taskId, [
+    String? ownerTaskId,
+  ]) {
+    final cancelled = RenderCancellationRegistry.consumeCancellation(taskId);
+    final ownerCancelled =
+        ownerTaskId != null &&
+        ownerTaskId != taskId &&
+        RenderCancellationRegistry.consumeCancellation(ownerTaskId);
+    if (cancelled || ownerCancelled) {
       throw const RenderCanceledException();
     }
   }

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -590,7 +590,7 @@ class VideoEditorRenderService {
     Duration? maxOutputDuration = VideoEditorConstants.maxDuration,
     bool reportEveryFailure = false,
   }) async {
-    var tempFilePaths = <String>[];
+    final tempFilePaths = <String>[];
 
     try {
       final override = renderVideoOverride;
@@ -636,8 +636,8 @@ class VideoEditorRenderService {
         cacheDir: cacheDir,
         parameters: parameters,
         taskId: effectiveTaskId,
+        tempFilePaths: tempFilePaths,
       );
-      tempFilePaths = result.tempFilePaths;
 
       final outputPath = await _concatenateSegments(
         clips: clips,
@@ -671,14 +671,14 @@ class VideoEditorRenderService {
         name: _logName,
         category: .video,
       );
-      unawaited(_cleanupTempFiles(tempFilePaths));
+      await _cleanupTempFiles(tempFilePaths);
       throw VideoRenderFailedException(
         VideoRenderFailureReason.canceled,
         cause: e,
       );
     } catch (e, stack) {
       Log.error('❌ Video render failed: $e', name: _logName, category: .video);
-      unawaited(_cleanupTempFiles(tempFilePaths));
+      await _cleanupTempFiles(tempFilePaths);
       VideoRenderWatchdog.reportFailure(
         e,
         stack,
@@ -825,12 +825,15 @@ class VideoEditorRenderService {
   ///
   /// [taskId] is the export's own id — the one a user cancel targets — so this
   /// pass can stop between clips instead of rendering the whole set (#7833).
+  /// [tempFilePaths] is owned by the caller so partial output remains visible
+  /// to its cleanup handlers when this pass throws.
   static Future<NormalizationResult> _normalizeClipsToAspectRatio({
     required List<DivineVideoClip> clips,
     required model.AspectRatio aspectRatio,
     required Directory cacheDir,
     required CompleteParameters? parameters,
     required String taskId,
+    required List<String> tempFilePaths,
   }) async {
     // Analyze all clips first to determine the optimal rendering strategy
     final clipAnalysis = await _analyzeClips(clips, aspectRatio);
@@ -879,8 +882,6 @@ class VideoEditorRenderService {
     );
 
     final segments = <VideoSegment>[];
-    final tempFilePaths = <String>[];
-
     for (int i = 0; i < clips.length; i++) {
       _throwIfCancellationRequested(taskId);
       final entry = clipAnalysis.entries[i];
@@ -907,15 +908,18 @@ class VideoEditorRenderService {
           ),
         );
       } else {
-        final normalizedPath = await _renderNormalizedClip(
+        final normalizedPath = path.join(
+          cacheDir.path,
+          'normalized_${i}_${DateTime.now().microsecondsSinceEpoch}.mp4',
+        );
+        tempFilePaths.add(normalizedPath);
+        await _renderNormalizedClip(
           clip: entry.clip,
-          index: i,
           cropParams: entry.cropParams,
-          tempDir: cacheDir,
+          outputPath: normalizedPath,
           parameters: parameters,
           ownerTaskId: taskId,
         );
-        tempFilePaths.add(normalizedPath);
         segments.add(
           VideoSegment(
             video: EditorVideo.file(File(normalizedPath)),
@@ -962,17 +966,11 @@ class VideoEditorRenderService {
   /// Renders a single clip with crop transform to normalize its aspect ratio.
   static Future<String> _renderNormalizedClip({
     required DivineVideoClip clip,
-    required int index,
     required CropParameters cropParams,
-    required Directory tempDir,
+    required String outputPath,
     required CompleteParameters? parameters,
     required String ownerTaskId,
   }) async {
-    final outputPath = path.join(
-      tempDir.path,
-      'normalized_${index}_${DateTime.now().microsecondsSinceEpoch}.mp4',
-    );
-
     final task = VideoRenderData(
       id: '${clip.id}_normalized',
       videoSegments: [

--- a/mobile/scripts/baseline/service_god_file_sizes.txt
+++ b/mobile/scripts/baseline/service_god_file_sizes.txt
@@ -9,6 +9,5 @@
 lib/services/auth_service.dart	4537
 lib/services/curated_list_service.dart	1847
 lib/services/upload_manager.dart	1958
-lib/services/video_editor/video_editor_render_service.dart	1539
 lib/services/video_event_publisher.dart	2295
 lib/services/video_event_service.dart	6517

--- a/mobile/test/services/video_editor/clip_normalization_models_test.dart
+++ b/mobile/test/services/video_editor/clip_normalization_models_test.dart
@@ -1,0 +1,134 @@
+// ABOUTME: Tests the crop geometry that decides whether a clip needs
+// ABOUTME: normalizing, and the analysis that picks per-clip vs global cropping
+
+import 'dart:ui' show Size;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/services/video_editor/clip_normalization_models.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+void main() {
+  ClipAnalysisEntry entry(String id, Size resolution) => ClipAnalysisEntry(
+    clip: DivineVideoClip(
+      id: id,
+      video: EditorVideo.file('/tmp/$id.mp4'),
+      duration: const Duration(seconds: 3),
+      recordedAt: DateTime(2026),
+      targetAspectRatio: model.AspectRatio.vertical,
+      originalAspectRatio: 9 / 16,
+    ),
+    resolution: resolution,
+    cropParams: CropParameters.forAspectRatio(
+      resolution: resolution,
+      aspectRatio: model.AspectRatio.vertical,
+    ),
+  );
+
+  group('CropParameters', () {
+    group('forAspectRatio', () {
+      test('centers a square crop on the shorter side', () {
+        final crop = CropParameters.forAspectRatio(
+          resolution: const Size(1920, 1080),
+          aspectRatio: model.AspectRatio.square,
+        );
+
+        expect(crop.width, 1080);
+        expect(crop.height, 1080);
+        expect(crop.x, 420);
+        expect(crop.y, 0);
+      });
+
+      test('crops width when the source is wider than 9:16', () {
+        final crop = CropParameters.forAspectRatio(
+          resolution: const Size(1920, 1080),
+          aspectRatio: model.AspectRatio.vertical,
+        );
+
+        expect(crop.height, 1080);
+        expect(crop.width, 608);
+        expect(crop.x, 656);
+        expect(crop.y, 0);
+      });
+
+      test('crops height when the source is taller than 9:16', () {
+        final crop = CropParameters.forAspectRatio(
+          resolution: const Size(1080, 2400),
+          aspectRatio: model.AspectRatio.vertical,
+        );
+
+        expect(crop.width, 1080);
+        expect(crop.height, 1920);
+        expect(crop.x, 0);
+        expect(crop.y, 240);
+      });
+    });
+
+    group('needsCropping', () {
+      test('is false for a source that already matches the target', () {
+        const resolution = Size(1080, 1920);
+        final crop = CropParameters.forAspectRatio(
+          resolution: resolution,
+          aspectRatio: model.AspectRatio.vertical,
+        );
+
+        expect(crop.needsCropping(resolution), isFalse);
+      });
+
+      test('is true for a source that must be cropped', () {
+        const resolution = Size(1920, 1080);
+        final crop = CropParameters.forAspectRatio(
+          resolution: resolution,
+          aspectRatio: model.AspectRatio.vertical,
+        );
+
+        expect(crop.needsCropping(resolution), isTrue);
+      });
+    });
+
+    group('toExportTransform', () {
+      test('carries the crop rectangle onto the export transform', () {
+        const crop = CropParameters(x: 1, y: 2, width: 3, height: 4);
+
+        final transform = crop.toExportTransform();
+
+        expect(transform.x, 1);
+        expect(transform.y, 2);
+        expect(transform.width, 3);
+        expect(transform.height, 4);
+      });
+    });
+  });
+
+  group('ClipAnalysis', () {
+    group('allSameCropParams', () {
+      test('is true when every clip crops to the same rectangle', () {
+        final analysis = ClipAnalysis(
+          entries: [
+            entry('a', const Size(1920, 1080)),
+            entry('b', const Size(1920, 1080)),
+          ],
+        );
+
+        expect(analysis.allSameCropParams, isTrue);
+      });
+
+      test('is false when resolutions crop differently, which is what puts '
+          'the export on the per-clip normalization path', () {
+        final analysis = ClipAnalysis(
+          entries: [
+            entry('a', const Size(1920, 1080)),
+            entry('b', const Size(1280, 720)),
+          ],
+        );
+
+        expect(analysis.allSameCropParams, isFalse);
+      });
+
+      test('is true for no clips at all', () {
+        expect(const ClipAnalysis(entries: []).allSameCropParams, isTrue);
+      });
+    });
+  });
+}

--- a/mobile/test/services/video_editor/video_editor_render_service_normalization_cancel_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_normalization_cancel_test.dart
@@ -161,6 +161,46 @@ void main() {
       // never normalized and the full video is never concatenated.
       expect(plugin.renderedTaskIds, ['clip-a_normalized']);
       expect(outputPath, isNull);
+      expect(
+        tempDir.listSync().whereType<File>().where(
+          (file) => file.path.endsWith('.mp4'),
+        ),
+        isEmpty,
+      );
     });
+
+    test(
+      'deletes earlier normalized clips when a later clip is cancelled',
+      () async {
+        RenderCancellationRegistry.start(exportTaskId);
+        final plugin = _MockProVideoEditor(
+          resolutions: resolutions,
+          onRender: (task) {
+            if (task.id == 'clip-b_normalized') {
+              RenderCancellationRegistry.cancel(exportTaskId);
+            }
+          },
+        );
+        ProVideoEditor.instance = plugin;
+
+        final outputPath = await VideoEditorRenderService.renderVideo(
+          clips: clips,
+          aspectRatio: model.AspectRatio.vertical,
+          taskId: exportTaskId,
+        );
+
+        expect(plugin.renderedTaskIds, [
+          'clip-a_normalized',
+          'clip-b_normalized',
+        ]);
+        expect(outputPath, isNull);
+        expect(
+          tempDir.listSync().whereType<File>().where(
+            (file) => file.path.endsWith('.mp4'),
+          ),
+          isEmpty,
+        );
+      },
+    );
   });
 }

--- a/mobile/test/services/video_editor/video_editor_render_service_normalization_cancel_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_normalization_cancel_test.dart
@@ -1,0 +1,166 @@
+// ABOUTME: Proves a user cancel stops the export's clip-normalization pass
+// ABOUTME: Captures and restores ProVideoEditor and PathProviderPlatform
+
+import 'dart:io';
+import 'dart:ui' show Size;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/services/video_editor/render_cancellation_registry.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+class _MockPathProviderPlatform extends Fake
+    with MockPlatformInterfaceMixin
+    implements PathProviderPlatform {
+  _MockPathProviderPlatform({required this.root});
+
+  final String root;
+
+  @override
+  Future<String?> getTemporaryPath() async => root;
+
+  @override
+  Future<String?> getApplicationCachePath() async => root;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => root;
+}
+
+class _MockProVideoEditor extends ProVideoEditor {
+  _MockProVideoEditor({required this.resolutions, this.onRender});
+
+  /// Reported resolution per source file path. Anything else reports a
+  /// already-vertical resolution, which needs no crop.
+  final Map<String, Size> resolutions;
+
+  /// Runs inside `renderVideoToFile`, so a test can cancel mid-render.
+  final void Function(VideoRenderData task)? onRender;
+
+  /// Every render the service asked the plugin for, in order.
+  final List<String> renderedTaskIds = [];
+
+  @override
+  Stream<dynamic> initializeStream() => const Stream.empty();
+
+  @override
+  Future<VideoMetadata> getMetadata(
+    EditorVideo value, {
+    bool checkStreamingOptimization = false,
+    NativeLogLevel? nativeLogLevel,
+  }) async => VideoMetadata(
+    duration: const Duration(seconds: 3),
+    extension: 'mp4',
+    fileSize: 1024,
+    resolution: resolutions[value.file?.path] ?? const Size(1080, 1920),
+    rotation: 0,
+    bitrate: 1000,
+  );
+
+  @override
+  Future<String> renderVideoToFile(
+    String filePath,
+    VideoRenderData value, {
+    NativeLogLevel? nativeLogLevel,
+  }) async {
+    renderedTaskIds.add(value.id);
+    onRender?.call(value);
+    File(filePath).createSync(recursive: true);
+    return filePath;
+  }
+
+  @override
+  Future<void> cancel(String taskId) async {}
+}
+
+void main() {
+  const exportTaskId = 'export-task';
+
+  late Directory tempDir;
+  late PathProviderPlatform originalPathProvider;
+  late ProVideoEditor originalProVideoEditor;
+
+  // Landscape and 720p sources crop to different rectangles for a vertical
+  // target, which is what pushes the export onto the per-clip normalization
+  // path instead of a single global transform.
+  late Map<String, Size> resolutions;
+  late List<DivineVideoClip> clips;
+
+  DivineVideoClip clipFor(String id) => DivineVideoClip(
+    id: id,
+    video: EditorVideo.file('${tempDir.path}/$id.mp4'),
+    duration: const Duration(seconds: 3),
+    recordedAt: DateTime(2026),
+    targetAspectRatio: model.AspectRatio.vertical,
+    originalAspectRatio: 16 / 9,
+  );
+
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    tempDir = Directory.systemTemp.createTempSync('openvine_render_cancel_');
+    originalPathProvider = PathProviderPlatform.instance;
+    originalProVideoEditor = ProVideoEditor.instance;
+    PathProviderPlatform.instance = _MockPathProviderPlatform(
+      root: tempDir.path,
+    );
+    clips = [clipFor('clip-a'), clipFor('clip-b')];
+    resolutions = {
+      '${tempDir.path}/clip-a.mp4': const Size(1920, 1080),
+      '${tempDir.path}/clip-b.mp4': const Size(1280, 720),
+    };
+  });
+
+  tearDown(() {
+    PathProviderPlatform.instance = originalPathProvider;
+    ProVideoEditor.instance = originalProVideoEditor;
+    RenderCancellationRegistry.reset();
+    VideoEditorRenderService.resetActiveNativeTaskIdsForTesting();
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  group('clip normalization cancellation (#7833/#7834)', () {
+    test('normalizes every mixed-resolution clip and concatenates when '
+        'nothing cancels', () async {
+      final plugin = _MockProVideoEditor(resolutions: resolutions);
+      ProVideoEditor.instance = plugin;
+
+      final outputPath = await VideoEditorRenderService.renderVideo(
+        clips: clips,
+        aspectRatio: model.AspectRatio.vertical,
+        taskId: exportTaskId,
+      );
+
+      expect(outputPath, isNotNull);
+      expect(plugin.renderedTaskIds, [
+        'clip-a_normalized',
+        'clip-b_normalized',
+        exportTaskId,
+      ]);
+    });
+
+    test('stops the pass when the user cancels the export mid-clip', () async {
+      // renderVideoToClip owns this generation in production; a cancel that
+      // arrives with no active generation is dropped by the registry.
+      RenderCancellationRegistry.start(exportTaskId);
+      final plugin = _MockProVideoEditor(
+        resolutions: resolutions,
+        onRender: (_) => RenderCancellationRegistry.cancel(exportTaskId),
+      );
+      ProVideoEditor.instance = plugin;
+
+      final outputPath = await VideoEditorRenderService.renderVideo(
+        clips: clips,
+        aspectRatio: model.AspectRatio.vertical,
+        taskId: exportTaskId,
+      );
+
+      // The cancel lands during the first clip's render, so the second clip is
+      // never normalized and the full video is never concatenated.
+      expect(plugin.renderedTaskIds, ['clip-a_normalized']);
+      expect(outputPath, isNull);
+    });
+  });
+}

--- a/mobile/test/services/video_editor/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_test.dart
@@ -598,8 +598,7 @@ void main() {
 
     // The reduced-resolution attempt is rebuilt with copyWith. Rebuilding it
     // with the constructor instead would silently reset every field the
-    // rebuild does not name — trimToCommonTrackEnd among them, which is what
-    // keeps the audio/video seam closed (#7788).
+    // rebuild does not name, including trimToCommonTrackEnd (#7788).
     test('carries non-quality task fields into the reduced-resolution '
         'attempt', () async {
       final harness = flakyEncoder(failuresBeforeSuccess: 2);

--- a/mobile/test/services/video_editor/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_test.dart
@@ -269,13 +269,17 @@ void main() {
     final fallbackResolution = VideoEditorConstants.encoderFallbackQuality
         .resolutionForAspectRatio(aspectRatio);
 
-    VideoRenderData baseTask() => VideoRenderData(
-      id: 'render-task',
+    VideoRenderData baseTask({
+      String id = 'render-task',
+      bool trimToCommonTrackEnd = false,
+    }) => VideoRenderData(
+      id: id,
       videoSegments: [
         VideoSegment(
           video: EditorVideo.file('${Directory.systemTemp.path}/a.mp4'),
         ),
       ],
+      trimToCommonTrackEnd: trimToCommonTrackEnd,
       qualityConfig: VideoQualityConfig.custom(
         bitrate: VideoEditorConstants.quality.bitrate,
         resolution: baseResolution,
@@ -531,6 +535,88 @@ void main() {
         async.elapse(const Duration(milliseconds: 1));
         expect(harness.calls, hasLength(3));
       });
+    });
+
+    // An intermediate pass (clip normalization) renders under an id of its
+    // own, while the user's Cancel targets the export's id. Without
+    // [ownerTaskId] the retry loop cannot see that cancel at all, so it
+    // settles, retries, and finishes work nobody is waiting for (#7833/#7834).
+    test("honors the owning export's cancellation during the settle "
+        'window', () {
+      fakeAsync((async) {
+        const settle = VideoEditorConstants.encoderRetrySettleDelay;
+        final harness = flakyEncoder(failuresBeforeSuccess: 1);
+        // renderVideoToClip owns this generation in production.
+        final ownerToken = RenderCancellationRegistry.start('export-task');
+        Object? caught;
+
+        unawaited(
+          VideoEditorRenderService.renderWithEncoderFallback(
+            baseTask: baseTask(id: 'clip-a_normalized'),
+            encode: harness.encode,
+            ownerTaskId: 'export-task',
+          ).catchError((Object error) {
+            caught = error;
+          }),
+        );
+
+        async.flushMicrotasks();
+        expect(harness.calls, hasLength(1));
+
+        RenderCancellationRegistry.cancel('export-task');
+
+        async.elapse(settle);
+        async.flushMicrotasks();
+
+        expect(caught, isA<RenderCanceledException>());
+        expect(harness.calls, hasLength(1));
+        RenderCancellationRegistry.finish('export-task', ownerToken);
+      });
+    });
+
+    test('stops after the running attempt when the owning export is '
+        'cancelled', () async {
+      final ownerToken = RenderCancellationRegistry.start('export-task');
+      var calls = 0;
+
+      await expectLater(
+        VideoEditorRenderService.renderWithEncoderFallback(
+          baseTask: baseTask(id: 'clip-a_normalized'),
+          encode: (_) async {
+            calls++;
+            RenderCancellationRegistry.cancel('export-task');
+          },
+          ownerTaskId: 'export-task',
+          settleDelay: Duration.zero,
+        ),
+        throwsA(isA<RenderCanceledException>()),
+      );
+
+      expect(calls, 1);
+      RenderCancellationRegistry.finish('export-task', ownerToken);
+    });
+
+    // The reduced-resolution attempt is rebuilt with copyWith. Rebuilding it
+    // with the constructor instead would silently reset every field the
+    // rebuild does not name — trimToCommonTrackEnd among them, which is what
+    // keeps the audio/video seam closed (#7788).
+    test('carries non-quality task fields into the reduced-resolution '
+        'attempt', () async {
+      final harness = flakyEncoder(failuresBeforeSuccess: 2);
+
+      await VideoEditorRenderService.renderWithEncoderFallback(
+        baseTask: baseTask(trimToCommonTrackEnd: true),
+        encode: harness.encode,
+        fallbackAspectRatio: aspectRatio,
+        settleDelay: Duration.zero,
+      );
+
+      expect(harness.calls, hasLength(3));
+      expect(
+        harness.calls.map((t) => t.trimToCommonTrackEnd),
+        everyElement(isTrue),
+      );
+      expect(harness.calls[2].qualityConfig?.resolution, fallbackResolution);
     });
   });
 


### PR DESCRIPTION
## Description

Cancelling a mixed-resolution video export did not stop the clip-normalization pass. Cancel targets the export draftId, while each normalized clip renders under clipId_normalized, so the pass could not observe the owner cancellation.

This threads the export task id through normalization and encoder fallback checks. Cancellation now stops before the next clip or retry. The pass also registers every normalized output path before rendering and awaits cleanup on cancellation or failure, so completed clips and a just-written in-flight output are not orphaned in cache.

The normalization value types move into clip_normalization_models.dart. The render service is now 1423 lines and leaves the oversized-service baseline.

## Deliberately unchanged

- A cancel still cannot interrupt work already executing inside the native plugin; it takes effect at the next service-controlled boundary.
- Cancellation remains scoped to the owning export and cannot stop another export.
- #7788 cited files and literal trimToCommonTrackEnd == true production path do not exist. This PR closes the stale request by pinning the actual invariant: reduced-resolution fallback preserves all non-quality task fields through copyWith.

## Verification

- Targeted render-service suite: 35 tests passed
- flutter analyze lib test: no issues
- Dart formatting check: no changes
- Service god-file and production/test Future.delayed ratchets: pass
- Full local test discovery reached 19,428 passing / 273 skipped tests. Three manual relay acceptance tests require the local stack, and three unrelated design-system goldens differ on this macOS runner; neither failing file is changed by this PR.

## Type of Change

- [x] Bug fix

Related issues: Closes #7833, closes #7834, closes #7788