### PR TITLE
refactor(video-editor): share one canvas render-size calculation

### DIFF
--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -43,6 +43,7 @@ import 'package:openvine/utils/path_resolver.dart';
 import 'package:openvine/utils/video_editor_playhead.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_editor/main_editor/hit_test_expander.dart';
+import 'package:openvine/widgets/video_editor/main_editor/video_editor_canvas_fit.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_clip_preview.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_cut_area_overlay.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_feed_preview_overlay.dart';
@@ -3010,47 +3011,38 @@ class _CanvasFitter extends ConsumerWidget {
       builder: (_, constraints) {
         final bodySize = constraints.biggest;
 
-        // Height is constrained by maxWidth or maxHeight,
-        // depending on which dimension is reached first
-        final height = min(bodySize.width, bodySize.height);
-        final renderSize = Size(height * clip.originalAspectRatio, height);
+        // The one model of the canvas mapping. Layer compensation reads the
+        // same geometry through VideoEditorScope.calculateFittedBoxScale.
+        final geometry = VideoEditorCanvasGeometry(
+          bodySize: bodySize,
+          originalAspectRatio: clip.originalAspectRatio,
+          targetAspectRatio: clip.targetAspectRatio.value,
+        );
 
         // Notify parent about body size
         scope.bodySizeNotifier.value = bodySize;
 
-        final targetSize = VideoEditorScope.calculateTargetSize(
-          bodySize,
-          clip.targetAspectRatio.value,
-        );
-
-        // The visual chain below (Center > SizedBox > FittedBox >
-        // SizedBox > Navigator) owns the aspect-ratio mapping: cover-fit
-        // [renderSize] into [targetSize], centered in [bodySize].
+        // [VideoEditorCanvasFit] owns the aspect-ratio mapping: cover-fit
+        // the render surface into the visible target area, centered in
+        // [bodySize].
         //
         // [HitTestExpander] wraps it so that taps in the scrim /
-        // letterbox zone (outside [targetSize]) are clamped to the
-        // nearest point inside [targetSize] and re-dispatched into the
-        // chain. Without this, `Center.hitTestChildren` drops every
-        // pointer event that falls outside its child rect, so the
-        // editor's top-level GestureDetector never opens an arena and
-        // [onScaleStart] / [onScaleUpdate] never fire.
+        // letterbox zone (outside the target area) are clamped to the
+        // nearest point inside it and re-dispatched into the chain.
+        // Without this, `Center.hitTestChildren` drops every pointer event
+        // that falls outside its child rect, so the editor's top-level
+        // GestureDetector never opens an arena and [onScaleStart] /
+        // [onScaleUpdate] never fire.
         return VideoEditorCutAreaOverlay(
           child: HitTestExpander(
-            visibleSize: targetSize,
-            child: Center(
-              child: SizedBox.fromSize(
-                size: targetSize,
-                child: FittedBox(
-                  fit: BoxFit.cover,
-                  child: SizedBox.fromSize(
-                    size: renderSize,
-                    child: Navigator(
-                      clipBehavior: Clip.none,
-                      onGenerateRoute: (_) => PageRouteBuilder(
-                        pageBuilder: (_, _, _) => builder(bodySize, renderSize),
-                      ),
-                    ),
-                  ),
+            visibleSize: geometry.targetSize,
+            child: VideoEditorCanvasFit(
+              geometry: geometry,
+              child: Navigator(
+                clipBehavior: Clip.none,
+                onGenerateRoute: (_) => PageRouteBuilder(
+                  pageBuilder: (_, _, _) =>
+                      builder(bodySize, geometry.renderSize),
                 ),
               ),
             ),

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas_fit.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas_fit.dart
@@ -12,10 +12,10 @@ import 'package:flutter/widgets.dart';
 /// are authored in render space, so they compensate for that transform with
 /// [fittedBoxScale].
 ///
-/// Both sides read this one object: [VideoEditorCanvasFit] applies the mapping
-/// and `VideoEditorScope.calculateFittedBoxScale` reports it. They used to
-/// model it separately, which is how #7534 changed only the reporting side and
-/// made layers compensate for a scale the canvas never applied.
+/// Canvas layout, layer compensation, and the cut-area overlay read this one
+/// model. The canvas and layer compensation used to model it separately, which
+/// is how #7534 changed only the reporting side and made layers compensate for
+/// a scale the canvas never applied.
 @immutable
 class VideoEditorCanvasGeometry {
   /// Derives the canvas geometry for [bodySize].
@@ -54,8 +54,9 @@ class VideoEditorCanvasGeometry {
 
   /// Unscaled canvas surface for [bodySize] at [aspectRatio].
   ///
-  /// The height is whichever body dimension runs out first, so the surface
-  /// always fits the body before the cover-fit into [targetSizeFor] scales it.
+  /// The height is the body's shorter dimension. For landscape clips in a
+  /// portrait body, the resulting width deliberately extends beyond the body
+  /// before the cover-fit into [targetSizeFor] scales it.
   static Size renderSizeFor(Size bodySize, double aspectRatio) {
     final height = bodySize.shortestSide;
     return Size(height * aspectRatio, height);

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas_fit.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas_fit.dart
@@ -1,0 +1,118 @@
+// ABOUTME: Canvas geometry shared by the editor canvas and layer compensation.
+// ABOUTME: Owns the render-size and cover-fit math both sides depend on.
+
+import 'dart:math';
+
+import 'package:flutter/widgets.dart';
+
+/// How the editor canvas maps a clip onto the body it is drawn in.
+///
+/// The canvas lays the editor out at [renderSize] and cover-fits it into
+/// [targetSize]. Layers (text, stickers, helper lines, drawing stroke widths)
+/// are authored in render space, so they compensate for that transform with
+/// [fittedBoxScale].
+///
+/// Both sides read this one object: [VideoEditorCanvasFit] applies the mapping
+/// and `VideoEditorScope.calculateFittedBoxScale` reports it. They used to
+/// model it separately, which is how #7534 changed only the reporting side and
+/// made layers compensate for a scale the canvas never applied.
+@immutable
+class VideoEditorCanvasGeometry {
+  /// Derives the canvas geometry for [bodySize].
+  ///
+  /// [targetAspectRatio] is the crop the viewer sees; it defaults to
+  /// [originalAspectRatio] when the clip is uncropped.
+  factory VideoEditorCanvasGeometry({
+    required Size bodySize,
+    required double originalAspectRatio,
+    double? targetAspectRatio,
+  }) {
+    return VideoEditorCanvasGeometry._(
+      bodySize: bodySize,
+      renderSize: renderSizeFor(bodySize, originalAspectRatio),
+      targetSize: targetSizeFor(
+        bodySize,
+        targetAspectRatio ?? originalAspectRatio,
+      ),
+    );
+  }
+
+  const VideoEditorCanvasGeometry._({
+    required this.bodySize,
+    required this.renderSize,
+    required this.targetSize,
+  });
+
+  /// Space the canvas was laid out in.
+  final Size bodySize;
+
+  /// Unscaled surface the editor and its layers are laid out at.
+  final Size renderSize;
+
+  /// Visible area the [renderSize] surface is cover-fitted into.
+  final Size targetSize;
+
+  /// Unscaled canvas surface for [bodySize] at [aspectRatio].
+  ///
+  /// The height is whichever body dimension runs out first, so the surface
+  /// always fits the body before the cover-fit into [targetSizeFor] scales it.
+  static Size renderSizeFor(Size bodySize, double aspectRatio) {
+    final height = bodySize.shortestSide;
+    return Size(height * aspectRatio, height);
+  }
+
+  /// Visible target area of [targetAspectRatio] contained in [bodySize].
+  static Size targetSizeFor(Size bodySize, double targetAspectRatio) {
+    if (bodySize == Size.zero) return Size.zero;
+    if (bodySize.aspectRatio > targetAspectRatio) {
+      return Size(bodySize.height * targetAspectRatio, bodySize.height);
+    }
+    return Size(bodySize.width, bodySize.width / targetAspectRatio);
+  }
+
+  /// Scale the canvas applies when cover-fitting [renderSize] into
+  /// [targetSize].
+  ///
+  /// Layers divide their size by this so they end up on screen at the size
+  /// they were authored at.
+  double get fittedBoxScale {
+    if (bodySize == Size.zero) return 1;
+    return max(
+      targetSize.width / renderSize.width,
+      targetSize.height / renderSize.height,
+    );
+  }
+}
+
+/// Applies [geometry] to the editor canvas.
+///
+/// [child] is laid out at [VideoEditorCanvasGeometry.renderSize] and
+/// cover-fitted into [VideoEditorCanvasGeometry.targetSize], centered in the
+/// body — the transform [VideoEditorCanvasGeometry.fittedBoxScale] describes.
+class VideoEditorCanvasFit extends StatelessWidget {
+  /// Creates a [VideoEditorCanvasFit].
+  const VideoEditorCanvasFit({
+    required this.geometry,
+    required this.child,
+    super.key,
+  });
+
+  /// Mapping applied to [child].
+  final VideoEditorCanvasGeometry geometry;
+
+  /// Canvas laid out at [VideoEditorCanvasGeometry.renderSize].
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SizedBox.fromSize(
+        size: geometry.targetSize,
+        child: FittedBox(
+          fit: BoxFit.cover,
+          child: SizedBox.fromSize(size: geometry.renderSize, child: child),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_cut_area_overlay.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_cut_area_overlay.dart
@@ -7,6 +7,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/widgets/video_editor/main_editor/video_editor_canvas_fit.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 
 /// Maps the editor's zoom [editorMatrix] (expressed in the editor's
@@ -33,16 +34,20 @@ Matrix4 scrimZoomTransform({
   required Size targetSize,
   required double originalAspectRatio,
 }) {
-  final renderHeight = boxSize.shortestSide;
-  final renderWidth = renderHeight * originalAspectRatio;
-  if (renderWidth <= 0 || renderHeight <= 0) return Matrix4.identity();
+  final renderSize = VideoEditorCanvasGeometry.renderSizeFor(
+    boxSize,
+    originalAspectRatio,
+  );
+  if (renderSize.width <= 0 || renderSize.height <= 0) {
+    return Matrix4.identity();
+  }
 
   final coverScale = max(
-    targetSize.width / renderWidth,
-    targetSize.height / renderHeight,
+    targetSize.width / renderSize.width,
+    targetSize.height / renderSize.height,
   );
-  final dx = (boxSize.width - coverScale * renderWidth) / 2;
-  final dy = (boxSize.height - coverScale * renderHeight) / 2;
+  final dx = (boxSize.width - coverScale * renderSize.width) / 2;
+  final dy = (boxSize.height - coverScale * renderSize.height) / 2;
 
   final k = editorMatrix.getMaxScaleOnAxis();
   final t = editorMatrix.getTranslation();
@@ -84,19 +89,12 @@ class VideoEditorCutAreaOverlay extends ConsumerWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final boxSize = constraints.biggest;
-        // Compute the visible child size: largest rect with
-        // targetAspectRatio that fits inside boxSize (BoxFit.contain).
-        final double childWidth;
-        final double childHeight;
-        if (boxSize.width / boxSize.height > targetAspectRatio.value) {
-          childHeight = boxSize.height;
-          childWidth = boxSize.height * targetAspectRatio.value;
-        } else {
-          childWidth = boxSize.width;
-          childHeight = boxSize.width / targetAspectRatio.value;
-        }
-        final verticalGap = (boxSize.height - childHeight) / 2;
-        final horizontalGap = (boxSize.width - childWidth) / 2;
+        final targetSize = VideoEditorCanvasGeometry.targetSizeFor(
+          boxSize,
+          targetAspectRatio.value,
+        );
+        final verticalGap = (boxSize.height - targetSize.height) / 2;
+        final horizontalGap = (boxSize.width - targetSize.width) / 2;
 
         final scrimBars = _ScrimBars(
           overlayColor: overlayColor,
@@ -117,7 +115,7 @@ class VideoEditorCutAreaOverlay extends ConsumerWidget {
                 transform: scrimZoomTransform(
                   editorMatrix: matrix,
                   boxSize: boxSize,
-                  targetSize: Size(childWidth, childHeight),
+                  targetSize: targetSize,
                   originalAspectRatio: scope.originalClipAspectRatio,
                 ),
                 child: child,

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_scope.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_scope.dart
@@ -1,9 +1,8 @@
 // ABOUTME: InheritedWidget providing access to the ProImageEditor instance.
 // ABOUTME: Allows child widgets to call editor methods directly without callbacks.
 
-import 'dart:math';
-
 import 'package:flutter/widgets.dart';
+import 'package:openvine/widgets/video_editor/main_editor/video_editor_canvas_fit.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 /// Provides access to the [ProImageEditorState] for descendant widgets.
@@ -111,31 +110,24 @@ class VideoEditorScope extends InheritedWidget {
   );
 
   /// Calculates the visible target area fitted inside [bodySize].
-  static Size calculateTargetSize(Size bodySize, double targetAspectRatio) {
-    if (bodySize == Size.zero) return Size.zero;
-    if (bodySize.aspectRatio > targetAspectRatio) {
-      return Size(bodySize.height * targetAspectRatio, bodySize.height);
-    }
-    return Size(bodySize.width, bodySize.width / targetAspectRatio);
-  }
+  static Size calculateTargetSize(Size bodySize, double targetAspectRatio) =>
+      VideoEditorCanvasGeometry.targetSizeFor(bodySize, targetAspectRatio);
 
-  /// Calculates the FittedBox scale factor for a given body size and aspect ratio.
+  /// Calculates the FittedBox scale factor for a given body size and aspect
+  /// ratio.
+  ///
+  /// Reads the same [VideoEditorCanvasGeometry] the canvas lays itself out
+  /// with, so a layer compensating for the transform can never disagree with
+  /// the transform the canvas applies.
   static double calculateFittedBoxScale(
     Size bodySize,
     double aspectRatio, {
     double? targetAspectRatio,
-  }) {
-    if (bodySize == Size.zero) return 1.0;
-    final targetRatio = targetAspectRatio ?? aspectRatio;
-    final height = bodySize.shortestSide;
-    final renderSize = Size(height * aspectRatio, height);
-    final targetSize = calculateTargetSize(bodySize, targetRatio);
-
-    return max(
-      targetSize.width / renderSize.width,
-      targetSize.height / renderSize.height,
-    );
-  }
+  }) => VideoEditorCanvasGeometry(
+    bodySize: bodySize,
+    originalAspectRatio: aspectRatio,
+    targetAspectRatio: targetAspectRatio,
+  ).fittedBoxScale;
 
   /// Returns the [ProImageEditorState] if available.
   ProImageEditorState? get editor => editorOverride ?? editorKey.currentState;

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_fit_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_fit_test.dart
@@ -1,0 +1,218 @@
+// ABOUTME: Tests for the shared video editor canvas geometry and fit widget.
+// ABOUTME: Pins the canvas chain and the layer-compensation helper together.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/video_editor/main_editor/video_editor_canvas_fit.dart';
+import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
+
+const ValueKey<String> _renderSurfaceKey = ValueKey('render-surface');
+
+/// One canvas mapping to check, named for the failure message.
+typedef _Case = ({
+  String description,
+  Size bodySize,
+  double originalAspectRatio,
+  double? targetAspectRatio,
+});
+
+/// Body sizes stay inside the 800x600 test surface so the chain is laid out
+/// at the size it asks for.
+const _cases = <_Case>[
+  (
+    description: 'portrait clip on a portrait body',
+    bodySize: Size(300, 600),
+    originalAspectRatio: 9 / 16,
+    targetAspectRatio: null,
+  ),
+  (
+    description: 'square clip on a portrait body',
+    bodySize: Size(300, 600),
+    originalAspectRatio: 1,
+    targetAspectRatio: 1,
+  ),
+  (
+    description: 'square clip cropped to portrait on a portrait body',
+    bodySize: Size(300, 600),
+    originalAspectRatio: 1,
+    targetAspectRatio: 9 / 16,
+  ),
+  (
+    description: 'landscape clip on a landscape body',
+    bodySize: Size(600, 300),
+    originalAspectRatio: 16 / 9,
+    targetAspectRatio: null,
+  ),
+  (
+    description: 'square clip cropped to portrait on a landscape body',
+    bodySize: Size(600, 300),
+    originalAspectRatio: 1,
+    targetAspectRatio: 9 / 16,
+  ),
+  (
+    description: 'portrait clip cropped to square on a square body',
+    bodySize: Size(400, 400),
+    originalAspectRatio: 9 / 16,
+    targetAspectRatio: 1,
+  ),
+];
+
+void main() {
+  group(VideoEditorCanvasGeometry, () {
+    group('renderSizeFor', () {
+      test('takes its height from the shorter body dimension', () {
+        expect(
+          VideoEditorCanvasGeometry.renderSizeFor(const Size(300, 600), 1),
+          equals(const Size(300, 300)),
+        );
+        expect(
+          VideoEditorCanvasGeometry.renderSizeFor(const Size(600, 300), 1),
+          equals(const Size(300, 300)),
+        );
+      });
+
+      test('widens the surface by the clip aspect ratio', () {
+        expect(
+          VideoEditorCanvasGeometry.renderSizeFor(const Size(300, 600), 16 / 9),
+          within(distance: 0.001, from: const Size(300 * 16 / 9, 300)),
+        );
+      });
+    });
+
+    group('targetSizeFor', () {
+      test('contains the target ratio inside the body', () {
+        expect(
+          VideoEditorCanvasGeometry.targetSizeFor(const Size(400, 800), 9 / 16),
+          equals(const Size(400, 400 / (9 / 16))),
+        );
+        expect(
+          VideoEditorCanvasGeometry.targetSizeFor(const Size(800, 400), 9 / 16),
+          equals(const Size(400 * 9 / 16, 400)),
+        );
+      });
+
+      test('collapses when the body has no size yet', () {
+        expect(
+          VideoEditorCanvasGeometry.targetSizeFor(Size.zero, 9 / 16),
+          equals(Size.zero),
+        );
+      });
+    });
+
+    group('fittedBoxScale', () {
+      test('falls back to 1 before the body has been laid out', () {
+        final geometry = VideoEditorCanvasGeometry(
+          bodySize: Size.zero,
+          originalAspectRatio: 9 / 16,
+        );
+
+        expect(geometry.fittedBoxScale, equals(1.0));
+      });
+
+      test('defaults the target ratio to the clip ratio', () {
+        final uncropped = VideoEditorCanvasGeometry(
+          bodySize: const Size(300, 600),
+          originalAspectRatio: 9 / 16,
+        );
+        final explicit = VideoEditorCanvasGeometry(
+          bodySize: const Size(300, 600),
+          originalAspectRatio: 9 / 16,
+          targetAspectRatio: 9 / 16,
+        );
+
+        expect(uncropped.targetSize, equals(explicit.targetSize));
+        expect(uncropped.fittedBoxScale, equals(explicit.fittedBoxScale));
+      });
+    });
+  });
+
+  group('canvas chain parity', () {
+    for (final testCase in _cases) {
+      testWidgets(
+        'VideoEditorCanvasFit renders ${testCase.description} at the '
+        'geometry the scale helper reports',
+        (tester) async {
+          final geometry = VideoEditorCanvasGeometry(
+            bodySize: testCase.bodySize,
+            originalAspectRatio: testCase.originalAspectRatio,
+            targetAspectRatio: testCase.targetAspectRatio,
+          );
+
+          await tester.pumpWidget(
+            Directionality(
+              textDirection: TextDirection.ltr,
+              child: Align(
+                alignment: Alignment.topLeft,
+                child: SizedBox.fromSize(
+                  size: testCase.bodySize,
+                  child: VideoEditorCanvasFit(
+                    geometry: geometry,
+                    child: const SizedBox.expand(key: _renderSurfaceKey),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          expect(tester.takeException(), isNull);
+
+          // The canvas lays the editor out at the geometry's render size...
+          final renderSurface = find.byKey(_renderSurfaceKey);
+          expect(
+            tester.getSize(renderSurface),
+            within(distance: 0.001, from: geometry.renderSize),
+          );
+
+          // ...inside the visible target area it reports...
+          expect(
+            tester.getSize(find.byType(FittedBox)),
+            within(distance: 0.001, from: geometry.targetSize),
+          );
+
+          // ...and the scale that cover-fit actually applies on screen is the
+          // one layers compensate for. A geometry that only agreed with itself
+          // would still pass the unit tests above; this is what #7534 broke.
+          final appliedScale =
+              tester.getRect(renderSurface).width / geometry.renderSize.width;
+          expect(appliedScale, closeTo(geometry.fittedBoxScale, 0.001));
+          expect(
+            VideoEditorScope.calculateFittedBoxScale(
+              testCase.bodySize,
+              testCase.originalAspectRatio,
+              targetAspectRatio: testCase.targetAspectRatio,
+            ),
+            closeTo(appliedScale, 0.001),
+          );
+        },
+      );
+    }
+
+    test('VideoEditorScope reports the shared geometry', () {
+      for (final testCase in _cases) {
+        final geometry = VideoEditorCanvasGeometry(
+          bodySize: testCase.bodySize,
+          originalAspectRatio: testCase.originalAspectRatio,
+          targetAspectRatio: testCase.targetAspectRatio,
+        );
+
+        expect(
+          VideoEditorScope.calculateTargetSize(
+            testCase.bodySize,
+            testCase.targetAspectRatio ?? testCase.originalAspectRatio,
+          ),
+          equals(geometry.targetSize),
+          reason: 'target size for ${testCase.description}',
+        );
+        expect(
+          VideoEditorScope.calculateFittedBoxScale(
+            testCase.bodySize,
+            testCase.originalAspectRatio,
+            targetAspectRatio: testCase.targetAspectRatio,
+          ),
+          equals(geometry.fittedBoxScale),
+          reason: 'fitted box scale for ${testCase.description}',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Description

The video editor's canvas mapping was modelled twice, by hand, in two files. `_CanvasFitter` computed the render size from `bodySize.shortestSide * originalAspectRatio` and cover-fitted it into the target; `VideoEditorScope.calculateFittedBoxScale` reconstructed that same render size independently, so text, stickers, helper lines and drawing stroke widths could compensate for the transform the canvas applies.

Nothing but comments and tests kept the two in sync, and #7534 showed how that fails: changing only the helper made layer compensation report a scale the canvas never actually applies, so overlays sat in the wrong place.

New `video_editor_canvas_fit.dart` holds one model:

- `VideoEditorCanvasGeometry` — immutable value object carrying `renderSize`, `targetSize` and `fittedBoxScale`, with the two statics `renderSizeFor(...)` and `targetSizeFor(...)`.
- `VideoEditorCanvasFit` — the small widget that *applies* that geometry (`Center > SizedBox(target) > FittedBox.cover > SizedBox(render)`).

`_CanvasFitter` now builds one geometry and hands it to the widget; `VideoEditorScope.calculateTargetSize` / `calculateFittedBoxScale` become thin delegates to the same object. Their signatures and `Size.zero` fallbacks are unchanged, so existing scope tests and `video_editor_screen.dart`'s `_fittedBoxScale` are untouched.

A helper-only divergence of the #7534 shape is now structurally impossible: there is no second render-size expression left to change.

## Out of Scope

`video_editor_canvas.dart` is ~3,343 lines and is named in the broader decomposition issue #6933. This change is scoped to the deduplication only and does not start that work.

## Verification

```
flutter analyze lib test    Analyzing 2 items... No issues found! (33.3s)
flutter test                00:32 +972 ~3: All tests passed!
```

(the 3 skips are pre-existing baselined skips in the video-editor suites, untouched)

The parity test pumps the **real** `VideoEditorCanvasFit` across six cases — square, portrait and landscape bodies × uncropped and cropped targets — and per case asserts three things: the laid-out surface equals `geometry.renderSize`, the visible box equals `geometry.targetSize`, and the scale Flutter's cover-fit *actually applies on screen* (`getRect().width / renderSize.width`) equals both `geometry.fittedBoxScale` and `VideoEditorScope.calculateFittedBoxScale(...)`.

Mutation-checked: reintroducing a separate render-size model inside `fittedBoxScale` — the exact #7534 shape — turns 3 of the 6 parity cases red.

No ratchet baseline needed regenerating; all five design-system ceilings pass unchanged (the moved chain contains no styled widgets), as do the test-structure and layer-direction guards.


**Verified on Galaxy S26.** Text, stickers, helper lines and drawing strokes sit where they should across portrait, landscape and cropped canvases — which is the failure this guards against, since a divergence here puts overlays in the wrong place rather than throwing.

## Type of Change

- [x] 🧹 Code refactor

**Related Issue:** Closes #7565

