### PR TITLE
refactor(video-editor): measure the screen colour when green screen opens

### DIFF
--- a/mobile/lib/blocs/video_editor/chroma_key/chroma_key_editor_cubit.dart
+++ b/mobile/lib/blocs/video_editor/chroma_key/chroma_key_editor_cubit.dart
@@ -73,22 +73,22 @@ class ChromaKeyEditorCubit extends Cubit<ChromaKeyEditorState>
   /// measurement never overwrites them.
   Future<void> detectFromFootage() async {
     if (state.isDetecting) return;
-    emit(state.copyWith(detectionStatus: ChromaKeyDetectionStatus.detecting));
+    // Both callers discard this future — the constructor with `unawaited`, the
+    // button with a tear-off assigned to a `VoidCallback` — so an `emit` that
+    // threw here would escape as an unhandled zone error instead of surfacing
+    // as a failure state.
+    if (!emitIfOpen(
+      state.copyWith(detectionStatus: ChromaKeyDetectionStatus.detecting),
+    )) {
+      return;
+    }
 
+    // Only the measurement is wrapped. A wider `try` would catch the emits
+    // below as well and file a post-close `emit` throw as a detection failure,
+    // which is both wrong and unfalsifiable from a test.
+    final ChromaKeyDetection detection;
     try {
-      final detection = await _detect(_video);
-      emitIfOpen(
-        state.copyWith(
-          chromaKey: ClipChromaKey(
-            key: state.chromaKey.key.copyWith(
-              color: detection.color,
-              similarity: detection.similarity,
-            ),
-            backgroundVideoPath: state.chromaKey.backgroundVideoPath,
-          ),
-          detectionStatus: ChromaKeyDetectionStatus.idle,
-        ),
-      );
+      detection = await _detect(_video);
     } on ChromaKeyDetectionException catch (error, stackTrace) {
       // Expected: plenty of footage has no screen reaching the frame border.
       // The UI says so and the user sets the key by hand — not a crash report.
@@ -101,6 +101,7 @@ class ChromaKeyEditorCubit extends Cubit<ChromaKeyEditorState>
       emitIfOpen(
         state.copyWith(detectionStatus: ChromaKeyDetectionStatus.failure),
       );
+      return;
     } catch (error, stackTrace) {
       // Same split as the bake in `ClipEditorBloc`: a decode or channel failure
       // is expected and stays out of Crashlytics, an invariant violation does
@@ -117,7 +118,21 @@ class ChromaKeyEditorCubit extends Cubit<ChromaKeyEditorState>
       emitIfOpen(
         state.copyWith(detectionStatus: ChromaKeyDetectionStatus.failure),
       );
+      return;
     }
+
+    emitIfOpen(
+      state.copyWith(
+        chromaKey: ClipChromaKey(
+          key: state.chromaKey.key.copyWith(
+            color: detection.color,
+            similarity: detection.similarity,
+          ),
+          backgroundVideoPath: state.chromaKey.backgroundVideoPath,
+        ),
+        detectionStatus: ChromaKeyDetectionStatus.idle,
+      ),
+    );
   }
 
   /// Clears a failed measurement so the UI stops reporting it.

--- a/mobile/lib/blocs/video_editor/chroma_key/chroma_key_editor_cubit.dart
+++ b/mobile/lib/blocs/video_editor/chroma_key/chroma_key_editor_cubit.dart
@@ -1,10 +1,12 @@
 // ABOUTME: Drives the chroma-key screen: key colour, tolerances, background
 // ABOUTME: choice, and the auto-detect measurement.
 
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/close_guard.dart';
 import 'package:openvine/models/video_editor/clip_chroma_key.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -31,16 +33,30 @@ const _initialKey = ClipChromaKey(key: ChromaKey.greenScreen());
 /// Everything here is in-memory: the clip is only updated when the screen is
 /// confirmed, and the key is applied by the renderer at export rather than
 /// baked into the clip's file.
-class ChromaKeyEditorCubit extends Cubit<ChromaKeyEditorState> {
+class ChromaKeyEditorCubit extends Cubit<ChromaKeyEditorState>
+    with CloseGuardedEmit<ChromaKeyEditorState> {
+  /// Starts measuring straight away when the clip arrives without a key.
+  ///
+  /// Set [detectOnOpen] to `false` only to keep a test off the measurement
+  /// path; the screen leaves it on.
   ChromaKeyEditorCubit({
     required EditorVideo video,
     ClipChromaKey? initialChromaKey,
     ChromaKeyDetectFn detect = ChromaKey.detect,
+    bool detectOnOpen = true,
   }) : _video = video,
        _detect = detect,
        super(
          ChromaKeyEditorState(chromaKey: initialChromaKey ?? _initialKey),
-       );
+       ) {
+    // Measuring beats guessing and costs one thumbnail decode, so the screen
+    // opens on a real cutout — or on the reason there isn't one — instead of
+    // an inert panel the user has to know to poke. A clip that already has a
+    // key keeps it: re-measuring would throw the user's tuning away.
+    if (detectOnOpen && initialChromaKey == null) {
+      unawaited(detectFromFootage());
+    }
+  }
 
   static const _logName = 'ChromaKeyEditorCubit';
 
@@ -61,8 +77,7 @@ class ChromaKeyEditorCubit extends Cubit<ChromaKeyEditorState> {
 
     try {
       final detection = await _detect(_video);
-      if (isClosed) return;
-      emit(
+      emitIfOpen(
         state.copyWith(
           chromaKey: ClipChromaKey(
             key: state.chromaKey.key.copyWith(
@@ -83,8 +98,9 @@ class ChromaKeyEditorCubit extends Cubit<ChromaKeyEditorState> {
         category: LogCategory.video,
       );
       addError(error, stackTrace);
-      if (isClosed) return;
-      emit(state.copyWith(detectionStatus: ChromaKeyDetectionStatus.failure));
+      emitIfOpen(
+        state.copyWith(detectionStatus: ChromaKeyDetectionStatus.failure),
+      );
     } catch (error, stackTrace) {
       // Same split as the bake in `ClipEditorBloc`: a decode or channel failure
       // is expected and stays out of Crashlytics, an invariant violation does
@@ -98,8 +114,9 @@ class ChromaKeyEditorCubit extends Cubit<ChromaKeyEditorState> {
         },
         stackTrace,
       );
-      if (isClosed) return;
-      emit(state.copyWith(detectionStatus: ChromaKeyDetectionStatus.failure));
+      emitIfOpen(
+        state.copyWith(detectionStatus: ChromaKeyDetectionStatus.failure),
+      );
     }
   }
 

--- a/mobile/lib/blocs/video_editor/chroma_key/chroma_key_editor_cubit.dart
+++ b/mobile/lib/blocs/video_editor/chroma_key/chroma_key_editor_cubit.dart
@@ -34,6 +34,11 @@ const _initialKey = ClipChromaKey(key: ChromaKey.greenScreen());
 /// Everything here is in-memory: the clip is only updated when the screen is
 /// confirmed, and the key is applied by the renderer at export rather than
 /// baked into the clip's file.
+///
+/// Constructing one is not free, though. A clip that arrives without a key
+/// starts a measurement from the constructor body, which crosses the platform
+/// channel and decodes frames, so build this once per screen — never in a
+/// `build()` or a list builder.
 class ChromaKeyEditorCubit extends Cubit<ChromaKeyEditorState>
     with CloseGuardedEmit<ChromaKeyEditorState> {
   /// Starts measuring straight away when the clip arrives without a key.

--- a/mobile/lib/blocs/video_editor/chroma_key/chroma_key_editor_cubit.dart
+++ b/mobile/lib/blocs/video_editor/chroma_key/chroma_key_editor_cubit.dart
@@ -19,7 +19,8 @@ part 'chroma_key_editor_state.dart';
 ///
 /// Injected so tests can supply a measurement without decoding a frame; in the
 /// app it is [ChromaKey.detect], which samples a ring around the frame border
-/// through the thumbnail pipeline — one decode, no render.
+/// through the thumbnail pipeline — a metadata call, three thumbnails from a
+/// quarter, half and three quarters through, and a decode each. No render.
 typedef ChromaKeyDetectFn =
     Future<ChromaKeyDetection> Function(EditorVideo video);
 
@@ -57,10 +58,11 @@ class ChromaKeyEditorCubit extends Cubit<ChromaKeyEditorState>
        super(
          ChromaKeyEditorState(chromaKey: initialChromaKey ?? _initialKey),
        ) {
-    // Measuring beats guessing and costs one thumbnail decode, so the screen
-    // opens on a real cutout — or on the reason there isn't one — instead of
-    // an inert panel the user has to know to poke. A clip that already has a
-    // key keeps it: re-measuring would throw the user's tuning away.
+    // Measuring beats guessing, at a metadata round trip and three decoded
+    // thumbnails, so the screen opens on a real cutout — or on the reason
+    // there isn't one — instead of an inert panel the user has to know to
+    // poke. A clip that already has a key keeps it: re-measuring would throw
+    // the user's tuning away.
     if (detectOnOpen && initialChromaKey == null) {
       unawaited(detectFromFootage());
     }

--- a/mobile/lib/blocs/video_editor/chroma_key/chroma_key_editor_cubit.dart
+++ b/mobile/lib/blocs/video_editor/chroma_key/chroma_key_editor_cubit.dart
@@ -6,6 +6,7 @@ import 'dart:ui';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:meta/meta.dart';
 import 'package:openvine/blocs/close_guard.dart';
 import 'package:openvine/models/video_editor/clip_chroma_key.dart';
 import 'package:openvine/observability/reportable_error.dart';
@@ -37,13 +38,15 @@ class ChromaKeyEditorCubit extends Cubit<ChromaKeyEditorState>
     with CloseGuardedEmit<ChromaKeyEditorState> {
   /// Starts measuring straight away when the clip arrives without a key.
   ///
-  /// Set [detectOnOpen] to `false` only to keep a test off the measurement
-  /// path; the screen leaves it on.
+  /// [detectOnOpen] exists only so a test can stay off the measurement path.
+  /// The screen passes nothing and takes the default, so a production caller
+  /// turning it off would ship the inert panel this measurement replaced —
+  /// hence `@visibleForTesting`, which makes that a static analysis failure.
   ChromaKeyEditorCubit({
     required EditorVideo video,
     ClipChromaKey? initialChromaKey,
     ChromaKeyDetectFn detect = ChromaKey.detect,
-    bool detectOnOpen = true,
+    @visibleForTesting bool detectOnOpen = true,
   }) : _video = video,
        _detect = detect,
        super(

--- a/mobile/lib/blocs/video_editor/chroma_key/chroma_key_editor_cubit.dart
+++ b/mobile/lib/blocs/video_editor/chroma_key/chroma_key_editor_cubit.dart
@@ -97,16 +97,13 @@ class ChromaKeyEditorCubit extends Cubit<ChromaKeyEditorState>
         name: _logName,
         category: LogCategory.video,
       );
-      addError(error, stackTrace);
-      emitIfOpen(
-        state.copyWith(detectionStatus: ChromaKeyDetectionStatus.failure),
-      );
+      _reportDetectionFailure(error, stackTrace);
       return;
     } catch (error, stackTrace) {
       // Same split as the bake in `ClipEditorBloc`: a decode or channel failure
       // is expected and stays out of Crashlytics, an invariant violation does
       // not.
-      addError(
+      _reportDetectionFailure(
         switch (error) {
           StateError() ||
           TypeError() ||
@@ -114,9 +111,6 @@ class ChromaKeyEditorCubit extends Cubit<ChromaKeyEditorState>
           _ => error,
         },
         stackTrace,
-      );
-      emitIfOpen(
-        state.copyWith(detectionStatus: ChromaKeyDetectionStatus.failure),
       );
       return;
     }
@@ -132,6 +126,20 @@ class ChromaKeyEditorCubit extends Cubit<ChromaKeyEditorState>
         ),
         detectionStatus: ChromaKeyDetectionStatus.idle,
       ),
+    );
+  }
+
+  /// Reports a failed measurement, unless the screen already closed.
+  ///
+  /// `BlocBase.addError` documents that it must not be called on a closed
+  /// sink, and it has no `isClosed` check of its own: it forwards straight to
+  /// the observer, which logs and — for an invariant violation — files a crash
+  /// report against a cubit the user already backed out of.
+  void _reportDetectionFailure(Object error, StackTrace stackTrace) {
+    if (isClosed) return;
+    addError(error, stackTrace);
+    emitIfOpen(
+      state.copyWith(detectionStatus: ChromaKeyDetectionStatus.failure),
     );
   }
 

--- a/mobile/lib/screens/video_editor/video_clip_chroma_key_screen.dart
+++ b/mobile/lib/screens/video_editor/video_clip_chroma_key_screen.dart
@@ -28,7 +28,7 @@ import 'package:openvine/widgets/video_editor/video_editor_color_picker_sheet.da
 import 'package:openvine/widgets/video_editor/video_editor_toolbar.dart';
 import 'package:path/path.dart' as p;
 import 'package:pro_video_editor/pro_video_editor.dart'
-    show EditorVideo, ProVideoEditor, ProgressModel;
+    show ChromaKey, EditorVideo, ProVideoEditor, ProgressModel;
 import 'package:unified_logger/unified_logger.dart';
 
 /// Sets up a clip's green screen.
@@ -44,18 +44,17 @@ import 'package:unified_logger/unified_logger.dart';
 class VideoClipChromaKeyScreen extends StatefulWidget {
   const VideoClipChromaKeyScreen({
     required this.clip,
-    @visibleForTesting this.detectOnOpen = true,
+    @visibleForTesting this.detect = ChromaKey.detect,
     super.key,
   });
 
   final DivineVideoClip clip;
 
-  /// Whether a clip without a key measures itself as soon as the screen opens.
+  /// The screen-colour measurement implementation.
   ///
-  /// Only a test turns this off, to stay clear of the native decode; the
-  /// measurement itself belongs to [ChromaKeyEditorCubit].
+  /// Tests replace the native decoder while keeping the on-open behavior on.
   @visibleForTesting
-  final bool detectOnOpen;
+  final ChromaKeyDetectFn detect;
 
   @override
   State<VideoClipChromaKeyScreen> createState() =>
@@ -87,7 +86,7 @@ class _VideoClipChromaKeyScreenState extends State<VideoClipChromaKeyScreen> {
     _cubit = ChromaKeyEditorCubit(
       video: EditorVideo.file(_previewPath),
       initialChromaKey: widget.clip.chromaKey,
-      detectOnOpen: widget.detectOnOpen,
+      detect: widget.detect,
     );
     unawaited(_initializePlayer());
   }

--- a/mobile/lib/screens/video_editor/video_clip_chroma_key_screen.dart
+++ b/mobile/lib/screens/video_editor/video_clip_chroma_key_screen.dart
@@ -51,6 +51,9 @@ class VideoClipChromaKeyScreen extends StatefulWidget {
   final DivineVideoClip clip;
 
   /// Whether a clip without a key measures itself as soon as the screen opens.
+  ///
+  /// Only a test turns this off, to stay clear of the native decode; the
+  /// measurement itself belongs to [ChromaKeyEditorCubit].
   @visibleForTesting
   final bool detectOnOpen;
 
@@ -84,13 +87,8 @@ class _VideoClipChromaKeyScreenState extends State<VideoClipChromaKeyScreen> {
     _cubit = ChromaKeyEditorCubit(
       video: EditorVideo.file(_previewPath),
       initialChromaKey: widget.clip.chromaKey,
+      detectOnOpen: widget.detectOnOpen,
     );
-    // Measuring beats guessing and costs one thumbnail decode, so a clip
-    // without a key opens with the screen colour already measured. A clip that
-    // has one keeps it: re-measuring would throw the user's tuning away.
-    if (widget.detectOnOpen && widget.clip.chromaKey == null) {
-      unawaited(_cubit.detectFromFootage());
-    }
     unawaited(_initializePlayer());
   }
 

--- a/mobile/test/blocs/video_editor/chroma_key/chroma_key_editor_cubit_test.dart
+++ b/mobile/test/blocs/video_editor/chroma_key/chroma_key_editor_cubit_test.dart
@@ -137,6 +137,27 @@ void main() {
         },
       );
 
+      test('measures on open by default, with no flag passed', () async {
+        var calls = 0;
+        final cubit = ChromaKeyEditorCubit(
+          video: video,
+          detect: (_) async {
+            calls++;
+            return measured;
+          },
+        );
+        addTearDown(cubit.close);
+        await pumpEventQueue();
+
+        // Constructed the way the screen constructs it — nothing passes
+        // `detectOnOpen`. Every other test in this file states the flag
+        // explicitly, so without this one, flipping the production default to
+        // `false` would leave the whole cubit suite green.
+        expect(calls, 1);
+        expect(cubit.state.chromaKey.key.color, const Color(0xFF19A55B));
+        expect(cubit.state.detectionStatus, ChromaKeyDetectionStatus.idle);
+      });
+
       test('drops a measurement that lands after the screen closed', () async {
         final gate = Completer<ChromaKeyDetection>();
         final cubit = build(detect: (_) => gate.future, detectOnOpen: true);

--- a/mobile/test/blocs/video_editor/chroma_key/chroma_key_editor_cubit_test.dart
+++ b/mobile/test/blocs/video_editor/chroma_key/chroma_key_editor_cubit_test.dart
@@ -142,8 +142,11 @@ void main() {
         final cubit = build(detect: (_) => gate.future, detectOnOpen: true);
         expect(cubit.state.isDetecting, isTrue);
 
-        // The measurement is in flight while the user backs out; resuming into
-        // a closed cubit would throw instead of being dropped.
+        // The measurement is in flight while the user backs out. With the emit
+        // unguarded this throws `Cannot emit new states after calling close`,
+        // and because the `try` wraps only `_detect` the throw is no longer
+        // swallowed as a detection failure — it escapes into the test zone and
+        // fails here. Widening that `try` again would silently disarm this.
         await cubit.close();
         gate.complete(measured);
         await pumpEventQueue();
@@ -259,6 +262,23 @@ void main() {
           '/a/backdrop.mp4',
         ),
       );
+
+      test('a measurement landing after close completes rather than '
+          'throwing', () async {
+        final gate = Completer<ChromaKeyDetection>();
+        final cubit = build(detect: (_) => gate.future);
+        // Driven by hand so the future is in hand. The on-open call is
+        // `unawaited` and the button assigns a tear-off to a `VoidCallback`,
+        // so in production nothing would observe this rejection — which is
+        // exactly why the test has to.
+        final measuring = cubit.detectFromFootage();
+
+        await cubit.close();
+        gate.complete(measured);
+
+        await expectLater(measuring, completes);
+        expect(cubit.state.detectionStatus, ChromaKeyDetectionStatus.detecting);
+      });
 
       blocTest<ChromaKeyEditorCubit, ChromaKeyEditorState>(
         'ignores a second request while one is in flight',

--- a/mobile/test/blocs/video_editor/chroma_key/chroma_key_editor_cubit_test.dart
+++ b/mobile/test/blocs/video_editor/chroma_key/chroma_key_editor_cubit_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:bloc_test/bloc_test.dart';
@@ -10,14 +11,25 @@ void main() {
   group(ChromaKeyEditorCubit, () {
     final video = EditorVideo.file('/a/clip.mp4');
 
+    const measured = ChromaKeyDetection(
+      color: Color(0xFF19A55B),
+      similarity: 0.1,
+      coverage: 0.8,
+      spread: 0.02,
+    );
+
+    // `detectOnOpen` defaults to off here so each test drives the measurement
+    // it is about; the on-open group turns it back on.
     ChromaKeyEditorCubit build({
       ClipChromaKey? initialChromaKey,
       ChromaKeyDetectFn? detect,
+      bool detectOnOpen = false,
     }) {
       return ChromaKeyEditorCubit(
         video: video,
         initialChromaKey: initialChromaKey,
         detect: detect ?? (_) async => throw UnimplementedError(),
+        detectOnOpen: detectOnOpen,
       );
     }
 
@@ -40,6 +52,108 @@ void main() {
       addTearDown(cubit.close);
 
       expect(cubit.state.chromaKey, existing);
+    });
+
+    group('detect on open', () {
+      test('measures the screen with no user action', () async {
+        final cubit = build(
+          detect: (_) async => measured,
+          detectOnOpen: true,
+        );
+        addTearDown(cubit.close);
+
+        // The screen has to open on a cutout rather than an inert panel, so
+        // the measurement starts with the cubit and not with a button tap.
+        expect(cubit.state.isDetecting, isTrue);
+        await pumpEventQueue();
+
+        expect(cubit.state.chromaKey.key.color, const Color(0xFF19A55B));
+        expect(cubit.state.chromaKey.key.similarity, 0.1);
+        expect(cubit.state.detectionStatus, ChromaKeyDetectionStatus.idle);
+      });
+
+      test('reports a failure and leaves a usable key behind', () async {
+        final cubit = build(
+          detect: (_) async =>
+              throw const ChromaKeyDetectionException('no screen'),
+          detectOnOpen: true,
+        );
+        addTearDown(cubit.close);
+        await pumpEventQueue();
+
+        expect(cubit.state.detectionStatus, ChromaKeyDetectionStatus.failure);
+        // Failing on open must not strand the user: the preset key the colour
+        // swatch and the sliders act on is still there to adjust by hand.
+        expect(cubit.state.chromaKey.key, const ChromaKey.greenScreen());
+      });
+
+      test('leaves a clip that already has a key alone', () async {
+        var calls = 0;
+        const existing = ClipChromaKey(
+          key: ChromaKey(color: Color(0xFF0000FF), similarity: 0.42),
+        );
+        final cubit = build(
+          initialChromaKey: existing,
+          detect: (_) async {
+            calls++;
+            return measured;
+          },
+          detectOnOpen: true,
+        );
+        addTearDown(cubit.close);
+        await pumpEventQueue();
+
+        // Re-opening a keyed clip would otherwise overwrite the tuning the
+        // user already settled on.
+        expect(calls, isZero);
+        expect(cubit.state.chromaKey, existing);
+      });
+
+      test(
+        'the manual control re-measures after the open attempt failed',
+        () async {
+          var calls = 0;
+          final cubit = build(
+            detect: (_) async {
+              calls++;
+              if (calls == 1) {
+                throw const ChromaKeyDetectionException('no screen');
+              }
+              return measured;
+            },
+            detectOnOpen: true,
+          );
+          addTearDown(cubit.close);
+          await pumpEventQueue();
+          expect(cubit.state.detectionStatus, ChromaKeyDetectionStatus.failure);
+
+          // Re-running after moving the clip or changing the light is still the
+          // user's call, so the on-open pass must not consume the one attempt.
+          await cubit.detectFromFootage();
+
+          expect(calls, 2);
+          expect(cubit.state.chromaKey.key.color, const Color(0xFF19A55B));
+          expect(cubit.state.detectionStatus, ChromaKeyDetectionStatus.idle);
+        },
+      );
+
+      test('drops a measurement that lands after the screen closed', () async {
+        final gate = Completer<ChromaKeyDetection>();
+        final cubit = build(detect: (_) => gate.future, detectOnOpen: true);
+        expect(cubit.state.isDetecting, isTrue);
+
+        // The measurement is in flight while the user backs out; resuming into
+        // a closed cubit would throw instead of being dropped.
+        await cubit.close();
+        gate.complete(measured);
+        await pumpEventQueue();
+
+        expect(
+          cubit.state.detectionStatus,
+          ChromaKeyDetectionStatus.detecting,
+        );
+        expect(cubit.state.chromaKey.key, const ChromaKey.greenScreen());
+      });
     });
 
     group('detectFromFootage', () {

--- a/mobile/test/blocs/video_editor/chroma_key/chroma_key_editor_cubit_test.dart
+++ b/mobile/test/blocs/video_editor/chroma_key/chroma_key_editor_cubit_test.dart
@@ -161,6 +161,7 @@ void main() {
       test('drops a measurement that lands after the screen closed', () async {
         final gate = Completer<ChromaKeyDetection>();
         final cubit = build(detect: (_) => gate.future, detectOnOpen: true);
+        addTearDown(cubit.close);
         expect(cubit.state.isDetecting, isTrue);
 
         // The measurement is in flight while the user backs out. With the emit

--- a/mobile/test/screens/video_editor/video_clip_chroma_key_screen_test.dart
+++ b/mobile/test/screens/video_editor/video_clip_chroma_key_screen_test.dart
@@ -1,7 +1,10 @@
 // ABOUTME: Pins the green-screen background photo to the camera — the gallery
 // ABOUTME: is how an AI-generated image would get into a Divine video.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -10,11 +13,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as model;
+import 'package:openvine/blocs/video_editor/chroma_key/chroma_key_editor_cubit.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/screens/video_editor/video_clip_chroma_key_screen.dart';
-import 'package:pro_video_editor/pro_video_editor.dart' show EditorVideo;
+import 'package:pro_video_editor/pro_video_editor.dart'
+    show ChromaKeyDetection, EditorVideo;
 
 import '../../helpers/shared_channel_override.dart';
 
@@ -56,7 +61,10 @@ void main() {
       originalAspectRatio: 9 / 16,
     );
 
-    Future<void> pump(WidgetTester tester) async {
+    Future<void> pump(
+      WidgetTester tester, {
+      required ChromaKeyDetectFn detect,
+    }) async {
       await tester.pumpWidget(
         ProviderScope(
           child: MaterialApp(
@@ -66,7 +74,7 @@ void main() {
               value: bloc,
               child: VideoClipChromaKeyScreen(
                 clip: clip,
-                detectOnOpen: false,
+                detect: detect,
               ),
             ),
           ),
@@ -75,10 +83,28 @@ void main() {
       await tester.pump();
     }
 
+    testWidgets('starts auto-detect as soon as the screen opens', (
+      tester,
+    ) async {
+      final detection = Completer<ChromaKeyDetection>();
+
+      await pump(tester, detect: (_) => detection.future);
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      final autoDetect = tester.widget<DivineButton>(
+        find.widgetWithText(
+          DivineButton,
+          l10n.videoEditorChromaKeyAutoDetect,
+        ),
+      );
+      expect(autoDetect.isLoading, isTrue);
+    });
+
     testWidgets('shoots the background photo instead of opening the gallery', (
       tester,
     ) async {
-      await pump(tester);
+      final detection = Completer<ChromaKeyDetection>();
+      await pump(tester, detect: (_) => detection.future);
 
       final l10n = lookupAppLocalizations(const Locale('en'));
       final imageChip = find.text(l10n.videoEditorChromaKeyBackgroundImage);

--- a/mobile/test/screens/video_editor/video_clip_chroma_key_screen_test.dart
+++ b/mobile/test/screens/video_editor/video_clip_chroma_key_screen_test.dart
@@ -1,4 +1,5 @@
-// ABOUTME: Pins the green-screen background photo to the camera — the gallery
+// ABOUTME: Covers the chroma-key screen's on-open measurement reaching the
+// ABOUTME: controls, and pins the background photo to the camera — the gallery
 // ABOUTME: is how an AI-generated image would get into a Divine video.
 
 import 'dart:async';
@@ -19,7 +20,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/screens/video_editor/video_clip_chroma_key_screen.dart';
 import 'package:pro_video_editor/pro_video_editor.dart'
-    show ChromaKeyDetection, EditorVideo;
+    show ChromaKeyDetection, ChromaKeyDetectionException, EditorVideo;
 
 import '../../helpers/shared_channel_override.dart';
 
@@ -83,12 +84,51 @@ void main() {
       await tester.pump();
     }
 
+    // A measurement the screen never asked to be told about: the colour is
+    // distinct from the green preset's 0xFF00B140 and the similarity renders
+    // as "10" against the preset's "20", so both are legible on screen.
+    const measured = ChromaKeyDetection(
+      color: Color(0xFF19A55B),
+      similarity: 0.1,
+      coverage: 0.8,
+      spread: 0.02,
+    );
+
+    // Only `_ColorSwatchButton` builds a `Semantics(button: true)` carrying
+    // the screen-colour label, so this reaches the swatch and not the row's
+    // text label, which repeats the same string.
+    Color? screenColor(WidgetTester tester, AppLocalizations l10n) {
+      final swatch = tester.widget<Container>(
+        find.descendant(
+          of: find.byWidgetPredicate(
+            (w) =>
+                w is Semantics &&
+                (w.properties.button ?? false) &&
+                w.properties.label == l10n.videoEditorChromaKeyScreenColorLabel,
+          ),
+          matching: find.byType(Container),
+        ),
+      );
+      return (swatch.decoration! as BoxDecoration).color;
+    }
+
     testWidgets('starts auto-detect as soon as the screen opens', (
       tester,
     ) async {
+      var calls = 0;
       final detection = Completer<ChromaKeyDetection>();
 
-      await pump(tester, detect: (_) => detection.future);
+      await pump(
+        tester,
+        detect: (_) {
+          calls++;
+          return detection.future;
+        },
+      );
+
+      // Nothing has been tapped. The screen opening is the whole trigger,
+      // which is what makes the panel arrive on a cutout rather than inert.
+      expect(calls, 1);
 
       final l10n = lookupAppLocalizations(const Locale('en'));
       final autoDetect = tester.widget<DivineButton>(
@@ -100,11 +140,50 @@ void main() {
       expect(autoDetect.isLoading, isTrue);
     });
 
-    testWidgets('shoots the background photo instead of opening the gallery', (
+    testWidgets('shows the measured colour and amount once it lands', (
       tester,
     ) async {
       final detection = Completer<ChromaKeyDetection>();
       await pump(tester, detect: (_) => detection.future);
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      // The green preset the panel opens on, so the assertions below cannot
+      // pass on a measurement that never reached the controls.
+      expect(screenColor(tester, l10n), const Color(0xFF00B140));
+      expect(find.text('20'), findsOneWidget);
+
+      detection.complete(measured);
+      await tester.pump();
+
+      expect(screenColor(tester, l10n), const Color(0xFF19A55B));
+      expect(find.text('10'), findsOneWidget);
+      expect(find.text('20'), findsNothing);
+    });
+
+    testWidgets('tells the user when no screen was found', (tester) async {
+      final detection = Completer<ChromaKeyDetection>();
+      await pump(tester, detect: (_) => detection.future);
+
+      detection.completeError(
+        const ChromaKeyDetectionException('no screen'),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.videoEditorChromaKeyDetectFailed), findsOneWidget);
+      // The key the sliders and swatch act on has to survive, or the user is
+      // left with nothing to adjust by hand.
+      expect(screenColor(tester, l10n), const Color(0xFF00B140));
+    });
+
+    testWidgets('shoots the background photo instead of opening the gallery', (
+      tester,
+    ) async {
+      // A measurement that resolves, so this runs against the settled panel
+      // the user actually taps in rather than a permanently mid-detect one.
+      await pump(tester, detect: (_) async => measured);
+      await tester.pump();
 
       final l10n = lookupAppLocalizations(const Locale('en'));
       final imageChip = find.text(l10n.videoEditorChromaKeyBackgroundImage);


### PR DESCRIPTION
## Description

The green screen screen opened onto a dead control panel. Someone who does not already know what chroma key is had no way to learn that Auto-detect is the first move, and the sliders do nothing visible until a key exists. Running the measurement on open means the user always lands on one of two legible states: a working cutout, or an explanation of why there isn't one.

The on-open detect already shipped in the original feature PR #6483, but it lived in the UI and had no coverage. This refactor moves ownership to `ChromaKeyEditorCubit`, where detection already belongs, and protects both the behavior and its production wiring with cubit and screen tests.

When a clip has no existing key, the cubit begins detection during construction. The first detecting state is emitted synchronously, so the screen's first build renders Auto-detect in its loading state without flashing an idle panel. An already-keyed clip keeps the user's tuning, and manual Auto-detect remains available for re-measuring after the clip or lighting changes.

The screen test injects only the measurement implementation, keeping the real on-open default active while avoiding the native decoder. The old test-only `detectOnOpen` widget flag is gone.

The cubit also mixes in `CloseGuardedEmit`, and all three post-`await` emits use `emitIfOpen`.

## Out of Scope

- No copy changes. The feature name, entry-point hint, and detect-failure message remain tracked by #8544, #8547, and #8546 pending the naming decision in #8543.
- #8548 tracks the live keyed composite in the viewfinder.

## Verification

- `dart format --set-exit-if-changed` on the changed files
- `flutter analyze lib test`
- `flutter test test/blocs/video_editor/chroma_key/chroma_key_editor_cubit_test.dart test/screens/video_editor/video_clip_chroma_key_screen_test.dart` — 22 tests passed
- `check_post_close_emit_ceiling.sh`
- `check_future_delayed_production_ceiling.sh`
- `check_ungrouped_tests.sh`
- `check_unpinned_unchanged_assertions.sh`
- `check_placeholder_tests.sh`

The local skip-ceiling check sees a skip removed on newer `origin/main` but still present in this older PR head, outside this diff. GitHub's merge-ref CI is the authority after the takeover push.

## Type of Change

- [x] Code refactor
- [x] Test coverage for previously unprotected behavior

Closes #8545
