### PR TITLE
fix(video-player): tell 403 and 404 playback failures apart without reading error text

### DIFF
--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -1264,6 +1264,8 @@ internal class DivineVideoPlayerInstance(
                 when {
                     status == 202 -> "media_processing"
                     status == 401 -> "auth_required"
+                    status == 403 -> "forbidden"
+                    status == 404 -> "not_found"
                     status in 400..499 -> "http_client_error"
                     else -> "http_server_error"
                 }

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -547,6 +547,60 @@ class DivineVideoPlayerInstanceTest {
         verify(exactly = 0) { result.success(any()) }
     }
 
+    @Test
+    fun `onPlayerError maps pending HTTP 403 setClips failure to forbidden`() {
+        val listener = capturePlayerListener()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        instance.onMethodCall(setClipsCall("https://example.com/protected.mp4"), result)
+
+        listener.onPlayerError(httpStatusError(403))
+
+        verify(exactly = 1) {
+            result.error(
+                "PLAYER_ERROR",
+                "HTTP 403",
+                mapOf("errorCode" to "forbidden"),
+            )
+        }
+        verify(exactly = 0) { result.success(any()) }
+    }
+
+    @Test
+    fun `onPlayerError maps pending HTTP 404 setClips failure to not_found`() {
+        val listener = capturePlayerListener()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        instance.onMethodCall(setClipsCall("https://example.com/protected.mp4"), result)
+
+        listener.onPlayerError(httpStatusError(404))
+
+        verify(exactly = 1) {
+            result.error(
+                "PLAYER_ERROR",
+                "HTTP 404",
+                mapOf("errorCode" to "not_found"),
+            )
+        }
+        verify(exactly = 0) { result.success(any()) }
+    }
+
+    @Test
+    fun `onPlayerError keeps other 4xx failures on http_client_error`() {
+        val listener = capturePlayerListener()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        instance.onMethodCall(setClipsCall("https://example.com/protected.mp4"), result)
+
+        listener.onPlayerError(httpStatusError(410))
+
+        verify(exactly = 1) {
+            result.error(
+                "PLAYER_ERROR",
+                "HTTP 410",
+                mapOf("errorCode" to "http_client_error"),
+            )
+        }
+        verify(exactly = 0) { result.success(any()) }
+    }
+
     /**
      * Builds a real [PlaybackException] carrying [ERROR_CODE_DECODER_INIT_FAILED]
      * — the `errorCode` is a public field mockk can't stub, so a genuine

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -1382,6 +1382,12 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             if httpResponse.statusCode == 401 {
                 return "auth_required"
             }
+            if httpResponse.statusCode == 403 {
+                return "forbidden"
+            }
+            if httpResponse.statusCode == 404 {
+                return "not_found"
+            }
             return httpResponse.statusCode >= 500 ? "http_server_error" : "http_client_error"
         }
 

--- a/mobile/packages/divine_video_player/lib/src/player_error_code.dart
+++ b/mobile/packages/divine_video_player/lib/src/player_error_code.dart
@@ -27,7 +27,8 @@ enum NativePlayerErrorCode {
   /// so this code names the transport fact rather than the policy behind it.
   ///
   /// Android: `ERROR_CODE_IO_BAD_HTTP_STATUS` with response code 403.
-  /// iOS: HTTP 403 in `userInfo`.
+  /// iOS: HTTP 403 in
+  /// `userInfo[NSURLErrorFailingURLResponseErrorKey]`.
   forbidden,
 
   /// HTTP 404 from the media server.
@@ -37,7 +38,8 @@ enum NativePlayerErrorCode {
   /// is gone — see [shouldFailover].
   ///
   /// Android: `ERROR_CODE_IO_BAD_HTTP_STATUS` with response code 404.
-  /// iOS: HTTP 404 in `userInfo`.
+  /// iOS: HTTP 404 in
+  /// `userInfo[NSURLErrorFailingURLResponseErrorKey]`.
   notFound,
 
   /// HTTP 4xx response from the media server.

--- a/mobile/packages/divine_video_player/lib/src/player_error_code.dart
+++ b/mobile/packages/divine_video_player/lib/src/player_error_code.dart
@@ -19,10 +19,32 @@ enum NativePlayerErrorCode {
   /// iOS: HTTP 401 in `userInfo` or `NSURLErrorUserAuthenticationRequired`.
   authRequired,
 
+  /// HTTP 403 from the media server.
+  ///
+  /// The server acknowledged the request and refused it outright, so no
+  /// credential the client can supply will change the answer. Divine returns
+  /// this for moderation-blocked media, but the player cannot see the reason,
+  /// so this code names the transport fact rather than the policy behind it.
+  ///
+  /// Android: `ERROR_CODE_IO_BAD_HTTP_STATUS` with response code 403.
+  /// iOS: HTTP 403 in `userInfo`.
+  forbidden,
+
+  /// HTTP 404 from the media server.
+  ///
+  /// The blob is absent from *this* source. Divine media is mirrored across
+  /// Blossom servers, so a 404 is per-source evidence and not proof the media
+  /// is gone — see [shouldFailover].
+  ///
+  /// Android: `ERROR_CODE_IO_BAD_HTTP_STATUS` with response code 404.
+  /// iOS: HTTP 404 in `userInfo`.
+  notFound,
+
   /// HTTP 4xx response from the media server.
   ///
-  /// Android: `ERROR_CODE_IO_BAD_HTTP_STATUS` when 400–499, except 401.
-  /// iOS: `NSError` with HTTP status in `userInfo`, except 401.
+  /// Android: `ERROR_CODE_IO_BAD_HTTP_STATUS` when 400–499, except 401,
+  /// 403, and 404.
+  /// iOS: `NSError` with HTTP status in `userInfo`, except 401, 403, and 404.
   httpClientError,
 
   /// HTTP 5xx response from the media server.
@@ -76,9 +98,16 @@ enum NativePlayerErrorCode {
   /// immediately. Other HTTP 4xx/5xx and parse errors indicate the current
   /// source is not usable right now, so the feed should skip to the next
   /// available source.
+  ///
+  /// [forbidden] and [notFound] fail over for that reason: both are answers
+  /// from one server about one URL, and Divine media is mirrored, so the next
+  /// source may still serve the blob. They are terminal for the *source*, not
+  /// for the media.
   bool get shouldFailover => switch (this) {
     mediaProcessing => false,
     authRequired => false,
+    forbidden => true,
+    notFound => true,
     httpClientError => true,
     httpServerError => true,
     ioError => true,
@@ -101,6 +130,8 @@ enum NativePlayerErrorCode {
     timeout => true,
     ioError => false,
     authRequired => false,
+    forbidden => false,
+    notFound => false,
     httpServerError => false,
     httpClientError => false,
     parseError => false,
@@ -112,6 +143,8 @@ enum NativePlayerErrorCode {
   static NativePlayerErrorCode fromString(String value) => switch (value) {
     'media_processing' => mediaProcessing,
     'auth_required' => authRequired,
+    'forbidden' => forbidden,
+    'not_found' => notFound,
     'http_client_error' => httpClientError,
     'http_server_error' => httpServerError,
     'network_error' => networkError,

--- a/mobile/packages/divine_video_player/test/src/native_http_status_error_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/native_http_status_error_contract_test.dart
@@ -48,8 +48,8 @@ void main() {
     });
   });
 
-  group('Apple native HTTP status error contract', () {
-    test('classifies 403 and 404 before the generic 4xx return', () {
+  group('Apple native HTTP response error contract', () {
+    test('classifies exposed 403 and 404 responses before generic 4xx', () {
       final source = _appleSourceFile().readAsStringSync();
 
       final responseBranch = source.indexOf(
@@ -70,8 +70,8 @@ void main() {
           statusCheck,
           greaterThan(responseBranch),
           reason:
-              'HTTP ${entry.key} needs its own branch so iOS stays normalised '
-              'with Android.',
+              'An exposed HTTP ${entry.key} response needs its own branch so '
+              'Apple platforms stay normalised with Android.',
         );
 
         final statusMapping = source.indexOf(

--- a/mobile/packages/divine_video_player/test/src/native_http_status_error_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/native_http_status_error_contract_test.dart
@@ -1,0 +1,116 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// HTTP 403 and 404 must reach Dart as their own codes rather than being
+/// flattened into `http_client_error`.
+///
+/// Without them, `classifyVideoError` can only recover "forbidden" and
+/// "not found" by scanning the raw error message for English status text —
+/// and on Android that message is `PlaybackException.localizedMessage`, which
+/// carries no guarantee of containing either.
+void main() {
+  group('Android native HTTP status error contract', () {
+    test('classifies 403 and 404 before the generic 4xx mapping', () {
+      final source = _androidSourceFile().readAsStringSync();
+
+      final badStatusBranch = source.indexOf(
+        'PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS',
+      );
+      final genericClientMapping = source.indexOf(
+        'status in 400..499 -> "http_client_error"',
+      );
+
+      expect(badStatusBranch, greaterThanOrEqualTo(0));
+      expect(genericClientMapping, greaterThan(badStatusBranch));
+
+      for (final entry in const {403: 'forbidden', 404: 'not_found'}.entries) {
+        final statusCheck = source.indexOf('status == ${entry.key}');
+        expect(
+          statusCheck,
+          greaterThan(badStatusBranch),
+          reason:
+              'HTTP ${entry.key} needs its own branch inside the '
+              'bad-HTTP-status mapping.',
+        );
+
+        final statusMapping = source.indexOf('"${entry.value}"', statusCheck);
+        expect(statusMapping, greaterThan(statusCheck));
+        expect(
+          statusMapping,
+          lessThan(genericClientMapping),
+          reason:
+              'HTTP ${entry.key} must be classified before the generic 4xx '
+              'mapping, which would otherwise swallow it as '
+              'http_client_error.',
+        );
+      }
+    });
+  });
+
+  group('Apple native HTTP status error contract', () {
+    test('classifies 403 and 404 before the generic 4xx return', () {
+      final source = _appleSourceFile().readAsStringSync();
+
+      final responseBranch = source.indexOf(
+        'NSURLErrorFailingURLResponseErrorKey',
+      );
+      final genericReturn = source.indexOf(
+        'return httpResponse.statusCode >= 500',
+      );
+
+      expect(responseBranch, greaterThanOrEqualTo(0));
+      expect(genericReturn, greaterThan(responseBranch));
+
+      for (final entry in const {403: 'forbidden', 404: 'not_found'}.entries) {
+        final statusCheck = source.indexOf(
+          'httpResponse.statusCode == ${entry.key}',
+        );
+        expect(
+          statusCheck,
+          greaterThan(responseBranch),
+          reason:
+              'HTTP ${entry.key} needs its own branch so iOS stays normalised '
+              'with Android.',
+        );
+
+        final statusMapping = source.indexOf(
+          'return "${entry.value}"',
+          statusCheck,
+        );
+        expect(statusMapping, greaterThan(statusCheck));
+        expect(
+          statusMapping,
+          lessThan(genericReturn),
+          reason:
+              'HTTP ${entry.key} must return before the generic 4xx/5xx '
+              'return, which would otherwise swallow it as '
+              'http_client_error.',
+        );
+      }
+    });
+  });
+}
+
+File _androidSourceFile() => _resolve(
+  'android/src/main/kotlin/com/divinevideo/divine_video_player/'
+  'DivineVideoPlayerInstance.kt',
+);
+
+/// The iOS and macOS players share a single Darwin source tree
+/// (`darwin/divine_video_player/Sources/`), so the contract is asserted once.
+File _appleSourceFile() => _resolve(
+  'darwin/divine_video_player/Sources/divine_video_player/'
+  'DivineVideoPlayerInstance.swift',
+);
+
+/// Resolves [packageRelativePath] whether the suite runs from the package
+/// root or from `mobile/`.
+File _resolve(String packageRelativePath) {
+  final packageRelative = File(packageRelativePath);
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File('packages/divine_video_player/$packageRelativePath');
+}

--- a/mobile/packages/divine_video_player/test/src/video_player_state_test.dart
+++ b/mobile/packages/divine_video_player/test/src/video_player_state_test.dart
@@ -12,6 +12,17 @@ void main() {
         expect(NativePlayerErrorCode.authRequired.shouldFailover, isFalse);
       });
 
+      test('returns true for forbidden', () {
+        expect(NativePlayerErrorCode.forbidden.shouldFailover, isTrue);
+      });
+
+      // A 404 is one mirror's answer about one URL. Divine media is mirrored
+      // across Blossom servers, so the feed must try the next source rather
+      // than treating the media as deleted.
+      test('returns true for notFound', () {
+        expect(NativePlayerErrorCode.notFound.shouldFailover, isTrue);
+      });
+
       test('returns true for httpClientError', () {
         expect(NativePlayerErrorCode.httpClientError.shouldFailover, isTrue);
       });
@@ -66,6 +77,14 @@ void main() {
         expect(NativePlayerErrorCode.authRequired.isTransient, isFalse);
       });
 
+      test('returns false for forbidden', () {
+        expect(NativePlayerErrorCode.forbidden.isTransient, isFalse);
+      });
+
+      test('returns false for notFound', () {
+        expect(NativePlayerErrorCode.notFound.isTransient, isFalse);
+      });
+
       test('returns false for httpServerError', () {
         expect(NativePlayerErrorCode.httpServerError.isTransient, isFalse);
       });
@@ -99,6 +118,20 @@ void main() {
         expect(
           NativePlayerErrorCode.fromString('auth_required'),
           equals(NativePlayerErrorCode.authRequired),
+        );
+      });
+
+      test('parses forbidden', () {
+        expect(
+          NativePlayerErrorCode.fromString('forbidden'),
+          equals(NativePlayerErrorCode.forbidden),
+        );
+      });
+
+      test('parses not_found', () {
+        expect(
+          NativePlayerErrorCode.fromString('not_found'),
+          equals(NativePlayerErrorCode.notFound),
         );
       });
 

--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
@@ -74,8 +74,13 @@ VideoErrorType classifyVideoError({
   String? errorMessage,
   String? source,
 }) {
+  // The typed native code is authoritative when the platform supplied one:
+  // it survives localisation and platform wording, unlike the message scan
+  // below, which stays as the fallback for paths that carry no typed code.
   final typedErrorType = switch (errorCode) {
     NativePlayerErrorCode.authRequired => VideoErrorType.ageRestricted,
+    NativePlayerErrorCode.forbidden => VideoErrorType.forbidden,
+    NativePlayerErrorCode.notFound => VideoErrorType.notFound,
     _ => null,
   };
   if (typedErrorType != null) return typedErrorType;

--- a/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
@@ -196,6 +196,40 @@ void main() {
       );
     });
 
+    // The message scan below cannot see a status the platform did not spell
+    // out in English. These two prove the typed code alone is enough.
+    test('returns forbidden for typed forbidden without 403 text', () {
+      expect(
+        classifyVideoError(
+          errorCode: NativePlayerErrorCode.forbidden,
+          errorMessage: 'Der Server hat die Anfrage abgelehnt',
+        ),
+        equals(VideoErrorType.forbidden),
+      );
+    });
+
+    test('returns notFound for typed notFound without 404 text', () {
+      expect(
+        classifyVideoError(
+          errorCode: NativePlayerErrorCode.notFound,
+          errorMessage: 'Die Datei wurde nicht gefunden',
+        ),
+        equals(VideoErrorType.notFound),
+      );
+    });
+
+    // httpClientError still means "some other 4xx", so it must not be
+    // upgraded to a specific category on the typed path.
+    test('leaves typed httpClientError on the message-scan path', () {
+      expect(
+        classifyVideoError(
+          errorCode: NativePlayerErrorCode.httpClientError,
+          errorMessage: 'HTTP 410 Gone',
+        ),
+        equals(VideoErrorType.generic),
+      );
+    });
+
     test('keeps null typed code on the existing generic path', () {
       expect(
         classifyVideoError(errorMessage: 'NSURLErrorDomain error -1013'),

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -3152,23 +3152,27 @@ void main() {
           <
             ({
               String name,
+              String errorCode,
               String message,
               String typeName,
             })
           >[
             (
               name: '403 forbidden',
-              message: 'HTTP 403 Forbidden',
+              errorCode: 'forbidden',
+              message: 'Der Server hat die Anfrage abgelehnt',
               typeName: 'forbidden',
             ),
             (
               name: '404 not found',
-              message: 'HTTP 404 Not Found',
+              errorCode: 'not_found',
+              message: 'Die Datei wurde nicht gefunden',
               typeName: 'notFound',
             ),
             (
               name: '401 age gate',
-              message: 'HTTP 401 Unauthorized',
+              errorCode: 'auth_required',
+              message: 'Anmeldung erforderlich',
               typeName: 'ageRestricted',
             ),
           ];
@@ -3200,7 +3204,7 @@ void main() {
 
               await harness.sendEvent(0, <Object?, Object?>{
                 'status': 'error',
-                'errorCode': 'network_error',
+                'errorCode': scenario.errorCode,
                 'errorMessage': scenario.message,
               });
               await tester.pump();


### PR DESCRIPTION
## Description

When video playback fails with a 403 or a 404, the native players reported both as a generic `http_client_error`. That left `classifyVideoError` with no typed value to switch on, so it fell back to scanning the error *message* for `"403"`, `"forbidden"`, `"404"` and `"not found"`. On Android that message is `PlaybackException.localizedMessage` — literally localized, with no guarantee of English status text. So on a non-English device the classification could silently miss.

That is precisely what the error-code enum exists to prevent; its own doc says it is there for "platform-independent retry/failover decisions without string-parsing the raw error message".

Android now emits `forbidden` and `not_found`, and Apple platforms emit them when AVFoundation exposes an `HTTPURLResponse` through `NSURLErrorFailingURLResponseErrorKey`. Dart reads those values as typed codes, while the message scan stays as a fallback.

**Routing is deliberately unchanged.** Both keep `shouldFailover: true, isTransient: false`, exactly what they inherited.

**Two things #7976 asked for that the evidence did not support, and why I did not do them:**

- **"401 → AgeRestricted."** Age-gating already works, one layer up: `playback_sources.dart:78` has mapped `authRequired => VideoErrorType.ageRestricted` all along. Pushing it into Kotlin would be actively wrong — I searched every `.kt`/`.swift`/`.dart`/`.md` for a disambiguating signal (`www-authenticate`, `x-reason`, an age-verification header, a response body) and **there is none**. The player genuinely cannot tell an age-gate 401 from an ordinary auth failure, so hard-coding "age-restricted" natively would destroy any way to represent a real auth error while just relocating the same assumption. Left alone.
- **"404 → terminal."** Divine media is mirrored across Blossom servers, so a 404 is one server's answer about one URL. Making it terminal would break mirror failover.

I also named the 403 code for the transport fact rather than `moderationBlocked` — the player sees a refusal, not a moderation decision. That reading is made in Dart, via the existing `VideoErrorType.forbidden`.

For the record, the issue's two quoted code snippets describe a version of the file that has never existed, and its path (`com/divinevideo/video_player/`) is wrong — the real one is `com/divinevideo/divine_video_player/`. Neither `ViewerAuthBlocked` nor `VideoError` is a real symbol. The defect underneath was real; the diagnosis was not.

## Scope notes

- **Apple error exposure is unchanged.** Swift maps 403/404 when AVFoundation exposes an `HTTPURLResponse` through `NSURLErrorFailingURLResponseErrorKey`; failures without that response keep the existing fallback behavior. The source-level contract test verifies the mapping branches, not AVFoundation runtime error shape.
- The feed regression scenarios now send `forbidden`, `not_found`, and `auth_required` with messages that cannot satisfy the English fallback, so they exercise the typed runtime path directly.

## Verification

```
mobile/ analyze lib test                    No issues found! (38.3s)
divine_video_player analyze + test          No issues found! · 00:06 +300: All tests passed!
infinite_video_feed analyze + test          No issues found! · 00:06 +270: All tests passed!
Android unit tests (Gradle)                 BUILD SUCCESSFUL · tests=51 failures=0 errors=0
```

Both packages gate at 100% coverage; both changed lib files are fully covered (`player_error_code` 38/38, `playback_sources` 47/47).

Mutation-verified: removing the Kotlin branches gives `51 tests completed, 2 failed` — exactly the 403/404 tests, with the 410 guard correctly staying green. Removing the Dart typed arms gives `+40 -2`.

**Verified on Galaxy S26.** Playback failure handling behaves as before for the untouched cases. The Android classification itself is exercised directly by the Gradle unit tests. No Apple device verification was performed; the Apple claim is limited to failures that expose an `HTTPURLResponse` through `NSURLErrorFailingURLResponseErrorKey`.

## Type of Change

- [x] 🛠️ Bug fix

**Related Issue:** Closes #7976




