### PR TITLE
fix(video_clip): stop the clip preview animation flying a blank rectangle

### DIFF
--- a/mobile/lib/widgets/library/clips_tab.dart
+++ b/mobile/lib/widgets/library/clips_tab.dart
@@ -301,17 +301,9 @@ class _FilterContent extends StatelessWidget {
   ) async {
     await Navigator.push(
       context,
-      PageRouteBuilder(
-        opaque: false,
-        pageBuilder: (_, _, _) => VideoClipPreview(
-          clip: clip,
-          onDelete: () => _confirmDeleteClip(context, clip),
-        ),
-        transitionsBuilder: (_, animation, _, child) {
-          return FadeTransition(opacity: animation, child: child);
-        },
-        transitionDuration: const Duration(milliseconds: 200),
-        reverseTransitionDuration: const Duration(milliseconds: 200),
+      videoClipPreviewRoute(
+        clip: clip,
+        onDelete: () => _confirmDeleteClip(context, clip),
       ),
     );
   }

--- a/mobile/lib/widgets/video_clip/video_clip_hero.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_hero.dart
@@ -18,3 +18,22 @@ class VideoClipThumbnailPlaceholder extends StatelessWidget {
     );
   }
 }
+
+/// [VideoClipThumbnailPlaceholder] with the ground the grid card paints
+/// behind it.
+///
+/// The card's [ColoredBox] sits *outside* its [Hero], so a shuttle flying in
+/// the navigator overlay has nothing behind it: a clip whose thumbnail file
+/// is gone would fly as a bare icon over the scrim instead of the tile the
+/// user just tapped. A flight brings its own ground.
+class VideoClipThumbnailTile extends StatelessWidget {
+  const VideoClipThumbnailTile({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: context.vineColors.card,
+      child: const VideoClipThumbnailPlaceholder(),
+    );
+  }
+}

--- a/mobile/lib/widgets/video_clip/video_clip_preview.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_preview.dart
@@ -299,12 +299,18 @@ class _ClipHero extends StatelessWidget {
     final cacheHeight = _stillCacheHeight(context);
     return Hero(
       tag: videoClipPreviewHeroTag(clip.id),
-      flightShuttleBuilder: (_, _, _, _, _) => ClipThumbnailImage(
-        path: thumbnailPath,
-        fit: BoxFit.cover,
-        cacheHeight: cacheHeight,
-        excludeFromSemantics: true,
-        placeholder: const VideoClipThumbnailPlaceholder(),
+      // `excludeFromSemantics` covers the decoded still but not the fallback:
+      // `Image` returns its `errorBuilder` before applying the flag, and the
+      // fallback icon is an SVG that announces itself as an image. Nothing in
+      // a flight is worth announcing, so the whole shuttle is excluded.
+      flightShuttleBuilder: (_, _, _, _, _) => ExcludeSemantics(
+        child: ClipThumbnailImage(
+          path: thumbnailPath,
+          fit: BoxFit.cover,
+          cacheHeight: cacheHeight,
+          excludeFromSemantics: true,
+          placeholder: const VideoClipThumbnailTile(),
+        ),
       ),
       child: child,
     );

--- a/mobile/lib/widgets/video_clip/video_clip_preview.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_preview.dart
@@ -22,6 +22,22 @@ import 'package:pro_video_editor/pro_video_editor.dart'
     show RenderCanceledException;
 import 'package:unified_logger/unified_logger.dart';
 
+/// Creates the transparent route used to fly a library thumbnail into preview.
+Route<void> videoClipPreviewRoute({
+  required DivineVideoClip clip,
+  VoidCallback? onDelete,
+}) {
+  return PageRouteBuilder<void>(
+    opaque: false,
+    pageBuilder: (_, _, _) => VideoClipPreview(clip: clip, onDelete: onDelete),
+    transitionsBuilder: (_, animation, _, child) {
+      return FadeTransition(opacity: animation, child: child);
+    },
+    transitionDuration: const Duration(milliseconds: 200),
+    reverseTransitionDuration: const Duration(milliseconds: 200),
+  );
+}
+
 class VideoClipPreview extends ConsumerStatefulWidget {
   const VideoClipPreview({required this.clip, this.onDelete, super.key});
 

--- a/mobile/test/widgets/video_clip/video_clip_preview_test.dart
+++ b/mobile/test/widgets/video_clip/video_clip_preview_test.dart
@@ -328,20 +328,10 @@ void main() {
       final frameFile = File('${tempDir.path}/frame.png')
         ..writeAsBytesSync(_transparentPngBytes);
 
-      final clip = DivineVideoClip(
+      final clip = _stopMotionClip(
         id: 'stop-motion-clip-1',
-        stopMotionFrames: [
-          StopMotionClipFrame(
-            path: frameFile.path,
-            duration: const Duration(milliseconds: 83),
-          ),
-        ],
+        framePath: frameFile.path,
         thumbnailPath: frameFile.path,
-        libraryTitle: 'Tiny jump',
-        duration: const Duration(milliseconds: 83),
-        recordedAt: DateTime(2026),
-        targetAspectRatio: .vertical,
-        originalAspectRatio: 9 / 16,
       );
 
       await tester.pumpWidget(buildTestWidget(clip: clip));
@@ -360,12 +350,191 @@ void main() {
         tester.element(heroFinder),
       );
 
-      final thumbnail = shuttle as ClipThumbnailImage;
+      // Nothing in a flight is worth announcing, and the exclusion has to sit
+      // outside the image: `Image` returns its `errorBuilder` before applying
+      // `excludeFromSemantics`, so the fallback icon would announce itself.
+      final excluded = shuttle as ExcludeSemantics;
+      final thumbnail = excluded.child! as ClipThumbnailImage;
       expect(thumbnail.path, frameFile.path);
       expect(thumbnail.fit, BoxFit.cover);
-      expect(thumbnail.cacheHeight, tester.view.physicalSize.height.round());
       expect(thumbnail.excludeFromSemantics, isTrue);
-      expect(thumbnail.placeholder, isA<VideoClipThumbnailPlaceholder>());
+      expect(thumbnail.placeholder, isA<VideoClipThumbnailTile>());
+
+      // The shuttle and the player resolve to one cache entry, so their decode
+      // bounds have to stay in step — pinned to the real value as well, or a
+      // pair that both collapsed to null would still match.
+      final player = tester.widget<StopMotionPlayer>(
+        find.byType(StopMotionPlayer),
+      );
+      expect(player.cacheHeight, tester.view.physicalSize.height.round());
+      expect(thumbnail.cacheHeight, player.cacheHeight);
+    });
+
+    group('hero flight', () {
+      /// The grid bounds its decode to the cell rather than the screen, so the
+      /// two ends of the flight carry different values and a test can tell
+      /// which one is flying.
+      const gridCacheHeight = 120;
+
+      Widget buildFlightApp(DivineVideoClip clip) {
+        return ProviderScope(
+          overrides: [
+            gallerySaveServiceProvider.overrideWithValue(
+              mockGallerySaveService,
+            ),
+          ],
+          child: MockGoRouterProvider(
+            goRouter: mockGoRouter,
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: _GridCardStub(clip: clip, cacheHeight: gridCacheHeight),
+            ),
+          ),
+        );
+      }
+
+      /// A failed resolution stays live in the process-global image cache, so
+      /// each test evicts the two keys it created rather than clearing the
+      /// cache other suites in the merged isolate share.
+      void evictAfterTest(WidgetTester tester, String path) {
+        addTearDown(() {
+          for (final height in <int?>[
+            gridCacheHeight,
+            tester.view.physicalSize.height.round(),
+          ]) {
+            PaintingBinding.instance.imageCache.evict(
+              ResizeImage.resizeIfNeeded(null, height, FileImage(File(path))),
+            );
+          }
+        });
+      }
+
+      /// Taps the grid card and stops halfway through the push flight.
+      Future<void> flyToPreview(WidgetTester tester) async {
+        await tester.tap(find.byKey(_GridCardStub.tapKey));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 150));
+      }
+
+      /// Waits for the shuttle's decode to actually fail, then renders it.
+      ///
+      /// Resolving the file is real I/O, so the failure needs a real
+      /// event-loop turn — taken here by performing the same read the decode
+      /// performs, rather than by guessing at a wall-clock delay. The pump
+      /// after it is load-bearing twice over: it drains the fake-async
+      /// microtask queue the widget's error continuation is parked in (so
+      /// blocking inside `runAsync` instead would deadlock), and it carries no
+      /// duration, so the flight stays where [flyToPreview] left it.
+      Future<void> settleDecodeFailure(WidgetTester tester, String path) async {
+        for (var attempt = 0; attempt < 50; attempt++) {
+          if (find.byType(VideoClipThumbnailTile).evaluate().isNotEmpty) return;
+          await tester.runAsync(
+            () =>
+                File(path).readAsBytes().then<void>((_) {}, onError: (_, _) {}),
+          );
+          await tester.pump();
+        }
+      }
+
+      /// The one thumbnail on screen mid-flight: a [Hero] hides both endpoints
+      /// while the shuttle is up.
+      ClipThumbnailImage flyingThumbnail(WidgetTester tester) =>
+          tester.widget<ClipThumbnailImage>(find.byType(ClipThumbnailImage));
+
+      testWidgets('flies the preview still out and back without errors', (
+        tester,
+      ) async {
+        final tempDir = Directory.systemTemp.createTempSync('clip_hero_flight');
+        addTearDown(() => tempDir.deleteSync(recursive: true));
+        final frameFile = File('${tempDir.path}/frame.png')
+          ..writeAsBytesSync(_transparentPngBytes);
+        evictAfterTest(tester, frameFile.path);
+
+        final clip = _stopMotionClip(
+          id: 'flight-clip-1',
+          framePath: frameFile.path,
+          thumbnailPath: frameFile.path,
+        );
+
+        await tester.pumpWidget(buildFlightApp(clip));
+        await flyToPreview(tester);
+
+        // A flight at all proves both ends resolved the same tag from the clip
+        // id; the decode bound proves it is the preview's shuttle flying and
+        // not Flutter's default (the grid card's own child).
+        expect(
+          flyingThumbnail(tester).cacheHeight,
+          tester.view.physicalSize.height.round(),
+        );
+        expect(flyingThumbnail(tester).cacheHeight, isNot(gridCacheHeight));
+
+        await tester.pumpAndSettle();
+        expect(find.byType(StopMotionPlayer), findsOneWidget);
+
+        // The grid card declares no shuttle of its own, so the return flight
+        // falls back to the preview's — which is why the hero has to outlive
+        // the placeholder it used to live in.
+        Navigator.of(tester.element(find.byType(VideoClipPreview))).pop();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 150));
+
+        expect(
+          flyingThumbnail(tester).cacheHeight,
+          tester.view.physicalSize.height.round(),
+        );
+
+        await tester.pumpAndSettle();
+        expect(find.byType(VideoClipPreview), findsNothing);
+        expect(tester.takeException(), isNull);
+      });
+
+      testWidgets('falls back to the grid tile when the still is missing', (
+        tester,
+      ) async {
+        final tempDir = Directory.systemTemp.createTempSync('clip_hero_gone');
+        addTearDown(() => tempDir.deleteSync(recursive: true));
+        // The frame is real so the player still renders; only the thumbnail
+        // the shuttle decodes is gone, which is the iOS container-UUID case
+        // #5796 covers for the grid.
+        final frameFile = File('${tempDir.path}/frame.png')
+          ..writeAsBytesSync(_transparentPngBytes);
+        final missingThumbnail = '${tempDir.path}/evicted_thumbnail.jpg';
+        evictAfterTest(tester, missingThumbnail);
+
+        final clip = _stopMotionClip(
+          id: 'flight-clip-2',
+          framePath: frameFile.path,
+          thumbnailPath: missingThumbnail,
+        );
+
+        await tester.pumpWidget(buildFlightApp(clip));
+        await flyToPreview(tester);
+        await settleDecodeFailure(tester, missingThumbnail);
+
+        // Without a ground of its own the shuttle would fly the bare icon over
+        // whatever is beneath it; the grid paints its card outside the hero.
+        expect(find.byType(VideoClipThumbnailTile), findsOneWidget);
+        final tile = tester.element(find.byType(VideoClipThumbnailTile));
+        final ground = tester.widget<ColoredBox>(
+          find.descendant(
+            of: find.byType(VideoClipThumbnailTile),
+            matching: find.byType(ColoredBox),
+          ),
+        );
+        expect(ground.color, tile.vineColors.card);
+
+        // The fallback bypasses `Image.excludeFromSemantics`, so the shuttle
+        // keeps it out of the tree itself.
+        expect(
+          find.ancestor(
+            of: find.byType(VideoClipThumbnailTile),
+            matching: find.byType(ExcludeSemantics),
+          ),
+          findsOneWidget,
+        );
+        expect(tester.takeException(), isNull);
+      });
     });
 
     group('save result snackbar', () {
@@ -434,6 +603,80 @@ void main() {
       });
     });
   });
+}
+
+/// A one-frame stop-motion clip: the frames path drives [StopMotionPlayer] and
+/// [thumbnailPath] drives the hero shuttle, so the two can be pointed at
+/// different files. One frame means no ticker, so the tree settles.
+DivineVideoClip _stopMotionClip({
+  required String id,
+  required String framePath,
+  required String thumbnailPath,
+}) {
+  return DivineVideoClip(
+    id: id,
+    stopMotionFrames: [
+      StopMotionClipFrame(
+        path: framePath,
+        duration: const Duration(milliseconds: 83),
+      ),
+    ],
+    thumbnailPath: thumbnailPath,
+    libraryTitle: 'Tiny jump',
+    duration: const Duration(milliseconds: 83),
+    recordedAt: DateTime(2026),
+    targetAspectRatio: .vertical,
+    originalAspectRatio: 9 / 16,
+  );
+}
+
+/// The library grid's side of the flight: the source [Hero] the preview flies
+/// from, and the tap that pushes the preview route.
+///
+/// Mirrors `VideoClipThumbnailCard` where the flight is concerned — same tag,
+/// same error-tolerant thumbnail, and the card's own background painted
+/// outside the hero.
+class _GridCardStub extends StatelessWidget {
+  const _GridCardStub({required this.clip, required this.cacheHeight});
+
+  static const tapKey = Key('grid-card-stub');
+
+  final DivineVideoClip clip;
+  final int cacheHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: SizedBox(
+          width: 80,
+          height: 140,
+          child: GestureDetector(
+            key: tapKey,
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => Scaffold(
+                  body: VideoClipPreview(clip: clip),
+                ),
+              ),
+            ),
+            child: ColoredBox(
+              color: context.vineColors.card,
+              child: Hero(
+                tag: videoClipPreviewHeroTag(clip.id),
+                child: ClipThumbnailImage(
+                  path: clip.thumbnailPath!,
+                  fit: BoxFit.cover,
+                  cacheHeight: cacheHeight,
+                  placeholder: const VideoClipThumbnailPlaceholder(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 const _transparentPngBytes = <int>[

--- a/mobile/test/widgets/video_clip/video_clip_preview_test.dart
+++ b/mobile/test/widgets/video_clip/video_clip_preview_test.dart
@@ -20,6 +20,7 @@ import 'package:openvine/widgets/stop_motion/stop_motion_player.dart';
 import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 import 'package:openvine/widgets/video_clip/video_clip_hero.dart';
 import 'package:openvine/widgets/video_clip/video_clip_preview.dart';
+import 'package:openvine/widgets/video_clip/video_clip_thumbnail_card.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
 import '../../helpers/go_router.dart';
@@ -98,7 +99,11 @@ void main() {
       originalAspectRatio: 9 / 16,
     );
 
-    Widget buildTestWidget({DivineVideoClip? clip, VoidCallback? onDelete}) {
+    Widget buildTestWidget({
+      DivineVideoClip? clip,
+      VoidCallback? onDelete,
+      Widget? home,
+    }) {
       return ProviderScope(
         overrides: [
           gallerySaveServiceProvider.overrideWithValue(mockGallerySaveService),
@@ -108,12 +113,14 @@ void main() {
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(
-              body: VideoClipPreview(
-                clip: clip ?? testClip,
-                onDelete: onDelete,
-              ),
-            ),
+            home:
+                home ??
+                Scaffold(
+                  body: VideoClipPreview(
+                    clip: clip ?? testClip,
+                    onDelete: onDelete,
+                  ),
+                ),
           ),
         ),
       );
@@ -148,10 +155,7 @@ void main() {
       final l10n = lookupAppLocalizations(const Locale('en'));
       final semantics = tester.getSemantics(find.byType(VideoClipPreview));
 
-      expect(
-        semantics.label,
-        l10n.videoMetadataClosePreviewSemanticLabel,
-      );
+      expect(semantics.label, l10n.videoMetadataClosePreviewSemanticLabel);
       expect(
         semantics.getSemanticsData().hasAction(SemanticsAction.tap),
         isTrue,
@@ -374,21 +378,29 @@ void main() {
       /// The grid bounds its decode to the cell rather than the screen, so the
       /// two ends of the flight carry different values and a test can tell
       /// which one is flying.
-      const gridCacheHeight = 120;
+      const gridCardKey = Key('hero-flight-grid-card');
+
+      int gridCacheHeight(WidgetTester tester) =>
+          (tester.view.physicalSize.width / 2).round();
 
       Widget buildFlightApp(DivineVideoClip clip) {
-        return ProviderScope(
-          overrides: [
-            gallerySaveServiceProvider.overrideWithValue(
-              mockGallerySaveService,
-            ),
-          ],
-          child: MockGoRouterProvider(
-            goRouter: mockGoRouter,
-            child: MaterialApp(
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              home: _GridCardStub(clip: clip, cacheHeight: gridCacheHeight),
+        return buildTestWidget(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 80,
+                height: 140,
+                child: Builder(
+                  builder: (context) => VideoClipThumbnailCard(
+                    key: gridCardKey,
+                    clip: clip,
+                    showSelectionIndicator: false,
+                    onTap: () => Navigator.of(
+                      context,
+                    ).push(videoClipPreviewRoute(clip: clip)),
+                  ),
+                ),
+              ),
             ),
           ),
         );
@@ -400,7 +412,7 @@ void main() {
       void evictAfterTest(WidgetTester tester, String path) {
         addTearDown(() {
           for (final height in <int?>[
-            gridCacheHeight,
+            gridCacheHeight(tester),
             tester.view.physicalSize.height.round(),
           ]) {
             PaintingBinding.instance.imageCache.evict(
@@ -412,9 +424,9 @@ void main() {
 
       /// Taps the grid card and stops halfway through the push flight.
       Future<void> flyToPreview(WidgetTester tester) async {
-        await tester.tap(find.byKey(_GridCardStub.tapKey));
+        await tester.tap(find.byKey(gridCardKey));
         await tester.pump();
-        await tester.pump(const Duration(milliseconds: 150));
+        await tester.pump(const Duration(milliseconds: 100));
       }
 
       /// Waits for the shuttle's decode to actually fail, then renders it.
@@ -467,7 +479,10 @@ void main() {
           flyingThumbnail(tester).cacheHeight,
           tester.view.physicalSize.height.round(),
         );
-        expect(flyingThumbnail(tester).cacheHeight, isNot(gridCacheHeight));
+        expect(
+          flyingThumbnail(tester).cacheHeight,
+          isNot(gridCacheHeight(tester)),
+        );
 
         await tester.pumpAndSettle();
         expect(find.byType(StopMotionPlayer), findsOneWidget);
@@ -477,7 +492,7 @@ void main() {
         // the placeholder it used to live in.
         Navigator.of(tester.element(find.byType(VideoClipPreview))).pop();
         await tester.pump();
-        await tester.pump(const Duration(milliseconds: 150));
+        await tester.pump(const Duration(milliseconds: 100));
 
         expect(
           flyingThumbnail(tester).cacheHeight,
@@ -628,55 +643,6 @@ DivineVideoClip _stopMotionClip({
     targetAspectRatio: .vertical,
     originalAspectRatio: 9 / 16,
   );
-}
-
-/// The library grid's side of the flight: the source [Hero] the preview flies
-/// from, and the tap that pushes the preview route.
-///
-/// Mirrors `VideoClipThumbnailCard` where the flight is concerned — same tag,
-/// same error-tolerant thumbnail, and the card's own background painted
-/// outside the hero.
-class _GridCardStub extends StatelessWidget {
-  const _GridCardStub({required this.clip, required this.cacheHeight});
-
-  static const tapKey = Key('grid-card-stub');
-
-  final DivineVideoClip clip;
-  final int cacheHeight;
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: Center(
-        child: SizedBox(
-          width: 80,
-          height: 140,
-          child: GestureDetector(
-            key: tapKey,
-            onTap: () => Navigator.of(context).push(
-              MaterialPageRoute<void>(
-                builder: (_) => Scaffold(
-                  body: VideoClipPreview(clip: clip),
-                ),
-              ),
-            ),
-            child: ColoredBox(
-              color: context.vineColors.card,
-              child: Hero(
-                tag: videoClipPreviewHeroTag(clip.id),
-                child: ClipThumbnailImage(
-                  path: clip.thumbnailPath!,
-                  fit: BoxFit.cover,
-                  cacheHeight: cacheHeight,
-                  placeholder: const VideoClipThumbnailPlaceholder(),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
 }
 
 const _transparentPngBytes = <int>[


### PR DESCRIPTION
## Description

When you close a stop-motion clip preview, the thumbnail flies back to its place in the grid. If that clip's still image is missing, the thing that flew was a bare icon over a blank rectangle — and on that same path a screen reader could announce the decorative animation.

**All three issues describe code that never landed, so the headline diagnoses are wrong while the symptoms are real.** They say the shuttle is `Image.memory(stillBytes, fit: BoxFit.cover)` with no `ExcludeSemantics` and no fallback. The merged PR #6800 — the only commit that has ever touched `_ClipHero` — already shipped `ClipThumbnailImage(..., excludeFromSemantics: true, placeholder: VideoClipThumbnailPlaceholder())`. The issues were written against a pre-merge revision. Here is what was actually broken underneath each:

**#7750 — accessibility.** `excludeFromSemantics: true` was set, but `Image` returns its `errorBuilder` *before* applying that flag (`image.dart:1380`). The missing-thumbnail fallback is a `DivineIcon` → `SvgPicture`, and `vector_graphics` emits `Semantics(image: true)` when not excluded. So a screen reader really could announce the flight — just only on the error path, which is why nobody caught it. Now the whole shuttle is wrapped in `ExcludeSemantics`.

**#7749 — the blank rectangle.** A fallback existed and already matched the grid card; the issue's `_MissingThumbnailPlaceholder` premise is wrong, both sides pass `VideoClipThumbnailPlaceholder`. The real gap is that the grid card paints its `ColoredBox(vineColors.card)` **outside** its `Hero`. A shuttle in the navigator overlay therefore has no ground under it, so a missing still flew as a bare icon over nothing — exactly the reported symptom. Added `VideoClipThumbnailTile` (icon plus card ground) so the shuttle carries its own background.

**#7747 — coverage.** Genuinely absent. New `hero flight` group driving a real two-route push and pop.

## Out of Scope

#7748 (iOS platform-view risk during the flight) is a separate investigation and is untouched here.

## Verification

```
flutter analyze lib test    Analyzing 2 items... No issues found! (50.5s)
flutter test                00:03 +72: All tests passed!
```
(`video_clip/`, `clips_tab`, `stop_motion/`)

Every new test proven red-before-green by reverting the production diff piecemeal: the shuttle unit test fails on the `ExcludeSemantics` cast; the fallback flight test reports `Found 0 widgets with type "VideoClipThumbnailTile"`; and with `flightShuttleBuilder` deleted entirely the push/pop test fails too, so it is not vacuous.

Worth knowing for the next person writing an image test here: the obvious polling helper trips `check_future_delayed_ceiling`, and the obvious replacement — blocking on the image stream inside `runAsync` — **deadlocks**, because the widget's error continuation parks in the fake-async microtask queue that only `pump()` drains, and `pump()` cannot run while `runAsync` blocks. The version here polls with a real `readAsBytes` round-trip for its event-loop turn.

Three ratchets fail in this environment — `check_coordinator_route_serving` (live relay 404), `check_ios_extension_signing_contract` (unset env var), `check_store_url_identifiers` (ruby locale). All three fail identically on a clean `main` checkout, so they are environmental, not this diff.

**Verified on Galaxy S26.** Open a stop-motion clip whose still is missing, then close it — the shuttle now carries its card ground through the flight instead of showing a bare icon over nothing.

## Type of Change

- [x] 🛠️ Bug fix

**Related Issue:** Closes #7749, closes #7750, closes #7747

