### PR TITLE
fix(divine_ui): keep locked scrollable sheets open

### DIFF
--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
@@ -172,6 +172,12 @@ class VineBottomSheet extends StatelessWidget {
   /// tap-catcher). Has no effect in fixed mode — the standard modal
   /// barrier already dismisses on tap there.
   ///
+  /// [enableDrag], when false, blocks both the modal route's drag gesture
+  /// and content-driven dismissal when a scrollable sheet reaches its minimum
+  /// extent. The sheet can still resize between [minChildSize] and
+  /// [maxChildSize]. Barrier dismissal remains governed by [isDismissible]
+  /// and [tapOutsideToDismiss].
+  ///
   /// [headerLeadingAction] and [headerTrailingAction] are forwarded to
   /// [VineBottomSheetHeader] to place icon buttons on the left/right side of
   /// the header. When only one is set, the other side receives an invisible
@@ -295,6 +301,7 @@ class VineBottomSheet extends StatelessWidget {
           if (!tapOutsideToDismiss) {
             return DraggableScrollableSheet(
               controller: draggableController,
+              shouldCloseOnMinExtent: enableDrag,
               initialChildSize: initialChildSize,
               minChildSize: minChildSize,
               maxChildSize: maxChildSize,
@@ -335,6 +342,7 @@ class VineBottomSheet extends StatelessWidget {
             child: DraggableScrollableSheet(
               controller: draggableController,
               expand: false,
+              shouldCloseOnMinExtent: enableDrag,
               initialChildSize: initialChildSize,
               minChildSize: minChildSize,
               maxChildSize: maxChildSize,

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_prompt.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_prompt.dart
@@ -111,11 +111,10 @@ class VineBottomSheetPrompt extends StatelessWidget {
   ///
   /// Set both [isDismissible] and [enableDrag] to false for a prompt that
   /// must stay open until the user picks an action — [isDismissible] blocks
-  /// barrier taps and [enableDrag] blocks route- and content-driven
-  /// drag-to-dismiss. A scrollable sheet can still resize while drag dismissal
-  /// is disabled. Setting only one leaves the other dismissal path active. The
-  /// drag handle follows [enableDrag], so a prompt with dragging disabled does
-  /// not advertise the unavailable gesture.
+  /// barrier taps and [enableDrag] blocks drag-to-dismiss. Setting only one
+  /// leaves the other dismissal path active. The drag handle follows
+  /// [enableDrag], so a prompt with dragging disabled does not advertise the
+  /// unavailable gesture.
   static Future<T?> show<T>({
     required BuildContext context,
     required DivineStickerName sticker,

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_prompt.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_prompt.dart
@@ -111,10 +111,11 @@ class VineBottomSheetPrompt extends StatelessWidget {
   ///
   /// Set both [isDismissible] and [enableDrag] to false for a prompt that
   /// must stay open until the user picks an action — [isDismissible] blocks
-  /// barrier taps and [enableDrag] blocks drag-to-dismiss. Setting only one
-  /// leaves the other dismissal path active. The drag handle follows
-  /// [enableDrag], so a prompt with dragging disabled does not advertise the
-  /// unavailable gesture.
+  /// barrier taps and [enableDrag] blocks route- and content-driven
+  /// drag-to-dismiss. A scrollable sheet can still resize while drag dismissal
+  /// is disabled. Setting only one leaves the other dismissal path active. The
+  /// drag handle follows [enableDrag], so a prompt with dragging disabled does
+  /// not advertise the unavailable gesture.
   static Future<T?> show<T>({
     required BuildContext context,
     required DivineStickerName sticker,

--- a/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_test.dart
+++ b/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_test.dart
@@ -946,6 +946,73 @@ void main() {
       });
     });
 
+    group('enableDrag', () {
+      Future<void> showDraggable(
+        WidgetTester tester, {
+        required bool enableDrag,
+        required bool tapOutsideToDismiss,
+      }) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => ElevatedButton(
+                  onPressed: () => VineBottomSheet.show<void>(
+                    context: context,
+                    enableDrag: enableDrag,
+                    tapOutsideToDismiss: tapOutsideToDismiss,
+                    title: const Text('Draggable Sheet'),
+                    children: const [Text('Sheet Body')],
+                  ),
+                  child: const Text('Open'),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+      }
+
+      for (final tapOutsideToDismiss in [true, false]) {
+        for (final enableDrag in [true, false]) {
+          testWidgets(
+            'min-extent dismissal is $enableDrag when enableDrag is '
+            '$enableDrag and tapOutsideToDismiss is $tapOutsideToDismiss',
+            (tester) async {
+              await showDraggable(
+                tester,
+                enableDrag: enableDrag,
+                tapOutsideToDismiss: tapOutsideToDismiss,
+              );
+
+              expect(
+                tester
+                    .widget<DraggableScrollableSheet>(
+                      find.byType(DraggableScrollableSheet),
+                    )
+                    .shouldCloseOnMinExtent,
+                enableDrag,
+              );
+
+              await tester.fling(
+                find.text('Sheet Body'),
+                const Offset(0, 600),
+                2000,
+              );
+              await tester.pumpAndSettle();
+
+              expect(
+                find.text('Sheet Body'),
+                enableDrag ? findsNothing : findsOneWidget,
+              );
+            },
+          );
+        }
+      }
+    });
+
     group('new parameters', () {
       test('snap without scrollable fails an assertion', () {
         expect(


### PR DESCRIPTION
## Problem

Scrollable bottom sheets could still close when their content was dragged to the minimum extent even when callers set `enableDrag: false`. The flag disabled the modal route gesture but left the inner draggable sheet's independent close path enabled.

## Why this fix

The draggable sheet now derives `shouldCloseOnMinExtent` from the existing `enableDrag` contract in both layout branches. This keeps drag-to-dismiss enabled for existing callers while preventing content-driven dismissal for locked sheets.

## Deliberately unchanged

Locked scrollable sheets may still resize down to `minChildSize`; this change prevents dismissal rather than pinning their extent. Barrier dismissal remains controlled by `isDismissible` and `tapOutsideToDismiss`, and fixed sheets are unchanged.

## Verification

- `mise exec -- flutter test`
- `mise exec -- flutter test --coverage`
- `mise exec -- flutter analyze`
- pre-push analyzer and focused bottom-sheet test hook

Regression tests cover downward flings and the forwarded close flag for both `enableDrag` values across both `tapOutsideToDismiss` layout branches.

Closes #8802