### PR TITLE
test(crosspost): make provisioning poll regressions observable

### DIFF
--- a/mobile/scripts/baseline/future_delayed_test_counts.txt
+++ b/mobile/scripts/baseline/future_delayed_test_counts.txt
@@ -11,7 +11,7 @@ test/blocs/change_email/change_email_cubit_test.dart	1
 test/blocs/clips_library/clips_library_bloc_test.dart	4
 test/blocs/comments/comments_list/comments_list_bloc_test.dart	3
 test/blocs/creator_sync/sound_sync_cubit_test.dart	1
-test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart	26
+test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart	23
 test/blocs/crossposting_settings/crossposting_settings_cubit_test.dart	1
 test/blocs/dm/conversation/conversation_bloc_test.dart	25
 test/blocs/dm/conversation_list/conversation_list_bloc_test.dart	9

--- a/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
+++ b/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
@@ -12,6 +12,20 @@ import 'package:openvine/services/crosspost_api_client.dart';
 class _MockBlueskyCrosspostRepository extends Mock
     implements BlueskyCrosspostRepository {}
 
+/// Asserts the provisioning poller is armed to fire at [pollInterval].
+///
+/// A bare `pendingTimers, isNotEmpty` also passes for a poller armed at some
+/// other interval, which never fires inside the elapsed window and leaves a
+/// "the poll was suppressed" assertion vacuous.
+void _expectProvisioningPollerArmed(FakeAsync fake, Duration pollInterval) {
+  expect(
+    fake.pendingTimers.where(
+      (timer) => timer.isPeriodic && timer.duration == pollInterval,
+    ),
+    isNotEmpty,
+  );
+}
+
 void main() {
   group(CrosspostSettingsCubit, () {
     late _MockBlueskyCrosspostRepository repository;
@@ -680,12 +694,16 @@ void main() {
             );
             fake.flushMicrotasks();
 
-            // Without this, every assertion below is satisfied by the initial
-            // user load even if provisioning polling never starts (#8806).
-            expect(fake.pendingTimers, isNotEmpty);
+            _expectProvisioningPollerArmed(
+              fake,
+              const Duration(milliseconds: 1),
+            );
             fake.elapse(const Duration(milliseconds: 3));
             fake.flushMicrotasks();
 
+            // Without these two, every assertion below is satisfied by the
+            // initial user load even if provisioning polling never runs
+            // (#8806).
             verify(() => repository.loadKeycastStatus()).called(3);
             expect(cubit.state.provisioningPollAttempts, 3);
             expect(cubit.state.status, CrosspostSettingsStatus.loaded);
@@ -821,7 +839,12 @@ void main() {
           );
           fake.flushMicrotasks();
 
-          expect(fake.pendingTimers, isNotEmpty);
+          // The verifyNever below only means anything if a poll would
+          // otherwise have fired inside the elapsed millisecond.
+          _expectProvisioningPollerArmed(
+            fake,
+            const Duration(milliseconds: 1),
+          );
 
           unawaited(cubit.toggleCrosspost(enabled: false));
           fake.flushMicrotasks();

--- a/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
+++ b/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
@@ -679,9 +679,15 @@ void main() {
               pollInterval: const Duration(milliseconds: 1),
             );
             fake.flushMicrotasks();
+
+            // Without this, every assertion below is satisfied by the initial
+            // user load even if provisioning polling never starts (#8806).
+            expect(fake.pendingTimers, isNotEmpty);
             fake.elapse(const Duration(milliseconds: 3));
             fake.flushMicrotasks();
 
+            verify(() => repository.loadKeycastStatus()).called(3);
+            expect(cubit.state.provisioningPollAttempts, 3);
             expect(cubit.state.status, CrosspostSettingsStatus.loaded);
             expect(
               cubit.state.provisioningState,
@@ -814,6 +820,8 @@ void main() {
             pollInterval: const Duration(milliseconds: 1),
           );
           fake.flushMicrotasks();
+
+          expect(fake.pendingTimers, isNotEmpty);
 
           unawaited(cubit.toggleCrosspost(enabled: false));
           fake.flushMicrotasks();

--- a/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
+++ b/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
@@ -770,7 +770,7 @@ void main() {
         });
       });
 
-      test('stale poll result does not overwrite toggle result', () async {
+      test('stale poll result does not overwrite toggle result', () {
         final pollCompleter = Completer<CrosspostStatus>();
         when(() => repository.loadStatus(pubkey: testPubkey)).thenAnswer(
           (_) async => const BlueskyCrosspostAccountStatus(
@@ -796,25 +796,37 @@ void main() {
           ),
         );
 
-        final cubit = buildCubit(pollInterval: const Duration(milliseconds: 1));
-        addTearDown(cubit.close);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(const Duration(milliseconds: 1));
+        fakeAsync((fake) {
+          final cubit = buildCubit(
+            pollInterval: const Duration(milliseconds: 1),
+          );
+          fake.flushMicrotasks();
 
-        await cubit.toggleCrosspost(enabled: false);
-        pollCompleter.complete(
-          const CrosspostStatus(
-            crosspostEnabled: true,
-            provisioningState: AtprotoProvisioningState.pending,
-          ),
-        );
-        await Future<void>.delayed(Duration.zero);
+          _expectProvisioningPollerArmed(
+            fake,
+            const Duration(milliseconds: 1),
+          );
+          fake.elapse(const Duration(milliseconds: 1));
+          fake.flushMicrotasks();
+          verify(() => repository.loadKeycastStatus()).called(1);
 
-        expect(cubit.state.enabled, isFalse);
-        expect(
-          cubit.state.provisioningState,
-          AtprotoProvisioningState.disabled,
-        );
+          unawaited(cubit.toggleCrosspost(enabled: false));
+          fake.flushMicrotasks();
+          pollCompleter.complete(
+            const CrosspostStatus(
+              crosspostEnabled: true,
+              provisioningState: AtprotoProvisioningState.pending,
+            ),
+          );
+          fake.flushMicrotasks();
+
+          expect(cubit.state.enabled, isFalse);
+          expect(
+            cubit.state.provisioningState,
+            AtprotoProvisioningState.disabled,
+          );
+          cubit.close();
+        });
       });
 
       test('poll that fires during toggle does not start', () {


### PR DESCRIPTION
## Problem

Three provisioning-polling tests could pass even if the periodic poller was removed or armed at an interval that never elapsed. Their assertions described unchanged state or a suppressed request, but did not prove the relevant poll had been armed and executed.

## Why this fix

The tests now assert that the poll timer exists at the expected interval before advancing fake time. The failed-poll test verifies all three repository polls and the matching internal attempt count. The stale-result test now uses deterministic fake time, proves that a repository poll is actually in flight, and only then verifies that its late result cannot overwrite a completed toggle.

## Deliberately unchanged

Production polling behavior is unchanged. This PR only strengthens the regression tests.

## Verification

- Mutation check: removing the periodic timer makes all three strengthened tests fail at their positive controls
- Mutation check: arming the timer at a one-day interval makes the interval-sensitive tests fail
- `flutter test test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart`
- `bash scripts/check_future_delayed_ceiling.sh` (file count reduced from 26 to 23)
- `flutter analyze lib test integration_test`
- repository pre-push analyzer and changed-file tests

Closes #8806
