### PR TITLE
test(crosspost): cover polling recovery after timeout

### DIFF
--- a/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
+++ b/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
@@ -889,6 +889,61 @@ void main() {
         });
       });
 
+      test('a user reload after the attempt cap restarts polling', () {
+        var loadCount = 0;
+        when(() => repository.loadStatus(pubkey: testPubkey)).thenAnswer((
+          _,
+        ) async {
+          loadCount += 1;
+          return const BlueskyCrosspostAccountStatus(
+            crosspostEnabled: true,
+            username: 'testuser',
+            handle: 'testuser.divine.video',
+            provisioningState: AtprotoProvisioningState.pending,
+            usernameClaimStatus: UsernameClaimStatus.claimed,
+          );
+        });
+        when(() => repository.loadKeycastStatus()).thenAnswer((_) async {
+          loadCount += 1;
+          return const CrosspostStatus(
+            crosspostEnabled: true,
+            provisioningState: AtprotoProvisioningState.pending,
+          );
+        });
+
+        fakeAsync((fake) {
+          final cubit = buildCubit(
+            pollInterval: const Duration(milliseconds: 1),
+            maxProvisioningPollAttempts: 1,
+          );
+          fake.flushMicrotasks();
+          fake.elapse(const Duration(milliseconds: 1));
+          fake.flushMicrotasks();
+
+          expect(cubit.state.provisioningPollAttempts, 1);
+          expect(cubit.state.provisioningPollingTimedOut, isTrue);
+          final cappedCount = loadCount;
+          expect(cappedCount, greaterThan(1));
+
+          fake.elapse(const Duration(milliseconds: 5));
+          fake.flushMicrotasks();
+          expect(loadCount, cappedCount);
+
+          unawaited(cubit.loadStatus());
+          fake.flushMicrotasks();
+
+          expect(cubit.state.provisioningPollAttempts, 0);
+          expect(cubit.state.provisioningPollingTimedOut, isFalse);
+          final postReloadCount = loadCount;
+          expect(postReloadCount, greaterThan(cappedCount));
+
+          fake.elapse(const Duration(milliseconds: 1));
+          fake.flushMicrotasks();
+          expect(loadCount, greaterThan(postReloadCount));
+          cubit.close();
+        });
+      });
+
       test(
         'retryProvisioning re-enables crossposting from failed state',
         () async {

--- a/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
+++ b/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
@@ -944,6 +944,63 @@ void main() {
         });
       });
 
+      test('a failed user reload after the cap clears the timeout', () {
+        var loadStatusCalls = 0;
+        when(() => repository.loadStatus(pubkey: testPubkey)).thenAnswer((
+          _,
+        ) async {
+          loadStatusCalls += 1;
+          if (loadStatusCalls > 1) {
+            throw const CrosspostApiException(
+              'unavailable',
+              statusCode: 503,
+              kind: CrosspostApiErrorKind.unavailable,
+            );
+          }
+          return const BlueskyCrosspostAccountStatus(
+            crosspostEnabled: true,
+            username: 'testuser',
+            handle: 'testuser.divine.video',
+            provisioningState: AtprotoProvisioningState.pending,
+            usernameClaimStatus: UsernameClaimStatus.claimed,
+          );
+        });
+        when(() => repository.loadKeycastStatus()).thenAnswer(
+          (_) async => const CrosspostStatus(
+            crosspostEnabled: true,
+            provisioningState: AtprotoProvisioningState.pending,
+          ),
+        );
+
+        fakeAsync((fake) {
+          final cubit = buildCubit(
+            pollInterval: const Duration(milliseconds: 1),
+            maxProvisioningPollAttempts: 1,
+          );
+          fake.flushMicrotasks();
+          fake.elapse(const Duration(milliseconds: 1));
+          fake.flushMicrotasks();
+
+          expect(cubit.state.provisioningPollAttempts, 1);
+          expect(cubit.state.provisioningPollingTimedOut, isTrue);
+
+          unawaited(cubit.loadStatus());
+          fake.flushMicrotasks();
+
+          // The reload threw, so the loaded path never ran and only the
+          // user-load reset can clear the timeout. Without it the settings
+          // screen keeps showing the timed-out copy for a pending account.
+          expect(cubit.state.status, CrosspostSettingsStatus.failure);
+          expect(
+            cubit.state.provisioningState,
+            AtprotoProvisioningState.pending,
+          );
+          expect(cubit.state.provisioningPollAttempts, 0);
+          expect(cubit.state.provisioningPollingTimedOut, isFalse);
+          cubit.close();
+        });
+      });
+
       test(
         'retryProvisioning re-enables crossposting from failed state',
         () async {


### PR DESCRIPTION
## Problem

Provisioning polling stops once repeated pending responses reach the attempt cap. A later user-initiated status reload resets that timeout and restarts polling, but no test protected the recovery path.

## Why these tests

The two deterministic `fakeAsync` tests cover both outcomes after polling reaches the cap:

- A successful user reload resets the timeout state and attempt count, then schedules a subsequent poll.
- A failed user reload still clears the timeout state. Because this path never reaches `_emitLoaded`, it specifically protects the reset in `_beginUserLoad`.

A cap of one makes failure to reset immediately observable. The production behavior is unchanged. The separate settings-screen retry affordance remains outside this test-only scope.

## Verification

- `flutter test test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart`
- `bash scripts/check_future_delayed_ceiling.sh`
- `bash scripts/check_ungrouped_tests.sh test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart`
- `flutter analyze lib test integration_test`
- Negative control: removing the `_beginUserLoad` attempt/timeout reset makes the failed-reload test fail (`expected 0`, `actual 1`) while the unmodified suite passes.

Closes #8807