### PR TITLE
fix(e2e): stop the key-backup journey dying on the Nostr Keys screen

### DIFF
--- a/mobile/e2e/maestro/asserts/assertNostrKeys.yaml
+++ b/mobile/e2e/maestro/asserts/assertNostrKeys.yaml
@@ -10,16 +10,21 @@ appId: co.openvine.app.staging
     • Your private key (nsec) is like your password - keep it secret!
 
     Your nsec lets you access your account on any Nostr app.
+
+# One assertion per accessibility node. A selector is matched against a single
+# element's text, never a concatenation across siblings, so the card's title
+# and subtitle match together while the field hint and the warning below it --
+# separate nodes -- have to be asserted on their own.
 - assertVisible: |-
     Import Existing Key
     Already have a Nostr account? Paste your private key (nsec) to access it here.
-    nsec1...
-    This will replace your current key!
+- assertVisible: nsec1...
+- assertVisible: This will replace your current key!
 - assertVisible: Import Key
 - scroll
 - assertVisible: |-
     Backup Your Key
     Save your private key (nsec) to use your account in other Nostr apps.
-    Never share your nsec with anyone!
+- assertVisible: Never share your nsec with anyone!
 - assertVisible:
     id: "copy_nsec_button"


### PR DESCRIPTION
## Problem

The manual key-backup regression journey still cannot finish. #8780 fixed its navigation and its clipboard assertion, and both of those work — on a device it now walks Settings → Nostr Settings → Key Management correctly and lands on the Nostr Keys screen. It then fails three steps before the thing it exists to test, so backing up a private key is still not covered by any end-to-end run.

## Why this fix

Maestro matches a selector against one element's text. It never matches against a concatenation across sibling elements. Two assertions on this screen span more than one node, so nothing on screen can satisfy either.

The Import card is three separate accessibility nodes, not one:

```
[node 6] 'Import Existing Key\nAlready have a Nostr account? Paste your private key (nsec) to access it here.'
[node 7] 'nsec1...'                              <- the text field's hint, nested deeper
[node 9] 'This will replace your current key!'   <- its own node
```

The assertion asked for all four lines together. After the scroll the same thing happens again: `Never share your nsec with anyone!` is its own info card, not part of the `Backup Your Key` block above it.

Splitting each assertion along the real node boundaries fixes both.

This was deferred in #8780 as a regex-escaping problem, and that diagnosis was wrong — worth recording, because escaping would have been the more invasive change and would have cost real copy bindings for nothing. Escaping was never needed: the block that *does* contain `(npub)` and `(nsec)` passes on device, because it happens to be a single node. Node structure is the whole story.

## Deliberately unchanged

- No product code, and no change to what the journey asserts. Every literal that was asserted before is still asserted.
- The copy-drift guard still reports the same **112 bindings**, so no ARB binding was traded away to get this passing.
- `backupYourKey.yaml` itself is untouched — its navigation and clipboard assertions from #8780 are correct and are what the run below exercises.

## Verification

Run on an iPhone 17 simulator (iOS 26.5), STAGING build with `GH_ACTIONS_PR_PREVIEW=true`, using the same sequence `fullRegression` runs — `loginFreshInstall` then `backupYourKey`. A freshly created account holds a local nsec, which is the condition that renders the copy button, so this needs no credentials.

Before:

```
Assert that "Import Existing Key
Already have a Nostr account? Paste your private key (nsec) to access it here.
nsec1...
This will replace your current key!" is visible... FAILED
```

After — the full journey, ending on the confirmation snackbar that had never been reached:

```
Tap on id: key_management_tile... COMPLETED
Assert that "Import Existing Key
Already have a Nostr account? Paste your private key (nsec) to access it here." is visible... COMPLETED
Assert that "nsec1..." is visible... COMPLETED
Assert that "This will replace your current key!" is visible... COMPLETED
Scroll vertically... COMPLETED
Assert that "Never share your nsec with anyone!" is visible... COMPLETED
Tap on id: copy_nsec_button... COMPLETED
Assert that "Private key copied to clipboard!

Store it somewhere safe." is visible... COMPLETED
```

Also run: `bash e2e/maestro/scripts/check_refs.sh` and `bash scripts/check_maestro_copy_drift.sh`.

Not covered: this is the iOS Simulator lane only. The suite treats Android as a separate lane and I did not run it there.

Refs #8775
