### PR TITLE
fix(notifications): preserve other clients' data when toggling bells

### DIFF
--- a/mobile/packages/people_lists_repository/lib/src/nip51_people_list_codec.dart
+++ b/mobile/packages/people_lists_repository/lib/src/nip51_people_list_codec.dart
@@ -85,38 +85,11 @@ abstract final class Nip51PeopleListCodec {
       );
     }
     if (sourceTags != null) {
-      if (_firstTagValue(sourceTags, 'd') != list.id) {
-        throw ArgumentError.value(
-          sourceTags,
-          'sourceTags',
-          'must contain the d tag represented by the list',
-        );
-      }
-      final wanted = list.pubkeys.where((pubkey) => pubkey.isNotEmpty).toSet();
-      final sourced = <String>{};
-      final tags = <List<String>>[];
-
-      for (final tag in sourceTags) {
-        if (tag.length < 2 || tag[0] != 'p' || tag[1].isEmpty) {
-          tags.add(List<String>.of(tag));
-          continue;
-        }
-        final pubkey = tag[1];
-        if (wanted.contains(pubkey)) {
-          tags.add(List<String>.of(tag));
-          sourced.add(pubkey);
-        }
-      }
-
-      for (final pubkey in list.pubkeys) {
-        if (pubkey.isNotEmpty && sourced.add(pubkey)) {
-          tags.add(['p', pubkey]);
-        }
-      }
-      return PeopleListEventPayload(
-        kind: kind,
-        tags: tags,
-        content: sourceContent!,
+      return _encodeMembershipEdit(
+        dTag: list.id,
+        pubkeys: list.pubkeys,
+        sourceTags: sourceTags,
+        sourceContent: sourceContent!,
       );
     }
 
@@ -152,15 +125,34 @@ abstract final class Nip51PeopleListCodec {
   ///
   /// An empty [pubkeys] is legitimate — it is how the user clears the list —
   /// and produces an event with `d` and `title` but no `p` tags.
+  ///
+  /// When [sourceTags] is supplied, membership is edited over the complete
+  /// source event and [sourceContent] passes through verbatim. The source
+  /// arguments must either both be present or both be absent.
   static PeopleListEventPayload encodeReserved({
     required String dTag,
     required String title,
     required Iterable<String> pubkeys,
+    List<List<String>>? sourceTags,
+    String? sourceContent,
   }) {
     assert(
       reservedDTags.contains(dTag),
       'encodeReserved is only for app-managed lists in reservedDTags',
     );
+    if ((sourceTags == null) != (sourceContent == null)) {
+      throw ArgumentError(
+        'sourceTags and sourceContent must both be present or both be absent',
+      );
+    }
+    if (sourceTags != null) {
+      return _encodeMembershipEdit(
+        dTag: dTag,
+        pubkeys: pubkeys,
+        sourceTags: sourceTags,
+        sourceContent: sourceContent!,
+      );
+    }
     return PeopleListEventPayload(
       kind: kind,
       tags: [
@@ -233,6 +225,47 @@ abstract final class Nip51PeopleListCodec {
   static Iterable<String> _memberPubkeys(List<List<String>> tags) => tags
       .where((tag) => tag.length >= 2 && tag[0] == 'p' && tag[1].isNotEmpty)
       .map((tag) => tag[1]);
+
+  static PeopleListEventPayload _encodeMembershipEdit({
+    required String dTag,
+    required Iterable<String> pubkeys,
+    required List<List<String>> sourceTags,
+    required String sourceContent,
+  }) {
+    if (_firstTagValue(sourceTags, 'd') != dTag) {
+      throw ArgumentError.value(
+        sourceTags,
+        'sourceTags',
+        'must contain the d tag represented by the list',
+      );
+    }
+    final wanted = pubkeys.where((pubkey) => pubkey.isNotEmpty).toSet();
+    final sourced = <String>{};
+    final tags = <List<String>>[];
+
+    for (final tag in sourceTags) {
+      if (tag.length < 2 || tag[0] != 'p' || tag[1].isEmpty) {
+        tags.add(List<String>.of(tag));
+        continue;
+      }
+      final pubkey = tag[1];
+      if (wanted.contains(pubkey)) {
+        tags.add(List<String>.of(tag));
+        sourced.add(pubkey);
+      }
+    }
+
+    for (final pubkey in pubkeys) {
+      if (pubkey.isNotEmpty && sourced.add(pubkey)) {
+        tags.add(['p', pubkey]);
+      }
+    }
+    return PeopleListEventPayload(
+      kind: kind,
+      tags: tags,
+      content: sourceContent,
+    );
+  }
 
   static String? _firstTagValue(List<List<String>> tags, String name) {
     for (final tag in tags) {

--- a/mobile/packages/people_lists_repository/lib/src/notify_subscriptions_repository_impl.dart
+++ b/mobile/packages/people_lists_repository/lib/src/notify_subscriptions_repository_impl.dart
@@ -219,6 +219,8 @@ class NotifySubscriptionsRepositoryImpl
       ownerPubkey: ownerPubkey,
       creators: desired,
       previousCreatedAt: snapshot.createdAt,
+      sourceTags: snapshot.sourceTags,
+      sourceContent: snapshot.sourceContent,
     );
 
     if (result.submitted) {
@@ -237,11 +239,15 @@ class NotifySubscriptionsRepositoryImpl
     required String ownerPubkey,
     required Set<String> creators,
     required int previousCreatedAt,
+    required List<List<String>>? sourceTags,
+    required String? sourceContent,
   }) async {
     final payload = Nip51PeopleListCodec.encodeReserved(
       dTag: Nip51PeopleListCodec.notifyDTag,
       title: _notifyListTitle,
       pubkeys: creators,
+      sourceTags: sourceTags,
+      sourceContent: sourceContent,
     );
 
     // NIP-33 replacement resolves by created_at, and relay behaviour for a
@@ -273,7 +279,12 @@ class NotifySubscriptionsRepositoryImpl
       }
       _publishSnapshot(
         ownerPubkey,
-        _NotifyListSnapshot(creators: creators, createdAt: createdAt),
+        _NotifyListSnapshot(
+          creators: creators,
+          createdAt: createdAt,
+          sourceTags: payload.tags,
+          sourceContent: payload.content,
+        ),
       );
       return PeopleListPublishResult.submitted(eventId: sent.event.id);
     } on Object catch (error, stackTrace) {
@@ -353,20 +364,29 @@ class NotifySubscriptionsRepositoryImpl
         return null;
       }
 
-      var newest = const _NotifyListSnapshot(creators: {}, createdAt: 0);
+      Event? newestEvent;
+      List<String>? newestMembers;
       for (final event in result.events) {
         final members = Nip51PeopleListCodec.decodeReservedMembers(
           event,
           dTag: Nip51PeopleListCodec.notifyDTag,
         );
         if (members == null) continue;
-        if (event.createdAt < newest.createdAt) continue;
-        newest = _NotifyListSnapshot(
-          creators: members.toSet(),
-          createdAt: event.createdAt,
-        );
+        if (newestEvent != null && !_isNewerRevision(event, newestEvent)) {
+          continue;
+        }
+        newestEvent = event;
+        newestMembers = members;
       }
-      return newest;
+      if (newestEvent == null) {
+        return _NotifyListSnapshot(creators: const {}, createdAt: 0);
+      }
+      return _NotifyListSnapshot(
+        creators: newestMembers!.toSet(),
+        createdAt: newestEvent.createdAt,
+        sourceTags: newestEvent.tags,
+        sourceContent: newestEvent.content,
+      );
     } on Object catch (error) {
       Log.warning(
         'Failed to read notify list for owner ${pubkeyForLogs(ownerPubkey)}: '
@@ -405,15 +425,42 @@ class NotifySubscriptionsRepositoryImpl
 
   static bool _sameMembers(Set<String> a, Set<String> b) =>
       a.length == b.length && a.containsAll(b);
+
+  static bool _isNewerRevision(Event candidate, Event selected) {
+    final createdAtComparison = candidate.createdAt.compareTo(
+      selected.createdAt,
+    );
+    if (createdAtComparison != 0) return createdAtComparison > 0;
+    // Match the user-facing people-list reconciliation rule so relay result
+    // order cannot change which complete event becomes the next publish base.
+    return candidate.id.compareTo(selected.id) < 0;
+  }
 }
 
-/// Immutable view of the notify list plus the `created_at` it was read at.
+/// Immutable view of the notify list and its complete replacement source.
 ///
 /// The timestamp is kept so the next publish can step past it — see
-/// `_publishReplacement`.
+/// `_publishReplacement`. Null source fields mean no relay event exists yet,
+/// which is distinct from an existing event with no members or empty content.
 class _NotifyListSnapshot {
-  const _NotifyListSnapshot({required this.creators, required this.createdAt});
+  _NotifyListSnapshot({
+    required Set<String> creators,
+    required this.createdAt,
+    List<List<String>>? sourceTags,
+    this.sourceContent,
+  }) : assert(
+         (sourceTags == null) == (sourceContent == null),
+         'sourceTags and sourceContent must both be present or both be absent',
+       ),
+       creators = Set<String>.unmodifiable(creators),
+       sourceTags = sourceTags == null
+           ? null
+           : List<List<String>>.unmodifiable(
+               sourceTags.map(List<String>.unmodifiable),
+             );
 
   final Set<String> creators;
   final int createdAt;
+  final List<List<String>>? sourceTags;
+  final String? sourceContent;
 }

--- a/mobile/packages/people_lists_repository/test/nip51_people_list_codec_test.dart
+++ b/mobile/packages/people_lists_repository/test/nip51_people_list_codec_test.dart
@@ -166,6 +166,80 @@ void main() {
       });
     });
 
+    group('encodeReserved', () {
+      test('edits members over the complete source event', () {
+        final payload = Nip51PeopleListCodec.encodeReserved(
+          dTag: Nip51PeopleListCodec.notifyDTag,
+          title: 'Notify',
+          pubkeys: const [memberPubkeyA, memberPubkeyB],
+          sourceTags: const [
+            ['d', 'notify', 'extra-position'],
+            ['title', 'Renamed elsewhere'],
+            ['p', memberPubkeyA, 'wss://relay.example', 'friend'],
+            ['p', memberPubkeyA, 'wss://backup.example'],
+            ['alt', 'Notification subscriptions'],
+          ],
+          sourceContent: 'nip44-ciphertext-written-by-another-client',
+        );
+
+        expect(payload.tags, const [
+          ['d', 'notify', 'extra-position'],
+          ['title', 'Renamed elsewhere'],
+          ['p', memberPubkeyA, 'wss://relay.example', 'friend'],
+          ['p', memberPubkeyA, 'wss://backup.example'],
+          ['alt', 'Notification subscriptions'],
+          ['p', memberPubkeyB],
+        ]);
+        expect(payload.content, 'nip44-ciphertext-written-by-another-client');
+      });
+
+      test('removes every source tag for a removed member', () {
+        final payload = Nip51PeopleListCodec.encodeReserved(
+          dTag: Nip51PeopleListCodec.notifyDTag,
+          title: 'Notify',
+          pubkeys: const [memberPubkeyB],
+          sourceTags: const [
+            ['d', 'notify'],
+            ['p', memberPubkeyA, 'wss://relay.example'],
+            ['p', memberPubkeyA, 'wss://backup.example'],
+            ['p', memberPubkeyB, 'wss://relay.example'],
+          ],
+          sourceContent: '',
+        );
+
+        expect(payload.tags, const [
+          ['d', 'notify'],
+          ['p', memberPubkeyB, 'wss://relay.example'],
+        ]);
+      });
+
+      test('rejects partial or mismatched source data', () {
+        expect(
+          () => Nip51PeopleListCodec.encodeReserved(
+            dTag: Nip51PeopleListCodec.notifyDTag,
+            title: 'Notify',
+            pubkeys: const [],
+            sourceTags: const [
+              ['d', 'notify'],
+            ],
+          ),
+          throwsArgumentError,
+        );
+        expect(
+          () => Nip51PeopleListCodec.encodeReserved(
+            dTag: Nip51PeopleListCodec.notifyDTag,
+            title: 'Notify',
+            pubkeys: const [],
+            sourceTags: const [
+              ['d', 'block'],
+            ],
+            sourceContent: '',
+          ),
+          throwsArgumentError,
+        );
+      });
+    });
+
     group('decode', () {
       test('parses a kind 30000 event into a UserList', () {
         final event = Event(

--- a/mobile/packages/people_lists_repository/test/notify_subscriptions_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/notify_subscriptions_repository_impl_test.dart
@@ -762,22 +762,42 @@ void main() {
     });
 
     group('refresh', () {
-      test('selects the lowest event id when timestamps tie', () async {
-        final higherId = _notifyEvent([creatorA])
-          ..id =
-              'ffffffffffffffffffffffffffffffff'
-              'ffffffffffffffffffffffffffffffff';
-        final lowerId = _notifyEvent([creatorB])
-          ..id =
-              '00000000000000000000000000000000'
-              '00000000000000000000000000000000';
-        stubRead([higherId, lowerId]);
+      test(
+        'picks the same tied revision whichever order relays return',
+        () async {
+          final higherId = _notifyEvent([creatorA])
+            ..id =
+                'ffffffffffffffffffffffffffffffff'
+                'ffffffffffffffffffffffffffffffff';
+          final lowerId = _notifyEvent([creatorB])
+            ..id =
+                '00000000000000000000000000000000'
+                '00000000000000000000000000000000';
 
-        expect(
-          await repository.readSubscriptions(ownerPubkey: ownerPubkey),
-          equals({creatorB}),
-        );
-      });
+          // Both orders must agree, or the tie-break is still relay order in
+          // disguise: a "last one wins" rule also answers creatorB for the
+          // first order alone, so one ordering cannot tell the two apart.
+          stubRead([higherId, lowerId]);
+          final higherFirst = await repository.readSubscriptions(
+            ownerPubkey: ownerPubkey,
+          );
+
+          final reversedClient = _MockNostrClient();
+          when(() => reversedClient.queryEventsDetailed(any())).thenAnswer(
+            (_) async => _readResult([lowerId, higherId]),
+          );
+          final reversedRepository = NotifySubscriptionsRepositoryImpl(
+            nostrClient: reversedClient,
+          );
+          addTearDown(reversedRepository.dispose);
+          final lowerFirst = await reversedRepository.readSubscriptions(
+            ownerPubkey: ownerPubkey,
+          );
+
+          expect(higherFirst, equals({creatorB}));
+          expect(lowerFirst, equals(higherFirst));
+        },
+      );
 
       test('replaces a stale snapshot and emits the new set', () async {
         var events = [

--- a/mobile/packages/people_lists_repository/test/notify_subscriptions_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/notify_subscriptions_repository_impl_test.dart
@@ -259,6 +259,106 @@ void main() {
     });
 
     group('subscribe', () {
+      test(
+        'preserves source metadata, member positions, and content',
+        () async {
+          final source = Event(
+            ownerPubkey,
+            Nip51PeopleListCodec.kind,
+            const [
+              ['d', 'notify'],
+              ['title', 'Renamed elsewhere'],
+              ['p', creatorA, 'wss://relay.example', 'friend'],
+              ['alt', 'Notification subscriptions'],
+            ],
+            'nip44-ciphertext-written-by-another-client',
+            createdAt: 1710000000,
+          );
+          stubRead([source]);
+          stubPublishSuccess();
+
+          await repository.subscribe(
+            ownerPubkey: ownerPubkey,
+            creatorPubkey: creatorB,
+          );
+
+          final published =
+              verify(() => client.publishEvent(captureAny())).captured.single
+                  as Event;
+          expect(published.tags, const [
+            ['d', 'notify'],
+            ['title', 'Renamed elsewhere'],
+            ['p', creatorA, 'wss://relay.example', 'friend'],
+            ['alt', 'Notification subscriptions'],
+            ['p', creatorB],
+          ]);
+          expect(
+            published.content,
+            'nip44-ciphertext-written-by-another-client',
+          );
+        },
+      );
+
+      test(
+        'two sequential edits retain the complete published source',
+        () async {
+          final source = Event(
+            ownerPubkey,
+            Nip51PeopleListCodec.kind,
+            const [
+              ['d', 'notify'],
+              ['alt', 'Keep me'],
+              ['p', creatorA, 'wss://relay.example'],
+            ],
+            'ciphertext',
+            createdAt: 1710000000,
+          );
+          stubRead([source]);
+          stubPublishSuccess();
+
+          await repository.subscribe(
+            ownerPubkey: ownerPubkey,
+            creatorPubkey: creatorB,
+          );
+          await repository.subscribe(
+            ownerPubkey: ownerPubkey,
+            creatorPubkey: creatorC,
+          );
+
+          final published = verify(
+            () => client.publishEvent(captureAny()),
+          ).captured.cast<Event>();
+          expect(published.last.tags, const [
+            ['d', 'notify'],
+            ['alt', 'Keep me'],
+            ['p', creatorA, 'wss://relay.example'],
+            ['p', creatorB],
+            ['p', creatorC],
+          ]);
+          expect(published.last.content, 'ciphertext');
+        },
+      );
+
+      test('mints the canonical tags when no source event exists', () async {
+        stubRead(const []);
+        stubPublishSuccess();
+
+        await repository.subscribe(
+          ownerPubkey: ownerPubkey,
+          creatorPubkey: creatorA,
+        );
+
+        final published =
+            verify(() => client.publishEvent(captureAny())).captured.single
+                as Event;
+        expect(published.tags, const [
+          ['d', 'notify'],
+          ['title', 'Notify'],
+          ['p', creatorA],
+        ]);
+        expect(published.content, isEmpty);
+      });
+
       test('publishes the full list including the new creator', () async {
         stubRead([
           _notifyEvent([creatorA]),
@@ -342,6 +442,39 @@ void main() {
     });
 
     group('unsubscribe', () {
+      test('removes every matching tag while preserving the source', () async {
+        final source = Event(
+          ownerPubkey,
+          Nip51PeopleListCodec.kind,
+          const [
+            ['d', 'notify'],
+            ['p', creatorA, 'wss://relay.example'],
+            ['alt', 'Keep me'],
+            ['p', creatorA, 'wss://backup.example'],
+            ['p', creatorB, 'wss://relay.example', 'friend'],
+          ],
+          'ciphertext',
+          createdAt: 1710000000,
+        );
+        stubRead([source]);
+        stubPublishSuccess();
+
+        await repository.unsubscribe(
+          ownerPubkey: ownerPubkey,
+          creatorPubkey: creatorA,
+        );
+
+        final published =
+            verify(() => client.publishEvent(captureAny())).captured.single
+                as Event;
+        expect(published.tags, const [
+          ['d', 'notify'],
+          ['alt', 'Keep me'],
+          ['p', creatorB, 'wss://relay.example', 'friend'],
+        ]);
+        expect(published.content, 'ciphertext');
+      });
+
       test('publishes the list without the creator', () async {
         stubRead([
           _notifyEvent([creatorA, creatorB]),
@@ -629,6 +762,23 @@ void main() {
     });
 
     group('refresh', () {
+      test('selects the lowest event id when timestamps tie', () async {
+        final higherId = _notifyEvent([creatorA])
+          ..id =
+              'ffffffffffffffffffffffffffffffff'
+              'ffffffffffffffffffffffffffffffff';
+        final lowerId = _notifyEvent([creatorB])
+          ..id =
+              '00000000000000000000000000000000'
+              '00000000000000000000000000000000';
+        stubRead([higherId, lowerId]);
+
+        expect(
+          await repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          equals({creatorB}),
+        );
+      });
+
       test('replaces a stale snapshot and emits the new set', () async {
         var events = [
           _notifyEvent([creatorA]),


### PR DESCRIPTION
## Problem

Toggling a creator notification replaced the user’s complete Nostr notification list with only the fields Divine understands. That could silently delete metadata, relay hints, renamed titles, duplicate member tags, and encrypted private entries written by another client.

## Why this fix

The notification repository now retains the complete relay event alongside its derived member set. Bell changes edit membership over that source: untouched tags and surviving member tags keep their original positions, removed members lose every matching tag, new members receive a minimal member tag, and event content passes through unchanged.

The reserved-list encoder shares the same membership-edit implementation as ordinary people lists, avoiding a second copy of the preservation algorithm. Relay revisions with identical timestamps also use a deterministic event-ID tie-break, so relay result order cannot change which complete event becomes the next publish source.

## Deliberately unchanged

A user with no existing notification-list event still gets the same fresh list with the canonical title. Unreadable relay results continue to fail closed without publishing. No UI, public repository interface, or block-list retirement behavior changes.

## Verification

- flutter analyze lib test
- very_good test --coverage --min-coverage 95 — 114 tests passed
- repository pre-push analyzer and focused tests

Closes #8783