### PR TITLE
fix(moderation): page the NIP-32 labeler query instead of scanning all history

### DIFF
--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -79,6 +79,10 @@ enum _LabelerHistoryStop {
   /// A page went unanswered, or the walk ran out of its per-load budget.
   /// Whatever arrived is still applied and the labeler stays retryable.
   incomplete,
+
+  /// The service was disposed, or the labeler was unloaded, mid-walk.
+  /// Nothing the walk collected may be applied.
+  cancelled,
 }
 
 /// Service for subscribing to Kind 1985 label events from labeler pubkeys.
@@ -215,6 +219,26 @@ class ModerationLabelService {
   /// Set by [dispose]; stops an in-flight load from arming a new retry.
   bool _disposed = false;
 
+  /// Bumped whenever a labeler's rows are dropped because the labeler itself
+  /// is going away.
+  ///
+  /// Nothing cancels an awaited page, so an unfollow or a pubkey rotation part
+  /// way through a multi-page walk would otherwise be undone by that walk
+  /// reapplying its rows and latching the labeler once it finished. A walk
+  /// carries the generation it started with and abandons itself when it no
+  /// longer matches.
+  final Map<String, int> _labelerLoadGenerations = {};
+
+  int _labelerLoadGeneration(String pubkey) =>
+      _labelerLoadGenerations[pubkey] ?? 0;
+
+  void _invalidateLabelerLoad(String pubkey) =>
+      _labelerLoadGenerations[pubkey] = _labelerLoadGeneration(pubkey) + 1;
+
+  /// Whether a walk started at [generation] may still act on its result.
+  bool _isLabelerLoadCurrent(String pubkey, int generation) =>
+      !_disposed && _labelerLoadGeneration(pubkey) == generation;
+
   /// Active subscriptions.
   final Map<String, StreamSubscription<dynamic>> _subscriptions = {};
 
@@ -329,13 +353,25 @@ class ModerationLabelService {
       _LabelerHistoryStop stop,
     })
   >
-  _loadLabelerHistory(String pubkey) async {
+  _loadLabelerHistory(String pubkey, int generation) async {
     final collected = <Event>[];
     final seenIds = <String>{};
     int? until;
     var pages = 0;
 
     while (true) {
+      // dispose() and _unloadLabeler() cannot cancel a page already awaited,
+      // so re-check between pages rather than keep querying the shared client
+      // on behalf of a labeler nothing wants any more.
+      if (!_isLabelerLoadCurrent(pubkey, generation)) {
+        return (
+          events: collected,
+          timedOut: false,
+          noRelays: false,
+          stop: _LabelerHistoryStop.cancelled,
+        );
+      }
+
       // Defensive stop: the loop below always terminates for a relay that
       // reports the end of a labeler's history, so reaching this cap means the
       // relay never does (see [defaultMaxLabelerHistoryPages]). Stop, apply
@@ -461,7 +497,24 @@ class ModerationLabelService {
     }
 
     try {
-      final result = await _loadLabelerHistory(pubkey);
+      final generation = _labelerLoadGeneration(pubkey);
+      final result = await _loadLabelerHistory(pubkey, generation);
+
+      // The final page's await is its own window: dispose() or an unfollow can
+      // land after the walk's last check and before this one. Applying past
+      // that point would restore rows _unloadLabeler() just dropped, and
+      // latching would mark a labeler nobody subscribes to as loaded.
+      if (result.stop == _LabelerHistoryStop.cancelled ||
+          !_isLabelerLoadCurrent(pubkey, generation)) {
+        Log.debug(
+          'Discarding labeler load for ${pubkeyForLogs(pubkey)}: it was '
+          'unloaded or the service was disposed while loading',
+          name: 'ModerationLabelService',
+          category: LogCategory.system,
+        );
+        return;
+      }
+
       final events = result.events;
       final isIncomplete = result.stop == _LabelerHistoryStop.incomplete;
 
@@ -878,6 +931,9 @@ class ModerationLabelService {
   }
 
   Future<void> _unloadLabeler(String pubkey) async {
+    // Synchronously, before the first await: a walk in flight has to see this
+    // the moment the caller decides the labeler is going away.
+    _invalidateLabelerLoad(pubkey);
     await _subscriptions[pubkey]?.cancel();
     _subscriptions.remove(pubkey);
     _removePendingLabelerRetry(pubkey);
@@ -1045,6 +1101,7 @@ class ModerationLabelService {
 
     for (final pubkey in retired) {
       // Clean up any labels fetched from the old key
+      _invalidateLabelerLoad(pubkey);
       _removePendingLabelerRetry(pubkey);
       _removeLabelsForLabeler(pubkey);
       _loadedLabelers.remove(pubkey);

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -71,6 +71,16 @@ class AIDetectionResult {
   final bool isVerified;
 }
 
+/// Why a labeler-history walk stopped.
+enum _LabelerHistoryStop {
+  /// The relay reported the end of this labeler's history.
+  complete,
+
+  /// A page went unanswered, or the walk ran out of its per-load budget.
+  /// Whatever arrived is still applied and the labeler stays retryable.
+  incomplete,
+}
+
 /// Service for subscribing to Kind 1985 label events from labeler pubkeys.
 ///
 /// Maintains an in-memory cache of labels keyed by target (event ID or pubkey).
@@ -305,11 +315,20 @@ class ModerationLabelService {
 
   /// Fetch a labeler's full label history in bounded pages, newest first.
   ///
-  /// Returns the merged events plus the incompleteness of the *last* page: a
-  /// `timedOut` / `noRelays` page ends the walk and surfaces so the caller can
-  /// apply whatever arrived and schedule a retry, exactly as a single query
-  /// did before paging. See [defaultLabelerHistoryPageSize] for why we page.
-  Future<({List<Event> events, bool timedOut, bool noRelays})>
+  /// Returns the merged events plus why the walk stopped. Only
+  /// [_LabelerHistoryStop.complete] means the relay reported the end of the
+  /// history; every other stop leaves labels unfetched, so the caller applies
+  /// what arrived without latching the labeler as loaded. `timedOut` /
+  /// `noRelays` carry the *last* page's answer for the log line.
+  /// See [defaultLabelerHistoryPageSize] for why we page.
+  Future<
+    ({
+      List<Event> events,
+      bool timedOut,
+      bool noRelays,
+      _LabelerHistoryStop stop,
+    })
+  >
   _loadLabelerHistory(String pubkey) async {
     final collected = <Event>[];
     final seenIds = <String>{};
@@ -319,17 +338,23 @@ class ModerationLabelService {
     while (true) {
       // Defensive stop: the loop below always terminates for a relay that
       // reports the end of a labeler's history, so reaching this cap means the
-      // relay never does (see [defaultMaxLabelerHistoryPages]). Stop and apply
-      // what we have rather than query unboundedly.
+      // relay never does (see [defaultMaxLabelerHistoryPages]). Stop, apply
+      // what we have, and report incomplete — latching here would make the
+      // omitted history permanent for the rest of the session.
       if (pages++ >= _maxLabelerHistoryPages) {
         Log.warning(
           'Labeler history paging hit the $_maxLabelerHistoryPages-page cap '
           'for ${pubkeyForLogs(pubkey)}; applying ${collected.length} '
-          'event(s) and stopping',
+          'event(s) and leaving it unloaded so a later attempt retries',
           name: 'ModerationLabelService',
           category: LogCategory.system,
         );
-        break;
+        return (
+          events: collected,
+          timedOut: false,
+          noRelays: false,
+          stop: _LabelerHistoryStop.incomplete,
+        );
       }
 
       // queryEventsDetailed, not queryEvents: the latter discards `timedOut`
@@ -383,6 +408,7 @@ class ModerationLabelService {
           events: collected,
           timedOut: result.timedOut,
           noRelays: result.noRelays,
+          stop: _LabelerHistoryStop.incomplete,
         );
       }
       // A short page means the relay has no older labels — history is complete.
@@ -416,7 +442,12 @@ class ModerationLabelService {
       until = oldest;
     }
 
-    return (events: collected, timedOut: false, noRelays: false);
+    return (
+      events: collected,
+      timedOut: false,
+      noRelays: false,
+      stop: _LabelerHistoryStop.complete,
+    );
   }
 
   Future<void> _subscribeToLabelerInternal(String pubkey) async {
@@ -432,7 +463,7 @@ class ModerationLabelService {
     try {
       final result = await _loadLabelerHistory(pubkey);
       final events = result.events;
-      final isIncomplete = result.noRelays || result.timedOut;
+      final isIncomplete = result.stop == _LabelerHistoryStop.incomplete;
 
       // Apply whatever came back before deciding whether to latch.
       // `queryEventsDetailed` merges cached rows into `events` regardless of
@@ -454,10 +485,14 @@ class ModerationLabelService {
       }
 
       if (isIncomplete) {
+        // Neither relay flag is set when the walk stopped on its own budget
+        // rather than on an unanswered page; that stop logs its own warning.
+        final reason = result.noRelays || result.timedOut
+            ? 'noRelays: ${result.noRelays}, timedOut: ${result.timedOut}'
+            : 'walk budget exhausted, see the warning above';
         Log.warning(
           'Labeler load incomplete for ${pubkeyForLogs(pubkey)} '
-          '(noRelays: ${result.noRelays}, timedOut: ${result.timedOut}, '
-          'applied ${events.length} cached label event(s)); '
+          '($reason, applied ${events.length} label event(s)); '
           'leaving it unloaded so a later attempt retries',
           name: 'ModerationLabelService',
           category: LogCategory.system,

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -354,8 +354,13 @@ class ModerationLabelService {
       }
       // A short page means the relay has no older labels — history is complete.
       if (!morePossible) break;
-      // A full page that added nothing new can only be the boundary repeating;
-      // advancing `until` again would spin, so stop with what we have.
+      // A full page that added nothing new means the cursor cannot advance:
+      // either the relay ignored `until`, or the whole page shares one
+      // created_at that already fills a page (more labels at that second than a
+      // page holds). Advancing again would spin, so stop. The same-timestamp
+      // case degrades to the newest page for that second — deterministic and
+      // bounded — because standard NIP filters expose no sub-second cursor to
+      // page within it.
       if (newThisPage == 0) break;
 
       // `until` is inclusive, so the oldest event reappears on the next page and

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -100,8 +100,9 @@ class ModerationLabelService {
   /// query is a full scan that silently truncates past that cap and grows
   /// without limit. Bounding each round-trip and paging backward keeps every
   /// query small enough to settle inside the load timeout — a single query's
-  /// breadth is a contributing cause of #8214's timeouts — and makes
-  /// truncation impossible rather than silent. #8252.
+  /// breadth is a contributing cause of #8214's timeouts — and removes the
+  /// silent truncation, save for the un-pageable remainder of a single second
+  /// that alone holds more than a page of labels. #8252.
   static const int defaultLabelerHistoryPageSize = 500;
 
   final int _labelerHistoryPageSize;
@@ -354,23 +355,33 @@ class ModerationLabelService {
       }
       // A short page means the relay has no older labels — history is complete.
       if (!morePossible) break;
-      // A full page that added nothing new means the cursor cannot advance:
-      // either the relay ignored `until`, or the whole page shares one
-      // created_at that already fills a page (more labels at that second than a
-      // page holds). Advancing again would spin, so stop. The same-timestamp
-      // case degrades to the newest page for that second — deterministic and
-      // bounded — because standard NIP filters expose no sub-second cursor to
-      // page within it.
-      if (newThisPage == 0) break;
 
       // `until` is inclusive, so the oldest event reappears on the next page and
       // is dropped by `seenIds`. Paging past the boundary this way is lossless
-      // across created_at ties, where a `oldest - 1` cursor would skip events
-      // that share the boundary timestamp.
-      until = page.fold<int>(
+      // across created_at ties, where an `oldest - 1` cursor would skip events
+      // that share the boundary second.
+      final oldest = page.fold<int>(
         page.first.createdAt,
-        (oldest, event) => event.createdAt < oldest ? event.createdAt : oldest,
+        (lowest, event) => event.createdAt < lowest ? event.createdAt : lowest,
       );
+
+      if (newThisPage == 0) {
+        // Nothing new came back and the cursor is stuck. If the whole page sits
+        // on a single second equal to the cursor, that second alone holds a
+        // full page of labels — step one second past it to reach any older
+        // history, since a NIP filter has no sub-second cursor to page within
+        // it. Only the un-pageable remainder at that exact second (labels beyond
+        // a page sharing one created_at) is dropped. Any other empty result
+        // means the relay is ignoring `until` (the page carries events newer
+        // than the cursor), so stop rather than spin.
+        if (until != null && page.every((event) => event.createdAt == until)) {
+          until = until - 1;
+          continue;
+        }
+        break;
+      }
+
+      until = oldest;
     }
 
     return (events: collected, timedOut: false, noRelays: false);

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -507,6 +507,16 @@ class ModerationLabelService {
         // means the relay is ignoring `until` (the page carries events newer
         // than the cursor), so stop rather than spin.
         if (until != null && page.every((event) => event.createdAt == until)) {
+          // Losing labels is a moderation-safety event, so say so rather than
+          // let it be invisible in a bug report.
+          Log.warning(
+            'Labeler ${pubkeyForLogs(pubkey)} has a full page of labels at '
+            'created_at $until; a NIP filter has no sub-second cursor, so '
+            'paging past that second drops any label beyond the first '
+            '$_labelerHistoryPageSize sharing it',
+            name: 'ModerationLabelService',
+            category: LogCategory.system,
+          );
           until = until - 1;
           continue;
         }

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -97,12 +97,14 @@ class ModerationLabelService {
     bool Function()? canQueryRelays,
     int labelerHistoryPageSize = defaultLabelerHistoryPageSize,
     int maxLabelerHistoryPages = defaultMaxLabelerHistoryPages,
+    Duration labelerHistoryBudget = defaultLabelerHistoryBudget,
   }) : _nostrClient = nostrClient,
        _authService = authService,
        _prefs = sharedPreferences,
        _canQueryRelays = canQueryRelays ?? (() => true),
        _labelerHistoryPageSize = labelerHistoryPageSize,
-       _maxLabelerHistoryPages = maxLabelerHistoryPages;
+       _maxLabelerHistoryPages = maxLabelerHistoryPages,
+       _labelerHistoryBudget = labelerHistoryBudget;
 
   final NostrClient _nostrClient;
   // ignore: unused_field
@@ -130,12 +132,27 @@ class ModerationLabelService {
   /// stop against an untrusted relay that never signals the end — e.g. one that
   /// fabricates events at the requested `until` on every response, which would
   /// otherwise step the cursor backward forever. At the default page size this
-  /// still allows a very large history (500 * 500k events) before capping. If
-  /// it is ever hit for a real labeler, that is the signal to move to persisted
-  /// labels or per-target queries rather than a cold-start full scan. #8252.
+  /// still allows a very large history (1000 pages of 500 = 500k events) before
+  /// capping. If it is ever hit for a real labeler, that is the signal to move
+  /// to persisted labels or per-target queries rather than a cold-start full
+  /// scan. #8252.
   static const int defaultMaxLabelerHistoryPages = 1000;
 
   final int _maxLabelerHistoryPages;
+
+  /// Wall-clock ceiling on one labeler-history walk.
+  ///
+  /// The page cap bounds pages, not time. Each page carries
+  /// `queryEventsDetailed`'s own five-second timeout and the sync loops await
+  /// labelers one at a time, so against a connected-but-silent relay a
+  /// cap-length walk would hold the shared query path for over an hour while
+  /// every later labeler waits behind it. This stops the walk while the app is
+  /// still starting up; what arrived is applied and the labeler stays
+  /// retryable. It is the stop that fires first in practice — the page cap is
+  /// the backstop for a relay that answers quickly and endlessly. #8252.
+  static const Duration defaultLabelerHistoryBudget = Duration(seconds: 30);
+
+  final Duration _labelerHistoryBudget;
 
   /// SharedPreferences key for subscribed labeler pubkeys.
   static const String _subscribedLabelersKey = 'subscribed_labeler_pubkeys';
@@ -358,6 +375,7 @@ class ModerationLabelService {
     final seenIds = <String>{};
     int? until;
     var pages = 0;
+    final elapsed = Stopwatch()..start();
 
     while (true) {
       // dispose() and _unloadLabeler() cannot cancel a page already awaited,
@@ -369,6 +387,26 @@ class ModerationLabelService {
           timedOut: false,
           noRelays: false,
           stop: _LabelerHistoryStop.cancelled,
+        );
+      }
+
+      // Checked only once a page has been attempted, so the budget bounds how
+      // long the walk may keep the shared query path rather than whether it
+      // runs at all.
+      if (pages > 0 && elapsed.elapsed >= _labelerHistoryBudget) {
+        Log.warning(
+          'Labeler history paging spent its $_labelerHistoryBudget budget '
+          'after $pages page(s) for ${pubkeyForLogs(pubkey)}; applying '
+          '${collected.length} event(s) and leaving it unloaded so a later '
+          'attempt retries',
+          name: 'ModerationLabelService',
+          category: LogCategory.system,
+        );
+        return (
+          events: collected,
+          timedOut: false,
+          noRelays: false,
+          stop: _LabelerHistoryStop.incomplete,
         );
       }
 

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -82,11 +82,13 @@ class ModerationLabelService {
     required SharedPreferences sharedPreferences,
     bool Function()? canQueryRelays,
     int labelerHistoryPageSize = defaultLabelerHistoryPageSize,
+    int maxLabelerHistoryPages = defaultMaxLabelerHistoryPages,
   }) : _nostrClient = nostrClient,
        _authService = authService,
        _prefs = sharedPreferences,
        _canQueryRelays = canQueryRelays ?? (() => true),
-       _labelerHistoryPageSize = labelerHistoryPageSize;
+       _labelerHistoryPageSize = labelerHistoryPageSize,
+       _maxLabelerHistoryPages = maxLabelerHistoryPages;
 
   final NostrClient _nostrClient;
   // ignore: unused_field
@@ -106,6 +108,20 @@ class ModerationLabelService {
   static const int defaultLabelerHistoryPageSize = 500;
 
   final int _labelerHistoryPageSize;
+
+  /// Hard ceiling on labeler-history pages per load.
+  ///
+  /// A well-behaved relay always ends the walk with a short page or an
+  /// unadvanceable cursor, so this never fires in practice. It is a defensive
+  /// stop against an untrusted relay that never signals the end — e.g. one that
+  /// fabricates events at the requested `until` on every response, which would
+  /// otherwise step the cursor backward forever. At the default page size this
+  /// still allows a very large history (500 * 500k events) before capping. If
+  /// it is ever hit for a real labeler, that is the signal to move to persisted
+  /// labels or per-target queries rather than a cold-start full scan. #8252.
+  static const int defaultMaxLabelerHistoryPages = 1000;
+
+  final int _maxLabelerHistoryPages;
 
   /// SharedPreferences key for subscribed labeler pubkeys.
   static const String _subscribedLabelersKey = 'subscribed_labeler_pubkeys';
@@ -298,8 +314,24 @@ class ModerationLabelService {
     final collected = <Event>[];
     final seenIds = <String>{};
     int? until;
+    var pages = 0;
 
     while (true) {
+      // Defensive stop: the loop below always terminates for a relay that
+      // reports the end of a labeler's history, so reaching this cap means the
+      // relay never does (see [defaultMaxLabelerHistoryPages]). Stop and apply
+      // what we have rather than query unboundedly.
+      if (pages++ >= _maxLabelerHistoryPages) {
+        Log.warning(
+          'Labeler history paging hit the $_maxLabelerHistoryPages-page cap '
+          'for ${pubkeyForLogs(pubkey)}; applying ${collected.length} '
+          'event(s) and stopping',
+          name: 'ModerationLabelService',
+          category: LogCategory.system,
+        );
+        break;
+      }
+
       // queryEventsDetailed, not queryEvents: the latter discards `timedOut`
       // and `noRelays`, so a load nobody answered returns [] and is
       // indistinguishable from "this labeler has no labels" — the caller would

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -85,6 +85,8 @@ enum _LabelerHistoryStop {
   cancelled,
 }
 
+typedef _LabelerLoad = ({int generation, Future<void> future});
+
 /// Service for subscribing to Kind 1985 label events from labeler pubkeys.
 ///
 /// Maintains an in-memory cache of labels keyed by target (event ID or pubkey).
@@ -215,7 +217,7 @@ class ModerationLabelService {
   final Set<String> _loadedLabelers = {};
 
   /// Labelers currently being loaded from relays.
-  final Map<String, Future<void>> _loadingLabelers = {};
+  final Map<String, _LabelerLoad> _loadingLabelers = {};
 
   /// Labelers whose load was abandoned because no relay answered.
   ///
@@ -338,19 +340,31 @@ class ModerationLabelService {
 
   /// Subscribe to Kind 1985 events from a labeler pubkey.
   Future<void> subscribeToLabeler(String pubkey) async {
-    if (_loadedLabelers.contains(pubkey)) return;
-    final inFlight = _loadingLabelers[pubkey];
-    if (inFlight != null) {
-      await inFlight;
-      return;
-    }
+    while (!_loadedLabelers.contains(pubkey)) {
+      final generation = _labelerLoadGeneration(pubkey);
+      final inFlight = _loadingLabelers[pubkey];
+      if (inFlight != null) {
+        await inFlight.future;
+        final generationChanged =
+            inFlight.generation != _labelerLoadGeneration(pubkey);
+        final isStillWanted =
+            _subscribedLabelers.contains(pubkey) ||
+            _followedLabelers.contains(pubkey);
+        if (generationChanged && isStillWanted) continue;
+        return;
+      }
 
-    final future = _subscribeToLabelerInternal(pubkey);
-    _loadingLabelers[pubkey] = future;
-    try {
-      await future;
-    } finally {
-      _loadingLabelers.remove(pubkey);
+      final future = _subscribeToLabelerInternal(pubkey, generation);
+      final load = (generation: generation, future: future);
+      _loadingLabelers[pubkey] = load;
+      try {
+        await future;
+      } finally {
+        if (_loadingLabelers[pubkey] == load) {
+          _loadingLabelers.remove(pubkey);
+        }
+      }
+      return;
     }
   }
 
@@ -520,7 +534,20 @@ class ModerationLabelService {
           until = until - 1;
           continue;
         }
-        break;
+        Log.warning(
+          'Labeler history paging stopped because a relay ignored the until '
+          'cursor for ${pubkeyForLogs(pubkey)}; applying '
+          '${collected.length} event(s) and leaving it unloaded so a later '
+          'attempt retries',
+          name: 'ModerationLabelService',
+          category: LogCategory.system,
+        );
+        return (
+          events: collected,
+          timedOut: false,
+          noRelays: false,
+          stop: _LabelerHistoryStop.incomplete,
+        );
       }
 
       until = oldest;
@@ -534,7 +561,10 @@ class ModerationLabelService {
     );
   }
 
-  Future<void> _subscribeToLabelerInternal(String pubkey) async {
+  Future<void> _subscribeToLabelerInternal(
+    String pubkey,
+    int generation,
+  ) async {
     if (!_canQueryRelays()) {
       Log.debug(
         'Deferring labeler subscription until Nostr session is ready: ${pubkeyForLogs(pubkey)}',
@@ -545,7 +575,6 @@ class ModerationLabelService {
     }
 
     try {
-      final generation = _labelerLoadGeneration(pubkey);
       final result = await _loadLabelerHistory(pubkey, generation);
 
       // The final page's await is its own window: dispose() or an unfollow can
@@ -590,7 +619,8 @@ class ModerationLabelService {
         // rather than on an unanswered page; that stop logs its own warning.
         final reason = result.noRelays || result.timedOut
             ? 'noRelays: ${result.noRelays}, timedOut: ${result.timedOut}'
-            : 'walk budget exhausted, see the warning above';
+            : 'history walk stopped before the relay reported completion, '
+                  'see the warning above';
         Log.warning(
           'Labeler load incomplete for ${pubkeyForLogs(pubkey)} '
           '($reason, applied ${events.length} label event(s)); '

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
 import 'package:nostr_sdk/nip05/nip05_validor.dart';
 import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
@@ -80,16 +81,30 @@ class ModerationLabelService {
     required AuthService authService,
     required SharedPreferences sharedPreferences,
     bool Function()? canQueryRelays,
+    int labelerHistoryPageSize = defaultLabelerHistoryPageSize,
   }) : _nostrClient = nostrClient,
        _authService = authService,
        _prefs = sharedPreferences,
-       _canQueryRelays = canQueryRelays ?? (() => true);
+       _canQueryRelays = canQueryRelays ?? (() => true),
+       _labelerHistoryPageSize = labelerHistoryPageSize;
 
   final NostrClient _nostrClient;
   // ignore: unused_field
   final AuthService _authService;
   final SharedPreferences _prefs;
   final bool Function() _canQueryRelays;
+
+  /// Page size for the paged labeler-history query.
+  ///
+  /// The Divine relay advertises `max_limit: 5000`, so an unbounded labeler
+  /// query is a full scan that silently truncates past that cap and grows
+  /// without limit. Bounding each round-trip and paging backward keeps every
+  /// query small enough to settle inside the load timeout — a single query's
+  /// breadth is a contributing cause of #8214's timeouts — and makes
+  /// truncation impossible rather than silent. #8252.
+  static const int defaultLabelerHistoryPageSize = 500;
+
+  final int _labelerHistoryPageSize;
 
   /// SharedPreferences key for subscribed labeler pubkeys.
   static const String _subscribedLabelersKey = 'subscribed_labeler_pubkeys';
@@ -271,6 +286,91 @@ class ModerationLabelService {
     }
   }
 
+  /// Fetch a labeler's full label history in bounded pages, newest first.
+  ///
+  /// Returns the merged events plus the incompleteness of the *last* page: a
+  /// `timedOut` / `noRelays` page ends the walk and surfaces so the caller can
+  /// apply whatever arrived and schedule a retry, exactly as a single query
+  /// did before paging. See [defaultLabelerHistoryPageSize] for why we page.
+  Future<({List<Event> events, bool timedOut, bool noRelays})>
+  _loadLabelerHistory(String pubkey) async {
+    final collected = <Event>[];
+    final seenIds = <String>{};
+    int? until;
+
+    while (true) {
+      // queryEventsDetailed, not queryEvents: the latter discards `timedOut`
+      // and `noRelays`, so a load nobody answered returns [] and is
+      // indistinguishable from "this labeler has no labels" — the caller would
+      // latch the labeler as loaded having contributed none.
+      // `requireAllRelaysSettled` is what makes a relay's `CLOSED` refusal and
+      // a partial fan-out surface as `timedOut` rather than completing on
+      // whichever relays answered first. Cache stays on: cached labels are
+      // still worth applying, and the fix is about not latching. #8214.
+      final result = await _nostrClient.queryEventsDetailed(
+        [
+          Filter(
+            authors: [pubkey],
+            kinds: [NostrEventKinds.label], // NIP-32 label events
+            limit: _labelerHistoryPageSize,
+            until: until,
+          ),
+        ],
+        requireAllRelaysSettled: true,
+      );
+
+      final page = result.events;
+      final incomplete = result.noRelays || result.timedOut;
+      // An incomplete page cannot promise there is more history; treat it as
+      // terminal (below) rather than a full page to page past.
+      final morePossible =
+          !incomplete && page.length >= _labelerHistoryPageSize;
+
+      // Collect this page's events — even an incomplete one, whose events carry
+      // cached rows still worth applying (matching the pre-paging behaviour of
+      // applying `result.events` regardless of `timedOut` / `noRelays`). The
+      // single-page common case never inspects event ids: dedup only matters
+      // once a second page can re-return the inclusive `until` boundary event.
+      var newThisPage = 0;
+      for (final event in page) {
+        if (seenIds.isEmpty && !morePossible) {
+          collected.add(event);
+          continue;
+        }
+        if (seenIds.add(event.id)) {
+          collected.add(event);
+          newThisPage++;
+        }
+      }
+
+      // A page nobody fully answered ends the walk. Hand back what we have so
+      // the caller applies it (cached rows are still worth showing) and retries.
+      if (incomplete) {
+        return (
+          events: collected,
+          timedOut: result.timedOut,
+          noRelays: result.noRelays,
+        );
+      }
+      // A short page means the relay has no older labels — history is complete.
+      if (!morePossible) break;
+      // A full page that added nothing new can only be the boundary repeating;
+      // advancing `until` again would spin, so stop with what we have.
+      if (newThisPage == 0) break;
+
+      // `until` is inclusive, so the oldest event reappears on the next page and
+      // is dropped by `seenIds`. Paging past the boundary this way is lossless
+      // across created_at ties, where a `oldest - 1` cursor would skip events
+      // that share the boundary timestamp.
+      until = page.fold<int>(
+        page.first.createdAt,
+        (oldest, event) => event.createdAt < oldest ? event.createdAt : oldest,
+      );
+    }
+
+    return (events: collected, timedOut: false, noRelays: false);
+  }
+
   Future<void> _subscribeToLabelerInternal(String pubkey) async {
     if (!_canQueryRelays()) {
       Log.debug(
@@ -282,24 +382,7 @@ class ModerationLabelService {
     }
 
     try {
-      final filter = Filter(
-        authors: [pubkey],
-        kinds: [NostrEventKinds.label], // NIP-32 label events
-      );
-
-      // queryEventsDetailed, not queryEvents: the latter discards `timedOut`
-      // and `noRelays`, so a load nobody answered returns [] and is
-      // indistinguishable from "this labeler has no labels" — the forEach
-      // no-ops and the labeler is latched as loaded having contributed none.
-      // `requireAllRelaysSettled` is what makes a relay's `CLOSED` refusal and
-      // a partial fan-out surface as `timedOut` rather than completing on
-      // whichever relays answered first. Cache stays on, unlike #8213's scan:
-      // cached labels are still worth applying, and the fix is about not
-      // latching. #8214.
-      final result = await _nostrClient.queryEventsDetailed(
-        [filter],
-        requireAllRelaysSettled: true,
-      );
+      final result = await _loadLabelerHistory(pubkey);
       final events = result.events;
       final isIncomplete = result.noRelays || result.timedOut;
 

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -1821,6 +1821,62 @@ void main() {
       );
 
       test(
+        'a walk that spends its time budget stops paging and stays retryable',
+        () async {
+          final paged = ModerationLabelService(
+            nostrClient: mockNostrClient,
+            authService: mockAuthService,
+            sharedPreferences: mockPrefs,
+            canQueryRelays: () => true,
+            labelerHistoryPageSize: 2,
+            // The page cap stays at its default, far beyond what this walk
+            // reaches: the budget, not the cap, has to stop a relay that
+            // answers endlessly.
+            labelerHistoryBudget: Duration.zero,
+          );
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((invocation) async {
+            final until = (invocation.positionalArguments.first as List<Filter>)
+                .single
+                .until;
+            final ts = until ?? 100;
+            return (
+              events: <Event>[
+                labelEvent('dup_1', ts, 'target_dup_1'),
+                labelEvent('dup_2', ts, 'target_dup_2'),
+              ],
+              timedOut: false,
+              noRelays: false,
+            );
+          });
+
+          await paged.subscribeToLabeler(labeler);
+          // One page, then the budget stops it — and the first page's labels
+          // are applied rather than discarded.
+          verify(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).called(1);
+          expect(paged.getContentWarnings('target_dup_1'), hasLength(1));
+
+          // Not latched: an incomplete walk must stay retryable.
+          await paged.subscribeToLabeler(labeler);
+          verify(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
         'a labeler unfollowed mid-walk does not get its labels reapplied',
         () async {
           final paged = pagedService(2);

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -1819,6 +1819,53 @@ void main() {
           expect(paged.getContentWarnings('target_dup_2'), hasLength(1));
         },
       );
+
+      test(
+        'a walk stopped by the page cap stays retryable rather than latching '
+        'the omitted history',
+        () async {
+          final paged = ModerationLabelService(
+            nostrClient: mockNostrClient,
+            authService: mockAuthService,
+            sharedPreferences: mockPrefs,
+            canQueryRelays: () => true,
+            labelerHistoryPageSize: 2,
+            maxLabelerHistoryPages: 2,
+          );
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((invocation) async {
+            final until = (invocation.positionalArguments.first as List<Filter>)
+                .single
+                .until;
+            final ts = until ?? 100;
+            return (
+              events: <Event>[
+                labelEvent('dup_1', ts, 'target_dup_1'),
+                labelEvent('dup_2', ts, 'target_dup_2'),
+              ],
+              timedOut: false,
+              noRelays: false,
+            );
+          });
+
+          await paged.subscribeToLabeler(labeler);
+          await paged.subscribeToLabeler(labeler);
+
+          // 2 pages per walk. Latching the labeler after the cap fired would
+          // short-circuit the second call and leave the omitted history gone
+          // for the rest of the session.
+          verify(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).called(4);
+        },
+      );
     });
   });
 }

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -1723,6 +1723,54 @@ void main() {
           ).called(4);
         },
       );
+
+      test(
+        'pages past a second that fills a whole page so older history still '
+        'loads',
+        () async {
+          final paged = pagedService(2);
+          // Second 90 holds a full page (b, c) with older history (d@80)
+          // behind it. A relay that honours `until` + `limit` newest-first
+          // must not let that dense second wall off the older label.
+          final history = <_FakeLabelEvent>[
+            labelEvent('id_a', 100, 'target_a'),
+            labelEvent('id_b', 90, 'target_b'),
+            labelEvent('id_c', 90, 'target_c'),
+            labelEvent('id_d', 80, 'target_d'),
+          ];
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((invocation) async {
+            final until = (invocation.positionalArguments.first as List<Filter>)
+                .single
+                .until;
+            final matching =
+                history
+                    .where((e) => until == null || e.createdAt <= until)
+                    .toList()
+                  ..sort((x, y) => y.createdAt.compareTo(x.createdAt));
+            return (
+              events: matching.take(2).toList(),
+              timedOut: false,
+              noRelays: false,
+            );
+          });
+
+          await paged.subscribeToLabeler(labeler);
+
+          expect(paged.getContentWarnings('target_a'), hasLength(1));
+          expect(paged.getContentWarnings('target_b'), hasLength(1));
+          expect(paged.getContentWarnings('target_c'), hasLength(1));
+          expect(
+            paged.getContentWarnings('target_d'),
+            hasLength(1),
+            reason: 'a full page at one second must not wall off older history',
+          );
+        },
+      );
     });
   });
 }

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -986,6 +986,55 @@ void main() {
         expect(service.getContentWarnings('coalesced_event'), hasLength(1));
       });
 
+      test('refollow during a cancelled load starts a fresh load', () async {
+        const labeler =
+            'abababababababababababababababababababababababababababababababab';
+        final firstPage =
+            Completer<({List<Event> events, bool timedOut, bool noRelays})>();
+        var queryCount = 0;
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer((_) {
+          queryCount++;
+          if (queryCount == 1) return firstPage.future;
+          return Future.value((
+            events: <Event>[
+              _FakeLabelEvent(
+                pubkey: labeler,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['l', 'nudity', 'content-warning'],
+                  ['e', 'refollowed_event'],
+                ],
+              ),
+            ],
+            timedOut: false,
+            noRelays: false,
+          ));
+        });
+
+        final initialFollow = service.setFollowingModerationEnabled(
+          true,
+          followedPubkeys: [labeler],
+        );
+        await pumpEventQueue();
+
+        await service.syncFollowedLabelers(const []);
+        final refollow = service.syncFollowedLabelers([labeler]);
+        firstPage.complete((
+          events: <Event>[],
+          timedOut: false,
+          noRelays: false,
+        ));
+        await Future.wait([initialFollow, refollow]);
+
+        expect(queryCount, 2, reason: 'the refollow needs a new generation');
+        expect(service.getContentWarnings('refollowed_event'), hasLength(1));
+      });
+
       test('disabling followed labelers removes their cached labels', () async {
         const followedLabeler =
             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
@@ -1673,12 +1722,16 @@ void main() {
 
           expect(paged.getContentWarnings('target_a'), hasLength(1));
           expect(paged.getContentWarnings('target_b'), hasLength(1));
+
+          // The relay, not the protocol, stopped this walk by ignoring until.
+          // It must remain retryable instead of latching truncated history.
+          await paged.subscribeToLabeler(labeler);
           verify(
             () => mockNostrClient.queryEventsDetailed(
               any(),
               requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
-          ).called(2);
+          ).called(4);
         },
       );
 

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -1771,6 +1771,54 @@ void main() {
           );
         },
       );
+
+      test(
+        'stops at the page cap against a relay that never signals the end',
+        () async {
+          final paged = ModerationLabelService(
+            nostrClient: mockNostrClient,
+            authService: mockAuthService,
+            sharedPreferences: mockPrefs,
+            canQueryRelays: () => true,
+            labelerHistoryPageSize: 2,
+            maxLabelerHistoryPages: 3,
+          );
+          // A hostile relay fabricates a full page at exactly the requested
+          // `until` on every response, so the cursor steps backward forever.
+          // Without the cap this never terminates.
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((invocation) async {
+            final until = (invocation.positionalArguments.first as List<Filter>)
+                .single
+                .until;
+            final ts = until ?? 100;
+            return (
+              events: <Event>[
+                labelEvent('dup_1', ts, 'target_dup_1'),
+                labelEvent('dup_2', ts, 'target_dup_2'),
+              ],
+              timedOut: false,
+              noRelays: false,
+            );
+          });
+
+          await paged.subscribeToLabeler(labeler);
+
+          // Terminated at the cap rather than hanging, and applied what it had.
+          verify(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).called(3);
+          expect(paged.getContentWarnings('target_dup_1'), hasLength(1));
+          expect(paged.getContentWarnings('target_dup_2'), hasLength(1));
+        },
+      );
     });
   });
 }

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -1821,6 +1821,93 @@ void main() {
       );
 
       test(
+        'a labeler unfollowed mid-walk does not get its labels reapplied',
+        () async {
+          final paged = pagedService(2);
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((invocation) async {
+            final until = (invocation.positionalArguments.first as List<Filter>)
+                .single
+                .until;
+            if (until == null) {
+              return (
+                events: <Event>[
+                  labelEvent('id_a', 100, 'target_a'),
+                  labelEvent('id_b', 90, 'target_b'),
+                ],
+                timedOut: false,
+                noRelays: false,
+              );
+            }
+            // The user unfollows the labeler while the walk is mid-flight.
+            await paged.removeLabeler(labeler);
+            return (
+              events: <Event>[labelEvent('id_b', 90, 'target_b')],
+              timedOut: false,
+              noRelays: false,
+            );
+          });
+
+          await paged.subscribeToLabeler(labeler);
+
+          expect(
+            paged.getContentWarnings('target_a'),
+            isEmpty,
+            reason: 'the walk must not restore rows the unload just dropped',
+          );
+          expect(paged.getContentWarnings('target_b'), isEmpty);
+        },
+      );
+
+      test(
+        'a disposed service stops walking instead of querying for more pages',
+        () async {
+          late final ModerationLabelService paged;
+          paged = ModerationLabelService(
+            nostrClient: mockNostrClient,
+            authService: mockAuthService,
+            sharedPreferences: mockPrefs,
+            canQueryRelays: () => true,
+            labelerHistoryPageSize: 2,
+            maxLabelerHistoryPages: 5,
+          );
+          var queries = 0;
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((invocation) async {
+            queries++;
+            final until = (invocation.positionalArguments.first as List<Filter>)
+                .single
+                .until;
+            final ts = until ?? 100;
+            // A relay that keeps handing back a full page would walk to the
+            // cap; dispose() during the second page must stop it sooner.
+            if (queries == 2) paged.dispose();
+            return (
+              events: <Event>[
+                labelEvent('dup_1', ts, 'target_dup_1'),
+                labelEvent('dup_2', ts, 'target_dup_2'),
+              ],
+              timedOut: false,
+              noRelays: false,
+            );
+          });
+
+          await paged.subscribeToLabeler(labeler);
+
+          expect(queries, 2, reason: 'the walk must stop at the next check');
+          expect(paged.getContentWarnings('target_dup_1'), isEmpty);
+        },
+      );
+
+      test(
         'a walk stopped by the page cap stays retryable rather than latching '
         'the omitted history',
         () async {

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -11,6 +11,7 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
 import 'package:nostr_sdk/nip05/nip05_validor.dart';
+import 'package:openvine/constants/nostr_event_kinds.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -48,8 +49,23 @@ class _FakeNip05Adapter implements HttpClientAdapter {
 }
 
 /// Fake event for testing label processing.
+///
+/// [id] and [createdAt] default to empty/zero because the single-page tests
+/// never read them; the paging tests (#8252) pass explicit values because the
+/// backward-`until` walk dedups on `id` and cursors on `createdAt`.
 class _FakeLabelEvent extends Fake implements Event {
-  _FakeLabelEvent({required this.pubkey, required this.tags});
+  _FakeLabelEvent({
+    required this.pubkey,
+    required this.tags,
+    this.id = '',
+    this.createdAt = 0,
+  });
+
+  @override
+  final String id;
+
+  @override
+  final int createdAt;
 
   @override
   final String pubkey;
@@ -1516,6 +1532,197 @@ void main() {
           reason: 'an inconclusive empty read must not erase known warnings',
         );
       });
+    });
+
+    group('labeler history paging (#8252)', () {
+      const labeler =
+          'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+      _FakeLabelEvent labelEvent(
+        String id,
+        int createdAt,
+        String targetEventId,
+      ) => _FakeLabelEvent(
+        pubkey: labeler,
+        id: id,
+        createdAt: createdAt,
+        tags: [
+          ['L', 'content-warning'],
+          ['l', 'nudity', 'content-warning'],
+          ['e', targetEventId],
+        ],
+      );
+
+      ModerationLabelService pagedService(int pageSize) =>
+          ModerationLabelService(
+            nostrClient: mockNostrClient,
+            authService: mockAuthService,
+            sharedPreferences: mockPrefs,
+            canQueryRelays: () => true,
+            labelerHistoryPageSize: pageSize,
+          );
+
+      test(
+        'the first-page query carries an explicit limit and no until',
+        () async {
+          final capturedFilters = <List<Filter>>[];
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((invocation) async {
+            capturedFilters.add(
+              invocation.positionalArguments.first as List<Filter>,
+            );
+            return (events: <Event>[], timedOut: false, noRelays: false);
+          });
+
+          await service.subscribeToLabeler(labeler);
+
+          final filter = capturedFilters.single.single;
+          expect(
+            filter.limit,
+            ModerationLabelService.defaultLabelerHistoryPageSize,
+          );
+          expect(filter.until, isNull);
+          expect(filter.authors, [labeler]);
+          expect(filter.kinds, [NostrEventKinds.label]);
+        },
+      );
+
+      test(
+        'pages backward until a short page, applying every label once across '
+        'the inclusive boundary',
+        () async {
+          final paged = pagedService(2);
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((invocation) async {
+            final until = (invocation.positionalArguments.first as List<Filter>)
+                .single
+                .until;
+            if (until == null) {
+              return (
+                events: <Event>[
+                  labelEvent('id_a', 100, 'target_a'),
+                  labelEvent('id_b', 90, 'target_b'),
+                ],
+                timedOut: false,
+                noRelays: false,
+              );
+            }
+            if (until == 90) {
+              return (
+                events: <Event>[
+                  labelEvent('id_b', 90, 'target_b'), // inclusive boundary
+                  labelEvent('id_c', 80, 'target_c'),
+                ],
+                timedOut: false,
+                noRelays: false,
+              );
+            }
+            // until == 80: only the boundary repeats -> short page ends paging.
+            return (
+              events: <Event>[labelEvent('id_c', 80, 'target_c')],
+              timedOut: false,
+              noRelays: false,
+            );
+          });
+
+          await paged.subscribeToLabeler(labeler);
+
+          expect(paged.getContentWarnings('target_a'), hasLength(1));
+          expect(paged.getContentWarnings('target_b'), hasLength(1));
+          expect(paged.getContentWarnings('target_c'), hasLength(1));
+          verify(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).called(3);
+        },
+      );
+
+      test(
+        'stops when a full page is entirely duplicates so it cannot spin',
+        () async {
+          final paged = pagedService(2);
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((invocation) async {
+            // A misbehaving relay ignores `until` and returns the same full
+            // page every time; the cursor cannot advance, so paging must stop.
+            return (
+              events: <Event>[
+                labelEvent('id_a', 100, 'target_a'),
+                labelEvent('id_b', 90, 'target_b'),
+              ],
+              timedOut: false,
+              noRelays: false,
+            );
+          });
+
+          await paged.subscribeToLabeler(labeler);
+
+          expect(paged.getContentWarnings('target_a'), hasLength(1));
+          expect(paged.getContentWarnings('target_b'), hasLength(1));
+          verify(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).called(2);
+        },
+      );
+
+      test(
+        'a timed-out later page applies the collected labels but does not latch',
+        () async {
+          final paged = pagedService(2);
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((invocation) async {
+            final until = (invocation.positionalArguments.first as List<Filter>)
+                .single
+                .until;
+            if (until == null) {
+              return (
+                events: <Event>[
+                  labelEvent('id_a', 100, 'target_a'),
+                  labelEvent('id_b', 90, 'target_b'),
+                ],
+                timedOut: false,
+                noRelays: false,
+              );
+            }
+            // The second page never settles.
+            return (events: <Event>[], timedOut: true, noRelays: false);
+          });
+
+          await paged.subscribeToLabeler(labeler);
+          expect(paged.getContentWarnings('target_a'), hasLength(1));
+          expect(paged.getContentWarnings('target_b'), hasLength(1));
+
+          // Not latched: a later call re-walks rather than short-circuiting.
+          await paged.subscribeToLabeler(labeler);
+          verify(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).called(4);
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
Refs #8252 — this bounds the query and makes its truncation explicit, but a cold
start still refetches the whole history, which is what that issue is titled for.
It stays open for the persisted-resume / per-target work described under "Why
this scope" below.

## What

The labeler query asked for a labeler's entire published history on every cold start: no `limit`, no `since`. Against the Divine relay's `max_limit: 5000` that means a large labeler returns a silently truncated, non-deterministic subset, and the breadth of the one-shot query is a contributing cause of the load timeouts tracked in #8214.

This pages the history in bounded requests instead: a `limit` on each round-trip, walking backward with an inclusive `until` cursor until a short page. The inclusive boundary event is deduped by id, so paging is lossless across `created_at` ties (an exclusive `until - 1` cursor would drop events sharing the boundary second).

Termination is guarded on all sides:
- If a full page adds nothing new **and** its events all sit on the cursor second, that second alone holds a page of labels; the cursor steps one second past it so older history still loads (a NIP filter has no sub-second cursor). Only the un-pageable remainder of labels sharing that exact second is dropped.
- If a full page adds nothing new but carries events newer than the cursor, the relay is ignoring `until`; the walk stops rather than spin.
- A hard per-load page cap (default 1000) stops an untrusted relay that never signals the end (e.g. one fabricating events at the requested `until` on every response). It never fires for a well-behaved relay.

The #8214 incomplete-load semantics are preserved unchanged: an incomplete page ends the walk, its cached rows are still applied, the labeler is not latched, and it retries when a relay reconnects.

## Why this scope

Labels aren't persisted across launches (in-memory maps only, rebuilt each cold start), so a `since` watermark alone would skip all historical labels on a cold start — a moderation-safety regression. Fully eliminating the cold-start refetch (persist labels + `since`, or narrow per on-screen target like the web client) is a larger follow-up worth its own issue. This change bounds and completes the query without touching the global-preload consumption model.

## Tests

New `labeler history paging (#8252)` group. Paging correctness: the first-page filter carries an explicit `limit` and no `until`; backward paging accumulates every label exactly once across the inclusive boundary; a page-filling `created_at` second does not wall off older history; a relay that ignores `until` terminates without spinning. Termination and lifecycle: the page cap stops a relay that never signals the end and the labeler stays retryable rather than latching; a walk that spends its time budget stops paging and stays retryable; a labeler unfollowed mid-walk does not get its rows reapplied; a disposed service stops walking instead of querying further; a timed-out later page applies collected labels and does not latch. Mutation-checked: removing the `limit`, disabling the cursor, and reverting the dense-second step each turn a test red; forcing the cap to report complete, defeating the generation guard, and disabling the time budget each turn their regression test red. Full `moderation_label_service_test.dart` suite green (53 tests), analyze clean.

