### PR TITLE
test(editor): stop clip proof work racing test teardown

### DIFF
--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -13,6 +13,7 @@ import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/providers/database_provider.dart';
+import 'package:openvine/providers/editor_background_work.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
@@ -40,6 +41,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
   final _recordStopwatch = Stopwatch();
   final List<DivineVideoClip> _clips = [];
   Timer? _pendingDeletionTimer;
+  late final EditorBackgroundWork _backgroundWork;
 
   /// Undo window before a scheduled deletion is committed to library
   /// trash for good. The snackbar must outlast this so the user can
@@ -67,6 +69,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
 
   @override
   ClipManagerState build() {
+    _backgroundWork = ref.read(editorBackgroundWorkProvider);
     ref.onDispose(() {
       _recordingDurationTimer?.cancel();
       _pendingDeletionTimer?.cancel();
@@ -260,7 +263,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
 
     // Fire-and-forget: generate proof attestation without blocking the UI.
     // This runs after trimming (if any) completes via the processingCompleter.
-    unawaited(_generateClipProof(clip));
+    _backgroundWork.track(_generateClipProof(clip));
 
     return clip;
   }

--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -42,10 +42,22 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
   final List<DivineVideoClip> _clips = [];
   Timer? _pendingDeletionTimer;
 
-  /// Not `late final`: Riverpod reuses this notifier instance when the
-  /// provider is invalidated and calls [build] again, and a second
-  /// assignment to a `late final` field throws `LateInitializationError`.
-  late EditorBackgroundWork _backgroundWork;
+  /// Nullable rather than `late`, which would throw a
+  /// `LateInitializationError` in two ways. Riverpod reuses this notifier
+  /// instance when the provider is invalidated and calls [build] again, so the
+  /// field is assigned twice — which rules out `late final`. And a test
+  /// subclass that replaces [build] without calling `super.build()` never
+  /// assigns it at all, which rules out bare `late`; that stub shape is
+  /// already in the suite, so [_editorBackgroundWork] resolves lazily too.
+  EditorBackgroundWork? _backgroundWork;
+
+  EditorBackgroundWork get _editorBackgroundWork {
+    final existing = _backgroundWork;
+    if (existing != null) return existing;
+    final backgroundWork = ref.read(editorBackgroundWorkProvider);
+    _backgroundWork = backgroundWork;
+    return backgroundWork;
+  }
 
   /// Undo window before a scheduled deletion is committed to library
   /// trash for good. The snackbar must outlast this so the user can
@@ -267,7 +279,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
 
     // Fire-and-forget: generate proof attestation without blocking the UI.
     // This runs after trimming (if any) completes via the processingCompleter.
-    _backgroundWork.track(_generateClipProof(clip));
+    _editorBackgroundWork.track(_generateClipProof(clip));
 
     return clip;
   }

--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -41,7 +41,11 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
   final _recordStopwatch = Stopwatch();
   final List<DivineVideoClip> _clips = [];
   Timer? _pendingDeletionTimer;
-  late final EditorBackgroundWork _backgroundWork;
+
+  /// Not `late final`: Riverpod reuses this notifier instance when the
+  /// provider is invalidated and calls [build] again, and a second
+  /// assignment to a `late final` field throws `LateInitializationError`.
+  late EditorBackgroundWork _backgroundWork;
 
   /// Undo window before a scheduled deletion is committed to library
   /// trash for good. The snackbar must outlast this so the user can

--- a/mobile/lib/providers/editor_background_work.dart
+++ b/mobile/lib/providers/editor_background_work.dart
@@ -27,8 +27,18 @@ class EditorBackgroundWork {
   /// Completes once all registered work, including work it starts, is done.
   @visibleForTesting
   Future<void> settle() async {
+    Object? firstError;
+    StackTrace? firstStackTrace;
     while (_operations.isNotEmpty) {
-      await Future.wait(_operations.toList());
+      try {
+        await Future.wait(_operations.toList());
+      } catch (error, stackTrace) {
+        firstError ??= error;
+        firstStackTrace ??= stackTrace;
+      }
+    }
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError, firstStackTrace!);
     }
   }
 

--- a/mobile/lib/providers/editor_background_work.dart
+++ b/mobile/lib/providers/editor_background_work.dart
@@ -1,0 +1,38 @@
+// ABOUTME: Tracks fire-and-forget editor work that must settle before test teardown
+// ABOUTME: Provides a fixed-point completion boundary shared by editor notifiers
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final editorBackgroundWorkProvider = Provider<EditorBackgroundWork>(
+  (ref) => EditorBackgroundWork(),
+);
+
+/// Tracks editor operations that remain fire-and-forget in production.
+class EditorBackgroundWork {
+  final Set<Future<void>> _operations = {};
+
+  /// Registers [operation] until it completes.
+  void track(Future<void> operation) {
+    late final Future<void> trackedOperation;
+    trackedOperation = operation.whenComplete(
+      () => _operations.remove(trackedOperation),
+    );
+    _operations.add(trackedOperation);
+    unawaited(trackedOperation);
+  }
+
+  /// Completes once all registered work, including work it starts, is done.
+  @visibleForTesting
+  Future<void> settle() async {
+    while (_operations.isNotEmpty) {
+      await Future.wait(_operations.toList());
+    }
+  }
+
+  /// Whether teardown currently has background work to await.
+  @visibleForTesting
+  bool get isNotEmptyForTest => _operations.isNotEmpty;
+}

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -29,6 +29,7 @@ import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/crash_reporting_provider.dart';
 import 'package:openvine/providers/database_provider.dart';
+import 'package:openvine/providers/editor_background_work.dart';
 import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/providers/service_providers.dart';
@@ -133,11 +134,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// run from `onDispose` without reading providers after disposal.
   DraftsDao? _deferredCleanupDraftsDao;
   ClipsDao? _deferredCleanupClipsDao;
-
-  /// In-flight [_startDeferredFileCleanup] operations, held only so
-  /// [pendingDeferredCleanupForTest] can await them. Production never reads
-  /// this back; the cleanup calls stay fire-and-forget.
-  final Set<Future<void>> _pendingDeferredCleanup = {};
+  late final EditorBackgroundWork _backgroundWork;
 
   /// Autosaves currently writing deferred orphan paths.
   ///
@@ -174,6 +171,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
 
   @override
   VideoEditorProviderState build() {
+    _backgroundWork = ref.read(editorBackgroundWorkProvider);
     ref.onDispose(() {
       _autosaveTimer?.cancel();
       // Safety net for files [reset] didn't already reap (e.g. a crash before
@@ -215,7 +213,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
 
     // Delete the old rendered file from disk to free up space
     final db = ref.read(databaseProvider);
-    unawaited(
+    _backgroundWork.track(
       FileCleanupService.deleteRecordingClipFiles(
         clip,
         draftsDao: db.draftsDao,
@@ -860,7 +858,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// genuinely-orphaned files are removed.
   ///
   /// Reach it through [_startDeferredFileCleanup] rather than calling it
-  /// directly: a direct call is invisible to [pendingDeferredCleanupForTest].
+  /// directly so test teardown can observe the operation.
   Future<void> _flushDeferredFileCleanup() async {
     if (_deferredFileCleanup.isEmpty) return;
     final draftsDao = _deferredCleanupDraftsDao;
@@ -878,22 +876,15 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
 
   /// Starts a best-effort cleanup without blocking the editor lifecycle.
   ///
-  /// The handle goes into [_pendingDeferredCleanup] so tests can await it;
-  /// that set is the only reason this is not a bare `unawaited(...)`. It is a
-  /// set rather than one slot because [reset] and [build]'s `onDispose` can
-  /// each have an operation running, and a single slot would drop the first.
-  /// Each operation waits for the autosaves active when it starts before it
-  /// snapshots the deferred paths.
+  /// The shared registry keeps this fire-and-forget in production while giving
+  /// tests a completion boundary that also covers other editor background work.
+  /// Cleanup waits for the autosaves active when it starts before it snapshots
+  /// deferred paths, so those writes cannot miss the session-end reap.
   void _startDeferredFileCleanup() {
     final activeAutosaves = _activeAutosaves.toList();
-    late final Future<void> operation;
-    operation = Future.wait(activeAutosaves)
-        .then((_) => _flushDeferredFileCleanup())
-        .whenComplete(() {
-          _pendingDeferredCleanup.remove(operation);
-        });
-    _pendingDeferredCleanup.add(operation);
-    unawaited(operation);
+    _backgroundWork.track(
+      Future.wait(activeAutosaves).then((_) => _flushDeferredFileCleanup()),
+    );
   }
 
   /// Queue clip-owned files that became unreachable in the live editor state.
@@ -913,20 +904,6 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// Test hook: the set of files awaiting cleanup.
   @visibleForTesting
   Set<String> get deferredFileCleanupForTest => _deferredFileCleanup;
-
-  /// Completes when the cleanups in flight *at the moment it is read*
-  /// complete.
-  ///
-  /// A snapshot, not a barrier: it ignores anything started afterwards and
-  /// resolves immediately when nothing is in flight, so read it after the
-  /// call whose cleanup you mean to await. Cleanup includes autosaves that were
-  /// active when it started, but this snapshot still ignores cleanup operations
-  /// started afterwards. Other fire-and-forget work on this notifier and on
-  /// [ClipManagerNotifier] settles on its own schedule.
-  @visibleForTesting
-  Future<void> get pendingDeferredCleanupForTest async {
-    await Future.wait(_pendingDeferredCleanup.toList());
-  }
 
   /// Save the current video project as a draft.
   ///

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -134,7 +134,15 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// run from `onDispose` without reading providers after disposal.
   DraftsDao? _deferredCleanupDraftsDao;
   ClipsDao? _deferredCleanupClipsDao;
-  late final EditorBackgroundWork _backgroundWork;
+  EditorBackgroundWork? _backgroundWork;
+
+  EditorBackgroundWork get _editorBackgroundWork {
+    final existing = _backgroundWork;
+    if (existing != null) return existing;
+    final backgroundWork = ref.read(editorBackgroundWorkProvider);
+    _backgroundWork = backgroundWork;
+    return backgroundWork;
+  }
 
   /// Autosaves currently writing deferred orphan paths.
   ///
@@ -213,7 +221,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
 
     // Delete the old rendered file from disk to free up space
     final db = ref.read(databaseProvider);
-    _backgroundWork.track(
+    _editorBackgroundWork.track(
       FileCleanupService.deleteRecordingClipFiles(
         clip,
         draftsDao: db.draftsDao,
@@ -882,7 +890,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// deferred paths, so those writes cannot miss the session-end reap.
   void _startDeferredFileCleanup() {
     final activeAutosaves = _activeAutosaves.toList();
-    _backgroundWork.track(
+    _editorBackgroundWork.track(
       Future.wait(activeAutosaves).then((_) => _flushDeferredFileCleanup()),
     );
   }

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -93,6 +93,20 @@ void main() {
       expect(state.totalDuration, equals(const Duration(seconds: 2)));
     });
 
+    group('provider lifecycle', () {
+      test('rebuilds after the provider is invalidated', () {
+        final first = container.read(clipManagerProvider.notifier);
+
+        container.invalidate(clipManagerProvider);
+        final second = container.read(clipManagerProvider.notifier);
+
+        // Riverpod reuses the notifier and re-runs build, so anything build
+        // assigns has to tolerate being assigned twice.
+        expect(identical(first, second), isTrue);
+        expect(container.read(clipManagerProvider).clips, isEmpty);
+      });
+    });
+
     group('muteAllClips', () {
       test('sets every clip volume to zero', () {
         final notifier = container.read(clipManagerProvider.notifier);

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -18,6 +19,14 @@ import 'package:shared_preferences/shared_preferences.dart';
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
 
 class _MockClipLibraryService extends Mock implements ClipLibraryService {}
+
+/// Mirrors the stub shape used by the widget suites (for example
+/// `library_screen_test.dart`): seed a clip list from `build` without calling
+/// `super.build()`.
+class _BuildOverrideClipManagerNotifier extends ClipManagerNotifier {
+  @override
+  ClipManagerState build() => ClipManagerState();
+}
 
 void main() {
   group('ClipManagerProvider', () {
@@ -104,6 +113,37 @@ void main() {
         // assigns has to tolerate being assigned twice.
         expect(identical(first, second), isTrue);
         expect(container.read(clipManagerProvider).clips, isEmpty);
+      });
+
+      test('addClip works when a subclass replaces build', () async {
+        final overridden = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(
+              await SharedPreferences.getInstance(),
+            ),
+            draftStorageServiceProvider.overrideWithValue(
+              mockDraftStorageService,
+            ),
+            clipLibraryServiceProvider.overrideWithValue(
+              mockClipLibraryService,
+            ),
+            clipManagerProvider.overrideWith(
+              _BuildOverrideClipManagerNotifier.new,
+            ),
+          ],
+        );
+        addTearDown(overridden.dispose);
+        final notifier = overridden.read(clipManagerProvider.notifier);
+
+        notifier.addClip(
+          limitClipDuration: false,
+          video: EditorVideo.file('/path/to/video.mp4'),
+          duration: const Duration(seconds: 2),
+          targetAspectRatio: .vertical,
+          originalAspectRatio: 9 / 16,
+        );
+
+        expect(overridden.read(clipManagerProvider).clips, hasLength(1));
       });
     });
 

--- a/mobile/test/providers/editor_background_work_test.dart
+++ b/mobile/test/providers/editor_background_work_test.dart
@@ -1,0 +1,32 @@
+// ABOUTME: Tests the editor background-work fixed-point completion boundary
+// ABOUTME: Verifies work spawned by tracked operations also settles
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/providers/editor_background_work.dart';
+
+void main() {
+  test('settle waits for work started by a tracked operation', () async {
+    final backgroundWork = EditorBackgroundWork();
+    final startSecondOperation = Completer<void>();
+    final finishSecondOperation = Completer<void>();
+
+    backgroundWork.track(() async {
+      await startSecondOperation.future;
+      backgroundWork.track(finishSecondOperation.future);
+    }());
+    expect(backgroundWork.isNotEmptyForTest, isTrue);
+
+    var settled = false;
+    final settling = backgroundWork.settle().then((_) => settled = true);
+    startSecondOperation.complete();
+    await startSecondOperation.future;
+    expect(settled, isFalse);
+
+    finishSecondOperation.complete();
+    await settling;
+    expect(settled, isTrue);
+    expect(backgroundWork.isNotEmptyForTest, isFalse);
+  });
+}

--- a/mobile/test/providers/editor_background_work_test.dart
+++ b/mobile/test/providers/editor_background_work_test.dart
@@ -7,26 +7,28 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/providers/editor_background_work.dart';
 
 void main() {
-  test('settle waits for work started by a tracked operation', () async {
-    final backgroundWork = EditorBackgroundWork();
-    final startSecondOperation = Completer<void>();
-    final finishSecondOperation = Completer<void>();
+  group('EditorBackgroundWork', () {
+    test('settle waits for work started by a tracked operation', () async {
+      final backgroundWork = EditorBackgroundWork();
+      final startSecondOperation = Completer<void>();
+      final finishSecondOperation = Completer<void>();
 
-    backgroundWork.track(() async {
+      backgroundWork.track(() async {
+        await startSecondOperation.future;
+        backgroundWork.track(finishSecondOperation.future);
+      }());
+      expect(backgroundWork.isNotEmptyForTest, isTrue);
+
+      var settled = false;
+      final settling = backgroundWork.settle().then((_) => settled = true);
+      startSecondOperation.complete();
       await startSecondOperation.future;
-      backgroundWork.track(finishSecondOperation.future);
-    }());
-    expect(backgroundWork.isNotEmptyForTest, isTrue);
+      expect(settled, isFalse);
 
-    var settled = false;
-    final settling = backgroundWork.settle().then((_) => settled = true);
-    startSecondOperation.complete();
-    await startSecondOperation.future;
-    expect(settled, isFalse);
-
-    finishSecondOperation.complete();
-    await settling;
-    expect(settled, isTrue);
-    expect(backgroundWork.isNotEmptyForTest, isFalse);
+      finishSecondOperation.complete();
+      await settling;
+      expect(settled, isTrue);
+      expect(backgroundWork.isNotEmptyForTest, isFalse);
+    });
   });
 }

--- a/mobile/test/providers/editor_background_work_test.dart
+++ b/mobile/test/providers/editor_background_work_test.dart
@@ -30,5 +30,40 @@ void main() {
       expect(settled, isTrue);
       expect(backgroundWork.isNotEmptyForTest, isFalse);
     });
+
+    test('settle drains spawned work before rethrowing an error', () async {
+      final backgroundWork = EditorBackgroundWork();
+      final startFailingOperation = Completer<void>();
+      final finishSpawnedOperation = Completer<void>();
+
+      backgroundWork.track(() async {
+        await startFailingOperation.future;
+        backgroundWork.track(finishSpawnedOperation.future);
+        throw StateError('tracked operation failed');
+      }());
+
+      var settlingFinished = false;
+      final settling = backgroundWork.settle();
+      settling.then<void>(
+        (_) => settlingFinished = true,
+        onError: (Object _, StackTrace _) => settlingFinished = true,
+      );
+      final errorExpectation = expectLater(
+        settling,
+        throwsA(isA<StateError>()),
+      );
+
+      startFailingOperation.complete();
+      await pumpEventQueue();
+      expect(
+        settlingFinished,
+        isFalse,
+        reason: 'settle must keep draining work spawned by a failed batch',
+      );
+
+      finishSpawnedOperation.complete();
+      await errorExpectation;
+      expect(backgroundWork.isNotEmptyForTest, isFalse);
+    });
   });
 }

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -3487,6 +3487,10 @@ void main() {
     late ProviderContainer container;
     late Directory tempDir;
     late EditorBackgroundWork backgroundWork;
+    // Restored by tearDown rather than addTearDown: addTearDown callbacks run
+    // *before* the group tearDown, so restoring there would pull the stub out
+    // from under the settle boundary that exists to drain proof generation.
+    late void Function() restoreProofFileOverride;
     var containerDisposed = false;
 
     void disposeContainer() {
@@ -3526,6 +3530,8 @@ void main() {
       containerDisposed = false;
       final originalProofFileOverride =
           NativeProofModeService.proofFileOverride;
+      restoreProofFileOverride = () =>
+          NativeProofModeService.proofFileOverride = originalProofFileOverride;
       NativeProofModeService.proofFileOverride =
           (
             file, {
@@ -3536,10 +3542,6 @@ void main() {
             clips,
             editorStateHistory,
           }) async => null;
-      addTearDown(
-        () => NativeProofModeService.proofFileOverride =
-            originalProofFileOverride,
-      );
       when(
         () => mockDraftStorage.draftExists(any()),
       ).thenAnswer((_) async => false);
@@ -3573,6 +3575,7 @@ void main() {
         // test isolate.
         await database.close();
         if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+        restoreProofFileOverride();
       }
     });
 

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -22,6 +22,7 @@ import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/database_provider.dart';
+import 'package:openvine/providers/editor_background_work.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
@@ -1404,70 +1405,67 @@ void main() {
             );
       }
 
-      test(
-        'overlapping renders each own a trace, stopped once, with their own '
-        'attributes',
-        () async {
-          final notifier = container.read(videoEditorProvider.notifier);
-          addOneClip();
+      test('overlapping renders each own a trace, stopped once, with their own '
+          'attributes', () async {
+        final notifier = container.read(videoEditorProvider.notifier);
+        addOneClip();
 
-          final slowCompleter = Completer<(DivineVideoClip, String?)>();
-          final fastCompleter = Completer<(DivineVideoClip, String?)>();
-          var callCount = 0;
-          VideoEditorRenderService.renderVideoToClipOverride =
-              ({
-                required clips,
-                required editorStateHistory,
-                parameters,
-                taskId,
-              }) {
-                callCount++;
-                return callCount == 1
-                    ? slowCompleter.future
-                    : fastCompleter.future;
-              };
+        final slowCompleter = Completer<(DivineVideoClip, String?)>();
+        final fastCompleter = Completer<(DivineVideoClip, String?)>();
+        var callCount = 0;
+        VideoEditorRenderService.renderVideoToClipOverride =
+            ({
+              required clips,
+              required editorStateHistory,
+              parameters,
+              taskId,
+            }) {
+              callCount++;
+              return callCount == 1
+                  ? slowCompleter.future
+                  : fastCompleter.future;
+            };
 
-          final freshClip = DivineVideoClip(
-            id: 'fresh',
-            video: EditorVideo.file('/docs/fresh.mp4'),
-            duration: const Duration(seconds: 3),
-            recordedAt: DateTime.now(),
-            targetAspectRatio: .vertical,
-            originalAspectRatio: 9 / 16,
-          );
+        final freshClip = DivineVideoClip(
+          id: 'fresh',
+          video: EditorVideo.file('/docs/fresh.mp4'),
+          duration: const Duration(seconds: 3),
+          recordedAt: DateTime.now(),
+          targetAspectRatio: .vertical,
+          originalAspectRatio: 9 / 16,
+        );
 
-          // render1 = generation 1 (slow, superseded); render2 = generation 2
-          // (fast, winner). Each captures its own operation-scoped trace.
-          final render1 = notifier.startRenderVideo();
-          final render2 = notifier.startRenderVideo();
-          expect(callCount, equals(2));
-          expect(
-            performanceMonitor.traces.length,
-            2,
-            reason: 'each render must start its own trace, not share one',
-          );
+        // render1 = generation 1 (slow, superseded); render2 = generation 2
+        // (fast, winner). Each captures its own operation-scoped trace.
+        final render1 = notifier.startRenderVideo();
+        final render2 = notifier.startRenderVideo();
+        expect(callCount, equals(2));
+        expect(
+          performanceMonitor.traces.length,
+          2,
+          reason: 'each render must start its own trace, not share one',
+        );
 
-          fastCompleter.complete((freshClip, null));
-          await render2;
-          slowCompleter.complete((freshClip, null));
-          await render1;
+        fastCompleter.complete((freshClip, null));
+        await render2;
+        slowCompleter.complete((freshClip, null));
+        await render1;
 
-          final trace1 = performanceMonitor.traces[0];
-          final trace2 = performanceMonitor.traces[1];
+        final trace1 = performanceMonitor.traces[0];
+        final trace2 = performanceMonitor.traces[1];
 
-          // Each trace is stopped exactly once — neither render stops the
-          // other's trace.
-          expect(trace1.stopCount, 1);
-          expect(trace2.stopCount, 1);
+        // Each trace is stopped exactly once — neither render stops the
+        // other's trace.
+        expect(trace1.stopCount, 1);
+        expect(trace2.stopCount, 1);
 
-          // Each trace keeps its own outcome: the winner is success, the
-          // superseded render is incomplete (not overwritten onto the winner).
-          expect(trace2.attributes['outcome'], 'success');
-          expect(trace1.attributes['outcome'], 'incomplete');
-          expect(trace1.attributes['clip_count'], '1');
-          expect(trace2.attributes['clip_count'], '1');
-        },
-      );
+        // Each trace keeps its own outcome: the winner is success, the
+        // superseded render is incomplete (not overwritten onto the winner).
+        expect(trace2.attributes['outcome'], 'success');
+        expect(trace1.attributes['outcome'], 'incomplete');
+        expect(trace1.attributes['clip_count'], '1');
+        expect(trace2.attributes['clip_count'], '1');
+      });
 
       void failRenderWith(VideoRenderFailedException failure) {
         VideoEditorRenderService.renderVideoToClipOverride =
@@ -1672,9 +1670,7 @@ void main() {
           );
 
           renderCompleter.completeError(
-            const VideoRenderFailedException(
-              VideoRenderFailureReason.canceled,
-            ),
+            const VideoRenderFailedException(VideoRenderFailureReason.canceled),
           );
           await cancel;
           await render;
@@ -2192,10 +2188,9 @@ void main() {
               .restoreDraft('draft-1');
 
           expect(result, isTrue);
-          expect(
-            container.read(videoEditorProvider).collaboratorPubkeys,
-            {collaboratorPubkey},
-          );
+          expect(container.read(videoEditorProvider).collaboratorPubkeys, {
+            collaboratorPubkey,
+          });
         },
       );
 
@@ -2618,121 +2613,115 @@ void main() {
         },
       );
 
-      test(
-        'viewing a draft is read-only: restore keeps the finalRenderedClip '
-        'instead of invalidating it (#5956)',
-        () async {
-          final renderedPath = '${tempDir.path}/rendered.mp4';
-          await File(renderedPath).writeAsBytes(const [0]);
+      test('viewing a draft is read-only: restore keeps the finalRenderedClip '
+          'instead of invalidating it (#5956)', () async {
+        final renderedPath = '${tempDir.path}/rendered.mp4';
+        await File(renderedPath).writeAsBytes(const [0]);
 
-          final draft = DivineVideoDraft.create(
-            id: 'draft-1',
-            clips: [
-              DivineVideoClip(
-                id: 'c1',
-                video: EditorVideo.file(clipVideoPath),
-                thumbnailPath: clipThumbnailPath,
-                duration: const Duration(seconds: 3),
-                recordedAt: DateTime.now(),
-                targetAspectRatio: .vertical,
-                originalAspectRatio: 9 / 16,
-              ),
-            ],
-            title: 'Title',
-            description: '',
-            hashtags: const {},
-            selectedApproach: 'video',
-            finalRenderedClip: DivineVideoClip(
-              id: 'rendered',
-              video: EditorVideo.file(renderedPath),
+        final draft = DivineVideoDraft.create(
+          id: 'draft-1',
+          clips: [
+            DivineVideoClip(
+              id: 'c1',
+              video: EditorVideo.file(clipVideoPath),
               thumbnailPath: clipThumbnailPath,
               duration: const Duration(seconds: 3),
               recordedAt: DateTime.now(),
               targetAspectRatio: .vertical,
               originalAspectRatio: 9 / 16,
             ),
-          );
-          when(
-            () => mockDraftStorage.getDraftById('draft-1'),
-          ).thenAnswer((_) async => draft);
+          ],
+          title: 'Title',
+          description: '',
+          hashtags: const {},
+          selectedApproach: 'video',
+          finalRenderedClip: DivineVideoClip(
+            id: 'rendered',
+            video: EditorVideo.file(renderedPath),
+            thumbnailPath: clipThumbnailPath,
+            duration: const Duration(seconds: 3),
+            recordedAt: DateTime.now(),
+            targetAspectRatio: .vertical,
+            originalAspectRatio: 9 / 16,
+          ),
+        );
+        when(
+          () => mockDraftStorage.getDraftById('draft-1'),
+        ).thenAnswer((_) async => draft);
 
-          final result = await container
+        final result = await container
+            .read(videoEditorProvider.notifier)
+            .restoreDraft('draft-1');
+
+        expect(result, isTrue);
+        expect(
+          container.read(videoEditorProvider).finalRenderedClip?.id,
+          'rendered',
+          reason:
+              'restoring a draft to view it must not autosave: an autosave '
+              'invalidates (and deletes) the restored finalRenderedClip and '
+              'bumps lastModified, making the draft look freshly saved',
+        );
+      });
+
+      test('viewing a draft is read-only: no re-save fires once the autosave '
+          'debounce elapses (#5956)', () {
+        final renderedPath = '${tempDir.path}/rendered.mp4';
+        File(renderedPath).writeAsBytesSync(const [0]);
+
+        final draft = DivineVideoDraft.create(
+          id: 'draft-1',
+          clips: [
+            DivineVideoClip(
+              id: 'c1',
+              video: EditorVideo.file(clipVideoPath),
+              thumbnailPath: clipThumbnailPath,
+              duration: const Duration(seconds: 3),
+              recordedAt: DateTime.now(),
+              targetAspectRatio: .vertical,
+              originalAspectRatio: 9 / 16,
+            ),
+          ],
+          title: 'Title',
+          description: '',
+          hashtags: const {},
+          selectedApproach: 'video',
+          finalRenderedClip: DivineVideoClip(
+            id: 'rendered',
+            video: EditorVideo.file(renderedPath),
+            thumbnailPath: clipThumbnailPath,
+            duration: const Duration(seconds: 3),
+            recordedAt: DateTime.now(),
+            targetAspectRatio: .vertical,
+            originalAspectRatio: 9 / 16,
+          ),
+        );
+        when(
+          () => mockDraftStorage.getDraftById('draft-1'),
+        ).thenAnswer((_) async => draft);
+
+        fakeAsync((async) {
+          bool? result;
+          container
               .read(videoEditorProvider.notifier)
-              .restoreDraft('draft-1');
-
+              .restoreDraft('draft-1')
+              .then((value) => result = value);
+          async.flushMicrotasks();
           expect(result, isTrue);
-          expect(
-            container.read(videoEditorProvider).finalRenderedClip?.id,
-            'rendered',
-            reason:
-                'restoring a draft to view it must not autosave: an autosave '
-                'invalidates (and deletes) the restored finalRenderedClip and '
-                'bumps lastModified, making the draft look freshly saved',
-          );
-        },
-      );
 
-      test(
-        'viewing a draft is read-only: no re-save fires once the autosave '
-        'debounce elapses (#5956)',
-        () {
-          final renderedPath = '${tempDir.path}/rendered.mp4';
-          File(renderedPath).writeAsBytesSync(const [0]);
+          // Elapse well past the autosave debounce; a restore that
+          // re-triggers autosave would re-save the draft here, bumping
+          // lastModified and reordering it to the top of the drafts list.
+          async.elapse(const Duration(seconds: 10));
 
-          final draft = DivineVideoDraft.create(
-            id: 'draft-1',
-            clips: [
-              DivineVideoClip(
-                id: 'c1',
-                video: EditorVideo.file(clipVideoPath),
-                thumbnailPath: clipThumbnailPath,
-                duration: const Duration(seconds: 3),
-                recordedAt: DateTime.now(),
-                targetAspectRatio: .vertical,
-                originalAspectRatio: 9 / 16,
-              ),
-            ],
-            title: 'Title',
-            description: '',
-            hashtags: const {},
-            selectedApproach: 'video',
-            finalRenderedClip: DivineVideoClip(
-              id: 'rendered',
-              video: EditorVideo.file(renderedPath),
-              thumbnailPath: clipThumbnailPath,
-              duration: const Duration(seconds: 3),
-              recordedAt: DateTime.now(),
-              targetAspectRatio: .vertical,
-              originalAspectRatio: 9 / 16,
+          verifyNever(
+            () => mockDraftStorage.saveDraft(
+              any(),
+              deferOrphanCleanup: any(named: 'deferOrphanCleanup'),
             ),
           );
-          when(
-            () => mockDraftStorage.getDraftById('draft-1'),
-          ).thenAnswer((_) async => draft);
-
-          fakeAsync((async) {
-            bool? result;
-            container
-                .read(videoEditorProvider.notifier)
-                .restoreDraft('draft-1')
-                .then((value) => result = value);
-            async.flushMicrotasks();
-            expect(result, isTrue);
-
-            // Elapse well past the autosave debounce; a restore that
-            // re-triggers autosave would re-save the draft here, bumping
-            // lastModified and reordering it to the top of the drafts list.
-            async.elapse(const Duration(seconds: 10));
-
-            verifyNever(
-              () => mockDraftStorage.saveDraft(
-                any(),
-                deferOrphanCleanup: any(named: 'deferOrphanCleanup'),
-              ),
-            );
-          });
-        },
-      );
+        });
+      });
     });
   });
 
@@ -3017,10 +3006,7 @@ void main() {
       expect(draft.inspiredByVideo, isNull);
       expect(
         draft.clipSourceCredits.map((credit) => credit.addressableId),
-        equals([
-          '34236:${'d' * 64}:source-a',
-          '34236:${'e' * 64}:source-b',
-        ]),
+        equals(['34236:${'d' * 64}:source-a', '34236:${'e' * 64}:source-b']),
       );
     });
 
@@ -3077,35 +3063,30 @@ void main() {
       createdAt: 1700000000,
     );
 
-    test(
-      'refreshes the snapshot when only the audio meta changes so the reuse '
-      "toggle tracks add/remove of another creator's sound",
-      () {
-        final notifier = container.read(videoEditorProvider.notifier);
+    test('refreshes the snapshot when only the audio meta changes so the reuse '
+        "toggle tracks add/remove of another creator's sound", () {
+      final notifier = container.read(videoEditorProvider.notifier);
 
-        notifier.updateEditorEditingParameters(
-          paramsWithTracks([reusedSound()]),
-        );
-        expect(
-          container.read(videoEditorProvider).reusesExternalAudio,
-          isTrue,
-          reason: 'adding a reused sound must update the snapshot',
-        );
+      notifier.updateEditorEditingParameters(paramsWithTracks([reusedSound()]));
+      expect(
+        container.read(videoEditorProvider).reusesExternalAudio,
+        isTrue,
+        reason: 'adding a reused sound must update the snapshot',
+      );
 
-        // Remove the sound. The only change is the audio meta — every render
-        // field CompleteParameters.diff compares (empty audioTracks field
-        // included) is identical, so without the audio-meta check the update
-        // is skipped and the snapshot stays stale.
-        notifier.updateEditorEditingParameters(paramsWithTracks(const []));
-        expect(
-          container.read(videoEditorProvider).reusesExternalAudio,
-          isFalse,
-          reason:
-              'removing the reused sound must refresh the snapshot even though '
-              'diff() sees no change in the render-time audioTracks field',
-        );
-      },
-    );
+      // Remove the sound. The only change is the audio meta — every render
+      // field CompleteParameters.diff compares (empty audioTracks field
+      // included) is identical, so without the audio-meta check the update
+      // is skipped and the snapshot stays stale.
+      notifier.updateEditorEditingParameters(paramsWithTracks(const []));
+      expect(
+        container.read(videoEditorProvider).reusesExternalAudio,
+        isFalse,
+        reason:
+            'removing the reused sound must refresh the snapshot even though '
+            'diff() sees no change in the render-time audioTracks field',
+      );
+    });
   });
 
   group('cover thumbnail persistence', () {
@@ -3505,7 +3486,7 @@ void main() {
     late AppDatabase database;
     late ProviderContainer container;
     late Directory tempDir;
-    late VideoEditorNotifier editorNotifier;
+    late EditorBackgroundWork backgroundWork;
     var containerDisposed = false;
 
     void disposeContainer() {
@@ -3514,15 +3495,14 @@ void main() {
       container.dispose();
     }
 
-    // Bounds every drain. The 20x pumpEventQueue poll this replaced bounded
+    // Bounds every settle. The 20x pumpEventQueue poll this replaced bounded
     // itself and failed with its own reason string; a bare await on a wedged
-    // cleanup instead hangs to the suite timeout with nothing naming deferred
-    // cleanup as the stuck party.
-    Future<void> drainDeferredCleanup(VideoEditorNotifier notifier) =>
-        notifier.pendingDeferredCleanupForTest.timeout(
-          const Duration(seconds: 10),
-          onTimeout: () => fail('deferred file cleanup did not settle'),
-        );
+    // operation instead hangs to the suite timeout with nothing naming editor
+    // background work as the stuck party.
+    Future<void> settleBackgroundWork() => backgroundWork.settle().timeout(
+      const Duration(seconds: 10),
+      onTimeout: () => fail('editor background work did not settle'),
+    );
 
     setUpAll(() {
       registerFallbackValue(
@@ -3544,6 +3524,22 @@ void main() {
       database = AppDatabase.test(NativeDatabase.memory());
       tempDir = Directory.systemTemp.createTempSync('editor_defer_test');
       containerDisposed = false;
+      final originalProofFileOverride =
+          NativeProofModeService.proofFileOverride;
+      NativeProofModeService.proofFileOverride =
+          (
+            file, {
+            required enableAdvancedCawgEmbedding,
+            creatorBindingAssertion,
+            cawgIdentityAssertion,
+            verifiedIdentityBundle,
+            clips,
+            editorStateHistory,
+          }) async => null;
+      addTearDown(
+        () => NativeProofModeService.proofFileOverride =
+            originalProofFileOverride,
+      );
       when(
         () => mockDraftStorage.draftExists(any()),
       ).thenAnswer((_) async => false);
@@ -3555,19 +3551,21 @@ void main() {
         ],
       );
       // Captured here, not in tearDown: a test that disposes the container
-      // itself must still get the drain, and `container.read` throws once the
-      // container is gone.
-      editorNotifier = container.read(videoEditorProvider.notifier);
+      // itself must still get the settle boundary, and `container.read` throws
+      // once the container is gone. Reading the notifier also installs its
+      // onDispose cleanup before any test action.
+      backgroundWork = container.read(editorBackgroundWorkProvider);
+      container.read(videoEditorProvider.notifier);
     });
 
     tearDown(() async {
       try {
-        // Unconditional: every test needs the deferred cleanup to stop
-        // querying the DAOs before the database closes under it. The old
-        // `if (!containerDisposed)` guard skipped the drain entirely for the
-        // three tests that dispose the container themselves.
+        // Unconditional: every test needs editor background work to stop
+        // reading media and querying the DAOs before those resources are
+        // destroyed. The old `if (!containerDisposed)` guard skipped the drain
+        // entirely for the tests that dispose the container themselves.
         disposeContainer();
-        await drainDeferredCleanup(editorNotifier);
+        await settleBackgroundWork();
       } finally {
         // The drain can throw — the reference check inside
         // `deleteFilesIfUnreferenced` is unguarded — and an open database or
@@ -3637,7 +3635,7 @@ void main() {
       expect(notifier.deferredFileCleanupForTest, contains(orphan.path));
 
       await notifier.reset(keepAutosavedDraft: true);
-      await drainDeferredCleanup(notifier);
+      await settleBackgroundWork();
 
       expect(
         orphan.existsSync(),
@@ -3672,7 +3670,7 @@ void main() {
       await notifier.reset(keepAutosavedDraft: true);
       saveMayFinish.complete();
       expect(await autosave, isTrue);
-      await drainDeferredCleanup(notifier);
+      await settleBackgroundWork();
 
       expect(
         orphan.existsSync(),
@@ -3710,9 +3708,7 @@ void main() {
 
         unawaited(notifier.reset(keepAutosavedDraft: true));
         var cleanupSettled = false;
-        notifier.pendingDeferredCleanupForTest.then(
-          (_) => cleanupSettled = true,
-        );
+        backgroundWork.settle().then((_) => cleanupSettled = true);
         async.flushMicrotasks();
         expect(
           cleanupSettled,
@@ -3742,7 +3738,7 @@ void main() {
       // it starts the flush, so it cannot have finished.
       expect(orphan.existsSync(), isTrue);
       disposeContainer();
-      await drainDeferredCleanup(notifier);
+      await settleBackgroundWork();
 
       expect(
         orphan.existsSync(),
@@ -3760,7 +3756,7 @@ void main() {
       expect(orphan.existsSync(), isTrue);
 
       disposeContainer();
-      await drainDeferredCleanup(notifier);
+      await settleBackgroundWork();
 
       expect(
         orphan.existsSync(),
@@ -3782,12 +3778,10 @@ void main() {
 
       final source = File(p.join(documentsDir.path, 'source.mp4'))
         ..writeAsBytesSync(const [1, 2, 3]);
-      final oldRendered = File(
-        p.join(documentsDir.path, 'old-rendered.mp4'),
-      )..writeAsBytesSync(const [4, 5, 6]);
-      final newRendered = File(
-        p.join(documentsDir.path, 'new-rendered.mp4'),
-      )..writeAsBytesSync(const [7, 8, 9]);
+      final oldRendered = File(p.join(documentsDir.path, 'old-rendered.mp4'))
+        ..writeAsBytesSync(const [4, 5, 6]);
+      final newRendered = File(p.join(documentsDir.path, 'new-rendered.mp4'))
+        ..writeAsBytesSync(const [7, 8, 9]);
       final realDraftStorage = DraftStorageService(
         draftsDao: database.draftsDao,
         clipsDao: database.clipsDao,
@@ -3856,7 +3850,7 @@ void main() {
       expect(notifier.deferredFileCleanupForTest, contains(oldRendered.path));
 
       disposeContainer();
-      await drainDeferredCleanup(notifier);
+      await settleBackgroundWork();
 
       expect(
         oldRendered.existsSync(),
@@ -3867,5 +3861,56 @@ void main() {
       );
       expect(newRendered.existsSync(), isTrue);
     });
+
+    test(
+      'teardown waits for clip proof to finish reading its source',
+      () async {
+        final proofStarted = Completer<void>();
+        final allowProofRead = Completer<void>();
+        final proofFinished = Completer<void>();
+        bool? sourcePresentDuringProof;
+        final originalProofFileOverride =
+            NativeProofModeService.proofFileOverride;
+        NativeProofModeService.proofFileOverride =
+            (
+              file, {
+              required enableAdvancedCawgEmbedding,
+              creatorBindingAssertion,
+              cawgIdentityAssertion,
+              verifiedIdentityBundle,
+              clips,
+              editorStateHistory,
+            }) async {
+              proofStarted.complete();
+              await allowProofRead.future;
+              sourcePresentDuringProof = file.existsSync();
+              proofFinished.complete();
+              return null;
+            };
+        addTearDown(
+          () => NativeProofModeService.proofFileOverride =
+              originalProofFileOverride,
+        );
+
+        addTimelineClip();
+        await proofStarted.future;
+        expect(backgroundWork.isNotEmptyForTest, isTrue);
+        disposeContainer();
+
+        final teardown = () async {
+          await settleBackgroundWork();
+          tempDir.deleteSync(recursive: true);
+        }();
+        allowProofRead.complete();
+        await teardown;
+        await proofFinished.future;
+
+        expect(
+          sourcePresentDuringProof,
+          isTrue,
+          reason: 'teardown deleted the media while proof generation read it',
+        );
+      },
+    );
   });
 }

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -1405,67 +1405,70 @@ void main() {
             );
       }
 
-      test('overlapping renders each own a trace, stopped once, with their own '
-          'attributes', () async {
-        final notifier = container.read(videoEditorProvider.notifier);
-        addOneClip();
+      test(
+        'overlapping renders each own a trace, stopped once, with their own '
+        'attributes',
+        () async {
+          final notifier = container.read(videoEditorProvider.notifier);
+          addOneClip();
 
-        final slowCompleter = Completer<(DivineVideoClip, String?)>();
-        final fastCompleter = Completer<(DivineVideoClip, String?)>();
-        var callCount = 0;
-        VideoEditorRenderService.renderVideoToClipOverride =
-            ({
-              required clips,
-              required editorStateHistory,
-              parameters,
-              taskId,
-            }) {
-              callCount++;
-              return callCount == 1
-                  ? slowCompleter.future
-                  : fastCompleter.future;
-            };
+          final slowCompleter = Completer<(DivineVideoClip, String?)>();
+          final fastCompleter = Completer<(DivineVideoClip, String?)>();
+          var callCount = 0;
+          VideoEditorRenderService.renderVideoToClipOverride =
+              ({
+                required clips,
+                required editorStateHistory,
+                parameters,
+                taskId,
+              }) {
+                callCount++;
+                return callCount == 1
+                    ? slowCompleter.future
+                    : fastCompleter.future;
+              };
 
-        final freshClip = DivineVideoClip(
-          id: 'fresh',
-          video: EditorVideo.file('/docs/fresh.mp4'),
-          duration: const Duration(seconds: 3),
-          recordedAt: DateTime.now(),
-          targetAspectRatio: .vertical,
-          originalAspectRatio: 9 / 16,
-        );
+          final freshClip = DivineVideoClip(
+            id: 'fresh',
+            video: EditorVideo.file('/docs/fresh.mp4'),
+            duration: const Duration(seconds: 3),
+            recordedAt: DateTime.now(),
+            targetAspectRatio: .vertical,
+            originalAspectRatio: 9 / 16,
+          );
 
-        // render1 = generation 1 (slow, superseded); render2 = generation 2
-        // (fast, winner). Each captures its own operation-scoped trace.
-        final render1 = notifier.startRenderVideo();
-        final render2 = notifier.startRenderVideo();
-        expect(callCount, equals(2));
-        expect(
-          performanceMonitor.traces.length,
-          2,
-          reason: 'each render must start its own trace, not share one',
-        );
+          // render1 = generation 1 (slow, superseded); render2 = generation 2
+          // (fast, winner). Each captures its own operation-scoped trace.
+          final render1 = notifier.startRenderVideo();
+          final render2 = notifier.startRenderVideo();
+          expect(callCount, equals(2));
+          expect(
+            performanceMonitor.traces.length,
+            2,
+            reason: 'each render must start its own trace, not share one',
+          );
 
-        fastCompleter.complete((freshClip, null));
-        await render2;
-        slowCompleter.complete((freshClip, null));
-        await render1;
+          fastCompleter.complete((freshClip, null));
+          await render2;
+          slowCompleter.complete((freshClip, null));
+          await render1;
 
-        final trace1 = performanceMonitor.traces[0];
-        final trace2 = performanceMonitor.traces[1];
+          final trace1 = performanceMonitor.traces[0];
+          final trace2 = performanceMonitor.traces[1];
 
-        // Each trace is stopped exactly once — neither render stops the
-        // other's trace.
-        expect(trace1.stopCount, 1);
-        expect(trace2.stopCount, 1);
+          // Each trace is stopped exactly once — neither render stops the
+          // other's trace.
+          expect(trace1.stopCount, 1);
+          expect(trace2.stopCount, 1);
 
-        // Each trace keeps its own outcome: the winner is success, the
-        // superseded render is incomplete (not overwritten onto the winner).
-        expect(trace2.attributes['outcome'], 'success');
-        expect(trace1.attributes['outcome'], 'incomplete');
-        expect(trace1.attributes['clip_count'], '1');
-        expect(trace2.attributes['clip_count'], '1');
-      });
+          // Each trace keeps its own outcome: the winner is success, the
+          // superseded render is incomplete (not overwritten onto the winner).
+          expect(trace2.attributes['outcome'], 'success');
+          expect(trace1.attributes['outcome'], 'incomplete');
+          expect(trace1.attributes['clip_count'], '1');
+          expect(trace2.attributes['clip_count'], '1');
+        },
+      );
 
       void failRenderWith(VideoRenderFailedException failure) {
         VideoEditorRenderService.renderVideoToClipOverride =
@@ -1670,7 +1673,9 @@ void main() {
           );
 
           renderCompleter.completeError(
-            const VideoRenderFailedException(VideoRenderFailureReason.canceled),
+            const VideoRenderFailedException(
+              VideoRenderFailureReason.canceled,
+            ),
           );
           await cancel;
           await render;
@@ -2188,9 +2193,10 @@ void main() {
               .restoreDraft('draft-1');
 
           expect(result, isTrue);
-          expect(container.read(videoEditorProvider).collaboratorPubkeys, {
-            collaboratorPubkey,
-          });
+          expect(
+            container.read(videoEditorProvider).collaboratorPubkeys,
+            {collaboratorPubkey},
+          );
         },
       );
 
@@ -2613,115 +2619,121 @@ void main() {
         },
       );
 
-      test('viewing a draft is read-only: restore keeps the finalRenderedClip '
-          'instead of invalidating it (#5956)', () async {
-        final renderedPath = '${tempDir.path}/rendered.mp4';
-        await File(renderedPath).writeAsBytes(const [0]);
+      test(
+        'viewing a draft is read-only: restore keeps the finalRenderedClip '
+        'instead of invalidating it (#5956)',
+        () async {
+          final renderedPath = '${tempDir.path}/rendered.mp4';
+          await File(renderedPath).writeAsBytes(const [0]);
 
-        final draft = DivineVideoDraft.create(
-          id: 'draft-1',
-          clips: [
-            DivineVideoClip(
-              id: 'c1',
-              video: EditorVideo.file(clipVideoPath),
+          final draft = DivineVideoDraft.create(
+            id: 'draft-1',
+            clips: [
+              DivineVideoClip(
+                id: 'c1',
+                video: EditorVideo.file(clipVideoPath),
+                thumbnailPath: clipThumbnailPath,
+                duration: const Duration(seconds: 3),
+                recordedAt: DateTime.now(),
+                targetAspectRatio: .vertical,
+                originalAspectRatio: 9 / 16,
+              ),
+            ],
+            title: 'Title',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'video',
+            finalRenderedClip: DivineVideoClip(
+              id: 'rendered',
+              video: EditorVideo.file(renderedPath),
               thumbnailPath: clipThumbnailPath,
               duration: const Duration(seconds: 3),
               recordedAt: DateTime.now(),
               targetAspectRatio: .vertical,
               originalAspectRatio: 9 / 16,
-            ),
-          ],
-          title: 'Title',
-          description: '',
-          hashtags: const {},
-          selectedApproach: 'video',
-          finalRenderedClip: DivineVideoClip(
-            id: 'rendered',
-            video: EditorVideo.file(renderedPath),
-            thumbnailPath: clipThumbnailPath,
-            duration: const Duration(seconds: 3),
-            recordedAt: DateTime.now(),
-            targetAspectRatio: .vertical,
-            originalAspectRatio: 9 / 16,
-          ),
-        );
-        when(
-          () => mockDraftStorage.getDraftById('draft-1'),
-        ).thenAnswer((_) async => draft);
-
-        final result = await container
-            .read(videoEditorProvider.notifier)
-            .restoreDraft('draft-1');
-
-        expect(result, isTrue);
-        expect(
-          container.read(videoEditorProvider).finalRenderedClip?.id,
-          'rendered',
-          reason:
-              'restoring a draft to view it must not autosave: an autosave '
-              'invalidates (and deletes) the restored finalRenderedClip and '
-              'bumps lastModified, making the draft look freshly saved',
-        );
-      });
-
-      test('viewing a draft is read-only: no re-save fires once the autosave '
-          'debounce elapses (#5956)', () {
-        final renderedPath = '${tempDir.path}/rendered.mp4';
-        File(renderedPath).writeAsBytesSync(const [0]);
-
-        final draft = DivineVideoDraft.create(
-          id: 'draft-1',
-          clips: [
-            DivineVideoClip(
-              id: 'c1',
-              video: EditorVideo.file(clipVideoPath),
-              thumbnailPath: clipThumbnailPath,
-              duration: const Duration(seconds: 3),
-              recordedAt: DateTime.now(),
-              targetAspectRatio: .vertical,
-              originalAspectRatio: 9 / 16,
-            ),
-          ],
-          title: 'Title',
-          description: '',
-          hashtags: const {},
-          selectedApproach: 'video',
-          finalRenderedClip: DivineVideoClip(
-            id: 'rendered',
-            video: EditorVideo.file(renderedPath),
-            thumbnailPath: clipThumbnailPath,
-            duration: const Duration(seconds: 3),
-            recordedAt: DateTime.now(),
-            targetAspectRatio: .vertical,
-            originalAspectRatio: 9 / 16,
-          ),
-        );
-        when(
-          () => mockDraftStorage.getDraftById('draft-1'),
-        ).thenAnswer((_) async => draft);
-
-        fakeAsync((async) {
-          bool? result;
-          container
-              .read(videoEditorProvider.notifier)
-              .restoreDraft('draft-1')
-              .then((value) => result = value);
-          async.flushMicrotasks();
-          expect(result, isTrue);
-
-          // Elapse well past the autosave debounce; a restore that
-          // re-triggers autosave would re-save the draft here, bumping
-          // lastModified and reordering it to the top of the drafts list.
-          async.elapse(const Duration(seconds: 10));
-
-          verifyNever(
-            () => mockDraftStorage.saveDraft(
-              any(),
-              deferOrphanCleanup: any(named: 'deferOrphanCleanup'),
             ),
           );
-        });
-      });
+          when(
+            () => mockDraftStorage.getDraftById('draft-1'),
+          ).thenAnswer((_) async => draft);
+
+          final result = await container
+              .read(videoEditorProvider.notifier)
+              .restoreDraft('draft-1');
+
+          expect(result, isTrue);
+          expect(
+            container.read(videoEditorProvider).finalRenderedClip?.id,
+            'rendered',
+            reason:
+                'restoring a draft to view it must not autosave: an autosave '
+                'invalidates (and deletes) the restored finalRenderedClip and '
+                'bumps lastModified, making the draft look freshly saved',
+          );
+        },
+      );
+
+      test(
+        'viewing a draft is read-only: no re-save fires once the autosave '
+        'debounce elapses (#5956)',
+        () {
+          final renderedPath = '${tempDir.path}/rendered.mp4';
+          File(renderedPath).writeAsBytesSync(const [0]);
+
+          final draft = DivineVideoDraft.create(
+            id: 'draft-1',
+            clips: [
+              DivineVideoClip(
+                id: 'c1',
+                video: EditorVideo.file(clipVideoPath),
+                thumbnailPath: clipThumbnailPath,
+                duration: const Duration(seconds: 3),
+                recordedAt: DateTime.now(),
+                targetAspectRatio: .vertical,
+                originalAspectRatio: 9 / 16,
+              ),
+            ],
+            title: 'Title',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'video',
+            finalRenderedClip: DivineVideoClip(
+              id: 'rendered',
+              video: EditorVideo.file(renderedPath),
+              thumbnailPath: clipThumbnailPath,
+              duration: const Duration(seconds: 3),
+              recordedAt: DateTime.now(),
+              targetAspectRatio: .vertical,
+              originalAspectRatio: 9 / 16,
+            ),
+          );
+          when(
+            () => mockDraftStorage.getDraftById('draft-1'),
+          ).thenAnswer((_) async => draft);
+
+          fakeAsync((async) {
+            bool? result;
+            container
+                .read(videoEditorProvider.notifier)
+                .restoreDraft('draft-1')
+                .then((value) => result = value);
+            async.flushMicrotasks();
+            expect(result, isTrue);
+
+            // Elapse well past the autosave debounce; a restore that
+            // re-triggers autosave would re-save the draft here, bumping
+            // lastModified and reordering it to the top of the drafts list.
+            async.elapse(const Duration(seconds: 10));
+
+            verifyNever(
+              () => mockDraftStorage.saveDraft(
+                any(),
+                deferOrphanCleanup: any(named: 'deferOrphanCleanup'),
+              ),
+            );
+          });
+        },
+      );
     });
   });
 
@@ -3006,7 +3018,10 @@ void main() {
       expect(draft.inspiredByVideo, isNull);
       expect(
         draft.clipSourceCredits.map((credit) => credit.addressableId),
-        equals(['34236:${'d' * 64}:source-a', '34236:${'e' * 64}:source-b']),
+        equals([
+          '34236:${'d' * 64}:source-a',
+          '34236:${'e' * 64}:source-b',
+        ]),
       );
     });
 
@@ -3063,30 +3078,35 @@ void main() {
       createdAt: 1700000000,
     );
 
-    test('refreshes the snapshot when only the audio meta changes so the reuse '
-        "toggle tracks add/remove of another creator's sound", () {
-      final notifier = container.read(videoEditorProvider.notifier);
+    test(
+      'refreshes the snapshot when only the audio meta changes so the reuse '
+      "toggle tracks add/remove of another creator's sound",
+      () {
+        final notifier = container.read(videoEditorProvider.notifier);
 
-      notifier.updateEditorEditingParameters(paramsWithTracks([reusedSound()]));
-      expect(
-        container.read(videoEditorProvider).reusesExternalAudio,
-        isTrue,
-        reason: 'adding a reused sound must update the snapshot',
-      );
+        notifier.updateEditorEditingParameters(
+          paramsWithTracks([reusedSound()]),
+        );
+        expect(
+          container.read(videoEditorProvider).reusesExternalAudio,
+          isTrue,
+          reason: 'adding a reused sound must update the snapshot',
+        );
 
-      // Remove the sound. The only change is the audio meta — every render
-      // field CompleteParameters.diff compares (empty audioTracks field
-      // included) is identical, so without the audio-meta check the update
-      // is skipped and the snapshot stays stale.
-      notifier.updateEditorEditingParameters(paramsWithTracks(const []));
-      expect(
-        container.read(videoEditorProvider).reusesExternalAudio,
-        isFalse,
-        reason:
-            'removing the reused sound must refresh the snapshot even though '
-            'diff() sees no change in the render-time audioTracks field',
-      );
-    });
+        // Remove the sound. The only change is the audio meta — every render
+        // field CompleteParameters.diff compares (empty audioTracks field
+        // included) is identical, so without the audio-meta check the update
+        // is skipped and the snapshot stays stale.
+        notifier.updateEditorEditingParameters(paramsWithTracks(const []));
+        expect(
+          container.read(videoEditorProvider).reusesExternalAudio,
+          isFalse,
+          reason:
+              'removing the reused sound must refresh the snapshot even though '
+              'diff() sees no change in the render-time audioTracks field',
+        );
+      },
+    );
   });
 
   group('cover thumbnail persistence', () {
@@ -3693,10 +3713,11 @@ void main() {
           deferOrphanCleanup: any(named: 'deferOrphanCleanup'),
         ),
       ).thenAnswer((_) => saveMayFinish.future);
-      addTimelineClip();
-
       fakeAsync((async) {
         saveMayFinish = Completer<void>();
+        // Create every tracked operation inside this fake-async zone so the
+        // zone can drive the shared settle boundary to completion.
+        addTimelineClip();
         final notifier = container.read(videoEditorProvider.notifier);
         notifier.triggerAutosave();
 
@@ -3781,10 +3802,12 @@ void main() {
 
       final source = File(p.join(documentsDir.path, 'source.mp4'))
         ..writeAsBytesSync(const [1, 2, 3]);
-      final oldRendered = File(p.join(documentsDir.path, 'old-rendered.mp4'))
-        ..writeAsBytesSync(const [4, 5, 6]);
-      final newRendered = File(p.join(documentsDir.path, 'new-rendered.mp4'))
-        ..writeAsBytesSync(const [7, 8, 9]);
+      final oldRendered = File(
+        p.join(documentsDir.path, 'old-rendered.mp4'),
+      )..writeAsBytesSync(const [4, 5, 6]);
+      final newRendered = File(
+        p.join(documentsDir.path, 'new-rendered.mp4'),
+      )..writeAsBytesSync(const [7, 8, 9]);
       final realDraftStorage = DraftStorageService(
         draftsDao: database.draftsDao,
         clipsDao: database.clipsDao,
@@ -3896,7 +3919,10 @@ void main() {
         );
 
         addTimelineClip();
-        await proofStarted.future;
+        await proofStarted.future.timeout(
+          const Duration(seconds: 10),
+          onTimeout: () => fail('clip proof generation did not start'),
+        );
         expect(backgroundWork.isNotEmptyForTest, isTrue);
         disposeContainer();
 
@@ -3906,7 +3932,10 @@ void main() {
         }();
         allowProofRead.complete();
         await teardown;
-        await proofFinished.future;
+        await proofFinished.future.timeout(
+          const Duration(seconds: 10),
+          onTimeout: () => fail('clip proof generation did not finish'),
+        );
 
         expect(
           sourcePresentDuringProof,


### PR DESCRIPTION
## Problem

Video-editor cleanup tests could delete temporary media or close their in-memory database while clip proof generation and rendered-file invalidation were still running. Those operations swallowed the resulting errors, so a test could pass while background work crossed its teardown boundary.

## Why this fix

A container-scoped registry now tracks the editor and clip manager fire-and-forget operations that touch teardown-owned resources. Its test-only settle boundary drains to a fixed point, so it also waits for tracked work started by another tracked operation. The cleanup tests capture that registry before disposal and await it before closing the database or deleting media.

The test group now gives ProofMode deterministic behavior, and a gated regression proves teardown cannot remove a clip while proof generation is reading it.

## Deliberately unchanged

Production editor actions remain fire-and-forget; rendering, autosave, file deletion, and proof generation do not become blocking UI work. Other background sinks that this test group cannot reach are outside this change.

## Verification

- `flutter test test/providers/editor_background_work_test.dart test/providers/video_editor_provider_test.dart test/providers/clip_manager_provider_test.dart`
- Five repeated `very_good test --optimization --concurrency=4 --exclude-tags integration test/providers/video_editor_provider_test.dart` runs
- `flutter analyze`
- Future-delayed test and production ratchets
- Uncancellable-timer, unpinned-assertion, and placeholder-test ratchets
- Red/green proof: making `settle()` return immediately causes the gated teardown regression to fail; restoring the fixed-point drain passes

Closes #8814