### PR TITLE
fix(editor): retry cleanup after temporary failures

### DIFF
--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -860,10 +860,11 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// [_deferredFileCleanup]). Reached through [_startDeferredFileCleanup] at
   /// editor-session end ([reset]) and as a teardown safety net ([build]'s
   /// `onDispose`). The entry point waits for autosaves already in flight before
-  /// this method snapshots and clears the set, so their deferred paths join the
-  /// same reap. Each path still goes through the draft/library reference check,
-  /// so anything a surviving draft (or the library) references is kept — only
-  /// genuinely-orphaned files are removed.
+  /// this method takes and clears the current set, so their deferred paths join
+  /// the same reap and a concurrent second call does not process the same batch.
+  /// Each path still goes through the draft/library reference check, so anything
+  /// a surviving draft (or the library) references is kept. Paths that could not
+  /// be safely processed are restored to the set for a later cleanup attempt.
   ///
   /// Reach it through [_startDeferredFileCleanup] rather than calling it
   /// directly so test teardown can observe the operation.
@@ -875,11 +876,23 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
 
     final paths = _deferredFileCleanup.toList();
     _deferredFileCleanup.clear();
-    await FileCleanupService.deleteFilesIfUnreferenced(
-      paths,
-      draftsDao: draftsDao,
-      clipsDao: clipsDao,
-    );
+    try {
+      final unprocessed = await FileCleanupService.deleteFilesIfUnreferenced(
+        paths,
+        draftsDao: draftsDao,
+        clipsDao: clipsDao,
+      );
+      _deferredFileCleanup.addAll(unprocessed);
+    } catch (error) {
+      // Backstop for unexpected service failures: retaining already-deleted
+      // paths is safe because the next pass skips files that no longer exist.
+      _deferredFileCleanup.addAll(paths);
+      Log.warning(
+        '⚠️ Deferred file cleanup failed; paths retained: $error',
+        name: 'VideoEditorNotifier',
+        category: LogCategory.video,
+      );
+    }
   }
 
   /// Starts a best-effort cleanup without blocking the editor lifecycle.
@@ -909,7 +922,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     _deferredFileCleanup.addAll(validPaths);
   }
 
-  /// Test hook: the set of files awaiting cleanup.
+  /// Test hook: the set of files awaiting cleanup or retry.
   @visibleForTesting
   Set<String> get deferredFileCleanupForTest => _deferredFileCleanup;
 

--- a/mobile/lib/services/file_cleanup_service.dart
+++ b/mobile/lib/services/file_cleanup_service.dart
@@ -37,7 +37,9 @@ class FileCleanupService {
   ///
   /// Throws:
   ///
-  /// * No exceptions – errors are logged and silently handled.
+  /// * Exceptions from filesystem existence checks or either reference query
+  ///   are propagated to the caller. File deletion failures are logged and
+  ///   otherwise ignored.
   static Future<void> deleteFileIfUnreferenced(
     String? filePath, {
     required DraftsDao draftsDao,
@@ -63,7 +65,13 @@ class FileCleanupService {
   }
 
   /// Deletes multiple files, only those not referenced elsewhere.
-  static Future<void> deleteFilesIfUnreferenced(
+  ///
+  /// A file is kept when its reference state cannot be established or its
+  /// deletion fails. The returned paths were not safely processed and may be
+  /// retried by callers that own a cleanup queue. Reference and filesystem
+  /// failures are logged rather than thrown so one failure does not abandon
+  /// the rest of the batch.
+  static Future<Set<String>> deleteFilesIfUnreferenced(
     List<String?> filePaths, {
     required DraftsDao draftsDao,
     required ClipsDao clipsDao,
@@ -72,21 +80,43 @@ class FileCleanupService {
         .where((path) => path != null && path.isNotEmpty)
         .cast<String>()
         .toList();
-    if (validPaths.isEmpty) return;
+    if (validPaths.isEmpty) return {};
 
     // Resolved as one set: a stop-motion clip hands every one of its stills to
     // this call, and the clip references that hold them are in an unindexed
     // JSON blob — asking per file would scan the table once per still.
-    final referencedByClips = await clipsDao.referencedFilenames(
-      validPaths.map(p.basename).toSet(),
-    );
+    late final Set<String> referencedByClips;
+    try {
+      referencedByClips = await clipsDao.referencedFilenames(
+        validPaths.map(p.basename).toSet(),
+      );
+    } catch (error) {
+      Log.warning(
+        '⚠️ Failed to check clip references for cleanup batch: $error',
+        name: 'FileCleanupService',
+        category: LogCategory.video,
+      );
+      return validPaths.toSet();
+    }
+
+    final unprocessed = <String>{};
 
     for (final path in validPaths) {
-      if (!File(path).existsSync()) continue;
+      try {
+        if (!File(path).existsSync()) continue;
+      } catch (error) {
+        Log.warning(
+          '⚠️ Failed to check file existence during cleanup: '
+          '$path - $error',
+          name: 'FileCleanupService',
+          category: LogCategory.video,
+        );
+        unprocessed.add(path);
+        continue;
+      }
 
       final filename = p.basename(path);
-      if (referencedByClips.contains(filename) ||
-          await draftsDao.isDraftFileReferenced(filename)) {
+      if (referencedByClips.contains(filename)) {
         Log.info(
           '🔗 File still referenced, skipping delete: $path',
           name: 'FileCleanupService',
@@ -95,8 +125,32 @@ class FileCleanupService {
         continue;
       }
 
-      await _deleteFile(path);
+      late final bool referencedByDraft;
+      try {
+        referencedByDraft = await draftsDao.isDraftFileReferenced(filename);
+      } catch (error) {
+        Log.warning(
+          '⚠️ Failed to check draft references during cleanup: '
+          '$path - $error',
+          name: 'FileCleanupService',
+          category: LogCategory.video,
+        );
+        unprocessed.add(path);
+        continue;
+      }
+      if (referencedByDraft) {
+        Log.info(
+          '🔗 File still referenced, skipping delete: $path',
+          name: 'FileCleanupService',
+          category: LogCategory.video,
+        );
+        continue;
+      }
+
+      if (!await _deleteFile(path)) unprocessed.add(path);
     }
+
+    return unprocessed;
   }
 
   /// [DivineVideoClip.ownedFilePaths] minus the ghost frame, which the callers
@@ -135,7 +189,9 @@ class FileCleanupService {
   ///
   /// Throws:
   ///
-  /// * No exceptions – errors are logged and silently handled.
+  /// * Exceptions from filesystem existence checks or either reference query
+  ///   are propagated to the caller. File deletion failures are logged and
+  ///   otherwise ignored.
   static Future<void> deleteDraftAudioFiles(
     Iterable<String> audioFilePaths, {
     required DraftsDao draftsDao,
@@ -174,7 +230,9 @@ class FileCleanupService {
   ///
   /// Throws:
   ///
-  /// * No exceptions – errors are logged and silently handled.
+  /// * Exceptions from filesystem existence checks or either reference query
+  ///   are propagated to the caller. File deletion failures are logged and
+  ///   otherwise ignored.
   static Future<void> deleteGhostFrameFiles(
     Iterable<String?> ghostFramePaths, {
     required DraftsDao draftsDao,
@@ -268,7 +326,7 @@ class FileCleanupService {
   }
 
   /// Internal helper to delete a single file
-  static Future<void> _deleteFile(String filePath) async {
+  static Future<bool> _deleteFile(String filePath) async {
     try {
       await File(filePath).delete();
       Log.info(
@@ -276,18 +334,21 @@ class FileCleanupService {
         name: 'FileCleanupService',
         category: LogCategory.video,
       );
+      return true;
     } on PathNotFoundException {
       Log.info(
         '🗑️ File already deleted: $filePath',
         name: 'FileCleanupService',
         category: LogCategory.video,
       );
+      return true;
     } catch (e) {
       Log.warning(
         '⚠️ Failed to delete file: $filePath - $e',
         name: 'FileCleanupService',
         category: LogCategory.video,
       );
+      return false;
     }
   }
 }

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -45,6 +45,14 @@ import '../mocks/mock_path_provider_platform.dart';
 
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
 
+class _MockAppDatabase extends Mock implements AppDatabase {}
+
+class _MockDraftsDao extends Mock implements DraftsDao {}
+
+class _MockClipsDao extends Mock implements ClipsDao {}
+
+class _MockStringSet extends Mock implements Set<String> {}
+
 /// An operation-scoped trace handle that records its attributes and stop count
 /// so tests can assert the `video_generation` per-render trace behaviour —
 /// which the real (uninitialised) service would silently no-op.
@@ -3504,6 +3512,9 @@ void main() {
   group('VideoEditorProvider deferred file cleanup', () {
     late _MockDraftStorageService mockDraftStorage;
     late AppDatabase database;
+    late _MockDraftsDao draftsDao;
+    late _MockClipsDao clipsDao;
+    late SharedPreferences prefs;
     late ProviderContainer container;
     late Directory tempDir;
     late EditorBackgroundWork backgroundWork;
@@ -3528,6 +3539,31 @@ void main() {
       onTimeout: () => fail('editor background work did not settle'),
     );
 
+    void useMockCleanupDatabase() {
+      disposeContainer();
+      final mockDatabase = _MockAppDatabase();
+      draftsDao = _MockDraftsDao();
+      clipsDao = _MockClipsDao();
+      when(() => mockDatabase.draftsDao).thenReturn(draftsDao);
+      when(() => mockDatabase.clipsDao).thenReturn(clipsDao);
+      when(
+        () => clipsDao.referencedFilenames(any()),
+      ).thenAnswer((_) async => const {});
+      when(
+        () => draftsDao.isDraftFileReferenced(any()),
+      ).thenAnswer((_) async => false);
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          draftStorageServiceProvider.overrideWithValue(mockDraftStorage),
+          databaseProvider.overrideWithValue(mockDatabase),
+        ],
+      );
+      containerDisposed = false;
+      backgroundWork = container.read(editorBackgroundWorkProvider);
+      container.read(videoEditorProvider.notifier);
+    }
+
     setUpAll(() {
       registerFallbackValue(
         DivineVideoDraft.create(
@@ -3543,7 +3579,7 @@ void main() {
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
-      final prefs = await SharedPreferences.getInstance();
+      prefs = await SharedPreferences.getInstance();
       mockDraftStorage = _MockDraftStorageService();
       database = AppDatabase.test(NativeDatabase.memory());
       tempDir = Directory.systemTemp.createTempSync('editor_defer_test');
@@ -3746,6 +3782,90 @@ void main() {
         async.flushMicrotasks();
         expect(cleanupSettled, isTrue);
       });
+    });
+
+    test('failed cleanup stays queued without escaping the drain', () async {
+      useMockCleanupDatabase();
+      final orphan = File(p.join(tempDir.path, 'failed.mp4'))
+        ..writeAsBytesSync(const [0, 1, 2, 3]);
+      final notifier = container.read(videoEditorProvider.notifier);
+      notifier.deferFileCleanup([orphan.path]);
+      expect(notifier.deferredFileCleanupForTest, contains(orphan.path));
+      when(
+        () => clipsDao.referencedFilenames(any()),
+      ).thenThrow(StateError('database closed'));
+
+      await notifier.reset(keepAutosavedDraft: true);
+      await settleBackgroundWork();
+
+      expect(notifier.deferredFileCleanupForTest, {orphan.path});
+      expect(orphan.existsSync(), isTrue);
+    });
+
+    test('partial failure retains only the unprocessed path', () async {
+      useMockCleanupDatabase();
+      final failing = File(p.join(tempDir.path, 'failing.mp4'))
+        ..writeAsBytesSync(const [0, 1, 2, 3]);
+      final deletable = File(p.join(tempDir.path, 'deletable.mp4'))
+        ..writeAsBytesSync(const [0, 1, 2, 3]);
+      final notifier = container.read(videoEditorProvider.notifier);
+      notifier.deferFileCleanup([failing.path, deletable.path]);
+      expect(notifier.deferredFileCleanupForTest, isNotEmpty);
+      when(
+        () => draftsDao.isDraftFileReferenced('failing.mp4'),
+      ).thenThrow(StateError('database closed'));
+
+      await notifier.reset(keepAutosavedDraft: true);
+      await settleBackgroundWork();
+
+      expect(notifier.deferredFileCleanupForTest, {failing.path});
+      expect(failing.existsSync(), isTrue);
+      expect(deletable.existsSync(), isFalse);
+    });
+
+    test('a retained cleanup path is retried successfully', () async {
+      useMockCleanupDatabase();
+      final orphan = File(p.join(tempDir.path, 'retry.mp4'))
+        ..writeAsBytesSync(const [0, 1, 2, 3]);
+      final notifier = container.read(videoEditorProvider.notifier);
+      notifier.deferFileCleanup([orphan.path]);
+      expect(notifier.deferredFileCleanupForTest, contains(orphan.path));
+      when(
+        () => clipsDao.referencedFilenames(any()),
+      ).thenThrow(StateError('database closed'));
+      await notifier.reset(keepAutosavedDraft: true);
+      await settleBackgroundWork();
+      expect(notifier.deferredFileCleanupForTest, {orphan.path});
+
+      when(
+        () => clipsDao.referencedFilenames(any()),
+      ).thenAnswer((_) async => const {});
+      await notifier.reset(keepAutosavedDraft: true);
+      await settleBackgroundWork();
+
+      expect(notifier.deferredFileCleanupForTest, isEmpty);
+      expect(orphan.existsSync(), isFalse);
+    });
+
+    test('unexpected cleanup failure retains the batch and settles', () async {
+      useMockCleanupDatabase();
+      final orphan = File(p.join(tempDir.path, 'unexpected.mp4'))
+        ..writeAsBytesSync(const [0, 1, 2, 3]);
+      final notifier = container.read(videoEditorProvider.notifier);
+      notifier.deferFileCleanup([orphan.path]);
+      final referencedFilenames = _MockStringSet();
+      when(
+        () => clipsDao.referencedFilenames(any()),
+      ).thenAnswer((_) async => referencedFilenames);
+      when(
+        () => referencedFilenames.contains(any()),
+      ).thenThrow(StateError('unexpected set failure'));
+
+      await notifier.reset(keepAutosavedDraft: true);
+      await settleBackgroundWork();
+
+      expect(notifier.deferredFileCleanupForTest, {orphan.path});
+      expect(orphan.existsSync(), isTrue);
     });
 
     test('reset cleanup remains awaitable during container teardown', () async {

--- a/mobile/test/services/file_cleanup_service_test.dart
+++ b/mobile/test/services/file_cleanup_service_test.dart
@@ -20,6 +20,8 @@ class _MockDraftsDao extends Mock implements DraftsDao {}
 
 class _MockClipsDao extends Mock implements ClipsDao {}
 
+class _MockFile extends Mock implements File {}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(<String>{});
@@ -103,6 +105,121 @@ void main() {
         );
       },
     );
+
+    group('batch failure recovery', () {
+      late Directory tempDir;
+
+      setUp(() {
+        tempDir = Directory.systemTemp.createTempSync(
+          'divine_cleanup_failure',
+        );
+      });
+
+      tearDown(() {
+        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+      });
+
+      File writeFile(String name) =>
+          File(p.join(tempDir.path, name))
+            ..writeAsBytesSync(const [0, 1, 2, 3]);
+
+      test('retains the whole batch when the clip lookup fails', () async {
+        final first = writeFile('first.mp4');
+        final second = writeFile('second.mp4');
+        when(
+          () => clipsDao.referencedFilenames(any()),
+        ).thenThrow(StateError('database closed'));
+
+        final unprocessed = await FileCleanupService.deleteFilesIfUnreferenced(
+          [first.path, second.path],
+          draftsDao: draftsDao,
+          clipsDao: clipsDao,
+        );
+
+        expect(unprocessed, {first.path, second.path});
+        expect(first.existsSync(), isTrue);
+        expect(second.existsSync(), isTrue);
+        verifyNever(() => draftsDao.isDraftFileReferenced(any()));
+      });
+
+      test('continues after one draft lookup fails', () async {
+        final failing = writeFile('failing.mp4');
+        final deletable = writeFile('deletable.mp4');
+        when(
+          () => clipsDao.referencedFilenames(any()),
+        ).thenAnswer((_) async => const {});
+        when(
+          () => draftsDao.isDraftFileReferenced('failing.mp4'),
+        ).thenThrow(StateError('database closed'));
+        when(
+          () => draftsDao.isDraftFileReferenced('deletable.mp4'),
+        ).thenAnswer((_) async => false);
+
+        final unprocessed = await FileCleanupService.deleteFilesIfUnreferenced(
+          [failing.path, deletable.path],
+          draftsDao: draftsDao,
+          clipsDao: clipsDao,
+        );
+
+        expect(unprocessed, {failing.path});
+        expect(failing.existsSync(), isTrue);
+        expect(deletable.existsSync(), isFalse);
+      });
+
+      test('continues after one existence check fails', () async {
+        final inaccessiblePath = p.join(tempDir.path, 'inaccessible.mp4');
+        final deletable = writeFile('deletable.mp4');
+        final inaccessibleFile = _MockFile();
+        when(inaccessibleFile.existsSync).thenThrow(
+          const FileSystemException('unavailable'),
+        );
+        when(
+          () => clipsDao.referencedFilenames(any()),
+        ).thenAnswer((_) async => const {});
+        when(
+          () => draftsDao.isDraftFileReferenced(any()),
+        ).thenAnswer((_) async => false);
+
+        final unprocessed = await IOOverrides.runZoned(
+          () => FileCleanupService.deleteFilesIfUnreferenced(
+            [inaccessiblePath, deletable.path],
+            draftsDao: draftsDao,
+            clipsDao: clipsDao,
+          ),
+          createFile: (path) =>
+              path == inaccessiblePath ? inaccessibleFile : deletable,
+        );
+
+        expect(unprocessed, {inaccessiblePath});
+        expect(deletable.existsSync(), isFalse);
+      });
+
+      test('retains a path when deletion fails', () async {
+        final failingPath = p.join(tempDir.path, 'undeletable.mp4');
+        final failingFile = _MockFile();
+        when(failingFile.existsSync).thenReturn(true);
+        when(failingFile.delete).thenThrow(
+          const FileSystemException('permission denied'),
+        );
+        when(
+          () => clipsDao.referencedFilenames(any()),
+        ).thenAnswer((_) async => const {});
+        when(
+          () => draftsDao.isDraftFileReferenced(any()),
+        ).thenAnswer((_) async => false);
+
+        final unprocessed = await IOOverrides.runZoned(
+          () => FileCleanupService.deleteFilesIfUnreferenced(
+            [failingPath],
+            draftsDao: draftsDao,
+            clipsDao: clipsDao,
+          ),
+          createFile: (_) => failingFile,
+        );
+
+        expect(unprocessed, {failingPath});
+      });
+    });
 
     group('deleteDraftAudioFiles', () {
       late Directory tempDir;


### PR DESCRIPTION
## Problem

Deferred editor cleanup emptied its queue before checking whether files were still referenced. A database or filesystem error could therefore lose the entire cleanup batch and escape from the fire-and-forget teardown task as an unhandled asynchronous error.

## Fix

File cleanup now treats an incomplete reference check as unsafe to delete, reports the affected paths back to callers, and continues processing independent paths where possible. The editor restores those paths to its deferred queue for a later retry and contains unexpected failures at the lifecycle boundary. Deletion and reference-check failures are logged locally and are not sent to Crashlytics.

The branch is rebased over the active-autosave cleanup work from #8820. Cleanup keeps the shared EditorBackgroundWork completion boundary: it waits for autosaves already in flight, takes and clears one batch to prevent duplicate concurrent processing, and restores only paths that could not be processed safely.

Existing callers may continue to ignore the returned retry set. Other single-file cleanup behavior is unchanged.

## Verification

- `flutter analyze lib test integration_test`
- `very_good test --optimization test/services/file_cleanup_service_test.dart test/providers/video_editor_provider_test.dart` (144 passed)
- Empty-catch, test and production Future.delayed, uncancellable-timer, and unchanged-assertion ratchets
- Red/green mutation proof: removing the retry `addAll` makes the partial-retention regression test fail with an empty queue

Closes #8813