### PR TITLE
test(editor): prove saved draft files survive session cleanup

### DIFF
--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -3830,10 +3830,11 @@ void main() {
           ),
         );
         addTimelineClip();
+        final notifier = container.read(videoEditorProvider.notifier);
 
-        expect(await editorNotifier.autosaveChanges(), isTrue);
+        expect(await notifier.autosaveChanges(), isTrue);
         expect(
-          editorNotifier.deferredFileCleanupForTest,
+          notifier.deferredFileCleanupForTest,
           containsAll([kept.path, goner.path]),
         );
         expect(kept.existsSync(), isTrue);
@@ -3843,8 +3844,8 @@ void main() {
           isTrue,
         );
 
-        await editorNotifier.reset(keepAutosavedDraft: true);
-        await drainDeferredCleanup(editorNotifier);
+        await notifier.reset(keepAutosavedDraft: true);
+        await settleBackgroundWork();
 
         expect(
           kept.existsSync(),

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -3599,12 +3599,19 @@ void main() {
       }
     });
 
-    // Stubs the next autosave to hand [orphan] to the deferral sink instead of
-    // deleting it — the editor's undo history may still need it — and returns
-    // the file it created on disk.
-    File stubDeferringAutosave() {
-      final orphan = File(p.join(tempDir.path, 'orphan.mp4'))
-        ..writeAsBytesSync(const [0, 1, 2, 3]);
+    // Stubs the next autosave to hand the named files to the deferral sink
+    // instead of deleting them — the editor's undo history may still need
+    // them — and returns the files it created on disk.
+    List<File> stubDeferringAutosave([
+      List<String> filenames = const ['orphan.mp4'],
+    ]) {
+      final orphans = filenames
+          .map(
+            (filename) =>
+                File(p.join(tempDir.path, filename))
+                  ..writeAsBytesSync(const [0, 1, 2, 3]),
+          )
+          .toList();
       when(
         () => mockDraftStorage.saveDraft(
           any(),
@@ -3614,9 +3621,9 @@ void main() {
         final defer =
             invocation.namedArguments[#deferOrphanCleanup]
                 as void Function(List<String?>)?;
-        defer?.call([orphan.path]);
+        defer?.call(orphans.map((file) => file.path).toList());
       });
-      return orphan;
+      return orphans;
     }
 
     void addTimelineClip() {
@@ -3634,7 +3641,7 @@ void main() {
     }
 
     test('an autosave keeps its orphaned files alive', () async {
-      final orphan = stubDeferringAutosave();
+      final orphan = stubDeferringAutosave().single;
       addTimelineClip();
       final notifier = container.read(videoEditorProvider.notifier);
 
@@ -3651,7 +3658,7 @@ void main() {
     });
 
     test('reset reaps deferred files at editor-session end', () async {
-      final orphan = stubDeferringAutosave();
+      final orphan = stubDeferringAutosave().single;
       addTimelineClip();
       final notifier = container.read(videoEditorProvider.notifier);
       expect(await notifier.autosaveChanges(), isTrue);
@@ -3749,7 +3756,7 @@ void main() {
     });
 
     test('reset cleanup remains awaitable during container teardown', () async {
-      final orphan = stubDeferringAutosave();
+      final orphan = stubDeferringAutosave().single;
       addTimelineClip();
       final notifier = container.read(videoEditorProvider.notifier);
       expect(await notifier.autosaveChanges(), isTrue);
@@ -3772,7 +3779,7 @@ void main() {
     });
 
     test('container teardown reaps deferred files as a safety net', () async {
-      final orphan = stubDeferringAutosave();
+      final orphan = stubDeferringAutosave().single;
       addTimelineClip();
       final notifier = container.read(videoEditorProvider.notifier);
       expect(await notifier.autosaveChanges(), isTrue);
@@ -3788,6 +3795,65 @@ void main() {
         reason: 'onDispose reaps deferred files left when reset never ran',
       );
     });
+
+    test(
+      'keeps a draft-referenced deferred file, reaping its peer',
+      () async {
+        final [kept, goner] = stubDeferringAutosave([
+          'kept.mp4',
+          'goner.mp4',
+        ]);
+        final timelineFile = File(p.join(tempDir.path, 'timeline.mp4'))
+          ..writeAsBytesSync(const [4, 5, 6]);
+        final realDraftStorage = DraftStorageService(
+          draftsDao: database.draftsDao,
+          clipsDao: database.clipsDao,
+        );
+        DivineVideoClip clip(String id, File file) => DivineVideoClip(
+          id: id,
+          video: EditorVideo.file(file.path),
+          duration: const Duration(seconds: 6),
+          recordedAt: DateTime(2026),
+          targetAspectRatio: AspectRatio.square,
+          originalAspectRatio: 9 / 16,
+        );
+
+        await realDraftStorage.saveDraft(
+          DivineVideoDraft.create(
+            id: 'survivor',
+            clips: [clip('timeline', timelineFile)],
+            title: '',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'video',
+            finalRenderedClip: clip('rendered', kept),
+          ),
+        );
+        addTimelineClip();
+
+        expect(await editorNotifier.autosaveChanges(), isTrue);
+        expect(
+          editorNotifier.deferredFileCleanupForTest,
+          containsAll([kept.path, goner.path]),
+        );
+        expect(kept.existsSync(), isTrue);
+        expect(goner.existsSync(), isTrue);
+        expect(
+          await database.draftsDao.isDraftFileReferenced('kept.mp4'),
+          isTrue,
+        );
+
+        await editorNotifier.reset(keepAutosavedDraft: true);
+        await drainDeferredCleanup(editorNotifier);
+
+        expect(
+          kept.existsSync(),
+          isTrue,
+          reason: 'the surviving draft still references this rendered file',
+        );
+        expect(goner.existsSync(), isFalse);
+      },
+    );
 
     test('container teardown reaps a replaced final rendered file', () async {
       // Point the documents dir at this group's unique per-test temp dir

--- a/mobile/test/services/file_cleanup_service_test.dart
+++ b/mobile/test/services/file_cleanup_service_test.dart
@@ -9,9 +9,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/video_editor/clip_chroma_key.dart';
 import 'package:openvine/services/clip_library_service.dart';
+import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/file_cleanup_service.dart';
 import 'package:path/path.dart' as p;
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -312,13 +314,40 @@ void main() {
         if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
       });
 
+      File write(String name) =>
+          File(p.join(tempDir.path, name))..writeAsBytesSync(const [1, 2, 3]);
+
+      Future<void> saveDraftReferencing(File renderedFile) async {
+        DivineVideoClip clip(String id, File file) => DivineVideoClip(
+          id: id,
+          video: EditorVideo.file(file.path),
+          duration: const Duration(seconds: 3),
+          recordedAt: DateTime(2026),
+          targetAspectRatio: model.AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+        );
+        final storage = DraftStorageService(
+          draftsDao: database.draftsDao,
+          clipsDao: database.clipsDao,
+        );
+
+        await storage.saveDraft(
+          DivineVideoDraft.create(
+            id: 'survivor',
+            clips: [clip('timeline', write('timeline.mp4'))],
+            title: '',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'video',
+            finalRenderedClip: clip('rendered', renderedFile),
+          ),
+        );
+      }
+
       test('deletes the reverse caches of a deleted clip', () async {
         // Reading [DivineVideoClip.ownedFilePaths] widened this delete to the
         // cached forward/reversed renders. They were previously enumerated
         // nowhere, so removing a reversed clip leaked both files.
-        File write(String name) =>
-            File(p.join(tempDir.path, name))..writeAsBytesSync(const [1, 2, 3]);
-
         final video = write('clip_rev.mp4');
         final forward = write('clip_rev_forward.mp4');
         final reversed = write('clip_rev_reversed.mp4');
@@ -348,9 +377,6 @@ void main() {
         // The reference check reads the JSON blob, which carries
         // `forwardVideoPath` — a duplicated clip shares the cache and must
         // keep it.
-        File write(String name) =>
-            File(p.join(tempDir.path, name))..writeAsBytesSync(const [1, 2, 3]);
-
         final shared = write('shared_forward.mp4');
         DivineVideoClip clipWithShare(String id, String videoName) =>
             DivineVideoClip(
@@ -375,6 +401,53 @@ void main() {
           shared.existsSync(),
           isTrue,
           reason: 'the surviving library clip still points at this cache',
+        );
+      });
+
+      test('batch cleanup keeps a file referenced by a draft', () async {
+        final kept = write('kept.mp4');
+        final goner = write('goner.mp4');
+        await saveDraftReferencing(kept);
+        expect(
+          await database.draftsDao.isDraftFileReferenced('kept.mp4'),
+          isTrue,
+        );
+        expect(kept.existsSync(), isTrue);
+        expect(goner.existsSync(), isTrue);
+
+        await FileCleanupService.deleteFilesIfUnreferenced(
+          [kept.path, goner.path],
+          draftsDao: database.draftsDao,
+          clipsDao: database.clipsDao,
+        );
+
+        expect(
+          kept.existsSync(),
+          isTrue,
+          reason: 'the surviving draft still points at this rendered file',
+        );
+        expect(goner.existsSync(), isFalse);
+      });
+
+      test('single-file cleanup keeps a file referenced by a draft', () async {
+        final kept = write('kept.mp4');
+        await saveDraftReferencing(kept);
+        expect(
+          await database.draftsDao.isDraftFileReferenced('kept.mp4'),
+          isTrue,
+        );
+        expect(kept.existsSync(), isTrue);
+
+        await FileCleanupService.deleteFileIfUnreferenced(
+          kept.path,
+          draftsDao: database.draftsDao,
+          clipsDao: database.clipsDao,
+        );
+
+        expect(
+          kept.existsSync(),
+          isTrue,
+          reason: 'the surviving draft still points at this rendered file',
         );
       });
     });


### PR DESCRIPTION
## Problem

Deferred-file cleanup tests mostly used mocked autosaves that never wrote draft or clip rows. They proved unreferenced files were deleted, but could not catch a regression that deletes a rendered file still owned by a saved draft. That regression would leave the saved draft pointing at missing media.

## Why this fix

The editor lifecycle regression now saves a real surviving draft, defers its rendered file alongside an unreferenced peer, and proves session cleanup keeps only the referenced file. Direct service tests pin the same draft-reference behavior for both batch and single-file cleanup. The autosave helper accepts multiple deferred files so this scenario uses the same setup path as the existing lifecycle cases.

The clip-library half of the reference guard was already covered by the reverse-cache test; these cases deliberately exercise the previously uncovered draft-owned columns.

## Deliberately unchanged

- No production behavior changes.
- Cleanup timing and the active-autosave coordination added by #8820 are unchanged.
- No generated code, localization, migration, or UI changes.

## Verification

- `flutter test --no-pub test/providers/video_editor_provider_test.dart` (126 tests)
- `flutter test --no-pub test/services/file_cleanup_service_test.dart` (12 tests)
- `flutter analyze --no-pub lib test integration_test`
- Pre-push changed-file analysis and tests (138 tests)
- Mutation proof: removing the batch draft-reference check made exactly the new lifecycle and direct batch tests fail; the other 136 tests passed

Closes #8815