### PR TITLE
fix(people-lists): stop membership edits caching the wrong event and failing silently

### DIFF
--- a/mobile/packages/people_lists_repository/lib/src/local_people_lists_cache.dart
+++ b/mobile/packages/people_lists_repository/lib/src/local_people_lists_cache.dart
@@ -97,6 +97,10 @@ class LocalPeopleListsCache {
   }
 
   /// Returns one non-tombstoned cache record, including its publish source.
+  ///
+  /// A row written before source preservation, or one whose stored source no
+  /// longer matches its list, comes back with
+  /// [CachedPeopleListRecord.hasPublishSource] false rather than as `null`.
   Future<CachedPeopleListRecord?> readRecord({
     required String ownerPubkey,
     required String listId,
@@ -160,7 +164,17 @@ class LocalPeopleListsCache {
   /// equal timestamp already exists. [receivedAt] is stored alongside the
   /// record for diagnostics and future sync logic.
   ///
-  /// Throws if the Hive box cannot be opened or the underlying write fails.
+  /// [sourceTags] and [sourceContent] are the exact tags and content of the
+  /// event [list] was decoded from. Supply both to keep the row editable: a
+  /// membership edit republishes from them, so a row stored without them can
+  /// be displayed but not edited. This write replaces the whole row, so
+  /// omitting them discards a source the row already carried.
+  ///
+  /// Throws:
+  ///
+  /// * [ArgumentError] if exactly one of [sourceTags] and [sourceContent] is
+  ///   supplied. They are both-or-neither.
+  /// * Whatever opening the Hive box or the underlying write throws.
   Future<void> putList({
     required String ownerPubkey,
     required UserList list,
@@ -193,6 +207,11 @@ class LocalPeopleListsCache {
 
   /// Persists every entry in [lists] via [putList], sharing the same
   /// [receivedAt] timestamp.
+  ///
+  /// Passes no publish source, so every row written here is display-only and
+  /// membership edits on it fail closed until a relay revision restores the
+  /// source. Prefer [putList] with the originating event's tags and content
+  /// for anything the user can edit.
   ///
   /// Throws if the Hive box cannot be opened or any underlying write fails.
   /// A partial failure leaves previously written entries in the box.
@@ -292,11 +311,16 @@ class LocalPeopleListsCache {
     return records;
   }
 
-  /// Decodes a single stored record into a [UserList].
+  /// Decodes a single stored record into a [CachedPeopleListRecord].
   ///
   /// Returns `null` and logs a warning when the record is shaped unexpectedly
   /// or when [UserList.fromJson] throws. A single malformed row must not
   /// poison the whole `readLists`/`watchLists` result.
+  ///
+  /// A row whose stored source is malformed, or names a different `d` tag than
+  /// its list, degrades to a record with no source rather than being dropped:
+  /// it still displays, but [CachedPeopleListRecord.hasPublishSource] is false
+  /// and it cannot drive a membership edit.
   CachedPeopleListRecord? _decodeRecord(Map<dynamic, dynamic> record) {
     final raw = record[_CacheKeys.list];
     if (raw is! Map) return null;

--- a/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
+++ b/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
@@ -341,19 +341,21 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
     List<List<String>>? sourceTags,
     String? sourceContent,
   }) async {
-    final payload = Nip51PeopleListCodec.encode(
-      list,
-      sourceTags: sourceTags,
-      sourceContent: sourceContent,
-    );
-    final event = Event(
-      ownerPubkey,
-      payload.kind,
-      payload.tags,
-      payload.content,
-    );
-
     try {
+      // encode throws ArgumentError on a malformed or mismatched source, so
+      // it belongs inside the catch: callers only ever see the documented
+      // failure result, never a raw programming-invariant throw.
+      final payload = Nip51PeopleListCodec.encode(
+        list,
+        sourceTags: sourceTags,
+        sourceContent: sourceContent,
+      );
+      final event = Event(
+        ownerPubkey,
+        payload.kind,
+        payload.tags,
+        payload.content,
+      );
       final sent = await _nostrClient.publishEvent(event);
       if (sent is! PublishSuccess) {
         return const PeopleListPublishResult.failed();

--- a/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
+++ b/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
@@ -178,6 +178,13 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
       return const PeopleListPublishResult.noop();
     }
     if (!record.hasPublishSource) {
+      Log.warning(
+        'Cannot add a member of people list $listId: the cached row '
+        'predates source preservation, so no complete replacement '
+        'can be built from it',
+        name: _logName,
+        category: LogCategory.relay,
+      );
       return const PeopleListPublishResult.failed();
     }
     final updated = existing.copyWith(
@@ -211,6 +218,13 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
       return const PeopleListPublishResult.noop();
     }
     if (!record.hasPublishSource) {
+      Log.warning(
+        'Cannot remove a member of people list $listId: the cached row '
+        'predates source preservation, so no complete replacement '
+        'can be built from it',
+        name: _logName,
+        category: LogCategory.relay,
+      );
       return const PeopleListPublishResult.failed();
     }
     final updated = existing.copyWith(

--- a/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
+++ b/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
@@ -324,7 +324,7 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
         list: list,
       );
       final existing = seen[result.addressableId];
-      if (existing != null && existing.list.updatedAt.isAfter(list.updatedAt)) {
+      if (existing != null && !_supersedes(list, existing.list)) {
         continue;
       }
       seen[result.addressableId] = result;
@@ -424,6 +424,20 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
       return false;
     }
     return true;
+  }
+
+  /// Whether revision [candidate] supersedes [selected] under NIP-01
+  /// replaceable-event ordering: the later `updatedAt` wins, and a tie is
+  /// broken on the lowest event id. An absent id on either side leaves the tie
+  /// unbroken, so the already-selected revision is kept.
+  static bool _supersedes(UserList candidate, UserList selected) {
+    if (candidate.updatedAt != selected.updatedAt) {
+      return candidate.updatedAt.isAfter(selected.updatedAt);
+    }
+    final candidateId = candidate.nostrEventId;
+    final selectedId = selected.nostrEventId;
+    if (candidateId == null || selectedId == null) return false;
+    return candidateId.compareTo(selectedId) < 0;
   }
 
   static bool _isNewerRevision(

--- a/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
+++ b/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
@@ -414,10 +414,9 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
           cached.nostrEventId != null &&
           cached.nostrEventId == incoming.nostrEventId;
     }
-    // NIP-01 breaks a created_at tie on the lowest event id. An absent id on
-    // either side leaves nothing to compare, so the tie-break does not apply;
-    // substituting '' for a missing incoming id sorts below every real id and
-    // would let the id-less revision win every tie instead of losing it.
+    // NIP-01 breaks a created_at tie on the lowest event id. If either id is
+    // absent, this guard does not apply and the incoming revision is adopted,
+    // preserving the existing behavior for incomplete identifiers.
     final cachedId = cached.nostrEventId;
     final incomingId = incoming.nostrEventId;
     if (cached.updatedAt == incoming.updatedAt &&

--- a/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
+++ b/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
@@ -410,10 +410,17 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
           cached.nostrEventId != null &&
           cached.nostrEventId == incoming.nostrEventId;
     }
+    // NIP-01 breaks a created_at tie on the lowest event id. An absent id on
+    // either side leaves nothing to compare, so the tie-break does not apply;
+    // substituting '' for a missing incoming id sorts below every real id and
+    // would let the id-less revision win every tie instead of losing it.
+    final cachedId = cached.nostrEventId;
+    final incomingId = incoming.nostrEventId;
     if (cached.updatedAt == incoming.updatedAt &&
-        cached.nostrEventId != null &&
-        cached.nostrEventId != incoming.nostrEventId &&
-        cached.nostrEventId!.compareTo(incoming.nostrEventId ?? '') < 0) {
+        cachedId != null &&
+        incomingId != null &&
+        cachedId != incomingId &&
+        cachedId.compareTo(incomingId) < 0) {
       return false;
     }
     return true;

--- a/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
+++ b/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
@@ -361,12 +361,16 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
         return const PeopleListPublishResult.failed();
       }
       final persisted = list.copyWith(nostrEventId: sent.event.id);
+      // Cache what was published, not what was handed to publishEvent: the
+      // client rebinds event.tags while applying the NIP-89 client tag, so the
+      // payload never sees it. Storing the payload would pair sourceTags with
+      // a nostrEventId those tags cannot hash to.
       await _cache.putList(
         ownerPubkey: ownerPubkey,
         list: persisted,
         receivedAt: DateTime.now().toUtc(),
-        sourceTags: payload.tags,
-        sourceContent: payload.content,
+        sourceTags: sent.event.tags,
+        sourceContent: sent.event.content,
       );
       return PeopleListPublishResult.submitted(eventId: sent.event.id);
     } on Object catch (error, stackTrace) {

--- a/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
@@ -528,6 +528,60 @@ void main() {
         final stored = await repository.readLists(ownerPubkey: _ownerPubkey);
         expect(stored.single.pubkeys, equals(const [_memberB]));
       });
+
+      test(
+        'preserves foreign tags, surviving p-tag fields, and content',
+        () async {
+          final client = _MockNostrClient();
+          when(() => client.publicKey).thenReturn(_ownerPubkey);
+          final remote = signedEvent(
+            kind: _peopleListKind,
+            tags: const [
+              ['d', 'shared-list'],
+              ['alt', 'Written by another client'],
+              ['p', _memberA, 'wss://relay.example', 'friend'],
+              ['p', _memberB, 'wss://other.example', 'bestie'],
+              ['expiration', '2000000000'],
+            ],
+            content: 'nip44-encrypted-private-members',
+            createdAt: 1000,
+          );
+          when(
+            () => client.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: true,
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => (events: [remote], timedOut: false, noRelays: false),
+          );
+          when(() => client.publishEvent(any())).thenAnswer((invocation) async {
+            final event = invocation.positionalArguments.first as Event;
+            return PublishSuccess(event: event);
+          });
+          final repository = buildRepository(nostrClient: client);
+
+          final result = await repository.removePubkey(
+            ownerPubkey: _ownerPubkey,
+            listId: 'shared-list',
+            pubkey: _memberA,
+          );
+
+          expect(result.status, PeopleListPublishStatus.submitted);
+          final published =
+              verify(() => client.publishEvent(captureAny())).captured.single
+                  as Event;
+          // The removed member loses every matching tag; the foreign tags and
+          // the surviving member's relay hint and petname survive verbatim.
+          expect(published.tags, const [
+            ['d', 'shared-list'],
+            ['alt', 'Written by another client'],
+            ['p', _memberB, 'wss://other.example', 'bestie'],
+            ['expiration', '2000000000'],
+          ]);
+          expect(published.content, 'nip44-encrypted-private-members');
+        },
+      );
     });
 
     group('inconclusive reconcile before a replacement (#8273)', () {

--- a/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
@@ -1502,6 +1502,45 @@ void main() {
         );
       });
 
+      test('uses the lowest event id when duplicate revisions tie', () async {
+        final client = _MockNostrClient();
+        when(() => client.publicKey).thenReturn(_ownerPubkey);
+
+        final higherId =
+            peopleEvent(
+                pubkey: _ownerPubkey,
+                dTag: 'crew',
+                title: 'Crew Higher id',
+                pubkeys: const [_memberA],
+                createdAt: 1710000000,
+              )
+              ..id =
+                  'ffffffffffffffffffffffffffffffff'
+                  'ffffffffffffffffffffffffffffffff';
+        final lowerId =
+            peopleEvent(
+                pubkey: _ownerPubkey,
+                dTag: 'crew',
+                title: 'Crew Lower id',
+                pubkeys: const [_memberB],
+                createdAt: 1710000000,
+              )
+              ..id =
+                  '00000000000000000000000000000000'
+                  '00000000000000000000000000000000';
+        when(
+          () => client.queryEvents(any(), useCache: any(named: 'useCache')),
+        ).thenAnswer((_) async => [lowerId, higherId]);
+
+        final repository = buildRepository(nostrClient: client);
+
+        final emissions = await repository.searchPublicLists('crew').toList();
+
+        expect(emissions, hasLength(1));
+        expect(emissions.single, hasLength(1));
+        expect(emissions.single.single.list.name, equals('Crew Lower id'));
+      });
+
       test('does not yield when no events match the query', () async {
         final client = _MockNostrClient();
         when(() => client.publicKey).thenReturn(_ownerPubkey);

--- a/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
@@ -343,6 +343,80 @@ void main() {
       );
 
       test(
+        'caches the tags the relay actually received, not the pre-publish ones',
+        () async {
+          final client = _MockNostrClient();
+          when(() => client.publicKey).thenReturn(_ownerPubkey);
+          final remote = signedEvent(
+            kind: _peopleListKind,
+            tags: const [
+              ['d', 'shared-list'],
+              ['alt', 'Keep me'],
+              ['p', _memberA],
+            ],
+            content: 'ciphertext',
+            createdAt: 1000,
+          );
+          when(
+            () => client.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: true,
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => (events: [remote], timedOut: false, noRelays: false),
+          );
+          // NostrClient appends the NIP-89 client tag during publish and
+          // rebinds event.tags to a new list, so the caller's pre-publish
+          // payload never observes it. Model that here.
+          when(() => client.publishEvent(any())).thenAnswer((invocation) async {
+            final outgoing = invocation.positionalArguments.first as Event;
+            return PublishSuccess(
+              event: signedEvent(
+                kind: outgoing.kind,
+                tags: [
+                  ...outgoing.tags,
+                  const ['client', 'Divine'],
+                ],
+                content: outgoing.content,
+                createdAt: outgoing.createdAt,
+              ),
+            );
+          });
+          final repository = buildRepository(nostrClient: client);
+
+          expect(
+            (await repository.addPubkey(
+              ownerPubkey: _ownerPubkey,
+              listId: 'shared-list',
+              pubkey: _memberB,
+            )).submitted,
+            isTrue,
+          );
+          expect(
+            (await repository.addPubkey(
+              ownerPubkey: _ownerPubkey,
+              listId: 'shared-list',
+              pubkey: _memberC,
+            )).submitted,
+            isTrue,
+          );
+
+          final published = verify(
+            () => client.publishEvent(captureAny()),
+          ).captured.cast<Event>();
+          // The second edit is built from the source cached by the first. If
+          // that source were the pre-publish payload, the tag the relay holds
+          // would be missing here and the cached nostrEventId would belong to
+          // an event the cached tags cannot reproduce.
+          expect(
+            published.last.tags,
+            contains(equals(const ['client', 'Divine'])),
+          );
+        },
+      );
+
+      test(
         'publishes a kind 30000 event with a full p tag for new pubkey',
         () async {
           final client = _MockNostrClient();


### PR DESCRIPTION
Follow-ups from reviewing #8784 after it merged, plus a comment-only correction clarifying unchanged missing-id behavior.

## Problem

#8784 made a people-list membership edit republish the complete source event, so metadata, relay hints and encrypted members written by other clients survive. Reviewing it turned up seven follow-ups. Two are user-visible:

- **The cached source was not the event that got published.** `publishEvent` appends the NIP-89 client tag by rebinding `event.tags` and recomputing the id, rather than mutating in place. `Event()` aliases the caller's list, so the pre-publish payload never observes that. Each edit stored those stale tags next to the *published* event's id — a source that cannot hash to the id sitting beside it, breaking the invariant `CachedPeopleListRecord` documents. It never self-corrects: the row's millisecond `updatedAt` always beats the relay copy's second-resolution `created_at`, so reconcile skips it forever.
- **An edit refused for missing source data had no diagnostic.** When a cached row has no publish source the repository correctly fails closed, but returned a bare `failed()` with no error or log line. The new warning identifies that specific refusal; other failure paths remain unchanged.

The rest: `Nip51PeopleListCodec.encode`'s `ArgumentError` escaped the repository instead of becoming the documented `failed()`; `searchPublicLists` resolved timestamp ties differently from the reconcile path; and the cache dartdoc still described the pre-#8784 shapes. The cached-revision comparison now checks explicitly for two non-null event ids, but this does not change its behavior for an incoming revision with no id: that case still falls through to replacement.

## Why this shape

The cached-source fix uses `sent.event.tags` and `sent.event.content`, already in hand: no new API, schema change, or migration. Search now picks the lowest event id when timestamps tie, matching reconcile's ordering for valid events. The paths retain separate comparator implementations; this is not a shared-comparator refactor.

## Deliberately unchanged

- **A preserved `client` tag defeating the attribution opt-out** — #8831. `applyToEvent` checks `hasClientTag` before `isEnabled()`, so once that tag is in the cached source a user who turns attribution off keeps publishing it. Real and user-facing, but the remedy is a privacy/product call.
- **NIP-40 `expiration` republished verbatim** — #8832. A protocol judgment about which tags are data worth preserving and which are the publisher's own assertion.
- **Publish and cache timestamps.** People-lists does not step `created_at` past the previous event, so rapid edits can tie and the relay selects the lowest event id. Its optimistic cache also retains millisecond `updatedAt`, which can reject a different relay-winning revision from that same second and build a later edit without those remote changes. Both limitations predate this PR and remain unchanged. The existing `updatedAt` field could hold event time, so a new schema is not inherently required; however, that field also controls millisecond deletion tombstones. Simply truncating it does not settle same-second ordering and deletion behavior.
- **Other failure diagnostics and malformed event ids.** The new warnings identify missing publish sources only. Other refusal paths retain their existing behavior, and this PR does not establish a consistent policy for incoming events without valid ids.
- No cache schema change and no revision watermark.

## Verification

- `dart format` clean; `flutter analyze lib test` clean
- `very_good test --coverage --min-coverage 95` — 117 tests passed, 96.16%
- Both new behavioural tests were confirmed red before their fix: the `removePubkey` one under a revert to `encode(list)` (it loses the `alt` and `expiration` tags, flattens the surviving member's relay hint and petname, and replaces the ciphertext), and the cached-source one under a revert to `payload.tags`.
- The explicit null-id guard has no behavior change for an incoming empty `event.id`, which a well-formed relay response does not produce. No new malformed-id regression test was added.
