### PR TITLE
fix(reporting): optimistic report UI (#8053 PR 2 of 2) — BLOCKED on PR 1

### DIFF
--- a/docs/superpowers/plans/2026-09-07-report-optimistic-ui-pr2.md
+++ b/docs/superpowers/plans/2026-09-07-report-optimistic-ui-pr2.md
@@ -1,0 +1,192 @@
+# Report optimistic UI (#8053 PR 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make content-report submission instant — persist the intent, show the confirmation immediately, and let the durable queue (landed in PR 1) drive all three channels — without ever silently dropping a report.
+
+**Architecture:** PR 1 added the `pending_reports` durable queue + `ReportRetryService` and routed the kind-1984 and Zendesk channels through it (delivery outcome unchanged). PR 2 flips the UI to optimistic: split an enqueue-only seam out of `DmRepository.sendMessage` so the moderation DM is awaited only to its durable `outgoing_dms` enqueue, have `reportContent` enqueue-and-return instead of awaiting the inline drive, make the confirmation unconditional, and remove the now-dead `ReportDelivery.localOnly` / `notSent` / DM-delayed UI.
+
+**Tech Stack:** Flutter/Dart, drift, Riverpod, mocktail, dm_repository (NIP-17), nostr_sdk.
+
+**Spec:** `docs/superpowers/specs/2026-09-07-report-durable-optimistic-design.md`
+
+**Depends on:** PR 1 (`fix/8053-report-optimistic-durable`, #8822). This branch is cut from PR 1; do NOT mark ready until PR 1 merges, then rebase onto `main` (which will contain PR 1) so the diff is PR-2-only.
+
+## Global Constraints
+
+- Preserve #6610 duplicate-DM coalescing: a repeat submit must re-drive the same parked `outgoing_dms` row via `recoverFullSend`, never mint a second rumor.
+- Preserve the #8352 self-report refusal: a self-report stays a silent no-op, never enqueued and never DM'd.
+- No secret persisted: redaction (`sanitizeDiagnosticText`) stays before any enqueue (already true from PR 1).
+- Confirmation becomes unconditional (product decision, endorsed): a report that fails every channel is never surfaced to the reporter; the queue owns delivery.
+- divine-mobile CI ratchets: every test inside a `group`; no new `Future.delayed` in tests (use `pumpEventQueue`/fake async); run `dart run build_runner build` and commit generated files; `flutter analyze` clean project-wide.
+
+---
+
+## File Structure
+
+- `mobile/packages/dm_repository/lib/src/dm_repository.dart` — extract `_prepareAndEnqueueRumor`; add public `enqueueSend`. Behemoth file; do not restructure beyond this seam.
+- `mobile/packages/models/lib/src/enqueue_send_result.dart` (create) — `EnqueueSendResult` result type; export from `models`.
+- `mobile/lib/blocs/report/report_submission_cubit.dart` — optimistic submit; drive DM via `enqueueSend` + unawaited `recoverFullSend`; drop `notSent` and `moderationDmFailed`.
+- `mobile/lib/services/content_reporting_service.dart` — add an enqueue-and-return path (no inline await of delivery); remove `ReportDelivery.localOnly` and the reached/localOnly computation.
+- `mobile/lib/widgets/report_content_dialog.dart` + `report_confirmation_body.dart` — unconditional confirmation; delete the "reached no channel" suppression and the DM-delayed caveat.
+- Tests: `dm_repository` send tests; `report_submission_cubit_test.dart`; `report_content_dialog_test.dart`; `report_content_confirmation_test.dart`; `content_reporting_service_test.dart`.
+
+---
+
+### Task 1: `DmRepository.enqueueSend` enqueue-only seam
+
+**Files:**
+- Modify: `mobile/packages/dm_repository/lib/src/dm_repository.dart` (`sendMessage` ~:4521-4637; add `enqueueSend` + private `_prepareAndEnqueueRumor`)
+- Create: `mobile/packages/models/lib/src/enqueue_send_result.dart`
+- Modify: `mobile/packages/models/lib/models.dart` (export the new type)
+- Test: `mobile/packages/dm_repository/test/src/dm_repository_send_test.dart` (or the existing send test file)
+
+**Interfaces:**
+- Produces: `EnqueueSendResult` — `{ String? queuedRumorId, bool refused, bool blocked, bool tooLong, String? error }` with `bool get accepted => queuedRumorId != null`.
+- Produces: `Future<EnqueueSendResult> DmRepository.enqueueSend({required String recipientPubkey, required String content, String? replyToId, List<List<String>> additionalTags})` — runs the guards (init/self-send/send-gate), builds the rumor (with the `#7326` sendBatchId), refuses oversize, enqueues the `outgoing_dms` row, and returns the `rumor.id` as `queuedRumorId`. Does NOT publish.
+- Consumes (unchanged): `recoverFullSend(rumorId:)` drives the parked row to publish afterward.
+
+- [ ] **Step 1: Write the failing test** — enqueueSend parks a row and does not publish.
+
+```dart
+test('enqueueSend enqueues a pending row and returns its rumor id without '
+    'publishing', () async {
+  final result = await repo.enqueueSend(
+    recipientPubkey: _peer,
+    content: 'report dm',
+  );
+  expect(result.accepted, isTrue);
+  final row = await outgoingDmsDao.getById(result.queuedRumorId!);
+  expect(row, isNotNull);
+  expect(row!.recipientWrapStatus, OutgoingWrapStatus.pending);
+  verifyNever(() => mockNip17MessageService.sendRumor(any()));
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails** — `flutter test .../dm_repository_send_test.dart -n "enqueueSend enqueues"` → FAIL (no `enqueueSend`).
+
+- [ ] **Step 3: Extract `_prepareAndEnqueueRumor`** — move `sendMessage`'s guards → send-gate → `sendBatchId`/`rumor` build → `_refuseIfOversized` → `outgoingDao.enqueue` block into a private method returning a record `({NIP17SendResult? refusal, Event? rumor, String? conversationId, String? sendBatchId, List<List<String>> rumorTags, List<String> participants})`. `sendMessage` calls it, returns `refusal` if set, else continues its existing publish/persist block using the returned `rumor`/`conversationId`/`rumorTags`/`participants`/`sendBatchId`. **Behavior-preserving** — no logic change, only extraction. Keep every invariant comment with its code.
+
+- [ ] **Step 4: Add `enqueueSend`** — call `_prepareAndEnqueueRumor`; map `refusal` (self-send→refused, blocked→blocked, tooLong→tooLong) onto `EnqueueSendResult`, else return `EnqueueSendResult(queuedRumorId: rumor.id)`.
+
+- [ ] **Step 5: Run the new test + the FULL dm_repository suite** — `flutter test packages/dm_repository/test` → all PASS. The existing `sendMessage` tests are the regression guard for the extraction; they must stay green unchanged.
+
+- [ ] **Step 6: Commit** — `feat(dm): add enqueueSend seam (enqueue without publish) for #8053`.
+
+---
+
+### Task 2: Optimistic moderation-DM dispatch in the cubit
+
+**Files:**
+- Modify: `mobile/lib/blocs/report/report_submission_cubit.dart` (`_dispatchModerationDm` ~:492-590)
+- Test: `mobile/test/blocs/report/report_submission_cubit_test.dart`
+
+**Interfaces:**
+- Consumes: `DmRepository.enqueueSend` (Task 1), `recoverFullSend(rumorId:)`.
+
+- [ ] **Step 1: Write the failing test** — submit awaits only the enqueue; publish is not awaited before the confirmed state.
+
+```dart
+test('submit confirms after the DM is enqueued, not after it publishes',
+    () async {
+  when(() => dmRepo.enqueueSend(...)).thenAnswer(
+    (_) async => const EnqueueSendResult(queuedRumorId: 'rumor1'));
+  final completer = Completer<NIP17SendResult>();
+  when(() => dmRepo.recoverFullSend(rumorId: 'rumor1'))
+      .thenAnswer((_) => completer.future); // never completes in-test
+  await cubit.submit(reason: ..., reasonTitle: ..., details: 'x');
+  expect(cubit.state.status, ReportSubmissionStatus.submitted);
+  verify(() => dmRepo.enqueueSend(...)).called(1);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails** — the current code awaits `sendMessage`, so it will not reach `submitted` without the publish resolving.
+
+- [ ] **Step 3: Rewrite `_dispatchModerationDm`** — first submit: `final r = await dmRepo.enqueueSend(...)`; if `r.refused`/`blocked`/`tooLong`, handle as today (no DM); else store `r.queuedRumorId` in `ModerationDmProgress` and `unawaited(dmRepo.recoverFullSend(rumorId: r.queuedRumorId!))`. Repeat submit (coalesce, #6610): if a `queuedRumorId` is already parked, `unawaited(recoverFullSend(rumorId: parked))` — never a second `enqueueSend`.
+
+- [ ] **Step 4: Run the cubit suite** — `flutter test test/blocs/report/report_submission_cubit_test.dart`. Rework the 5 pinned tests (`:225`, `:303`, `:342`, `:380`, `:525`) to the enqueue+recover shape; the coalescing test (`:380`, `:525`) must still prove one rumor per report.
+
+- [ ] **Step 5: Commit** — `feat(report): enqueue the moderation DM and confirm optimistically (#8053)`.
+
+---
+
+### Task 3: `reportContent` enqueue-and-return; remove `localOnly`
+
+**Files:**
+- Modify: `mobile/lib/services/content_reporting_service.dart` (`reportContent` inline-drive block; `ReportDelivery` enum ~:24)
+- Test: `mobile/test/services/content_reporting_service_test.dart`
+
+**Interfaces:**
+- Produces: `reportContent` returns `ReportResult` with `delivery` in `{reached (=queued), refused}` only; `localOnly` is removed.
+
+- [ ] **Step 1: Write the failing test** — with a wired DAO, `reportContent` enqueues and returns without awaiting relay/Zendesk delivery.
+
+```dart
+test('reportContent returns after enqueue without awaiting the channels',
+    () async {
+  final publishCompleter = Completer<PublishResult>();
+  when(() => nostr.publishEvent(any(), targetRelays: any(named: 'targetRelays')))
+      .thenAnswer((_) => publishCompleter.future); // never completes
+  final result = await service.reportContent(...);
+  expect(result.success, isTrue);
+  expect(await dao.getById(result.reportId!), isNotNull); // parked, undelivered
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails** — current `reportContent` awaits `_publishReportEvent`, so it hangs on the never-completing publish.
+
+- [ ] **Step 3: Change the queue path** — when the DAO is wired: enqueue, then `unawaited(_driveReportChannelsOnce(reportId))` (a helper that drives relay+zendesk once via the existing `deliverReportChannel` and records outcomes best-effort), and return `createSuccess(reportId, delivery: reached)` immediately. Delete the reached/localOnly computation and the `ReportDelivery.localOnly` enum value; update `ReportResult.failure` to use a non-localOnly default (introduce `queued` or reuse `reached`). Null-DAO path (legacy callers/tests) keeps the old inline behavior guarded behind the null check.
+
+- [ ] **Step 4: Run the content-reporting suite** — rework `content_reporting_service_test.dart` delivery assertions (`:839`, `:883`, `:920`) that reference `localOnly`/`reached` to the new queued semantics.
+
+- [ ] **Step 5: Commit** — `feat(report): make reportContent enqueue-and-return, drop localOnly (#8053)`.
+
+---
+
+### Task 4: Unconditional confirmation UI; remove DM-delayed / no-channel
+
+**Files:**
+- Modify: `mobile/lib/blocs/report/report_submission_cubit.dart` (`ReportSubmissionState.moderationDmFailed`, `notSent` status)
+- Modify: `mobile/lib/widgets/report_content_dialog.dart` (`_submitReport` ~:423-468; `_ConfirmationBody`)
+- Modify: `mobile/lib/widgets/report_confirmation_body.dart` (or wherever `reportModerationDmDelayed` renders)
+- Test: `mobile/test/widgets/report_content_dialog_test.dart`, `report_content_confirmation_test.dart`
+
+- [ ] **Step 1: Write the failing test** — the dialog always animates to the confirmation after submit, with no delayed caveat.
+
+```dart
+testWidgets('shows the unconditional confirmation after submit', (t) async {
+  // even when every channel is failing/unconfirmed
+  await _submitAReport(t);
+  expect(find.byType(ReportConfirmationBody), findsOneWidget);
+  expect(find.text(l10n.reportModerationDmDelayed), findsNothing);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails** — the delayed caveat/no-channel suppression still exists.
+
+- [ ] **Step 3: Remove the dead UI** — delete `moderationDmFailed` from the state, the `notSent` status branch in `_submitReport`, the "reached no channel" inline error, and the `reportModerationDmDelayed` caveat. Confirmation is shown whenever `status == submitted`; `submitted` is now the only non-refused success terminal.
+
+- [ ] **Step 4: Run the dialog + confirmation suites** — rework the pinned tests: `report_content_dialog_test.dart` (`:1096`, `:1121`, `:1139`, `:1153`, `:1169`, `:1189`, `:2017`, `:2056`) and `report_content_confirmation_test.dart` (`:31`). Delete the ones asserting removed behavior; keep/repoint the ones asserting the confirmation shows.
+
+- [ ] **Step 5: l10n** — remove the now-unused `reportModerationDmDelayed` (and any `reportNotSent`) ARB keys across locales, or add them to the orphaned-key baseline with a `# staged` note; run `flutter gen-l10n`. Confirm the orphaned-arb-key ratchet passes.
+
+- [ ] **Step 6: Commit** — `feat(report): unconditional confirmation, remove DM-delayed UI (#8053)`.
+
+---
+
+### Task 5: Final verification pass
+
+- [ ] **Step 1:** `dart run build_runner build --delete-conflicting-outputs` in `mobile/` and `packages/db_client`; commit any generated changes.
+- [ ] **Step 2:** `flutter analyze` project-wide → clean.
+- [ ] **Step 3:** Run the ratchet scripts touched: `scripts/check_ungrouped_tests.sh`, `scripts/check_future_delayed_ceiling.sh`, `scripts/check_orphaned_arb_key_floor.sh`.
+- [ ] **Step 4:** Full affected-suite run: dm_repository send, report cubit, report dialog, confirmation, content-reporting, and the PR-1 durable-queue tests (unchanged, must stay green).
+- [ ] **Step 5:** Adversarial self-review loop (independent reviewer + first-hand + mutation checks), focusing on: coalescing (#6610) still one-rumor-per-report; no silent-drop path reintroduced; the `sendMessage` extraction is truly behavior-preserving.
+
+---
+
+## Resume checklist (after PR 1 merges)
+
+1. `git fetch origin && git rebase origin/main` this branch (PR 1 is now in main; the diff becomes PR-2-only).
+2. Re-run the PR-1 durable-queue tests to confirm the base is intact.
+3. Execute Tasks 1-5.
+4. Only then mark ready + request `@divinevideo/reviewers` (on Matt's go).

--- a/mobile/lib/blocs/report/report_submission_cubit.dart
+++ b/mobile/lib/blocs/report/report_submission_cubit.dart
@@ -218,13 +218,9 @@ enum ReportSubmissionStatus {
   /// A submit is in flight.
   submitting,
 
-  /// The report reached a channel off this device — show the confirmation.
+  /// The report was durably submitted — show the confirmation. Delivery of the
+  /// three channels is owned by their durable queues, so this is unconditional.
   submitted,
-
-  /// The report was recorded but nothing left the device, so the confirmation
-  /// would be false in four places at once. Keeps the form live so retrying is
-  /// one tap.
-  notSent,
 
   /// The report was rejected or the submit threw.
   failure,
@@ -233,15 +229,10 @@ enum ReportSubmissionStatus {
 class ReportSubmissionState extends Equatable {
   const ReportSubmissionState({
     this.status = ReportSubmissionStatus.editing,
-    this.moderationDmFailed = false,
     this.moderationDm = const ModerationDmProgress(),
   });
 
   final ReportSubmissionStatus status;
-
-  /// Whether the moderation team could not be reached directly, which drives
-  /// the `reportModerationDmDelayed` caveat on the confirmation screen.
-  final bool moderationDmFailed;
 
   final ModerationDmProgress moderationDm;
 
@@ -249,16 +240,14 @@ class ReportSubmissionState extends Equatable {
 
   ReportSubmissionState copyWith({
     ReportSubmissionStatus? status,
-    bool? moderationDmFailed,
     ModerationDmProgress? moderationDm,
   }) => ReportSubmissionState(
     status: status ?? this.status,
-    moderationDmFailed: moderationDmFailed ?? this.moderationDmFailed,
     moderationDm: moderationDm ?? this.moderationDm,
   );
 
   @override
-  List<Object?> get props => [status, moderationDmFailed, moderationDm];
+  List<Object?> get props => [status, moderationDm];
 }
 
 /// Owns one report sheet's submission: the kind-1984 / Zendesk report and the
@@ -290,7 +279,7 @@ class ReportSubmissionCubit extends Cubit<ReportSubmissionState> {
   ///
   /// A coordination primitive rather than data — it is never rendered and
   /// never asserted on, so it stays off [ReportSubmissionState].
-  Future<bool>? _moderationDmInFlight;
+  Future<void>? _moderationDmInFlight;
 
   /// Submits one report through both channels.
   ///
@@ -337,52 +326,23 @@ class ReportSubmissionCubit extends Cubit<ReportSubmissionState> {
       if (result.isSilentSuccess && result.delivery == ReportDelivery.refused) {
         // A deliberate refusal — a self-report (#8352). Nothing was built,
         // published, or recorded, and nothing should be sent: not the
-        // kind-1984 event, and NOT the moderation DM. Unlike `localOnly`
-        // below (a real report that couldn't reach a channel and is handed to
-        // the retrying DM), `refused` must never touch the DM path, or a
-        // self-naming report leaves the device privately. Silent success —
-        // show the normal confirmation.
+        // kind-1984 event, and NOT the moderation DM, or a self-naming report
+        // would leave the device privately. Silent success — show the normal
+        // confirmation without touching the DM path.
         _update(status: ReportSubmissionStatus.submitted);
         return;
       }
 
-      if (result.success && result.delivery == ReportDelivery.localOnly) {
-        // Nothing left the device — every channel refused, which usually
-        // means no connectivity. The confirmation screen would be false in
-        // four places at once (its title, the review promise, the green
-        // check, and any DM caveat), so don't show it: surface the failure
-        // and leave Submit live so retrying is one tap.
-        //
-        // Still hand the report to the moderation DM. `sendMessage` writes
-        // a durable `outgoing_dms` row before any I/O and marks it failed
-        // when the publish can't go out, which is precisely what
-        // `OutgoingDmRetryService`'s second sweep arm replays once
-        // connectivity returns. It is the only report channel with a
-        // retry — the kind-1984 publish and the Zendesk ticket are both
-        // fire-and-forget — so skipping it here would make an offline
-        // report deliver less often than before this fix.
-        //
-        // Not awaited: the user already knows the submit failed, and must
-        // not sit through a doomed relay round-trip to be told.
-        // `_sendModerationDm` coalesces onto whatever this sheet already
-        // has outstanding, so a repeat tap re-drives the parked row
-        // instead of stacking a second one for the sweep (#6610).
-        unawaited(_sendModerationDm(reason, reasonTitle, details));
-        _update(status: ReportSubmissionStatus.notSent);
-        return;
-      }
-
       if (result.success) {
-        final moderationDmFailed = await _sendModerationDm(
-          reason,
-          reasonTitle,
-          details,
-        );
+        // Optimistic: the report is durable the moment reportContent returns
+        // (PR 1 queues its relay + Zendesk channels), so confirm now. Enqueue
+        // the moderation DM durably too — awaiting only the fast local write —
+        // and let it publish in the background, so the confirmation never waits
+        // on a relay. Delivery of all three channels is owned by their durable
+        // queues, so the confirmation is unconditional. #8053.
+        await _sendModerationDm(reason, reasonTitle, details);
         if (isClosed) return;
-        _update(
-          status: ReportSubmissionStatus.submitted,
-          moderationDmFailed: moderationDmFailed,
-        );
+        _update(status: ReportSubmissionStatus.submitted);
         return;
       }
 
@@ -432,7 +392,7 @@ class ReportSubmissionCubit extends Cubit<ReportSubmissionState> {
   /// returning its result to a submit the user has since re-aimed would report
   /// the superseded snapshot. Waiting lets the re-aimed submit see the row the
   /// first one parked and replace it.
-  Future<bool> _sendModerationDm(
+  Future<void> _sendModerationDm(
     ContentFilterReason reason,
     String reasonTitle,
     String details,
@@ -442,7 +402,7 @@ class ReportSubmissionCubit extends Cubit<ReportSubmissionState> {
         ? _runModerationDm(reason, reasonTitle, details)
         // _dispatchModerationDm absorbs its own errors, but handle the error
         // arm anyway so a hypothetical one cannot cancel the queued submit.
-        : outstanding.then<bool>(
+        : outstanding.then<void>(
             (_) => _runModerationDm(reason, reasonTitle, details),
             onError: (_) => _runModerationDm(reason, reasonTitle, details),
           );
@@ -459,18 +419,20 @@ class ReportSubmissionCubit extends Cubit<ReportSubmissionState> {
 
   /// One link in the [_sendModerationDm] queue: re-checks the terminal
   /// outcomes, which an earlier link may have reached while this one waited.
-  Future<bool> _runModerationDm(
+  Future<void> _runModerationDm(
     ContentFilterReason reason,
     String reasonTitle,
     String details,
   ) {
     final progress = state.moderationDm;
-    if (progress.matchesDelivered(reason, details)) return Future.value(false);
+    // Already delivered with this exact reason/details, or terminal
+    // (unverifiable / blocked / tooLong): do not send another copy (#6610).
+    if (progress.matchesDelivered(reason, details)) return Future.value();
     if (progress.outcome
         case ModerationDmOutcome.unverifiable ||
             ModerationDmOutcome.blocked ||
             ModerationDmOutcome.tooLong) {
-      return Future.value(true);
+      return Future.value();
     }
     return _dispatchModerationDm(reason, reasonTitle, details);
   }
@@ -489,7 +451,7 @@ class ReportSubmissionCubit extends Cubit<ReportSubmissionState> {
   /// reason cards live, so the selection can move while a send is in flight,
   /// and the row parked below must be recorded under the reason its rumor
   /// actually carries or the staleness check above it goes blind.
-  Future<bool> _dispatchModerationDm(
+  Future<void> _dispatchModerationDm(
     ContentFilterReason dispatchReason,
     String dispatchReasonTitle,
     String dispatchDetails,
@@ -525,129 +487,161 @@ class ReportSubmissionCubit extends Cubit<ReportSubmissionState> {
             // account changed. Do not mint a fresh report DM when we cannot
             // prove the stale one was cancelled.
             _markUnverifiable();
-            return true;
+            return;
           }
         }
         _update(moderationDm: state.moderationDm.withoutQueuedRow());
       }
 
       final parked = state.moderationDm.queuedRumorId;
-
-      final NIP17SendResult dmResult;
-      if (parked == null) {
-        dmResult = await transport.repository.sendMessage(
-          recipientPubkey: transport.pubkey,
-          content: content,
-          // Moderation reports carry user identity + reported content;
-          // never let them degrade to a metadata-leaking NIP-04
-          // plaintext duplicate. NIP-17 gift wrap only.
-          skipNip04Fallback: true,
-          additionalTags: ContentReportingService.moderationDmTags(
-            reason: dispatchReason,
-            sha256: _target.moderationSha256,
-            videoUrl: _target.moderationVideoUrl,
-          ),
-        );
-      } else {
-        try {
-          // Re-drive the parked row instead of minting a second one. This
-          // joins an in-flight sweep replay for the same rumor rather than
-          // publishing alongside it, and `resetRetryBudget` re-arms a row
-          // the sweep may have already spent — an explicit resubmit is the
-          // signal to hand it back a fresh budget, so coalescing here can
-          // never turn a duplicated report into a dropped one.
-          dmResult = await transport.repository.recoverFullSend(
-            rumorId: parked,
-            resetRetryBudget: true,
-          );
-          // ignore: avoid_catching_errors
-        } on ArgumentError {
-          // Ambiguous. `recoverFullSend` throws the same type when the row is
-          // gone (possibly delivered by the sweep, possibly deleted by the
-          // user) and when the row belongs to another account. Coalescing still
-          // must not mint a second report DM, but it also must not claim the
-          // team has this copy when the repository could not prove that — so
-          // this sheet stops sending and keeps the caveat.
-          _markUnverifiable();
-          return true;
-        }
+      if (parked != null) {
+        // Coalesce (#6610): re-drive the row an earlier submit parked rather
+        // than minting a second rumor. The drive runs in the background so the
+        // confirmation is never blocked on a relay.
+        _driveModerationDm(transport, parked, dispatchReason, dispatchDetails);
+        return;
       }
 
-      // sendMessage signals non-delivery by RETURNING a failure, not
-      // by throwing, so the catch below cannot see it. Switch over the
-      // sealed type rather than reading `.success` so a new variant
-      // becomes a compile error here instead of a silent success.
-      final failed = switch (dmResult) {
-        // Includes selfWrapPublished: false — the team received the
-        // report; only the sender's own cross-device copy is missing.
-        NIP17SendSuccess() => false,
-        // blocked, retryablePending, and hard failures alike.
-        NIP17SendFailure() => true,
-      };
-      final queuedRumorId = switch (dmResult) {
-        // The row was consumed by the delivery.
-        NIP17SendSuccess() => null,
-        // A block is terminal: the send gate drops the row and re-driving
-        // would only re-hit the same policy.
-        NIP17SendFailure(blocked: true) => null,
-        // The size guard also refuses before enqueue. A retry has no row and
-        // unchanged content necessarily hits the same ceiling.
-        NIP17SendFailure(tooLong: true) => null,
-        // A hard failure and a soft-unconfirmed both leave the row for the
-        // sweep. `sendMessage` reports the row it just parked; a re-drive
-        // reports nothing new and keeps the row it was given.
-        NIP17SendFailure(:final queuedRumorId) => queuedRumorId ?? parked,
-      };
-      final outcome = switch (dmResult) {
-        NIP17SendSuccess() => ModerationDmOutcome.delivered,
-        NIP17SendFailure(blocked: true) => ModerationDmOutcome.blocked,
-        NIP17SendFailure(tooLong: true) => ModerationDmOutcome.tooLong,
-        NIP17SendFailure() => ModerationDmOutcome.pending,
-      };
-      _update(
-        moderationDm: ModerationDmProgress(
-          outcome: outcome,
-          delivered: failed
-              ? state.moderationDm.delivered
-              : (reason: dispatchReason, details: dispatchDetails),
-          queuedRumorId: queuedRumorId,
-          // Track the row's reason alongside it, so the staleness check above
-          // can tell a plain resubmit (coalesce, #6610) from a changed mind
-          // (replace). The snapshot, not live selection: this runs after an
-          // await, and the rumor now parked was built with the snapshot.
-          queuedReason: queuedRumorId == null ? null : dispatchReason,
-          queuedDetails: queuedRumorId == null ? null : dispatchDetails,
+      // Fresh send: enqueue the DM durably, awaiting only the fast local write.
+      // The enqueue-then-recoverFullSend path is NIP-17 gift wrap only and
+      // never fires the metadata-leaking NIP-04 fallback (that lives in
+      // sendMessage's publish path alone), so identity-bearing report content
+      // cannot leak as plaintext even though we no longer pass
+      // skipNip04Fallback. #8053.
+      final enqueued = await transport.repository.enqueueSend(
+        recipientPubkey: transport.pubkey,
+        content: content,
+        additionalTags: ContentReportingService.moderationDmTags(
+          reason: dispatchReason,
+          sha256: _target.moderationSha256,
+          videoUrl: _target.moderationVideoUrl,
         ),
       );
 
-      if (dmResult case final NIP17SendFailure failure) {
+      if (enqueued.blocked || enqueued.tooLong) {
+        // Terminal before a row was parked: the policy gate (#176) or the size
+        // ceiling (#7331) refused it. Record it so a resubmit does not
+        // re-attempt (#6610); the report reached its other channels regardless.
+        _update(
+          moderationDm: ModerationDmProgress(
+            outcome: enqueued.blocked
+                ? ModerationDmOutcome.blocked
+                : ModerationDmOutcome.tooLong,
+            delivered: state.moderationDm.delivered,
+          ),
+        );
         Log.warning(
-          'Moderation DM not delivered '
+          'Moderation DM refused before enqueue '
           '(recipient=${pubkeyForLogs(transport.pubkey)}, '
-          'blocked=${failure.blocked}, '
-          'retryablePending=${failure.retryablePending}): '
-          '${failure.error}',
+          'blocked=${enqueued.blocked}, tooLong=${enqueued.tooLong}): '
+          '${enqueued.error}',
           name: 'ReportSubmissionCubit',
           category: LogCategory.system,
         );
+        return;
       }
-      return failed;
+
+      final rumorId = enqueued.queuedRumorId;
+      if (rumorId == null) {
+        // A refusal with no row (a self-addressed send) — unreachable for the
+        // moderation pubkey, handled defensively: nothing parked, nothing to
+        // drive.
+        return;
+      }
+
+      // The row is durable now; record it for coalescing, then drive its
+      // publish in the background.
+      _update(
+        moderationDm: ModerationDmProgress(
+          delivered: state.moderationDm.delivered,
+          queuedRumorId: rumorId,
+          // The snapshot, not live selection: the parked rumor was built with
+          // it, and the staleness check compares against it on a later submit.
+          queuedReason: dispatchReason,
+          queuedDetails: dispatchDetails,
+        ),
+      );
+      _driveModerationDm(transport, rumorId, dispatchReason, dispatchDetails);
     } catch (e, stackTrace) {
-      // On the delivered path the report already reached the team through
-      // another channel; the moderation DM is a secondary notification.
-      // Don't fail the flow, but surface the outcome instead of swallowing
-      // it so the user isn't told the team was reached when it wasn't.
-      // Reachable for pre-flight throws only (uninitialized repository,
-      // invalid recipient) — never for a delivery outcome, which arrives
-      // as a returned value above.
+      // Pre-flight throws only (uninitialized repository, invalid recipient) —
+      // never a delivery outcome. The report already reached its other
+      // channels; a moderation-DM preflight failure must not take it down.
       Log.warning(
-        'Failed to send moderation DM: $e',
+        'Failed to enqueue moderation DM: $e',
         name: 'ReportSubmissionCubit',
         category: LogCategory.system,
       );
       // Unwrapped, for the same reason as the submit path above.
       addError(e, stackTrace);
-      return true;
+    }
+  }
+
+  /// Drives a parked moderation-DM row's publish in the background, recording
+  /// the outcome for #6610 coalescing when it settles. Never blocks the
+  /// confirmation. A row that is gone (delivered by the sweep, or cancelled)
+  /// surfaces as an `ArgumentError` and is left to the sweep — never re-sent.
+  void _driveModerationDm(
+    ModerationDmTransport transport,
+    String rumorId,
+    ContentFilterReason reason,
+    String details,
+  ) {
+    unawaited(
+      transport.repository
+          .recoverFullSend(rumorId: rumorId, resetRetryBudget: true)
+          .then(
+            (result) {
+              if (!isClosed) _recordDmDriveResult(result, reason, details);
+            },
+            onError: (Object e) {
+              Log.warning(
+                'Moderation DM background drive could not resolve $rumorId: $e',
+                name: 'ReportSubmissionCubit',
+                category: LogCategory.system,
+              );
+              // `recoverFullSend` raises ArgumentError when the row is gone
+              // (delivered by the sweep, cancelled, or a foreign account):
+              // delivery can be neither confirmed nor retried. Mark it
+              // unverifiable so a resubmit does not mint the #6610 duplicate.
+              if (e is ArgumentError && !isClosed) _markUnverifiable();
+            },
+          ),
+    );
+  }
+
+  void _recordDmDriveResult(
+    NIP17SendResult result,
+    ContentFilterReason reason,
+    String details,
+  ) {
+    switch (result) {
+      case NIP17SendSuccess():
+        // Delivered: the team has it. Clear the parked row so a plain resubmit
+        // does not send a second copy (#6610).
+        _update(
+          moderationDm: ModerationDmProgress(
+            outcome: ModerationDmOutcome.delivered,
+            delivered: (reason: reason, details: details),
+          ),
+        );
+      case NIP17SendFailure(blocked: true):
+        _update(
+          moderationDm: ModerationDmProgress(
+            outcome: ModerationDmOutcome.blocked,
+            delivered: state.moderationDm.delivered,
+          ),
+        );
+      case NIP17SendFailure(tooLong: true):
+        _update(
+          moderationDm: ModerationDmProgress(
+            outcome: ModerationDmOutcome.tooLong,
+            delivered: state.moderationDm.delivered,
+          ),
+        );
+      case NIP17SendFailure():
+        // Soft/hard failure: the row stays parked (already recorded) for the
+        // sweep; leave the pending state untouched.
+        break;
     }
   }
 
@@ -679,14 +673,12 @@ class ReportSubmissionCubit extends Cubit<ReportSubmissionState> {
   /// to record an outcome after `close()`.
   void _update({
     ReportSubmissionStatus? status,
-    bool? moderationDmFailed,
     ModerationDmProgress? moderationDm,
   }) {
     if (isClosed) return;
     emit(
       state.copyWith(
         status: status,
-        moderationDmFailed: moderationDmFailed,
         moderationDm: moderationDm,
       ),
     );

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4200,8 +4200,6 @@
     "reportReasonChildSafetySubtitle": "ስለ ታዳጊዎች ደህንነት አጠቃላይ ስጋቶች",
     "reportReasonUnderageUser": "ተጠቃሚው ከ16 ዓመት በታች ይመስላል",
     "reportReasonUnderageUserSubtitle": "የመለያው ባለቤት ዕድሜው ያልደረሰ ይመስላል",
-    "reportModerationDmDelayed": "አሁን የልከኝነት ቡድኑን በቀጥታ ማግኘት አልቻልንም፣ ነገር ግን ሪፖርትዎ ተቀብሏል እና ይገመገማል።",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "የልከኝነት ቡድኑን መልእክት ላክ",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "ቪዲዮ ተለጠፈ፣ ግን {count, plural, =1{{count} የተባባሪ ግብዣ አልተላከም።} other{{count} የተባባሪ ግብዣዎች አልተላኩም።}}",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4068,8 +4068,6 @@
     "reportReasonChildSafetySubtitle": "مخاوف عامة بشأن سلامة القُصَّر",
     "reportReasonUnderageUser": "يبدو أن المستخدم دون 16 عامًا",
     "reportReasonUnderageUserSubtitle": "يبدو أن صاحب الحساب دون السن القانونية",
-    "reportModerationDmDelayed": "تعذّر علينا الوصول إلى فريق الإشراف مباشرةً الآن، لكن تم استلام بلاغك وسيُراجَع.",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "راسل فريق الإشراف",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "تم نشر الفيديو، لكن {count, plural, zero{لم تُرسَل أي دعوة تعاون.} one{لم تُرسَل دعوة تعاون واحدة.} two{لم تُرسَل دعوتا تعاون.} few{لم تُرسَل {count} دعوات تعاون.} many{لم تُرسَل {count} دعوة تعاون.} other{لم تُرسَل {count} دعوة تعاون.}}",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4206,8 +4206,6 @@
     "reportReasonChildSafetySubtitle": "Общи притеснения за безопасността на непълнолетни",
     "reportReasonUnderageUser": "Потребителят изглежда под 16 г.",
     "reportReasonUnderageUserSubtitle": "Собственикът на акаунта изглежда непълнолетен",
-    "reportModerationDmDelayed": "Точно сега не успяхме да се свържем директно с екипа по модерация, но докладът ти е получен и ще бъде прегледан.",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "Пиши на екипа по модерация",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "Видеото е публикувано, но {count, plural, =1{1 покана за сътрудник не се изпрати.} other{{count} покани за сътрудници не се изпратиха.}}",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4068,8 +4068,6 @@
     "reportReasonChildSafetySubtitle": "Allgemeine Bedenken zur Sicherheit von Minderjährigen",
     "reportReasonUnderageUser": "Nutzer scheint unter 16 zu sein",
     "reportReasonUnderageUserSubtitle": "Kontoinhaber scheint minderjährig zu sein",
-    "reportModerationDmDelayed": "Wir konnten das Moderationsteam gerade nicht direkt erreichen, aber deine Meldung ist eingegangen und wird geprüft.",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "Moderationsteam anschreiben",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "Video gepostet, aber {count, plural, =1{1 Mitwirkenden-Einladung wurde nicht gesendet.} other{{count} Mitwirkenden-Einladungen wurden nicht gesendet.}}",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2974,10 +2974,6 @@
   "reportReceivedTitle": "Report Received",
   "reportReceivedThankYou": "Thank you for helping keep Divine safe.",
   "reportReceivedReviewNotice": "Our team will review your report and take appropriate action. You may receive updates via direct message.",
-  "reportModerationDmDelayed": "We couldn't reach the moderation team directly just now, but your report was received and will be reviewed.",
-  "@reportModerationDmDelayed": {
-    "description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."
-  },
   "reportContactModeration": "Message the moderation team",
   "@reportContactModeration": {
     "description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4068,8 +4068,6 @@
     "reportReasonChildSafetySubtitle": "Inquietudes generales sobre la seguridad de menores",
     "reportReasonUnderageUser": "El usuario parece ser menor de 16",
     "reportReasonUnderageUserSubtitle": "El titular de la cuenta parece ser menor de edad",
-    "reportModerationDmDelayed": "No pudimos contactar directamente al equipo de moderación ahora mismo, pero recibimos tu reporte y lo vamos a revisar.",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "Escribile al equipo de moderación",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "Video publicado, pero {count, plural, =1{no se envió 1 invitación de colaborador.} other{no se enviaron {count} invitaciones de colaborador.}}",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3024,8 +3024,6 @@
     "reportReasonChildSafetySubtitle": "Pangkalahatang alalahanin tungkol sa kaligtasan ng mga menor de edad",
     "reportReasonUnderageUser": "Mukhang Wala Pang 16 ang User",
     "reportReasonUnderageUserSubtitle": "Mukhang menor de edad ang may-ari ng account",
-    "reportModerationDmDelayed": "Hindi namin naabot nang direkta ang moderation team ngayon, pero natanggap ang iyong report at ire-review ito.",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "I-message ang moderation team",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "Nai-post ang video, pero {count, plural, =1{{count} collaborator invite ang hindi naipadala.} other{{count} collaborator invite ang hindi naipadala.}}",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4068,8 +4068,6 @@
     "reportReasonChildSafetySubtitle": "Préoccupations générales sur la sécurité des mineurs",
     "reportReasonUnderageUser": "L'utilisateur semble avoir moins de 16 ans",
     "reportReasonUnderageUserSubtitle": "Le titulaire du compte semble être mineur",
-    "reportModerationDmDelayed": "On n'a pas pu joindre l'équipe de modération directement à l'instant, mais ton signalement a bien été reçu et sera examiné.",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "Contacter l'équipe de modération",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "Vidéo publiée, mais {count, plural, =1{{count} invitation de collaborateur n'a pas été envoyée.} other{{count} invitations de collaborateur n'ont pas été envoyées.}}",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4068,8 +4068,6 @@
     "reportReasonChildSafetySubtitle": "Kekhawatiran umum tentang keselamatan anak di bawah umur",
     "reportReasonUnderageUser": "Pengguna Tampak di Bawah 16 Tahun",
     "reportReasonUnderageUserSubtitle": "Pemilik akun tampak masih di bawah umur",
-    "reportModerationDmDelayed": "Kami tidak bisa menjangkau tim moderasi secara langsung saat ini, tapi laporanmu sudah kami terima dan akan ditinjau.",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "Kirim pesan ke tim moderasi",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "Video terposting, tapi {count, plural, =1{1 undangan kolaborator tidak terkirim.} other{{count} undangan kolaborator tidak terkirim.}}",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4068,8 +4068,6 @@
     "reportReasonChildSafetySubtitle": "Preoccupazioni generali sulla sicurezza dei minori",
     "reportReasonUnderageUser": "L'utente sembra avere meno di 16 anni",
     "reportReasonUnderageUserSubtitle": "Il titolare dell'account sembra essere minorenne",
-    "reportModerationDmDelayed": "Non siamo riusciti a contattare direttamente il team di moderazione in questo momento, ma la tua segnalazione è stata ricevuta e sarà esaminata.",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "Scrivi al team di moderazione",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "Video pubblicato, ma {count, plural, =1{1 invito a collaborare non è stato inviato.} other{{count} inviti a collaborare non sono stati inviati.}}",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4068,8 +4068,6 @@
     "reportReasonChildSafetySubtitle": "未成年の安全に関する一般的な懸念",
     "reportReasonUnderageUser": "ユーザーが16歳未満に見える",
     "reportReasonUnderageUserSubtitle": "アカウント所有者が未成年に見える",
-    "reportModerationDmDelayed": "今はモデレーションチームに直接連絡できなかったけど、あなたの報告は受け取ったから、あとで確認するね。",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "モデレーションチームにメッセージを送る",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "動画を投稿したよ。でも{count, plural, =1{コラボの招待が1件送信されなかったよ。} other{コラボの招待が{count}件送信されなかったよ。}}",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3606,8 +3606,6 @@
     "reportReasonChildSafetySubtitle": "미성년자 안전에 대한 전반적인 우려",
     "reportReasonUnderageUser": "사용자가 16세 미만으로 보임",
     "reportReasonUnderageUserSubtitle": "계정 소유자가 미성년자로 보여요",
-    "reportModerationDmDelayed": "지금은 조절 팀에 바로 연결하지 못했지만, 신고는 접수됐고 검토될 거예요.",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "조절 팀에 메시지 보내기",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "영상을 올렸지만, {count, plural, =1{콜라보 초대 1건이 전송되지 않았어요.} other{콜라보 초대 {count}건이 전송되지 않았어요.}}",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -2398,10 +2398,6 @@
   "reportReceivedTitle": "Laporan Diterima",
   "reportReceivedThankYou": "Terima kasih kerana membantu memastikan Divine selamat.",
   "reportReceivedReviewNotice": "Pasukan kami akan menyemak laporan anda dan mengambil tindakan yang sewajarnya. Anda mungkin menerima kemas kini melalui mesej langsung.",
-  "reportModerationDmDelayed": "Kami tidak dapat menghubungi pasukan kesederhanaan secara langsung sekarang, tetapi laporan anda telah diterima dan akan disemak.",
-  "@reportModerationDmDelayed": {
-    "description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."
-  },
   "reportContactModeration": "Hantar mesej kepada pasukan kesederhanaan",
   "@reportContactModeration": {
     "description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4068,8 +4068,6 @@
     "reportReasonChildSafetySubtitle": "Algemene zorgen over de veiligheid van minderjarigen",
     "reportReasonUnderageUser": "Gebruiker lijkt jonger dan 16",
     "reportReasonUnderageUserSubtitle": "Accounthouder lijkt minderjarig",
-    "reportModerationDmDelayed": "We konden het moderatieteam zojuist niet rechtstreeks bereiken, maar je melding is ontvangen en wordt bekeken.",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "Stuur het moderatieteam een bericht",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "Video geplaatst, maar {count, plural, =1{1 samenwerkingsuitnodiging is niet verzonden.} other{{count} samenwerkingsuitnodigingen zijn niet verzonden.}}",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4068,8 +4068,6 @@
     "reportReasonChildSafetySubtitle": "Ogólne obawy o bezpieczeństwo nieletnich",
     "reportReasonUnderageUser": "Użytkownik wygląda na osobę poniżej 16 lat",
     "reportReasonUnderageUserSubtitle": "Właściciel konta wygląda na osobę niepełnoletnią",
-    "reportModerationDmDelayed": "Nie udało nam się teraz bezpośrednio skontaktować z zespołem moderacji, ale twoje zgłoszenie zostało przyjęte i zostanie rozpatrzone.",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "Napisz do zespołu moderacji",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "Film opublikowany, ale {count, plural, =1{1 zaproszenie dla współtwórcy nie zostało wysłane.} few{{count} zaproszenia dla współtwórców nie zostały wysłane.} many{{count} zaproszeń dla współtwórców nie zostało wysłanych.} other{{count} zaproszenia dla współtwórców nie zostało wysłanych.}}",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4068,8 +4068,6 @@
     "reportReasonChildSafetySubtitle": "Preocupações gerais com a segurança de menores",
     "reportReasonUnderageUser": "Usuário aparenta ter menos de 16 anos",
     "reportReasonUnderageUserSubtitle": "O titular da conta aparenta ser menor de idade",
-    "reportModerationDmDelayed": "Não conseguimos falar com a equipe de moderação diretamente agora, mas sua denúncia foi recebida e será revisada.",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "Mandar mensagem para a equipe de moderação",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "Vídeo publicado, mas {count, plural, =1{{count} convite de colaborador não foi enviado.} other{{count} convites de colaborador não foram enviados.}}",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4068,8 +4068,6 @@
     "reportReasonChildSafetySubtitle": "Îngrijorări generale privind siguranța minorilor",
     "reportReasonUnderageUser": "Utilizatorul pare să aibă sub 16 ani",
     "reportReasonUnderageUserSubtitle": "Titularul contului pare să fie minor",
-    "reportModerationDmDelayed": "Nu am putut contacta direct echipa de moderare chiar acum, dar raportul tău a fost primit și va fi analizat.",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "Scrie echipei de moderare",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "Videoclip publicat, dar {count, plural, =1{1 invitație de colaborator nu a fost trimisă.} few{{count} invitații de colaborator nu au fost trimise.} other{{count} de invitații de colaborator nu au fost trimise.}}",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4068,8 +4068,6 @@
     "reportReasonChildSafetySubtitle": "Allmänna farhågor om minderårigas säkerhet",
     "reportReasonUnderageUser": "Användaren verkar vara under 16",
     "reportReasonUnderageUserSubtitle": "Kontoinnehavaren verkar vara minderårig",
-    "reportModerationDmDelayed": "Vi kunde inte nå modereringsteamet direkt just nu, men din anmälan togs emot och kommer att granskas.",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "Meddela modereringsteamet",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "Videon publicerades, men {count, plural, =1{1 samarbetsinbjudan skickades inte.} other{{count} samarbetsinbjudningar skickades inte.}}",

--- a/mobile/lib/l10n/app_te.arb
+++ b/mobile/lib/l10n/app_te.arb
@@ -2921,10 +2921,6 @@
   "reportReceivedTitle": "నివేదిక స్వీకరించబడింది",
   "reportReceivedThankYou": "Divineని సురక్షితంగా ఉంచడంలో సహాయం చేసినందుకు ధన్యవాదాలు.",
   "reportReceivedReviewNotice": "మా బృందం మీ నివేదికను సమీక్షించి తగిన చర్య తీసుకుంటుంది. మీరు ప్రత్యక్ష సందేశం ద్వారా నవీకరణలను స్వీకరించవచ్చు.",
-  "reportModerationDmDelayed": "మేము ఇప్పుడే మోడరేషన్ బృందాన్ని నేరుగా చేరుకోలేకపోయాము, కానీ మీ నివేదిక స్వీకరించబడింది మరియు సమీక్షించబడుతుంది.",
-  "@reportModerationDmDelayed": {
-    "description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."
-  },
   "reportContactModeration": "మోడరేషన్ బృందానికి సందేశం పంపండి",
   "@reportContactModeration": {
     "description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4068,8 +4068,6 @@
     "reportReasonChildSafetySubtitle": "Reşit olmayanların güvenliğiyle ilgili genel endişeler",
     "reportReasonUnderageUser": "Kullanıcı 16 Yaşından Küçük Görünüyor",
     "reportReasonUnderageUserSubtitle": "Hesap sahibi reşit değil gibi görünüyor",
-    "reportModerationDmDelayed": "Moderasyon ekibine şu an doğrudan ulaşamadık ama bildirimin alındı ve incelenecek.",
-    "@reportModerationDmDelayed": {"description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."},
     "reportContactModeration": "Moderasyon ekibine mesaj gönder",
     "@reportContactModeration": {"description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."},
     "videoPublishCollaboratorInviteWarning": "Video paylaşıldı ama {count, plural, =1{1 iş birlikçi daveti gönderilemedi.} other{{count} iş birlikçi daveti gönderilemedi.}}",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -2398,10 +2398,6 @@
   "reportReceivedTitle": "رپورٹ موصول ہو گئی",
   "reportReceivedThankYou": "Divine کو محفوظ رکھنے میں مدد کے لیے شکریہ۔",
   "reportReceivedReviewNotice": "ہماری ٹیم آپ کی رپورٹ کا جائزہ لے گی اور مناسب کارروائی کرے گی۔ آپ کو براہ راست پیغام کے ذریعے اپڈیٹس مل سکتی ہیں۔",
-  "reportModerationDmDelayed": "ہم ابھی موڈریشن ٹیم تک براہ راست نہیں پہنچ سکے، لیکن آپ کی رپورٹ موصول ہو گئی ہے اور اس کا جائزہ لیا جائے گا۔",
-  "@reportModerationDmDelayed": {
-    "description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."
-  },
   "reportContactModeration": "موڈریشن ٹیم کو پیغام بھیجیں",
   "@reportContactModeration": {
     "description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -2398,10 +2398,6 @@
   "reportReceivedTitle": "Đã nhận báo cáo",
   "reportReceivedThankYou": "Cảm ơn bạn đã giúp giữ Divine an toàn.",
   "reportReceivedReviewNotice": "Đội ngũ của bọn mình sẽ xem xét báo cáo của bạn và có hành động phù hợp. Bạn có thể nhận được cập nhật qua tin nhắn trực tiếp.",
-  "reportModerationDmDelayed": "Bọn mình chưa liên hệ trực tiếp được với đội kiểm duyệt lúc này, nhưng báo cáo của bạn đã được nhận và sẽ được xem xét.",
-  "@reportModerationDmDelayed": {
-    "description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."
-  },
   "reportContactModeration": "Nhắn tin cho đội kiểm duyệt",
   "@reportContactModeration": {
     "description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -2398,10 +2398,6 @@
   "reportReceivedTitle": "举报已收到",
   "reportReceivedThankYou": "谢谢你帮助维护 Divine 的安全。",
   "reportReceivedReviewNotice": "我们的团队会审核你的举报并采取适当措施。你可能会通过私信收到进展通知。",
-  "reportModerationDmDelayed": "暂时没能直接联系上管理团队，但你的举报已收到，我们会审核的。",
-  "@reportModerationDmDelayed": {
-    "description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."
-  },
   "reportContactModeration": "给管理团队发消息",
   "@reportContactModeration": {
     "description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -8185,12 +8185,6 @@ abstract class AppLocalizations {
   /// **'Our team will review your report and take appropriate action. You may receive updates via direct message.'**
   String get reportReceivedReviewNotice;
 
-  /// Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels.
-  ///
-  /// In en, this message translates to:
-  /// **'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.'**
-  String get reportModerationDmDelayed;
-
   /// Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4653,10 +4653,6 @@ class AppLocalizationsAm extends AppLocalizations {
       'ቡድናችን የእርስዎን ሪፖርት ተመልክቶ ተገቢውን እርምጃ ይወስዳል። ዝማኔዎችን በቀጥታ መልእክት ሊቀበሉ ይችላሉ።';
 
   @override
-  String get reportModerationDmDelayed =>
-      'አሁን የልከኝነት ቡድኑን በቀጥታ ማግኘት አልቻልንም፣ ነገር ግን ሪፖርትዎ ተቀብሏል እና ይገመገማል።';
-
-  @override
   String get reportContactModeration => 'የልከኝነት ቡድኑን መልእክት ላክ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4730,10 +4730,6 @@ class AppLocalizationsAr extends AppLocalizations {
       'سيُراجع فريقنا بلاغك ويتخذ الإجراء المناسب. قد تتلقى تحديثات عبر رسالة مباشرة.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'تعذّر علينا الوصول إلى فريق الإشراف مباشرةً الآن، لكن تم استلام بلاغك وسيُراجَع.';
-
-  @override
   String get reportContactModeration => 'راسل فريق الإشراف';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4826,10 +4826,6 @@ class AppLocalizationsBg extends AppLocalizations {
       'Екипът ни ще прегледа сигнала ти и ще предприеме нужните действия. Може да получаваш новини чрез директно съобщение.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'Точно сега не успяхме да се свържем директно с екипа по модерация, но докладът ти е получен и ще бъде прегледан.';
-
-  @override
   String get reportContactModeration => 'Пиши на екипа по модерация';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4836,10 +4836,6 @@ class AppLocalizationsDe extends AppLocalizations {
       'Unser Team prüft deine Meldung und ergreift entsprechende Maßnahmen. Du erhältst möglicherweise Updates per Direktnachricht.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'Wir konnten das Moderationsteam gerade nicht direkt erreichen, aber deine Meldung ist eingegangen und wird geprüft.';
-
-  @override
   String get reportContactModeration => 'Moderationsteam anschreiben';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4860,10 +4860,6 @@ class AppLocalizationsEn extends AppLocalizations {
       'Our team will review your report and take appropriate action. You may receive updates via direct message.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
-
-  @override
   String get reportContactModeration => 'Message the moderation team';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4822,10 +4822,6 @@ class AppLocalizationsEs extends AppLocalizations {
       'Nuestro equipo va a revisar tu reporte y tomar las medidas necesarias. Quizás recibas novedades por mensaje directo.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'No pudimos contactar directamente al equipo de moderación ahora mismo, pero recibimos tu reporte y lo vamos a revisar.';
-
-  @override
   String get reportContactModeration => 'Escribile al equipo de moderación';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4808,10 +4808,6 @@ class AppLocalizationsFil extends AppLocalizations {
       'Susuriin ng team namin ang report mo at gagawa ng naaangkop na aksyon. Maaari kang makatanggap ng updates via direct message.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'Hindi namin naabot nang direkta ang moderation team ngayon, pero natanggap ang iyong report at ire-review ito.';
-
-  @override
   String get reportContactModeration => 'I-message ang moderation team';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4842,10 +4842,6 @@ class AppLocalizationsFr extends AppLocalizations {
       'Notre équipe va examiner ton signalement et prendre les mesures appropriées. Tu pourras recevoir des mises à jour par message direct.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'On n\'a pas pu joindre l\'équipe de modération directement à l\'instant, mais ton signalement a bien été reçu et sera examiné.';
-
-  @override
   String get reportContactModeration => 'Contacter l\'équipe de modération';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4707,10 +4707,6 @@ class AppLocalizationsId extends AppLocalizations {
       'Tim kami akan meninjau laporanmu dan mengambil tindakan yang sesuai. Kamu mungkin menerima pembaruan via pesan langsung.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'Kami tidak bisa menjangkau tim moderasi secara langsung saat ini, tapi laporanmu sudah kami terima dan akan ditinjau.';
-
-  @override
   String get reportContactModeration => 'Kirim pesan ke tim moderasi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4827,10 +4827,6 @@ class AppLocalizationsIt extends AppLocalizations {
       'Il nostro team esaminerà la tua segnalazione e prenderà i provvedimenti del caso. Potresti ricevere aggiornamenti tramite messaggio diretto.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'Non siamo riusciti a contattare direttamente il team di moderazione in questo momento, ma la tua segnalazione è stata ricevuta e sarà esaminata.';
-
-  @override
   String get reportContactModeration => 'Scrivi al team di moderazione';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4484,10 +4484,6 @@ class AppLocalizationsJa extends AppLocalizations {
       'チームが報告を確認して、適切に対応するね。ダイレクトメッセージでアップデートが届くかも。';
 
   @override
-  String get reportModerationDmDelayed =>
-      '今はモデレーションチームに直接連絡できなかったけど、あなたの報告は受け取ったから、あとで確認するね。';
-
-  @override
   String get reportContactModeration => 'モデレーションチームにメッセージを送る';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4499,10 +4499,6 @@ class AppLocalizationsKo extends AppLocalizations {
       '저희 팀이 신고를 검토하고 적절한 조치를 취할 거예요. 다이렉트 메시지로 업데이트를 받을 수 있어요.';
 
   @override
-  String get reportModerationDmDelayed =>
-      '지금은 조절 팀에 바로 연결하지 못했지만, 신고는 접수됐고 검토될 거예요.';
-
-  @override
   String get reportContactModeration => '조절 팀에 메시지 보내기';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -4776,10 +4776,6 @@ class AppLocalizationsMs extends AppLocalizations {
       'Pasukan kami akan menyemak laporan anda dan mengambil tindakan yang sewajarnya. Anda mungkin menerima kemas kini melalui mesej langsung.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'Kami tidak dapat menghubungi pasukan kesederhanaan secara langsung sekarang, tetapi laporan anda telah diterima dan akan disemak.';
-
-  @override
   String get reportContactModeration =>
       'Hantar mesej kepada pasukan kesederhanaan';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4794,10 +4794,6 @@ class AppLocalizationsNl extends AppLocalizations {
       'Ons team bekijkt je melding en onderneemt passende actie. Je kunt updates ontvangen via directe berichten.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'We konden het moderatieteam zojuist niet rechtstreeks bereiken, maar je melding is ontvangen en wordt bekeken.';
-
-  @override
   String get reportContactModeration => 'Stuur het moderatieteam een bericht';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4897,10 +4897,6 @@ class AppLocalizationsPl extends AppLocalizations {
       'Nasz zespół przejrzy twoje zgłoszenie i podejmie odpowiednie działania. Możesz otrzymać aktualizacje przez wiadomość bezpośrednią.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'Nie udało nam się teraz bezpośrednio skontaktować z zespołem moderacji, ale twoje zgłoszenie zostało przyjęte i zostanie rozpatrzone.';
-
-  @override
   String get reportContactModeration => 'Napisz do zespołu moderacji';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4807,10 +4807,6 @@ class AppLocalizationsPt extends AppLocalizations {
       'Nossa equipe vai revisar sua denúncia e tomar as medidas adequadas. Você pode receber atualizações por mensagem direta.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'Não conseguimos falar com a equipe de moderação diretamente agora, mas sua denúncia foi recebida e será revisada.';
-
-  @override
   String get reportContactModeration =>
       'Mandar mensagem para a equipe de moderação';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4912,10 +4912,6 @@ class AppLocalizationsRo extends AppLocalizations {
       'Echipa noastră âți va revizui raportul și va lua măsuri corespunzătoare. S-ar putea să primești actualizări prin mesaj direct.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'Nu am putut contacta direct echipa de moderare chiar acum, dar raportul tău a fost primit și va fi analizat.';
-
-  @override
   String get reportContactModeration => 'Scrie echipei de moderare';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4771,10 +4771,6 @@ class AppLocalizationsSv extends AppLocalizations {
       'Vårt team granskar din rapport och vidtar lämpliga åtgärder. Du kan få uppdateringar via direktmeddelande.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'Vi kunde inte nå modereringsteamet direkt just nu, men din anmälan togs emot och kommer att granskas.';
-
-  @override
   String get reportContactModeration => 'Meddela modereringsteamet';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -4946,10 +4946,6 @@ class AppLocalizationsTe extends AppLocalizations {
       'మా బృందం మీ నివేదికను సమీక్షించి తగిన చర్య తీసుకుంటుంది. మీరు ప్రత్యక్ష సందేశం ద్వారా నవీకరణలను స్వీకరించవచ్చు.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'మేము ఇప్పుడే మోడరేషన్ బృందాన్ని నేరుగా చేరుకోలేకపోయాము, కానీ మీ నివేదిక స్వీకరించబడింది మరియు సమీక్షించబడుతుంది.';
-
-  @override
   String get reportContactModeration => 'మోడరేషన్ బృందానికి సందేశం పంపండి';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4714,10 +4714,6 @@ class AppLocalizationsTr extends AppLocalizations {
       'Ekibimiz bildirimini inceleyecek ve uygun adımı atacak. Direkt mesaj yoluyla güncelleme alabilirsin.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'Moderasyon ekibine şu an doğrudan ulaşamadık ama bildirimin alındı ve incelenecek.';
-
-  @override
   String get reportContactModeration => 'Moderasyon ekibine mesaj gönder';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -4778,10 +4778,6 @@ class AppLocalizationsUr extends AppLocalizations {
       'ہماری ٹیم آپ کی رپورٹ کا جائزہ لے گی اور مناسب کارروائی کرے گی۔ آپ کو براہ راست پیغام کے ذریعے اپڈیٹس مل سکتی ہیں۔';
 
   @override
-  String get reportModerationDmDelayed =>
-      'ہم ابھی موڈریشن ٹیم تک براہ راست نہیں پہنچ سکے، لیکن آپ کی رپورٹ موصول ہو گئی ہے اور اس کا جائزہ لیا جائے گا۔';
-
-  @override
   String get reportContactModeration => 'موڈریشن ٹیم کو پیغام بھیجیں';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -4741,10 +4741,6 @@ class AppLocalizationsVi extends AppLocalizations {
       'Đội ngũ của bọn mình sẽ xem xét báo cáo của bạn và có hành động phù hợp. Bạn có thể nhận được cập nhật qua tin nhắn trực tiếp.';
 
   @override
-  String get reportModerationDmDelayed =>
-      'Bọn mình chưa liên hệ trực tiếp được với đội kiểm duyệt lúc này, nhưng báo cáo của bạn đã được nhận và sẽ được xem xét.';
-
-  @override
   String get reportContactModeration => 'Nhắn tin cho đội kiểm duyệt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -4463,9 +4463,6 @@ class AppLocalizationsZh extends AppLocalizations {
       '我们的团队会审核你的举报并采取适当措施。你可能会通过私信收到进展通知。';
 
   @override
-  String get reportModerationDmDelayed => '暂时没能直接联系上管理团队，但你的举报已收到，我们会审核的。';
-
-  @override
   String get reportContactModeration => '给管理团队发消息';
 
   @override

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Content reporting service for user-generated content violations
 // ABOUTME: Implements NIP-56 reporting events (kind 1984) for Apple compliance and community-driven moderation
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:db_client/db_client.dart';
@@ -343,45 +344,34 @@ class ContentReportingService implements ReportChannelDriver {
         }
       }
 
-      // Drive both channels once now. Their outcome is what the UI reports in
-      // this change; a channel that fails stays queued for the background
-      // sweep. Always continue to local save regardless of the outcome.
-      final relayAccepted = await _publishReportEvent(
-        reportEvent,
-        targetRelays,
-      );
+      // Optimistic delivery: once the report is durably queued, return right
+      // away and drive the channels in the background — an immediate best-effort
+      // attempt here, then ReportRetryService on later foregrounds. A caller
+      // with no durable queue (legacy) falls back to a one-shot inline attempt
+      // so its result still reflects whether anything reached a channel. #8053.
+      final ReportDelivery delivery;
       if (queued && dao != null) {
-        await _recordDriveOutcome(
-          dao,
-          reportId,
-          ReportChannel.relay,
-          relayAccepted,
+        unawaited(_driveReportChannelsOnce(reportId));
+        delivery = ReportDelivery.reached;
+      } else {
+        final relayAccepted = await _publishReportEvent(
+          reportEvent,
+          targetRelays,
         );
-      }
-
-      final zendeskFiled = await _fileZendeskTicket(
-        zendeskPayload,
-        externalId: reportId,
-      );
-      if (queued && dao != null) {
-        await _recordDriveOutcome(
-          dao,
-          reportId,
-          ReportChannel.zendesk,
-          zendeskFiled,
+        final zendeskFiled = await _fileZendeskTicket(
+          zendeskPayload,
+          externalId: reportId,
         );
-        // A fully delivered report need not linger in the queue.
-        if (relayAccepted && zendeskFiled) {
-          try {
-            await dao.deleteById(reportId);
-          } catch (e) {
-            Log.warning(
-              'Failed to remove delivered report $reportId from the queue; '
-              'the sweep will find both channels done and drop it: $e',
-              name: 'ContentReportingService',
-              category: LogCategory.system,
-            );
-          }
+        delivery = (relayAccepted || zendeskFiled)
+            ? ReportDelivery.reached
+            : ReportDelivery.localOnly;
+        if (delivery == ReportDelivery.localOnly) {
+          Log.error(
+            'Report $reportId reached no channel: relay and Zendesk both '
+            'failed and there is no durable queue to retry them.',
+            name: 'ContentReportingService',
+            category: LogCategory.system,
+          );
         }
       }
 
@@ -402,23 +392,6 @@ class ContentReportingService implements ReportChannelDriver {
 
       _reportHistory.add(report);
       await _saveReportHistory();
-
-      // The report is recorded either way, but only an off-device channel
-      // makes it visible to moderation. Treat the two as a disjunction: a
-      // filed Zendesk ticket means a human has the report even when every
-      // relay refused it, and vice versa.
-      final delivery = (relayAccepted || zendeskFiled)
-          ? ReportDelivery.reached
-          : ReportDelivery.localOnly;
-      if (delivery == ReportDelivery.localOnly) {
-        Log.error(
-          'Report $reportId reached no channel: relay and Zendesk both '
-          'failed. Local history is never replayed, so it is lost unless '
-          'the user submits again.',
-          name: 'ContentReportingService',
-          category: LogCategory.system,
-        );
-      }
 
       Log.debug(
         'Content report submitted: $reportId',
@@ -894,6 +867,70 @@ class ContentReportingService implements ReportChannelDriver {
         name: 'ContentReportingService',
         category: LogCategory.system,
       );
+    }
+  }
+
+  /// Best-effort first delivery attempt for a freshly-enqueued report, run
+  /// unawaited by [reportContent] so the confirmation is not blocked on the
+  /// network. Whatever fails stays queued for [ReportRetryService]'s sweep.
+  /// #8053.
+  Future<void> _driveReportChannelsOnce(String reportId) async {
+    final dao = _pendingReportsDao;
+    if (dao == null) return;
+
+    PendingReport? row;
+    try {
+      row = await dao.getById(reportId);
+    } catch (e) {
+      Log.warning(
+        'Failed to load report $reportId for its first drive: $e',
+        name: 'ContentReportingService',
+        category: LogCategory.system,
+      );
+      return;
+    }
+    if (row == null) return;
+
+    if (row.relayStatus == PendingReportChannelStatus.pending) {
+      await _recordDriveOutcome(
+        dao,
+        reportId,
+        ReportChannel.relay,
+        await _tryDeliver(row, ReportChannel.relay),
+      );
+    }
+    if (row.zendeskStatus == PendingReportChannelStatus.pending) {
+      await _recordDriveOutcome(
+        dao,
+        reportId,
+        ReportChannel.zendesk,
+        await _tryDeliver(row, ReportChannel.zendesk),
+      );
+    }
+
+    // A fully delivered report need not linger in the queue.
+    try {
+      final updated = await dao.getById(reportId);
+      if (updated != null &&
+          updated.relayStatus == PendingReportChannelStatus.done &&
+          updated.zendeskStatus == PendingReportChannelStatus.done) {
+        await dao.deleteById(reportId);
+      }
+    } catch (_) {
+      // Best-effort cleanup; the sweep will drop a both-done row later.
+    }
+  }
+
+  Future<bool> _tryDeliver(PendingReport row, ReportChannel channel) async {
+    try {
+      return await deliverReportChannel(row, channel);
+    } catch (e) {
+      Log.warning(
+        'Report ${row.reportId} ${channel.name} first-drive threw: $e',
+        name: 'ContentReportingService',
+        category: LogCategory.system,
+      );
+      return false;
     }
   }
 

--- a/mobile/lib/widgets/report_content_confirmation.dart
+++ b/mobile/lib/widgets/report_content_confirmation.dart
@@ -14,12 +14,7 @@ import 'package:url_launcher/url_launcher.dart';
 /// Scrollable content shown after a report is accepted.
 class ReportConfirmationBody extends StatelessWidget {
   /// Creates a [ReportConfirmationBody].
-  const ReportConfirmationBody({required this.moderationDmFailed, super.key});
-
-  /// Whether the secondary NIP-17 DM to the moderation team failed to
-  /// send. The report itself still succeeded; this only drives a calm
-  /// informational notice so the user isn't misled.
-  final bool moderationDmFailed;
+  const ReportConfirmationBody({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -58,15 +53,6 @@ class ReportConfirmationBody extends StatelessWidget {
             color: context.vineColors.onSurfaceMuted,
           ),
         ),
-        if (moderationDmFailed) ...[
-          const SizedBox(height: 12),
-          Text(
-            l10n.reportModerationDmDelayed,
-            style: VineTheme.bodySmallFont(
-              color: context.vineColors.onSurfaceMuted,
-            ),
-          ),
-        ],
         const SizedBox(height: 8),
         const _SafetyPolicyLink(),
       ],

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -447,9 +447,6 @@ class _ReportContentViewState extends State<_ReportContentView> {
     final status = cubit.state.status;
     setState(() {
       _errorMessage = switch (status) {
-        // Nothing left the device, so the confirmation would be false in four
-        // places at once. Surface the failure and leave Submit live.
-        ReportSubmissionStatus.notSent => l10n.reportNotSent,
         ReportSubmissionStatus.failure => l10n.reportFailed,
         _ => null,
       };
@@ -476,18 +473,13 @@ class _ReportContentViewState extends State<_ReportContentView> {
   }
 }
 
-/// The post-submit confirmation, carrying the caveat when the moderation team
-/// could not be reached directly.
+/// The post-submit confirmation. Delivery is owned by the durable queues, so
+/// the confirmation is unconditional. #8053.
 class _ConfirmationBody extends StatelessWidget {
   const _ConfirmationBody();
 
   @override
-  Widget build(BuildContext context) {
-    final moderationDmFailed = context.select(
-      (ReportSubmissionCubit cubit) => cubit.state.moderationDmFailed,
-    );
-    return ReportConfirmationBody(moderationDmFailed: moderationDmFailed);
-  }
+  Widget build(BuildContext context) => const ReportConfirmationBody();
 }
 
 // =============================================================================

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -4493,37 +4493,26 @@ class DmRepository {
     );
   }
 
-  /// Send a text message to a 1:1 conversation.
-  ///
-  /// Throws [StateError] if the repository has not been initialized.
-  /// Throws [ArgumentError] if [recipientPubkey] is not a 64-character
-  /// hex string or if [content] is empty.
-  ///
-  /// Returns a failure result, publishing nothing, when [recipientPubkey] is
-  /// the sender — see the refusal below.
-  ///
-  /// Returns [NIP17SendResult.tooLong], publishing nothing and leaving no
-  /// queue row, when the built rumor exceeds [maxDmRumorBytes].
-  ///
-  /// When an [OutgoingDmsDao] is injected, the send goes through the
-  /// durable queue: build the rumor, enqueue a `pending`/`pending` row
-  /// keyed by the rumor's id, publish, then transition the queue row
-  /// by wrap outcome:
-  ///
-  /// - Full NIP-17 delivery (`selfWrapPublished == true`): delete the
-  ///   queue row in the same transaction that inserts `direct_messages`.
-  /// - Partial delivery (`selfWrapPublished == false`): keep the row,
-  ///   mark the recipient wrap `sent`, and mark the self-wrap `failed`
-  ///   so only the missing self-wrap is retried later.
-  /// - Recipient publish failure: mark both wraps `failed` and leave
-  ///   the row queued for replay.
-  @useResult
-  Future<NIP17SendResult> sendMessage({
+  /// The guards, rumor build, and durable enqueue shared by [sendMessage] and
+  /// [enqueueSend] — everything up to and including parking the `outgoing_dms`
+  /// row, but NOT the publish. Returns a terminal [NIP17SendResult] in
+  /// `refusal` (self-send / policy block / oversized) or the built rumor and
+  /// its derived send context. #8053.
+  Future<
+    ({
+      NIP17SendResult? refusal,
+      Event? rumor,
+      String? conversationId,
+      String? sendBatchId,
+      List<List<String>>? rumorTags,
+      List<String>? participants,
+    })
+  >
+  _prepareAndEnqueueSend({
     required String recipientPubkey,
     required String content,
     String? replyToId,
     List<List<String>> additionalTags = const [],
-    bool skipNip04Fallback = false,
   }) async {
     _assertInitialized();
     validatePubkey(recipientPubkey);
@@ -4546,8 +4535,15 @@ class DmRepository {
     // author funnelcake matches a kind-5 against, so the real sender is never
     // authorized to delete it.
     if (_isSelf(recipientPubkey)) {
-      return const NIP17SendResult.failure(
-        'refused: a message cannot be addressed to its own sender',
+      return (
+        refusal: const NIP17SendResult.failure(
+          'refused: a message cannot be addressed to its own sender',
+        ),
+        rumor: null,
+        conversationId: null,
+        sendBatchId: null,
+        rumorTags: null,
+        participants: null,
       );
     }
 
@@ -4556,8 +4552,15 @@ class DmRepository {
     // covers the drain replay); this earlier check avoids storing a queue row
     // that would only ever re-fail the gate.
     if (!await _messageService!.canSendTo(recipientPubkey)) {
-      return const NIP17SendResult.blocked(
-        'blocked: recipient not permitted by send policy',
+      return (
+        refusal: const NIP17SendResult.blocked(
+          'blocked: recipient not permitted by send policy',
+        ),
+        rumor: null,
+        conversationId: null,
+        sendBatchId: null,
+        rumorTags: null,
+        participants: null,
       );
     }
 
@@ -4606,7 +4609,16 @@ class DmRepository {
     );
 
     final oversized = _refuseIfOversized(rumor);
-    if (oversized != null) return oversized;
+    if (oversized != null) {
+      return (
+        refusal: oversized,
+        rumor: null,
+        conversationId: null,
+        sendBatchId: null,
+        rumorTags: null,
+        participants: null,
+      );
+    }
 
     // Enqueue before publish so an app crash mid-send leaves a
     // recoverable trace. No-op when the queue dao isn't wired in
@@ -4635,6 +4647,96 @@ class DmRepository {
         ),
       );
     }
+
+    return (
+      refusal: null,
+      rumor: rumor,
+      conversationId: conversationId,
+      sendBatchId: sendBatchId,
+      rumorTags: rumorTags,
+      participants: participants,
+    );
+  }
+
+  /// Enqueues a NIP-17 DM durably WITHOUT publishing it, returning the parked
+  /// rumor id so a caller can await only the fast local write and drive
+  /// delivery afterward (via [recoverFullSend] or the retry sweep). The
+  /// optimistic counterpart of [sendMessage]. #8053.
+  ///
+  /// Coalescing (#6610): a caller that wants to try the same report DM again
+  /// must re-drive the returned [EnqueueSendResult.queuedRumorId] with
+  /// [recoverFullSend], never call [enqueueSend] again — a second call mints a
+  /// fresh rumor and a second durable row, so the sweep and the retry each
+  /// deliver a copy.
+  @useResult
+  Future<EnqueueSendResult> enqueueSend({
+    required String recipientPubkey,
+    required String content,
+    String? replyToId,
+    List<List<String>> additionalTags = const [],
+  }) async {
+    final prep = await _prepareAndEnqueueSend(
+      recipientPubkey: recipientPubkey,
+      content: content,
+      replyToId: replyToId,
+      additionalTags: additionalTags,
+    );
+    final refusal = prep.refusal;
+    if (refusal != null) {
+      final message = refusal.error ?? 'send refused';
+      if (refusal.blocked) return EnqueueSendResult.blocked(message);
+      if (refusal.tooLong) return EnqueueSendResult.tooLong(message);
+      return EnqueueSendResult.refused(message);
+    }
+    return EnqueueSendResult.enqueued(prep.rumor!.id);
+  }
+
+  /// Send a text message to a 1:1 conversation.
+  ///
+  /// Throws [StateError] if the repository has not been initialized.
+  /// Throws [ArgumentError] if [recipientPubkey] is not a 64-character
+  /// hex string or if [content] is empty.
+  ///
+  /// Returns a failure result, publishing nothing, when [recipientPubkey] is
+  /// the sender — see the refusal below.
+  ///
+  /// Returns [NIP17SendResult.tooLong], publishing nothing and leaving no
+  /// queue row, when the built rumor exceeds [maxDmRumorBytes].
+  ///
+  /// When an [OutgoingDmsDao] is injected, the send goes through the
+  /// durable queue: build the rumor, enqueue a `pending`/`pending` row
+  /// keyed by the rumor's id, publish, then transition the queue row
+  /// by wrap outcome:
+  ///
+  /// - Full NIP-17 delivery (`selfWrapPublished == true`): delete the
+  ///   queue row in the same transaction that inserts `direct_messages`.
+  /// - Partial delivery (`selfWrapPublished == false`): keep the row,
+  ///   mark the recipient wrap `sent`, and mark the self-wrap `failed`
+  ///   so only the missing self-wrap is retried later.
+  /// - Recipient publish failure: mark both wraps `failed` and leave
+  ///   the row queued for replay.
+  @useResult
+  Future<NIP17SendResult> sendMessage({
+    required String recipientPubkey,
+    required String content,
+    String? replyToId,
+    List<List<String>> additionalTags = const [],
+    bool skipNip04Fallback = false,
+  }) async {
+    final prep = await _prepareAndEnqueueSend(
+      recipientPubkey: recipientPubkey,
+      content: content,
+      replyToId: replyToId,
+      additionalTags: additionalTags,
+    );
+    final refusal = prep.refusal;
+    if (refusal != null) return refusal;
+    final rumor = prep.rumor!;
+    final conversationId = prep.conversationId!;
+    final sendBatchId = prep.sendBatchId!;
+    final rumorTags = prep.rumorTags!;
+    final participants = prep.participants!;
+    final outgoingDao = _outgoingDmsDao;
 
     // Route the gift wrap to the recipient's NIP-17 DM inbox relays
     // (kind 10050) when they advertise one; null falls back to the

--- a/mobile/packages/dm_repository/test/src/dm_enqueue_send_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_enqueue_send_test.dart
@@ -1,0 +1,155 @@
+// ABOUTME: #8053 — enqueueSend parks a durable DM row without publishing, so a
+// ABOUTME: caller (the optimistic report flow) can await only the local write.
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockMessageService extends Mock implements NIP17MessageService {}
+
+class _FakeEvent extends Fake implements Event {}
+
+const _owner =
+    'a4f5c1b2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8';
+const _peer =
+    'b1c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0';
+const _privateKey =
+    '5426e5b8b4b0e2a1f5e8d3c7a9b2f4e6d8c0a2b4f6e8d0c2a4b6f8e0d2c4a6b8';
+const _rumorId =
+    '2222222222222222222222222222222222222222222222222222222222222222';
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+    registerFallbackValue(Duration.zero);
+  });
+
+  group('enqueueSend (#8053)', () {
+    late AppDatabase db;
+    late OutgoingDmsDao outgoingDao;
+    late _MockNostrClient nostrClient;
+    late _MockMessageService messageService;
+    late DmRepository repository;
+
+    Event fakeRumor(String id) => Event.fromJson({
+      'id': id,
+      'pubkey': _owner,
+      'created_at': 1700000000,
+      'kind': EventKind.privateDirectMessage,
+      'tags': [
+        ['p', _peer],
+      ],
+      'content': 'report dm',
+      'sig': '',
+    });
+
+    void stubBuildRumor(Event rumor) {
+      when(
+        () => messageService.buildRumor(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          additionalTags: any(named: 'additionalTags'),
+        ),
+      ).thenReturn(rumor);
+    }
+
+    setUp(() async {
+      db = AppDatabase.test(NativeDatabase.memory());
+      outgoingDao = OutgoingDmsDao(db);
+      nostrClient = _MockNostrClient();
+      messageService = _MockMessageService();
+
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(() => nostrClient.configuredRelayCount).thenReturn(1);
+      when(() => messageService.canSendTo(any())).thenAnswer((_) async => true);
+
+      repository = DmRepository(
+        nostrClient: nostrClient,
+        messageService: messageService,
+        directMessagesDao: DirectMessagesDao(db),
+        conversationsDao: ConversationsDao(db),
+        outgoingDmsDao: outgoingDao,
+        userPubkey: _owner,
+        signer: LocalNostrSigner(_privateKey),
+      );
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    test(
+      'parks a pending row and returns its rumor id without publishing',
+      () async {
+        stubBuildRumor(fakeRumor(_rumorId));
+
+        final result = await repository.enqueueSend(
+          recipientPubkey: _peer,
+          content: 'report dm',
+        );
+
+        expect(result.accepted, isTrue);
+        expect(result.queuedRumorId, _rumorId);
+
+        final row = await outgoingDao.getById(_rumorId);
+        expect(row, isNotNull);
+        expect(row!.recipientWrapStatus, OutgoingWrapStatus.pending);
+        expect(row.selfWrapStatus, OutgoingWrapStatus.pending);
+
+        // The whole point: no network publish happened.
+        verifyNever(
+          () => messageService.sendRumor(
+            rumorEvent: any(named: 'rumorEvent'),
+            recipientPubkey: any(named: 'recipientPubkey'),
+            targetRelays: any(named: 'targetRelays'),
+            selfWrapTargetRelays: any(named: 'selfWrapTargetRelays'),
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
+            selfWrapOnSoftUnconfirmed: any(named: 'selfWrapOnSoftUnconfirmed'),
+            recipientWrapBuildTimeout: any(named: 'recipientWrapBuildTimeout'),
+            selfWrapBuildTimeout: any(named: 'selfWrapBuildTimeout'),
+          ),
+        );
+      },
+    );
+
+    test('refuses a self-addressed send and enqueues nothing', () async {
+      final result = await repository.enqueueSend(
+        recipientPubkey: _owner,
+        content: 'to myself',
+      );
+
+      expect(result.refused, isTrue);
+      expect(result.accepted, isFalse);
+      verifyNever(
+        () => messageService.buildRumor(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          additionalTags: any(named: 'additionalTags'),
+        ),
+      );
+    });
+
+    test('reports a policy block and enqueues nothing', () async {
+      when(
+        () => messageService.canSendTo(any()),
+      ).thenAnswer((_) async => false);
+
+      final result = await repository.enqueueSend(
+        recipientPubkey: _peer,
+        content: 'blocked',
+      );
+
+      expect(result.blocked, isTrue);
+      expect(result.accepted, isFalse);
+      expect(await outgoingDao.getById(_rumorId), isNull);
+    });
+  });
+}

--- a/mobile/packages/models/lib/models.dart
+++ b/mobile/packages/models/lib/models.dart
@@ -18,6 +18,7 @@ export 'src/dm_conversation.dart';
 export 'src/dm_message.dart';
 export 'src/dm_reaction.dart';
 export 'src/dm_shared_video_ref.dart';
+export 'src/enqueue_send_result.dart';
 export 'src/feed_type.dart';
 export 'src/hashtag_search_result.dart';
 export 'src/home_feed_response.dart';

--- a/mobile/packages/models/lib/src/enqueue_send_result.dart
+++ b/mobile/packages/models/lib/src/enqueue_send_result.dart
@@ -1,0 +1,64 @@
+// ABOUTME: Result of DmRepository.enqueueSend — the enqueue-only DM seam.
+// ABOUTME: Reports the parked rumor id, or why nothing was enqueued.
+
+import 'package:meta/meta.dart';
+
+/// Outcome of enqueuing a NIP-17 DM without publishing it (#8053).
+///
+/// `enqueueSend` runs the same guards and durable enqueue as `sendMessage` but
+/// stops before the network publish, so a caller can await only the fast local
+/// write and drive delivery later (via `recoverFullSend` or the retry sweep).
+///
+/// Exactly one of these holds:
+/// - [accepted] (`queuedRumorId != null`): a row is parked and ready to drive.
+/// - [refused]: a self-addressed send (#8352) — a silent no-op, never queued.
+/// - [blocked]: refused by send policy (#176) — not retryable.
+/// - [tooLong]: the rumor exceeds the NIP-44 size ceiling (#7331) — not
+///   retryable, nothing queued.
+@immutable
+class EnqueueSendResult {
+  const EnqueueSendResult({
+    this.queuedRumorId,
+    this.refused = false,
+    this.blocked = false,
+    this.tooLong = false,
+    this.error,
+  });
+
+  /// A row was enqueued; drive it with `recoverFullSend(rumorId:)`.
+  const EnqueueSendResult.enqueued(String rumorId)
+    : queuedRumorId = rumorId,
+      refused = false,
+      blocked = false,
+      tooLong = false,
+      error = null;
+
+  const EnqueueSendResult.refused(String this.error)
+    : queuedRumorId = null,
+      refused = true,
+      blocked = false,
+      tooLong = false;
+
+  const EnqueueSendResult.blocked(String this.error)
+    : queuedRumorId = null,
+      refused = false,
+      blocked = true,
+      tooLong = false;
+
+  const EnqueueSendResult.tooLong(String this.error)
+    : queuedRumorId = null,
+      refused = false,
+      blocked = false,
+      tooLong = true;
+
+  /// The durable `outgoing_dms` row id (the rumor id) when enqueued, else null.
+  final String? queuedRumorId;
+
+  final bool refused;
+  final bool blocked;
+  final bool tooLong;
+  final String? error;
+
+  /// Whether a durable row was parked and is ready to drive.
+  bool get accepted => queuedRumorId != null;
+}

--- a/mobile/test/blocs/report/report_submission_cubit_test.dart
+++ b/mobile/test/blocs/report/report_submission_cubit_test.dart
@@ -1,7 +1,6 @@
 // ABOUTME: Unit tests for ReportSubmissionCubit, the report sheet's
 // ABOUTME: submission state machine across the kind-1984 and DM channels.
 
-import 'package:bloc_test/bloc_test.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -62,12 +61,14 @@ void main() {
     late _MockContentReportingService reportingService;
     late _MockDmRepository dmRepository;
 
-    setUp(() {
-      reportingService = _MockContentReportingService();
-      dmRepository = _MockDmRepository();
-
+    void stubReportContent(
+      _MockContentReportingService service, {
+      ReportDelivery delivery = ReportDelivery.reached,
+      bool success = true,
+      String error = 'rejected',
+    }) {
       when(
-        () => reportingService.reportContent(
+        () => service.reportContent(
           eventId: any(named: 'eventId'),
           authorPubkey: any(named: 'authorPubkey'),
           reason: any(named: 'reason'),
@@ -77,25 +78,46 @@ void main() {
           hashtags: any(named: 'hashtags'),
         ),
       ).thenAnswer(
-        (_) async =>
-            ReportResult.createSuccess('id', delivery: ReportDelivery.reached),
+        (_) async => success
+            ? ReportResult.createSuccess('id', delivery: delivery)
+            : ReportResult.failure(error),
       );
+    }
 
+    void stubEnqueueSend(EnqueueSendResult result) {
       when(
-        () => dmRepository.sendMessage(
+        () => dmRepository.enqueueSend(
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
           additionalTags: any(named: 'additionalTags'),
         ),
-      ).thenAnswer(
-        (_) async => NIP17SendResult.success(
-          rumorEventId: 'rumor_id',
-          messageEventId: 'dm_event_id',
-          recipientPubkey: _moderationPubkey,
+      ).thenAnswer((_) async => result);
+    }
+
+    void stubRecoverFullSend(NIP17SendResult result) {
+      when(
+        () => dmRepository.recoverFullSend(
+          rumorId: any(named: 'rumorId'),
+          resetRetryBudget: any(named: 'resetRetryBudget'),
         ),
-      );
+      ).thenAnswer((_) async => result);
+    }
+
+    NIP17SendResult dmSuccess() => NIP17SendResult.success(
+      rumorEventId: 'rumor_id',
+      messageEventId: 'dm_event_id',
+      recipientPubkey: _moderationPubkey,
+    );
+
+    setUp(() {
+      reportingService = _MockContentReportingService();
+      dmRepository = _MockDmRepository();
+
+      stubReportContent(reportingService);
+      // Default: the DM enqueues durably and its background drive delivers.
+      stubEnqueueSend(const EnqueueSendResult.enqueued('rumor_id'));
+      stubRecoverFullSend(dmSuccess());
     });
 
     ReportSubmissionCubit buildCubit({
@@ -121,148 +143,112 @@ void main() {
       details: 'Spam',
     );
 
-    blocTest<ReportSubmissionCubit, ReportSubmissionState>(
-      'reaches submitted with no caveat when both channels land',
-      build: buildCubit,
-      act: submit,
-      verify: (cubit) {
+    void verifyEnqueueSendCalled(int times) {
+      verify(
+        () => dmRepository.enqueueSend(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          replyToId: any(named: 'replyToId'),
+          additionalTags: any(named: 'additionalTags'),
+        ),
+      ).called(times);
+    }
+
+    test('confirms as submitted and records the DM delivered once its '
+        'background drive lands', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      await submit(cubit);
+      // The confirmation is unconditional and shown as soon as the report is
+      // durably enqueued — before the DM publishes.
+      expect(cubit.state.status, ReportSubmissionStatus.submitted);
+
+      // The DM publish is driven in the background; let it settle.
+      await pumpEventQueue();
+      expect(cubit.state.moderationDm.outcome, ModerationDmOutcome.delivered);
+      verifyEnqueueSendCalled(1);
+    });
+
+    test(
+      'confirms unconditionally even if a channel could not be reached',
+      () async {
+        // A legacy no-queue report can still return localOnly; the confirmation
+        // no longer gates on delivery, so it is shown regardless.
+        stubReportContent(reportingService, delivery: ReportDelivery.localOnly);
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+
+        await submit(cubit);
+
         expect(cubit.state.status, ReportSubmissionStatus.submitted);
-        expect(cubit.state.moderationDmFailed, isFalse);
-        expect(cubit.state.moderationDm.outcome, ModerationDmOutcome.delivered);
       },
     );
 
-    blocTest<ReportSubmissionCubit, ReportSubmissionState>(
-      'stays resubmittable when the report reached no channel',
-      build: () {
-        when(
-          () => reportingService.reportContent(
-            eventId: any(named: 'eventId'),
-            authorPubkey: any(named: 'authorPubkey'),
-            reason: any(named: 'reason'),
-            details: any(named: 'details'),
-            sourceRelay: any(named: 'sourceRelay'),
-            additionalContext: any(named: 'additionalContext'),
-            hashtags: any(named: 'hashtags'),
-          ),
-        ).thenAnswer(
-          (_) async => ReportResult.createSuccess(
-            'id',
-            delivery: ReportDelivery.localOnly,
-          ),
-        );
-        return buildCubit();
-      },
-      act: submit,
-      verify: (cubit) {
-        // Not `submitted`: the confirmation screen would be false in four
-        // places at once, so the form stays live for a one-tap retry.
-        expect(cubit.state.status, ReportSubmissionStatus.notSent);
-      },
-    );
+    test('a refused self-report is silent — confirmation shown, nothing '
+        'enqueued (#8352)', () async {
+      stubReportContent(reportingService, delivery: ReportDelivery.refused);
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
 
-    blocTest<ReportSubmissionCubit, ReportSubmissionState>(
-      'a refused self-report is silent — confirmation shown, nothing sent (#8352)',
-      build: () {
-        when(
-          () => reportingService.reportContent(
-            eventId: any(named: 'eventId'),
-            authorPubkey: any(named: 'authorPubkey'),
-            reason: any(named: 'reason'),
-            details: any(named: 'details'),
-            sourceRelay: any(named: 'sourceRelay'),
-            additionalContext: any(named: 'additionalContext'),
-            hashtags: any(named: 'hashtags'),
-          ),
-        ).thenAnswer(
-          (_) async => ReportResult.createSuccess(
-            'id',
-            delivery: ReportDelivery.refused,
-          ),
+      await submit(cubit);
+      await pumpEventQueue();
+
+      // Silent success — a refusal must NOT hand off to the moderation DM, or
+      // a self-naming report would still leave the device privately (#8352).
+      expect(cubit.state.status, ReportSubmissionStatus.submitted);
+      verifyNever(
+        () => dmRepository.enqueueSend(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          replyToId: any(named: 'replyToId'),
+          additionalTags: any(named: 'additionalTags'),
+        ),
+      );
+    });
+
+    test('reports failure status when the report itself is rejected', () async {
+      stubReportContent(reportingService, success: false);
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      await submit(cubit);
+
+      // #3589: the service's prose is logged, never emitted. The status is the
+      // whole contract the UI reads.
+      expect(cubit.state.status, ReportSubmissionStatus.failure);
+    });
+
+    test(
+      'a moderation-side preflight failure does not sink the report',
+      () async {
+        // The transport is resolved inside the dispatch precisely so this stays
+        // a DM-only failure. Resolving it when the sheet opened would let the
+        // moderation label service take down a report the kind-1984 channel
+        // carried fine.
+        final cubit = buildCubit(
+          resolveTransport: () => throw StateError('moderation unavailable'),
         );
-        return buildCubit();
-      },
-      act: submit,
-      verify: (cubit) {
-        // Silent success — unlike the `localOnly` offline path, a refusal must
-        // NOT hand off to the moderation DM, or a self-naming report would
-        // still leave the device privately (the exact bug #8352 fixes).
+        addTearDown(cubit.close);
+
+        await submit(cubit);
+        await pumpEventQueue();
+
         expect(cubit.state.status, ReportSubmissionStatus.submitted);
         verifyNever(
-          () => dmRepository.sendMessage(
+          () => dmRepository.enqueueSend(
             recipientPubkey: any(named: 'recipientPubkey'),
             content: any(named: 'content'),
             replyToId: any(named: 'replyToId'),
-            skipNip04Fallback: any(named: 'skipNip04Fallback'),
             additionalTags: any(named: 'additionalTags'),
           ),
         );
       },
     );
 
-    test('hands back the rejection detail for the inline error', () async {
-      when(
-        () => reportingService.reportContent(
-          eventId: any(named: 'eventId'),
-          authorPubkey: any(named: 'authorPubkey'),
-          reason: any(named: 'reason'),
-          details: any(named: 'details'),
-          sourceRelay: any(named: 'sourceRelay'),
-          additionalContext: any(named: 'additionalContext'),
-          hashtags: any(named: 'hashtags'),
-        ),
-      ).thenAnswer((_) async => ReportResult.failure('Not authenticated'));
-      final cubit = buildCubit();
-      addTearDown(cubit.close);
-
-      await submit(cubit);
-
-      // #3589: the service's prose is logged, never returned and never
-      // emitted. The status is the whole contract the UI reads.
-      expect(cubit.state.status, ReportSubmissionStatus.failure);
-    });
-
-    test('a moderation-side failure does not sink the report', () async {
-      // The transport is resolved inside the dispatch precisely so this stays
-      // a DM-only failure. Resolving it when the sheet opened would let the
-      // moderation label service take down a report the kind-1984 channel
-      // carried fine.
-      final cubit = buildCubit(
-        resolveTransport: () => throw StateError('moderation unavailable'),
-      );
-      addTearDown(cubit.close);
-
-      await submit(cubit);
-
-      expect(cubit.state.status, ReportSubmissionStatus.submitted);
-      expect(cubit.state.moderationDmFailed, isTrue);
-      verifyNever(
-        () => dmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      );
-    });
-
     test('resolves the reporting service for each submit', () async {
       final nextReportingService = _MockContentReportingService();
-      when(
-        () => nextReportingService.reportContent(
-          eventId: any(named: 'eventId'),
-          authorPubkey: any(named: 'authorPubkey'),
-          reason: any(named: 'reason'),
-          details: any(named: 'details'),
-          sourceRelay: any(named: 'sourceRelay'),
-          additionalContext: any(named: 'additionalContext'),
-          hashtags: any(named: 'hashtags'),
-        ),
-      ).thenAnswer(
-        (_) async =>
-            ReportResult.createSuccess('id', delivery: ReportDelivery.reached),
-      );
+      stubReportContent(nextReportingService);
 
       final services = <ContentReportingService>[
         reportingService,
@@ -274,7 +260,9 @@ void main() {
       addTearDown(cubit.close);
 
       await submit(cubit);
+      await pumpEventQueue();
       await submit(cubit);
+      await pumpEventQueue();
 
       verify(
         () => reportingService.reportContent(
@@ -300,37 +288,18 @@ void main() {
       ).called(1);
     });
 
-    test('does not retry a blocked moderation DM on resubmit', () async {
-      when(
-        () => dmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).thenAnswer(
-        (_) async => const NIP17SendResult.blocked(
-          'blocked: recipient not permitted by send policy',
-        ),
-      );
+    test('does not re-enqueue a blocked moderation DM on resubmit', () async {
+      stubEnqueueSend(const EnqueueSendResult.blocked('policy blocked'));
       final cubit = buildCubit();
       addTearDown(cubit.close);
 
       await submit(cubit);
+      await pumpEventQueue();
       await submit(cubit);
+      await pumpEventQueue();
 
-      expect(cubit.state.moderationDmFailed, isTrue);
       expect(cubit.state.moderationDm.outcome, ModerationDmOutcome.blocked);
-      verify(
-        () => dmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).called(1);
+      verifyEnqueueSendCalled(1);
       verifyNever(
         () => dmRepository.recoverFullSend(
           rumorId: any(named: 'rumorId'),
@@ -339,111 +308,72 @@ void main() {
       );
     });
 
-    test('does not retry an oversized moderation DM on resubmit', () async {
-      when(
-        () => dmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).thenAnswer(
-        (_) async =>
-            const NIP17SendResult.tooLong('moderation DM is too large'),
-      );
-      final cubit = buildCubit();
-      addTearDown(cubit.close);
+    test(
+      'does not re-enqueue an oversized moderation DM on resubmit',
+      () async {
+        stubEnqueueSend(const EnqueueSendResult.tooLong('too large'));
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
 
-      await submit(cubit);
-      await submit(cubit);
+        await submit(cubit);
+        await pumpEventQueue();
+        await submit(cubit);
+        await pumpEventQueue();
 
-      expect(cubit.state.moderationDmFailed, isTrue);
-      expect(cubit.state.moderationDm.outcome, ModerationDmOutcome.tooLong);
-      verify(
-        () => dmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).called(1);
-      verifyNever(
-        () => dmRepository.recoverFullSend(
-          rumorId: any(named: 'rumorId'),
-          resetRetryBudget: any(named: 'resetRetryBudget'),
-        ),
-      );
-    });
+        expect(cubit.state.moderationDm.outcome, ModerationDmOutcome.tooLong);
+        verifyEnqueueSendCalled(1);
+        verifyNever(
+          () => dmRepository.recoverFullSend(
+            rumorId: any(named: 'rumorId'),
+            resetRetryBudget: any(named: 'resetRetryBudget'),
+          ),
+        );
+      },
+    );
 
-    test('re-drives the parked row rather than minting a second DM', () async {
-      when(
-        () => dmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).thenAnswer(
-        (_) async => const NIP17SendResult.failure(
-          'no relays',
-          queuedRumorId: 'parked_rumor_id',
-        ),
-      );
-      when(
-        () => dmRepository.recoverFullSend(
-          rumorId: any(named: 'rumorId'),
-          resetRetryBudget: any(named: 'resetRetryBudget'),
-        ),
-      ).thenAnswer(
-        (_) async => NIP17SendResult.success(
-          rumorEventId: 'parked_rumor_id',
-          messageEventId: 'dm_event_id',
-          recipientPubkey: _moderationPubkey,
-        ),
-      );
-      final cubit = buildCubit();
-      addTearDown(cubit.close);
+    test(
+      're-drives the parked row rather than enqueuing a second DM (#6610)',
+      () async {
+        stubEnqueueSend(const EnqueueSendResult.enqueued('parked_rumor_id'));
+        // The background drive does not land, so the row stays parked.
+        stubRecoverFullSend(
+          const NIP17SendResult.failure(
+            'no relays',
+            retryablePending: true,
+            queuedRumorId: 'parked_rumor_id',
+          ),
+        );
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
 
-      await submit(cubit);
-      expect(cubit.state.moderationDm.queuedRumorId, equals('parked_rumor_id'));
+        await submit(cubit);
+        await pumpEventQueue();
+        expect(
+          cubit.state.moderationDm.queuedRumorId,
+          equals('parked_rumor_id'),
+        );
 
-      // The same reason again: coalesce onto the row rather than stack a
-      // second one for the sweep to deliver (#6610).
-      await submit(cubit);
+        // The same reason again coalesces onto the parked row rather than
+        // stacking a second one for the sweep to deliver (#6610).
+        await submit(cubit);
+        await pumpEventQueue();
 
-      verify(
-        () => dmRepository.recoverFullSend(
-          rumorId: 'parked_rumor_id',
-          resetRetryBudget: true,
-        ),
-      ).called(1);
-      verify(
-        () => dmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).called(1);
-      expect(cubit.state.moderationDm.queuedRumorId, isNull);
-    });
+        verifyEnqueueSendCalled(1);
+        verify(
+          () => dmRepository.recoverFullSend(
+            rumorId: 'parked_rumor_id',
+            resetRetryBudget: true,
+          ),
+        ).called(2);
+      },
+    );
 
     test('replaces the parked row when the reason moved', () async {
-      when(
-        () => dmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).thenAnswer(
-        (_) async => const NIP17SendResult.failure(
+      stubEnqueueSend(const EnqueueSendResult.enqueued('parked_rumor_id'));
+      stubRecoverFullSend(
+        const NIP17SendResult.failure(
           'no relays',
+          retryablePending: true,
           queuedRumorId: 'parked_rumor_id',
         ),
       );
@@ -454,83 +384,65 @@ void main() {
       addTearDown(cubit.close);
 
       await submit(cubit);
+      await pumpEventQueue();
 
       // A parked rumor's tags are frozen at build time and replayed verbatim,
       // so re-driving after the user changed their mind would ship the
       // superseded NIP-32 label while the kind-1984 republish carries the new
-      // one. Cancel and mint a correct one instead.
+      // one. Cancel and enqueue a correct one instead.
       await cubit.submit(
         reason: ContentFilterReason.harassment,
         reasonTitle: 'Harassment',
         details: 'Harassment',
       );
+      await pumpEventQueue();
 
       verify(
         () => dmRepository.cancelOutgoingSend(rumorId: 'parked_rumor_id'),
       ).called(1);
-      verifyNever(
-        () => dmRepository.recoverFullSend(
-          rumorId: any(named: 'rumorId'),
-          resetRetryBudget: any(named: 'resetRetryBudget'),
-        ),
-      );
+      // Two enqueues: the original, then a fresh one after the stale row was
+      // cancelled — never a re-drive of the stale row.
+      verifyEnqueueSendCalled(2);
     });
 
-    test('stops sending once a parked row becomes unreachable', () async {
-      when(
-        () => dmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).thenAnswer(
-        (_) async => const NIP17SendResult.failure(
-          'no relays',
-          queuedRumorId: 'parked_rumor_id',
-        ),
-      );
+    test('stops sending once a parked row becomes unreachable (#6610)', () async {
+      stubEnqueueSend(const EnqueueSendResult.enqueued('parked_rumor_id'));
+      // The background drive cannot resolve the row. recoverFullSend is async,
+      // so an ArgumentError arrives as a rejected future, not a sync throw.
       when(
         () => dmRepository.recoverFullSend(
           rumorId: any(named: 'rumorId'),
           resetRetryBudget: any(named: 'resetRetryBudget'),
         ),
-      ).thenThrow(ArgumentError('no such outgoing send'));
+      ).thenAnswer((_) async => throw ArgumentError('no such outgoing send'));
       final cubit = buildCubit();
       addTearDown(cubit.close);
 
       await submit(cubit);
-      await submit(cubit);
-      // Delivery can be neither confirmed nor retried, so a third submit must
-      // not mint the #6610 duplicate — and must keep the caveat.
-      await submit(cubit);
-
+      await pumpEventQueue();
       expect(
         cubit.state.moderationDm.outcome,
         ModerationDmOutcome.unverifiable,
       );
-      expect(cubit.state.moderationDmFailed, isTrue);
-      verify(
-        () => dmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).called(1);
+
+      // Unverifiable is terminal: a resubmit must not mint the #6610 duplicate.
+      await submit(cubit);
+      await pumpEventQueue();
+      verifyEnqueueSendCalled(1);
     });
 
-    test('does not DM the team twice for an unchanged resubmit', () async {
+    test('does not enqueue the DM twice for an unchanged resubmit', () async {
       final cubit = buildCubit();
       addTearDown(cubit.close);
 
       await submit(cubit);
+      await pumpEventQueue();
       await submit(cubit);
+      await pumpEventQueue();
 
       // The kind-1984 republishes deliberately; the DM is the report itself,
-      // so a second copy is a second ticket to triage.
+      // so a second copy is a second ticket to triage (#6610). Once the first
+      // DM is delivered, a plain resubmit sends no second copy.
       verify(
         () => reportingService.reportContent(
           eventId: any(named: 'eventId'),
@@ -542,15 +454,7 @@ void main() {
           hashtags: any(named: 'hashtags'),
         ),
       ).called(2);
-      verify(
-        () => dmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).called(1);
+      verifyEnqueueSendCalled(1);
     });
   });
 }

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -1861,9 +1861,12 @@ void main() {
         details: 'spam',
       );
 
-      // Delivery outcome is unchanged from the pre-queue behavior: the relay
-      // accepted, so the report reached a channel.
+      // Optimistic: the report is reported reached as soon as it is durably
+      // queued, before the channels are driven.
       expect(result.delivery, ReportDelivery.reached);
+
+      // The channels are driven unawaited in the background; let that run.
+      await pumpEventQueue();
 
       // Zendesk is not configured under test, so its leg stays queued for the
       // background sweep while the relay leg is retired.
@@ -1897,6 +1900,9 @@ void main() {
         reason: ContentFilterReason.spam,
         details: 'spam',
       );
+
+      // The background drive runs unawaited; let it attempt and fail.
+      await pumpEventQueue();
 
       final row = await dao.getById(result.reportId!);
       expect(row!.relayStatus, PendingReportChannelStatus.pending);

--- a/mobile/test/widgets/report_content_confirmation_test.dart
+++ b/mobile/test/widgets/report_content_confirmation_test.dart
@@ -10,12 +10,10 @@ import 'package:openvine/widgets/report_content_confirmation.dart';
 void main() {
   final l10n = lookupAppLocalizations(const Locale('en'));
 
-  Widget buildSubject({bool moderationDmFailed = false}) => MaterialApp(
+  Widget buildSubject() => const MaterialApp(
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
-    home: Scaffold(
-      body: ReportConfirmationBody(moderationDmFailed: moderationDmFailed),
-    ),
+    home: Scaffold(body: ReportConfirmationBody()),
   );
 
   group(ReportConfirmationBody, () {
@@ -25,16 +23,7 @@ void main() {
 
       expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
       expect(find.text(l10n.reportReceivedThankYou), findsOneWidget);
-      expect(find.text(l10n.reportModerationDmDelayed), findsNothing);
-    });
-
-    testWidgets('surfaces the delayed-DM notice when the DM failed', (
-      tester,
-    ) async {
-      await tester.pumpWidget(buildSubject(moderationDmFailed: true));
-      await tester.pumpAndSettle();
-
-      expect(find.text(l10n.reportModerationDmDelayed), findsOneWidget);
+      expect(find.text(l10n.reportReceivedReviewNotice), findsOneWidget);
     });
 
     testWidgets('safety link is a button that announces its label once', (

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -752,13 +752,23 @@ void main() {
       when(
         () => mockModerationLabelService.divineModerationPubkeyHex,
       ).thenReturn(ModerationLabelService.fallbackModerationPubkeyHex);
+      // The moderation DM now goes out optimistically (#8053): the cubit
+      // enqueues it durably (awaiting only the fast local write) and drives the
+      // publish in the background via recoverFullSend. Stub both halves of that
+      // seam to the happy path.
       when(
-        () => mockDmRepository.sendMessage(
+        () => mockDmRepository.enqueueSend(
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
           additionalTags: any(named: 'additionalTags'),
+        ),
+      ).thenAnswer(
+        (_) async => const EnqueueSendResult.enqueued('dm_rumor_id'),
+      );
+      when(
+        () => mockDmRepository.recoverFullSend(
+          rumorId: any(named: 'rumorId'),
+          resetRetryBudget: any(named: 'resetRetryBudget'),
         ),
       ).thenAnswer(
         (_) async => NIP17SendResult.success(
@@ -840,11 +850,9 @@ void main() {
     /// The `additionalTags` the dialog attached to the single moderation DM.
     List<List<String>> captureDmTags() {
       final captured = verify(
-        () => mockDmRepository.sendMessage(
+        () => mockDmRepository.enqueueSend(
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
           additionalTags: captureAny(named: 'additionalTags'),
         ),
       ).captured;
@@ -859,11 +867,9 @@ void main() {
       await openAndSubmitReport(tester);
 
       verify(
-        () => mockDmRepository.sendMessage(
+        () => mockDmRepository.enqueueSend(
           recipientPubkey: ModerationLabelService.fallbackModerationPubkeyHex,
           content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
           additionalTags: any(named: 'additionalTags'),
         ),
       ).called(1);
@@ -929,11 +935,9 @@ void main() {
       await tester.pumpAndSettle();
 
       final captured = verify(
-        () => mockDmRepository.sendMessage(
+        () => mockDmRepository.enqueueSend(
           recipientPubkey: any(named: 'recipientPubkey'),
           content: captureAny(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
           additionalTags: any(named: 'additionalTags'),
         ),
       ).captured;
@@ -950,11 +954,9 @@ void main() {
       await openAndSubmitReport(tester);
 
       final captured = verify(
-        () => mockDmRepository.sendMessage(
+        () => mockDmRepository.enqueueSend(
           recipientPubkey: any(named: 'recipientPubkey'),
           content: captureAny(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
           additionalTags: any(named: 'additionalTags'),
         ),
       ).captured;
@@ -1052,11 +1054,9 @@ void main() {
 
     testWidgets('report succeeds even if moderation DM fails', (tester) async {
       when(
-        () => mockDmRepository.sendMessage(
+        () => mockDmRepository.enqueueSend(
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
           additionalTags: any(named: 'additionalTags'),
         ),
       ).thenThrow(Exception('DM relay unreachable'));
@@ -1064,202 +1064,33 @@ void main() {
       await setLargeSurface(tester);
       await openAndSubmitReport(tester);
 
+      // The report is durable the moment reportContent returns; a DM enqueue
+      // failure is best-effort and must not take down the confirmation (#8053).
       expect(
         find.text(l10n.reportReceivedTitle),
         findsOneWidget,
-        reason: 'Report should succeed even if DM fails',
+        reason: 'Report should succeed even if the moderation DM fails',
       );
-      // C9: the swallowed DM failure is now surfaced as a calm notice
-      // instead of only a log line.
-      expect(find.text(l10n.reportModerationDmDelayed), findsOneWidget);
     });
 
-    testWidgets('moderation DM opts out of the NIP-04 fallback (privacy)', (
+    testWidgets('moderation DM uses the gift-wrap-only enqueue path (privacy)', (
       tester,
     ) async {
       await setLargeSurface(tester);
       await openAndSubmitReport(tester);
 
-      // C8: moderation reports carry user identity + reported content and
-      // must never degrade to a metadata-leaking NIP-04 plaintext duplicate.
+      // C8: moderation reports carry user identity + reported content and must
+      // never degrade to a metadata-leaking NIP-04 plaintext duplicate. The DM
+      // goes out via enqueueSend, which is NIP-17 gift wrap only and never fires
+      // the NIP-04 fallback (that lives in sendMessage's publish path alone),
+      // so the report DM must take enqueueSend and never sendMessage.
       verify(
-        () => mockDmRepository.sendMessage(
+        () => mockDmRepository.enqueueSend(
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: true,
           additionalTags: any(named: 'additionalTags'),
         ),
       ).called(1);
-    });
-
-    testWidgets('does not show the DM-delayed notice when the DM succeeds', (
-      tester,
-    ) async {
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-
-      expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
-      expect(find.text(l10n.reportModerationDmDelayed), findsNothing);
-    });
-
-    // #6387: sendMessage signals non-delivery by RETURNING a failure, never
-    // by throwing, so the sibling `thenThrow` test above exercises a shape
-    // production cannot produce. These pin the shapes it actually produces.
-    void stubDmResult(NIP17SendResult result) {
-      when(
-        () => mockDmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).thenAnswer((_) async => result);
-    }
-
-    testWidgets('shows the DM-delayed notice when the send is blocked', (
-      tester,
-    ) async {
-      // The #176 protected-minor send gate returns before the outgoing
-      // queue row is written, so this is the one branch with no retry.
-      stubDmResult(
-        const NIP17SendResult.blocked(
-          'blocked: recipient not permitted by send policy',
-        ),
-      );
-
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-
-      expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
-      expect(find.text(l10n.reportModerationDmDelayed), findsOneWidget);
-    });
-
-    testWidgets('shows the DM-delayed notice on a hard send failure', (
-      tester,
-    ) async {
-      stubDmResult(
-        const NIP17SendResult.failure('Message publish failed to relays'),
-      );
-
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-
-      expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
-      expect(find.text(l10n.reportModerationDmDelayed), findsOneWidget);
-    });
-
-    testWidgets('shows the DM-delayed notice when the device is offline', (
-      tester,
-    ) async {
-      // Verbatim the value NIP17MessageService returns when its
-      // connectivity probe reports offline — the most common instance.
-      stubDmResult(
-        const NIP17SendResult.failure('Message not sent: device offline'),
-      );
-
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-
-      expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
-      expect(find.text(l10n.reportModerationDmDelayed), findsOneWidget);
-    });
-
-    testWidgets('shows the DM-delayed notice when the send is unconfirmed', (
-      tester,
-    ) async {
-      // Recipient frame written but no relay OK inside the window. The
-      // durable queue re-drives it, so the notice is pessimistic rather
-      // than wrong — but silence would be a claim we cannot support.
-      stubDmResult(
-        const NIP17SendResult.failure(
-          'Message publish timed out',
-          retryablePending: true,
-        ),
-      );
-
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-
-      expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
-      expect(find.text(l10n.reportModerationDmDelayed), findsOneWidget);
-    });
-
-    testWidgets('does not confirm when the report reached no channel', (
-      tester,
-    ) async {
-      // #6387/R2: reportContent returns success even when the kind-1984
-      // publish failed on every relay AND the Zendesk ticket failed. The
-      // confirmation screen would then be false in four places at once, so
-      // the flow must surface the failure instead of confirming.
-      when(
-        () => mockReportingService.reportContent(
-          eventId: any(named: 'eventId'),
-          authorPubkey: any(named: 'authorPubkey'),
-          reason: any(named: 'reason'),
-          details: any(named: 'details'),
-          sourceRelay: any(named: 'sourceRelay'),
-          hashtags: any(named: 'hashtags'),
-        ),
-      ).thenAnswer(
-        (_) async => ReportResult.createSuccess(
-          'test_report_id',
-          delivery: ReportDelivery.localOnly,
-        ),
-      );
-
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-
-      expect(find.text(l10n.reportReceivedTitle), findsNothing);
-      expect(find.text(l10n.reportNotSent), findsOneWidget);
-      // The DM still goes out: sendMessage writes a durable outgoing_dms
-      // row before any I/O, and OutgoingDmRetryService replays it on
-      // reconnect. It is the only report channel with a retry, so skipping
-      // it would make an offline report deliver less often than before.
-      verify(
-        () => mockDmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).called(1);
-    });
-
-    testWidgets('handles unawaited moderation DM preflight failures', (
-      tester,
-    ) async {
-      // The localOnly path fires the moderation DM unawaited. Provider reads
-      // and DM formatting must still be inside _dispatchModerationDm's catch,
-      // otherwise a preflight error escapes to the zone handler.
-      when(
-        () => mockReportingService.reportContent(
-          eventId: any(named: 'eventId'),
-          authorPubkey: any(named: 'authorPubkey'),
-          reason: any(named: 'reason'),
-          details: any(named: 'details'),
-          sourceRelay: any(named: 'sourceRelay'),
-          hashtags: any(named: 'hashtags'),
-        ),
-      ).thenAnswer(
-        (_) async => ReportResult.createSuccess(
-          'test_report_id',
-          delivery: ReportDelivery.localOnly,
-        ),
-      );
-      when(
-        () => mockModerationLabelService.divineModerationPubkeyHex,
-      ).thenThrow(StateError('moderation labels unavailable'));
-
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-      await tester.pump();
-
-      expect(find.text(l10n.reportNotSent), findsOneWidget);
-      expect(tester.takeException(), isNull);
       verifyNever(
         () => mockDmRepository.sendMessage(
           recipientPubkey: any(named: 'recipientPubkey'),
@@ -1270,75 +1101,6 @@ void main() {
         ),
       );
     });
-
-    testWidgets('does not queue a second moderation DM on a repeat submit', (
-      tester,
-    ) async {
-      // Submit stays live on the undelivered path so retrying is one tap.
-      // Each tap must not stack another identical row for the sweep to
-      // deliver — the user is being invited to retry, not to spam.
-      when(
-        () => mockReportingService.reportContent(
-          eventId: any(named: 'eventId'),
-          authorPubkey: any(named: 'authorPubkey'),
-          reason: any(named: 'reason'),
-          details: any(named: 'details'),
-          sourceRelay: any(named: 'sourceRelay'),
-          hashtags: any(named: 'hashtags'),
-        ),
-      ).thenAnswer(
-        (_) async => ReportResult.createSuccess(
-          'test_report_id',
-          delivery: ReportDelivery.localOnly,
-        ),
-      );
-
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-
-      await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
-      await tester.pumpAndSettle();
-
-      verify(
-        () => mockReportingService.reportContent(
-          eventId: any(named: 'eventId'),
-          authorPubkey: any(named: 'authorPubkey'),
-          reason: any(named: 'reason'),
-          details: any(named: 'details'),
-          sourceRelay: any(named: 'sourceRelay'),
-          hashtags: any(named: 'hashtags'),
-        ),
-      ).called(2);
-      verify(
-        () => mockDmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).called(1);
-    });
-
-    /// Stubs `reportContent` to walk [deliveries], one per successive call,
-    /// holding the last entry once exhausted.
-    void stubReportDeliveries(List<ReportDelivery> deliveries) {
-      var call = 0;
-      when(
-        () => mockReportingService.reportContent(
-          eventId: any(named: 'eventId'),
-          authorPubkey: any(named: 'authorPubkey'),
-          reason: any(named: 'reason'),
-          details: any(named: 'details'),
-          sourceRelay: any(named: 'sourceRelay'),
-          hashtags: any(named: 'hashtags'),
-        ),
-      ).thenAnswer((_) async {
-        final delivery = deliveries[call.clamp(0, deliveries.length - 1)];
-        call++;
-        return ReportResult.createSuccess('test_report_id', delivery: delivery);
-      });
-    }
 
     testWidgets('both channels label one submit with the reason it started on', (
       tester,
@@ -1432,11 +1194,9 @@ void main() {
                 as ContentFilterReason;
         final tags =
             verify(
-                  () => mockDmRepository.sendMessage(
+                  () => mockDmRepository.enqueueSend(
                     recipientPubkey: any(named: 'recipientPubkey'),
                     content: any(named: 'content'),
-                    replyToId: any(named: 'replyToId'),
-                    skipNip04Fallback: any(named: 'skipNip04Fallback'),
                     additionalTags: captureAny(named: 'additionalTags'),
                   ),
                 ).captured.single
@@ -1494,11 +1254,9 @@ void main() {
               as String;
       final dmContent =
           verify(
-                () => mockDmRepository.sendMessage(
+                () => mockDmRepository.enqueueSend(
                   recipientPubkey: any(named: 'recipientPubkey'),
                   content: captureAny(named: 'content'),
-                  replyToId: any(named: 'replyToId'),
-                  skipNip04Fallback: any(named: 'skipNip04Fallback'),
                   additionalTags: any(named: 'additionalTags'),
                 ),
               ).captured.single
@@ -1507,617 +1265,6 @@ void main() {
       expect(reportedDetails, 'First details');
       expect(dmContent, contains('Details: First details'));
       expect(dmContent, isNot(contains('Edited details')));
-    });
-
-    testWidgets('re-drives the parked DM when a later submit gets through', (
-      tester,
-    ) async {
-      // #6610: the undelivered submit parks a durable outgoing_dms row for
-      // the sweep. A later submit that does reach a relay must re-drive
-      // THAT row — calling sendMessage again mints a fresh rumor and a
-      // second row, so the sweep delivers one copy of the report and the
-      // retry delivers another. Receiver-side gift-wrap dedup keys on the
-      // rumor id and cannot collapse two of them.
-      stubReportDeliveries([ReportDelivery.localOnly, ReportDelivery.reached]);
-      stubDmResult(
-        const NIP17SendResult.failure(
-          'No relays connected',
-          queuedRumorId: 'parked_rumor_id',
-        ),
-      );
-      when(
-        () => mockDmRepository.recoverFullSend(
-          rumorId: any(named: 'rumorId'),
-          resetRetryBudget: any(named: 'resetRetryBudget'),
-        ),
-      ).thenAnswer(
-        (_) async => NIP17SendResult.success(
-          rumorEventId: 'parked_rumor_id',
-          messageEventId: 'dm_event_id',
-          recipientPubkey: ModerationLabelService.fallbackModerationPubkeyHex,
-        ),
-      );
-
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-      expect(find.text(l10n.reportNotSent), findsOneWidget);
-
-      await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
-      await tester.pumpAndSettle();
-
-      // Exactly one row ever existed, and the second submit drove it.
-      verify(
-        () => mockDmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).called(1);
-      verify(
-        () => mockDmRepository.recoverFullSend(
-          rumorId: 'parked_rumor_id',
-          // An explicit resubmit re-arms a budget the sweep may already
-          // have spent, so coalescing can't turn a duplicate into a drop.
-          resetRetryBudget: true,
-        ),
-      ).called(1);
-      // The team got it, so the confirmation carries no delayed caveat.
-      expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
-      expect(find.text(l10n.reportModerationDmDelayed), findsNothing);
-    });
-
-    testWidgets('sends a changed resubmit after an earlier DM delivered', (
-      tester,
-    ) async {
-      stubReportDeliveries([ReportDelivery.localOnly, ReportDelivery.reached]);
-      stubDmResult(
-        NIP17SendResult.success(
-          rumorEventId: 'dm_rumor_id',
-          messageEventId: 'dm_event_id',
-          recipientPubkey: ModerationLabelService.fallbackModerationPubkeyHex,
-        ),
-      );
-
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-      expect(find.text(l10n.reportNotSent), findsOneWidget);
-
-      await selectReason(
-        tester,
-        l10n.reportReasonTitle(ContentFilterReason.csam),
-      );
-      await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
-      await tester.pumpAndSettle();
-
-      final capturedTags =
-          verify(
-                () => mockDmRepository.sendMessage(
-                  recipientPubkey: any(named: 'recipientPubkey'),
-                  content: any(named: 'content'),
-                  replyToId: any(named: 'replyToId'),
-                  skipNip04Fallback: any(named: 'skipNip04Fallback'),
-                  additionalTags: captureAny(named: 'additionalTags'),
-                ),
-              ).captured
-              as List<Object?>;
-
-      expect(capturedTags, hasLength(2));
-      expect(
-        capturedTags.last,
-        equals([
-          ['L', kReportLabelNamespace],
-          ['l', 'NS-csam', kReportLabelNamespace],
-          ['report_type', 'illegal'],
-        ]),
-      );
-    });
-
-    testWidgets('replaces the parked DM when the user changes the reason', (
-      tester,
-    ) async {
-      // A parked rumor's tags are frozen at build time and replayed verbatim
-      // by recoverFullSend, so re-driving it after the user picked a different
-      // reason would ship the OLD NIP-32 label while the kind-1984 republish
-      // carries the new one. `user_reports` is INSERT OR IGNORE on
-      // (sha256, reporter_pubkey), so the first write to land would pin the
-      // superseded reason permanently.
-      stubReportDeliveries([ReportDelivery.localOnly, ReportDelivery.reached]);
-      stubDmResult(
-        const NIP17SendResult.failure(
-          'No relays connected',
-          queuedRumorId: 'parked_rumor_id',
-        ),
-      );
-      when(
-        () =>
-            mockDmRepository.cancelOutgoingSend(rumorId: any(named: 'rumorId')),
-      ).thenAnswer((_) async => true);
-
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-      expect(find.text(l10n.reportNotSent), findsOneWidget);
-
-      // Change of mind: spam -> csam. NIP-56 collapses csam to 'illegal'
-      // while spam stays 'spam', so a stale re-drive is visible in both tags.
-      await selectReason(
-        tester,
-        l10n.reportReasonTitle(ContentFilterReason.csam),
-      );
-      await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
-      await tester.pumpAndSettle();
-
-      // The superseded row is dropped rather than re-driven...
-      verify(
-        () => mockDmRepository.cancelOutgoingSend(rumorId: 'parked_rumor_id'),
-      ).called(1);
-      verifyNever(
-        () => mockDmRepository.recoverFullSend(
-          rumorId: any(named: 'rumorId'),
-          resetRetryBudget: any(named: 'resetRetryBudget'),
-        ),
-      );
-
-      // ...and the replacement DM carries the reason the user actually ended
-      // on, not the one the parked rumor froze.
-      final tags =
-          verify(
-                () => mockDmRepository.sendMessage(
-                  recipientPubkey: any(named: 'recipientPubkey'),
-                  content: any(named: 'content'),
-                  replyToId: any(named: 'replyToId'),
-                  skipNip04Fallback: any(named: 'skipNip04Fallback'),
-                  additionalTags: captureAny(named: 'additionalTags'),
-                ),
-              ).captured.last
-              as List<List<String>>;
-      expect(
-        tags,
-        equals([
-          ['L', kReportLabelNamespace],
-          ['l', 'NS-csam', kReportLabelNamespace],
-          // NIP-56 collapses csam to 'illegal'; spam would have stayed 'spam'.
-          ['report_type', 'illegal'],
-        ]),
-      );
-    });
-
-    testWidgets(
-      'does not keep retrying a stale cancel after the row becomes ambiguous',
-      (tester) async {
-        stubReportDeliveries([ReportDelivery.localOnly]);
-        stubDmResult(
-          const NIP17SendResult.failure(
-            'No relays connected',
-            queuedRumorId: 'parked_rumor_id',
-          ),
-        );
-        when(
-          () => mockDmRepository.cancelOutgoingSend(
-            rumorId: any(named: 'rumorId'),
-          ),
-        ).thenThrow(
-          ArgumentError.value(
-            'parked_rumor_id',
-            'rumorId',
-            'no queued outgoing DM with this id',
-          ),
-        );
-
-        await setLargeSurface(tester);
-        await openAndSubmitReport(tester);
-
-        await selectReason(
-          tester,
-          l10n.reportReasonTitle(ContentFilterReason.csam),
-        );
-
-        await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
-        await tester.pumpAndSettle();
-        await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
-        await tester.pumpAndSettle();
-
-        verify(
-          () => mockDmRepository.cancelOutgoingSend(rumorId: 'parked_rumor_id'),
-        ).called(1);
-        verifyNever(
-          () => mockDmRepository.recoverFullSend(
-            rumorId: any(named: 'rumorId'),
-            resetRetryBudget: any(named: 'resetRetryBudget'),
-          ),
-        );
-        verify(
-          () => mockDmRepository.sendMessage(
-            recipientPubkey: any(named: 'recipientPubkey'),
-            content: any(named: 'content'),
-            replyToId: any(named: 'replyToId'),
-            skipNip04Fallback: any(named: 'skipNip04Fallback'),
-            additionalTags: any(named: 'additionalTags'),
-          ),
-        ).called(1);
-        expect(find.text(l10n.reportNotSent), findsOneWidget);
-      },
-    );
-
-    testWidgets('replaces the parked DM when the reason changed mid-send', (
-      tester,
-    ) async {
-      // Same divergence as the test above, through the narrower window the
-      // offline path opens: it fires the dispatch unawaited and leaves the
-      // reason cards live, so the selection can move while the send is still
-      // in flight. The parked row must be recorded under the reason its rumor
-      // actually carries, not whatever is selected when the await returns.
-      stubReportDeliveries([ReportDelivery.localOnly, ReportDelivery.reached]);
-      final firstSend = Completer<NIP17SendResult>();
-      when(
-        () => mockDmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).thenAnswer(
-        (_) => firstSend.isCompleted
-            ? Future.value(
-                NIP17SendResult.success(
-                  rumorEventId: 'replacement_rumor_id',
-                  messageEventId: 'dm_event_id',
-                  recipientPubkey:
-                      ModerationLabelService.fallbackModerationPubkeyHex,
-                ),
-              )
-            : firstSend.future,
-      );
-      when(
-        () =>
-            mockDmRepository.cancelOutgoingSend(rumorId: any(named: 'rumorId')),
-      ).thenAnswer((_) async => true);
-
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-
-      // The send is still pending here — change the reason before it parks.
-      await selectReason(
-        tester,
-        l10n.reportReasonTitle(ContentFilterReason.csam),
-      );
-
-      firstSend.complete(
-        const NIP17SendResult.failure(
-          'No relays connected',
-          queuedRumorId: 'parked_rumor_id',
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
-      await tester.pumpAndSettle();
-
-      // The parked row was built with spam, so it is superseded and must not
-      // be re-driven, even though csam was already selected when it parked.
-      verify(
-        () => mockDmRepository.cancelOutgoingSend(rumorId: 'parked_rumor_id'),
-      ).called(1);
-      verifyNever(
-        () => mockDmRepository.recoverFullSend(
-          rumorId: any(named: 'rumorId'),
-          resetRetryBudget: any(named: 'resetRetryBudget'),
-        ),
-      );
-
-      final tags =
-          verify(
-                () => mockDmRepository.sendMessage(
-                  recipientPubkey: any(named: 'recipientPubkey'),
-                  content: any(named: 'content'),
-                  replyToId: any(named: 'replyToId'),
-                  skipNip04Fallback: any(named: 'skipNip04Fallback'),
-                  additionalTags: captureAny(named: 'additionalTags'),
-                ),
-              ).captured.last
-              as List<List<String>>;
-      expect(
-        tags,
-        equals([
-          ['L', kReportLabelNamespace],
-          ['l', 'NS-csam', kReportLabelNamespace],
-          ['report_type', 'illegal'],
-        ]),
-      );
-    });
-
-    testWidgets("a resubmit does not inherit an in-flight send's reason", (
-      tester,
-    ) async {
-      // The narrowest window of the three: resubmit while the FIRST send is
-      // still pending. Returning that outstanding future would report its
-      // spam-labelled result as this submit's outcome and never run the
-      // replacement pass at all, so the team keeps only the superseded label.
-      // The queued submit has to wait for the row to park, then replace it.
-      stubReportDeliveries([ReportDelivery.localOnly, ReportDelivery.reached]);
-      final firstSend = Completer<NIP17SendResult>();
-      when(
-        () => mockDmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).thenAnswer(
-        (_) => firstSend.isCompleted
-            ? Future.value(
-                NIP17SendResult.success(
-                  rumorEventId: 'replacement_rumor_id',
-                  messageEventId: 'dm_event_id',
-                  recipientPubkey:
-                      ModerationLabelService.fallbackModerationPubkeyHex,
-                ),
-              )
-            : firstSend.future,
-      );
-      when(
-        () =>
-            mockDmRepository.cancelOutgoingSend(rumorId: any(named: 'rumorId')),
-      ).thenAnswer((_) async => true);
-
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-
-      await selectReason(
-        tester,
-        l10n.reportReasonTitle(ContentFilterReason.csam),
-      );
-
-      // Resubmit BEFORE the first send settles.
-      await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
-      await tester.pump();
-
-      firstSend.complete(
-        const NIP17SendResult.failure(
-          'No relays connected',
-          queuedRumorId: 'parked_rumor_id',
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      verify(
-        () => mockDmRepository.cancelOutgoingSend(rumorId: 'parked_rumor_id'),
-      ).called(1);
-
-      final tags =
-          verify(
-                () => mockDmRepository.sendMessage(
-                  recipientPubkey: any(named: 'recipientPubkey'),
-                  content: any(named: 'content'),
-                  replyToId: any(named: 'replyToId'),
-                  skipNip04Fallback: any(named: 'skipNip04Fallback'),
-                  additionalTags: captureAny(named: 'additionalTags'),
-                ),
-              ).captured.last
-              as List<List<String>>;
-      expect(
-        tags,
-        equals([
-          ['L', kReportLabelNamespace],
-          ['l', 'NS-csam', kReportLabelNamespace],
-          ['report_type', 'illegal'],
-        ]),
-      );
-    });
-
-    testWidgets(
-      'keeps the delayed caveat when recovery cannot prove delivery',
-      (tester) async {
-        // The sweep can land between two submits and delete the row, but
-        // recoverFullSend also throws ArgumentError when the user deleted the
-        // failed DM or the row belongs to another account. The dialog cannot
-        // distinguish those cases, so it must coalesce (no fresh sendMessage)
-        // without claiming this DM definitely reached moderation.
-        stubReportDeliveries([
-          ReportDelivery.localOnly,
-          ReportDelivery.reached,
-        ]);
-        stubDmResult(
-          const NIP17SendResult.failure(
-            'No relays connected',
-            queuedRumorId: 'parked_rumor_id',
-          ),
-        );
-        when(
-          () => mockDmRepository.recoverFullSend(
-            rumorId: any(named: 'rumorId'),
-            resetRetryBudget: any(named: 'resetRetryBudget'),
-          ),
-        ).thenThrow(
-          ArgumentError.value(
-            'parked_rumor_id',
-            'rumorId',
-            'no queued outgoing DM with this id',
-          ),
-        );
-
-        await setLargeSurface(tester);
-        await openAndSubmitReport(tester);
-
-        await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
-        await tester.pumpAndSettle();
-
-        verify(
-          () => mockDmRepository.sendMessage(
-            recipientPubkey: any(named: 'recipientPubkey'),
-            content: any(named: 'content'),
-            replyToId: any(named: 'replyToId'),
-            skipNip04Fallback: any(named: 'skipNip04Fallback'),
-            additionalTags: any(named: 'additionalTags'),
-          ),
-        ).called(1);
-        expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
-        expect(find.text(l10n.reportModerationDmDelayed), findsOneWidget);
-      },
-    );
-
-    testWidgets('never mints a second DM after recovery loses the row', (
-      tester,
-    ) async {
-      // Losing track of the parked row must not re-arm the fresh-send path.
-      // Submit stays live on the undelivered path, so an ambiguous
-      // ArgumentError followed by one more tap is a third dispatch — and
-      // that one has no row to re-drive. Minting a rumor there is the #6610
-      // duplicate wearing a different hat: two kind-1059 wraps, two reports
-      // to triage, and no correlator to collapse them receiver-side.
-      stubReportDeliveries([ReportDelivery.localOnly]);
-      stubDmResult(
-        const NIP17SendResult.failure(
-          'No relays connected',
-          queuedRumorId: 'parked_rumor_id',
-        ),
-      );
-      when(
-        () => mockDmRepository.recoverFullSend(
-          rumorId: any(named: 'rumorId'),
-          resetRetryBudget: any(named: 'resetRetryBudget'),
-        ),
-      ).thenThrow(
-        ArgumentError.value(
-          'parked_rumor_id',
-          'rumorId',
-          'no queued outgoing DM with this id',
-        ),
-      );
-
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-
-      await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
-      await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
-      await tester.pumpAndSettle();
-
-      verify(
-        () => mockDmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).called(1);
-      // Coalescing spent the row, so the re-drive is not retried either.
-      verify(
-        () => mockDmRepository.recoverFullSend(
-          rumorId: 'parked_rumor_id',
-          resetRetryBudget: true,
-        ),
-      ).called(1);
-    });
-
-    testWidgets('keeps the delayed caveat when the re-drive also fails', (
-      tester,
-    ) async {
-      // Coalescing must not launder a still-undelivered DM into silence:
-      // the row survives for the sweep, but the team does not have the
-      // report yet, so the confirmation still has to say so.
-      stubReportDeliveries([ReportDelivery.localOnly, ReportDelivery.reached]);
-      stubDmResult(
-        const NIP17SendResult.failure(
-          'No relays connected',
-          queuedRumorId: 'parked_rumor_id',
-        ),
-      );
-      when(
-        () => mockDmRepository.recoverFullSend(
-          rumorId: any(named: 'rumorId'),
-          resetRetryBudget: any(named: 'resetRetryBudget'),
-        ),
-      ).thenAnswer((_) async => const NIP17SendResult.failure('Still offline'));
-
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-
-      await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
-      await tester.pumpAndSettle();
-
-      expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
-      expect(find.text(l10n.reportModerationDmDelayed), findsOneWidget);
-      verify(
-        () => mockDmRepository.sendMessage(
-          recipientPubkey: any(named: 'recipientPubkey'),
-          content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
-          additionalTags: any(named: 'additionalTags'),
-        ),
-      ).called(1);
-    });
-
-    testWidgets('leaves the report resubmittable after it reached no channel', (
-      tester,
-    ) async {
-      // Leaving Submit live is the whole reason this branch shows an inline
-      // error instead of the confirmation, so pin it: a second tap must
-      // reach the service again. That also proves the reason selection
-      // survived, since _handleSubmitReport short-circuits to
-      // reportSelectReason when _selectedReason is null.
-      when(
-        () => mockReportingService.reportContent(
-          eventId: any(named: 'eventId'),
-          authorPubkey: any(named: 'authorPubkey'),
-          reason: any(named: 'reason'),
-          details: any(named: 'details'),
-          sourceRelay: any(named: 'sourceRelay'),
-          hashtags: any(named: 'hashtags'),
-        ),
-      ).thenAnswer(
-        (_) async => ReportResult.createSuccess(
-          'test_report_id',
-          delivery: ReportDelivery.localOnly,
-        ),
-      );
-
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-
-      expect(find.text(l10n.reportNotSent), findsOneWidget);
-
-      await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
-      await tester.pumpAndSettle();
-
-      expect(find.text(l10n.reportSelectReason), findsNothing);
-      verify(
-        () => mockReportingService.reportContent(
-          eventId: any(named: 'eventId'),
-          authorPubkey: any(named: 'authorPubkey'),
-          reason: any(named: 'reason'),
-          details: any(named: 'details'),
-          sourceRelay: any(named: 'sourceRelay'),
-          hashtags: any(named: 'hashtags'),
-        ),
-      ).called(2);
-    });
-
-    testWidgets('stays silent when only the sender self-wrap failed', (
-      tester,
-    ) async {
-      // The moderation team DID receive the report; only the sender's own
-      // cross-device copy is missing. Claiming we couldn't reach the team
-      // would be false, so this must NOT show the notice.
-      stubDmResult(
-        NIP17SendResult.success(
-          rumorEventId: 'dm_rumor_id',
-          messageEventId: 'dm_event_id',
-          recipientPubkey: ModerationLabelService.fallbackModerationPubkeyHex,
-          selfWrapPublished: false,
-        ),
-      );
-
-      await setLargeSurface(tester);
-      await openAndSubmitReport(tester);
-
-      expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
-      expect(find.text(l10n.reportModerationDmDelayed), findsNothing);
     });
 
     Widget buildSubjectWithAuth(MockAuthService auth) {
@@ -2204,11 +1351,9 @@ void main() {
       (tester) async {
         final noKeysDmRepo = _MockDmRepository();
         when(
-          () => noKeysDmRepo.sendMessage(
+          () => noKeysDmRepo.enqueueSend(
             recipientPubkey: any(named: 'recipientPubkey'),
             content: any(named: 'content'),
-            replyToId: any(named: 'replyToId'),
-            skipNip04Fallback: any(named: 'skipNip04Fallback'),
             additionalTags: any(named: 'additionalTags'),
           ),
         ).thenThrow(Exception('No keys available'));
@@ -2263,11 +1408,9 @@ void main() {
 
         expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
         verifyNever(
-          () => mockDmRepository.sendMessage(
+          () => mockDmRepository.enqueueSend(
             recipientPubkey: any(named: 'recipientPubkey'),
             content: any(named: 'content'),
-            replyToId: any(named: 'replyToId'),
-            skipNip04Fallback: any(named: 'skipNip04Fallback'),
             additionalTags: any(named: 'additionalTags'),
           ),
         );
@@ -2294,12 +1437,18 @@ void main() {
         () => mockModerationLabelService.divineModerationPubkeyHex,
       ).thenReturn(ModerationLabelService.fallbackModerationPubkeyHex);
       when(
-        () => mockDmRepository.sendMessage(
+        () => mockDmRepository.enqueueSend(
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
           additionalTags: any(named: 'additionalTags'),
+        ),
+      ).thenAnswer(
+        (_) async => const EnqueueSendResult.enqueued('dm_rumor_id'),
+      );
+      when(
+        () => mockDmRepository.recoverFullSend(
+          rumorId: any(named: 'rumorId'),
+          resetRetryBudget: any(named: 'resetRetryBudget'),
         ),
       ).thenAnswer(
         (_) async => NIP17SendResult.success(
@@ -2377,11 +1526,9 @@ void main() {
         await openAndSubmitMessageReport(tester);
 
         final captured = verify(
-          () => mockDmRepository.sendMessage(
+          () => mockDmRepository.enqueueSend(
             recipientPubkey: any(named: 'recipientPubkey'),
             content: captureAny(named: 'content'),
-            replyToId: any(named: 'replyToId'),
-            skipNip04Fallback: any(named: 'skipNip04Fallback'),
             additionalTags: any(named: 'additionalTags'),
           ),
         ).captured;
@@ -2429,12 +1576,18 @@ void main() {
         () => mockModerationLabelService.divineModerationPubkeyHex,
       ).thenReturn(ModerationLabelService.fallbackModerationPubkeyHex);
       when(
-        () => mockDmRepository.sendMessage(
+        () => mockDmRepository.enqueueSend(
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
-          replyToId: any(named: 'replyToId'),
-          skipNip04Fallback: any(named: 'skipNip04Fallback'),
           additionalTags: any(named: 'additionalTags'),
+        ),
+      ).thenAnswer(
+        (_) async => const EnqueueSendResult.enqueued('dm_rumor_id'),
+      );
+      when(
+        () => mockDmRepository.recoverFullSend(
+          rumorId: any(named: 'rumorId'),
+          resetRetryBudget: any(named: 'resetRetryBudget'),
         ),
       ).thenAnswer(
         (_) async => NIP17SendResult.success(
@@ -2523,11 +1676,9 @@ void main() {
 
       final tags =
           verify(
-                () => mockDmRepository.sendMessage(
+                () => mockDmRepository.enqueueSend(
                   recipientPubkey: any(named: 'recipientPubkey'),
                   content: any(named: 'content'),
-                  replyToId: any(named: 'replyToId'),
-                  skipNip04Fallback: any(named: 'skipNip04Fallback'),
                   additionalTags: captureAny(named: 'additionalTags'),
                 ),
               ).captured.single
@@ -2572,11 +1723,9 @@ void main() {
         await openAndSubmitUserReport(tester);
 
         final captured = verify(
-          () => mockDmRepository.sendMessage(
+          () => mockDmRepository.enqueueSend(
             recipientPubkey: any(named: 'recipientPubkey'),
             content: captureAny(named: 'content'),
-            replyToId: any(named: 'replyToId'),
-            skipNip04Fallback: any(named: 'skipNip04Fallback'),
             additionalTags: any(named: 'additionalTags'),
           ),
         ).captured;


### PR DESCRIPTION
Closes #8053

Part 2 of 2 for #8053. **Draft, blocked on PR 1 (#8822).** Staked early to reserve the work; only the implementation plan is committed so far.

## Status

- Branched off PR 1 (`fix/8053-report-optimistic-durable`); base is set to that branch so this diff stays PR-2-only.
- **Not to be marked ready until PR 1 merges.** Then this branch rebases onto `main` (which will contain PR 1) and the base flips to `main`, per the no-stacked-PRs policy.
- Contains: the implementation plan (`docs/superpowers/plans/2026-09-07-report-optimistic-ui-pr2.md`). No code yet.

## Why the code is deferred

PR 2's core change extracts an enqueue-only seam out of `DmRepository.sendMessage` — a critical, heavily-invariant DM path (the #7326 sendBatchId, enqueue-before-publish, the cancel interlock, per-wrap OK confirmation, NIP-04 fallback gating). Doing that surgery on a stacked branch before PR 1 lands is regression risk for no mergeable payoff. The plan pins the exact seam so implementation is fast and safe once PR 1 is in `main`.

## What PR 2 will do (see the plan)

1. `DmRepository.enqueueSend` — enqueue-only seam returning the parked rumor id (extracted from `sendMessage`, behavior-preserving).
2. Optimistic cubit dispatch — await only the enqueue, drive publish via unawaited `recoverFullSend`; preserve #6610 coalescing.
3. `reportContent` enqueue-and-return; remove `ReportDelivery.localOnly`.
4. Unconditional confirmation; remove the DM-delayed / "reached no channel" UI.
5. Rework the ~20 pinned tests across the cubit, dialog, confirmation, and content-reporting suites.

Design doc: `docs/superpowers/specs/2026-09-07-report-durable-optimistic-design.md`.