### PR TITLE
fix(editor): remove orphaned clip files when a video session ends

### DIFF
--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -297,11 +297,18 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         .isAudioSharingEnabled;
     state = VideoEditorProviderState(allowAudioReuse: audioSharingEnabled);
     _autosaveTimer?.cancel();
-    _startDeferredFileCleanup();
     draftId = null;
     if (!keepAutosavedDraft) {
       await removeAutosavedDraft();
     }
+    // Started last, not first: the cleanup reference-checks each path against
+    // the drafts table, so it has to run against the state this reset leaves
+    // behind. Started before [removeAutosavedDraft], it sees the autosave row
+    // that is about to be deleted, keeps the file it references, and cannot
+    // retry — [_flushDeferredFileCleanup] empties the deferral set as it goes.
+    // [removeAutosavedDraft] logs its own failures instead of throwing, so
+    // this still runs on every path.
+    _startDeferredFileCleanup();
   }
 
   // === METADATA ===

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -195,17 +195,15 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       ref.read(videoReplyContextProvider.notifier).clear();
       reset();
 
-      // Keep the autosave through the parallel phase: both branches used to
-      // delete it concurrently, so the same id was torn down up to three times
-      // at once. The deletion is hoisted out here and runs exactly once, after
-      // both resets have settled.
+      // The editor owns autosave deletion and starts deferred cleanup only
+      // after that row is gone. Keeping the autosave here and deleting it after
+      // reset would let cleanup permanently skip files the stale row protects.
       await Future.wait([
         ref.read(clipManagerProvider.notifier).clearSessionClips(),
-        ref.read(videoEditorProvider.notifier).reset(keepAutosavedDraft: true),
+        ref
+            .read(videoEditorProvider.notifier)
+            .reset(keepAutosavedDraft: keepAutosavedDraft),
       ]);
-      if (!keepAutosavedDraft) {
-        await ref.read(videoEditorProvider.notifier).removeAutosavedDraft();
-      }
     } catch (error, stackTrace) {
       Log.error(
         '❌ Failed to clear video providers: $error',

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -3856,6 +3856,73 @@ void main() {
       },
     );
 
+    test(
+      'discard reaps the files its deleted autosave row referenced',
+      () async {
+        // The deferred reference check asks the drafts table whether anything
+        // still points at a path. On discard reset() deletes the autosave row,
+        // so the check is only meaningful once that row is gone: run it first
+        // and the row it is about to delete keeps the file, while the flush has
+        // already emptied the deferral set so nothing retries it.
+        final orphan = File(p.join(tempDir.path, 'discarded-orphan.mp4'))
+          ..writeAsBytesSync(const [0, 1, 2, 3]);
+        final realDraftStorage = DraftStorageService(
+          draftsDao: database.draftsDao,
+          clipsDao: database.clipsDao,
+        );
+        await realDraftStorage.saveDraft(
+          DivineVideoDraft.create(
+            id: VideoEditorConstants.autoSaveId,
+            clips: [
+              DivineVideoClip(
+                id: 'discarded',
+                video: EditorVideo.file(orphan.path),
+                duration: const Duration(seconds: 6),
+                recordedAt: DateTime(2025),
+                targetAspectRatio: AspectRatio.square,
+                originalAspectRatio: 9 / 16,
+              ),
+            ],
+            title: '',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'video',
+          ),
+        );
+        when(() => mockDraftStorage.draftExists(any())).thenAnswer(
+          (invocation) => realDraftStorage.draftExists(
+            invocation.positionalArguments.first as String,
+          ),
+        );
+        when(() => mockDraftStorage.deleteDraft(any())).thenAnswer(
+          (invocation) => realDraftStorage.deleteDraft(
+            invocation.positionalArguments.first as String,
+          ),
+        );
+
+        final notifier = container.read(videoEditorProvider.notifier);
+        notifier.deferFileCleanup([orphan.path]);
+        expect(notifier.deferredFileCleanupForTest, contains(orphan.path));
+
+        await notifier.reset();
+        await settleBackgroundWork();
+
+        expect(
+          await realDraftStorage.draftExists(VideoEditorConstants.autoSaveId),
+          isFalse,
+          reason: 'discard must have deleted the autosave row',
+        );
+        expect(
+          orphan.existsSync(),
+          isFalse,
+          reason:
+              'the discarded autosave row was the only thing referencing this '
+              'file, so the same reset must reap it',
+        );
+        expect(notifier.deferredFileCleanupForTest, isEmpty);
+      },
+    );
+
     test('container teardown reaps a replaced final rendered file', () async {
       // Point the documents dir at this group's unique per-test temp dir
       // instead of the shared global `/tmp/documents`: the draft_storage suite

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -26,6 +26,7 @@ import 'package:openvine/providers/editor_background_work.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/native_proofmode_service.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
@@ -3904,7 +3905,7 @@ void main() {
         notifier.deferFileCleanup([orphan.path]);
         expect(notifier.deferredFileCleanupForTest, contains(orphan.path));
 
-        await notifier.reset();
+        await container.read(videoPublishProvider.notifier).clearAll();
         await settleBackgroundWork();
 
         expect(


### PR DESCRIPTION
## The problem

Ending an editing session by discarding, publishing, or starting over could leave clip and thumbnail files on the device permanently. Deferred cleanup checked the drafts table while the autosave row still referenced those files, skipped them as live, and then forgot them before the row was deleted.

## Why this fix

`VideoEditorNotifier.reset()` now starts deferred cleanup after autosave deletion. The higher-level `VideoPublishNotifier.clearAll()` also passes its real `keepAutosavedDraft` decision into that reset instead of always preserving the row and deleting it afterward. This keeps autosave deletion owned by the editor and makes the production discard, publish, and start-over paths use the safe ordering.

## What this deliberately leaves alone

- Cleanup remains best-effort background work tracked by `EditorBackgroundWork`.
- Files referenced by surviving drafts or the clip library remain protected.
- Sessions that explicitly request `keepAutosavedDraft: true` still preserve the autosave.

## Verification

- The real-database regression test now enters through `VideoPublishNotifier.clearAll()`. It failed on the previous PR head because the file remained on disk, then passed with the coordinator fix.
- `flutter test test/providers/video_editor_provider_test.dart test/providers/video_publish_provider_test.dart test/providers/clip_manager_provider_test.dart test/blocs/video_recorder/video_recorder_bloc_test.dart` — 309 tests passed.
- `flutter analyze lib test integration_test` — no issues.
- All GitHub checks passed at `d3667eae021676dbff6cf0cba6fb58c007ac2b12`.

Closes #8837
