### PR TITLE
docs(rules): describe how the prune report actually decides containment

### DIFF
--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -61,7 +61,7 @@ report-only classifier for likely stale local branches and worktrees. It
 does not delete anything; prune the reported rows manually after reviewing
 the output.
 
-Do **not** improvise the classification. Three things that look like they
+Do **not** improvise the classification. Four things that look like they
 work do not:
 
 - `git branch --merged main` reports 5 of 1185 branches here. This repo
@@ -73,16 +73,26 @@ work do not:
 - Matching branch names against an issue number deletes live work.
   `fix/7606-semantic-tokens` was destroyed exactly this way: unpushed
   local work on a parallel attempt at the same task.
+- `git merge-base --is-ancestor` cannot tell you a tip is already on
+  `main`. This checkout is **shallow**, and a shallow clone's ancestry
+  walk stops at the graft boundary, so it answers "not an ancestor" for a
+  commit that is one — exit 1, silently, with the ref still resolving and
+  no error to catch. A worktree you are still working in reads as
+  prunable.
 
-The useful signals are GitHub reporting a same-repo merged PR to `main` with
-that head ref, or a worktree tip that belongs to a merged PR but is not already
-an ancestor of `main`. The latter identifies review worktrees whose scratch
-branch name never matched the reviewed PR while excluding fresh worktrees
-created at `origin/main`. Two vetoes apply on top: the local branch tip must
-exist in GitHub's repository object database, and the worktree must have no
-uncommitted, untracked, or non-regenerable ignored files. Ignored toolchain
-output such as `build/`, `.dart_tool/`, and generated plugin registrants does
-not veto because tracked inputs can recreate it. This keeps branch-name reuse,
+The useful signals are GitHub reporting a same-repo merged PR to `main`
+with that head ref, or a worktree tip that belongs to a merged PR and is
+not already contained in `main`. The second identifies review worktrees
+whose scratch branch name never matched the reviewed PR, while excluding
+worktrees that hold no commits of their own. **Containment is asked of
+GitHub, for the reason above** — nothing in the classifier walks local
+history.
+
+Two vetoes apply on top: the local branch tip must exist in GitHub's
+repository object database, and the worktree must have no uncommitted,
+untracked, or non-regenerable ignored files. Ignored toolchain output such
+as `build/`, `.dart_tool/`, and generated plugin registrants does not veto
+because tracked inputs can recreate it. This keeps branch-name reuse,
 unpushed commits, and local-only worktree files out of the prunable set.
 
 ### Optional: warn on concurrent sessions in one worktree

--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -73,12 +73,11 @@ work do not:
 - Matching branch names against an issue number deletes live work.
   `fix/7606-semantic-tokens` was destroyed exactly this way: unpushed
   local work on a parallel attempt at the same task.
-- `git merge-base --is-ancestor` cannot tell you a tip is already on
-  `main`. This checkout is **shallow**, and a shallow clone's ancestry
-  walk stops at the graft boundary, so it answers "not an ancestor" for a
-  commit that is one — exit 1, silently, with the ref still resolving and
-  no error to catch. A worktree you are still working in reads as
-  prunable.
+- In a **shallow** checkout, `git merge-base --is-ancestor` can miss a tip
+  already on `main`. The ancestry walk stops at the graft boundary, so it
+  can answer "not an ancestor" for a commit that is one — exit 1, silently,
+  with the ref still resolving and no error to catch. A worktree you are
+  still working in can read as prunable.
 
 The useful signals are GitHub reporting a same-repo merged PR to `main`
 with that head ref, or a worktree tip that belongs to a merged PR and is

--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -88,12 +88,18 @@ worktrees that hold no commits of their own. **Containment is asked of
 GitHub, for the reason above** — nothing in the classifier walks local
 history.
 
-Because that answer comes over the network, it can fail to arrive. An
-unanswerable containment lookup — auth expired, rate limit, a tip GitHub
-does not have — reports the tip as contained, which lands on `KEEP`, and
-prints a warning to stderr naming the commit. Read those warnings before
-trusting a run: a degraded run and a genuinely clean one both end
-"0 likely prunable".
+Because those answers come over the network, they can fail to arrive. The
+initial merged-PR lookup aborts the run, but the per-tip commit-existence
+and merged-PR-containment lookups discard API errors and silently land on
+`KEEP-LOCAL` or `KEEP`. Only an unanswerable base-containment lookup warns
+on stderr; it reports the tip as contained, which lands on `KEEP`.
+
+Treat a containment warning as proof that the report is incomplete, but
+do not treat the absence of warnings as proof that every lookup succeeded.
+A warning can accompany any prunable total because it suppresses only the
+affected `MERGED-TIP` candidate. When failed lookups suppress every
+candidate, a degraded run and a genuinely clean one both end "0 likely
+prunable".
 
 Two vetoes apply on top: the local branch tip must exist in GitHub's
 repository object database, and the worktree must have no uncommitted,

--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -88,6 +88,13 @@ worktrees that hold no commits of their own. **Containment is asked of
 GitHub, for the reason above** — nothing in the classifier walks local
 history.
 
+Because that answer comes over the network, it can fail to arrive. An
+unanswerable containment lookup — auth expired, rate limit, a tip GitHub
+does not have — reports the tip as contained, which lands on `KEEP`, and
+prints a warning to stderr naming the commit. Read those warnings before
+trusting a run: a degraded run and a genuinely clean one both end
+"0 likely prunable".
+
 Two vetoes apply on top: the local branch tip must exist in GitHub's
 repository object database, and the worktree must have no uncommitted,
 untracked, or non-regenerable ignored files. Ignored toolchain output such


### PR DESCRIPTION
Closes #8842

## The problem

`.claude/rules/agent_workflow.md` told anyone reimplementing the stale-branch classifier to use the one mechanism that is now documented as broken here.

Its second useful signal read *"a worktree tip that belongs to a merged PR but is **not already an ancestor of `main`**."* Ancestry is exactly what #8786 removed: in a shallow checkout, the ancestry walk stops at the graft boundary and can answer "not an ancestor" for a commit that is one — silently, exit 1, ref still resolving, nothing to catch. Following the old wording leads straight to `git merge-base --is-ancestor` and back into #8761.

So the paragraph named a mechanism the classifier no longer uses and cannot use, three bullets below a list of approaches that look like they work and don't.

## What changed

**Recovered commit** (`docs(rules): say that prune containment is answered by GitHub`) — cherry-picked with `-x` from `fix/8761-shallow-containment`, the parallel branch closed as superseded by #8786. Liz noted on #8768 that the branch remained available if documentation wording needed recovering; this is that wording. It adds the shallow-clone trap as a fourth "looks like it works" bullet and states that containment is asked of GitHub.

**Failure behavior** — documents how each GitHub lookup fails conservatively. Failure to load merged PRs aborts the run; the per-tip commit-existence and merged-PR-containment checks silently produce `KEEP-LOCAL` or `KEEP`; only a failed base-containment check warns before producing `KEEP`. The guidance therefore treats a warning as proof that the report is incomplete without treating silence or a non-zero total as proof that every lookup succeeded.

## What this does not change

This is documentation-only. It does not change the classifier or its conservative report-only behavior.

## Verification

- Checked every lookup and fallback against `scripts/prune-merged-branches.sh` on the rebased head.
- Confirmed the shallow-clone behavior and containment warning expectations against `mobile/test/tools/prune_merged_branches_test.dart`.
- Ran `env TMPDIR=/tmp .codex/scripts/test-config.sh` successfully.
- Confirmed the docs-only scope keeps app jobs skipped.
