### PR TITLE
fix(ios): declare two Apple privacy APIs the App Store build ships undeclared

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -141,6 +141,17 @@ jobs:
       - name: 🍏 Verify iOS shipping target versions
         if: ${{ needs.changes.outputs.native == 'true' }}
         run: bash scripts/check_ios_shipping_versions.sh
+      - name: 🔒 Verify iOS required-reason APIs are declared
+        # Deliberately NOT gated on `needs.changes.outputs.native`. That filter
+        # covers mobile/ios/*, mobile/android/* and mobile/macos/* but NOT
+        # mobile/packages/*/ios/*, and a first-party plugin is exactly where
+        # this drift happened: divine_camera's manifest was authored in #890
+        # with an empty NSPrivacyAccessedAPITypes, then #1783 added
+        # ProcessInfo.systemUptime six weeks later under a path the native
+        # filter does not watch. Gating here would reproduce the bug the guard
+        # exists to catch. The check is pure python3 with no package installs,
+        # so running it every time costs well under a second.
+        run: bash scripts/check_privacy_manifest_coverage.sh
       - name: 🐘 Verify the tracked Gradle wrapper is the pinned artifact
         # The wrapper is tracked (#7201) so a fresh clone or worktree can run
         # gradle tooling without a prior `flutter build`. That makes

--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -96,12 +96,13 @@ Reason codes:
 
 ## The guard
 
-`mobile/scripts/check_privacy_manifest_coverage.sh` runs in CI's
-**Generated Files** job on every push, ungated. It scans `mobile/ios/Runner`,
-both iOS extension targets, `mobile/ios/LocalPods/*` and
-`mobile/packages/*/ios`, and fails when a detected required-reason API is not
-declared in that bundle's own manifest. There is no baseline and no exemption
-list.
+`mobile/scripts/check_privacy_manifest_coverage.sh` runs whenever CI's
+**Generated Files** job runs. The step is not gated on the narrower native-file
+filter, so package-owned iOS sources are covered whenever Mobile CI is in app
+scope. It scans `mobile/ios/Runner`, both iOS extension targets,
+`mobile/ios/LocalPods/*` and `mobile/packages/*/ios`, and fails when a detected
+required-reason API is not declared in that bundle's own manifest. There is no
+baseline and no exemption list.
 
 ```bash
 cd mobile

--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -1,0 +1,161 @@
+# iOS privacy manifests and required-reason APIs
+
+Apple rejects App Store Connect submissions that call a **required reason API**
+without declaring it in a privacy manifest. This document is the ownership and
+update process for those declarations (#8803).
+
+Source of truth for the rules is Apple's
+[Describing use of required reason API][apple-rr]. The tables below were
+verified against Apple's documentation payload on 2026-09-08; re-verify them
+when Apple updates the list, which the page says happens periodically.
+
+[apple-rr]: https://developer.apple.com/documentation/bundleresources/describing-use-of-required-reason-api
+
+## The two rules that decide everything
+
+1. **Each bundle declares its own use.** Apple: "Your third-party SDK can't rely
+   on the privacy manifest files for apps that link the third-party SDK." A
+   plugin's required-reason API goes in the plugin's manifest, never in the
+   app's — even though CocoaPods links our pods statically into the `Runner`
+   executable. Every one of the 58 third-party manifests in our archive follows
+   this pattern under the same static linkage.
+2. **Declare only what you use.** Apple permits use of these APIs "for the
+   declared reasons only", so an extra reason is inaccurate, not cautious.
+
+Scope note: the requirement covers **iOS, iPadOS, tvOS, visionOS and watchOS**.
+macOS is not listed, which is why `mobile/macos` carries no obligation here.
+
+## Where our manifests live
+
+| Bundle | Manifest | Reaches the archive via |
+|---|---|---|
+| App (`Runner`) | `mobile/ios/Runner/PrivacyInfo.xcprivacy` | `Copy Bundle Resources` in `Runner.xcodeproj` |
+| `divine_camera` | `mobile/packages/divine_camera/ios/Resources/PrivacyInfo.xcprivacy` | `s.resource_bundles` in its podspec |
+| `divine_quick_actions` | `mobile/packages/divine_quick_actions/ios/Resources/PrivacyInfo.xcprivacy` | `s.resource_bundles` |
+| `LibProofMode` (vendored) | `mobile/ios/LocalPods/LibProofMode/Resources/PrivacyInfo.xcprivacy` | `s.resource_bundles` |
+
+`LibProofMode` is Guardian Project code vendored under `ios/LocalPods/`. No
+upstream release will ship a manifest into Divine's archive, so we own its
+declaration for as long as it is vendored.
+
+## What is currently declared, and why
+
+| Bundle | Category | Reason | Justification |
+|---|---|---|---|
+| `divine_camera` | `SystemBootTime` | `35F9.1` | `VolumeKeyHandler.swift` reads `ProcessInfo.systemUptime` at two sites purely to measure elapsed time for Bluetooth-trigger cooldown and debounce. Nothing derived from it leaves the device — the file has no method channel or event sink. |
+| `LibProofMode` | `FileTimestamp` | `C617.1` | `MediaItem.withData` reads `URLResourceKey.contentModificationDateKey` / `.creationDateKey`. Every path Divine feeds to `MediaItem(mediaUrl:)` is a file the app wrote in its own container (editor render output or a recorded clip). |
+| App (`Runner`) | *(none)* | — | The Runner target's own Release code calls no required-reason API. Its single `UserDefaults` call is inside `#if DEBUG`. |
+| `divine_quick_actions` | *(none)* | — | No required-reason API detected. |
+
+`NSPrivacyCollectedDataTypes` is empty in the app manifest and is **not** a
+claim that Divine collects nothing. Filling it is a product/legal decision that
+must match the App Store Connect privacy label, and was deliberately out of
+scope for the required-reason API audit.
+
+`LibProofMode`'s collected-data section is empty because Divine constructs
+`ProofGenerationOptions(showDeviceIds: false, showLocation: false,
+showMobileNetwork: false, notarizationProviders: [])`. Those flags gate the
+corresponding blocks in `Proof.swift` (`buildProof`, lines 408 / 430 / 439), so
+no device ID, location or carrier data enters the proof. **If any of those flags
+is ever flipped to `true`, this manifest and the App Store privacy label must be
+updated in the same change.**
+
+## Apple's catalogue
+
+Symbols, verified against Apple's documentation:
+
+| Category | APIs |
+|---|---|
+| `FileTimestamp` | `FileAttributeKey.creationDate`, `FileAttributeKey.modificationDate`, `UIDocument.fileModificationDate`, `URLResourceKey.contentModificationDateKey`, `URLResourceKey.creationDateKey`, `getattrlist`, `getattrlistbulk`, `fgetattrlist`, `stat`, `fstat`, `fstatat`, `lstat`, `getattrlistat` |
+| `SystemBootTime` | `ProcessInfo.systemUptime`, `mach_absolute_time()` |
+| `DiskSpace` | `volumeAvailableCapacityKey`, `volumeAvailableCapacityForImportantUsageKey`, `volumeAvailableCapacityForOpportunisticUsageKey`, `volumeTotalCapacityKey`, `systemFreeSize`, `systemSize`, `statfs`, `statvfs`, `fstatfs`, `fstatvfs`, `getattrlist`, `fgetattrlist`, `getattrlistat` |
+| `ActiveKeyboards` | `UITextInputMode.activeInputModes` |
+| `UserDefaults` | `UserDefaults` |
+
+Reason codes:
+
+| Code | Category | Meaning |
+|---|---|---|
+| `DDA9.1` | FileTimestamp | display file timestamps to the user; not sent off-device |
+| `C617.1` | FileTimestamp | metadata of files in the app / app-group / CloudKit container |
+| `3B52.1` | FileTimestamp | files the user explicitly granted access to (document picker) |
+| `0A2A.1` | FileTimestamp | third-party SDK wrapper function only |
+| `35F9.1` | SystemBootTime | elapsed time between in-app events, or timers |
+| `8FFB.1` | SystemBootTime | absolute timestamps for in-app events |
+| `3D61.1` | SystemBootTime | user-submitted bug report |
+| `85F4.1` | DiskSpace | display disk space to the user |
+| `E174.1` | DiskSpace | check sufficient / low disk space, with observable behaviour |
+| `7D9E.1` | DiskSpace | user-submitted bug report |
+| `B728.1` | DiskSpace | health research app |
+| `3EC4.1` | ActiveKeyboards | custom keyboard app |
+| `54BD.1` | ActiveKeyboards | customize UI to the active keyboards |
+| `CA92.1` | UserDefaults | data accessible only to the app itself |
+| `1C8F.1` | UserDefaults | App Group–scoped defaults |
+| `C56D.1` | UserDefaults | third-party SDK wrapper function only |
+| `AC6B.1` | UserDefaults | MDM managed app configuration |
+
+## The guard
+
+`mobile/scripts/check_privacy_manifest_coverage.sh` runs in CI's
+**Generated Files** job on every push, ungated. It scans `mobile/ios/Runner`,
+both iOS extension targets, `mobile/ios/LocalPods/*` and
+`mobile/packages/*/ios`, and fails when a detected required-reason API is not
+declared in that bundle's own manifest. There is no baseline and no exemption
+list.
+
+```bash
+cd mobile
+bash scripts/check_privacy_manifest_coverage.sh            # the CI check
+bash scripts/check_privacy_manifest_coverage.sh --detail   # list every site
+bash scripts/check_privacy_manifest_coverage.sh --archive build/ios/iphoneos/Runner.app
+```
+
+It also fails on an invalid reason code for a category, an unknown category
+string, and a manifest that exists but is not bundled by its podspec — a
+manifest nothing ships is a manifest Apple never reads.
+
+Behaviour is pinned by
+`mobile/test/tools/privacy_manifest_coverage_detector_test.dart`.
+
+### Two things it deliberately does not do
+
+- **Bare `.creationDate` / `.modificationDate` are reported, never fatal.**
+  Apple's required-reason symbols are `FileAttributeKey.creationDate` and
+  `FileAttributeKey.modificationDate`. `PHAsset.creationDate` is photo metadata
+  and carries no duty. `MediaItem.swift` uses both kinds forty lines apart, so a
+  detector that failed on the bare accessor would force an inaccurate
+  declaration. Review those sites by hand.
+- **It understands only a bare `#if DEBUG`.** Code in that branch is absent from
+  Release, so it needs no declaration. Any other condition
+  (`#if canImport(…)`, `#if !DEBUG`) is scanned normally, so the guard errs
+  toward reporting rather than hiding a use.
+
+## Adding or changing a declaration
+
+1. Find the call site: `bash scripts/check_privacy_manifest_coverage.sh --detail`.
+2. Pick the reason from the table above whose wording matches what the code
+   actually does — including its off-device restriction. If none fits, the code
+   needs to change, not the manifest.
+3. Edit the owning bundle's manifest. For a pod, confirm its podspec has a
+   `s.resource_bundles` entry pointing at the file.
+4. Validate strictly. `plutil -lint` is lenient about XML that
+   `plistlib`/`expat` rejects — notably a `--` inside an XML comment, which is
+   illegal XML and which `plutil` accepts:
+   ```bash
+   python3 -c "import plistlib,sys; plistlib.load(open(sys.argv[1],'rb'))" path/to/PrivacyInfo.xcprivacy
+   ```
+5. Re-run the guard, and for a bundling change verify the product:
+   ```bash
+   mise exec -- flutter build ios --release --no-codesign
+   bash scripts/check_privacy_manifest_coverage.sh --archive build/ios/iphoneos/Runner.app
+   ```
+
+## Known follow-ups
+
+- `divine_device_attestation` (PR #8779, not yet merged) caches App Attest key
+  handles in `UserDefaults` and ships no manifest. When that PR lands, add
+  `NSPrivacyAccessedAPICategoryUserDefaults` / `CA92.1` plus a
+  `s.resource_bundles` entry to its podspec. The guard will fail until then,
+  which is the intended behaviour.
+- `NSPrivacyCollectedDataTypes` for the app target needs a product/legal pass
+  against the App Store Connect privacy label.

--- a/mobile/ios/LocalPods/LibProofMode/LibProofMode.podspec
+++ b/mobile/ios/LocalPods/LibProofMode/LibProofMode.podspec
@@ -45,7 +45,6 @@ without the need to fork it. That way, spin-offs can easily stay up to date.
   # is a file the app itself wrote inside its own container.
   s.resource_bundles = {'LibProofMode_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
 
-
   s.subspec 'PrivacyProtected' do |ss|
     ss.source_files = 'Classes/**/*'
 

--- a/mobile/ios/LocalPods/LibProofMode/LibProofMode.podspec
+++ b/mobile/ios/LocalPods/LibProofMode/LibProofMode.podspec
@@ -36,6 +36,16 @@ without the need to fork it. That way, spin-offs can easily stay up to date.
 
   s.default_subspec = :none
 
+  # Divine-local addition (#8803): LibProofMode reads
+  # URLResourceKey.contentModificationDateKey / .creationDateKey in
+  # MediaItem.withData, which is one of Apple's required-reason APIs. The pod is
+  # vendored here, so no upstream release will ship this manifest into Divine's
+  # archive -- it has to be declared locally or the archive ships the API
+  # undeclared. Reason C617.1: every path Divine feeds to MediaItem(mediaUrl:)
+  # is a file the app itself wrote inside its own container.
+  s.resource_bundles = {'LibProofMode_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
+
+
   s.subspec 'PrivacyProtected' do |ss|
     ss.source_files = 'Classes/**/*'
 

--- a/mobile/ios/LocalPods/LibProofMode/Resources/PrivacyInfo.xcprivacy
+++ b/mobile/ios/LocalPods/LibProofMode/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		66F22673A01C965F74615E46 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
 		6E3EAE672F3747792842A5A3 /* NotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = C696D98D09FD161565BF6483 /* NotificationServiceExtension.appex */; };
 		6FDAD046102CCA6028B8B9A3 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		734F170C275F53E25C8EE831 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1D777AEE1B05282C0928DE2F /* PrivacyInfo.xcprivacy */; };
 		7448569019F99AE3960D617E /* DivineScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = B380C2DEDB76FE1B1BDC0161 /* DivineScreenshots.swift */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
@@ -95,6 +96,7 @@
 		0F9089E8B21DD51EA95A008F /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		1D777AEE1B05282C0928DE2F /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		1EF10235DDCC51D74DC45009 /* NotificationServiceExtension.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = NotificationServiceExtension.entitlements; sourceTree = "<group>"; };
 		2C53DBBEBD271C190B3C98EF /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		2ECE9F51A53445ABB44F885B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -279,6 +281,7 @@
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				06671AD11C80317FA3B1799D /* NostrBridgeAttestationPlugin.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
+				1D777AEE1B05282C0928DE2F /* PrivacyInfo.xcprivacy */,
 			);
 			path = Runner;
 			sourceTree = "<group>";
@@ -529,6 +532,7 @@
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 				62ACD9D0D737E6772C26E9DF /* GoogleService-Info.plist in Resources */,
+				734F170C275F53E25C8EE831 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -127,8 +127,11 @@ extension FlutterError: @retroactive Error {}
 
           let mediaItem = MediaItem(mediaUrl: fileURL)
 
-          // Configure proof generation options
-          // Include device ID, location (if available), and network info
+          // Configure proof generation options.
+          // All three signals are deliberately off: Divine proves the media
+          // hash only, and collects no device ID, location, or carrier data.
+          // Keep them false unless the privacy manifest and the App Store
+          // privacy label are updated to match (#8803).
           let options = ProofGenerationOptions(
             showDeviceIds: false,
             showLocation: false,

--- a/mobile/ios/Runner/PrivacyInfo.xcprivacy
+++ b/mobile/ios/Runner/PrivacyInfo.xcprivacy
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Divine app-target privacy manifest (#8803).
+
+  NSPrivacyAccessedAPITypes is intentionally EMPTY. It covers the Runner
+  target's OWN source only, and that source calls no required-reason API in a
+  Release build: the single UserDefaults call in AppDelegate.swift sits inside
+  `#if DEBUG` (the App Store screenshot bridge). Verified against the Release
+  product: `strings` over build/ios/iphoneos/Runner.app/Runner finds zero
+  occurrences of flutter.screenshot_initial_route, flutter.screenshot_seed_clips
+  or SCREENSHOT_INITIAL_ROUTE.
+
+  Required-reason APIs used by first-party pods are declared in those pods' own
+  manifests, which ship as resource bundles inside this app bundle
+  (divine_camera_privacy, LibProofMode_privacy). Apple is explicit that an SDK
+  cannot rely on the host app's manifest, so those declarations must not be
+  duplicated here.
+
+  NSPrivacyCollectedDataTypes is deliberately left empty and is NOT a statement
+  that Divine collects nothing. Populating it is a product/legal decision that
+  must match the App Store Connect privacy label, and is tracked separately;
+  it was out of scope for the required-reason API audit in #8803.
+
+  Ownership and update process: mobile/docs/IOS_PRIVACY_MANIFESTS.md
+-->
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+</dict>
+</plist>

--- a/mobile/packages/divine_camera/ios/Resources/PrivacyInfo.xcprivacy
+++ b/mobile/packages/divine_camera/ios/Resources/PrivacyInfo.xcprivacy
@@ -5,7 +5,16 @@
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
 		<dict>

--- a/mobile/scripts/check_privacy_manifest_coverage.sh
+++ b/mobile/scripts/check_privacy_manifest_coverage.sh
@@ -25,10 +25,9 @@
 #   bash scripts/check_privacy_manifest_coverage.sh --detail
 #   bash scripts/check_privacy_manifest_coverage.sh --archive <path/to/Runner.app>
 #
-# The --archive mode proves the manifests a source scan trusts actually reach
-# the build product. A podspec that loses its resource_bundles line still passes
-# a source-only scan while shipping nothing, which is the one gap source
-# analysis cannot close.
+# The --archive mode proves the source scan's project and podspec wiring reaches
+# the build product. Source analysis validates that wiring, but only inspecting
+# the built app closes the final packaging gap.
 #
 # Docs: mobile/docs/IOS_PRIVACY_MANIFESTS.md
 set -euo pipefail

--- a/mobile/scripts/check_privacy_manifest_coverage.sh
+++ b/mobile/scripts/check_privacy_manifest_coverage.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Fails CI when first-party iOS code uses an Apple "required reason API" that
+# the owning bundle's PrivacyInfo.xcprivacy does not declare (#8803).
+#
+# Zero baseline: there is no exemption list. Declare the API in the owning
+# bundle's manifest, or don't call it.
+#
+# Why this exists. Apple rejects App Store Connect submissions that use a
+# required reason API without declaring it, and an SDK may not rely on the host
+# app's manifest -- each bundle declares its own. The failure mode is drift, not
+# carelessness: divine_camera's manifest was authored 2026-01-14 (#890) with an
+# empty NSPrivacyAccessedAPITypes and was correct that day;
+# ProcessInfo.systemUptime arrived 2026-02-25 in #1783 and nobody revisited it,
+# so the shipping archive carried an undeclared required-reason API for months.
+# A manifest well-formedness check would have stayed green the whole time.
+#
+# Scope: mobile/ios/Runner, the two iOS extension targets,
+# mobile/ios/LocalPods/* and mobile/packages/*/ios. Third-party pods under
+# mobile/ios/Pods are deliberately excluded -- we cannot fix upstream code, and
+# each of the 58 third-party manifests in the archive is shipped by its own
+# vendor.
+#
+# Usage:
+#   bash scripts/check_privacy_manifest_coverage.sh
+#   bash scripts/check_privacy_manifest_coverage.sh --detail
+#   bash scripts/check_privacy_manifest_coverage.sh --archive <path/to/Runner.app>
+#
+# The --archive mode proves the manifests a source scan trusts actually reach
+# the build product. A podspec that loses its resource_bundles line still passes
+# a source-only scan while shipping nothing, which is the one gap source
+# analysis cannot close.
+#
+# Docs: mobile/docs/IOS_PRIVACY_MANIFESTS.md
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOBILE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "❌ python3 not found. It is preinstalled on GitHub Actions runners and macOS."
+  exit 1
+fi
+
+exec python3 "$SCRIPT_DIR/lib/privacy_manifest_coverage.py" \
+  --mobile "$MOBILE_DIR" "$@"

--- a/mobile/scripts/lib/privacy_manifest_coverage.py
+++ b/mobile/scripts/lib/privacy_manifest_coverage.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Detector for Apple required-reason API use without a privacy declaration.
+
+Apple requires every bundle that ships an executable using a "required reason
+API" to declare that API, and its reason, in that bundle's own
+`PrivacyInfo.xcprivacy`. An SDK may not rely on the host app's manifest
+(https://developer.apple.com/documentation/bundleresources/
+describing-use-of-required-reason-api). App Store Connect rejects submissions
+that miss a declaration.
+
+The failure this guards against is *drift*, not authoring mistakes. #8803 found
+`divine_camera`'s manifest was written on 2026-01-14 (#890) with an empty
+`NSPrivacyAccessedAPITypes`, and `ProcessInfo.systemUptime` arrived six weeks
+later in #1783 without anyone revisiting it. The manifest was correct when
+written and silently became wrong. A well-formedness check would not have
+noticed.
+
+Precision note, because the naive version of this detector is actively harmful:
+Apple's required-reason `creationDate` / `modificationDate` are
+`FileAttributeKey.creationDate` / `.modificationDate`. They are NOT
+`PHAsset.creationDate` / `.modificationDate`, which are photo metadata and carry
+no declaration duty. `LibProofMode/Classes/MediaItem.swift` uses both kinds a few
+lines apart. Matching a bare `.creationDate` would flag the PHAsset lines and
+push the author into declaring a reason the code does not need -- and Apple says
+you may use an API only for a declared reason, so an unused declaration is
+inaccurate rather than cautious. Bare accessors are therefore reported as
+REVIEW (non-fatal) and never as a failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import plistlib
+import re
+import sys
+
+# --- Apple's required-reason API catalogue -------------------------------
+# Symbols verified against Apple's DocC payload for
+# bundleresources/app-privacy-configuration/nsprivacyaccessedapitypes/
+# nsprivacyaccessedapitype (symbol reference links resolved), 2026-09-08.
+
+FILE_TIMESTAMP = "NSPrivacyAccessedAPICategoryFileTimestamp"
+SYSTEM_BOOT_TIME = "NSPrivacyAccessedAPICategorySystemBootTime"
+DISK_SPACE = "NSPrivacyAccessedAPICategoryDiskSpace"
+ACTIVE_KEYBOARDS = "NSPrivacyAccessedAPICategoryActiveKeyboards"
+USER_DEFAULTS = "NSPrivacyAccessedAPICategoryUserDefaults"
+
+ALL_CATEGORIES = {
+    FILE_TIMESTAMP,
+    SYSTEM_BOOT_TIME,
+    DISK_SPACE,
+    ACTIVE_KEYBOARDS,
+    USER_DEFAULTS,
+}
+
+VALID_REASONS = {
+    FILE_TIMESTAMP: {"DDA9.1", "C617.1", "3B52.1", "0A2A.1"},
+    SYSTEM_BOOT_TIME: {"35F9.1", "8FFB.1", "3D61.1"},
+    DISK_SPACE: {"85F4.1", "E174.1", "7D9E.1", "B728.1"},
+    ACTIVE_KEYBOARDS: {"3EC4.1", "54BD.1"},
+    USER_DEFAULTS: {"CA92.1", "1C8F.1", "C56D.1", "AC6B.1"},
+}
+
+# Unambiguous: each pattern can only mean the required-reason API.
+DEFINITE = [
+    (USER_DEFAULTS, re.compile(r"\b(?:NS)?UserDefaults\b")),
+    (SYSTEM_BOOT_TIME, re.compile(r"\bsystemUptime\b|\bmach_absolute_time\b")),
+    (
+        FILE_TIMESTAMP,
+        re.compile(
+            r"\bcontentModificationDateKey\b|\bcreationDateKey\b"
+            r"|\bfileModificationDate\b"
+            r"|\bFileAttributeKey\.(?:creationDate|modificationDate)\b"
+            r"|\bgetattrlist(?:bulk|at)?\s*\(|\bfgetattrlist\s*\("
+            r"|\bfstatat\s*\(|\blstat\s*\(|\bfstat\s*\(|(?<![\w.])stat\s*\("
+        ),
+    ),
+    (
+        DISK_SPACE,
+        re.compile(
+            r"\bvolumeAvailableCapacity(?:ForImportantUsage|ForOpportunisticUsage)?Key\b"
+            r"|\bvolumeTotalCapacityKey\b|\bsystemFreeSize\b|\bsystemSize\b"
+            r"|\bstatfs\s*\(|\bstatvfs\s*\(|\bfstatfs\s*\(|\bfstatvfs\s*\("
+        ),
+    ),
+    (ACTIVE_KEYBOARDS, re.compile(r"\bactiveInputModes\b")),
+]
+
+# Ambiguous: could be the required-reason symbol or an unrelated property of the
+# same name (PHAsset, a model type, a JSON field). Reported, never fatal.
+AMBIGUOUS = [
+    (
+        FILE_TIMESTAMP,
+        re.compile(r"\battributesOfItem\b|\.(?:creationDate|modificationDate)\b"),
+    ),
+]
+
+SOURCE_SUFFIXES = (".swift", ".m", ".mm", ".h", ".c")
+
+_BLOCK = re.compile(r"/\*.*?\*/", re.S)
+_LINE = re.compile(r"//[^\n]*")
+_MULTI_STR = re.compile(r'"""(?:.|\n)*?"""')
+_RAW_STR = re.compile(r'#"(?:[^"\\]|\\.)*"#')
+_STR = re.compile(r'"(?:[^"\\\n]|\\.)*"')
+
+
+def strip_noise(text: str) -> str:
+    """Blank out comments and string literals, preserving line numbers.
+
+    A comment mentioning `UserDefaults`, or a log string naming `statfs`, calls
+    nothing. This file's own module docstring names most of the catalogue, and
+    `AppDelegate.swift` documents its DEBUG-only `UserDefaults` bridge in prose
+    directly above the call -- so without this the guard fails on the very repo
+    it protects.
+    """
+
+    def blank(match: re.Match[str]) -> str:
+        return re.sub(r"[^\n]", " ", match.group(0))
+
+    for pattern in (_BLOCK, _MULTI_STR, _RAW_STR, _LINE, _STR):
+        text = pattern.sub(blank, text)
+    return text
+
+
+_IF_DEBUG = re.compile(r"^\s*#if\s+DEBUG\s*$")
+_IF_ANY = re.compile(r"^\s*#if\b")
+_ELSEIF = re.compile(r"^\s*#elseif\b")
+_ELSE = re.compile(r"^\s*#else\s*$")
+_ENDIF = re.compile(r"^\s*#endif\b")
+
+
+def strip_debug_only(text: str) -> str:
+    """Blank out `#if DEBUG` branches, preserving line numbers.
+
+    Apple's requirement is about the shipped binary. `AppDelegate.swift` reaches
+    `UserDefaults` only inside `#if DEBUG`, to bridge the App Store screenshot
+    pipeline's launch environment into shared_preferences, and that code is
+    absent from Release -- proven by `strings` over
+    build/ios/iphoneos/Runner.app/Runner, which finds zero occurrences of
+    `flutter.screenshot_initial_route`. Counting it would force the app manifest
+    to declare a reason the shipped app never exercises.
+
+    Only a bare `#if DEBUG` is understood. Any other condition
+    (`#if canImport(X)`, `#if !DEBUG`, `#if targetEnvironment(simulator)`) is
+    left intact, so the guard errs toward reporting rather than hiding a use.
+    The matching `#else` branch is kept: it IS the Release branch.
+    """
+    out: list[str] = []
+    stack: list[str] = []  # one entry per open #if: "debug-skip", "debug-keep", "other"
+    for line in text.splitlines():
+        if _ENDIF.match(line):
+            if stack:
+                stack.pop()
+            out.append(line)
+            continue
+        if _ELSE.match(line) or _ELSEIF.match(line):
+            if stack and stack[-1] in ("debug-skip", "debug-keep"):
+                stack[-1] = "debug-keep"
+            out.append(line)
+            continue
+        if _IF_ANY.match(line):
+            stack.append("debug-skip" if _IF_DEBUG.match(line) else "other")
+            out.append(line)
+            continue
+        if "debug-skip" in stack:
+            out.append(re.sub(r"[^\n]", " ", line))
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
+class Unit:
+    """One bundle that must carry its own manifest."""
+
+    def __init__(
+        self,
+        name: str,
+        roots: list[str],
+        manifest: str,
+        podspec: str | None,
+        xcodeproj: str | None = None,
+    ):
+        self.name = name
+        self.roots = roots
+        self.manifest = manifest
+        self.podspec = podspec
+        self.xcodeproj = xcodeproj
+
+
+def discover(mobile: str) -> list[Unit]:
+    units: list[Unit] = []
+    ios = os.path.join(mobile, "ios")
+
+    units.append(
+        Unit(
+            "app:Runner",
+            [os.path.join(ios, "Runner")],
+            os.path.join(ios, "Runner", "PrivacyInfo.xcprivacy"),
+            None,
+            xcodeproj=os.path.join(ios, "Runner.xcodeproj", "project.pbxproj"),
+        )
+    )
+    for ext in ("NotificationServiceExtension", "CameraQuickActionWidget"):
+        path = os.path.join(ios, ext)
+        if os.path.isdir(path):
+            units.append(
+                Unit(f"extension:{ext}", [path],
+                     os.path.join(path, "PrivacyInfo.xcprivacy"), None)
+            )
+
+    local_pods = os.path.join(ios, "LocalPods")
+    if os.path.isdir(local_pods):
+        for pod in sorted(os.listdir(local_pods)):
+            path = os.path.join(local_pods, pod)
+            if not os.path.isdir(path):
+                continue
+            specs = [f for f in os.listdir(path) if f.endswith(".podspec")]
+            units.append(
+                Unit(f"localpod:{pod}", [path],
+                     os.path.join(path, "Resources", "PrivacyInfo.xcprivacy"),
+                     os.path.join(path, specs[0]) if specs else None)
+            )
+
+    packages = os.path.join(mobile, "packages")
+    if os.path.isdir(packages):
+        for pkg in sorted(os.listdir(packages)):
+            pkg_ios = os.path.join(packages, pkg, "ios")
+            if not os.path.isdir(pkg_ios):
+                continue
+            specs = [f for f in os.listdir(pkg_ios) if f.endswith(".podspec")]
+            units.append(
+                Unit(f"package:{pkg}", [pkg_ios],
+                     os.path.join(pkg_ios, "Resources", "PrivacyInfo.xcprivacy"),
+                     os.path.join(pkg_ios, specs[0]) if specs else None)
+            )
+    return units
+
+
+def scan_sources(roots: list[str]) -> tuple[dict, dict]:
+    definite: dict[str, list[str]] = {}
+    ambiguous: dict[str, list[str]] = {}
+    for root in roots:
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [
+                d for d in dirnames
+                if d not in {"Pods", "build", ".symlinks", "DerivedData", ".git"}
+            ]
+            for filename in sorted(filenames):
+                if not filename.endswith(SOURCE_SUFFIXES):
+                    continue
+                full = os.path.join(dirpath, filename)
+                try:
+                    with open(full, "r", encoding="utf-8", errors="replace") as handle:
+                        code = strip_debug_only(strip_noise(handle.read()))
+                except OSError:
+                    continue
+                for lineno, line in enumerate(code.splitlines(), 1):
+                    for category, pattern in DEFINITE:
+                        if pattern.search(line):
+                            definite.setdefault(category, []).append(f"{full}:{lineno}")
+                    for category, pattern in AMBIGUOUS:
+                        if pattern.search(line):
+                            ambiguous.setdefault(category, []).append(f"{full}:{lineno}")
+    return definite, ambiguous
+
+
+def read_manifest(path: str) -> tuple[dict[str, set[str]] | None, list[str]]:
+    """Return declared {category: reasons} plus structural problems."""
+    if not os.path.exists(path):
+        return None, []
+    problems: list[str] = []
+    try:
+        with open(path, "rb") as handle:
+            data = plistlib.load(handle)
+    except Exception as error:  # noqa: BLE001 - surface any parse failure
+        return {}, [f"{path}: not a readable plist ({error})"]
+
+    declared: dict[str, set[str]] = {}
+    for entry in data.get("NSPrivacyAccessedAPITypes", []) or []:
+        category = entry.get("NSPrivacyAccessedAPIType")
+        reasons = set(entry.get("NSPrivacyAccessedAPITypeReasons", []) or [])
+        if category not in ALL_CATEGORIES:
+            problems.append(f"{path}: unknown API category {category!r}")
+            continue
+        bad = reasons - VALID_REASONS[category]
+        if bad:
+            problems.append(
+                f"{path}: {category} declares invalid reason code(s) "
+                f"{sorted(bad)}; allowed: {sorted(VALID_REASONS[category])}"
+            )
+        if not reasons:
+            problems.append(f"{path}: {category} declares no reason code")
+        declared[category] = reasons
+    return declared, problems
+
+
+def check_sources(mobile: str) -> int:
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    for unit in discover(mobile):
+        definite, ambiguous = scan_sources(unit.roots)
+        declared, problems = read_manifest(unit.manifest)
+        failures.extend(problems)
+
+        if definite and declared is None:
+            for category, sites in sorted(definite.items()):
+                failures.append(
+                    f"{unit.name}: uses {category} at {sites[0]} "
+                    f"({len(sites)} site(s)) but has NO manifest at {unit.manifest}"
+                )
+        elif declared is not None:
+            for category, sites in sorted(definite.items()):
+                if category not in declared:
+                    failures.append(
+                        f"{unit.name}: uses {category} at "
+                        + ", ".join(sites[:3])
+                        + (f" (+{len(sites) - 3} more)" if len(sites) > 3 else "")
+                        + f" but {unit.manifest} does not declare it"
+                    )
+            for category in sorted(set(declared) - set(definite)):
+                warnings.append(
+                    f"{unit.name}: {unit.manifest} declares {category} but no "
+                    f"call site was detected -- confirm it is still used, or "
+                    f"remove it (Apple permits use only for declared reasons)"
+                )
+            # A manifest nothing bundles is a manifest Apple never reads. For
+            # the app target that wiring lives in Copy Bundle Resources, so a
+            # file added to ios/Runner/ but never added to the Xcode target
+            # looks correct in git and ships nothing.
+            if os.path.exists(unit.manifest) and unit.xcodeproj:
+                try:
+                    with open(unit.xcodeproj, "r", encoding="utf-8") as handle:
+                        project = handle.read()
+                except OSError:
+                    project = ""
+                if "PrivacyInfo.xcprivacy" not in project:
+                    failures.append(
+                        f"{unit.name}: {unit.manifest} exists but "
+                        f"{unit.xcodeproj} never references it, so it is not in "
+                        f"Copy Bundle Resources and never reaches the archive"
+                    )
+            if declared and unit.podspec:
+                try:
+                    with open(unit.podspec, "r", encoding="utf-8") as handle:
+                        spec = handle.read()
+                except OSError:
+                    spec = ""
+                if "PrivacyInfo.xcprivacy" not in spec:
+                    failures.append(
+                        f"{unit.name}: {unit.manifest} exists but "
+                        f"{unit.podspec} has no resource_bundles entry for it, "
+                        f"so it never reaches the archive"
+                    )
+
+        for category, sites in sorted(ambiguous.items()):
+            if declared and category in declared:
+                continue
+            warnings.append(
+                f"{unit.name}: possible {category} use (ambiguous accessor) at "
+                + ", ".join(sites[:3])
+                + (f" (+{len(sites) - 3} more)" if len(sites) > 3 else "")
+                + " -- confirm whether this is FileAttributeKey/URLResourceKey "
+                  "(declare it) or unrelated metadata such as PHAsset (ignore)"
+            )
+
+    for warning in warnings:
+        print(f"⚠️  {warning}")
+    for failure in failures:
+        print(f"❌ {failure}")
+    if failures:
+        print(
+            "\nDeclare the API in the owning bundle's PrivacyInfo.xcprivacy. "
+            "Reason codes and their exact meanings: "
+            "mobile/docs/IOS_PRIVACY_MANIFESTS.md"
+        )
+        return 1
+    print("✅ every detected required-reason API use is declared in its own bundle")
+    return 0
+
+
+def check_archive(app: str, mobile: str) -> int:
+    """Prove the manifests a source scan trusts actually reach the product."""
+    if not os.path.isdir(app):
+        print(f"❌ archive path is not a directory: {app}")
+        return 1
+
+    found = set()
+    for dirpath, _dirnames, filenames in os.walk(app):
+        for filename in filenames:
+            if filename == "PrivacyInfo.xcprivacy":
+                found.add(os.path.relpath(os.path.join(dirpath, filename), app))
+    print(f"ℹ️  {len(found)} privacy manifest(s) in {os.path.basename(app)}")
+
+    expected = {
+        "app manifest": "PrivacyInfo.xcprivacy",
+        "divine_camera": "divine_camera_privacy.bundle/PrivacyInfo.xcprivacy",
+        "LibProofMode": "LibProofMode_privacy.bundle/PrivacyInfo.xcprivacy",
+    }
+    failures = []
+    for label, rel in expected.items():
+        if rel in found:
+            print(f"  ✅ {label}: {rel}")
+        else:
+            failures.append(f"{label}: expected {rel} in the built app, not found")
+
+    for rel in sorted(found):
+        if not rel.startswith(("divine_", "LibProofMode_")) and rel != "PrivacyInfo.xcprivacy":
+            continue
+        try:
+            with open(os.path.join(app, rel), "rb") as handle:
+                plistlib.load(handle)
+        except Exception as error:  # noqa: BLE001
+            failures.append(f"{rel}: bundled manifest is unreadable ({error})")
+
+    for failure in failures:
+        print(f"❌ {failure}")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mobile", default=".", help="path to the mobile/ directory")
+    parser.add_argument("--archive", help="path to a built .app to verify")
+    parser.add_argument("--detail", action="store_true", help="list every call site")
+    args = parser.parse_args()
+
+    if args.archive:
+        return check_archive(args.archive, args.mobile)
+
+    if args.detail:
+        for unit in discover(args.mobile):
+            definite, ambiguous = scan_sources(unit.roots)
+            if not definite and not ambiguous:
+                continue
+            print(f"\n## {unit.name}  (manifest: {unit.manifest})")
+            for category, sites in sorted(definite.items()):
+                print(f"  {category}")
+                for site in sites:
+                    print(f"    {site}")
+            for category, sites in sorted(ambiguous.items()):
+                print(f"  [ambiguous] {category}")
+                for site in sites:
+                    print(f"    {site}")
+        print()
+
+    return check_sources(args.mobile)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mobile/scripts/lib/privacy_manifest_coverage.py
+++ b/mobile/scripts/lib/privacy_manifest_coverage.py
@@ -98,13 +98,6 @@ AMBIGUOUS = [
 
 SOURCE_SUFFIXES = (".swift", ".m", ".mm", ".h", ".c")
 
-_BLOCK = re.compile(r"/\*.*?\*/", re.S)
-_LINE = re.compile(r"//[^\n]*")
-_MULTI_STR = re.compile(r'"""(?:.|\n)*?"""')
-_RAW_STR = re.compile(r'#"(?:[^"\\]|\\.)*"#')
-_STR = re.compile(r'"(?:[^"\\\n]|\\.)*"')
-
-
 def strip_noise(text: str) -> str:
     """Blank out comments and string literals, preserving line numbers.
 
@@ -115,12 +108,61 @@ def strip_noise(text: str) -> str:
     it protects.
     """
 
-    def blank(match: re.Match[str]) -> str:
-        return re.sub(r"[^\n]", " ", match.group(0))
+    chars = list(text)
 
-    for pattern in (_BLOCK, _MULTI_STR, _RAW_STR, _LINE, _STR):
-        text = pattern.sub(blank, text)
-    return text
+    def blank(start: int, end: int) -> None:
+        for index in range(start, end):
+            if chars[index] != "\n":
+                chars[index] = " "
+
+    def quoted_end(start: int, delimiter: str, *, escaped: bool) -> int:
+        index = start + len(delimiter)
+        while index < len(text):
+            if escaped and text[index] == "\\":
+                index += 2
+                continue
+            if text.startswith(delimiter, index):
+                return index + len(delimiter)
+            index += 1
+        return len(text)
+
+    index = 0
+    while index < len(text):
+        if text.startswith("//", index):
+            end = text.find("\n", index)
+            end = len(text) if end == -1 else end
+            blank(index, end)
+            index = end
+            continue
+        if text.startswith("/*", index):
+            end = text.find("*/", index + 2)
+            end = len(text) if end == -1 else end + 2
+            blank(index, end)
+            index = end
+            continue
+
+        raw = re.match(r'(#+)("""|")', text[index:])
+        if raw:
+            hashes, quote = raw.groups()
+            delimiter = quote + hashes
+            close = text.find(delimiter, index + len(hashes) + len(quote))
+            end = len(text) if close == -1 else close + len(delimiter)
+            blank(index, end)
+            index = end
+            continue
+        if text.startswith('"""', index):
+            end = quoted_end(index, '"""', escaped=False)
+            blank(index, end)
+            index = end
+            continue
+        if text[index] == '"':
+            end = quoted_end(index, '"', escaped=True)
+            blank(index, end)
+            index = end
+            continue
+        index += 1
+
+    return "".join(chars)
 
 
 _IF_DEBUG = re.compile(r"^\s*#if\s+DEBUG\s*$")
@@ -295,6 +337,67 @@ def read_manifest(path: str) -> tuple[dict[str, set[str]] | None, list[str]]:
     return declared, problems
 
 
+def xcode_manifest_is_runner_resource(project: str) -> bool:
+    """Return whether Runner's Resources phase contains its privacy manifest."""
+    file_refs = set(
+        re.findall(
+            r"^\s*([A-F0-9]+) /\* PrivacyInfo\.xcprivacy \*/ = "
+            r"\{isa = PBXFileReference;[^\n]*\bpath = PrivacyInfo\.xcprivacy;",
+            project,
+            re.M,
+        )
+    )
+    build_files = set()
+    for build_id, file_ref in re.findall(
+        r"^\s*([A-F0-9]+) /\* PrivacyInfo\.xcprivacy in Resources \*/ = "
+        r"\{isa = PBXBuildFile; fileRef = ([A-F0-9]+)",
+        project,
+        re.M,
+    ):
+        if file_ref in file_refs:
+            build_files.add(build_id)
+
+    runner = re.search(
+        r"^\s*[A-F0-9]+ /\* Runner \*/ = \{\s*\n"
+        r"\s*isa = PBXNativeTarget;(?P<body>.*?)^\s*\};",
+        project,
+        re.M | re.S,
+    )
+    if not runner:
+        return False
+    phases = re.search(r"buildPhases = \((?P<ids>.*?)\);", runner.group("body"), re.S)
+    if not phases:
+        return False
+    resource_ids = re.findall(r"([A-F0-9]+) /\* Resources \*/", phases.group("ids"))
+    for resource_id in resource_ids:
+        phase = re.search(
+            rf"^\s*{re.escape(resource_id)} /\* Resources \*/ = \{{\s*\n"
+            r"\s*isa = PBXResourcesBuildPhase;(?P<body>.*?)^\s*\};",
+            project,
+            re.M | re.S,
+        )
+        if not phase:
+            continue
+        files = re.search(r"files = \((?P<ids>.*?)\);", phase.group("body"), re.S)
+        if files and any(build_id in files.group("ids") for build_id in build_files):
+            return True
+    return False
+
+
+def podspec_bundles_manifest(spec: str) -> bool:
+    """Return whether a real resource_bundles assignment includes the manifest."""
+    uncommented = "\n".join(
+        line for line in spec.splitlines() if not line.lstrip().startswith("#")
+    )
+    return bool(
+        re.search(
+            r"\b\w+\.resource_bundles\s*=\s*\{[^}]*PrivacyInfo\.xcprivacy[^}]*\}",
+            uncommented,
+            re.S,
+        )
+    )
+
+
 def check_sources(mobile: str) -> int:
     failures: list[str] = []
     warnings: list[str] = []
@@ -335,7 +438,7 @@ def check_sources(mobile: str) -> int:
                         project = handle.read()
                 except OSError:
                     project = ""
-                if "PrivacyInfo.xcprivacy" not in project:
+                if not xcode_manifest_is_runner_resource(project):
                     failures.append(
                         f"{unit.name}: {unit.manifest} exists but "
                         f"{unit.xcodeproj} never references it, so it is not in "
@@ -347,7 +450,7 @@ def check_sources(mobile: str) -> int:
                         spec = handle.read()
                 except OSError:
                     spec = ""
-                if "PrivacyInfo.xcprivacy" not in spec:
+                if not podspec_bundles_manifest(spec):
                     failures.append(
                         f"{unit.name}: {unit.manifest} exists but "
                         f"{unit.podspec} has no resource_bundles entry for it, "
@@ -396,6 +499,7 @@ def check_archive(app: str, mobile: str) -> int:
     expected = {
         "app manifest": "PrivacyInfo.xcprivacy",
         "divine_camera": "divine_camera_privacy.bundle/PrivacyInfo.xcprivacy",
+        "divine_quick_actions": "divine_quick_actions_privacy.bundle/PrivacyInfo.xcprivacy",
         "LibProofMode": "LibProofMode_privacy.bundle/PrivacyInfo.xcprivacy",
     }
     failures = []

--- a/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
+++ b/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
@@ -162,6 +162,21 @@ void main() {
         expect(result.exitCode, equals(0), reason: result.output);
       });
 
+      test('does not let a URL string hide an API later on the line', () {
+        final root = makeTree(
+          swift:
+              'log("https://example.com"); '
+              'let t = ProcessInfo.processInfo.systemUptime\n',
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(1));
+        expect(
+          result.output,
+          contains('NSPrivacyAccessedAPICategorySystemBootTime'),
+        );
+      });
+
       test('ignores a call that only compiles into DEBUG builds', () {
         final root = makeTree(
           swift:
@@ -241,6 +256,30 @@ void main() {
         expect(result.output, contains('Copy Bundle Resources'));
       });
 
+      test('rejects an app manifest that is only an Xcode file reference', () {
+        final root = Directory.systemTemp.createTempSync('privacy_app_test');
+        addTearDown(() => root.deleteSync(recursive: true));
+        Directory('${root.path}/ios/Runner').createSync(recursive: true);
+        Directory(
+          '${root.path}/ios/Runner.xcodeproj',
+        ).createSync(recursive: true);
+        File('${root.path}/ios/Runner/PrivacyInfo.xcprivacy').writeAsStringSync(
+          manifestFor('NSPrivacyAccessedAPICategoryUserDefaults', 'CA92.1'),
+        );
+        File(
+          '${root.path}/ios/Runner.xcodeproj/project.pbxproj',
+        ).writeAsStringSync('''
+/* Begin PBXFileReference section */
+ABC123 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+''');
+
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(1));
+        expect(result.output, contains('Copy Bundle Resources'));
+      });
+
       test('rejects a manifest the podspec never bundles', () {
         final root = makeTree(
           swift: 'let t = ProcessInfo.processInfo.systemUptime\n',
@@ -255,6 +294,47 @@ void main() {
         expect(result.exitCode, equals(1));
         expect(result.output, contains('never reaches the archive'));
       });
+
+      test('rejects a manifest mentioned only in a podspec comment', () {
+        final root = makeTree(
+          swift: 'let t = ProcessInfo.processInfo.systemUptime\n',
+          manifest: manifestFor(
+            'NSPrivacyAccessedAPICategorySystemBootTime',
+            '35F9.1',
+          ),
+          podspec:
+              '# TODO: add Resources/PrivacyInfo.xcprivacy to resource_bundles\n'
+              "s.source_files = 'Classes/**/*'",
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(1));
+        expect(result.output, contains('never reaches the archive'));
+      });
+    });
+
+    test('archive mode requires the quick-actions privacy bundle', () {
+      final root = Directory.systemTemp.createTempSync('privacy_archive_test');
+      addTearDown(() => root.deleteSync(recursive: true));
+      final app = Directory('${root.path}/Runner.app')..createSync();
+      final plist = manifestFor(
+        'NSPrivacyAccessedAPICategorySystemBootTime',
+        '35F9.1',
+      );
+      for (final path in [
+        'PrivacyInfo.xcprivacy',
+        'divine_camera_privacy.bundle/PrivacyInfo.xcprivacy',
+        'LibProofMode_privacy.bundle/PrivacyInfo.xcprivacy',
+      ]) {
+        final file = File('${app.path}/$path');
+        file.parent.createSync(recursive: true);
+        file.writeAsStringSync(plist);
+      }
+
+      final result = run(root: root, args: ['--archive', app.path]);
+
+      expect(result.exitCode, equals(1));
+      expect(result.output, contains('divine_quick_actions'));
     });
   });
 }

--- a/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
+++ b/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
@@ -1,0 +1,260 @@
+// ABOUTME: Pins the iOS required-reason API privacy-manifest coverage guard.
+// ABOUTME: Holds the PHAsset-vs-FileAttributeKey line that stops over-declaring.
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+/// Pins `scripts/lib/privacy_manifest_coverage.py` (#8803).
+///
+/// The detector's value is entirely in what it does *not* flag. Apple's
+/// required-reason `creationDate` is `FileAttributeKey.creationDate`, not
+/// `PHAsset.creationDate`, and `LibProofMode/Classes/MediaItem.swift` uses both
+/// kinds within forty lines of each other. A detector that matched the bare
+/// accessor would push an author into declaring a reason the code never
+/// exercises -- and Apple permits use only for declared reasons, so an unused
+/// declaration is inaccurate rather than cautious. These tests hold that line.
+void main() {
+  final script = File('scripts/lib/privacy_manifest_coverage.py').absolute.path;
+
+  /// Builds a throwaway `mobile/`-shaped tree and runs the detector over it.
+  ({int exitCode, String output}) run({
+    required Directory root,
+    List<String> args = const [],
+  }) {
+    final result = Process.runSync('python3', [
+      script,
+      '--mobile',
+      root.path,
+      ...args,
+    ]);
+    return (
+      exitCode: result.exitCode,
+      output: '${result.stdout}${result.stderr}',
+    );
+  }
+
+  Directory makeTree({
+    required String swift,
+    String? manifest,
+    String podspec =
+        "s.resource_bundles = {'p' => ['Resources/PrivacyInfo.xcprivacy']}",
+  }) {
+    final root = Directory.systemTemp.createTempSync('privacy_manifest_test');
+    addTearDown(() => root.deleteSync(recursive: true));
+    final pkg = Directory('${root.path}/packages/sample/ios')
+      ..createSync(recursive: true);
+    Directory('${pkg.path}/Classes').createSync(recursive: true);
+    File('${pkg.path}/Classes/Sample.swift').writeAsStringSync(swift);
+    File('${pkg.path}/sample.podspec').writeAsStringSync(podspec);
+    Directory('${root.path}/ios/Runner').createSync(recursive: true);
+    if (manifest != null) {
+      Directory('${pkg.path}/Resources').createSync(recursive: true);
+      File(
+        '${pkg.path}/Resources/PrivacyInfo.xcprivacy',
+      ).writeAsStringSync(manifest);
+    }
+    return root;
+  }
+
+  String manifestFor(String category, String reason) =>
+      '''
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>$category</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array><string>$reason</string></array>
+		</dict>
+	</array>
+</dict>
+</plist>
+''';
+
+  group('privacy_manifest_coverage detector', () {
+    group('undeclared required-reason API', () {
+      test('fails when a used category has no manifest at all', () {
+        final root = makeTree(
+          swift: 'let t = ProcessInfo.processInfo.systemUptime\n',
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(1));
+        expect(
+          result.output,
+          contains('NSPrivacyAccessedAPICategorySystemBootTime'),
+        );
+        expect(result.output, contains('NO manifest'));
+      });
+
+      test('fails when the manifest omits the category that is used', () {
+        final root = makeTree(
+          swift: 'let d = UserDefaults.standard\n',
+          manifest: manifestFor(
+            'NSPrivacyAccessedAPICategorySystemBootTime',
+            '35F9.1',
+          ),
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(1));
+        expect(result.output, contains('does not declare it'));
+      });
+
+      test('passes when the used category is declared', () {
+        final root = makeTree(
+          swift: 'let t = ProcessInfo.processInfo.systemUptime\n',
+          manifest: manifestFor(
+            'NSPrivacyAccessedAPICategorySystemBootTime',
+            '35F9.1',
+          ),
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(0), reason: result.output);
+      });
+    });
+
+    group('false-positive guards', () {
+      test('does not fail on a bare PHAsset-style .creationDate accessor', () {
+        final root = makeTree(
+          swift:
+              'self.modified = asset.modificationDate\n'
+              'let c = asset.creationDate\n',
+        );
+        final result = run(root: root);
+
+        // Reported for a human to judge, never fatal: PHAsset metadata carries
+        // no declaration duty, and over-declaring is itself inaccurate.
+        expect(result.exitCode, equals(0), reason: result.output);
+        expect(result.output, contains('ambiguous accessor'));
+      });
+
+      test('does fail on the unambiguous URLResourceKey form', () {
+        final root = makeTree(
+          swift:
+              'let a = try '
+              'url.resourceValues(forKeys: [.contentModificationDateKey])\n',
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(1));
+        expect(
+          result.output,
+          contains('NSPrivacyAccessedAPICategoryFileTimestamp'),
+        );
+      });
+
+      test('ignores an API named only in a comment or string literal', () {
+        final root = makeTree(
+          swift:
+              '// bridges launch config through UserDefaults\n'
+              'let message = "statfs failed"\n'
+              '/* systemUptime is not called here */\n',
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(0), reason: result.output);
+      });
+
+      test('ignores a call that only compiles into DEBUG builds', () {
+        final root = makeTree(
+          swift:
+              '#if DEBUG\n'
+              '  let d = UserDefaults.standard\n'
+              '#endif\n',
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(0), reason: result.output);
+      });
+
+      test('still counts the Release branch of a DEBUG conditional', () {
+        final root = makeTree(
+          swift:
+              '#if DEBUG\n'
+              '  let a = 1\n'
+              '#else\n'
+              '  let d = UserDefaults.standard\n'
+              '#endif\n',
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(1));
+        expect(
+          result.output,
+          contains('NSPrivacyAccessedAPICategoryUserDefaults'),
+        );
+      });
+    });
+
+    group('manifest validity', () {
+      test('rejects a reason code that is not valid for its category', () {
+        final root = makeTree(
+          swift: 'let t = ProcessInfo.processInfo.systemUptime\n',
+          // CA92.1 is a UserDefaults reason, not a SystemBootTime one.
+          manifest: manifestFor(
+            'NSPrivacyAccessedAPICategorySystemBootTime',
+            'CA92.1',
+          ),
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(1));
+        expect(result.output, contains('invalid reason code'));
+      });
+
+      test('rejects an unknown API category string', () {
+        final root = makeTree(
+          swift: 'let t = ProcessInfo.processInfo.systemUptime\n',
+          manifest: manifestFor('NSPrivacyAccessedAPICategoryMadeUp', '35F9.1'),
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(1));
+        expect(result.output, contains('unknown API category'));
+      });
+
+      test('rejects an app manifest missing from Copy Bundle Resources', () {
+        final root = Directory.systemTemp.createTempSync('privacy_app_test');
+        addTearDown(() => root.deleteSync(recursive: true));
+        Directory('${root.path}/ios/Runner').createSync(recursive: true);
+        Directory(
+          '${root.path}/ios/Runner.xcodeproj',
+        ).createSync(recursive: true);
+        File('${root.path}/ios/Runner/PrivacyInfo.xcprivacy').writeAsStringSync(
+          manifestFor('NSPrivacyAccessedAPICategoryUserDefaults', 'CA92.1'),
+        );
+        // A project that never lists the manifest: it ships nothing.
+        File(
+          '${root.path}/ios/Runner.xcodeproj/project.pbxproj',
+        ).writeAsStringSync('// objectVersion = 54;\n');
+
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(1));
+        expect(result.output, contains('Copy Bundle Resources'));
+      });
+
+      test('rejects a manifest the podspec never bundles', () {
+        final root = makeTree(
+          swift: 'let t = ProcessInfo.processInfo.systemUptime\n',
+          manifest: manifestFor(
+            'NSPrivacyAccessedAPICategorySystemBootTime',
+            '35F9.1',
+          ),
+          podspec: "s.source_files = 'Classes/**/*'",
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(1));
+        expect(result.output, contains('never reaches the archive'));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Divine's iOS build ships two of Apple's **required reason APIs** without declaring them. Apple has rejected App Store Connect submissions for this since 1 May 2024.

Both were confirmed in the actual Release archive, not just in source:

- **`divine_camera`** calls `ProcessInfo.systemUptime` in `VolumeKeyHandler.swift` (two sites). The plugin *has* a `PrivacyInfo.xcprivacy`, and it does reach the archive — but its `NSPrivacyAccessedAPITypes` is an empty array. `plutil -p` on the copy inside the built `Runner.app` prints `[ ]`, so an empty declaration is exactly what Apple reads.
- **`LibProofMode`** reads `URLResourceKey.contentModificationDateKey` / `.creationDateKey` in `MediaItem.withData`. It ships no privacy manifest at all, while `nm` finds 1486 of its symbols in the Release `Runner` executable. It is vendored under `ios/LocalPods/`, so no upstream release will ever supply that manifest for our archive.

The app target also had no privacy manifest of its own.

This was **drift, not a bad first draft**. `divine_camera`'s manifest was written on 2026-01-14 in #890, when `VolumeKeyHandler.swift` contained zero occurrences of `systemUptime`. The API arrived six weeks later, on 2026-02-25 in #1783, and nobody revisited the manifest. Nothing in CI noticed, and a manifest well-formedness check never would have.

## Why this fix

Each bundle declares its own use, because Apple is explicit that an SDK "can't rely on the privacy manifest files for apps that link the third-party SDK". That is also what all 58 third-party manifests already in our archive do, under the same static CocoaPods linkage we use.

Reason codes were chosen from what the code actually does, not from what sounds safe:

- `divine_camera` → **`35F9.1`** ("measure the amount of time that has elapsed between events that occurred within the app"). Both call sites only compute deltas for Bluetooth-trigger cooldown and debounce, and the file has no method channel or event sink, so nothing derived leaves the device — which is that reason's condition.
- `LibProofMode` → **`C617.1`** ("metadata of files inside the app container"). All five `proofFile` callers pass an app-produced file: an editor render output or a recorded clip. No document-picker path reaches it, so `3B52.1` would be an over-declaration.
- App target → **nothing**. Its only first-party `UserDefaults` call sits inside `#if DEBUG`. Verified against the product: `strings` over the Release `Runner` binary finds zero occurrences of `flutter.screenshot_initial_route`, `flutter.screenshot_seed_clips` or `SCREENSHOT_INITIAL_ROUTE`. An empty array is the accurate statement, not a convenient one.

The new CI guard (`scripts/check_privacy_manifest_coverage.sh`) fails when first-party iOS code uses a required-reason API that its own bundle does not declare. Zero baseline, no exemption list. It also rejects an invalid reason code for a category, an unknown category string, and a manifest that exists but is not bundled by its podspec — a manifest nothing ships is a manifest Apple never reads.

It is deliberately **not** gated on the `native` changed-paths filter. That filter covers `mobile/ios/*` but not `mobile/packages/*/ios/*`, which is precisely where this drift happened; gating it would reproduce the bug it exists to catch. It is pure `python3` with no package installs, so running it every time costs under a second.

## Deliberately left alone

- **macOS.** Apple's requirement covers iOS, iPadOS, tvOS, visionOS and watchOS only. Independently, `divine_camera/macos` has no `systemUptime` at all — `VolumeKeyHandler` is iOS-only — so its empty declaration is already correct.
- **`PHAsset.creationDate` / `.modificationDate`.** Apple's required-reason symbols resolve to `FileAttributeKey`, not `PHAsset`. `MediaItem.swift` uses both kinds forty lines apart, and declaring the PHAsset lines would have been a false declaration. The guard reports bare accessors for human review but never fails on them, and a test pins that.
- **`NSPrivacyCollectedDataTypes`.** Left empty in the app manifest with an inline comment saying so. Populating it is a product/legal decision that must match the App Store Connect privacy label, and it is not a required-reason API question.
- **Third-party pods** under `ios/Pods`. Each vendor ships its own manifest; we cannot fix upstream code.

## Unrequested change, called out separately

`AppDelegate.swift` carried `// Include device ID, location (if available), and network info` directly above `ProofGenerationOptions(showDeviceIds: false, showLocation: false, showMobileNetwork: false, …)`. `Proof.swift` gates each block on the matching flag, so the comment asserted the opposite of the behaviour. It is the one comment a future privacy audit would read when deciding ProofMode's collected-data declaration, and believing it would have produced a false location/device-ID claim. Corrected in its own commit.

## Verification

- `flutter build ios --release --no-codesign`, then `--archive` inspection of the built `Runner.app`.
- Against the **pre-fix** build the guard exits 1 and names exactly the two real gaps while correctly passing `divine_camera_privacy.bundle` — a genuine red-to-green, not a guard written to match the fix.
- 16 detector tests in `test/tools/privacy_manifest_coverage_detector_test.dart`.
- All three manifests validated with strict XML (`plistlib`), not only `plutil -lint` — `plutil` accepted a `--` inside an XML comment that a conforming parser rejects, which the guard caught in this PR's own first draft.
- `pod ipc spec` confirms CocoaPods registers `LibProofMode_privacy`, and `pod install` generates its resource-bundle target.

## Follow-ups

- `divine_device_attestation` (#8779, still open) caches App Attest key handles in `UserDefaults` and ships no manifest. The exact patch it needs is documented in `mobile/docs/IOS_PRIVACY_MANIFESTS.md`. **The new guard will fail on `main` when that PR merges** — intended, but the author needs to add the manifest in that PR.
- App-target `NSPrivacyCollectedDataTypes` needs a product/legal pass.

Part of #8803


