### PR TITLE
fix(editor): finish clip processing after leaving the editor

### DIFF
--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -241,8 +241,10 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
           clip: clip,
           duration: remainingDuration,
           onComplete: (success) async {
-            if (!ref.mounted) return;
+            // The render outlives this notifier, and this is the only signal
+            // that releases proof generation waiting on the trimmed file.
             processingCompleter!.complete(success);
+            if (!ref.mounted) return;
 
             /// If the clip exists already we use the newest thumbnail
             /// from that clip.

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -216,6 +216,18 @@ class VideoEditorRenderService {
   })?
   renderVideoOverride;
 
+  /// Test-only override for [limitClipDuration].
+  ///
+  /// When set, [limitClipDuration] delegates to this callback instead of
+  /// running the real render pipeline. Reset to `null` in `tearDown`.
+  @visibleForTesting
+  static Future<void> Function({
+    required DivineVideoClip clip,
+    required Duration duration,
+    required ValueChanged<bool> onComplete,
+  })?
+  limitClipDurationOverride;
+
   @visibleForTesting
   static void Function(Object error, StackTrace stackTrace)?
   get crashReporterOverride => VideoRenderWatchdog.crashReporterOverride;
@@ -697,6 +709,11 @@ class VideoEditorRenderService {
     required Duration duration,
     required ValueChanged<bool> onComplete,
   }) async {
+    final override = limitClipDurationOverride;
+    if (override != null) {
+      return override(clip: clip, duration: duration, onComplete: onComplete);
+    }
+
     try {
       final inputPath = await clip.requireVideo.safeFilePath();
 

--- a/mobile/scripts/check_process_global_mutations.sh
+++ b/mobile/scripts/check_process_global_mutations.sh
@@ -111,6 +111,7 @@ RESET_TO_DEFAULT_GLOBALS=(
   'VideoEditorRenderService\.renderVideoOverride:null'
   'VideoEditorRenderService\.renderVideoToClipOverride:null'
   'VideoEditorRenderService\.crashReporterOverride:null'
+  'VideoEditorRenderService\.limitClipDurationOverride:null'
   'NativeProofModeService\.proofFileOverride:null'
   'NativeProofModeService\.c2paSigningServiceFactoryOverride:null'
   'InfiniteVideoFeed\.debugIsSupportedOverride:null'

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -10,9 +10,12 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/editor_background_work.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
+import 'package:openvine/services/native_proofmode_service.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -100,6 +103,60 @@ void main() {
       final state = container.read(clipManagerProvider);
       expect(state.clips.length, equals(1));
       expect(state.totalDuration, equals(const Duration(seconds: 2)));
+    });
+
+    group('trim completion lifecycle', () {
+      late void Function(bool success) completeTrim;
+
+      setUp(() {
+        VideoEditorRenderService.limitClipDurationOverride =
+            ({required clip, required duration, required onComplete}) async {
+              completeTrim = onComplete;
+            };
+        NativeProofModeService.proofFileOverride =
+            (
+              _, {
+              required enableAdvancedCawgEmbedding,
+              creatorBindingAssertion,
+              cawgIdentityAssertion,
+              verifiedIdentityBundle,
+              clips,
+              editorStateHistory,
+            }) async => null;
+      });
+
+      tearDown(() {
+        VideoEditorRenderService.limitClipDurationOverride = null;
+        NativeProofModeService.proofFileOverride = null;
+      });
+
+      test('settles background work when disposed during trim', () async {
+        final backgroundWork = container.read(editorBackgroundWorkProvider);
+        final notifier = container.read(clipManagerProvider.notifier);
+        final clip = notifier.addClip(
+          limitClipDuration: true,
+          video: EditorVideo.file('/path/to/video.mp4'),
+          duration:
+              VideoEditorConstants.maxDuration +
+              const Duration(milliseconds: 1),
+          targetAspectRatio: .vertical,
+          originalAspectRatio: 9 / 16,
+        );
+
+        expect(clip.processingCompleter, isNotNull);
+        expect(clip.processingCompleter!.isCompleted, isFalse);
+        expect(backgroundWork.isNotEmptyForTest, isTrue);
+
+        container.dispose();
+        completeTrim(true);
+
+        expect(clip.processingCompleter!.isCompleted, isTrue);
+        await backgroundWork.settle().timeout(
+          const Duration(seconds: 10),
+          onTimeout: () => fail('editor background work did not settle'),
+        );
+        expect(backgroundWork.isNotEmptyForTest, isFalse);
+      });
     });
 
     group('provider lifecycle', () {


### PR DESCRIPTION
## Problem

Leaving the editor while an over-duration clip was still being trimmed could leave that clip permanently marked as processing. Proof generation then waited forever, which also prevented the editor background-work boundary from settling during teardown.

## Why this fix

The trim render can outlive its provider. Its completion signal is independent of provider state, so the callback now settles that signal before checking whether the provider is still mounted. Clip lookup, thumbnail refresh, and other notifier state updates remain protected by the mounted check.

A focused test-only render seam reproduces completion after provider disposal without invoking the native renderer. The regression test proves the processing signal and shared background-work registry both settle.

## Deliberately unchanged

Proof generation is still allowed to finish after the provider is disposed; only notifier state updates are skipped. No editor UI, duration calculation, or render behavior changes.

## Verification

- `flutter test test/providers/clip_manager_provider_test.dart test/providers/editor_background_work_test.dart test/providers/video_editor_provider_test.dart` (169 tests)
- `flutter analyze`
- service god-file, shared setup stub, Future.delayed production/test, and unpinned unchanged assertion ratchets
- red/green regression proof: the new test fails on the original mounted-check ordering and passes with this change

Closes #8824