### PR TITLE
fix(vgv): stop non-code text from hiding leaked test globals

### DIFF
--- a/mobile/scripts/check_process_global_mutations.sh
+++ b/mobile/scripts/check_process_global_mutations.sh
@@ -144,11 +144,14 @@ is_skip_vgv_tagged() {
 run_scan() {
   local violations="" core files f body def
 
-  # All classification depends on this filter. Validate it before scanning so
-  # a missing or invalid filter cannot turn every source body into an empty,
-  # apparently compliant file.
-  if ! awk -f "$SCRIPT_DIR/lib/dart_code_only.awk" /dev/null >/dev/null; then
-    echo "FAIL [process_global_mutations]: Dart code-only filter is unavailable" >&2
+  # All classification depends on this filter. Validate it against a known code
+  # line before scanning, so a missing, invalid, or silently empty filter cannot
+  # turn every source body into an empty, apparently compliant file. Testing on
+  # empty input would miss a filter that loads but emits nothing.
+  local probe
+  probe=$(printf 'code_only_probe = 0;\n' | awk -f "$SCRIPT_DIR/lib/dart_code_only.awk" 2>/dev/null || true)
+  if [[ "$probe" != *code_only_probe* ]]; then
+    echo "FAIL [process_global_mutations]: Dart code-only filter is unavailable or produced no output" >&2
     return 1
   fi
 

--- a/mobile/scripts/check_process_global_mutations.sh
+++ b/mobile/scripts/check_process_global_mutations.sh
@@ -49,12 +49,12 @@
 #      harness, before `testMain`, or in the isolated golden tree. Calling one
 #      from an ordinary merged suite makes every later test order-dependent.
 #
-# Detection is textual for all three classes. For the first two, it cannot prove
-# the restore is reachable or lives in a tearDown (an inline end-of-body reset
-# satisfies the check but not a mid-test throw). The snapshot+restore /
-# reset-to-default pair is the canonical fix; the tag is the escape hatch for
-# tests that legitimately cannot restore (real plugin / integration tests).
-# Class 3 scans code only, with comments and string-literal bodies removed.
+# Detection is textual for all three classes, after comments and string-literal
+# bodies are removed by dart_code_only.awk. It cannot prove the restore is
+# reachable or lives in a tearDown (an inline end-of-body reset satisfies the
+# check but not a mid-test throw). The snapshot+restore / reset-to-default pair
+# is the canonical fix; the tag is the escape hatch for tests that legitimately
+# cannot restore (real plugin / integration tests).
 #
 # Scope: assignment classes inspect only `*_test.dart`; irreversible initializer
 # detection inspects every Dart file under mobile/test and mobile/packages/*/test.
@@ -136,7 +136,7 @@ fi
 
 is_skip_vgv_tagged() {
   local f="$1" tag_body tag_flat
-  tag_body=$(grep -vE '^[[:space:]]*//' "$f" || true)
+  tag_body=$(awk -v preserve_tag_literals=1 -f "$SCRIPT_DIR/lib/dart_code_only.awk" "$f")
   tag_flat=$(tr -d '[:space:]' <<<"$tag_body")
   grep -qE "@Tags\(\[[^]]*['\"]skip_very_good_optimization['\"]" <<<"$tag_flat"
 }
@@ -144,11 +144,19 @@ is_skip_vgv_tagged() {
 run_scan() {
   local violations="" core files f body def
 
+  # All classification depends on this filter. Validate it before scanning so
+  # a missing or invalid filter cannot turn every source body into an empty,
+  # apparently compliant file.
+  if ! awk -f "$SCRIPT_DIR/lib/dart_code_only.awk" /dev/null >/dev/null; then
+    echo "FAIL [process_global_mutations]: Dart code-only filter is unavailable" >&2
+    return 1
+  fi
+
   # --- Class 1: capture-restore ---
   for core in "${GLOBALS[@]}"; do
     files=$(grep -rlE --include='*_test.dart' "$core" "${SCAN_ROOTS[@]}" || true)
     for f in $files; do
-      body=$(grep -vE '^[[:space:]]*//' "$f" || true)
+      body=$(awk -f "$SCRIPT_DIR/lib/dart_code_only.awk" "$f")
 
       # A real ASSIGNMENT (install or restore): (<prefix>.)?CORE = , not == / =>.
       if ! grep -qE "(^|[^A-Za-z0-9_.])([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=([^=>]|$)" <<<"$body"; then
@@ -221,7 +229,7 @@ run_scan() {
     def="${entry##*:}"
     files=$(grep -rlE --include='*_test.dart' "$core" "${SCAN_ROOTS[@]}" || true)
     for f in $files; do
-      body=$(grep -vE '^[[:space:]]*//' "$f" || true)
+      body=$(awk -f "$SCRIPT_DIR/lib/dart_code_only.awk" "$f")
 
       if ! grep -qE "(^|[^A-Za-z0-9_.])([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=([^=>]|$)" <<<"$body"; then
         continue
@@ -261,7 +269,7 @@ run_scan() {
   irreversible='(^|[^[:alnum:]_])loadAppFonts([^[:alnum:]_]|$)'
   files=$(grep -rlE --include='*.dart' "$irreversible" "${SCAN_ROOTS[@]}" || true)
   for f in $files; do
-    body=$(awk -f "$SCRIPT_DIR/lib/dart_code_only.awk" "$f" 2>/dev/null || true)
+    body=$(awk -f "$SCRIPT_DIR/lib/dart_code_only.awk" "$f")
     if ! grep -qE "$irreversible" <<<"$body"; then
       continue
     fi
@@ -466,6 +474,89 @@ void main() {
   // debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
   // Bloc.observer = MyObserver();
 }
+'
+  _case "capture-restore install inside a block comment → PASS" 0 \
+'import "x";
+void main() {
+  /* Bloc.observer = MyObserver(); */
+}
+'
+  _case "capture-restore install inside a string → PASS" 0 \
+'import "x";
+void main() {
+  final message = "Bloc.observer = MyObserver();";
+}
+'
+  _case "capture-restore install inside a trailing comment → PASS" 0 \
+'import "x";
+void main() { final value = 1; // Bloc.observer = MyObserver();
+}
+'
+  _case "capture-restore install inside a raw string → PASS" 0 \
+"import 'x';
+void main() {
+  final message = r'Bloc.observer = MyObserver();';
+}
+"
+  _case "capture-restore leak with restore only in a string → FAIL" 1 \
+'import "x";
+void main() {
+  final prior = Bloc.observer;
+  Bloc.observer = MyObserver();
+  final message = "Bloc.observer = prior;";
+}
+'
+  _case "capture-restore leak with restore only in a trailing comment → FAIL" 1 \
+'import "x";
+void main() {
+  final prior = Bloc.observer;
+  Bloc.observer = MyObserver(); // Bloc.observer = prior;
+}
+'
+  _case "capture-restore leak with capture and restore only in a block comment → FAIL" 1 \
+'import "x";
+void main() {
+  Bloc.observer = MyObserver();
+  /*
+  final prior = Bloc.observer;
+  addTearDown(() => Bloc.observer = prior);
+  */
+}
+'
+  _case "reset-to-default install inside a string → PASS" 0 \
+'import "x";
+void main() {
+  final message = "debugDefaultTargetPlatformOverride = TargetPlatform.iOS;";
+}
+'
+  _case "reset-to-default leak with reset only in a string → FAIL" 1 \
+'import "x";
+void main() {
+  debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+  final message = "debugDefaultTargetPlatformOverride = null;";
+}
+'
+  _case "reset-to-default leak with reset only in a trailing comment → FAIL" 1 \
+'import "x";
+void main() {
+  debugDefaultTargetPlatformOverride = TargetPlatform.iOS; // debugDefaultTargetPlatformOverride = null;
+}
+'
+  _case "optimization tag inside a string does not exempt a leak → FAIL" 1 \
+'import "x";
+void main() {
+  final message = """@Tags(["skip_very_good_optimization"])""";
+  Bloc.observer = MyObserver();
+}
+'
+  _case "optimization tag inside a block comment does not exempt a leak → FAIL" 1 \
+'/* @Tags(["skip_very_good_optimization"]) */
+import "x";
+void main() { Bloc.observer = MyObserver(); }
+'
+  _case "optimization tag inside a trailing comment does not exempt a leak → FAIL" 1 \
+'import "x"; // @Tags(["skip_very_good_optimization"])
+void main() { Bloc.observer = MyObserver(); }
 '
   _case "lone default assignment (= null only, no install) → PASS" 0 \
 'import "x";

--- a/mobile/scripts/lib/dart_code_only.awk
+++ b/mobile/scripts/lib/dart_code_only.awk
@@ -6,6 +6,9 @@
 # """…""", and r'…' raw forms). Interpolated expressions (`${…}`) are PRESERVED
 # as code, since a token there is a real reference. Quote delimiters are kept so
 # neighbouring tokens cannot fuse. Line count is preserved.
+# With `-v preserve_tag_literals=1`, string bodies inside a real `@Tags(...)`
+# annotation are retained. This lets callers classify semantic test tags while
+# still removing `@Tags(...)` text that occurs inside comments or other strings.
 #
 # Why not `sed 's|//.*||'`: that truncates at the `//` of a URL (`'https://…'`)
 # or a path literal (`startsWith('//')`), silently DROPPING a real detector match
@@ -13,9 +16,19 @@
 # ratchet — it lets drift through and can fake a STALE win. This pass tracks
 # string state, so a `//` inside a literal is never mistaken for a comment.
 #
-# Pinned by test/tools/dart_code_only_test.dart. Bash 3.2 / POSIX awk compatible.
+# Pinned by test/tools/design_system_ceiling_detectors_test.dart.
+# Bash 3.2 / POSIX awk compatible.
 
-BEGIN { blk = 0; instr = 0; israw = 0; q = ""; qlen = 0 }
+BEGIN {
+  blk = 0
+  instr = 0
+  israw = 0
+  q = ""
+  qlen = 0
+  keepbody = 0
+  tagann = 0
+  tagdepth = 0
+}
 
 {
   line = $0
@@ -37,7 +50,11 @@ BEGIN { blk = 0; instr = 0; israw = 0; q = ""; qlen = 0 }
 
     # --- inside a string literal: drop the body, keep ${…} as code ---
     if (instr) {
-      if (!israw && c == "\\") { i += 2; continue }
+      if (!israw && c == "\\") {
+        if (keepbody) out = out substr(line, i, 2)
+        i += 2
+        continue
+      }
       if (c == "$" && substr(line, i + 1, 1) == "{") {
         out = out " "
         i += 2
@@ -55,7 +72,14 @@ BEGIN { blk = 0; instr = 0; israw = 0; q = ""; qlen = 0 }
         out = out " "
         continue
       }
-      if (substr(line, i, qlen) == q) { instr = 0; i += qlen; continue }
+      if (substr(line, i, qlen) == q) {
+        if (keepbody) out = out q
+        instr = 0
+        keepbody = 0
+        i += qlen
+        continue
+      }
+      if (keepbody) out = out c
       i++
       continue
     }
@@ -64,11 +88,23 @@ BEGIN { blk = 0; instr = 0; israw = 0; q = ""; qlen = 0 }
     if (c2 == "//") break                       # rest of the line is a comment
     if (c2 == "/*") { blk++; i += 2; continue }
 
+    if (!tagann && substr(line, i) ~ /^@Tags[[:space:]]*\(/) {
+      tagann = 1
+      tagdepth = 0
+    }
+
+    if (tagann && c == "(") tagdepth++
+    else if (tagann && c == ")") {
+      tagdepth--
+      if (tagdepth == 0) tagann = 0
+    }
+
     if (c == "'" || c == "\"") {
       israw = (i > 1 && substr(line, i - 1, 1) == "r")
       if (substr(line, i, 3) == c c c) { q = c c c; qlen = 3 }
       else { q = c; qlen = 1 }
       instr = 1
+      keepbody = (preserve_tag_literals && tagann)
       out = out q
       i += qlen
       continue

--- a/mobile/test/tools/design_system_ceiling_detectors_test.dart
+++ b/mobile/test/tools/design_system_ceiling_detectors_test.dart
@@ -334,11 +334,16 @@ final p = showLicensePage(context: c);
 
   group('dart_code_only.awk', () {
     // Runs the shared filter over [source] and returns its output.
-    String filter(String source) {
+    String filter(String source, {bool preserveTagLiterals = false}) {
       final f = File('${tmp.path}/lib/in.dart')..writeAsStringSync(source);
       final res = Process.runSync(
         'awk',
-        ['-f', File('scripts/lib/dart_code_only.awk').absolute.path, f.path],
+        [
+          if (preserveTagLiterals) ...['-v', 'preserve_tag_literals=1'],
+          '-f',
+          File('scripts/lib/dart_code_only.awk').absolute.path,
+          f.path,
+        ],
       );
       expect(res.exitCode, 0, reason: res.stderr.toString());
       return res.stdout as String;
@@ -377,6 +382,25 @@ final t = """
     test('strips nested block comments', () {
       final out = filter('/* outer /* inner TextStyle( */ still comment */\n');
       expect(out, isNot(contains('TextStyle(')));
+    });
+
+    test('optionally preserves literals only inside real Tags annotations', () {
+      final out = filter(
+        '''
+@Tags([
+  'skip_very_good_optimization',
+])
+final message = '@Tags(["skip_very_good_optimization"])';
+/* @Tags(['skip_very_good_optimization']) */
+''',
+        preserveTagLiterals: true,
+      );
+
+      expect(out, contains("'skip_very_good_optimization'"));
+      expect(
+        'skip_very_good_optimization'.allMatches(out),
+        hasLength(1),
+      );
     });
   });
 }

--- a/mobile/test/tools/design_system_ceiling_detectors_test.dart
+++ b/mobile/test/tools/design_system_ceiling_detectors_test.dart
@@ -385,22 +385,22 @@ final t = """
     });
 
     test('optionally preserves literals only inside real Tags annotations', () {
+      const tag =
+          'skip_very_good_'
+          'optimization';
       final out = filter(
         '''
 @Tags([
-  'skip_very_good_optimization',
+  '$tag',
 ])
-final message = '@Tags(["skip_very_good_optimization"])';
-/* @Tags(['skip_very_good_optimization']) */
+final message = '@Tags(["$tag"])';
+/* @Tags(['$tag']) */
 ''',
         preserveTagLiterals: true,
       );
 
-      expect(out, contains("'skip_very_good_optimization'"));
-      expect(
-        'skip_very_good_optimization'.allMatches(out),
-        hasLength(1),
-      );
+      expect(out, contains("'$tag'"));
+      expect(tag.allMatches(out), hasLength(1));
     });
   });
 }

--- a/mobile/test/tools/process_global_mutations_selftest_test.dart
+++ b/mobile/test/tools/process_global_mutations_selftest_test.dart
@@ -5,7 +5,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// The guard ships 27 fixture cases behind `--selftest`, and until this test
+/// The guard ships 40 fixture cases behind `--selftest`, and until this test
 /// existed nothing in the repository ran them: the flag appears in no workflow,
 /// no mise task, no git hook, and no Codex config, so CI invoked the scanner
 /// bare. A later edit to GLOBALS, to the snapshot/restore regexes, or to the
@@ -19,17 +19,46 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('check_process_global_mutations --selftest', () {
     late ProcessResult result;
+    late String sourceScriptPath;
+    late String sourceFilterPath;
+
+    ({Directory root, String scriptPath}) copyGuard({
+      bool includeFilter = true,
+    }) {
+      final root = Directory.systemTemp.createTempSync(
+        'process_global_mutations_test',
+      );
+      final scriptsDirectory = Directory('${root.path}/mobile/scripts')
+        ..createSync(recursive: true);
+      final scriptPath =
+          '${scriptsDirectory.path}/check_process_global_mutations.sh';
+      File(sourceScriptPath).copySync(scriptPath);
+      if (includeFilter) {
+        final filterDirectory = Directory('${scriptsDirectory.path}/lib')
+          ..createSync(recursive: true);
+        File(
+          sourceFilterPath,
+        ).copySync('${filterDirectory.path}/dart_code_only.awk');
+      }
+      return (root: root, scriptPath: scriptPath);
+    }
 
     setUpAll(() {
-      final scriptPath = File(
+      sourceScriptPath = File(
         'scripts/check_process_global_mutations.sh',
-      ).absolute;
+      ).absolute.path;
+      sourceFilterPath = File('scripts/lib/dart_code_only.awk').absolute.path;
       expect(
-        scriptPath.existsSync(),
+        File(sourceScriptPath).existsSync(),
         isTrue,
-        reason: 'guard script must exist at ${scriptPath.path}',
+        reason: 'guard script must exist at $sourceScriptPath',
       );
-      result = Process.runSync('bash', [scriptPath.path, '--selftest']);
+      expect(
+        File(sourceFilterPath).existsSync(),
+        isTrue,
+        reason: 'code-only filter must exist at $sourceFilterPath',
+      );
+      result = Process.runSync('bash', [sourceScriptPath, '--selftest']);
     });
 
     test('every fixture case still produces its expected exit code', () {
@@ -52,7 +81,69 @@ void main() {
       // Shrink guard: deleting cases would make the assertion above pass
       // vacuously. Raise this number when cases are added; lower it only
       // deliberately, in the same change that removes one.
-      expect(passingCases, greaterThanOrEqualTo(27));
+      expect(passingCases, greaterThanOrEqualTo(40));
+    });
+
+    test('removing a detection class turns the self-test red', () {
+      final sandbox = copyGuard();
+      addTearDown(() => sandbox.root.deleteSync(recursive: true));
+      final script = File(sandbox.scriptPath);
+      final original = script.readAsStringSync();
+      final mutated = original.replaceFirst("  'Bloc\\.observer'\n", '');
+      expect(mutated, isNot(equals(original)));
+      script.writeAsStringSync(mutated);
+
+      final mutationResult = Process.runSync('bash', [
+        sandbox.scriptPath,
+        '--selftest',
+      ]);
+
+      expect(mutationResult.exitCode, equals(1));
+      expect(
+        mutationResult.stdout,
+        contains('capture-restore leaker (Bloc.observer install, no restore)'),
+      );
+      expect(mutationResult.stdout, contains('FAIL (got 0, want 1)'));
+    });
+
+    test('fails closed when the code-only filter is missing', () {
+      final sandbox = copyGuard(includeFilter: false);
+      addTearDown(() => sandbox.root.deleteSync(recursive: true));
+      Directory('${sandbox.root.path}/mobile/test').createSync(recursive: true);
+
+      final missingFilterResult = Process.runSync('bash', [sandbox.scriptPath]);
+
+      expect(missingFilterResult.exitCode, equals(1));
+      expect(
+        missingFilterResult.stderr,
+        contains('Dart code-only filter is unavailable'),
+      );
+    });
+
+    test('production scan includes package test trees', () {
+      final sandbox = copyGuard();
+      addTearDown(() => sandbox.root.deleteSync(recursive: true));
+      Directory('${sandbox.root.path}/mobile/test').createSync(recursive: true);
+      final packageTest = File(
+        '${sandbox.root.path}/mobile/packages/example/test/leak_test.dart',
+      )..createSync(recursive: true);
+      packageTest.writeAsStringSync('''
+void main() {
+  Bloc.observer = MyObserver();
+}
+''');
+
+      final packageResult = Process.runSync('bash', [sandbox.scriptPath]);
+
+      expect(packageResult.exitCode, equals(1));
+      expect(
+        packageResult.stdout,
+        contains('packages/example/test/leak_test.dart'),
+      );
+      expect(
+        packageResult.stdout,
+        contains('(Bloc.observer) [capture-restore]'),
+      );
     });
   });
 }

--- a/mobile/test/tools/process_global_mutations_selftest_test.dart
+++ b/mobile/test/tools/process_global_mutations_selftest_test.dart
@@ -120,6 +120,22 @@ void main() {
       );
     });
 
+    test('fails closed when the filter loads but emits nothing', () {
+      final sandbox = copyGuard();
+      addTearDown(() => sandbox.root.deleteSync(recursive: true));
+      Directory('${sandbox.root.path}/mobile/test').createSync(recursive: true);
+      // A filter that parses and runs but discards every line would pass a
+      // check against empty input while erasing every real detector match.
+      File(
+        '${sandbox.root.path}/mobile/scripts/lib/dart_code_only.awk',
+      ).writeAsStringSync('{ next }\n');
+
+      final emptyOutputResult = Process.runSync('bash', [sandbox.scriptPath]);
+
+      expect(emptyOutputResult.exitCode, equals(1));
+      expect(emptyOutputResult.stderr, contains('produced no output'));
+    });
+
     test('production scan includes package test trees', () {
       final sandbox = copyGuard();
       addTearDown(() => sandbox.root.deleteSync(recursive: true));


### PR DESCRIPTION
Comments and diagnostic strings could satisfy the process-global mutation guard's restore checks, allowing a genuinely leaked test singleton to pass CI. The same raw-text parsing could report harmless mentions as violations or treat a commented/stringified optimizer tag as a real isolation exemption.

This change sends all three mutation classes through the shared Dart code-only filter and adds an opt-in mode that preserves tag literals only inside real `@Tags(...)` annotations. The guard now also validates that filter before scanning, so a missing or invalid dependency fails closed.

The real shell scanner now carries 40 fixture cases covering block comments, trailing comments, ordinary and raw strings, false restores/resets, and false optimizer tags. Its Flutter contract test adds a mutation proof, missing-filter coverage, and an isolated package-test-tree scan. The shared filter's tag mode is pinned directly as well.

Deliberately unchanged: this remains a textual guard. It does not attempt an AST detector, lexical capture/restore binding, or cleanup-reachability analysis.

Verified with:

- `bash -n scripts/check_process_global_mutations.sh`
- `bash scripts/check_process_global_mutations.sh --selftest`
- `bash scripts/check_process_global_mutations.sh`
- `flutter test test/tools/design_system_ceiling_detectors_test.dart test/tools/process_global_mutations_selftest_test.dart`
- `flutter analyze`

Closes #8847
