### PR TITLE
chore(analyzer): enforce Riverpod override list types

### DIFF
--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -23,7 +23,6 @@ analyzer:
     inference_failure_on_function_return_type: ignore
     inference_failure_on_instance_creation: ignore
     inference_failure_on_untyped_parameter: ignore
-    list_element_type_not_assignable: ignore
     prefer_int_literals: ignore
     sort_constructors_first: ignore
     strict_raw_type: ignore

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -33,6 +33,7 @@ import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/subscription_manager.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:profile_repository/profile_repository.dart';
+import 'package:riverpod/misc.dart' show Override;
 import 'package:shared_preferences/shared_preferences.dart';
 
 // Mock classes (public because they are imported by many test files)
@@ -372,7 +373,7 @@ MockVideoEventService createMockVideoEventService() {
 }
 
 /// Standard provider overrides that fix most ProviderException failures
-List<dynamic> getStandardTestOverrides({
+List<Override> getStandardTestOverrides({
   SharedPreferences? mockSharedPreferences,
   AuthService? mockAuthService,
   AnalyticsService? analyticsService,
@@ -480,7 +481,7 @@ List<dynamic> getStandardTestOverrides({
 /// ```
 Widget testProviderScope({
   required Widget child,
-  List<dynamic>? additionalOverrides,
+  List<Override>? additionalOverrides,
   SharedPreferences? mockSharedPreferences,
   AuthService? mockAuthService,
   AnalyticsService? analyticsService,
@@ -519,7 +520,7 @@ Widget testProviderScope({
   );
 }
 
-bool _overridesProvider(List<dynamic>? overrides, Object provider) {
+bool _overridesProvider(List<Override>? overrides, Object provider) {
   final providerPrefix = '$provider.';
   return overrides?.any((override) => '$override'.startsWith(providerPrefix)) ??
       false;
@@ -543,7 +544,7 @@ Widget testMaterialApp({
   Widget? home,
   Map<String, WidgetBuilder>? routes,
   String? initialRoute,
-  List<dynamic>? additionalOverrides,
+  List<Override>? additionalOverrides,
   SharedPreferences? mockSharedPreferences,
   AuthService? mockAuthService,
   AnalyticsService? analyticsService,

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -22,6 +22,7 @@ import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/notification_preferences_service.dart';
 import 'package:openvine/services/notification_service.dart';
 import 'package:openvine/services/push_notification_service.dart';
+import 'package:riverpod/misc.dart' show Override;
 
 class _MockFirebaseMessaging extends Mock implements FirebaseMessaging {}
 
@@ -293,7 +294,7 @@ void main() {
 
   ProviderContainer buildContainer({
     _TestNostrSession? nostrSession,
-    List<dynamic> extraOverrides = const [],
+    List<Override> extraOverrides = const [],
   }) {
     final container = ProviderContainer(
       overrides: [

--- a/mobile/test/router/minor_account_review_router_test.dart
+++ b/mobile/test/router/minor_account_review_router_test.dart
@@ -23,6 +23,7 @@ import 'package:openvine/screens/minor_account_review_under13_support_screen.dar
 import 'package:openvine/screens/settings/support_center_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/bug_report_service.dart';
+import 'package:riverpod/misc.dart' show Override;
 
 import '../helpers/test_provider_overrides.dart';
 
@@ -266,7 +267,7 @@ void main() {
   group('Minor account review router gating', () {
     late MockAuthService mockAuthService;
 
-    List<dynamic> routerOverrides({
+    List<Override> routerOverrides({
       AccountDeletionAttempt? deletionAttempt,
     }) => [
       ...getStandardTestOverrides(mockAuthService: mockAuthService),

--- a/mobile/test/screens/explore_search_transition_test.dart
+++ b/mobile/test/screens/explore_search_transition_test.dart
@@ -24,6 +24,7 @@ import 'package:openvine/screens/explore/explore_screen.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/services/curated_list_service.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:riverpod/misc.dart' show Override;
 
 import '../helpers/test_provider_overrides.dart';
 
@@ -68,7 +69,7 @@ void main() {
       when(() => videoEventService.hasListeners).thenReturn(false);
     });
 
-    List<dynamic> exploreOverrides() => [
+    List<Override> exploreOverrides() => [
       appForegroundProvider.overrideWith(_FakeAppForeground.new),
       videoEventServiceProvider.overrideWithValue(videoEventService),
       routerLocationStreamProvider.overrideWith(

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -47,6 +47,7 @@ import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
 import 'package:openvine/widgets/video_feed_item/fullscreen_sponsor_disclosure.dart';
 import 'package:openvine/widgets/video_feed_item/inline_comment_composer_bar.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
+import 'package:riverpod/misc.dart' show Override;
 
 import '../../helpers/test_provider_overrides.dart';
 import '../../test_data/video_test_data.dart';
@@ -283,7 +284,7 @@ void main() {
 
     Widget buildSubject({
       FullscreenFeedState? state,
-      List<dynamic>? additionalOverrides,
+      List<Override>? additionalOverrides,
       MockAuthService? mockAuthService,
       String? contextTitle,
       String? sponsorName,

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -22,6 +22,7 @@ import 'package:openvine/screens/inbox/conversation/widgets/message_bubble.dart'
 import 'package:openvine/screens/inbox/dm_display_text.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
+import 'package:riverpod/misc.dart' show Override;
 import 'package:videos_repository/videos_repository.dart';
 
 import '../../../../helpers/test_provider_overrides.dart';
@@ -75,7 +76,7 @@ GoRouter _messageRouter(String message) {
 
 Widget _routerTestApp(
   GoRouter router, {
-  List<dynamic>? additionalOverrides,
+  List<Override>? additionalOverrides,
   MockNostrClient? mockNostrService,
 }) {
   return testProviderScope(

--- a/mobile/test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart
@@ -14,6 +14,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/reactions_detail_sheet.dart';
 import 'package:openvine/widgets/user_avatar.dart';
+import 'package:riverpod/misc.dart' show Override;
 
 import '../../../../helpers/test_provider_overrides.dart';
 
@@ -55,7 +56,7 @@ void main() {
 
   Widget host(
     _MockConversationReactionsCubit cubit, {
-    List<dynamic> additionalOverrides = const <dynamic>[],
+    List<Override> additionalOverrides = const <Override>[],
     Locale? locale,
   }) {
     return testMaterialApp(

--- a/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
@@ -16,6 +16,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/reactions_row.dart';
 import 'package:openvine/widgets/user_avatar.dart';
+import 'package:riverpod/misc.dart' show Override;
 
 import '../../../../helpers/test_provider_overrides.dart';
 
@@ -66,7 +67,7 @@ void main() {
   Widget buildSubject(
     _MockConversationReactionsCubit cubit, {
     Set<String> blockedPubkeys = const <String>{},
-    List<dynamic> additionalOverrides = const <dynamic>[],
+    List<Override> additionalOverrides = const <Override>[],
     bool removalEnabled = true,
   }) {
     return testMaterialApp(

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -38,6 +38,7 @@ import 'package:openvine/screens/inbox/widgets/inbox_filter_chips.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_segmented_toggle.dart';
 import 'package:openvine/screens/inbox/widgets/restore_paused_banner.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
+import 'package:riverpod/misc.dart' show Override;
 
 import '../../helpers/go_router.dart';
 import '../../helpers/test_provider_overrides.dart';
@@ -126,7 +127,7 @@ void main() {
       Stream<int>? notificationStream,
       TextScaler? textScaler,
       ConversationActionsCubit? actionsCubit,
-      List<dynamic> additionalOverrides = const [],
+      List<Override> additionalOverrides = const [],
       // InboxView has no Scaffold of its own, and a ScaffoldMessenger with
       // no registered Scaffold silently queues SnackBars instead of showing
       // them. Opt in when the test asserts on one.

--- a/mobile/test/screens/inbox/widgets/following_bar_test.dart
+++ b/mobile/test/screens/inbox/widgets/following_bar_test.dart
@@ -11,6 +11,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/widgets/following_bar.dart';
 import 'package:openvine/widgets/user_avatar.dart';
+import 'package:riverpod/misc.dart' show Override;
 
 import '../../../helpers/test_provider_overrides.dart';
 
@@ -52,7 +53,7 @@ void main() {
 
     Widget buildSubject({
       required MyFollowingState state,
-      List<dynamic> additionalOverrides = const [],
+      List<Override> additionalOverrides = const [],
       ValueChanged<String>? onUserTapped,
       Locale? locale,
       String viewerPubkey = currentUserPubkey,

--- a/mobile/test/screens/profile_setup_screen_test.dart
+++ b/mobile/test/screens/profile_setup_screen_test.dart
@@ -21,6 +21,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/profile_setup/profile_setup.dart';
 import 'package:openvine/widgets/profile_editor/username_status_indicator.dart';
+import 'package:riverpod/misc.dart' show Override;
 
 import '../helpers/test_provider_overrides.dart';
 
@@ -612,7 +613,7 @@ void main() {
       mockProfileRepository = createMockProfileRepository();
     });
 
-    List<dynamic> baseOverrides() {
+    List<Override> baseOverrides() {
       return [
         authServiceProvider.overrideWithValue(mockAuthService),
         profileRepositoryProvider.overrideWith((ref) => mockProfileRepository),

--- a/mobile/test/screens/settings/general_settings_screen_test.dart
+++ b/mobile/test/screens/settings/general_settings_screen_test.dart
@@ -19,6 +19,7 @@ import 'package:openvine/screens/settings/general_settings_screen.dart';
 import 'package:openvine/services/audio_sharing_preference_service.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/feed_aspect_ratio_preference_service.dart';
+import 'package:riverpod/misc.dart' show Override;
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
@@ -60,7 +61,7 @@ void main() {
       ).thenAnswer((_) async {});
     });
 
-    List<dynamic> baseOverrides() => [
+    List<Override> baseOverrides() => [
       sharedPreferencesProvider.overrideWithValue(sharedPreferences),
       authServiceProvider.overrideWithValue(authService),
       currentAuthStateProvider.overrideWithValue(AuthState.unauthenticated),
@@ -74,7 +75,7 @@ void main() {
 
     Widget wrap(
       Widget child, {
-      List<dynamic> overrides = const [],
+      List<Override> overrides = const [],
     }) {
       return ProviderScope(
         overrides: [...baseOverrides(), ...overrides],

--- a/mobile/test/screens/settings/settings_taxonomy_test.dart
+++ b/mobile/test/screens/settings/settings_taxonomy_test.dart
@@ -36,6 +36,7 @@ import 'package:openvine/services/feed_aspect_ratio_preference_service.dart';
 import 'package:openvine/services/language_preference_service.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:riverpod/misc.dart' show Override;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../helpers/scroll.dart';
@@ -161,7 +162,7 @@ void main() {
     ).thenAnswer((_) => const Stream<List<String>>.empty());
   });
 
-  List<dynamic> baseOverrides() => [
+  List<Override> baseOverrides() => [
     sharedPreferencesProvider.overrideWithValue(sharedPreferences),
     authServiceProvider.overrideWithValue(authService),
     currentAuthStateProvider.overrideWithValue(AuthState.unauthenticated),
@@ -185,7 +186,7 @@ void main() {
   Widget wrap(
     Widget child, {
     Locale? locale,
-    List<dynamic> overrides = const [],
+    List<Override> overrides = const [],
     AppUpdateBloc? appUpdateBloc,
   }) {
     return ProviderScope(

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -25,6 +25,7 @@ import 'package:openvine/services/sound_library_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/user_avatar.dart';
+import 'package:riverpod/misc.dart' show Override;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sound_service/sound_service.dart';
 
@@ -130,7 +131,7 @@ class MockVideosUsingSoundErrorNotifier
 /// defaults to signed-out (null).
 Widget createTestWidget({
   required Widget child,
-  List<dynamic>? overrides,
+  List<Override>? overrides,
   String? viewerPubkey,
   TextScaler textScaler = TextScaler.noScaling,
 }) {
@@ -893,7 +894,7 @@ void main() {
             sourceVideo(allowReuse: allowReuse),
           );
 
-      List<dynamic> gridOverrides() => [
+      List<Override> gridOverrides() => [
         soundUsageCountProvider(
           sourceVideoId,
         ).overrideWith((ref) => Future.value(0)),

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -21,6 +21,7 @@ import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/services/video_provenance_filter_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
+import 'package:riverpod/misc.dart' show Override;
 import 'package:videos_repository/videos_repository.dart';
 
 import '../helpers/test_provider_overrides.dart';
@@ -106,7 +107,7 @@ void main() {
     Widget buildSubject({
       String videoId = 'test_video_id',
       List<String> fallbackVideoIds = const [],
-      List<dynamic> extraOverrides = const <dynamic>[],
+      List<Override> extraOverrides = const <Override>[],
     }) {
       return testMaterialApp(
         mockNostrService: mockNostrClient,

--- a/mobile/test/widgets/audio_attribution_row_test.dart
+++ b/mobile/test/widgets/audio_attribution_row_test.dart
@@ -9,6 +9,7 @@ import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/widgets/video_feed_item/audio_attribution_row.dart';
+import 'package:riverpod/misc.dart' show Override;
 
 void main() {
   group(AudioAttributionRow, () {
@@ -69,7 +70,7 @@ void main() {
       AudioEvent? audioOverride,
       bool resolvesAudio = true,
       Object? audioError,
-      List<dynamic> additionalOverrides = const [],
+      List<Override> additionalOverrides = const [],
     }) {
       return ProviderScope(
         overrides: [

--- a/mobile/test/widgets/find_people_sheet_test.dart
+++ b/mobile/test/widgets/find_people_sheet_test.dart
@@ -16,6 +16,7 @@ import 'package:openvine/screens/inbox/widgets/moderation_identity.dart';
 import 'package:openvine/services/video_sharing_service.dart';
 import 'package:openvine/widgets/find_people_sheet.dart';
 import 'package:profile_repository/profile_repository.dart';
+import 'package:riverpod/misc.dart' show Override;
 
 import '../helpers/test_provider_overrides.dart';
 
@@ -38,7 +39,7 @@ void main() {
     Widget createTestWidget({
       List<ShareableUser> contacts = const [],
       Duration? searchTimeout = const Duration(seconds: 20),
-      List<dynamic> extraOverrides = const [],
+      List<Override> extraOverrides = const [],
     }) {
       return testMaterialApp(
         home: Builder(

--- a/mobile/test/widgets/profile/new_people_list_sheet_test.dart
+++ b/mobile/test/widgets/profile/new_people_list_sheet_test.dart
@@ -18,6 +18,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/widgets/profile/new_people_list_sheet.dart';
 import 'package:profile_repository/profile_repository.dart';
+import 'package:riverpod/misc.dart' show Override;
 import 'package:rxdart/rxdart.dart';
 
 class _MockPeopleListsBloc extends MockBloc<PeopleListsEvent, PeopleListsState>
@@ -165,7 +166,7 @@ void main() {
 Widget _buildSubject({
   required bool curatedListsEnabled,
   required PeopleListsBloc Function() createBloc,
-  List<dynamic> extraOverrides = const [],
+  List<Override> extraOverrides = const [],
 }) {
   return ProviderScope(
     overrides: [

--- a/mobile/test/widgets/profile/profile_videos_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_videos_grid_test.dart
@@ -28,6 +28,7 @@ import 'package:openvine/services/video_publish/video_publish_service.dart';
 import 'package:openvine/widgets/profile/profile_videos_grid.dart';
 import 'package:openvine/widgets/profile/profile_videos_grid_skeleton.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:riverpod/misc.dart' show Override;
 
 import '../../helpers/test_provider_overrides.dart';
 
@@ -123,7 +124,7 @@ void main() {
       bool isLoading = false,
       List<PendingCollaboratorInviteGroup> pendingInviteGroups = const [],
       Locale? locale,
-      List<dynamic> additionalOverrides = const [],
+      List<Override> additionalOverrides = const [],
     }) {
       final profileFeedCubit = _stubbedProfileFeedCubit();
       return testProviderScope(

--- a/mobile/test/widgets/video_feed_item/video_description_label_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_description_label_test.dart
@@ -13,6 +13,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:reposts_repository/reposts_repository.dart';
+import 'package:riverpod/misc.dart' show Override;
 
 import '../../builders/test_video_event_builder.dart';
 import '../../helpers/test_provider_overrides.dart';
@@ -55,7 +56,7 @@ void main() {
 
       await tester.pumpWidget(
         testProviderScope(
-          additionalOverrides: <dynamic>[
+          additionalOverrides: <Override>[
             repostsRepositoryProvider.overrideWithValue(reposts),
           ],
           mockFollowRepository: follow,

--- a/mobile/test/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/services/content_deletion_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/services/video_metadata_update_service.dart';
 import 'package:openvine/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart';
+import 'package:riverpod/misc.dart' show Override;
 
 import '../../../../helpers/go_router.dart';
 import '../../../../helpers/test_helpers.dart';
@@ -56,7 +57,7 @@ void main() {
       MockGoRouter goRouter, {
       ValueChanged<VideoEvent>? onVideoUpdated,
       VideoMetadataUpdateService? updateService,
-      List<dynamic> additionalOverrides = const [],
+      List<Override> additionalOverrides = const [],
     }) {
       return ProviderScope(
         overrides: [


### PR DESCRIPTION
## Problem

The app globally ignored `list_element_type_not_assignable`, hiding 67 error-level findings in tests. Every finding came from Riverpod override lists whose helper or wrapper API erased the element type to `dynamic`.

## Why this fix

Type the shared and local test override boundaries as `List<Override>`, then remove the analyzer suppression. This fixes the declarations that created the invalid collection elements instead of adding casts at 67 call sites.

## Deliberately unchanged

This PR does not address the separate ignore-documentation or async-safety diagnostics tracked by #3342. Those were measured independently and will be delivered separately. Runtime behavior is unchanged; these edits tighten test-only static types.

## Verification

- `flutter analyze --no-pub lib test integration_test tools` — no issues
- 20 affected test suites — 583 tests passed
- `dart format --output=none --set-exit-if-changed` on all changed Dart files
- pre-push checks

Part of #3342.