### PR TITLE
fix(video-editor): delete the partial export file on cancel or failure (#8818)

### DIFF
--- a/mobile/lib/services/video_editor/clip_normalization_models.dart
+++ b/mobile/lib/services/video_editor/clip_normalization_models.dart
@@ -10,15 +10,11 @@ import 'package:pro_video_editor/pro_video_editor.dart';
 class NormalizationResult {
   const NormalizationResult({
     required this.segments,
-    required this.tempFilePaths,
     this.globalTransform,
   });
 
   /// The video segments ready for concatenation.
   final List<VideoSegment> segments;
-
-  /// Paths to temporary files that should be cleaned up after rendering.
-  final List<String> tempFilePaths;
 
   /// Global crop transform to apply during concatenation (if all clips match).
   final CropParameters? globalTransform;

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -603,6 +603,11 @@ class VideoEditorRenderService {
     bool reportEveryFailure = false,
   }) async {
     final tempFilePaths = <String>[];
+    // Tracked so a cancel or a failed final encoder attempt mid-concatenation
+    // can delete the partial output. _concatenateSegments only returns the path
+    // on success, so without this the file it wrote (in the documents directory
+    // for a persistent export) is orphaned. #8818.
+    String? finalOutputPath;
 
     try {
       final override = renderVideoOverride;
@@ -627,6 +632,15 @@ class VideoEditorRenderService {
       final outputDir = usePersistentStorage
           ? await getApplicationDocumentsDirectory()
           : cacheDir;
+
+      // Resolve the final output path up front so it can be cleaned up on a
+      // cancel/failure that throws out of _concatenateSegments before it
+      // returns the path. #8818.
+      final resolvedOutputPath = path.join(
+        outputDir.path,
+        'divine_${DateTime.now().microsecondsSinceEpoch}.mp4',
+      );
+      finalOutputPath = resolvedOutputPath;
 
       Log.debug(
         '🎞️ Rendering ${clips.length} clip(s) to final video',
@@ -655,7 +669,7 @@ class VideoEditorRenderService {
         clips: clips,
         segments: result.segments,
         taskId: effectiveTaskId,
-        outputDir: outputDir,
+        outputPath: resolvedOutputPath,
         globalTransform: result.globalTransform,
         aspectRatio: aspectRatio ?? clips.first.targetAspectRatio,
         parameters: parameters,
@@ -683,14 +697,17 @@ class VideoEditorRenderService {
         name: _logName,
         category: .video,
       );
-      await _cleanupTempFiles(tempFilePaths);
+      // Also remove the partial final output the cancelled concatenation may
+      // have written; on success this path is the returned result, so it is
+      // only cleaned on the failure/cancel exits. #8818.
+      await _cleanupTempFiles([...tempFilePaths, ?finalOutputPath]);
       throw VideoRenderFailedException(
         VideoRenderFailureReason.canceled,
         cause: e,
       );
     } catch (e, stack) {
       Log.error('❌ Video render failed: $e', name: _logName, category: .video);
-      await _cleanupTempFiles(tempFilePaths);
+      await _cleanupTempFiles([...tempFilePaths, ?finalOutputPath]);
       VideoRenderWatchdog.reportFailure(
         e,
         stack,
@@ -881,7 +898,6 @@ class VideoEditorRenderService {
               ),
             )
             .toList(),
-        tempFilePaths: [],
         globalTransform:
             clipAnalysis.entries.first.cropParams.needsCropping(
               clipAnalysis.entries.first.resolution,
@@ -948,7 +964,6 @@ class VideoEditorRenderService {
 
     return NormalizationResult(
       segments: segments,
-      tempFilePaths: tempFilePaths,
     );
   }
 
@@ -1039,17 +1054,12 @@ class VideoEditorRenderService {
     required List<DivineVideoClip> clips,
     required List<VideoSegment> segments,
     required String taskId,
-    required Directory outputDir,
+    required String outputPath,
     required CompleteParameters? parameters,
     required model.AspectRatio aspectRatio,
     required Duration? maxOutputDuration,
     CropParameters? globalTransform,
   }) async {
-    final outputPath = path.join(
-      outputDir.path,
-      'divine_${DateTime.now().microsecondsSinceEpoch}.mp4',
-    );
-
     // Overlap transitions shorten the rendered output, so the true video
     // length is the transition-mapped output duration, capped by
     // [maxOutputDuration]. Audio windows are clamped to it below so a short

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -855,7 +855,8 @@ class VideoEditorRenderService {
   /// - Using a single global transform if all clips have the same resolution
   /// - Only pre-rendering clips that differ from the majority
   ///
-  /// Returns video segments ready for concatenation and temp file paths for cleanup.
+  /// Returns video segments ready for concatenation and an optional global
+  /// transform when all clips share the same crop parameters.
   ///
   /// [taskId] is the export's own id — the one a user cancel targets — so this
   /// pass can stop between clips instead of rendering the whole set (#7833).

--- a/mobile/test/services/video_editor/video_editor_render_service_normalization_cancel_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_normalization_cancel_test.dart
@@ -202,5 +202,47 @@ void main() {
         );
       },
     );
+
+    test(
+      'deletes the partial final output when the export is cancelled during '
+      'concatenation (#8818)',
+      () async {
+        // Cancel while the FINAL concatenation render runs, after normalization
+        // has completed — so the partial `divine_*.mp4` has been written to the
+        // output directory and must not be left orphaned.
+        RenderCancellationRegistry.start(exportTaskId);
+        final plugin = _MockProVideoEditor(
+          resolutions: resolutions,
+          onRender: (task) {
+            if (task.id == exportTaskId) {
+              RenderCancellationRegistry.cancel(exportTaskId);
+            }
+          },
+        );
+        ProVideoEditor.instance = plugin;
+
+        final outputPath = await VideoEditorRenderService.renderVideo(
+          clips: clips,
+          aspectRatio: model.AspectRatio.vertical,
+          taskId: exportTaskId,
+        );
+
+        // Normalization ran for both clips, then the concat render was reached
+        // and cancelled.
+        expect(plugin.renderedTaskIds, [
+          'clip-a_normalized',
+          'clip-b_normalized',
+          exportTaskId,
+        ]);
+        expect(outputPath, isNull);
+        expect(
+          tempDir.listSync().whereType<File>().where(
+            (file) => file.path.endsWith('.mp4'),
+          ),
+          isEmpty,
+          reason: 'the partial divine_*.mp4 must not be left behind on cancel',
+        );
+      },
+    );
   });
 }

--- a/mobile/test/services/video_editor/video_editor_render_service_normalization_cancel_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_normalization_cancel_test.dart
@@ -244,5 +244,43 @@ void main() {
         );
       },
     );
+
+    test(
+      'a persistent export leaves no partial file in the documents directory '
+      'on cancel (#8818)',
+      () async {
+        // The AC names the documents directory specifically. usePersistentStorage
+        // routes the final output there (mocked to tempDir), exercising the
+        // getApplicationDocumentsDirectory() branch rather than the cache path.
+        RenderCancellationRegistry.start(exportTaskId);
+        final plugin = _MockProVideoEditor(
+          resolutions: resolutions,
+          onRender: (task) {
+            if (task.id == exportTaskId) {
+              RenderCancellationRegistry.cancel(exportTaskId);
+            }
+          },
+        );
+        ProVideoEditor.instance = plugin;
+
+        final outputPath = await VideoEditorRenderService.renderVideo(
+          clips: clips,
+          aspectRatio: model.AspectRatio.vertical,
+          taskId: exportTaskId,
+          usePersistentStorage: true,
+        );
+
+        expect(outputPath, isNull);
+        expect(
+          tempDir.listSync().whereType<File>().where(
+            (file) => file.path.endsWith('.mp4'),
+          ),
+          isEmpty,
+          reason:
+              'a cancelled persistent export must not orphan a divine_*.mp4 '
+              'in the documents directory',
+        );
+      },
+    );
   });
 }

--- a/mobile/test/services/video_editor/video_editor_render_service_normalization_cancel_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_normalization_cancel_test.dart
@@ -16,9 +16,10 @@ import 'package:pro_video_editor/pro_video_editor.dart';
 class _MockPathProviderPlatform extends Fake
     with MockPlatformInterfaceMixin
     implements PathProviderPlatform {
-  _MockPathProviderPlatform({required this.root});
+  _MockPathProviderPlatform({required this.root, required this.documentsRoot});
 
   final String root;
+  final String documentsRoot;
 
   @override
   Future<String?> getTemporaryPath() async => root;
@@ -27,7 +28,7 @@ class _MockPathProviderPlatform extends Fake
   Future<String?> getApplicationCachePath() async => root;
 
   @override
-  Future<String?> getApplicationDocumentsPath() async => root;
+  Future<String?> getApplicationDocumentsPath() async => documentsRoot;
 }
 
 class _MockProVideoEditor extends ProVideoEditor {
@@ -51,6 +52,9 @@ class _MockProVideoEditor extends ProVideoEditor {
 
   /// Every render the service asked the plugin for, in order.
   final List<String> renderedTaskIds = [];
+
+  /// Every output path the service asked the plugin to write, in order.
+  final List<String> renderedFilePaths = [];
 
   @override
   Stream<dynamic> initializeStream() => const Stream.empty();
@@ -76,6 +80,7 @@ class _MockProVideoEditor extends ProVideoEditor {
     NativeLogLevel? nativeLogLevel,
   }) async {
     renderedTaskIds.add(value.id);
+    renderedFilePaths.add(filePath);
     onRender?.call(value);
     File(filePath).createSync(recursive: true);
     if (failEncoderTaskIds.contains(value.id)) {
@@ -92,6 +97,7 @@ void main() {
   const exportTaskId = 'export-task';
 
   late Directory tempDir;
+  late Directory documentsDir;
   late PathProviderPlatform originalPathProvider;
   late ProVideoEditor originalProVideoEditor;
 
@@ -113,10 +119,14 @@ void main() {
   setUp(() {
     TestWidgetsFlutterBinding.ensureInitialized();
     tempDir = Directory.systemTemp.createTempSync('openvine_render_cancel_');
+    documentsDir = Directory.systemTemp.createTempSync(
+      'openvine_render_documents_',
+    );
     originalPathProvider = PathProviderPlatform.instance;
     originalProVideoEditor = ProVideoEditor.instance;
     PathProviderPlatform.instance = _MockPathProviderPlatform(
       root: tempDir.path,
+      documentsRoot: documentsDir.path,
     );
     clips = [clipFor('clip-a'), clipFor('clip-b')];
     resolutions = {
@@ -131,6 +141,7 @@ void main() {
     RenderCancellationRegistry.reset();
     VideoEditorRenderService.resetActiveNativeTaskIdsForTesting();
     if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    if (documentsDir.existsSync()) documentsDir.deleteSync(recursive: true);
   });
 
   group('clip normalization cancellation (#7833/#7834)', () {
@@ -261,9 +272,9 @@ void main() {
       'a persistent export leaves no partial file in the documents directory '
       'on cancel (#8818)',
       () async {
-        // The AC names the documents directory specifically. usePersistentStorage
-        // routes the final output there (mocked to tempDir), exercising the
-        // getApplicationDocumentsDirectory() branch rather than the cache path.
+        // The AC names the documents directory specifically. A distinct mock
+        // root proves usePersistentStorage routes the final output there rather
+        // than to the cache path.
         RenderCancellationRegistry.start(exportTaskId);
         final plugin = _MockProVideoEditor(
           resolutions: resolutions,
@@ -284,7 +295,13 @@ void main() {
 
         expect(outputPath, isNull);
         expect(
-          tempDir.listSync().whereType<File>().where(
+          plugin.renderedFilePaths.last,
+          startsWith(
+            '${documentsDir.path}${Platform.pathSeparator}divine_',
+          ),
+        );
+        expect(
+          documentsDir.listSync().whereType<File>().where(
             (file) => file.path.endsWith('.mp4'),
           ),
           isEmpty,
@@ -325,7 +342,7 @@ void main() {
         expect(plugin.renderedTaskIds, contains(exportTaskId));
         expect(outputPath, isNull);
         expect(
-          tempDir.listSync().whereType<File>().where(
+          documentsDir.listSync().whereType<File>().where(
             (file) => file.path.endsWith('.mp4'),
           ),
           isEmpty,

--- a/mobile/test/services/video_editor/video_editor_render_service_normalization_cancel_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_normalization_cancel_test.dart
@@ -31,7 +31,11 @@ class _MockPathProviderPlatform extends Fake
 }
 
 class _MockProVideoEditor extends ProVideoEditor {
-  _MockProVideoEditor({required this.resolutions, this.onRender});
+  _MockProVideoEditor({
+    required this.resolutions,
+    this.onRender,
+    this.failEncoderTaskIds = const {},
+  });
 
   /// Reported resolution per source file path. Anything else reports a
   /// already-vertical resolution, which needs no crop.
@@ -39,6 +43,11 @@ class _MockProVideoEditor extends ProVideoEditor {
 
   /// Runs inside `renderVideoToFile`, so a test can cancel mid-render.
   final void Function(VideoRenderData task)? onRender;
+
+  /// Task ids whose render writes its partial output file and then throws a
+  /// [RenderEncoderException], modelling an encoder that fails after starting
+  /// to write. The file is created first so the failure leaves a real partial.
+  final Set<String> failEncoderTaskIds;
 
   /// Every render the service asked the plugin for, in order.
   final List<String> renderedTaskIds = [];
@@ -69,6 +78,9 @@ class _MockProVideoEditor extends ProVideoEditor {
     renderedTaskIds.add(value.id);
     onRender?.call(value);
     File(filePath).createSync(recursive: true);
+    if (failEncoderTaskIds.contains(value.id)) {
+      throw const RenderEncoderException('mock encoder failure');
+    }
     return filePath;
   }
 
@@ -279,6 +291,45 @@ void main() {
           reason:
               'a cancelled persistent export must not orphan a divine_*.mp4 '
               'in the documents directory',
+        );
+      },
+    );
+
+    test(
+      'deletes the partial final output when the final encoder attempt fails '
+      'during concatenation (#8818)',
+      () async {
+        // Not a cancel: the concat render itself fails. The encoder writes a
+        // partial `divine_*.mp4` and then throws on every attempt, so the
+        // retry chain is exhausted and the failure propagates. The partial
+        // must be cleaned up, exactly as on cancel.
+        final plugin = _MockProVideoEditor(
+          resolutions: resolutions,
+          failEncoderTaskIds: {exportTaskId},
+        );
+        ProVideoEditor.instance = plugin;
+
+        final outputPath = await VideoEditorRenderService.renderVideo(
+          clips: clips,
+          aspectRatio: model.AspectRatio.vertical,
+          taskId: exportTaskId,
+          usePersistentStorage: true,
+        );
+
+        // Normalization succeeded for both clips, then the concat render was
+        // attempted and failed.
+        expect(plugin.renderedTaskIds.take(2), [
+          'clip-a_normalized',
+          'clip-b_normalized',
+        ]);
+        expect(plugin.renderedTaskIds, contains(exportTaskId));
+        expect(outputPath, isNull);
+        expect(
+          tempDir.listSync().whereType<File>().where(
+            (file) => file.path.endsWith('.mp4'),
+          ),
+          isEmpty,
+          reason: 'a failed export must not orphan a partial divine_*.mp4',
         );
       },
     );


### PR DESCRIPTION
Closes #8818

## What

When a video export is cancelled — or the final encoder attempt fails — during concatenation, `_concatenateSegments` throws before returning the output path, so the partial `divine_<ts>.mp4` it already wrote is never cleaned up. For a final export (`usePersistentStorage: true`) that file lands in the **application documents directory**, so it's persistent storage, not a cache temp.

## Fix

Resolve the final output path in `_renderVideoOrThrow` up front and pass it into `_concatenateSegments`. The two failure exits (cancel + generic) already `await _cleanupTempFiles(...)` for the intermediate normalized clips; they now also delete the partial final output. The success path returns it untouched. This mirrors the register-before-render cleanup #8790 added for intermediate clips (which explicitly left this final-output case out of scope).

Also removes the now-unread `NormalizationResult.tempFilePaths` field (the caller-owned `tempFilePaths` list is what actually drives cleanup), per the issue's related-cleanup item.

## Tests

New test in `video_editor_render_service_normalization_cancel_test.dart`: cancelling during the final concatenation render leaves no `divine_*.mp4` behind. Mutation-checked — it fails without the fix (the orphaned file is found), passes with it. Full `test/services/video_editor/` suite green (327), analyze clean.

## Acceptance criteria
- [x] A cancelled or failed export does not leave a partial `divine_*.mp4` in the documents directory.
- [x] `NormalizationResult.tempFilePaths` is removed.