### PR TITLE
fix(ci): prevent service tests from silently missing new dependencies

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -174,6 +174,8 @@ jobs:
         run: bash scripts/check_integration_test_error_restore_safety.sh
       - name: 🧾 Verify every E2E service suite is accounted for
         run: bash scripts/check_service_suite_coverage.sh
+      - name: 🕸️ Verify focused service-suite dependency scopes
+        run: bash scripts/check_service_suite_scope_drift.sh
       - name: 🔌 Verify no new raw shared-channel installs (heal-and-blame ratchet)
         run: |
           # LIST ratchet vs origin/main (fails closed if the base baseline can't

--- a/mobile/scripts/check_service_suite_coverage.sh
+++ b/mobile/scripts/check_service_suite_coverage.sh
@@ -16,6 +16,7 @@ SUITE_PATH_ROOT="${SERVICE_SUITE_PATH_ROOT:-$MOBILE_DIR}"
 MANIFEST_FILE="${SERVICE_SUITE_MANIFEST_FILE:-$E2E_DIR/service_suite_exclusions.txt}"
 MANIFEST_REPO_PATH="${MANIFEST_FILE#"$REPO_DIR"/}"
 BASE_REF="${SERVICE_SUITE_BASE_REF:-origin/main}"
+WORKFLOW_PARSER="${SERVICE_SUITE_WORKFLOW_PARSER:-$SCRIPT_DIR/lib/service_suite_workflow_parser.dart}"
 
 scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
@@ -45,45 +46,17 @@ parse_manifest() {
   ' "$1"
 }
 
-parse_workflow_suites() {
-  awk '
-    /SERVICE_SUITE_LIST_START/ { capture = 1; next }
-    /SERVICE_SUITE_LIST_END/ { capture = 0; next }
-    !capture { next }
-    /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
-    /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=\([[:space:]]*$/ { inside = 1; next }
-    /^[[:space:]]*\)[[:space:]]*$/ { inside = 0; next }
-    {
-      entry = $0
-      gsub(/^[[:space:]]+|[[:space:]]+$/, "", entry)
-      if (!inside) {
-        printf "Unexpected line %d between the suite-list markers: %s\n", FNR, entry > "/dev/stderr"
-        invalid = 1
-        next
-      }
-      if (entry !~ /^integration_test\/e2e\/[[:alnum:]_.\/-]+_test\.dart$/) {
-        printf "Unrecognized suite-array entry on line %d: %s\n", FNR, entry > "/dev/stderr"
-        invalid = 1
-        next
-      }
-      print entry
-    }
-    END { exit invalid }
-  ' "$1"
-}
-
 find "$E2E_DIR" -type f -name '*_test.dart' -print \
   | sed "s|^$SUITE_PATH_ROOT/||" \
   | sort > "$scratch/all"
 
-start_markers="$(grep -c 'SERVICE_SUITE_LIST_START' "$WORKFLOW_FILE" || true)"
-end_markers="$(grep -c 'SERVICE_SUITE_LIST_END' "$WORKFLOW_FILE" || true)"
-if [ "$start_markers" -ne 1 ] || [ "$end_markers" -ne 1 ]; then
-  echo "FAIL [service_suite_coverage]: workflow must contain exactly one service-suite list marker pair."
+parser_error="$scratch/workflow_parser_error"
+if ! dart run "$WORKFLOW_PARSER" --workflow "$WORKFLOW_FILE" --all \
+  2> "$parser_error" | sort > "$scratch/included"; then
+  cat "$parser_error" >&2
+  echo "FAIL [service_suite_coverage]: could not parse the workflow suite lists."
   exit 1
 fi
-
-parse_workflow_suites "$WORKFLOW_FILE" | sort > "$scratch/included"
 
 parse_manifest "$MANIFEST_FILE" | sort > "$scratch/excluded"
 

--- a/mobile/scripts/check_service_suite_scope_drift.sh
+++ b/mobile/scripts/check_service_suite_scope_drift.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# ABOUTME: Fails when focused service suites outgrow their declared CI scopes.
+# ABOUTME: Keeps changed-file suite selection synchronized with Dart dependencies.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOBILE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_DIR="$(cd "$MOBILE_DIR/.." && pwd)"
+
+cd "$MOBILE_DIR"
+dart run scripts/lib/service_suite_scope_detector.dart \
+  --repo-root "$REPO_DIR" "$@"

--- a/mobile/scripts/ci/detect_service_suite_scope.sh
+++ b/mobile/scripts/ci/detect_service_suite_scope.sh
@@ -47,6 +47,7 @@ while IFS= read -r path; do
   # These inputs affect the runner or the suites as a population, so changes
   # run both dependency groups.
   case "$path" in
+    # SHARED_SCOPE_START — parsed by service_suite_scope_detector.dart.
     .github/workflows/mobile_service_integration_tests.yaml|\
     mobile/scripts/ci/detect_service_suite_scope.sh|\
     mobile/scripts/check_service_suite_coverage.sh|\
@@ -57,6 +58,7 @@ while IFS= read -r path; do
     mobile/pubspec.lock|\
     mobile/dart_test.yaml|\
     mobile/linux/*)
+    # SHARED_SCOPE_END
       focused=true
       app=true
       ;;
@@ -64,6 +66,7 @@ while IFS= read -r path; do
 
   # Eleven suites have this maintainable production dependency closure.
   case "$path" in
+    # FOCUSED_SCOPE_START — parsed by service_suite_scope_detector.dart.
     mobile/packages/cache_sync/*|\
     mobile/packages/db_client/*|\
     mobile/packages/dm_repository/*|\
@@ -79,6 +82,7 @@ while IFS= read -r path; do
     mobile/lib/services/outgoing_dm_retry_service_reportable_sites.dart|\
     mobile/lib/services/relay_discovery_service.dart|\
     mobile/lib/utils/relay_url_utils.dart)
+    # FOCUSED_SCOPE_END
       focused=true
       ;;
   esac

--- a/mobile/scripts/lib/service_suite_scope_detector.dart
+++ b/mobile/scripts/lib/service_suite_scope_detector.dart
@@ -97,12 +97,10 @@ ServiceSuiteScopeResult detectServiceSuiteScope({
   }
 
   final uncovered = <String>[];
+  // Either selector arm sets focused=true, including for local path packages.
+  final matchers = [...focusedMatchers, ...sharedMatchers];
   for (final file in visited) {
     final relative = _relative(root, file);
-    final production =
-        relative.startsWith('mobile/lib/') ||
-        relative.startsWith('mobile/packages/');
-    final matchers = production ? focusedMatchers : sharedMatchers;
     if (!matchers.any((matcher) => matcher.hasMatch(relative))) {
       final parent = importers[file];
       uncovered.add(
@@ -114,16 +112,9 @@ ServiceSuiteScopeResult detectServiceSuiteScope({
   }
 
   final stale = <String>[];
-  final productionPaths = visited
-      .map((file) => _relative(root, file))
-      .where(
-        (path) =>
-            path.startsWith('mobile/lib/') ||
-            path.startsWith('mobile/packages/'),
-      )
-      .toList();
+  final paths = visited.map((file) => _relative(root, file)).toList();
   for (var index = 0; index < scopes.focused.length; index++) {
-    if (!productionPaths.any(focusedMatchers[index].hasMatch)) {
+    if (!paths.any(focusedMatchers[index].hasMatch)) {
       stale.add(scopes.focused[index]);
     }
   }
@@ -236,6 +227,46 @@ Map<String, String> _workspacePackages(String mobileRoot) {
   }
   for (final entity in packages.listSync()) {
     if (entity is Directory) addPackage(entity.path);
+  }
+
+  // Path overrides can live elsewhere in the repo, outside the workspace list.
+  final lockPath = p.join(mobileRoot, 'pubspec.lock');
+  Object? lock;
+  try {
+    lock = loadYaml(File(lockPath).readAsStringSync());
+  } on Object catch (error) {
+    throw ScopeDriftException('unreadable lockfile $lockPath: $error');
+  }
+  final lockedPackages = lock is YamlMap ? lock['packages'] : null;
+  if (lockedPackages is! YamlMap) {
+    throw ScopeDriftException('lockfile has no package map: $lockPath');
+  }
+  for (final entry in lockedPackages.entries) {
+    final package = entry.value;
+    if (package is! YamlMap) {
+      throw ScopeDriftException('invalid locked package: ${entry.key}');
+    }
+    if (package['source'] != 'path') continue;
+    final description = package['description'];
+    final path = description is YamlMap ? description['path'] : null;
+    final relative = description is YamlMap ? description['relative'] : null;
+    if (entry.key is! String ||
+        path is! String ||
+        path.isEmpty ||
+        relative is! bool ||
+        relative == p.isAbsolute(path)) {
+      throw ScopeDriftException('invalid path package mapping: ${entry.key}');
+    }
+    final directory = p.normalize(
+      relative ? p.join(mobileRoot, path) : path,
+    );
+    if (!p.isWithin(p.dirname(mobileRoot), directory)) continue;
+    final lib = p.join(directory, 'lib');
+    if (roots[entry.key] == lib) continue;
+    addPackage(directory);
+    if (roots[entry.key] != lib) {
+      throw ScopeDriftException('path package name mismatch: ${entry.key}');
+    }
   }
   return roots;
 }

--- a/mobile/scripts/lib/service_suite_scope_detector.dart
+++ b/mobile/scripts/lib/service_suite_scope_detector.dart
@@ -1,0 +1,400 @@
+// ABOUTME: Verifies focused service suites remain inside their declared CI scopes.
+// ABOUTME: Walks every local Dart import, export, part, and conditional branch.
+
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/features.dart';
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/error/error.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+import 'service_suite_workflow_parser.dart';
+
+class ScopeDriftException implements Exception {
+  const ScopeDriftException(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+class ServiceSuiteScopeResult {
+  const ServiceSuiteScopeResult({required this.files, required this.importers});
+  final Set<String> files;
+  final Map<String, String> importers;
+}
+
+ServiceSuiteScopeResult detectServiceSuiteScope({
+  required String repoRoot,
+  required String workflowPath,
+  required String scopeScriptPath,
+}) {
+  final root = p.normalize(p.absolute(repoRoot));
+  final mobileRoot = p.join(root, 'mobile');
+  final arrays = _readWorkflow(workflowPath);
+  final focusedSuites = arrays['focused_suites'];
+  if (focusedSuites == null || focusedSuites.isEmpty) {
+    throw const ScopeDriftException(
+      'workflow focused_suites array is missing or empty',
+    );
+  }
+  final scopes = _readScopes(scopeScriptPath);
+  final focusedMatchers = scopes.focused.map(_bashCaseMatcher).toList();
+  final sharedMatchers = scopes.shared.map(_bashCaseMatcher).toList();
+  final packageRoots = _workspacePackages(mobileRoot);
+
+  final queue = <String>[];
+  final importers = <String, String>{};
+  for (final suite in focusedSuites) {
+    final path = p.normalize(p.join(mobileRoot, suite));
+    _requireInside(root, path, 'focused suite $suite');
+    if (!File(path).existsSync()) {
+      throw ScopeDriftException('focused suite does not exist: mobile/$suite');
+    }
+    queue.add(path);
+  }
+
+  final visited = <String>{};
+  while (queue.isNotEmpty) {
+    final file = queue.removeLast();
+    if (!visited.add(file)) continue;
+    final source = _readFile(file, root);
+    final parsed = parseString(
+      content: source,
+      path: file,
+      featureSet: FeatureSet.latestLanguageVersion(),
+      throwIfDiagnostics: false,
+    );
+    final errors = parsed.errors
+        .where(
+          (error) => error.diagnosticCode.severity == DiagnosticSeverity.ERROR,
+        )
+        .toList();
+    if (errors.isNotEmpty) {
+      throw ScopeDriftException(
+        'Dart parse failed for ${_relative(root, file)}: ${errors.first.message}',
+      );
+    }
+
+    for (final reference in _references(parsed.unit)) {
+      final target = _resolveReference(
+        reference,
+        importer: file,
+        repoRoot: root,
+        packageRoots: packageRoots,
+      );
+      if (target == null) continue;
+      if (!File(target).existsSync()) {
+        throw ScopeDriftException(
+          '${_relative(root, file)} references missing local file '
+          '${_relative(root, target)}',
+        );
+      }
+      importers.putIfAbsent(target, () => file);
+      queue.add(target);
+    }
+  }
+
+  final uncovered = <String>[];
+  for (final file in visited) {
+    final relative = _relative(root, file);
+    final production =
+        relative.startsWith('mobile/lib/') ||
+        relative.startsWith('mobile/packages/');
+    final matchers = production ? focusedMatchers : sharedMatchers;
+    if (!matchers.any((matcher) => matcher.hasMatch(relative))) {
+      final parent = importers[file];
+      uncovered.add(
+        parent == null
+            ? relative
+            : '$relative (imported by ${_relative(root, parent)})',
+      );
+    }
+  }
+
+  final stale = <String>[];
+  final productionPaths = visited
+      .map((file) => _relative(root, file))
+      .where(
+        (path) =>
+            path.startsWith('mobile/lib/') ||
+            path.startsWith('mobile/packages/'),
+      )
+      .toList();
+  for (var index = 0; index < scopes.focused.length; index++) {
+    if (!productionPaths.any(focusedMatchers[index].hasMatch)) {
+      stale.add(scopes.focused[index]);
+    }
+  }
+
+  if (uncovered.isNotEmpty || stale.isNotEmpty) {
+    final message = StringBuffer('service-suite dependency scope drifted');
+    if (uncovered.isNotEmpty) {
+      message.writeln('\nuncovered dependency paths:');
+      for (final path in uncovered..sort()) {
+        message.writeln('  $path');
+      }
+    }
+    if (stale.isNotEmpty) {
+      message.writeln('\nstale focused scope patterns:');
+      for (final pattern in stale..sort()) {
+        message.writeln('  $pattern');
+      }
+    }
+    throw ScopeDriftException(message.toString().trimRight());
+  }
+  return ServiceSuiteScopeResult(files: visited, importers: importers);
+}
+
+Map<String, List<String>> _readWorkflow(String path) {
+  try {
+    return parseServiceSuiteWorkflow(File(path).readAsStringSync());
+  } on FileSystemException catch (error) {
+    throw ScopeDriftException('workflow read failed: ${error.message}');
+  } on FormatException catch (error) {
+    throw ScopeDriftException('workflow parse failed: ${error.message}');
+  }
+}
+
+({List<String> focused, List<String> shared}) _readScopes(String path) {
+  final source = _readFile(path, p.dirname(p.dirname(p.dirname(path))));
+  List<String> extract(String name) {
+    final start = RegExp(
+      '^\\s*# $name'
+      r'_SCOPE_START[^\n]*$',
+      multiLine: true,
+    );
+    final end = RegExp(
+      '^\\s*# $name'
+      r'_SCOPE_END\s*$',
+      multiLine: true,
+    );
+    final starts = start.allMatches(source).toList();
+    final ends = end.allMatches(source).toList();
+    if (starts.length != 1 ||
+        ends.length != 1 ||
+        starts.single.end >= ends.single.start) {
+      throw ScopeDriftException(
+        '$name scope must contain exactly one ordered marker pair',
+      );
+    }
+    final block = source.substring(starts.single.end, ends.single.start);
+    final normalized = block.replaceAll(RegExp(r'\\\s*\n'), '');
+    final close = normalized.lastIndexOf(')');
+    if (close < 0 || normalized.substring(close + 1).trim().isNotEmpty) {
+      throw ScopeDriftException(
+        '$name scope has an invalid case-pattern block',
+      );
+    }
+    final patterns = normalized
+        .substring(0, close)
+        .split('|')
+        .map((value) => value.trim())
+        .where((value) => value.isNotEmpty)
+        .toList();
+    if (patterns.isEmpty) {
+      throw ScopeDriftException('$name scope must not be empty');
+    }
+    return patterns;
+  }
+
+  return (focused: extract('FOCUSED'), shared: extract('SHARED'));
+}
+
+Map<String, String> _workspacePackages(String mobileRoot) {
+  final roots = <String, String>{};
+  void addPackage(String directory) {
+    final pubspec = File(p.join(directory, 'pubspec.yaml'));
+    if (!pubspec.existsSync()) {
+      throw ScopeDriftException('missing pubspec: ${pubspec.path}');
+    }
+    Object? yaml;
+    try {
+      yaml = loadYaml(pubspec.readAsStringSync());
+    } on Object catch (error) {
+      throw ScopeDriftException('unreadable pubspec ${pubspec.path}: $error');
+    }
+    final name = yaml is YamlMap ? yaml['name'] : null;
+    if (name is! String || name.isEmpty) {
+      throw ScopeDriftException(
+        'pubspec has no readable package name: ${pubspec.path}',
+      );
+    }
+    if (roots.containsKey(name)) {
+      throw ScopeDriftException('duplicate workspace package name: $name');
+    }
+    roots[name] = p.join(directory, 'lib');
+  }
+
+  addPackage(mobileRoot);
+  final packages = Directory(p.join(mobileRoot, 'packages'));
+  if (!packages.existsSync()) {
+    throw ScopeDriftException(
+      'workspace packages directory is missing: ${packages.path}',
+    );
+  }
+  for (final entity in packages.listSync()) {
+    if (entity is Directory) addPackage(entity.path);
+  }
+  return roots;
+}
+
+Iterable<String> _references(CompilationUnit unit) sync* {
+  for (final directive in unit.directives) {
+    if (directive is ImportDirective) {
+      final value = directive.uri.stringValue;
+      if (value != null) yield value;
+      for (final configuration in directive.configurations) {
+        final configured = configuration.uri.stringValue;
+        if (configured != null) yield configured;
+      }
+    } else if (directive is ExportDirective) {
+      final value = directive.uri.stringValue;
+      if (value != null) yield value;
+      for (final configuration in directive.configurations) {
+        final configured = configuration.uri.stringValue;
+        if (configured != null) yield configured;
+      }
+    } else if (directive is PartDirective) {
+      final value = directive.uri.stringValue;
+      if (value != null) yield value;
+    }
+  }
+}
+
+String? _resolveReference(
+  String reference, {
+  required String importer,
+  required String repoRoot,
+  required Map<String, String> packageRoots,
+}) {
+  final uri = Uri.tryParse(reference);
+  if (uri == null || uri.hasQuery || uri.hasFragment) {
+    throw ScopeDriftException(
+      'invalid local URI in ${_relative(repoRoot, importer)}: $reference',
+    );
+  }
+  if (uri.scheme == 'dart') return null;
+  String? target;
+  if (uri.scheme == 'package') {
+    if (uri.pathSegments.length < 2) {
+      throw ScopeDriftException(
+        'invalid package URI in ${_relative(repoRoot, importer)}: $reference',
+      );
+    }
+    final packageRoot = packageRoots[uri.pathSegments.first];
+    if (packageRoot == null) return null;
+    target = p.joinAll([packageRoot, ...uri.pathSegments.skip(1)]);
+  } else if (uri.scheme.isEmpty &&
+      !uri.hasAuthority &&
+      !p.isAbsolute(reference)) {
+    target = p.join(p.dirname(importer), uri.toFilePath());
+  } else {
+    throw ScopeDriftException(
+      'unsupported local URI in ${_relative(repoRoot, importer)}: $reference',
+    );
+  }
+  target = p.normalize(p.absolute(target));
+  _requireInside(
+    repoRoot,
+    target,
+    'URI $reference in ${_relative(repoRoot, importer)}',
+  );
+  return target;
+}
+
+RegExp _bashCaseMatcher(String pattern) {
+  if (!RegExp(r'^[A-Za-z0-9_./*-]+$').hasMatch(pattern)) {
+    throw ScopeDriftException('unsupported Bash case pattern: $pattern');
+  }
+  final escaped = pattern.split('*').map(RegExp.escape).join('.*');
+  return RegExp('^$escaped\$');
+}
+
+String _readFile(String path, String root) {
+  try {
+    return File(path).readAsStringSync();
+  } on FileSystemException catch (error) {
+    throw ScopeDriftException(
+      'could not read ${_relative(root, path)}: ${error.message}',
+    );
+  }
+}
+
+void _requireInside(String root, String path, String description) {
+  if (path != root && !p.isWithin(root, path)) {
+    throw ScopeDriftException('$description escapes the repository: $path');
+  }
+}
+
+String _relative(String root, String path) => p.posix.normalize(
+  p.relative(path, from: root).split(p.separator).join('/'),
+);
+
+void main(List<String> arguments) {
+  var detail = false;
+  var repoRoot = p.dirname(Directory.current.absolute.path);
+  String? workflow;
+  String? scopeScript;
+  for (var index = 0; index < arguments.length; index++) {
+    switch (arguments[index]) {
+      case '--detail':
+        detail = true;
+      case '--repo-root':
+        if (++index >= arguments.length) _usage();
+        repoRoot = arguments[index];
+      case '--workflow':
+        if (++index >= arguments.length) _usage();
+        workflow = arguments[index];
+      case '--scope-script':
+        if (++index >= arguments.length) _usage();
+        scopeScript = arguments[index];
+      default:
+        _usage('unknown argument: ${arguments[index]}');
+    }
+  }
+  workflow ??= p.join(
+    repoRoot,
+    '.github',
+    'workflows',
+    'mobile_service_integration_tests.yaml',
+  );
+  scopeScript ??= p.join(
+    repoRoot,
+    'mobile',
+    'scripts',
+    'ci',
+    'detect_service_suite_scope.sh',
+  );
+  try {
+    final result = detectServiceSuiteScope(
+      repoRoot: repoRoot,
+      workflowPath: workflow,
+      scopeScriptPath: scopeScript,
+    );
+    if (detail) {
+      final paths =
+          result.files
+              .map((file) => _relative(p.absolute(repoRoot), file))
+              .toList()
+            ..sort();
+      paths.forEach(stdout.writeln);
+    }
+    stdout.writeln(
+      'OK: focused service-suite dependency scopes cover ${result.files.length} files.',
+    );
+  } on ScopeDriftException catch (error) {
+    stderr.writeln('FAIL [service_suite_scope]: ${error.message}');
+    exitCode = 1;
+  }
+}
+
+Never _usage([String? message]) {
+  if (message != null) stderr.writeln(message);
+  stderr.writeln(
+    'usage: dart run service_suite_scope_detector.dart [--detail] '
+    '[--repo-root <path>] [--workflow <path>] [--scope-script <path>]',
+  );
+  exit(64);
+}

--- a/mobile/scripts/lib/service_suite_workflow_parser.dart
+++ b/mobile/scripts/lib/service_suite_workflow_parser.dart
@@ -1,0 +1,113 @@
+// ABOUTME: Parses the marker-delimited service-suite arrays from the CI workflow.
+// ABOUTME: Gives coverage and dependency-scope guards one fail-closed interpretation.
+
+import 'dart:io';
+
+const _startMarker = 'SERVICE_SUITE_LIST_START';
+const _endMarker = 'SERVICE_SUITE_LIST_END';
+final _arrayStart = RegExp(r'^([A-Za-z_][A-Za-z0-9_]*)=\($');
+final _suiteEntry = RegExp(
+  r'^integration_test/e2e/[A-Za-z0-9_./-]+_test\.dart$',
+);
+
+Map<String, List<String>> parseServiceSuiteWorkflow(String source) {
+  final lines = source.split('\n');
+  final starts = <int>[];
+  final ends = <int>[];
+  for (var index = 0; index < lines.length; index++) {
+    if (lines[index].contains(_startMarker)) starts.add(index);
+    if (lines[index].contains(_endMarker)) ends.add(index);
+  }
+  if (starts.length != 1 || ends.length != 1 || starts.single >= ends.single) {
+    throw const FormatException(
+      'workflow must contain exactly one service-suite list marker pair',
+    );
+  }
+
+  final arrays = <String, List<String>>{};
+  String? current;
+  for (var index = starts.single + 1; index < ends.single; index++) {
+    final line = lines[index].trim();
+    if (line.isEmpty || line.startsWith('#')) continue;
+    if (current == null) {
+      final match = _arrayStart.firstMatch(line);
+      if (match == null) {
+        throw FormatException(
+          'Unexpected line ${index + 1} between the suite-list markers: $line',
+        );
+      }
+      final arrayName = match.group(1);
+      if (arrayName == null) {
+        throw StateError('suite array parser did not capture a name');
+      }
+      current = arrayName;
+      if (arrays.containsKey(current)) {
+        throw FormatException('duplicate suite array: $current');
+      }
+      arrays[current] = <String>[];
+      continue;
+    }
+    if (line == ')') {
+      current = null;
+      continue;
+    }
+    if (!_suiteEntry.hasMatch(line)) {
+      throw FormatException(
+        'unrecognized entry on workflow line ${index + 1}: $line',
+      );
+    }
+    arrays[current]!.add(line);
+  }
+  if (current != null) {
+    throw FormatException('unterminated suite array: $current');
+  }
+  return arrays;
+}
+
+void main(List<String> arguments) {
+  String? workflowPath;
+  var mode = 'all';
+  for (var index = 0; index < arguments.length; index++) {
+    switch (arguments[index]) {
+      case '--workflow':
+        if (++index >= arguments.length) _usage();
+        workflowPath = arguments[index];
+      case '--focused':
+        mode = 'focused';
+      case '--all':
+        mode = 'all';
+      default:
+        _usage('unknown argument: ${arguments[index]}');
+    }
+  }
+  if (workflowPath == null) _usage('--workflow is required');
+
+  try {
+    final arrays = parseServiceSuiteWorkflow(
+      File(workflowPath).readAsStringSync(),
+    );
+    final focused = arrays['focused_suites'];
+    if (mode == 'focused' && (focused == null || focused.isEmpty)) {
+      throw const FormatException('focused_suites must exist and not be empty');
+    }
+    final selected = mode == 'focused'
+        ? focused!
+        : arrays.values.expand((entries) => entries);
+    selected.forEach(stdout.writeln);
+  } on FileSystemException catch (error) {
+    stderr.writeln('service-suite workflow read failed: ${error.message}');
+    exitCode = 1;
+  } on FormatException catch (error) {
+    stderr.writeln('service-suite workflow parse failed: ${error.message}');
+    exitCode = 1;
+  }
+}
+
+Never _usage([String? message]) {
+  if (message != null) stderr.writeln(message);
+  stderr.writeln(
+    'usage: dart run service_suite_workflow_parser.dart '
+    '--workflow <path> [--focused|--all]',
+  );
+  exit(64);
+}

--- a/mobile/test/tools/service_suite_coverage_test.dart
+++ b/mobile/test/tools/service_suite_coverage_test.dart
@@ -14,6 +14,7 @@ void main() {
     late Directory e2eDirectory;
     late File manifest;
     late File baseManifest;
+    late String workflowParserPath;
 
     setUp(() {
       sandbox = Directory.systemTemp.createTempSync('service_suite_coverage_');
@@ -22,6 +23,14 @@ void main() {
           Directory.current.path,
           'scripts',
           'check_service_suite_coverage.sh',
+        ),
+      ).absolute.path;
+      workflowParserPath = File(
+        p.join(
+          Directory.current.path,
+          'scripts',
+          'lib',
+          'service_suite_workflow_parser.dart',
         ),
       ).absolute.path;
       workflow = File(p.join(sandbox.path, 'workflow.yaml'));
@@ -61,6 +70,7 @@ void main() {
         'SERVICE_SUITE_MANIFEST_FILE': manifest.path,
         'SERVICE_SUITE_BASE_MANIFEST': baseManifest.path,
         'SERVICE_SUITE_BASE_REF': 'test-base',
+        'SERVICE_SUITE_WORKFLOW_PARSER': workflowParserPath,
       },
     );
 
@@ -115,7 +125,7 @@ void main() {
       final result = runGuard();
 
       expect(result.exitCode, 1);
-      expect(result.stdout, contains('exactly one service-suite list marker'));
+      expect(result.stderr, contains('exactly one service-suite list marker'));
     });
 
     test('rejects an exclusion without a reason', () {
@@ -230,6 +240,7 @@ void main() {
     late File manifest;
     late String scriptPath;
     late String defaultPath;
+    late String workflowParserPath;
 
     ProcessResult git(List<String> arguments) =>
         Process.runSync('git', arguments, workingDirectory: repo.path);
@@ -267,6 +278,7 @@ void main() {
         'SERVICE_SUITE_PATH_ROOT': p.join(repo.path, 'mobile'),
         'SERVICE_SUITE_MANIFEST_FILE': manifest.path,
         'SERVICE_SUITE_BASE_REF': baseRef,
+        'SERVICE_SUITE_WORKFLOW_PARSER': workflowParserPath,
         if (allowNoBase) 'SERVICE_SUITE_ALLOW_NO_BASE': '1',
       },
     );
@@ -275,6 +287,14 @@ void main() {
       repo = Directory.systemTemp.createTempSync('service_suite_base_ref_');
       expect(git(['init', '-q']).exitCode, 0);
       defaultPath = Platform.environment['PATH']!;
+      workflowParserPath = File(
+        p.join(
+          Directory.current.path,
+          'scripts',
+          'lib',
+          'service_suite_workflow_parser.dart',
+        ),
+      ).absolute.path;
       final scripts = Directory(p.join(repo.path, 'mobile', 'scripts'))
         ..createSync(recursive: true);
       final sourceScript = File(

--- a/mobile/test/tools/service_suite_scope_detector_test.dart
+++ b/mobile/test/tools/service_suite_scope_detector_test.dart
@@ -100,6 +100,94 @@ focused_suites=(
       );
     });
 
+    test('reports transitive dependencies of in-repo path packages', () {
+      fixture
+        ..writePathPackage()
+        ..writeApp(
+          'covered.dart',
+          "import 'package:local_override/entry.dart';\n",
+        )
+        ..writeSuite("import 'package:openvine/covered.dart';\n")
+        ..writeScopes(focused: ['mobile/lib/covered.dart']);
+
+      expect(
+        fixture.detect,
+        throwsA(
+          isA<ScopeDriftException>().having(
+            (error) => error.message,
+            'message',
+            contains('mobile/overrides/local_override/lib/dependency.dart'),
+          ),
+        ),
+      );
+    });
+
+    test('accepts covered in-repo path packages', () {
+      fixture
+        ..writePathPackage()
+        ..writeSuite("import 'package:local_override/entry.dart';\n")
+        ..writeScopes(focused: ['mobile/overrides/local_override/*']);
+
+      expect(fixture.detect().files, hasLength(3));
+    });
+
+    test('accepts a production dependency covered by the shared arm', () {
+      fixture
+        ..writeApp('covered.dart', "export 'shared.dart';\n")
+        ..writeApp('shared.dart', 'const value = true;\n')
+        ..writeSuite("import 'package:openvine/covered.dart';\n")
+        ..writeScopes(focused: ['mobile/lib/covered.dart']);
+      fixture.writeRawScopes(
+        File(fixture.scopes).readAsStringSync().replaceFirst(
+          'mobile/integration_test/e2e/*)',
+          'mobile/integration_test/e2e/*|mobile/lib/shared.dart)',
+        ),
+      );
+
+      expect(fixture.detect().files, hasLength(3));
+    });
+
+    test('fails on malformed path package mappings', () {
+      fixture
+        ..writeSuite('const value = true;\n')
+        ..writeScopes(focused: ['mobile/lib/*'])
+        ..writeLock('packages: {broken: {source: path, description: {}}}\n');
+
+      expect(
+        fixture.detect,
+        throwsA(
+          isA<ScopeDriftException>().having(
+            (error) => error.message,
+            'message',
+            contains('invalid path package mapping'),
+          ),
+        ),
+      );
+    });
+
+    test('fails when a path package name disagrees with its pubspec', () {
+      fixture
+        ..writePathPackage()
+        ..writeSuite("import 'package:local_override/entry.dart';\n")
+        ..writeScopes(focused: ['mobile/overrides/local_override/*']);
+      fixture.writeLock(
+        File(
+          p.join(fixture.mobile, 'pubspec.lock'),
+        ).readAsStringSync().replaceFirst('local_override:', 'wrong_name:'),
+      );
+
+      expect(
+        fixture.detect,
+        throwsA(
+          isA<ScopeDriftException>().having(
+            (error) => error.message,
+            'message',
+            contains('path package name mismatch'),
+          ),
+        ),
+      );
+    });
+
     test('walks every conditional import and export branch', () {
       fixture
         ..writeApp(
@@ -331,11 +419,36 @@ class _Fixture {
 
   void createBase() {
     _write(p.join(mobile, 'pubspec.yaml'), 'name: openvine\n');
+    _write(p.join(mobile, 'pubspec.lock'), 'packages: {}\n');
     Directory(p.join(mobile, 'packages')).createSync(recursive: true);
     writeWorkflow(_workflow());
   }
 
   void writeWorkflow(String source) => _write(workflow, source);
+
+  void writeLock(String source) =>
+      _write(p.join(mobile, 'pubspec.lock'), source);
+
+  void writePathPackage() {
+    _write(p.join(mobile, 'pubspec.lock'), '''
+packages:
+  local_override:
+    source: path
+    description:
+      path: overrides/local_override
+      relative: true
+''');
+    final directory = p.join(mobile, 'overrides', 'local_override');
+    _write(p.join(directory, 'pubspec.yaml'), 'name: local_override\n');
+    _write(
+      p.join(directory, 'lib', 'entry.dart'),
+      "export 'dependency.dart';\n",
+    );
+    _write(
+      p.join(directory, 'lib', 'dependency.dart'),
+      'const value = true;\n',
+    );
+  }
 
   void writeSuite(String source) => _write(
     p.join(mobile, 'integration_test', 'e2e', 'focused_test.dart'),

--- a/mobile/test/tools/service_suite_scope_detector_test.dart
+++ b/mobile/test/tools/service_suite_scope_detector_test.dart
@@ -1,0 +1,403 @@
+// ABOUTME: Tests fail-closed service-suite dependency-closure validation.
+// ABOUTME: Covers local URI forms, workflow parsing, and Bash scope semantics.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+// ignore: avoid_relative_lib_imports, scripts are outside lib/ and not package-importable.
+import '../../scripts/lib/service_suite_scope_detector.dart';
+// ignore: avoid_relative_lib_imports, scripts are outside lib/ and not package-importable.
+import '../../scripts/lib/service_suite_workflow_parser.dart';
+
+void main() {
+  group('service suite workflow parser', () {
+    test('keeps focused and app suite arrays distinct', () {
+      final arrays = parseServiceSuiteWorkflow(_workflow());
+
+      expect(arrays['focused_suites'], [
+        'integration_test/e2e/focused_test.dart',
+      ]);
+      expect(arrays['app_suites'], ['integration_test/e2e/app_test.dart']);
+    });
+
+    test('fails on missing markers', () {
+      expect(
+        () => parseServiceSuiteWorkflow('focused_suites=()'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('fails on duplicate arrays', () {
+      expect(
+        () => parseServiceSuiteWorkflow(
+          _workflow(
+            body: '''
+focused_suites=(
+  integration_test/e2e/first_test.dart
+)
+focused_suites=(
+  integration_test/e2e/second_test.dart
+)
+''',
+          ),
+        ),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+
+  group('service suite scope detector', () {
+    late Directory sandbox;
+    late _Fixture fixture;
+
+    setUp(() {
+      sandbox = Directory.systemTemp.createTempSync('service_scope_detector_');
+      fixture = _Fixture(sandbox.path)..createBase();
+    });
+
+    tearDown(() {
+      if (sandbox.existsSync()) sandbox.deleteSync(recursive: true);
+    });
+
+    test('accepts covered app and workspace-package dependencies', () {
+      fixture
+        ..writeApp('covered.dart', "import 'package:covered/covered.dart';\n")
+        ..writePackage('covered', 'covered.dart', 'const covered = true;\n')
+        ..writeSuite("import 'package:openvine/covered.dart';\n")
+        ..writeScopes(
+          focused: ['mobile/lib/covered.dart', 'mobile/packages/covered/*'],
+        );
+
+      final result = fixture.detect();
+
+      expect(result.files, hasLength(3));
+    });
+
+    test('reports a transitive uncovered dependency and its importer', () {
+      fixture
+        ..writeApp('covered.dart', "import 'uncovered.dart';\n")
+        ..writeApp('uncovered.dart', 'const value = true;\n')
+        ..writeSuite("import 'package:openvine/covered.dart';\n")
+        ..writeScopes(focused: ['mobile/lib/covered.dart']);
+
+      expect(
+        fixture.detect,
+        throwsA(
+          isA<ScopeDriftException>()
+              .having(
+                (error) => error.message,
+                'message',
+                contains('mobile/lib/uncovered.dart'),
+              )
+              .having(
+                (error) => error.message,
+                'message',
+                contains('imported by mobile/lib/covered.dart'),
+              ),
+        ),
+      );
+    });
+
+    test('walks every conditional import and export branch', () {
+      fixture
+        ..writeApp(
+          'covered.dart',
+          "import 'default.dart' if (dart.library.io) 'native.dart';\n"
+              "export 'export_default.dart' if (dart.library.js_interop) 'export_web.dart';\n",
+        )
+        ..writeApp('default.dart', 'const value = 1;\n')
+        ..writeApp('native.dart', 'const value = 2;\n')
+        ..writeApp('export_default.dart', 'const value = 3;\n')
+        ..writeApp('export_web.dart', 'const value = 4;\n')
+        ..writeSuite("import 'package:openvine/covered.dart';\n")
+        ..writeScopes(focused: ['mobile/lib/*']);
+
+      expect(fixture.detect().files, hasLength(6));
+    });
+
+    test('walks exports and parts but ignores part-of directives', () {
+      fixture
+        ..writeApp(
+          'covered.dart',
+          "export 'exported.dart';\npart 'piece.dart';\n",
+        )
+        ..writeApp('exported.dart', 'const exported = true;\n')
+        ..writeApp(
+          'piece.dart',
+          "part of 'covered.dart';\nconst piece = true;\n",
+        )
+        ..writeSuite("import 'package:openvine/covered.dart';\n")
+        ..writeScopes(focused: ['mobile/lib/*']);
+
+      expect(fixture.detect().files, hasLength(4));
+    });
+
+    test('fails when focused suites are missing', () {
+      fixture
+        ..writeWorkflow(
+          _workflow(
+            body: 'app_suites=(\n  integration_test/e2e/app_test.dart\n)',
+          ),
+        )
+        ..writeScopes(focused: ['mobile/lib/*']);
+
+      expect(
+        fixture.detect,
+        throwsA(
+          isA<ScopeDriftException>().having(
+            (error) => error.message,
+            'message',
+            contains('focused_suites array is missing or empty'),
+          ),
+        ),
+      );
+    });
+
+    test('fails on a missing scope marker pair', () {
+      fixture
+        ..writeSuite("import 'package:openvine/covered.dart';\n")
+        ..writeApp('covered.dart', 'const value = true;\n')
+        ..writeRawScopes('case "\$path" in\nmobile/lib/*) ;;\nesac\n');
+
+      expect(
+        fixture.detect,
+        throwsA(
+          isA<ScopeDriftException>().having(
+            (error) => error.message,
+            'message',
+            contains('exactly one ordered marker pair'),
+          ),
+        ),
+      );
+    });
+
+    test('fails on duplicate workspace package names', () {
+      fixture
+        ..writePackage(
+          'first',
+          'first.dart',
+          'const first = true;\n',
+          packageName: 'duplicate',
+        )
+        ..writePackage(
+          'second',
+          'second.dart',
+          'const second = true;\n',
+          packageName: 'duplicate',
+        )
+        ..writeSuite("import 'package:openvine/covered.dart';\n")
+        ..writeApp('covered.dart', 'const value = true;\n')
+        ..writeScopes(focused: ['mobile/lib/*']);
+
+      expect(
+        fixture.detect,
+        throwsA(
+          isA<ScopeDriftException>().having(
+            (error) => error.message,
+            'message',
+            contains('duplicate workspace package name: duplicate'),
+          ),
+        ),
+      );
+    });
+
+    test('fails on a missing local import target', () {
+      fixture
+        ..writeSuite("import 'package:openvine/missing.dart';\n")
+        ..writeScopes(focused: ['mobile/lib/*']);
+
+      expect(
+        fixture.detect,
+        throwsA(
+          isA<ScopeDriftException>().having(
+            (error) => error.message,
+            'message',
+            contains('references missing local file mobile/lib/missing.dart'),
+          ),
+        ),
+      );
+    });
+
+    test('fails on unparseable Dart', () {
+      fixture
+        ..writeSuite("import 'package:openvine/covered.dart';\n")
+        ..writeApp('covered.dart', 'void broken( {\n')
+        ..writeScopes(focused: ['mobile/lib/*']);
+
+      expect(
+        fixture.detect,
+        throwsA(
+          isA<ScopeDriftException>().having(
+            (error) => error.message,
+            'message',
+            contains('Dart parse failed for mobile/lib/covered.dart'),
+          ),
+        ),
+      );
+    });
+
+    test('fails when a relative URI escapes the repository', () {
+      fixture
+        ..writeSuite("import '../../../../outside.dart';\n")
+        ..writeScopes(focused: ['mobile/lib/*']);
+
+      expect(
+        fixture.detect,
+        throwsA(
+          isA<ScopeDriftException>().having(
+            (error) => error.message,
+            'message',
+            contains('escapes the repository'),
+          ),
+        ),
+      );
+    });
+
+    test('fails on unsupported Bash case constructs', () {
+      fixture
+        ..writeSuite("import 'package:openvine/covered.dart';\n")
+        ..writeApp('covered.dart', 'const value = true;\n')
+        ..writeScopes(focused: ['mobile/lib/covered?.dart']);
+
+      expect(
+        fixture.detect,
+        throwsA(
+          isA<ScopeDriftException>().having(
+            (error) => error.message,
+            'message',
+            contains('unsupported Bash case pattern'),
+          ),
+        ),
+      );
+    });
+
+    test('fails when a focused scope pattern is stale', () {
+      fixture
+        ..writeSuite("import 'package:openvine/covered.dart';\n")
+        ..writeApp('covered.dart', 'const value = true;\n')
+        ..writeScopes(
+          focused: ['mobile/lib/covered.dart', 'mobile/packages/unused/*'],
+        );
+
+      expect(
+        fixture.detect,
+        throwsA(
+          isA<ScopeDriftException>().having(
+            (error) => error.message,
+            'message',
+            contains(
+              'stale focused scope patterns:\n  mobile/packages/unused/*',
+            ),
+          ),
+        ),
+      );
+    });
+
+    test('current repository closure is fully covered', () {
+      final mobileRoot = Directory.current.absolute.path;
+      final repoRoot = p.dirname(mobileRoot);
+
+      final result = detectServiceSuiteScope(
+        repoRoot: repoRoot,
+        workflowPath: p.join(
+          repoRoot,
+          '.github',
+          'workflows',
+          'mobile_service_integration_tests.yaml',
+        ),
+        scopeScriptPath: p.join(
+          mobileRoot,
+          'scripts',
+          'ci',
+          'detect_service_suite_scope.sh',
+        ),
+      );
+
+      expect(result.files, isNotEmpty);
+    });
+  });
+}
+
+class _Fixture {
+  _Fixture(this.root);
+
+  final String root;
+
+  String get mobile => p.join(root, 'mobile');
+  String get workflow => p.join(root, '.github', 'workflows', 'service.yaml');
+  String get scopes => p.join(mobile, 'scripts', 'ci', 'scope.sh');
+
+  void createBase() {
+    _write(p.join(mobile, 'pubspec.yaml'), 'name: openvine\n');
+    Directory(p.join(mobile, 'packages')).createSync(recursive: true);
+    writeWorkflow(_workflow());
+  }
+
+  void writeWorkflow(String source) => _write(workflow, source);
+
+  void writeSuite(String source) => _write(
+    p.join(mobile, 'integration_test', 'e2e', 'focused_test.dart'),
+    source,
+  );
+
+  void writeApp(String relative, String source) =>
+      _write(p.join(mobile, 'lib', relative), source);
+
+  void writePackage(
+    String directory,
+    String relative,
+    String source, {
+    String? packageName,
+  }) {
+    final root = p.join(mobile, 'packages', directory);
+    _write(p.join(root, 'pubspec.yaml'), 'name: ${packageName ?? directory}\n');
+    _write(p.join(root, 'lib', relative), source);
+  }
+
+  void writeScopes({required List<String> focused}) {
+    writeRawScopes('''
+case "\$path" in
+  # SHARED_SCOPE_START
+  mobile/integration_test/e2e/*)
+  # SHARED_SCOPE_END
+    ;;
+esac
+case "\$path" in
+  # FOCUSED_SCOPE_START
+  ${focused.join('|\\\n  ')})
+  # FOCUSED_SCOPE_END
+    ;;
+esac
+''');
+  }
+
+  void writeRawScopes(String source) => _write(scopes, source);
+
+  ServiceSuiteScopeResult detect() => detectServiceSuiteScope(
+    repoRoot: root,
+    workflowPath: workflow,
+    scopeScriptPath: scopes,
+  );
+
+  void _write(String path, String source) {
+    final file = File(path)..parent.createSync(recursive: true);
+    file.writeAsStringSync(source);
+  }
+}
+
+String _workflow({String? body}) {
+  const defaultBody = '''
+focused_suites=(
+  integration_test/e2e/focused_test.dart
+)
+app_suites=(
+  integration_test/e2e/app_test.dart
+)''';
+  return '''
+# SERVICE_SUITE_LIST_START
+${body ?? defaultBody}
+# SERVICE_SUITE_LIST_END
+''';
+}


### PR DESCRIPTION
Focused headless service tests are selected from a hand-maintained dependency scope. When a suite imported a new app file or workspace package outside that scope, later changes to the dependency could skip the affected tests while CI stayed green.

This adds a Generated Files guard that parses the focused suite list, walks every local Dart import, conditional import, export, and part, and compares the resulting closure with the Bash case patterns used by the selector. It resolves both workspace packages and in-repo path dependencies recorded in the lockfile, and accepts dependencies covered by either shared or focused selector patterns. It fails closed for malformed source or configuration, reports uncovered dependencies with their importer, and also rejects stale focused patterns. The workflow suite parser is shared with the existing coverage guard so the two checks cannot interpret the same arrays differently.

The broad app-connected suite scope is unchanged. Runtime-only dependency declarations are intentionally not introduced because the current closure is fully represented by static Dart references.

Verification:
- 46 affected tool tests; 44 rerun locally on the rebased head, with the two fetch-fallback fixtures left to CI
- CI-declared Flutter analysis and separate analysis of the changed Dart scripts pass; broad local analysis reports two documentation infos in unchanged utility scripts
- service-suite scope guard: 337 files covered
- service-suite coverage guard: 13 included, 5 excluded
- Codex configuration checks and 81 CI configuration tests pass
- all 21 current-head GitHub checks pass, including Generated Files, four test shards, and service integration tests

Closes #8848
