### PR TITLE
fix(curation): stop the provider from staying stuck in loading state

### DIFF
--- a/mobile/lib/providers/curation_providers.dart
+++ b/mobile/lib/providers/curation_providers.dart
@@ -137,13 +137,14 @@ class Curation extends _$Curation {
       }
     });
 
-    // Initialize with empty state
-    _initializeCuration();
-
-    return const CurationState(editorsPicks: [], isLoading: true);
+    return _initialCurationState();
   }
 
-  Future<void> _initializeCuration() async {
+  /// Reads the caches [CurationRepository] populates in its constructor.
+  ///
+  /// Returned rather than assigned to `state`: the read is synchronous, so an
+  /// assignment here is immediately overwritten by whatever `build` returns.
+  CurationState _initialCurationState() {
     try {
       final service = ref.read(curationRepositoryProvider);
 
@@ -153,18 +154,17 @@ class Curation extends _$Curation {
         category: LogCategory.system,
       );
 
-      // CurationRepository initializes itself in constructor
-      // Just get the current data
-      state = CurationState(
-        editorsPicks: service.getVideosForSetType(CurationSetType.editorsPicks),
-        isLoading: false,
+      final editorsPicks = service.getVideosForSetType(
+        CurationSetType.editorsPicks,
       );
 
       Log.info(
-        'Curation: Loaded ${state.editorsPicks.length} editor picks',
+        'Curation: Loaded ${editorsPicks.length} editor picks',
         name: 'CurationProvider',
         category: LogCategory.system,
       );
+
+      return CurationState(editorsPicks: editorsPicks, isLoading: false);
     } catch (e) {
       Log.error(
         'Curation: Initialization error: $e',
@@ -172,8 +172,8 @@ class Curation extends _$Curation {
         category: LogCategory.system,
       );
 
-      state = CurationState(
-        editorsPicks: [],
+      return CurationState(
+        editorsPicks: const [],
         isLoading: false,
         error: e.toString(),
       );

--- a/mobile/lib/providers/curation_providers.g.dart
+++ b/mobile/lib/providers/curation_providers.g.dart
@@ -175,7 +175,7 @@ final class CurationProvider
   }
 }
 
-String _$curationHash() => r'ad00dcafab8d01dc071511cb8113aa32c985aef3';
+String _$curationHash() => r'997d7c7eee62ed0d110655bcaea3b4f91de9ecb9';
 
 /// Main curation provider that manages curated content sets
 /// keepAlive ensures provider persists across tab navigation

--- a/mobile/scripts/baseline/future_delayed_test_counts.txt
+++ b/mobile/scripts/baseline/future_delayed_test_counts.txt
@@ -80,7 +80,6 @@ test/providers/auth_rpc_capability_provider_test.dart	1
 test/providers/broken_video_tracker_identity_test.dart	1
 test/providers/bug_report_providers_test.dart	1
 test/providers/crossposting_providers_test.dart	1
-test/providers/curation_provider_lifecycle_test.dart	1
 test/providers/curation_provider_tab_refresh_test.dart	2
 test/providers/deep_link_provider_test.dart	3
 test/providers/dm_repository_provider_test.dart	4

--- a/mobile/scripts/baseline/future_delayed_test_counts.txt
+++ b/mobile/scripts/baseline/future_delayed_test_counts.txt
@@ -80,7 +80,6 @@ test/providers/auth_rpc_capability_provider_test.dart	1
 test/providers/broken_video_tracker_identity_test.dart	1
 test/providers/bug_report_providers_test.dart	1
 test/providers/crossposting_providers_test.dart	1
-test/providers/curation_provider_tab_refresh_test.dart	2
 test/providers/deep_link_provider_test.dart	3
 test/providers/dm_repository_provider_test.dart	4
 test/providers/feed_background_preservation_test.dart	8

--- a/mobile/scripts/baseline/skip_test_ceilings.txt
+++ b/mobile/scripts/baseline/skip_test_ceilings.txt
@@ -16,8 +16,6 @@
 # Fix a skip rather than regenerating this file. Skip-debt epic: #4337 (WS-1).
 packages/blossom_upload_service/test/src/blossom_upload_service_test.dart	3 # delete: uploadImage returns extensionless canonical blossom url (#4836)
 test/infrastructure/drift_setup_test.dart	1 # delete: asserts schemaVersion 6, now 9; db_client owns migrations (#4836)
-test/providers/curation_provider_lifecycle_test.dart	2 # rewrite: mock authservice lacks authstatestream, init errors out (#4836)
-test/providers/curation_provider_tab_refresh_test.dart	1 # rewrite: unstubbed authstatestream, no videoevent fallback value (#4836)
 test/providers/readiness_gate_providers_test.dart	1 # delete: appready no longer gates on nostr, only on foreground (#4836)
 test/providers/seen_videos_notifier_test.dart	1 # rewrite: races hydration, load lands after the 100ms expect (#4836)
 test/providers/video_events_provider_fresh_test.dart	1 # quarantine: real relay via realintegrationtesthelper, 40s timeout (#4836)

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -25,6 +25,7 @@ import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/services/analytics_service.dart';
+import 'package:openvine/services/auth/nostr_identity.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/background_activity_manager.dart';
 import 'package:openvine/services/moderation_label_service.dart';
@@ -153,6 +154,13 @@ MockAuthService createMockAuthService({
   when(
     () => mockAuth.authStateStream,
   ).thenAnswer((_) => const Stream<AuthState>.empty());
+
+  // Providers built from an authenticated identity read requireIdentity, which
+  // throws on the real service and returned null here. A pubkey-only identity
+  // keeps those providers constructible without granting signing ability.
+  when(() => mockAuth.requireIdentity).thenReturn(
+    PubkeyOnlyNostrIdentity(pubkey: currentPublicKeyHex ?? 'a' * 64),
+  );
   _stubSessionCleanupRegistration(mockAuth);
 
   return mockAuth;

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -16,7 +16,6 @@ import 'package:nostr_sdk/event.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/auth_rpc_capability.dart';
-import 'package:openvine/models/known_account.dart';
 import 'package:openvine/models/signer_readiness.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/app_version_provider.dart';
@@ -129,8 +128,6 @@ MockAuthService createMockAuthService({
     () => mockAuth.isAuthenticated,
   ).thenReturn(authState == AuthState.authenticated);
   when(() => mockAuth.canExportLocalNsec).thenReturn(false);
-  when(() => mockAuth.isAnonymous).thenReturn(false);
-  when(() => mockAuth.hasExpiredOAuthSession).thenReturn(false);
   when(
     () => mockAuth.authenticationSource,
   ).thenReturn(AuthenticationSource.none);
@@ -156,8 +153,6 @@ MockAuthService createMockAuthService({
   when(
     () => mockAuth.authStateStream,
   ).thenAnswer((_) => const Stream<AuthState>.empty());
-  when(mockAuth.getKnownAccounts).thenAnswer((_) async => <KnownAccount>[]);
-  when(mockAuth.getSessionRecoveryAnchorNpub).thenAnswer((_) async => null);
   _stubSessionCleanupRegistration(mockAuth);
 
   return mockAuth;
@@ -180,14 +175,6 @@ MockNostrClient createMockNostrService() {
   when(() => mockNostr.hasKeys).thenReturn(false);
   when(() => mockNostr.connectedRelayCount).thenReturn(1);
   when(() => mockNostr.configuredRelays).thenReturn(<String>[]);
-  when(
-    () => mockNostr.relayStatuses,
-  ).thenReturn(<String, RelayConnectionStatus>{});
-  when(
-    () => mockNostr.relayStatusStream,
-  ).thenAnswer(
-    (_) => const Stream<Map<String, RelayConnectionStatus>>.empty(),
-  );
 
   // Stub subscribe() to return empty stream (never null) so
   // SubscriptionManager batch fetch does not get

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -16,6 +16,7 @@ import 'package:nostr_sdk/event.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/auth_rpc_capability.dart';
+import 'package:openvine/models/known_account.dart';
 import 'package:openvine/models/signer_readiness.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/app_version_provider.dart';
@@ -128,6 +129,8 @@ MockAuthService createMockAuthService({
     () => mockAuth.isAuthenticated,
   ).thenReturn(authState == AuthState.authenticated);
   when(() => mockAuth.canExportLocalNsec).thenReturn(false);
+  when(() => mockAuth.isAnonymous).thenReturn(false);
+  when(() => mockAuth.hasExpiredOAuthSession).thenReturn(false);
   when(
     () => mockAuth.authenticationSource,
   ).thenReturn(AuthenticationSource.none);
@@ -153,6 +156,8 @@ MockAuthService createMockAuthService({
   when(
     () => mockAuth.authStateStream,
   ).thenAnswer((_) => const Stream<AuthState>.empty());
+  when(mockAuth.getKnownAccounts).thenAnswer((_) async => <KnownAccount>[]);
+  when(mockAuth.getSessionRecoveryAnchorNpub).thenAnswer((_) async => null);
   _stubSessionCleanupRegistration(mockAuth);
 
   return mockAuth;
@@ -175,6 +180,14 @@ MockNostrClient createMockNostrService() {
   when(() => mockNostr.hasKeys).thenReturn(false);
   when(() => mockNostr.connectedRelayCount).thenReturn(1);
   when(() => mockNostr.configuredRelays).thenReturn(<String>[]);
+  when(
+    () => mockNostr.relayStatuses,
+  ).thenReturn(<String, RelayConnectionStatus>{});
+  when(
+    () => mockNostr.relayStatusStream,
+  ).thenAnswer(
+    (_) => const Stream<Map<String, RelayConnectionStatus>>.empty(),
+  );
 
   // Stub subscribe() to return empty stream (never null) so
   // SubscriptionManager batch fetch does not get

--- a/mobile/test/helpers/test_provider_overrides_test.dart
+++ b/mobile/test/helpers/test_provider_overrides_test.dart
@@ -22,12 +22,16 @@ void main() {
       });
     }
 
-    test('defaults to an unauthenticated session without a public key', () {
+    test('defaults to an inert unauthenticated session', () async {
       final auth = createMockAuthService();
 
       expect(auth.authState, AuthState.unauthenticated);
       expect(auth.isAuthenticated, isFalse);
       expect(auth.currentPublicKeyHex, isNull);
+      expect(auth.isAnonymous, isFalse);
+      expect(auth.hasExpiredOAuthSession, isFalse);
+      expect(await auth.getKnownAccounts(), isEmpty);
+      expect(await auth.getSessionRecoveryAnchorNpub(), isNull);
     });
 
     test('accepts an authenticated state and public key together', () {

--- a/mobile/test/helpers/test_provider_overrides_test.dart
+++ b/mobile/test/helpers/test_provider_overrides_test.dart
@@ -22,16 +22,12 @@ void main() {
       });
     }
 
-    test('defaults to an inert unauthenticated session', () async {
+    test('defaults to an unauthenticated session without a public key', () {
       final auth = createMockAuthService();
 
       expect(auth.authState, AuthState.unauthenticated);
       expect(auth.isAuthenticated, isFalse);
       expect(auth.currentPublicKeyHex, isNull);
-      expect(auth.isAnonymous, isFalse);
-      expect(auth.hasExpiredOAuthSession, isFalse);
-      expect(await auth.getKnownAccounts(), isEmpty);
-      expect(await auth.getSessionRecoveryAnchorNpub(), isNull);
     });
 
     test('accepts an authenticated state and public key together', () {

--- a/mobile/test/providers/curation_provider_lifecycle_test.dart
+++ b/mobile/test/providers/curation_provider_lifecycle_test.dart
@@ -13,9 +13,9 @@ import 'package:nostr_sdk/filter.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/curation_providers.dart';
-import 'package:openvine/providers/nostr_client_provider.dart';
-import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/video_event_service.dart';
+
+import '../helpers/test_provider_overrides.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 
@@ -23,13 +23,13 @@ class _MockVideoEventService extends Mock implements VideoEventService {}
 
 class _MockLikesRepository extends Mock implements LikesRepository {}
 
-class _MockAuthService extends Mock implements AuthService {}
-
 class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
 
 class _MockNostrSigner extends Mock implements NostrSigner {}
 
 class _MockVideoEventCache extends Mock implements VideoEventCache {}
+
+class _MockCurationRepository extends Mock implements CurationRepository {}
 
 void main() {
   setUpAll(() {
@@ -41,16 +41,18 @@ void main() {
     late _MockNostrClient mockNostrService;
     late _MockVideoEventService mockVideoEventService;
     late _MockLikesRepository mockLikesRepository;
-    late _MockAuthService mockAuthService;
+    late MockAuthService mockAuthService;
     late _MockFunnelcakeApiClient mockFunnelcakeApiClient;
+    late _MockCurationRepository mockCurationRepository;
     late List<VideoEvent> sampleVideos;
 
     setUp(() {
       mockNostrService = _MockNostrClient();
       mockVideoEventService = _MockVideoEventService();
       mockLikesRepository = _MockLikesRepository();
-      mockAuthService = _MockAuthService();
+      mockAuthService = createMockAuthService();
       mockFunnelcakeApiClient = _MockFunnelcakeApiClient();
+      mockCurationRepository = _MockCurationRepository();
 
       // Create sample videos for editor's picks
       sampleVideos = List.generate(
@@ -80,87 +82,83 @@ void main() {
       when(
         () => mockLikesRepository.getLikeCounts(any()),
       ).thenAnswer((_) async => {});
+      when(
+        () => mockCurationRepository.getVideosForSetType(
+          CurationSetType.editorsPicks,
+        ),
+      ).thenReturn(sampleVideos);
     });
 
     test('curation provider uses keepAlive to persist state', () async {
       // ARRANGE: Create first container
       final container = ProviderContainer(
         overrides: [
-          nostrServiceProvider.overrideWithValue(mockNostrService),
+          ...getStandardTestOverrides(
+            mockAuthService: mockAuthService,
+            mockNostrService: mockNostrService,
+          ),
           videoEventServiceProvider.overrideWithValue(mockVideoEventService),
-          authServiceProvider.overrideWithValue(mockAuthService),
+          curationRepositoryProvider.overrideWithValue(
+            mockCurationRepository,
+          ),
           funnelcakeApiClientProvider.overrideWithValue(
             mockFunnelcakeApiClient,
           ),
         ],
       );
 
-      // ACT: Read curation provider
-      final curationState = container.read(curationProvider);
+      final subscription = container.listen(curationProvider, (_, _) {});
+      await container.read(curationProvider.notifier).refreshAll();
+      final populatedState = container.read(curationProvider);
 
-      // ASSERT: Provider should initialize synchronously
-      // with loading state
-      expect(
-        curationState.isLoading,
-        isTrue,
-        reason: 'Provider initializes in loading state',
+      subscription.close();
+      await pumpEventQueue();
+
+      expect(container.read(curationProvider), same(populatedState));
+      expect(populatedState.editorsPicks, sampleVideos);
+
+      await pumpEventQueue();
+      container.dispose();
+    });
+
+    test('curation provider initialization completes and populates '
+        'editor picks', () async {
+      // ARRANGE: Create container
+      final container = ProviderContainer(
+        overrides: [
+          ...getStandardTestOverrides(
+            mockAuthService: mockAuthService,
+            mockNostrService: mockNostrService,
+          ),
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          curationRepositoryProvider.overrideWithValue(
+            mockCurationRepository,
+          ),
+          funnelcakeApiClientProvider.overrideWithValue(
+            mockFunnelcakeApiClient,
+          ),
+        ],
       );
 
-      // The key point: with @Riverpod(keepAlive: true),
-      // the provider will:
-      // 1. NOT autodispose when unwatched
-      // 2. Persist state across navigation
-      // 3. Complete initialization once and reuse that state
+      // ACT: Read initial state
+      final initialState = container.read(curationProvider);
 
-      // This test verifies the annotation is present and
-      // provider is marked as keepAlive
-      // In production, this prevents the "0 videos" bug when
-      // navigating back to Editor's Pick
+      // ASSERT: Initially loading
+      expect(initialState.isLoading, isTrue);
+      expect(initialState.editorsPicks, isEmpty);
 
+      await container.read(curationProvider.notifier).refreshAll();
+
+      // ACT: Read after initialization
+      final loadedState = container.read(curationProvider);
+      final editorsPicks = container.read(editorsPicksProvider);
+
+      expect(loadedState.editorsPicks, sampleVideos);
+      expect(editorsPicks, sampleVideos);
+
+      await pumpEventQueue();
       container.dispose();
-      // TODO(any): Fix and re-enable this test
-    }, skip: true);
-
-    test(
-      'curation provider initialization completes and populates '
-      'editor picks',
-      () async {
-        // ARRANGE: Create container
-        final container = ProviderContainer(
-          overrides: [
-            nostrServiceProvider.overrideWithValue(mockNostrService),
-            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
-            authServiceProvider.overrideWithValue(mockAuthService),
-            funnelcakeApiClientProvider.overrideWithValue(
-              mockFunnelcakeApiClient,
-            ),
-          ],
-        );
-
-        // ACT: Read initial state
-        final initialState = container.read(curationProvider);
-
-        // ASSERT: Initially loading
-        expect(initialState.isLoading, isTrue);
-        expect(initialState.editorsPicks, isEmpty);
-
-        // Wait for async initialization
-        await Future.microtask(() {});
-        await Future.delayed(const Duration(milliseconds: 10));
-
-        // ACT: Read after initialization
-        final loadedState = container.read(curationProvider);
-        final editorsPicks = container.read(editorsPicksProvider);
-
-        // ASSERT: Should be loaded with videos
-        expect(loadedState.isLoading, isFalse);
-        expect(editorsPicks.length, greaterThan(0));
-
-        container.dispose();
-      },
-      // TODO(any): Fix and re-enable this test
-      skip: true,
-    );
+    });
 
     test('curation service initializes with sample data', () {
       // ARRANGE: Create curation service directly

--- a/mobile/test/providers/curation_provider_lifecycle_test.dart
+++ b/mobile/test/providers/curation_provider_lifecycle_test.dart
@@ -1,10 +1,11 @@
-// ABOUTME: Tests curation provider lifecycle behavior during navigation
-// ABOUTME: Verifies editor's picks persist when navigating away and back to tab
+// ABOUTME: Tests curation provider lifecycle: build, keepAlive and auto-refresh
+// ABOUTME: Verifies editor's picks survive navigating away from and back to tab
+
+import 'dart:async';
 
 import 'package:curation_repository/curation_repository.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
@@ -13,17 +14,14 @@ import 'package:nostr_sdk/filter.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/curation_providers.dart';
-import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/providers/video_events_providers.dart';
 
+import '../helpers/test_helpers.dart';
 import '../helpers/test_provider_overrides.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 
-class _MockVideoEventService extends Mock implements VideoEventService {}
-
 class _MockLikesRepository extends Mock implements LikesRepository {}
-
-class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
 
 class _MockNostrSigner extends Mock implements NostrSigner {}
 
@@ -31,160 +29,164 @@ class _MockVideoEventCache extends Mock implements VideoEventCache {}
 
 class _MockCurationRepository extends Mock implements CurationRepository {}
 
+/// Lets a test drive the `videoEventsProvider` that `Curation.build` listens
+/// to, so the auto-refresh path can be exercised rather than left in
+/// `AsyncError` by an unstubbed service.
+class _ControllableVideoEvents extends VideoEvents {
+  _ControllableVideoEvents(this.controller);
+
+  final StreamController<List<VideoEvent>> controller;
+
+  @override
+  Stream<List<VideoEvent>> build() => controller.stream;
+}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(<Filter>[]);
-    registerFallbackValue(<String>[]);
   });
 
-  group('CurationProvider Lifecycle', () {
-    late _MockNostrClient mockNostrService;
-    late _MockVideoEventService mockVideoEventService;
-    late _MockLikesRepository mockLikesRepository;
-    late MockAuthService mockAuthService;
-    late _MockFunnelcakeApiClient mockFunnelcakeApiClient;
+  group('CurationProvider lifecycle', () {
     late _MockCurationRepository mockCurationRepository;
-    late List<VideoEvent> sampleVideos;
+    late MockAuthService mockAuthService;
+    late StreamController<List<VideoEvent>> videoEvents;
 
     setUp(() {
-      mockNostrService = _MockNostrClient();
-      mockVideoEventService = _MockVideoEventService();
-      mockLikesRepository = _MockLikesRepository();
-      mockAuthService = createMockAuthService();
-      mockFunnelcakeApiClient = _MockFunnelcakeApiClient();
       mockCurationRepository = _MockCurationRepository();
+      mockAuthService = createMockAuthService();
+      videoEvents = StreamController<List<VideoEvent>>.broadcast();
+      addTearDown(videoEvents.close);
+    });
 
-      // Create sample videos for editor's picks
-      sampleVideos = List.generate(
-        23,
-        (i) => VideoEvent(
-          id: 'video_$i',
-          pubkey: 'pubkey_$i',
-          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-          content: 'Test video $i',
-          timestamp: DateTime.now(),
-          title: 'Video $i',
-        ),
-      );
-
-      // Mock video event service to return sample videos
-      when(
-        () => mockVideoEventService.discoveryVideos,
-      ).thenReturn(sampleVideos);
-
-      // Stub nostr service methods
-      when(
-        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
-      ).thenAnswer((_) => const Stream.empty());
-
-      // Mock getLikeCounts to return empty counts
-      // (replaced getCachedLikeCount)
-      when(
-        () => mockLikesRepository.getLikeCounts(any()),
-      ).thenAnswer((_) async => {});
+    void stubEditorsPicks(List<VideoEvent> videos) {
       when(
         () => mockCurationRepository.getVideosForSetType(
           CurationSetType.editorsPicks,
         ),
-      ).thenReturn(sampleVideos);
-    });
+      ).thenReturn(videos);
+    }
 
-    test('curation provider uses keepAlive to persist state', () async {
-      // ARRANGE: Create first container
+    ProviderContainer createContainer() {
       final container = ProviderContainer(
         overrides: [
-          ...getStandardTestOverrides(
-            mockAuthService: mockAuthService,
-            mockNostrService: mockNostrService,
-          ),
-          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
-          curationRepositoryProvider.overrideWithValue(
-            mockCurationRepository,
-          ),
-          funnelcakeApiClientProvider.overrideWithValue(
-            mockFunnelcakeApiClient,
+          ...getStandardTestOverrides(mockAuthService: mockAuthService),
+          curationRepositoryProvider.overrideWithValue(mockCurationRepository),
+          videoEventsProvider.overrideWith(
+            () => _ControllableVideoEvents(videoEvents),
           ),
         ],
       );
+      addTearDown(container.dispose);
+      return container;
+    }
 
+    test('build publishes the repository cache on the first read', () {
+      final cached = TestHelpers.createMockVideoEvents(23);
+      stubEditorsPicks(cached);
+
+      final container = createContainer();
+      final state = container.read(curationProvider);
+
+      expect(state.editorsPicks, hasLength(23));
+      expect(
+        state.editorsPicks.map((v) => v.title).toList(),
+        cached.map((v) => v.title).toList(),
+        reason: 'VideoEvent == compares id alone, so pin a carried field too',
+      );
+      expect(
+        state.isLoading,
+        isFalse,
+        reason: 'the repository read is synchronous, so nothing stays pending',
+      );
+      expect(state.error, isNull);
+      expect(container.read(curationLoadingProvider), isFalse);
+      expect(container.read(editorsPicksProvider), hasLength(23));
+    });
+
+    test('a failing repository read leaves an error, not a stuck spinner', () {
+      when(
+        () => mockCurationRepository.getVideosForSetType(
+          CurationSetType.editorsPicks,
+        ),
+      ).thenThrow(StateError('no signer'));
+
+      final container = createContainer();
+      final state = container.read(curationProvider);
+
+      expect(state.error, contains('no signer'));
+      expect(state.editorsPicks, isEmpty);
+      expect(
+        state.isLoading,
+        isFalse,
+        reason: 'a failed load must not leave the tab spinning forever',
+      );
+    });
+
+    test('keepAlive holds the state after the last listener closes', () async {
+      final cached = TestHelpers.createMockVideoEvents(23);
+      stubEditorsPicks(cached);
+      when(mockCurationRepository.refreshIfNeeded).thenReturn(null);
+
+      final container = createContainer();
       final subscription = container.listen(curationProvider, (_, _) {});
       await container.read(curationProvider.notifier).refreshAll();
       final populatedState = container.read(curationProvider);
+      expect(populatedState.editorsPicks, hasLength(23));
 
       subscription.close();
       await pumpEventQueue();
 
       expect(container.read(curationProvider), same(populatedState));
-      expect(populatedState.editorsPicks, sampleVideos);
-
-      await pumpEventQueue();
-      container.dispose();
     });
 
-    test('curation provider initialization completes and populates '
-        'editor picks', () async {
-      // ARRANGE: Create container
-      final container = ProviderContainer(
-        overrides: [
-          ...getStandardTestOverrides(
-            mockAuthService: mockAuthService,
-            mockNostrService: mockNostrService,
-          ),
-          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
-          curationRepositoryProvider.overrideWithValue(
-            mockCurationRepository,
-          ),
-          funnelcakeApiClientProvider.overrideWithValue(
-            mockFunnelcakeApiClient,
-          ),
-        ],
-      );
+    test(
+      'a change in the video event count refreshes the curation sets',
+      () async {
+        stubEditorsPicks([]);
+        when(mockCurationRepository.refreshIfNeeded).thenReturn(null);
 
-      // ACT: Read initial state
-      final initialState = container.read(curationProvider);
+        final container = createContainer();
+        // Riverpod pauses a stream subscription while nothing is actively
+        // listening, so a bare read would never see the emission below.
+        final subscription = container.listen(curationProvider, (_, _) {});
+        addTearDown(subscription.close);
 
-      // ASSERT: Initially loading
-      expect(initialState.isLoading, isTrue);
-      expect(initialState.editorsPicks, isEmpty);
+        expect(container.read(curationProvider).editorsPicks, isEmpty);
+        verifyNever(mockCurationRepository.refreshIfNeeded);
 
-      await container.read(curationProvider.notifier).refreshAll();
+        final arrived = TestHelpers.createMockVideoEvents(3);
+        stubEditorsPicks(arrived);
+        videoEvents.add(TestHelpers.createMockVideoEvents(2));
+        await pumpEventQueue();
 
-      // ACT: Read after initialization
-      final loadedState = container.read(curationProvider);
-      final editorsPicks = container.read(editorsPicksProvider);
+        verify(mockCurationRepository.refreshIfNeeded).called(1);
+        expect(container.read(curationProvider).editorsPicks, hasLength(3));
+      },
+    );
 
-      expect(loadedState.editorsPicks, sampleVideos);
-      expect(editorsPicks, sampleVideos);
-
-      await pumpEventQueue();
-      container.dispose();
-    });
-
-    test('curation service initializes with sample data', () {
-      // ARRANGE: Create curation service directly
-      final mockSigner = _MockNostrSigner();
+    test('CurationRepository reports no work pending once constructed', () {
+      final mockNostrService = _MockNostrClient();
+      when(
+        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+      ).thenAnswer((_) => const Stream.empty());
       final mockVideoEventCache = _MockVideoEventCache();
       when(() => mockVideoEventCache.discoveryVideos).thenReturn([]);
+
       final service = CurationRepository(
         nostrService: mockNostrService,
         videoEventCache: mockVideoEventCache,
-        likesRepository: mockLikesRepository,
-        signer: mockSigner,
+        likesRepository: _MockLikesRepository(),
+        signer: _MockNostrSigner(),
         divineTeamPubkeys: const [],
       );
+      addTearDown(service.dispose);
 
-      // ACT & ASSERT: Service should initialize with sample data
       expect(service.isLoading, isFalse);
-      final editorsPicks = service.getVideosForSetType(
-        CurationSetType.editorsPicks,
+      expect(
+        service.getVideosForSetType(CurationSetType.editorsPicks),
+        isEmpty,
+        reason: 'the Divine Team fetch has not returned, so nothing is curated',
       );
-
-      // Editor's picks may be empty if no videos available,
-      // but service should not be loading
-      expect(service.isLoading, isFalse);
-      // Verify editorsPicks is a valid list
-      // (may be empty if no videos available)
-      expect(editorsPicks, isA<List<VideoEvent>>());
     });
   });
 }

--- a/mobile/test/providers/curation_provider_tab_refresh_test.dart
+++ b/mobile/test/providers/curation_provider_tab_refresh_test.dart
@@ -1,215 +1,159 @@
-// ABOUTME: Tests that curation provider refreshes when Editor's Pick tab becomes active
-// ABOUTME: Verifies the fix for videos showing blank when navigating from video back to tab
+// ABOUTME: Tests that the curation provider re-reads editor's picks on refresh
+// ABOUTME: Covers the tab-return path that left Editor's Pick blank after nav
 
 import 'package:curation_repository/curation_repository.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:funnelcake_api_client/funnelcake_api_client.dart';
-import 'package:likes_repository/likes_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
-import 'package:nostr_client/nostr_client.dart';
-import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/curation_providers.dart';
-import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/providers/video_events_providers.dart';
 
+import '../helpers/test_helpers.dart';
 import '../helpers/test_provider_overrides.dart';
-
-class _MockNostrClient extends Mock implements NostrClient {}
-
-class _MockVideoEventService extends Mock implements VideoEventService {}
-
-class _MockLikesRepository extends Mock implements LikesRepository {}
-
-class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
 
 class _MockCurationRepository extends Mock implements CurationRepository {}
 
-class _FakeVideoEvent extends Fake implements VideoEvent {}
+/// Emits nothing, so the `videoEventsProvider` listener in `Curation.build`
+/// cannot fire and add refresh calls this file's `verify` counts would see.
+class _SilentVideoEvents extends VideoEvents {
+  @override
+  Stream<List<VideoEvent>> build() => const Stream.empty();
+}
 
 void main() {
-  setUpAll(() {
-    registerFallbackValue(<Filter>[]);
-    registerFallbackValue(<String>[]);
-    registerFallbackValue(_FakeVideoEvent());
-  });
-
-  group('CurationProvider Tab Refresh', () {
-    late _MockNostrClient mockNostrService;
-    late _MockVideoEventService mockVideoEventService;
-    late _MockLikesRepository mockLikesRepository;
-    late MockAuthService mockAuthService;
-    late _MockFunnelcakeApiClient mockFunnelcakeApiClient;
+  group('CurationProvider tab refresh', () {
     late _MockCurationRepository mockCurationRepository;
+    late MockAuthService mockAuthService;
 
     setUp(() {
-      mockNostrService = _MockNostrClient();
-      mockVideoEventService = _MockVideoEventService();
-      mockLikesRepository = _MockLikesRepository();
-      mockAuthService = createMockAuthService();
-      mockFunnelcakeApiClient = _MockFunnelcakeApiClient();
       mockCurationRepository = _MockCurationRepository();
+      mockAuthService = createMockAuthService();
+    });
 
-      // Stub nostr service to return empty stream (no async fetch for this test)
-      when(
-        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
-      ).thenAnswer((_) => const Stream.empty());
-
-      // Mock getLikeCounts to return empty counts (replaced getCachedLikeCount)
-      when(
-        () => mockLikesRepository.getLikeCounts(any()),
-      ).thenAnswer((_) async => {});
+    void stubEditorsPicks(List<VideoEvent> videos) {
       when(
         () => mockCurationRepository.getVideosForSetType(
           CurationSetType.editorsPicks,
         ),
-      ).thenAnswer((_) => mockVideoEventService.discoveryVideos);
-      when(() => mockCurationRepository.refreshIfNeeded()).thenReturn(null);
-    });
+      ).thenReturn(videos);
+    }
+
+    ProviderContainer createContainer() {
+      final container = ProviderContainer(
+        overrides: [
+          ...getStandardTestOverrides(mockAuthService: mockAuthService),
+          curationRepositoryProvider.overrideWithValue(mockCurationRepository),
+          videoEventsProvider.overrideWith(_SilentVideoEvents.new),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
 
     test(
-      'refreshAll() picks up videos added to cache after provider initialization',
+      'refreshAll picks up editor picks the repository gained after build',
       () async {
-        // ARRANGE: Start with empty discoveryVideos
-        when(() => mockVideoEventService.discoveryVideos).thenReturn([]);
-        when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
+        stubEditorsPicks([]);
+        when(mockCurationRepository.refreshIfNeeded).thenReturn(null);
 
-        final container = ProviderContainer(
-          overrides: [
-            ...getStandardTestOverrides(
-              mockAuthService: mockAuthService,
-              mockNostrService: mockNostrService,
-            ),
-            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
-            curationRepositoryProvider.overrideWithValue(
-              mockCurationRepository,
-            ),
-            funnelcakeApiClientProvider.overrideWithValue(
-              mockFunnelcakeApiClient,
-            ),
-          ],
-        );
-
-        // ACT: Wait for initialization
-        container.read(curationProvider);
-        // Wait for initialization
-        await Future.delayed(const Duration(milliseconds: 50));
-
-        final stateAfterInit = container.read(curationProvider);
+        final container = createContainer();
         expect(
-          stateAfterInit.editorsPicks,
+          container.read(curationProvider).editorsPicks,
           isEmpty,
-          reason: 'Should be empty initially with no videos',
+          reason: 'the repository has nothing cached yet',
         );
 
-        // SIMULATE: Videos fetched asynchronously and added to cache
-        final newVideos = List.generate(
-          5,
-          (i) => VideoEvent(
-            id: 'video_$i',
-            pubkey: 'editor_pubkey',
-            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-            content: 'Editor pick $i',
-            timestamp: DateTime.now(),
-            vineId: 'video_$i',
-            videoUrl: 'https://example.com/video_$i.mp4',
-          ),
-        );
+        final fetched = TestHelpers.createMockVideoEvents(3);
+        stubEditorsPicks(fetched);
 
-        // Update mock to return new videos
-        when(() => mockVideoEventService.discoveryVideos).thenReturn(newVideos);
-
-        // ACT: Call refreshAll() (simulates tab change to Editor's Pick)
         await container.read(curationProvider.notifier).refreshAll();
 
-        // ASSERT: Should now have videos from cache
-        final stateAfterRefresh = container.read(curationProvider);
+        final picks = container.read(curationProvider).editorsPicks;
+        expect(picks, hasLength(3));
+        // VideoEvent's == compares id alone, so a plain equals() on the list
+        // would pass on events that lost every other field in transit.
         expect(
-          stateAfterRefresh.editorsPicks.length,
-          greaterThan(0),
-          reason: 'Should have videos after refreshAll() picks up cache',
+          picks.map((v) => v.id).toList(),
+          fetched.map((v) => v.id).toList(),
         );
-
-        container.dispose();
+        expect(
+          picks.map((v) => v.title).toList(),
+          fetched.map((v) => v.title).toList(),
+        );
+        expect(
+          picks.map((v) => v.videoUrl).toList(),
+          fetched.map((v) => v.videoUrl).toList(),
+        );
       },
     );
 
     test(
-      "navigating from video back to Editor's Pick tab triggers refresh",
+      'refreshAll asks the repository to refresh before re-reading it',
       () async {
-        // This test documents the expected behavior:
-        // 1. User opens Editor's Pick tab (provider initializes)
-        // 2. Async fetch starts, adds videos to _editorPicksVideoCache
-        // 3. User clicks a video (navigates within Explore)
-        // 4. User presses back (returns to Editor's Pick tab)
-        // 5. _onTabChanged() detects tab index == 2 and calls refreshAll()
-        // 6. refreshAll() reads updated cache and displays videos
+        stubEditorsPicks([]);
+        when(mockCurationRepository.refreshIfNeeded).thenReturn(null);
 
-        // ARRANGE: Create sample editor's picks videos
-        final editorVideos = List.generate(
-          3,
-          (i) => VideoEvent(
-            id: 'editor_video_$i',
-            pubkey: 'curator_pubkey',
-            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-            content: 'Curated video $i',
-            timestamp: DateTime.now(),
-            vineId: 'editor_video_$i',
-            videoUrl: 'https://example.com/editor_$i.mp4',
-          ),
-        );
-
-        // Initially empty, then populated (simulating async fetch)
-        when(() => mockVideoEventService.discoveryVideos).thenReturn([]);
-
-        final container = ProviderContainer(
-          overrides: [
-            ...getStandardTestOverrides(
-              mockAuthService: mockAuthService,
-              mockNostrService: mockNostrService,
-            ),
-            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
-            curationRepositoryProvider.overrideWithValue(
-              mockCurationRepository,
-            ),
-            funnelcakeApiClientProvider.overrideWithValue(
-              mockFunnelcakeApiClient,
-            ),
-          ],
-        );
-
-        // ACT: Initialize and wait for async work
+        final container = createContainer();
         container.read(curationProvider);
-        await Future.delayed(const Duration(milliseconds: 50));
+        verifyNever(mockCurationRepository.refreshIfNeeded);
 
-        final stateBeforeNav = container.read(curationProvider);
-        expect(
-          stateBeforeNav.editorsPicks,
-          isEmpty,
-          reason: 'Empty before navigation',
-        );
+        await container.read(curationProvider.notifier).refreshAll();
 
-        // SIMULATE: Videos fetched, cache populated
-        // Update mock to return videos now
+        verifyInOrder([
+          mockCurationRepository.refreshIfNeeded,
+          () => mockCurationRepository.getVideosForSetType(
+            CurationSetType.editorsPicks,
+          ),
+        ]);
+      },
+    );
+
+    test(
+      'a failed refresh records the error and keeps the visible picks',
+      () async {
+        final loaded = TestHelpers.createMockVideoEvents(2);
+        stubEditorsPicks(loaded);
+        when(mockCurationRepository.refreshIfNeeded).thenReturn(null);
+
+        final container = createContainer();
+        expect(container.read(curationProvider).editorsPicks, hasLength(2));
+
         when(
-          () => mockVideoEventService.discoveryVideos,
-        ).thenReturn(editorVideos);
+          mockCurationRepository.refreshIfNeeded,
+        ).thenThrow(StateError('relay unreachable'));
 
-        // SIMULATE: User navigates back to Editor's Pick tab
-        // _onTabChanged() calls refreshAll()
         await container.read(curationProvider.notifier).refreshAll();
 
-        // ASSERT: Videos should now be visible
-        final stateAfterReturn = container.read(curationProvider);
+        final state = container.read(curationProvider);
+        expect(state.error, contains('relay unreachable'));
         expect(
-          stateAfterReturn.editorsPicks.length,
-          equals(editorVideos.length),
-          reason: 'Videos visible after tab return and refresh',
+          state.editorsPicks,
+          hasLength(2),
+          reason: 'a failed refresh must not blank the tab it was refreshing',
         );
-
-        container.dispose();
       },
     );
+
+    test('a later successful refresh clears the stale error', () async {
+      stubEditorsPicks([]);
+      when(
+        mockCurationRepository.refreshIfNeeded,
+      ).thenThrow(StateError('relay unreachable'));
+
+      final container = createContainer();
+      await container.read(curationProvider.notifier).refreshAll();
+      expect(container.read(curationProvider).error, isNotNull);
+
+      when(mockCurationRepository.refreshIfNeeded).thenReturn(null);
+      stubEditorsPicks(TestHelpers.createMockVideoEvents(1));
+
+      await container.read(curationProvider.notifier).refreshAll();
+
+      final state = container.read(curationProvider);
+      expect(state.error, isNull);
+      expect(state.editorsPicks, hasLength(1));
+    });
   });
 }

--- a/mobile/test/providers/curation_provider_tab_refresh_test.dart
+++ b/mobile/test/providers/curation_provider_tab_refresh_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests that curation provider refreshes when Editor's Pick tab becomes active
 // ABOUTME: Verifies the fix for videos showing blank when navigating from video back to tab
 
+import 'package:curation_repository/curation_repository.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
@@ -11,9 +12,9 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/curation_providers.dart';
-import 'package:openvine/providers/nostr_client_provider.dart';
-import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/video_event_service.dart';
+
+import '../helpers/test_provider_overrides.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 
@@ -21,29 +22,34 @@ class _MockVideoEventService extends Mock implements VideoEventService {}
 
 class _MockLikesRepository extends Mock implements LikesRepository {}
 
-class _MockAuthService extends Mock implements AuthService {}
-
 class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
+
+class _MockCurationRepository extends Mock implements CurationRepository {}
+
+class _FakeVideoEvent extends Fake implements VideoEvent {}
 
 void main() {
   setUpAll(() {
     registerFallbackValue(<Filter>[]);
     registerFallbackValue(<String>[]);
+    registerFallbackValue(_FakeVideoEvent());
   });
 
   group('CurationProvider Tab Refresh', () {
     late _MockNostrClient mockNostrService;
     late _MockVideoEventService mockVideoEventService;
     late _MockLikesRepository mockLikesRepository;
-    late _MockAuthService mockAuthService;
+    late MockAuthService mockAuthService;
     late _MockFunnelcakeApiClient mockFunnelcakeApiClient;
+    late _MockCurationRepository mockCurationRepository;
 
     setUp(() {
       mockNostrService = _MockNostrClient();
       mockVideoEventService = _MockVideoEventService();
       mockLikesRepository = _MockLikesRepository();
-      mockAuthService = _MockAuthService();
+      mockAuthService = createMockAuthService();
       mockFunnelcakeApiClient = _MockFunnelcakeApiClient();
+      mockCurationRepository = _MockCurationRepository();
 
       // Stub nostr service to return empty stream (no async fetch for this test)
       when(
@@ -54,6 +60,12 @@ void main() {
       when(
         () => mockLikesRepository.getLikeCounts(any()),
       ).thenAnswer((_) async => {});
+      when(
+        () => mockCurationRepository.getVideosForSetType(
+          CurationSetType.editorsPicks,
+        ),
+      ).thenAnswer((_) => mockVideoEventService.discoveryVideos);
+      when(() => mockCurationRepository.refreshIfNeeded()).thenReturn(null);
     });
 
     test(
@@ -65,9 +77,14 @@ void main() {
 
         final container = ProviderContainer(
           overrides: [
-            nostrServiceProvider.overrideWithValue(mockNostrService),
+            ...getStandardTestOverrides(
+              mockAuthService: mockAuthService,
+              mockNostrService: mockNostrService,
+            ),
             videoEventServiceProvider.overrideWithValue(mockVideoEventService),
-            authServiceProvider.overrideWithValue(mockAuthService),
+            curationRepositoryProvider.overrideWithValue(
+              mockCurationRepository,
+            ),
             funnelcakeApiClientProvider.overrideWithValue(
               mockFunnelcakeApiClient,
             ),
@@ -148,9 +165,14 @@ void main() {
 
         final container = ProviderContainer(
           overrides: [
-            nostrServiceProvider.overrideWithValue(mockNostrService),
+            ...getStandardTestOverrides(
+              mockAuthService: mockAuthService,
+              mockNostrService: mockNostrService,
+            ),
             videoEventServiceProvider.overrideWithValue(mockVideoEventService),
-            authServiceProvider.overrideWithValue(mockAuthService),
+            curationRepositoryProvider.overrideWithValue(
+              mockCurationRepository,
+            ),
             funnelcakeApiClientProvider.overrideWithValue(
               mockFunnelcakeApiClient,
             ),
@@ -189,6 +211,5 @@ void main() {
         container.dispose();
       },
     );
-    // TODO(any): Fix and enable this test
-  }, skip: true);
+  });
 }


### PR DESCRIPTION
## Problem

The curation provider lifecycle and tab-refresh tests carried three unconditional skips. Their local auth mock no longer satisfied the shared provider graph, and the provider itself discarded the synchronously loaded state returned during `build()`. That left its loading state stuck and made `forceRefresh()` unreachable.

## Why this fix

- Returns the repository-backed initial state directly from `build()` so it cannot be overwritten by the old loading placeholder.
- Replaces the incomplete local auth fake with the existing shared inert auth helper, including a pubkey-only identity for providers that require one.
- Overrides the curation repository at the provider boundary so focused tests do not construct unrelated relay infrastructure.
- Rewrites the lifecycle and refresh coverage around the provider's real repository interactions, failure behavior, and video-event listener.
- Removes arbitrary timer waits and ratchets both skip and `Future.delayed` baselines down.

The provider currently has no production callers outside its generated declarations, so this fixes its state contract without changing a user-visible screen today. It prevents future callers from inheriting a permanently loading provider.

## Deliberately unchanged

The remaining router and widget skip rows need separate harness or UI-drift work. This PR does not broaden into those unrelated route, relay, timer, or stale-UI failures.

## Verification

- `flutter test --no-pub test/helpers/test_provider_overrides_test.dart test/providers/curation_provider_lifecycle_test.dart test/providers/curation_provider_tab_refresh_test.dart` (20 tests pass)
- `flutter analyze --no-pub lib test integration_test tools`
- `bash scripts/check_skip_ceiling.sh`
- `bash scripts/check_future_delayed_ceiling.sh`
- repository pre-push checks

Part of #4836
