### PR TITLE
ci(qa): run only relevant mobile checks

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -30,8 +30,17 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
+      docs_only: ${{ steps.scope.outputs.docs_only }}
       app: ${{ steps.scope.outputs.app }}
       native: ${{ steps.scope.outputs.native }}
+      android: ${{ steps.scope.outputs.android }}
+      ios: ${{ steps.scope.outputs.ios }}
+      service: ${{ steps.scope.outputs.service }}
+      goldens: ${{ steps.scope.outputs.goldens }}
+      maestro_static: ${{ steps.scope.outputs.maestro_static }}
+      smoke: ${{ steps.scope.outputs.smoke }}
+      performance: ${{ steps.scope.outputs.performance }}
+      ci_config: ${{ steps.scope.outputs.ci_config }}
     steps:
       # Fetch only the test-backed detector. The changed-file list itself still
       # comes from the REST API, avoiding a full-history checkout on the
@@ -47,6 +56,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           QUEUE_BASE_SHA: ${{ github.event.merge_group.base_sha }}
           QUEUE_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          PUSH_AFTER_SHA: ${{ github.sha }}
         run: bash mobile/scripts/ci/detect_mobile_ci_scope.sh
 
   codex-config:
@@ -749,7 +760,7 @@ jobs:
   goldens:
     name: Goldens
     needs: changes
-    if: ${{ needs.changes.outputs.app == 'true' }}
+    if: ${{ needs.changes.outputs.goldens == 'true' || inputs.update_goldens }}
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -830,9 +841,11 @@ jobs:
           VGV_TAG_GATE_RESULT: ${{ needs.vgv-tag-gate.result }}
           GOLDENS_RESULT: ${{ needs.goldens.result }}
           APP_CI_REQUIRED: ${{ needs.changes.outputs.app }}
+          GOLDENS_REQUIRED: ${{ needs.changes.outputs.goldens }}
           UPDATE_GOLDENS: ${{ inputs.update_goldens }}
         run: |
           echo "app-ci-required: ${APP_CI_REQUIRED}"
+          echo "goldens-required: ${GOLDENS_REQUIRED}"
           echo "codemagic-groups: ${CODEMAGIC_GROUPS_RESULT}"
           echo "generated-files: ${GENERATED_FILES_RESULT}"
           echo "ci-config-tests: ${CI_CONFIG_TESTS_RESULT}"
@@ -863,18 +876,24 @@ jobs:
             exit 1
           fi
 
-          results=(
+          required_results=(
             "${CI_CONFIG_TESTS_RESULT}"
             "${GENERATED_FILES_RESULT}"
             "${FORMAT_RESULT}"
             "${ANALYZE_RESULT}"
             "${TESTS_RESULT}"
             "${VGV_TAG_GATE_RESULT}"
-            "${GOLDENS_RESULT}"
           )
 
+          if [ "${GOLDENS_REQUIRED}" = "true" ]; then
+            required_results+=("${GOLDENS_RESULT}")
+          elif [[ "${GOLDENS_RESULT}" != "success" && "${GOLDENS_RESULT}" != "skipped" ]]; then
+            echo "Goldens failed or were cancelled despite not being required."
+            exit 1
+          fi
+
           if [ "${APP_CI_REQUIRED}" = "false" ]; then
-            for result in "${results[@]}"; do
+            for result in "${required_results[@]}"; do
               if [[ "${result}" != "success" && "${result}" != "skipped" ]]; then
                 echo "One or more Mobile CI jobs failed or were cancelled."
                 exit 1
@@ -884,7 +903,7 @@ jobs:
             exit 0
           fi
 
-          for result in "${results[@]}"; do
+          for result in "${required_results[@]}"; do
             if [ "${result}" != "success" ]; then
               echo "One or more Mobile CI jobs failed."
               exit 1

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -36,7 +36,6 @@ jobs:
       android: ${{ steps.scope.outputs.android }}
       ios: ${{ steps.scope.outputs.ios }}
       service: ${{ steps.scope.outputs.service }}
-      goldens: ${{ steps.scope.outputs.goldens }}
       maestro_static: ${{ steps.scope.outputs.maestro_static }}
       smoke: ${{ steps.scope.outputs.smoke }}
       performance: ${{ steps.scope.outputs.performance }}
@@ -760,7 +759,9 @@ jobs:
   goldens:
     name: Goldens
     needs: changes
-    if: ${{ needs.changes.outputs.goldens == 'true' || inputs.update_goldens }}
+    # Golden tests render through enough of the app dependency graph that a
+    # hand-maintained path allowlist cannot safely describe their inputs.
+    if: ${{ needs.changes.outputs.app == 'true' || inputs.update_goldens }}
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -841,11 +842,9 @@ jobs:
           VGV_TAG_GATE_RESULT: ${{ needs.vgv-tag-gate.result }}
           GOLDENS_RESULT: ${{ needs.goldens.result }}
           APP_CI_REQUIRED: ${{ needs.changes.outputs.app }}
-          GOLDENS_REQUIRED: ${{ needs.changes.outputs.goldens }}
           UPDATE_GOLDENS: ${{ inputs.update_goldens }}
         run: |
           echo "app-ci-required: ${APP_CI_REQUIRED}"
-          echo "goldens-required: ${GOLDENS_REQUIRED}"
           echo "codemagic-groups: ${CODEMAGIC_GROUPS_RESULT}"
           echo "generated-files: ${GENERATED_FILES_RESULT}"
           echo "ci-config-tests: ${CI_CONFIG_TESTS_RESULT}"
@@ -885,20 +884,12 @@ jobs:
             "${VGV_TAG_GATE_RESULT}"
           )
 
-          # An unset value means the scope never resolved — a renamed or
-          # misspelled `goldens` output leaves both the job's `if` and this
-          # variable empty. Without this arm that reads as "not required",
-          # the elif accepts the skip, and every PR reports green having
-          # verified no pixels. Mirrors the APP_CI_REQUIRED backstop below.
-          if [ "${GOLDENS_REQUIRED}" != "true" ] && [ "${GOLDENS_REQUIRED}" != "false" ]; then
-            echo "Could not determine the Goldens scope."
-            exit 1
-          fi
-
-          if [ "${GOLDENS_REQUIRED}" = "true" ]; then
+          # Goldens follow the app scope. Their transitive dependency graph is
+          # too broad for an independently maintained path allowlist.
+          if [ "${APP_CI_REQUIRED}" = "true" ]; then
             required_results+=("${GOLDENS_RESULT}")
           elif [[ "${GOLDENS_RESULT}" != "success" && "${GOLDENS_RESULT}" != "skipped" ]]; then
-            echo "Goldens failed or were cancelled despite not being required."
+            echo "Goldens failed or were cancelled despite app CI not being required."
             exit 1
           fi
 

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -885,6 +885,16 @@ jobs:
             "${VGV_TAG_GATE_RESULT}"
           )
 
+          # An unset value means the scope never resolved — a renamed or
+          # misspelled `goldens` output leaves both the job's `if` and this
+          # variable empty. Without this arm that reads as "not required",
+          # the elif accepts the skip, and every PR reports green having
+          # verified no pixels. Mirrors the APP_CI_REQUIRED backstop below.
+          if [ "${GOLDENS_REQUIRED}" != "true" ] && [ "${GOLDENS_REQUIRED}" != "false" ]; then
+            echo "Could not determine the Goldens scope."
+            exit 1
+          fi
+
           if [ "${GOLDENS_REQUIRED}" = "true" ]; then
             required_results+=("${GOLDENS_RESULT}")
           elif [[ "${GOLDENS_RESULT}" != "success" && "${GOLDENS_RESULT}" != "skipped" ]]; then

--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -36,8 +36,8 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      focused: ${{ steps.scope.outputs.focused || steps.mobile-scope.outputs.service || steps.full-scope.outputs.focused }}
-      app: ${{ steps.scope.outputs.app || steps.mobile-scope.outputs.service || steps.full-scope.outputs.app }}
+      focused: ${{ steps.resolved.outputs.focused }}
+      app: ${{ steps.resolved.outputs.app }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -66,6 +66,26 @@ jobs:
         run: |
           echo "focused=true" >> "$GITHUB_OUTPUT"
           echo "app=true" >> "$GITHUB_OUTPUT"
+      # The three steps above are mutually exclusive and cover only the four
+      # events in `on:`. With no fallback, an event none of them matches
+      # leaves every lookup empty, the job SUCCEEDS, service-tests skips, and
+      # the workflow reports green having run nothing. The same happens if a
+      # step id is renamed on one side of the `||` chain, which degrades to
+      # '' rather than erroring. Resolving once here makes both fail loudly,
+      # the way mobile_ci.yaml's aggregator already does.
+      - name: Resolve the service suite scope
+        id: resolved
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          FOCUSED: ${{ steps.scope.outputs.focused || steps.mobile-scope.outputs.service || steps.full-scope.outputs.focused }}
+          APP: ${{ steps.scope.outputs.app || steps.mobile-scope.outputs.service || steps.full-scope.outputs.app }}
+        run: |
+          if [ -z "${FOCUSED}" ] || [ -z "${APP}" ]; then
+            echo "Could not determine the service suite scope for ${EVENT_NAME}."
+            exit 1
+          fi
+          echo "focused=${FOCUSED}" >> "$GITHUB_OUTPUT"
+          echo "app=${APP}" >> "$GITHUB_OUTPUT"
 
   service-tests:
     name: Integration Tests (services)

--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -2,6 +2,10 @@ name: Mobile Integration Tests (Services)
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '23 7 * * *'
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -15,7 +19,7 @@ on:
 # sync when suite dependencies change.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -26,19 +30,36 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      focused: ${{ steps.scope.outputs.focused }}
-      app: ${{ steps.scope.outputs.app }}
+      focused: ${{ steps.scope.outputs.focused || steps.mobile-scope.outputs.service || steps.full-scope.outputs.focused }}
+      app: ${{ steps.scope.outputs.app || steps.mobile-scope.outputs.service || steps.full-scope.outputs.app }}
     steps:
       - uses: actions/checkout@v7
         with:
-          sparse-checkout: mobile/scripts/ci/detect_service_suite_scope.sh
+          sparse-checkout: |
+            mobile/scripts/ci/detect_mobile_ci_scope.sh
+            mobile/scripts/ci/detect_service_suite_scope.sh
           sparse-checkout-cone-mode: false
       - name: Detect affected service suites
         id: scope
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: bash mobile/scripts/ci/detect_service_suite_scope.sh
+      - name: Detect whether a main-branch merge affects services
+        id: mobile-scope
+        if: ${{ github.event_name == 'push' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          PUSH_AFTER_SHA: ${{ github.sha }}
+        run: bash mobile/scripts/ci/detect_mobile_ci_scope.sh
+      - name: Run the full deterministic suite on schedules and dispatches
+        id: full-scope
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "focused=true" >> "$GITHUB_OUTPUT"
+          echo "app=true" >> "$GITHUB_OUTPUT"
 
   service-tests:
     name: Integration Tests (services)

--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -19,7 +19,13 @@ on:
 # sync when suite dependencies change.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  # Pushes get a per-commit group. The ref alone is constant across every
+  # merge to main, so the next merge would cancel the previous merge's
+  # post-merge suite — and if that next merge is docs-only its own service
+  # scope is false, so nothing reruns and the regression goes unreported
+  # until the nightly. Every other event still collapses to the ref, so a
+  # PR's superseded runs are cancelled as before.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -23,7 +23,7 @@ concurrency:
   # merge to main, so the next merge would cancel the previous merge's
   # post-merge suite — and if that next merge is docs-only its own service
   # scope is false, so nothing reruns and the regression goes unreported
-  # until the nightly. Every other event still collapses to the ref, so a
+  # until the daily run. Every other event still collapses to the ref, so a
   # PR's superseded runs are cancelled as before.
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || '' }}
   cancel-in-progress: true
@@ -176,3 +176,78 @@ jobs:
             echo "── $suite"
             xvfb-run -a flutter test "$suite" --tags service -d linux
           done
+  daily-signal:
+    name: Publish daily service-test result
+    needs: [changes, service-tests]
+    if: ${{ always() && github.event_name == 'schedule' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the daily service-test incident
+        if: ${{ needs.changes.result != 'success' || needs.service-tests.result != 'success' }}
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const marker = '<!-- daily-service-integration-incident -->';
+            const title = 'ci(services): daily integration tests are failing';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              marker,
+              'The daily deterministic service integration run is failing.',
+              '',
+              `Latest failed run: ${runUrl}`,
+              '',
+              'The first maintainer who picks this up owns initial classification and leaves a handoff if another time zone needs to continue. This issue closes automatically after the daily run recovers.',
+            ].join('\n');
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all',
+              per_page: 100,
+            });
+            const existing = issues.find(issue =>
+              !issue.pull_request && issue.body && issue.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+                state: 'open',
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['bug'],
+              });
+            }
+      - name: Close the recovered daily service-test incident
+        if: ${{ needs.changes.result == 'success' && needs.service-tests.result == 'success' }}
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const marker = '<!-- daily-service-integration-incident -->';
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const existing = issues.find(issue =>
+              !issue.pull_request && issue.body && issue.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+            }

--- a/mobile/docs/AUTOMATED_QA.md
+++ b/mobile/docs/AUTOMATED_QA.md
@@ -8,20 +8,28 @@ small change wait for a device build.
 
 | Event | Automatic coverage | Blocking |
 |---|---|---|
-| Pull request | Change-scoped Mobile CI and headless service integration; iOS Maestro PR smoke when Codemagic webhooks are connected | Mobile CI and service checks are blocking; Maestro is observational |
+| Pull request | Change-scoped Mobile CI and headless service integration; iOS Maestro PR smoke when Codemagic webhooks are connected | Mobile CI is blocking; service integration and Maestro are additional evidence |
 | Merge to `main` | Change-scoped Mobile CI and all service suites when service dependencies changed | Reports regressions on `main` |
-| Nightly | Every deterministic headless service suite | Alert/triage signal |
+| Daily at 07:23 UTC | Every deterministic headless service suite | Opens or updates a shared triage issue on failure and closes it after recovery |
 | Manual | Full headless service suite; platform-specific Maestro workflows | Operator-owned |
 
-The shared classifier is `scripts/ci/detect_mobile_ci_scope.sh`. It is the
-source of truth for documentation-only, app, native platform, service, golden,
-Maestro, smoke, performance, and CI-configuration applicability. Incomplete or
+The shared classifier is `mobile/scripts/ci/detect_mobile_ci_scope.sh`. It is
+the source of truth for documentation-only, app, native platform, service,
+Maestro, smoke, performance, and CI-configuration applicability. Goldens follow
+the app scope because their transitive dependency graph is too broad for a safe
+independent path allowlist. Incomplete or
 unsupported change data fails open to all scopes.
 
 Documentation-only pull requests and merges still publish the required Mobile
 CI result, but skip Flutter analysis, tests, goldens, and device builds. Cheap
 configuration guards remain unconditional because they protect the filters
 themselves.
+
+The daily time gives Europe a start-of-day signal, Asia a daytime signal, and
+the Americas results ready for the start of their day. The odd minute avoids
+the top-of-hour scheduler surge. The first maintainer who picks up a failure
+owns initial classification and leaves a handoff when another time zone needs
+to continue.
 
 ## Maestro policy
 

--- a/mobile/docs/AUTOMATED_QA.md
+++ b/mobile/docs/AUTOMATED_QA.md
@@ -1,0 +1,60 @@
+# Automated QA
+
+Automated QA is split by feedback speed and determinism. Pull requests should
+get a useful answer quickly; broad regression coverage should not make every
+small change wait for a device build.
+
+## Coverage by event
+
+| Event | Automatic coverage | Blocking |
+|---|---|---|
+| Pull request | Change-scoped Mobile CI and headless service integration; iOS Maestro PR smoke when Codemagic webhooks are connected | Mobile CI and service checks are blocking; Maestro is observational |
+| Merge to `main` | Change-scoped Mobile CI and all service suites when service dependencies changed | Reports regressions on `main` |
+| Nightly | Every deterministic headless service suite | Alert/triage signal |
+| Manual | Full headless service suite; platform-specific Maestro workflows | Operator-owned |
+
+The shared classifier is `scripts/ci/detect_mobile_ci_scope.sh`. It is the
+source of truth for documentation-only, app, native platform, service, golden,
+Maestro, smoke, performance, and CI-configuration applicability. Incomplete or
+unsupported change data fails open to all scopes.
+
+Documentation-only pull requests and merges still publish the required Mobile
+CI result, but skip Flutter analysis, tests, goldens, and device builds. Cheap
+configuration guards remain unconditional because they protect the filters
+themselves.
+
+## Maestro policy
+
+The PR suite is limited to launch readiness, an authenticated Home shell, and
+one immutable video fixture. It does not search live content or use a shared
+account. JUnit, screenshots, hierarchy dumps, Maestro logs, app logs, and
+XCTest logs are retained for triage.
+
+Keep the iOS check non-blocking until at least 30 comparable runs achieve both
+an infrastructure-clean rate of 95% or better and a p95 duration below 15
+minutes. Reset the observation window after changing a flow, the Maestro
+version, the Xcode image, or the fixture. Demote the check immediately if
+infrastructure failures block healthy pull requests.
+
+Recorder journeys require physical camera hardware and belong in manual or
+scheduled device regression, not the simulator PR gate. A green run that skips
+hardware-guarded assertions is not evidence that the recorder path passed.
+
+## Triage and ownership
+
+The author owns product regressions introduced by a pull request. The first
+maintainer investigating an infrastructure failure owns classification and
+artifact capture; do not rerun blindly until the failure is identified.
+
+1. Read the JUnit case name and screenshot first.
+2. Check the hierarchy and app/XCTest logs to distinguish selector, app, driver,
+   fixture, and network failures.
+3. Reproduce against the same commit, Maestro version, platform image, and
+   fixture.
+4. Fix product or test defects in the change that exposed them. Do not skip or
+   quarantine a failing test to make the gate green.
+
+Codemagic webhook connectivity is external to this repository and tracked in
+[#7504](https://github.com/divinevideo/divine-mobile/issues/7504). The team
+admin who connected the repository must use Codemagic's **Update webhook**
+control. Repository YAML cannot compensate for a missing delivery.

--- a/mobile/scripts/ci/detect_mobile_ci_scope.sh
+++ b/mobile/scripts/ci/detect_mobile_ci_scope.sh
@@ -92,7 +92,10 @@ ci_config=false
 
 while IFS= read -r path; do
   case "$path" in
-    *.md|docs/*|brand-guidelines/*|mobile/docs/*) ;;
+    # A markdown file renders no pixel, builds no binary and exercises no
+    # service suite, wherever it sits. Skipping the scope blocks outright
+    # keeps a README inside a code directory from turning them on.
+    *.md|docs/*|brand-guidelines/*|mobile/docs/*) continue ;;
     *) docs_only=false ;;
   esac
 
@@ -113,7 +116,6 @@ while IFS= read -r path; do
       ci_config=true ;;
     mobile/scripts/ci/*)
       app=true; ci_config=true ;;
-    *.md|docs/*|brand-guidelines/*|mobile/docs/*) ;;
     mobile/lib/*|mobile/test/*|mobile/integration_test/*|mobile/scripts/*|scripts/*)
       app=true ;;
     mobile/android/*|mobile/ios/*|mobile/macos/*|mobile/web/*|mobile/assets/*|mobile/fonts/*|mobile/overrides/*|mobile/l10n/*)

--- a/mobile/scripts/ci/detect_mobile_ci_scope.sh
+++ b/mobile/scripts/ci/detect_mobile_ci_scope.sh
@@ -137,7 +137,22 @@ while IFS= read -r path; do
   esac
 
   case "$path" in
-    mobile/lib/*|mobile/packages/*|mobile/integration_test/e2e/*|mobile/integration_test/helpers/*|.github/workflows/mobile_service_integration_tests.yaml|mobile/scripts/ci/detect_service_suite_scope.sh|mobile/scripts/check_service_suite_coverage.sh)
+    # Keep this in lockstep with detect_service_suite_scope.sh. That
+    # detector decides which suites run; this one decides whether a merge
+    # to main schedules them at all, so anything it treats as a service
+    # dependency has to be here too — including the runner-level inputs
+    # (pubspec, dart_test.yaml, the Linux embedder the suites build on).
+    mobile/lib/*|\
+    mobile/packages/*|\
+    mobile/integration_test/e2e/*|\
+    mobile/integration_test/helpers/*|\
+    mobile/pubspec.yaml|\
+    mobile/pubspec.lock|\
+    mobile/dart_test.yaml|\
+    mobile/linux/*|\
+    .github/workflows/mobile_service_integration_tests.yaml|\
+    mobile/scripts/ci/detect_service_suite_scope.sh|\
+    mobile/scripts/check_service_suite_coverage.sh)
       service=true ;;
   esac
 

--- a/mobile/scripts/ci/detect_mobile_ci_scope.sh
+++ b/mobile/scripts/ci/detect_mobile_ci_scope.sh
@@ -102,7 +102,14 @@ while IFS= read -r path; do
     .github/workflows/mobile_ci.yaml|mobile/scripts/ci/detect_mobile_ci_scope.sh)
       app=true; native=true; android=true; ios=true; service=true; goldens=true
       maestro_static=true; smoke=true; performance=true; ci_config=true ;;
-    .github/workflows/*|codemagic.yaml)
+    .github/workflows/*)
+      # Four `generated-files` guards read workflow files as their only input
+      # (package coverage floor, package CI floor, backend host defaults,
+      # service suite coverage), and `mobile/test/tools/` holds the contract
+      # tests that pin these workflows. Both live behind `app`, so a workflow
+      # edit has to keep running it.
+      app=true; ci_config=true ;;
+    codemagic.yaml)
       ci_config=true ;;
     mobile/scripts/ci/*)
       app=true; ci_config=true ;;

--- a/mobile/scripts/ci/detect_mobile_ci_scope.sh
+++ b/mobile/scripts/ci/detect_mobile_ci_scope.sh
@@ -1,116 +1,158 @@
 #!/usr/bin/env bash
-# ABOUTME: Classifies changed files to decide which Mobile CI jobs must run.
-# ABOUTME: Handles pull requests, merge-queue groups, and fall-open events.
+# ABOUTME: Classifies changed files for Mobile CI and automated QA workflows.
+# ABOUTME: Uses one fail-open contract across pull requests, merge groups, and pushes.
 
 set -euo pipefail
 
 changed_files="$(mktemp)"
 trap 'rm -f "$changed_files"' EXIT
 
+scope_names=(docs_only app native android ios service goldens maestro_static smoke performance ci_config)
+
+write_all_true() {
+  for scope in "${scope_names[@]}"; do
+    if [ "$scope" = "docs_only" ]; then
+      echo "$scope=false" >> "$GITHUB_OUTPUT"
+    else
+      echo "$scope=true" >> "$GITHUB_OUTPUT"
+    fi
+  done
+}
+
 fall_open() {
-  echo "app=true" >> "$GITHUB_OUTPUT"
-  echo "native=true" >> "$GITHUB_OUTPUT"
+  write_all_true
   echo "$1"
   exit 0
 }
 
+fetch_compare_files() {
+  local base_sha="$1"
+  local head_sha="$2"
+  local label="$3"
+  if [ -z "$base_sha" ] || [ -z "$head_sha" ]; then
+    fall_open "$label is missing a base or head SHA; running all mobile QA."
+  fi
+
+  gh api --method GET --paginate -F per_page=100 \
+    "/repos/${GITHUB_REPOSITORY}/compare/${base_sha}...${head_sha}" \
+    --jq '.files[]?.filename' > "$changed_files"
+
+  local file_count
+  file_count=$(( $(wc -l < "$changed_files") ))
+  if [ "$file_count" -eq 0 ] || [ "$file_count" -ge 300 ]; then
+    fall_open "$label returned $file_count files (empty or at the 300-file compare API cap); running all mobile QA."
+  fi
+}
+
 case "${GITHUB_EVENT_NAME}" in
   pull_request)
-    # The files endpoint caps at 3000 entries. A PR that large is not a scoped
-    # change, so fall open rather than under-running CI on a truncated list.
     changed_total=$(gh api "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.changed_files')
     if [ "$changed_total" -gt 3000 ]; then
-      fall_open "PR touches $changed_total files (> 3000 API cap); running full app CI."
+      fall_open "PR touches $changed_total files (> 3000 API cap); running all mobile QA."
     fi
-
     gh api --method GET --paginate -F per_page=100 \
       "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
       --jq '.[].filename' > "$changed_files"
-
     file_count=$(( $(wc -l < "$changed_files") ))
     if [ "$file_count" -eq 0 ] || [ "$file_count" -ne "$changed_total" ]; then
-      fall_open "PR returned $file_count files but reported $changed_total changed files; running full app CI."
+      fall_open "PR returned $file_count files but reported $changed_total changed files; running all mobile QA."
     fi
     ;;
   merge_group)
-    # The queue head is a speculative merge of main plus every PR ahead of it
-    # in the batch, so this diff is exactly what the queue is about to land.
-    gh api --method GET --paginate -F per_page=100 \
-      "/repos/${GITHUB_REPOSITORY}/compare/${QUEUE_BASE_SHA}...${QUEUE_HEAD_SHA}" \
-      --jq '.files[]?.filename' > "$changed_files"
-
-    # The compare endpoint includes at most 300 changed files for the whole
-    # comparison. A queue entry always has a change, so empty or capped output
-    # is unusable and must fall open to the full matrix.
-    file_count=$(( $(wc -l < "$changed_files") ))
-    if [ "$file_count" -eq 0 ] || [ "$file_count" -ge 300 ]; then
-      fall_open "Merge group returned $file_count files (empty or at the 300-file compare API cap); running full app CI."
+    fetch_compare_files "${QUEUE_BASE_SHA:-}" "${QUEUE_HEAD_SHA:-}" "Merge group"
+    ;;
+  push)
+    if [[ "${PUSH_BEFORE_SHA:-}" =~ ^0+$ ]]; then
+      fall_open "Push has no comparable before SHA; running all mobile QA."
     fi
+    fetch_compare_files "${PUSH_BEFORE_SHA:-}" "${PUSH_AFTER_SHA:-}" "Push"
+    ;;
+  workflow_dispatch)
+    fall_open "Manual dispatch requested; running all mobile QA."
     ;;
   *)
-    fall_open "Non-PR event; running full app CI."
+    fall_open "Unsupported event ${GITHUB_EVENT_NAME}; running all mobile QA."
     ;;
 esac
 
 echo "Changed files:"
 cat "$changed_files"
 
+docs_only=true
 app=false
 native=false
+android=false
+ios=false
+service=false
+goldens=false
+maestro_static=false
+smoke=false
+performance=false
+ci_config=false
+
 while IFS= read -r path; do
   case "$path" in
-    .gitattributes)
-      app=true
-      ;;
-    analytics-contract.lock|analytics-contract.manifest.json)
-      app=true
-      ;;
-    .github/ci-timing-budgets.json)
-      app=true
-      ;;
-    .github/workflows/*)
-      app=true
-      native=true
-      ;;
-    *.md|docs/*|brand-guidelines/*|mobile/docs/*)
-      # Docs-only changes do not need the full app test matrix.
-      ;;
-    mobile/lib/*|mobile/test/*|mobile/integration_test/*|mobile/scripts/*)
-      app=true
-      ;;
-    scripts/*)
-      # Repo-root tooling is covered by mobile/test/tools/, which only runs in
-      # the app matrix. Without this arm a scripts/-only PR skips the one job
-      # that tests it, and there is no shellcheck or `bash -n` step to catch it
-      # instead (#8761).
-      app=true
-      ;;
-    mobile/android/*|mobile/ios/*|mobile/macos/*|mobile/web/*|mobile/assets/*|mobile/fonts/*|mobile/overrides/*|mobile/l10n/*)
-      app=true
-      ;;
-    mobile/pubspec.yaml|mobile/pubspec.lock|mobile/dart_test.yaml|mobile/analysis_options.yaml|mobile/build.yaml|mobile/l10n.yaml)
-      app=true
-      ;;
-    mobile/*)
-      app=true
-      ;;
+    *.md|docs/*|brand-guidelines/*|mobile/docs/*) ;;
+    *) docs_only=false ;;
   esac
 
-  # The transport-security guard reads native configuration plus its own
-  # scripts. Match at directory level so this gate cannot silently drift when
-  # the guard gains another native input.
+  case "$path" in
+    .gitattributes|analytics-contract.lock|analytics-contract.manifest.json|.github/ci-timing-budgets.json)
+      app=true ;;
+    .github/workflows/mobile_ci.yaml|mobile/scripts/ci/detect_mobile_ci_scope.sh)
+      app=true; native=true; android=true; ios=true; service=true; goldens=true
+      maestro_static=true; smoke=true; performance=true; ci_config=true ;;
+    .github/workflows/*|codemagic.yaml)
+      ci_config=true ;;
+    mobile/scripts/ci/*)
+      app=true; ci_config=true ;;
+    *.md|docs/*|brand-guidelines/*|mobile/docs/*) ;;
+    mobile/lib/*|mobile/test/*|mobile/integration_test/*|mobile/scripts/*|scripts/*)
+      app=true ;;
+    mobile/android/*|mobile/ios/*|mobile/macos/*|mobile/web/*|mobile/assets/*|mobile/fonts/*|mobile/overrides/*|mobile/l10n/*)
+      app=true ;;
+    mobile/pubspec.yaml|mobile/pubspec.lock|mobile/dart_test.yaml|mobile/analysis_options.yaml|mobile/build.yaml|mobile/l10n.yaml|mobile/*)
+      app=true ;;
+  esac
+
   case "$path" in
     .gitattributes|mobile/android/*|mobile/ios/*|mobile/macos/*|mobile/scripts/check_native_transport_security.sh|mobile/scripts/check_ios_shipping_versions.sh|mobile/scripts/check_gradle_wrapper_checksum.sh|mobile/scripts/ci/detect_mobile_ci_scope.sh)
-      native=true
-      ;;
+      native=true ;;
+  esac
+
+  case "$path" in
+    mobile/android/*) android=true; smoke=true ;;
+    mobile/ios/*) ios=true; smoke=true ;;
+    mobile/lib/*|mobile/assets/*|mobile/fonts/*|mobile/integration_test/*|mobile/pubspec.yaml|mobile/pubspec.lock)
+      android=true; ios=true; smoke=true ;;
+  esac
+
+  case "$path" in
+    mobile/lib/*|mobile/packages/*|mobile/integration_test/e2e/*|mobile/integration_test/helpers/*|.github/workflows/mobile_service_integration_tests.yaml|mobile/scripts/ci/detect_service_suite_scope.sh|mobile/scripts/check_service_suite_coverage.sh)
+      service=true ;;
+  esac
+
+  case "$path" in
+    mobile/test/goldens/*|mobile/lib/screens/*|mobile/lib/widgets/*|mobile/packages/divine_ui/*|mobile/assets/*|mobile/fonts/*|mobile/scripts/golden.sh)
+      goldens=true ;;
+  esac
+
+  case "$path" in
+    mobile/e2e/maestro/*|mobile/scripts/check_maestro_copy_drift.sh|mobile/lib/l10n/app_*.arb|codemagic.yaml)
+      maestro_static=true ;;
+  esac
+
+  case "$path" in
+    mobile/lib/screens/feed/*|mobile/lib/widgets/video_feed*|mobile/lib/widgets/video_feed_item/*|mobile/lib/blocs/video_feed/*|mobile/lib/repositories/feed*|mobile/packages/feed_repository/*|mobile/packages/infinite_video_feed/*|mobile/test/screens/feed/*|mobile/test/widgets/video_feed*|mobile/test/blocs/video_feed/*|mobile/test/repositories/feed*|mobile/integration_test/*feed*|mobile/e2e/maestro/*feed*|mobile/e2e/maestro/*performance*)
+      performance=true ;;
   esac
 done < "$changed_files"
 
-echo "app=$app" >> "$GITHUB_OUTPUT"
-echo "native=$native" >> "$GITHUB_OUTPUT"
-if [ "$app" = "true" ]; then
-  echo "App CI required."
-else
-  echo "Package-only/docs-only change; app CI jobs may be skipped."
-fi
-echo "Native transport-security inputs changed: $native"
+for scope in "${scope_names[@]}"; do
+  echo "$scope=${!scope}" >> "$GITHUB_OUTPUT"
+done
+
+echo "Mobile QA scope:"
+for scope in "${scope_names[@]}"; do
+  echo "  $scope=${!scope}"
+done

--- a/mobile/scripts/ci/detect_mobile_ci_scope.sh
+++ b/mobile/scripts/ci/detect_mobile_ci_scope.sh
@@ -133,7 +133,7 @@ while IFS= read -r path; do
   esac
 
   case "$path" in
-    mobile/test/goldens/*|mobile/lib/screens/*|mobile/lib/widgets/*|mobile/packages/divine_ui/*|mobile/assets/*|mobile/fonts/*|mobile/scripts/golden.sh)
+    mobile/test/goldens/*|mobile/lib/screens/*|mobile/lib/widgets/*|mobile/lib/notifications/widgets/*|mobile/lib/l10n/*|mobile/packages/divine_ui/*|mobile/assets/*|mobile/fonts/*|mobile/pubspec.yaml|mobile/pubspec.lock|mobile/scripts/golden.sh)
       goldens=true ;;
   esac
 

--- a/mobile/scripts/ci/detect_mobile_ci_scope.sh
+++ b/mobile/scripts/ci/detect_mobile_ci_scope.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 changed_files="$(mktemp)"
 trap 'rm -f "$changed_files"' EXIT
 
-scope_names=(docs_only app native android ios service goldens maestro_static smoke performance ci_config)
+scope_names=(docs_only app native android ios service maestro_static smoke performance ci_config)
 
 write_all_true() {
   for scope in "${scope_names[@]}"; do
@@ -93,7 +93,6 @@ native=false
 android=false
 ios=false
 service=false
-goldens=false
 maestro_static=false
 smoke=false
 performance=false
@@ -112,7 +111,7 @@ while IFS= read -r path; do
     .gitattributes|analytics-contract.lock|analytics-contract.manifest.json|.github/ci-timing-budgets.json)
       app=true ;;
     .github/workflows/mobile_ci.yaml|mobile/scripts/ci/detect_mobile_ci_scope.sh)
-      app=true; native=true; android=true; ios=true; service=true; goldens=true
+      app=true; native=true; android=true; ios=true; service=true
       maestro_static=true; smoke=true; performance=true; ci_config=true ;;
     .github/workflows/*)
       # Four `generated-files` guards read workflow files as their only input
@@ -163,11 +162,6 @@ while IFS= read -r path; do
     mobile/scripts/ci/detect_service_suite_scope.sh|\
     mobile/scripts/check_service_suite_coverage.sh)
       service=true ;;
-  esac
-
-  case "$path" in
-    mobile/test/goldens/*|mobile/lib/screens/*|mobile/lib/widgets/*|mobile/lib/notifications/widgets/*|mobile/lib/l10n/*|mobile/packages/divine_ui/*|mobile/assets/*|mobile/fonts/*|mobile/pubspec.yaml|mobile/pubspec.lock|mobile/scripts/golden.sh)
-      goldens=true ;;
   esac
 
   case "$path" in

--- a/mobile/scripts/ci/detect_mobile_ci_scope.sh
+++ b/mobile/scripts/ci/detect_mobile_ci_scope.sh
@@ -33,9 +33,11 @@ fetch_compare_files() {
     fall_open "$label is missing a base or head SHA; running all mobile QA."
   fi
 
-  gh api --method GET --paginate -F per_page=100 \
+  if ! gh api --method GET --paginate -F per_page=100 \
     "/repos/${GITHUB_REPOSITORY}/compare/${base_sha}...${head_sha}" \
-    --jq '.files[]?.filename' > "$changed_files"
+    --jq '.files[]?.filename' > "$changed_files"; then
+    fall_open "$label compare API call failed; running all mobile QA."
+  fi
 
   local file_count
   file_count=$(( $(wc -l < "$changed_files") ))
@@ -46,13 +48,20 @@ fetch_compare_files() {
 
 case "${GITHUB_EVENT_NAME}" in
   pull_request)
-    changed_total=$(gh api "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.changed_files')
+    if ! changed_total=$(gh api "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.changed_files'); then
+      fall_open "PR metadata API call failed; running all mobile QA."
+    fi
+    if ! [[ "$changed_total" =~ ^[0-9]+$ ]]; then
+      fall_open "PR reported a non-numeric changed-file count; running all mobile QA."
+    fi
     if [ "$changed_total" -gt 3000 ]; then
       fall_open "PR touches $changed_total files (> 3000 API cap); running all mobile QA."
     fi
-    gh api --method GET --paginate -F per_page=100 \
+    if ! gh api --method GET --paginate -F per_page=100 \
       "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
-      --jq '.[].filename' > "$changed_files"
+      --jq '.[].filename' > "$changed_files"; then
+      fall_open "PR files API call failed; running all mobile QA."
+    fi
     file_count=$(( $(wc -l < "$changed_files") ))
     if [ "$file_count" -eq 0 ] || [ "$file_count" -ne "$changed_total" ]; then
       fall_open "PR returned $file_count files but reported $changed_total changed files; running all mobile QA."

--- a/mobile/test/tools/detect_mobile_ci_scope_test.dart
+++ b/mobile/test/tools/detect_mobile_ci_scope_test.dart
@@ -443,25 +443,113 @@ esac
       });
     }
 
-    test('classifies focused QA scopes independently', () {
-      final run = runDetector(
-        event: 'pull_request',
-        changedFiles: [
-          'mobile/lib/screens/feed/video_feed_page.dart',
-          'mobile/e2e/maestro/flows/feed.yaml',
-          '.github/workflows/mobile_ci.yaml',
-        ],
-        changedTotal: 3,
-      );
+    // One path per row, and the complete set of scopes it must turn on —
+    // everything else is asserted false. The test this replaced passed three
+    // paths at once, one of them .github/workflows/mobile_ci.yaml, which hits
+    // the arm that sets every scope true; the other two contributed nothing,
+    // so deleting the performance block, the maestro pattern and the goldens
+    // screens pattern together left it green.
+    const allScopes = {
+      'app',
+      'native',
+      'android',
+      'ios',
+      'service',
+      'goldens',
+      'maestro_static',
+      'smoke',
+      'performance',
+      'ci_config',
+    };
 
+    const scopeArms = <String, Set<String>>{
+      'mobile/lib/screens/feed/video_feed_page.dart': {
+        'app',
+        'android',
+        'ios',
+        'service',
+        'goldens',
+        'smoke',
+        'performance',
+      },
+      'mobile/e2e/maestro/flows/feed.yaml': {
+        'app',
+        'maestro_static',
+        'performance',
+      },
+      'mobile/packages/dm_repository/lib/src/dm_repository.dart': {
+        'app',
+        'service',
+      },
+      'mobile/test/goldens/widgets/notification_rows_golden_test.dart': {
+        'app',
+        'goldens',
+      },
+      'mobile/scripts/golden.sh': {'app', 'goldens'},
+      'mobile/packages/divine_ui/lib/src/divine_button.dart': {
+        'app',
+        'service',
+        'goldens',
+      },
+      'mobile/lib/widgets/user_avatar.dart': {
+        'app',
+        'android',
+        'ios',
+        'service',
+        'goldens',
+        'smoke',
+      },
+      'mobile/fonts/Roboto.ttf': {
+        'app',
+        'android',
+        'ios',
+        'goldens',
+        'smoke',
+      },
+      'mobile/android/app/build.gradle.kts': {
+        'app',
+        'native',
+        'android',
+        'smoke',
+      },
+      'mobile/ios/Runner/Info.plist': {'app', 'native', 'ios', 'smoke'},
+      '.github/workflows/badge_repository.yaml': {'app', 'ci_config'},
+    };
+
+    for (final entry in scopeArms.entries) {
+      test('${entry.key} turns on exactly its own scopes', () {
+        final run = runDetector(
+          event: 'pull_request',
+          changedFiles: [entry.key],
+          changedTotal: 1,
+        );
+
+        expect(run.result.exitCode, 0, reason: run.result.stderr.toString());
+        expect(run.outputs['docs_only'], 'false');
+        for (final scope in allScopes) {
+          expect(
+            run.outputs[scope],
+            entry.value.contains(scope) ? 'true' : 'false',
+            reason: '$scope for ${entry.key}',
+          );
+        }
+      });
+    }
+
+    test('a mobile_ci.yaml change runs every scope', () {
       expectScope(
-        run,
+        runDetector(
+          event: 'pull_request',
+          changedFiles: ['.github/workflows/mobile_ci.yaml'],
+          changedTotal: 1,
+        ),
         app: true,
         native: true,
         also: const {
           'docs_only': false,
           'android': true,
           'ios': true,
+          'service': true,
           'goldens': true,
           'maestro_static': true,
           'smoke': true,

--- a/mobile/test/tools/detect_mobile_ci_scope_test.dart
+++ b/mobile/test/tools/detect_mobile_ci_scope_test.dart
@@ -6,6 +6,14 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 
+/// One detector invocation: its process result, the parsed $GITHUB_OUTPUT,
+/// and the argument line of every `gh` call it made.
+typedef DetectorRun = ({
+  ProcessResult result,
+  Map<String, String> outputs,
+  List<String> ghCalls,
+});
+
 void main() {
   group('detect_mobile_ci_scope.sh', () {
     late Directory sandbox;
@@ -31,6 +39,10 @@ void main() {
           r'''
 set -euo pipefail
 
+if [ -n "${FAKE_GH_LOG:-}" ]; then
+  printf '%s\n' "$*" >> "$FAKE_GH_LOG"
+fi
+
 emit_files() {
   if [ -n "${FAKE_CHANGED_FILES:-}" ]; then
     printf '%s\n' "$FAKE_CHANGED_FILES"
@@ -52,17 +64,19 @@ esac
       if (sandbox.existsSync()) sandbox.deleteSync(recursive: true);
     });
 
-    ({ProcessResult result, Map<String, String> outputs}) runDetector({
+    DetectorRun runDetector({
       required String event,
       List<String> changedFiles = const [],
       int changedTotal = 0,
       String pushBeforeSha = 'push-before',
       String pushAfterSha = 'push-after',
     }) {
+      final ghLogPath = p.join(sandbox.path, 'gh-calls');
       final result = Process.runSync(
         'bash',
         [scriptPath],
         environment: {
+          'FAKE_GH_LOG': ghLogPath,
           'PATH':
               '${p.join(sandbox.path, 'bin')}:${Platform.environment['PATH']}',
           'GITHUB_EVENT_NAME': event,
@@ -90,11 +104,18 @@ esac
           }
         }
       }
-      return (result: result, outputs: outputs);
+      final ghLog = File(ghLogPath);
+      return (
+        result: result,
+        outputs: outputs,
+        ghCalls: ghLog.existsSync()
+            ? ghLog.readAsLinesSync()
+            : const <String>[],
+      );
     }
 
     void expectScope(
-      ({ProcessResult result, Map<String, String> outputs}) run, {
+      DetectorRun run, {
       required bool app,
       required bool native,
       Map<String, bool> also = const {},
@@ -332,7 +353,38 @@ esac
       );
     });
 
-    test('push classifies the actual before/after comparison', () {
+    test('push compares github.event.before against github.sha', () {
+      // The compared range is the whole point of the push path, and nothing
+      // else observes it: the fake gh answers any /compare/ URL, so swapping
+      // the two SHAs, or passing the merge-group pair instead, produces an
+      // identical $GITHUB_OUTPUT. In production a reversed range three-dot
+      // resolves to before-vs-before, returns 0 files, and falls open to
+      // every scope on every merge to main — green, and silently the
+      // opposite of what this PR is for.
+      final run = runDetector(
+        event: 'push',
+        changedFiles: ['mobile/lib/main.dart'],
+      );
+
+      expect(
+        run.ghCalls.singleWhere((call) => call.contains('/compare/')),
+        contains('/compare/push-before...push-after'),
+      );
+      expectScope(
+        run,
+        app: true,
+        native: false,
+        also: const {
+          'docs_only': false,
+          'android': true,
+          'ios': true,
+          'service': true,
+          'smoke': true,
+        },
+      );
+    });
+
+    test('push classifies a docs-only merge as docs-only', () {
       expectScope(
         runDetector(event: 'push', changedFiles: ['docs/release-notes.md']),
         app: false,

--- a/mobile/test/tools/detect_mobile_ci_scope_test.dart
+++ b/mobile/test/tools/detect_mobile_ci_scope_test.dart
@@ -514,6 +514,14 @@ esac
       },
       'mobile/ios/Runner/Info.plist': {'app', 'native', 'ios', 'smoke'},
       '.github/workflows/badge_repository.yaml': {'app', 'ci_config'},
+      // `app` is what keeps mobile/test/tools/ running — the contract test
+      // that pins this very workflow lives there, so without it the test
+      // could not fire on a change to its own subject.
+      '.github/workflows/mobile_service_integration_tests.yaml': {
+        'app',
+        'service',
+        'ci_config',
+      },
     };
 
     for (final entry in scopeArms.entries) {

--- a/mobile/test/tools/detect_mobile_ci_scope_test.dart
+++ b/mobile/test/tools/detect_mobile_ci_scope_test.dart
@@ -394,11 +394,19 @@ esac
     });
 
     test('push falls open when the before SHA is all zeroes', () {
+      // A docs-only file, so the zero-file fall-open cannot fire and stand in
+      // for the zeroes guard: without it this test passed unchanged when the
+      // guard was deleted, because the default empty file list falls open on
+      // its own. The stdout reason is what distinguishes the two.
+      final run = runDetector(
+        event: 'push',
+        changedFiles: ['docs/release-notes.md'],
+        pushBeforeSha: '0000000000000000000000000000000000000000',
+      );
+
+      expect(run.result.stdout, contains('no comparable before SHA'));
       expectScope(
-        runDetector(
-          event: 'push',
-          pushBeforeSha: '0000000000000000000000000000000000000000',
-        ),
+        run,
         app: true,
         native: true,
         also: const {

--- a/mobile/test/tools/detect_mobile_ci_scope_test.dart
+++ b/mobile/test/tools/detect_mobile_ci_scope_test.dart
@@ -132,7 +132,6 @@ esac
           'android',
           'ios',
           'service',
-          'goldens',
           'maestro_static',
           'smoke',
           'performance',
@@ -315,7 +314,6 @@ esac
           'android': true,
           'ios': true,
           'service': true,
-          'goldens': true,
           'maestro_static': true,
           'smoke': true,
           'performance': true,
@@ -414,7 +412,6 @@ esac
           'android': true,
           'ios': true,
           'service': true,
-          'goldens': true,
           'maestro_static': true,
           'smoke': true,
           'performance': true,
@@ -422,26 +419,6 @@ esac
         },
       );
     });
-
-    for (final path in [
-      'mobile/lib/notifications/widgets/actor_notification_row.dart',
-      'mobile/lib/l10n/app_en.arb',
-      'mobile/pubspec.yaml',
-      'mobile/pubspec.lock',
-    ]) {
-      test('$path runs the golden suite', () {
-        expectScope(
-          runDetector(
-            event: 'pull_request',
-            changedFiles: [path],
-            changedTotal: 1,
-          ),
-          app: true,
-          native: false,
-          also: const {'goldens': true},
-        );
-      });
-    }
 
     // One path per row, and the complete set of scopes it must turn on —
     // everything else is asserted false. The test this replaced passed three
@@ -455,7 +432,6 @@ esac
       'android',
       'ios',
       'service',
-      'goldens',
       'maestro_static',
       'smoke',
       'performance',
@@ -468,7 +444,6 @@ esac
         'android',
         'ios',
         'service',
-        'goldens',
         'smoke',
         'performance',
       },
@@ -481,31 +456,20 @@ esac
         'app',
         'service',
       },
-      'mobile/test/goldens/widgets/notification_rows_golden_test.dart': {
-        'app',
-        'goldens',
-      },
-      'mobile/scripts/golden.sh': {'app', 'goldens'},
+      'mobile/test/goldens/widgets/notification_rows_golden_test.dart': {'app'},
+      'mobile/scripts/golden.sh': {'app'},
       'mobile/packages/divine_ui/lib/src/divine_button.dart': {
         'app',
         'service',
-        'goldens',
       },
       'mobile/lib/widgets/user_avatar.dart': {
         'app',
         'android',
         'ios',
         'service',
-        'goldens',
         'smoke',
       },
-      'mobile/fonts/Roboto.ttf': {
-        'app',
-        'android',
-        'ios',
-        'goldens',
-        'smoke',
-      },
+      'mobile/fonts/Roboto.ttf': {'app', 'android', 'ios', 'smoke'},
       'mobile/android/app/build.gradle.kts': {
         'app',
         'native',
@@ -558,7 +522,6 @@ esac
           'android': true,
           'ios': true,
           'service': true,
-          'goldens': true,
           'maestro_static': true,
           'smoke': true,
           'performance': true,

--- a/mobile/test/tools/detect_mobile_ci_scope_test.dart
+++ b/mobile/test/tools/detect_mobile_ci_scope_test.dart
@@ -363,6 +363,26 @@ esac
       );
     });
 
+    for (final path in [
+      'mobile/lib/notifications/widgets/actor_notification_row.dart',
+      'mobile/lib/l10n/app_en.arb',
+      'mobile/pubspec.yaml',
+      'mobile/pubspec.lock',
+    ]) {
+      test('$path runs the golden suite', () {
+        expectScope(
+          runDetector(
+            event: 'pull_request',
+            changedFiles: [path],
+            changedTotal: 1,
+          ),
+          app: true,
+          native: false,
+          also: const {'goldens': true},
+        );
+      });
+    }
+
     test('classifies focused QA scopes independently', () {
       final run = runDetector(
         event: 'pull_request',

--- a/mobile/test/tools/detect_mobile_ci_scope_test.dart
+++ b/mobile/test/tools/detect_mobile_ci_scope_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Tests Mobile CI scope detection across PR and merge-queue events.
-// ABOUTME: Pins app/native classification and every fall-open API boundary.
+// ABOUTME: Tests Mobile CI and QA scope detection across GitHub event types.
+// ABOUTME: Pins focused classifications and every fail-open API boundary.
 
 import 'dart:io';
 
@@ -56,6 +56,8 @@ esac
       required String event,
       List<String> changedFiles = const [],
       int changedTotal = 0,
+      String pushBeforeSha = 'push-before',
+      String pushAfterSha = 'push-after',
     }) {
       final result = Process.runSync(
         'bash',
@@ -69,6 +71,8 @@ esac
           'PR_NUMBER': '7058',
           'QUEUE_BASE_SHA': 'base-sha',
           'QUEUE_HEAD_SHA': 'head-sha',
+          'PUSH_BEFORE_SHA': pushBeforeSha,
+          'PUSH_AFTER_SHA': pushAfterSha,
           'FAKE_CHANGED_FILES': changedFiles.join('\n'),
           'FAKE_CHANGED_TOTAL': '$changedTotal',
         },
@@ -93,9 +97,30 @@ esac
       ({ProcessResult result, Map<String, String> outputs}) run, {
       required bool app,
       required bool native,
+      Map<String, bool> also = const {},
     }) {
       expect(run.result.exitCode, 0, reason: run.result.stderr.toString());
-      expect(run.outputs, {'app': '$app', 'native': '$native'});
+      expect(run.outputs['app'], '$app');
+      expect(run.outputs['native'], '$native');
+      expect(
+        run.outputs.keys,
+        containsAll(<String>{
+          'docs_only',
+          'app',
+          'native',
+          'android',
+          'ios',
+          'service',
+          'goldens',
+          'maestro_static',
+          'smoke',
+          'performance',
+          'ci_config',
+        }),
+      );
+      for (final entry in also.entries) {
+        expect(run.outputs[entry.key], '${entry.value}', reason: entry.key);
+      }
     }
 
     for (final event in ['pull_request', 'merge_group']) {
@@ -109,6 +134,12 @@ esac
             ),
             app: true,
             native: false,
+            also: const {
+              'docs_only': false,
+              'android': true,
+              'ios': true,
+              'smoke': true,
+            },
           );
         });
 
@@ -148,6 +179,11 @@ esac
             ),
             app: false,
             native: false,
+            also: const {
+              'docs_only': false,
+              'maestro_static': true,
+              'ci_config': true,
+            },
           );
         });
 
@@ -160,6 +196,7 @@ esac
             ),
             app: false,
             native: false,
+            also: const {'docs_only': true},
           );
         });
 
@@ -172,6 +209,7 @@ esac
             ),
             app: true,
             native: true,
+            also: const {'android': false, 'ios': true, 'smoke': true},
           );
         });
       });
@@ -252,6 +290,16 @@ esac
         ),
         app: true,
         native: true,
+        also: const {
+          'android': true,
+          'ios': true,
+          'service': true,
+          'goldens': true,
+          'maestro_static': true,
+          'smoke': true,
+          'performance': true,
+          'ci_config': true,
+        },
       );
     });
 
@@ -284,8 +332,63 @@ esac
       );
     });
 
-    test('push falls open to preserve the full main-branch matrix', () {
-      expectScope(runDetector(event: 'push'), app: true, native: true);
+    test('push classifies the actual before/after comparison', () {
+      expectScope(
+        runDetector(event: 'push', changedFiles: ['docs/release-notes.md']),
+        app: false,
+        native: false,
+        also: const {'docs_only': true, 'smoke': false},
+      );
+    });
+
+    test('push falls open when the before SHA is all zeroes', () {
+      expectScope(
+        runDetector(
+          event: 'push',
+          pushBeforeSha: '0000000000000000000000000000000000000000',
+        ),
+        app: true,
+        native: true,
+        also: const {
+          'docs_only': false,
+          'android': true,
+          'ios': true,
+          'service': true,
+          'goldens': true,
+          'maestro_static': true,
+          'smoke': true,
+          'performance': true,
+          'ci_config': true,
+        },
+      );
+    });
+
+    test('classifies focused QA scopes independently', () {
+      final run = runDetector(
+        event: 'pull_request',
+        changedFiles: [
+          'mobile/lib/screens/feed/video_feed_page.dart',
+          'mobile/e2e/maestro/flows/feed.yaml',
+          '.github/workflows/mobile_ci.yaml',
+        ],
+        changedTotal: 3,
+      );
+
+      expectScope(
+        run,
+        app: true,
+        native: true,
+        also: const {
+          'docs_only': false,
+          'android': true,
+          'ios': true,
+          'goldens': true,
+          'maestro_static': true,
+          'smoke': true,
+          'performance': true,
+          'ci_config': true,
+        },
+      );
     });
   });
 }

--- a/mobile/test/tools/mobile_qa_workflow_contract_test.dart
+++ b/mobile/test/tools/mobile_qa_workflow_contract_test.dart
@@ -1,46 +1,115 @@
 // ABOUTME: Pins event routing for selective post-merge and nightly mobile QA.
-// ABOUTME: Ensures docs-aware service scope and full scheduled coverage coexist.
+// ABOUTME: Parses the workflow so each clause is asserted where it lives.
 
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:yaml/yaml.dart';
 
 void main() {
   group('mobile service QA workflow', () {
-    late String workflow;
+    late Map<dynamic, dynamic> workflow;
+    late Map<dynamic, dynamic> triggers;
+    late Map<dynamic, dynamic> changes;
 
+    // Parsed rather than substring-matched. Three of the twelve `contains`
+    // assertions this replaced already passed on the base commit, and
+    // `contains('branches: [main]')` was satisfied by the pre-existing
+    // pull_request trigger — so deleting `branches: [main]` from under the
+    // new `push:` left every needle matching while the workflow started
+    // firing on every push to every branch.
     setUpAll(() {
-      workflow = File(
-        '../.github/workflows/mobile_service_integration_tests.yaml',
-      ).readAsStringSync();
+      workflow =
+          loadYaml(
+                File(
+                  '../.github/workflows/mobile_service_integration_tests.yaml',
+                ).readAsStringSync(),
+              )
+              as Map<dynamic, dynamic>;
+      triggers = workflow['on'] as Map<dynamic, dynamic>;
+      changes =
+          (workflow['jobs'] as Map<dynamic, dynamic>)['changes']
+              as Map<dynamic, dynamic>;
     });
 
-    test('runs for pull requests, main pushes, schedules, and dispatches', () {
-      expect(workflow, contains('pull_request:'));
-      expect(workflow, contains('push:'));
-      expect(workflow, contains('branches: [main]'));
-      expect(workflow, contains('schedule:'));
-      expect(workflow, contains('workflow_dispatch:'));
+    Map<dynamic, dynamic> stepById(String id) => (changes['steps'] as List)
+        .cast<Map<dynamic, dynamic>>()
+        .firstWhere((step) => step['id'] == id);
+
+    group('triggers', () {
+      test('runs on pushes to main only', () {
+        final push = triggers['push'] as Map<dynamic, dynamic>;
+        expect((push['branches'] as List).cast<String>(), equals(['main']));
+      });
+
+      test('runs on pull requests to main', () {
+        final pr = triggers['pull_request'] as Map<dynamic, dynamic>;
+        expect((pr['branches'] as List).cast<String>(), equals(['main']));
+      });
+
+      test('runs nightly on a cron schedule', () {
+        final schedule = (triggers['schedule'] as List)
+            .cast<Map<dynamic, dynamic>>();
+        expect(schedule, isNotEmpty);
+        expect(schedule.single['cron'], isA<String>());
+      });
+
+      test('can be dispatched manually', () {
+        expect(triggers.containsKey('workflow_dispatch'), isTrue);
+      });
     });
 
-    test('uses the shared mobile classifier after merges', () {
-      expect(workflow, contains('detect_mobile_ci_scope.sh'));
-      expect(workflow, contains("github.event_name == 'push'"));
-      expect(workflow, contains('steps.mobile-scope.outputs.service'));
-      expect(workflow, contains('PUSH_BEFORE_SHA:'));
-      expect(workflow, contains('PUSH_AFTER_SHA:'));
+    group('post-merge classification', () {
+      test('classifies a merge with the shared mobile detector', () {
+        final step = stepById('mobile-scope');
+        expect(step['if'] as String, contains("github.event_name == 'push'"));
+        expect(step['run'] as String, contains('detect_mobile_ci_scope.sh'));
+      });
+
+      test('compares github.event.before against github.sha', () {
+        final env = stepById('mobile-scope')['env'] as Map<dynamic, dynamic>;
+        expect(env['PUSH_BEFORE_SHA'], equals(r'${{ github.event.before }}'));
+        expect(env['PUSH_AFTER_SHA'], equals(r'${{ github.sha }}'));
+      });
+
+      test('feeds the mobile service scope into both suite groups', () {
+        final env = stepById('resolved')['env'] as Map<dynamic, dynamic>;
+        for (final key in ['FOCUSED', 'APP']) {
+          expect(
+            env[key] as String,
+            contains('steps.mobile-scope.outputs.service'),
+            reason: key,
+          );
+        }
+      });
+
+      test('gives each merge its own concurrency group', () {
+        final concurrency = workflow['concurrency'] as Map<dynamic, dynamic>;
+        expect(concurrency['group'] as String, contains('github.sha'));
+        expect(concurrency['cancel-in-progress'], isTrue);
+      });
     });
 
-    test('runs every service group on schedules and manual dispatches', () {
-      expect(
-        workflow,
-        contains(
-          "github.event_name == 'schedule' || "
-          "github.event_name == 'workflow_dispatch'",
-        ),
-      );
-      expect(workflow, contains('echo "focused=true"'));
-      expect(workflow, contains('echo "app=true"'));
+    group('scope resolution', () {
+      test('takes both job outputs from the resolve step', () {
+        final outputs = changes['outputs'] as Map<dynamic, dynamic>;
+        expect(outputs['focused'], contains('steps.resolved.outputs.focused'));
+        expect(outputs['app'], contains('steps.resolved.outputs.app'));
+      });
+
+      test('resolves unconditionally so an unclassified event fails', () {
+        expect(stepById('resolved')['if'], isNull);
+        expect(stepById('resolved')['run'] as String, contains('exit 1'));
+      });
+
+      test('runs every service group on schedules and manual dispatches', () {
+        final step = stepById('full-scope');
+        final gate = step['if'] as String;
+        expect(gate, contains("github.event_name == 'schedule'"));
+        expect(gate, contains("github.event_name == 'workflow_dispatch'"));
+        expect(step['run'] as String, contains('focused=true'));
+        expect(step['run'] as String, contains('app=true'));
+      });
     });
   });
 }

--- a/mobile/test/tools/mobile_qa_workflow_contract_test.dart
+++ b/mobile/test/tools/mobile_qa_workflow_contract_test.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Pins event routing for selective post-merge and nightly mobile QA.
+// ABOUTME: Pins event routing and alerting for selective post-merge and daily mobile QA.
 // ABOUTME: Parses the workflow so each clause is asserted where it lives.
 
 import 'dart:io';
@@ -9,8 +9,11 @@ import 'package:yaml/yaml.dart';
 void main() {
   group('mobile service QA workflow', () {
     late Map<dynamic, dynamic> workflow;
+    late Map<dynamic, dynamic> mobileCiWorkflow;
     late Map<dynamic, dynamic> triggers;
     late Map<dynamic, dynamic> changes;
+    late Map<dynamic, dynamic> serviceTests;
+    late Map<dynamic, dynamic> dailySignal;
 
     // Parsed rather than substring-matched. Three of the twelve `contains`
     // assertions this replaced already passed on the base commit, and
@@ -26,15 +29,31 @@ void main() {
                 ).readAsStringSync(),
               )
               as Map<dynamic, dynamic>;
+      mobileCiWorkflow =
+          loadYaml(
+                File('../.github/workflows/mobile_ci.yaml').readAsStringSync(),
+              )
+              as Map<dynamic, dynamic>;
       triggers = workflow['on'] as Map<dynamic, dynamic>;
       changes =
           (workflow['jobs'] as Map<dynamic, dynamic>)['changes']
+              as Map<dynamic, dynamic>;
+      serviceTests =
+          (workflow['jobs'] as Map<dynamic, dynamic>)['service-tests']
+              as Map<dynamic, dynamic>;
+      dailySignal =
+          (workflow['jobs'] as Map<dynamic, dynamic>)['daily-signal']
               as Map<dynamic, dynamic>;
     });
 
     Map<dynamic, dynamic> stepById(String id) => (changes['steps'] as List)
         .cast<Map<dynamic, dynamic>>()
         .firstWhere((step) => step['id'] == id);
+
+    Map<dynamic, dynamic> serviceStepByName(String name) =>
+        (dailySignal['steps'] as List).cast<Map<dynamic, dynamic>>().firstWhere(
+          (step) => step['name'] == name,
+        );
 
     group('triggers', () {
       test('runs on pushes to main only', () {
@@ -47,11 +66,11 @@ void main() {
         expect((pr['branches'] as List).cast<String>(), equals(['main']));
       });
 
-      test('runs nightly on a cron schedule', () {
+      test('runs daily at 07:23 UTC', () {
         final schedule = (triggers['schedule'] as List)
             .cast<Map<dynamic, dynamic>>();
         expect(schedule, isNotEmpty);
-        expect(schedule.single['cron'], isA<String>());
+        expect(schedule.single['cron'], equals('23 7 * * *'));
       });
 
       test('can be dispatched manually', () {
@@ -109,6 +128,60 @@ void main() {
         expect(gate, contains("github.event_name == 'workflow_dispatch'"));
         expect(step['run'] as String, contains('focused=true'));
         expect(step['run'] as String, contains('app=true'));
+      });
+    });
+
+    group('daily failure signal', () {
+      test('isolates issue access in the scheduled signal job', () {
+        expect(serviceTests['permissions'], isNull);
+        final permissions = dailySignal['permissions'] as Map<dynamic, dynamic>;
+        expect(permissions['contents'], equals('read'));
+        expect(permissions['issues'], equals('write'));
+        expect(
+          dailySignal['if'] as String,
+          contains("github.event_name == 'schedule'"),
+        );
+      });
+
+      test('opens one durable incident only after a scheduled failure', () {
+        final step = serviceStepByName(
+          'Open or update the daily service-test incident',
+        );
+        final gate = step['if'] as String;
+        expect(gate, contains("needs.changes.result != 'success'"));
+        expect(gate, contains("needs.service-tests.result != 'success'"));
+        final script =
+            (step['with'] as Map<dynamic, dynamic>)['script'] as String;
+        expect(script, contains('daily-service-integration-incident'));
+        expect(script, contains('issues.create'));
+        expect(script, contains("state: 'open'"));
+      });
+
+      test('closes the incident only after a scheduled recovery', () {
+        final step = serviceStepByName(
+          'Close the recovered daily service-test incident',
+        );
+        final gate = step['if'] as String;
+        expect(gate, contains("needs.changes.result == 'success'"));
+        expect(gate, contains("needs.service-tests.result == 'success'"));
+        final script =
+            (step['with'] as Map<dynamic, dynamic>)['script'] as String;
+        expect(script, contains('daily-service-integration-incident'));
+        expect(script, contains("state: 'closed'"));
+      });
+    });
+
+    group('golden coverage', () {
+      test('follows app scope instead of a separate path allowlist', () {
+        final jobs = mobileCiWorkflow['jobs'] as Map<dynamic, dynamic>;
+        final goldens = jobs['goldens'] as Map<dynamic, dynamic>;
+        final gate = goldens['if'] as String;
+        expect(gate, contains("needs.changes.outputs.app == 'true'"));
+        expect(gate, isNot(contains('outputs.goldens')));
+
+        final changesJob = jobs['changes'] as Map<dynamic, dynamic>;
+        final outputs = changesJob['outputs'] as Map<dynamic, dynamic>;
+        expect(outputs.containsKey('goldens'), isFalse);
       });
     });
   });

--- a/mobile/test/tools/mobile_qa_workflow_contract_test.dart
+++ b/mobile/test/tools/mobile_qa_workflow_contract_test.dart
@@ -1,0 +1,46 @@
+// ABOUTME: Pins event routing for selective post-merge and nightly mobile QA.
+// ABOUTME: Ensures docs-aware service scope and full scheduled coverage coexist.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('mobile service QA workflow', () {
+    late String workflow;
+
+    setUpAll(() {
+      workflow = File(
+        '../.github/workflows/mobile_service_integration_tests.yaml',
+      ).readAsStringSync();
+    });
+
+    test('runs for pull requests, main pushes, schedules, and dispatches', () {
+      expect(workflow, contains('pull_request:'));
+      expect(workflow, contains('push:'));
+      expect(workflow, contains('branches: [main]'));
+      expect(workflow, contains('schedule:'));
+      expect(workflow, contains('workflow_dispatch:'));
+    });
+
+    test('uses the shared mobile classifier after merges', () {
+      expect(workflow, contains('detect_mobile_ci_scope.sh'));
+      expect(workflow, contains("github.event_name == 'push'"));
+      expect(workflow, contains('steps.mobile-scope.outputs.service'));
+      expect(workflow, contains('PUSH_BEFORE_SHA:'));
+      expect(workflow, contains('PUSH_AFTER_SHA:'));
+    });
+
+    test('runs every service group on schedules and manual dispatches', () {
+      expect(
+        workflow,
+        contains(
+          "github.event_name == 'schedule' || "
+          "github.event_name == 'workflow_dispatch'",
+        ),
+      );
+      expect(workflow, contains('echo "focused=true"'));
+      expect(workflow, contains('echo "app=true"'));
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Mobile CI exposed only broad app/native decisions and automatically ran the full matrix on every push to main. Docs-only merges paid for Flutter tests and goldens, later QA workflows had no shared applicability contract, and deterministic service integration ran only before merge.

## Why this change

This adds one fail-open classifier for pull requests, merge groups, pushes, and manual runs. It publishes focused scopes for docs, platforms, service integration, Maestro static checks, smoke, performance, and CI configuration. Main pushes compare their actual before/after SHAs, so docs-only merges stay cheap without duplicated path filters.

Goldens deliberately follow the broad `app` scope. Their transitive dependency graph is too wide for a hand-maintained path allowlist to be a sound merge gate.

Service integration runs selectively after relevant merges, runs every deterministic suite daily at 07:23 UTC, and preserves its conservative PR grouping. The UTC label avoids implying a single team's night; a durable, de-duplicated issue makes failures visible for follow-the-sun ownership and closes automatically after recovery. Event-specific concurrency prevents a scheduled run from cancelling merge validation.

The QA runbook documents the coverage matrix, artifact-first triage, global handoff, ownership, device-test boundaries, and evidence needed before making Maestro blocking.

## Deliberately unchanged

This PR does not activate Codemagic device automation or replace the specialized service-suite grouping used on pull requests. Post-merge service coverage remains conservative: both groups use the coarse service scope until a narrower dependency policy is proven safe. External Codemagic webhook restoration remains tracked by #7504.

## Verification

- `flutter test test/tools/detect_mobile_ci_scope_test.dart test/tools/mobile_qa_workflow_contract_test.dart` (52 tests)
- `flutter analyze lib test integration_test`
- `flutter test test/tools --concurrency=1` (763 passed, 2 intentional skips)
- `python3 -m unittest discover -s .github/scripts/tests` (88 tests)
- parsed both changed GitHub workflows with Ruby YAML
- service-suite coverage and scope-drift guards
- package coverage and package CI floor guards
- Future.delayed production/test and uncancellable-timer guards
- `.codex/scripts/test-config.sh`
- repository pre-push checks

Closes #8865
Closes #8866
Related to #8864
