### PR TITLE
fix(moderation): receive new safety labels without restarting the app

### DIFF
--- a/docs/superpowers/specs/2026-09-07-labeler-live-subscription-design.md
+++ b/docs/superpowers/specs/2026-09-07-labeler-live-subscription-design.md
@@ -22,8 +22,8 @@ reaches the running client until an app restart. This is the complement of #8214
    (which exists precisely to avoid OOM/timeout on large histories). So the paged
    backfill (`_loadLabelerHistory`) stays as-is and latches "loaded"; the live
    subscription opens from the oldest per-labeler watermark. Each author still has
-   its own watermark, so events older than that author's boundary are ignored even
-   when another author requires an older shared `since`.
+   its own watermark and a five-minute replay tolerance, so distinct events that
+   arrive slightly out of timestamp order still apply while older replay is ignored.
 
 3. **Auto-reconnect above the SDK**, mirroring `DmRepository`'s gift-wrap
    subscription: store the shared `StreamSubscription`; on `onError`
@@ -42,10 +42,11 @@ reaches the running client until an app restart. This is the complement of #8214
 
 `_processLabelEvent` appends unconditionally, so a reconnect that replays the tail
 window (and the small backfill/tail overlap) would create duplicate label rows.
-Track event ids only at or after each labeler's current watermark:
+Track event ids within a bounded window around each labeler's current watermark:
 - `_processLabelEvent` skips an event id already applied for its labeler.
-- advancing a labeler's watermark discards ids from older seconds, bounding retained
-  dedup state to the timestamp-tie replay window rather than its complete history;
+- advancing a labeler's watermark discards ids older than the five-minute replay
+  tolerance, bounding retained dedup state without treating cross-relay delivery
+  order as timestamp order;
 - `_removeLabelsForLabeler(pubkey)` also clears that labeler's id-set, so the
   backfill's existing remove-then-reprocess still re-applies, and the
   backfill/tail overlap dedups.

--- a/docs/superpowers/specs/2026-09-07-labeler-live-subscription-design.md
+++ b/docs/superpowers/specs/2026-09-07-labeler-live-subscription-design.md
@@ -11,7 +11,7 @@ reaches the running client until an app restart. This is the complement of #8214
 1. **One shared subscription for all loaded trusted labelers.** Explicitly selected
    labelers and followed accounts are multiplexed into one `authors:[...]` filter.
    The followed-labeler product setting applies to the entire follow list, which can
-   exceed the production relay's 100-subscription limit; one REQ keeps relay work
+   exceed a relay's per-connection subscription limit; one REQ keeps relay work
    constant without silently weakening that setting. Per-labeler state remains
    independent for history loading, moderation rows, watermarks, and unloads. A
    follow-list change cancels the old listener before replacing the stable REQ id,

--- a/docs/superpowers/specs/2026-09-07-labeler-live-subscription-design.md
+++ b/docs/superpowers/specs/2026-09-07-labeler-live-subscription-design.md
@@ -8,27 +8,30 @@ reaches the running client until an app restart. This is the complement of #8214
 
 ## Approved design decisions
 
-1. **One subscription per labeler.** Reuse the existing per-pubkey `_subscriptions`
-   map. The whole service is keyed per-pubkey (load generation, `_loadingLabelers`,
-   `_unloadLabeler`, follow-list churn), so per-labeler subscriptions are the
-   surgical fit. Practical count stays well under the relay's `max_subscriptions:
-   100`. A single combined `authors:[...]` filter was rejected: it would force
-   re-architecting the per-pubkey model and replay every labeler's stored window on
-   each follow-list change.
+1. **One shared subscription for all loaded trusted labelers.** Explicitly selected
+   labelers and followed accounts are multiplexed into one `authors:[...]` filter.
+   The followed-labeler product setting applies to the entire follow list, which can
+   exceed the production relay's 100-subscription limit; one REQ keeps relay work
+   constant without silently weakening that setting. Per-labeler state remains
+   independent for history loading, moderation rows, watermarks, and unloads. A
+   follow-list change cancels the old listener before replacing the stable REQ id,
+   and bulk changes are coalesced into one replacement.
 
 2. **Tail-only live subscription; keep the paged backfill.** A no-`since`
    subscription would re-request the full stored window and undo #8817's paging
    (which exists precisely to avoid OOM/timeout on large histories). So the paged
    backfill (`_loadLabelerHistory`) stays as-is and latches "loaded"; the live
-   subscription opens with `since` = the newest applied label's `created_at`
-   (fallback: now) and carries only new labels.
+   subscription opens from the oldest per-labeler watermark. Each author still has
+   its own watermark, so events older than that author's boundary are ignored even
+   when another author requires an older shared `since`.
 
 3. **Auto-reconnect above the SDK**, mirroring `DmRepository`'s gift-wrap
-   subscription: store the per-pubkey `StreamSubscription`; on `onError`
+   subscription: store the shared `StreamSubscription`; on `onError`
    (relay `CLOSED` → `RelaySubscriptionRefusedException`) or `onDone`, cancel and
-   re-open the tail via a cancellable `Timer`, guarded by `_disposed` and the
-   existing per-pubkey load generation so an unload / account switch / dispose kills
-   pending reconnects. The reconnect re-opens with an updated `since` (newest seen).
+   re-open the tail via one cancellable `Timer`, guarded by `_disposed` and the tail
+   generation so replacement / account switch / dispose kills stale callbacks. The
+   reconnect delay backs off from two seconds to one minute, resets after delivery
+   or EOSE, and logs both the drop and planned retry.
 
 4. **Keep #8214's relay-ready retry.** It recovers an *incomplete backfill* (timed
    out / no relays), a different failure mode than a dropped tail: the tail only
@@ -39,8 +42,10 @@ reaches the running client until an app restart. This is the complement of #8214
 
 `_processLabelEvent` appends unconditionally, so a reconnect that replays the tail
 window (and the small backfill/tail overlap) would create duplicate label rows.
-Track `_appliedLabelEventIds: Map<pubkey, Set<eventId>>`:
+Track event ids only at or after each labeler's current watermark:
 - `_processLabelEvent` skips an event id already applied for its labeler.
+- advancing a labeler's watermark discards ids from older seconds, bounding retained
+  dedup state to the timestamp-tie replay window rather than its complete history;
 - `_removeLabelsForLabeler(pubkey)` also clears that labeler's id-set, so the
   backfill's existing remove-then-reprocess still re-applies, and the
   backfill/tail overlap dedups.
@@ -50,8 +55,8 @@ Track `_appliedLabelEventIds: Map<pubkey, Set<eventId>>`:
 - A labeler's kind-1985 events published *after* subscription reach the label maps
   without an app restart.
 - The same event arriving twice does not produce duplicate label rows.
-- `_subscriptions` holds real subscriptions; `_unloadLabeler` and `dispose()`
-  tear them down.
+- the shared subscription carries all loaded trusted authors; author-set changes and
+  `dispose()` tear down the previous listener.
 - Behaviour survives a relay reconnect (verified, not assumed).
 - No regression to #8214: an incomplete initial load still must not latch loaded.
 
@@ -61,6 +66,8 @@ Extend `test/services/moderation_label_service_test.dart` (mocktail harness). St
 `nostrClient.subscribe(...)` to return a controllable `StreamController<Event>`:
 - live label after load lands in the maps (no restart);
 - duplicate event id → single row (dedup);
+- all followed labelers use one REQ, author-set changes replace it, and old
+  per-author replay is ignored;
 - `_unloadLabeler` / account switch / `dispose` cancels the subscription and stops
   a pending reconnect;
 - stream `onDone`/`onError` triggers a reconnect that re-opens the tail;

--- a/docs/superpowers/specs/2026-09-07-labeler-live-subscription-design.md
+++ b/docs/superpowers/specs/2026-09-07-labeler-live-subscription-design.md
@@ -1,0 +1,68 @@
+# Live labeler subscription (#8255) — design
+
+**Problem.** `ModerationLabelService.subscribeToLabeler` performs a one-shot paged
+history load and never opens a live subscription. `_subscriptions` is declared but
+never assigned. A kind-1985 label published *after* a client loads a labeler never
+reaches the running client until an app restart. This is the complement of #8214
+(a *failed* load latched as done); here a *successful* load is treated as final.
+
+## Approved design decisions
+
+1. **One subscription per labeler.** Reuse the existing per-pubkey `_subscriptions`
+   map. The whole service is keyed per-pubkey (load generation, `_loadingLabelers`,
+   `_unloadLabeler`, follow-list churn), so per-labeler subscriptions are the
+   surgical fit. Practical count stays well under the relay's `max_subscriptions:
+   100`. A single combined `authors:[...]` filter was rejected: it would force
+   re-architecting the per-pubkey model and replay every labeler's stored window on
+   each follow-list change.
+
+2. **Tail-only live subscription; keep the paged backfill.** A no-`since`
+   subscription would re-request the full stored window and undo #8817's paging
+   (which exists precisely to avoid OOM/timeout on large histories). So the paged
+   backfill (`_loadLabelerHistory`) stays as-is and latches "loaded"; the live
+   subscription opens with `since` = the newest applied label's `created_at`
+   (fallback: now) and carries only new labels.
+
+3. **Auto-reconnect above the SDK**, mirroring `DmRepository`'s gift-wrap
+   subscription: store the per-pubkey `StreamSubscription`; on `onError`
+   (relay `CLOSED` → `RelaySubscriptionRefusedException`) or `onDone`, cancel and
+   re-open the tail via a cancellable `Timer`, guarded by `_disposed` and the
+   existing per-pubkey load generation so an unload / account switch / dispose kills
+   pending reconnects. The reconnect re-opens with an updated `since` (newest seen).
+
+4. **Keep #8214's relay-ready retry.** It recovers an *incomplete backfill* (timed
+   out / no relays), a different failure mode than a dropped tail: the tail only
+   carries new labels and cannot backfill unfetched history. Complementary, so it
+   stays; the boundary is documented in code.
+
+## Mandatory: per-event dedup (AC #2)
+
+`_processLabelEvent` appends unconditionally, so a reconnect that replays the tail
+window (and the small backfill/tail overlap) would create duplicate label rows.
+Track `_appliedLabelEventIds: Map<pubkey, Set<eventId>>`:
+- `_processLabelEvent` skips an event id already applied for its labeler.
+- `_removeLabelsForLabeler(pubkey)` also clears that labeler's id-set, so the
+  backfill's existing remove-then-reprocess still re-applies, and the
+  backfill/tail overlap dedups.
+
+## Acceptance criteria (from #8255)
+
+- A labeler's kind-1985 events published *after* subscription reach the label maps
+  without an app restart.
+- The same event arriving twice does not produce duplicate label rows.
+- `_subscriptions` holds real subscriptions; `_unloadLabeler` and `dispose()`
+  tear them down.
+- Behaviour survives a relay reconnect (verified, not assumed).
+- No regression to #8214: an incomplete initial load still must not latch loaded.
+
+## Test plan (TDD)
+
+Extend `test/services/moderation_label_service_test.dart` (mocktail harness). Stub
+`nostrClient.subscribe(...)` to return a controllable `StreamController<Event>`:
+- live label after load lands in the maps (no restart);
+- duplicate event id → single row (dedup);
+- `_unloadLabeler` / account switch / `dispose` cancels the subscription and stops
+  a pending reconnect;
+- stream `onDone`/`onError` triggers a reconnect that re-opens the tail;
+- incomplete backfill still does not latch (unchanged #8214 contract);
+- each new test mutation-checked (break the guard, watch it go red).

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -261,6 +261,11 @@ class ModerationLabelService {
   /// Active subscriptions.
   final Map<String, StreamSubscription<dynamic>> _subscriptions = {};
 
+  /// Label event ids already applied per labeler, so a reconnect that replays
+  /// the relay's stored window does not double-count. Cleared with a labeler's
+  /// rows in [_removeLabelsForLabeler]. #8255.
+  final Map<String, Set<String>> _appliedLabelEventIds = {};
+
   /// Whether persisted settings have been loaded.
   bool _loadedPersistedState = false;
   Future<void>? _loadPersistedStateFuture;
@@ -864,6 +869,18 @@ class ModerationLabelService {
     try {
       final tags = event.tags as List<dynamic>;
       final labelerPubkey = event.pubkey as String;
+      final eventId = event.id as String;
+
+      // A reconnect replays the relay's stored window, so the same label event
+      // arrives again; apply each label event at most once per labeler. Empty
+      // ids come only from test fakes on the single-shot backfill path; real
+      // wire events always carry one, so skipping dedup for them is safe. #8255.
+      if (eventId.isNotEmpty &&
+          !_appliedLabelEventIds
+              .putIfAbsent(labelerPubkey, () => <String>{})
+              .add(eventId)) {
+        return;
+      }
 
       final namespaces = <String>{};
       final labels = <_PendingModerationLabel>[];
@@ -1072,6 +1089,9 @@ class ModerationLabelService {
   }
 
   void _removeLabelsForLabeler(String pubkey) {
+    // Drop the dedup set too: the backfill removes then reprocesses a labeler's
+    // rows, so its events must be allowed to apply again. #8255.
+    _appliedLabelEventIds.remove(pubkey);
     _labelsByEventId.forEach((_, labels) {
       labels.removeWhere((l) => l.labelerPubkey == pubkey);
     });

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -167,6 +167,12 @@ class ModerationLabelService {
   /// Maximum delay between attempts to restore the shared labeler tail.
   static const Duration defaultTailMaxReconnectDelay = Duration(minutes: 1);
 
+  /// How far behind an author's newest label the live tail accepts unseen
+  /// events. Relays deliver independently, so arrival order is not timestamp
+  /// order; this window prevents a faster relay from suppressing a distinct
+  /// label delivered later by another relay while keeping replay dedup bounded.
+  static const Duration defaultTailReplayTolerance = Duration(minutes: 5);
+
   final Duration _tailReconnectDelay;
   final Duration _tailMaxReconnectDelay;
 
@@ -289,11 +295,12 @@ class ModerationLabelService {
   int _tailRebuildDeferrals = 0;
   bool _tailRebuildPending = false;
 
-  /// Ids at each labeler's current watermark second.
+  /// Ids within each labeler's retained replay window.
   ///
-  /// Events older than the watermark are ignored on replay. Moving to a newer
-  /// second replaces this set, so dedup retention is bounded by timestamp ties
-  /// rather than the labeler's complete history. #8255.
+  /// Relays can deliver distinct events out of timestamp order. Moving the
+  /// watermark therefore prunes only ids older than
+  /// [defaultTailReplayTolerance],
+  /// rather than rejecting every event older than the newest one. #8255.
   final Map<String, Map<String, int>> _appliedLabelEventIds = {};
 
   /// Newest label timestamp seen per labeler. A reconnect resumes the tail from
@@ -755,7 +762,7 @@ class ModerationLabelService {
     if (authors.isEmpty) return;
 
     final since = authors
-        .map((pubkey) => _tailWatermark[pubkey]!)
+        .map((pubkey) => _tailReplayFloor(_tailWatermark[pubkey]!))
         .reduce((oldest, value) => value < oldest ? value : oldest);
     final stream = _nostrClient.subscribe(
       [
@@ -778,15 +785,20 @@ class ModerationLabelService {
   void _onTailEvent(Event event) {
     final watermark = _tailWatermark[event.pubkey];
     if (watermark == null || !_tailAuthors.contains(event.pubkey)) return;
-    if (event.createdAt < watermark) return;
+    if (event.createdAt < _tailReplayFloor(watermark)) return;
     if (event.createdAt > watermark) {
       _tailWatermark[event.pubkey] = event.createdAt;
       _appliedLabelEventIds[event.pubkey]?.removeWhere((_, createdAt) {
-        return createdAt < event.createdAt;
+        return createdAt < _tailReplayFloor(event.createdAt);
       });
     }
     _tailReconnectAttempt = 0;
     _processLabelEvent(event);
+  }
+
+  int _tailReplayFloor(int watermark) {
+    final floor = watermark - defaultTailReplayTolerance.inSeconds;
+    return floor < 0 ? 0 : floor;
   }
 
   void _scheduleTailReconnect(int generation, [Object? error]) {
@@ -1027,7 +1039,7 @@ class ModerationLabelService {
       }
 
       final watermark = _tailWatermark[labelerPubkey];
-      if (watermark != null && event.createdAt >= watermark) {
+      if (watermark != null && event.createdAt >= _tailReplayFloor(watermark)) {
         final applied = _appliedLabelEventIds.putIfAbsent(
           labelerPubkey,
           () => <String, int>{},

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -634,6 +634,11 @@ class ModerationLabelService {
 
       _loadedLabelers.add(pubkey);
 
+      // The paged history above is a snapshot; open a live tail so labels
+      // published after this load reach a running client without a restart.
+      // #8255.
+      _openLiveTail(pubkey, events);
+
       Log.debug(
         'Subscribed to labeler ${pubkeyForLogs(pubkey)}, '
         'loaded ${events.length} label events',
@@ -647,6 +652,44 @@ class ModerationLabelService {
         category: LogCategory.system,
       );
     }
+  }
+
+  /// Stable subscription id for a labeler's live tail, so a reconnect reuses
+  /// the same REQ id rather than leaking anonymous subscriptions.
+  String _labelerTailSubscriptionId(String pubkey) =>
+      'moderation_labeler_tail_$pubkey';
+
+  /// Open the live tail for [pubkey], carrying only labels published after the
+  /// paged backfill. History comes from [_loadLabelerHistory] (paged to avoid
+  /// re-scanning the whole history, #8817); this covers everything after load.
+  /// One subscription per labeler, keyed in [_subscriptions] like the rest of
+  /// the service's per-pubkey state. #8255.
+  void _openLiveTail(String pubkey, List<Event> backfilled) {
+    if (_disposed) return;
+    final stream = _nostrClient.subscribe(
+      [
+        Filter(
+          authors: [pubkey],
+          kinds: [NostrEventKinds.label],
+          since: _tailSince(backfilled),
+        ),
+      ],
+      subscriptionId: _labelerTailSubscriptionId(pubkey),
+    );
+    unawaited(_subscriptions[pubkey]?.cancel());
+    _subscriptions[pubkey] = stream.listen(_processLabelEvent);
+  }
+
+  /// Where the live tail starts: the newest backfilled label's timestamp, or
+  /// now when there is no history. Overlapping the backfill by that one second
+  /// is deliberate — a `since` past it could drop a label written in the same
+  /// second as the walk's newest, and per-event dedup absorbs the overlap.
+  int _tailSince(List<Event> backfilled) {
+    var newest = 0;
+    for (final event in backfilled) {
+      if (event.createdAt > newest) newest = event.createdAt;
+    }
+    return newest > 0 ? newest : DateTime.now().millisecondsSinceEpoch ~/ 1000;
   }
 
   /// Retry [pubkey] the next time a relay connects.

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -1233,8 +1233,14 @@ class ModerationLabelService {
   }
 
   void _removeLabelsForLabeler(String pubkey) {
-    // Drop the dedup set too: the backfill removes then reprocesses a labeler's
-    // rows, so its events must be allowed to apply again. #8255.
+    // Drop the dedup set too, so the labeler's events can apply again once its
+    // rows are gone. This matters at the [_unloadLabeler] call site, where the
+    // tail has been recording ids all session: without it, a labeler removed
+    // and re-added would have its re-delivered events skipped as duplicates
+    // after their rows were dropped. On the backfill path the set is always
+    // empty — ids are only recorded once a watermark exists, a watermark only
+    // exists once the labeler has latched, and a latched labeler never
+    // reloads. #8255.
     _appliedLabelEventIds.remove(pubkey);
     _labelsByEventId.forEach((_, labels) {
       labels.removeWhere((l) => l.labelerPubkey == pubkey);

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -818,19 +818,28 @@ class ModerationLabelService {
     _tailSubscription = null;
   }
 
+  /// Exponential backoff for the shared tail, clamped to
+  /// [_tailMaxReconnectDelay].
+  ///
+  /// Doubles the delay itself and returns as soon as it reaches the cap, so
+  /// the loop runs at most log2(cap / base) times however high the attempt
+  /// count climbs. Scaling a separate multiplier by the attempt count cannot
+  /// terminate early when the base delay is zero — `0 * multiplier >= cap` is
+  /// never true — leaving the multiplier to double until it wraps at 64 bits.
+  /// A zero base is what tests use to drive the reconnect path, so that is the
+  /// configuration the early return has to survive.
   Duration _nextTailReconnectDelay() {
-    var multiplier = 1;
+    final base = _tailReconnectDelay.inMicroseconds;
+    final cap = _tailMaxReconnectDelay.inMicroseconds;
+    if (base <= 0) return Duration.zero;
+    if (base >= cap) return _tailMaxReconnectDelay;
+
+    var delay = base;
     for (var attempt = 0; attempt < _tailReconnectAttempt; attempt++) {
-      if (_tailReconnectDelay.inMicroseconds * multiplier >=
-          _tailMaxReconnectDelay.inMicroseconds) {
-        return _tailMaxReconnectDelay;
-      }
-      multiplier *= 2;
+      delay *= 2;
+      if (delay >= cap) return _tailMaxReconnectDelay;
     }
-    final candidate = _tailReconnectDelay * multiplier;
-    return candidate.inMicroseconds > _tailMaxReconnectDelay.inMicroseconds
-        ? _tailMaxReconnectDelay
-        : candidate;
+    return Duration(microseconds: delay);
   }
 
   /// Retry [pubkey] the next time a relay connects.

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -101,6 +101,7 @@ class ModerationLabelService {
     int maxLabelerHistoryPages = defaultMaxLabelerHistoryPages,
     Duration labelerHistoryBudget = defaultLabelerHistoryBudget,
     Duration tailReconnectDelay = defaultTailReconnectDelay,
+    Duration tailMaxReconnectDelay = defaultTailMaxReconnectDelay,
   }) : _nostrClient = nostrClient,
        _authService = authService,
        _prefs = sharedPreferences,
@@ -108,7 +109,8 @@ class ModerationLabelService {
        _labelerHistoryPageSize = labelerHistoryPageSize,
        _maxLabelerHistoryPages = maxLabelerHistoryPages,
        _labelerHistoryBudget = labelerHistoryBudget,
-       _tailReconnectDelay = tailReconnectDelay;
+       _tailReconnectDelay = tailReconnectDelay,
+       _tailMaxReconnectDelay = tailMaxReconnectDelay;
 
   final NostrClient _nostrClient;
   // ignore: unused_field
@@ -162,7 +164,11 @@ class ModerationLabelService {
   /// `DmRepository`'s gift-wrap reconnect. #8255.
   static const Duration defaultTailReconnectDelay = Duration(seconds: 2);
 
+  /// Maximum delay between attempts to restore the shared labeler tail.
+  static const Duration defaultTailMaxReconnectDelay = Duration(minutes: 1);
+
   final Duration _tailReconnectDelay;
+  final Duration _tailMaxReconnectDelay;
 
   /// SharedPreferences key for subscribed labeler pubkeys.
   static const String _subscribedLabelersKey = 'subscribed_labeler_pubkeys';
@@ -266,21 +272,38 @@ class ModerationLabelService {
   bool _isLabelerLoadCurrent(String pubkey, int generation) =>
       !_disposed && _labelerLoadGeneration(pubkey) == generation;
 
-  /// Active subscriptions.
-  final Map<String, StreamSubscription<dynamic>> _subscriptions = {};
+  /// One multiplexed live tail for every loaded trusted labeler.
+  StreamSubscription<Event>? _tailSubscription;
 
-  /// Label event ids already applied per labeler, so a reconnect that replays
-  /// the relay's stored window does not double-count. Cleared with a labeler's
-  /// rows in [_removeLabelsForLabeler]. #8255.
-  final Map<String, Set<String>> _appliedLabelEventIds = {};
+  /// Serializes tail replacement so an old explicit subscription id is fully
+  /// released before [NostrClient.subscribe] sees it again.
+  Future<void> _tailUpdate = Future<void>.value();
+
+  /// Stable identity of the author set currently carried by the live tail.
+  Set<String> _tailAuthors = {};
+
+  /// Invalidates callbacks from a tail intentionally replaced or disposed.
+  int _tailGeneration = 0;
+
+  /// Coalesces the many per-labeler loads in one follow-list sync into one REQ.
+  int _tailRebuildDeferrals = 0;
+  bool _tailRebuildPending = false;
+
+  /// Ids at each labeler's current watermark second.
+  ///
+  /// Events older than the watermark are ignored on replay. Moving to a newer
+  /// second replaces this set, so dedup retention is bounded by timestamp ties
+  /// rather than the labeler's complete history. #8255.
+  final Map<String, Map<String, int>> _appliedLabelEventIds = {};
 
   /// Newest label timestamp seen per labeler. A reconnect resumes the tail from
   /// here (dedup absorbs the overlap) rather than from now, so labels published
   /// during the gap are not missed. #8255.
   final Map<String, int> _tailWatermark = {};
 
-  /// Pending tail reconnect timers, one per labeler. #8255.
-  final Map<String, Timer> _tailReconnectTimers = {};
+  /// Pending reconnect for the one shared tail. #8255.
+  Timer? _tailReconnectTimer;
+  int _tailReconnectAttempt = 0;
 
   /// Whether persisted settings have been loaded.
   bool _loadedPersistedState = false;
@@ -354,9 +377,11 @@ class ModerationLabelService {
   }
 
   Future<void> _syncSubscribedLabelersWithRelays() async {
-    for (final pubkey in _subscribedLabelers) {
-      await subscribeToLabeler(pubkey);
-    }
+    await _withDeferredTailRebuild(() async {
+      for (final pubkey in _subscribedLabelers) {
+        await subscribeToLabeler(pubkey);
+      }
+    });
   }
 
   /// Subscribe to Kind 1985 events from a labeler pubkey.
@@ -595,6 +620,7 @@ class ModerationLabelService {
       return;
     }
 
+    final tailStart = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     try {
       final result = await _loadLabelerHistory(pubkey, generation);
 
@@ -631,6 +657,9 @@ class ModerationLabelService {
       // expire. Preserve existing warnings until a retry produces events or an
       // affirmative empty answer.
       if (events.isNotEmpty || !isIncomplete) {
+        if (!isIncomplete) {
+          _tailWatermark[pubkey] = tailStart;
+        }
         _removeLabelsForLabeler(pubkey);
         events.forEach(_processLabelEvent);
       }
@@ -654,11 +683,7 @@ class ModerationLabelService {
       }
 
       _loadedLabelers.add(pubkey);
-
-      // The paged history above is a snapshot; open a live tail so labels
-      // published after this load reach a running client without a restart.
-      // #8255.
-      _openLiveTail(pubkey, events);
+      await _requestTailRebuild();
 
       Log.debug(
         'Subscribed to labeler ${pubkeyForLogs(pubkey)}, '
@@ -675,89 +700,137 @@ class ModerationLabelService {
     }
   }
 
-  /// Stable subscription id for a labeler's live tail, so a reconnect reuses
-  /// the same REQ id rather than leaking anonymous subscriptions.
-  String _labelerTailSubscriptionId(String pubkey) =>
-      'moderation_labeler_tail_$pubkey';
+  static const String _tailSubscriptionId = 'moderation_labeler_tail';
 
-  /// Open the live tail for [pubkey], carrying only labels published after the
-  /// paged backfill. History comes from [_loadLabelerHistory] (paged to avoid
-  /// re-scanning the whole history, #8817); this covers everything after load.
-  /// One subscription per labeler, keyed in [_subscriptions] like the rest of
-  /// the service's per-pubkey state. #8255.
-  void _openLiveTail(String pubkey, List<Event> backfilled) {
-    if (_disposed) return;
-    _tailWatermark[pubkey] = _tailSince(backfilled);
-    _listenTail(pubkey);
+  Set<String> get _wantedLoadedLabelers => Set<String>.of(_loadedLabelers);
+
+  Future<void> _requestTailRebuild() {
+    _tailRebuildPending = true;
+    if (_tailRebuildDeferrals > 0) return Future<void>.value();
+
+    final next = _tailUpdate.then((_) => _flushTailRebuild());
+    _tailUpdate = next.then<void>(
+      (_) {},
+      onError: (Object error, StackTrace stackTrace) {
+        Log.error(
+          'Failed to rebuild moderation label tail: $error',
+          name: 'ModerationLabelService',
+          category: LogCategory.system,
+        );
+      },
+    );
+    return next;
   }
 
-  /// Open (or reopen) the tail REQ for [pubkey] from its current watermark and
-  /// wire it to reconnect when it drops. #8255.
-  void _listenTail(String pubkey) {
-    if (_disposed) return;
+  Future<void> _flushTailRebuild() async {
+    while (_tailRebuildPending && !_disposed) {
+      _tailRebuildPending = false;
+      await _replaceLiveTail();
+    }
+  }
+
+  Future<void> _withDeferredTailRebuild(Future<void> Function() action) async {
+    _tailRebuildDeferrals++;
+    try {
+      await action();
+    } finally {
+      _tailRebuildDeferrals--;
+      if (_tailRebuildDeferrals == 0 && _tailRebuildPending) {
+        await _requestTailRebuild();
+      }
+    }
+  }
+
+  Future<void> _replaceLiveTail() async {
+    final generation = ++_tailGeneration;
+    _tailReconnectTimer?.cancel();
+    _tailReconnectTimer = null;
+    final previous = _tailSubscription;
+    _tailSubscription = null;
+    await previous?.cancel();
+    if (_disposed || generation != _tailGeneration) return;
+
+    final authors = _wantedLoadedLabelers;
+    _tailAuthors = authors;
+    if (authors.isEmpty) return;
+
+    final since = authors
+        .map((pubkey) => _tailWatermark[pubkey]!)
+        .reduce((oldest, value) => value < oldest ? value : oldest);
     final stream = _nostrClient.subscribe(
       [
         Filter(
-          authors: [pubkey],
+          authors: authors.toList(),
           kinds: [NostrEventKinds.label],
-          since: _tailWatermark[pubkey],
+          since: since,
         ),
       ],
-      subscriptionId: _labelerTailSubscriptionId(pubkey),
+      subscriptionId: _tailSubscriptionId,
+      onEose: () => _tailReconnectAttempt = 0,
     );
-    unawaited(_subscriptions[pubkey]?.cancel());
-    _subscriptions[pubkey] = stream.listen(
-      (event) => _onTailEvent(pubkey, event),
-      // A relay CLOSED surfaces as onError; a socket/Dart-side close as onDone.
-      // Either way the tail is dead and must be re-opened. #8255.
-      onError: (Object _) => _scheduleTailReconnect(pubkey),
-      onDone: () => _scheduleTailReconnect(pubkey),
+    _tailSubscription = stream.listen(
+      _onTailEvent,
+      onError: (Object error) => _scheduleTailReconnect(generation, error),
+      onDone: () => _scheduleTailReconnect(generation),
     );
   }
 
-  void _onTailEvent(String pubkey, dynamic event) {
-    final createdAt = event.createdAt as int;
-    if (createdAt > (_tailWatermark[pubkey] ?? 0)) {
-      _tailWatermark[pubkey] = createdAt;
+  void _onTailEvent(Event event) {
+    final watermark = _tailWatermark[event.pubkey];
+    if (watermark == null || !_tailAuthors.contains(event.pubkey)) return;
+    if (event.createdAt < watermark) return;
+    if (event.createdAt > watermark) {
+      _tailWatermark[event.pubkey] = event.createdAt;
+      _appliedLabelEventIds[event.pubkey]?.removeWhere((_, createdAt) {
+        return createdAt < event.createdAt;
+      });
     }
+    _tailReconnectAttempt = 0;
     _processLabelEvent(event);
   }
 
-  /// Re-open [pubkey]'s tail after a delay, mirroring `DmRepository`'s
-  /// gift-wrap reconnect. Bounded by the number of subscribed/followed labelers
-  /// and cancelled by [_unloadLabeler] / [dispose], so it cannot outlive a
-  /// labeler nothing wants any more. #8255.
-  void _scheduleTailReconnect(String pubkey) {
-    if (_disposed) return;
-    // A labeler that has since been unloaded must not reconnect.
-    if (!_subscribedLabelers.contains(pubkey) &&
-        !_followedLabelers.contains(pubkey)) {
-      return;
-    }
-    unawaited(_subscriptions[pubkey]?.cancel());
-    _subscriptions.remove(pubkey);
-    _tailReconnectTimers[pubkey]?.cancel();
-    _tailReconnectTimers[pubkey] = Timer(_tailReconnectDelay, () {
-      _tailReconnectTimers.remove(pubkey);
-      if (_disposed) return;
-      if (!_subscribedLabelers.contains(pubkey) &&
-          !_followedLabelers.contains(pubkey)) {
-        return;
-      }
-      _listenTail(pubkey);
+  void _scheduleTailReconnect(int generation, [Object? error]) {
+    if (_disposed || generation != _tailGeneration) return;
+    if (_tailReconnectTimer != null || _wantedLoadedLabelers.isEmpty) return;
+
+    final delay = _nextTailReconnectDelay();
+    final reason = error == null
+        ? 'stream closed'
+        : 'subscription error: $error';
+    Log.warning(
+      'Moderation label tail dropped ($reason)',
+      name: 'ModerationLabelService',
+      category: LogCategory.system,
+    );
+    Log.info(
+      'Re-subscribing to moderation labels in ${delay.inSeconds}s',
+      name: 'ModerationLabelService',
+      category: LogCategory.system,
+    );
+
+    _tailReconnectTimer = Timer(delay, () {
+      _tailReconnectTimer = null;
+      if (_disposed || generation != _tailGeneration) return;
+      unawaited(_requestTailRebuild());
     });
+    _tailReconnectAttempt++;
+    unawaited(_tailSubscription?.cancel());
+    _tailSubscription = null;
   }
 
-  /// Where the live tail starts: the newest backfilled label's timestamp, or
-  /// now when there is no history. Overlapping the backfill by that one second
-  /// is deliberate — a `since` past it could drop a label written in the same
-  /// second as the walk's newest, and per-event dedup absorbs the overlap.
-  int _tailSince(List<Event> backfilled) {
-    var newest = 0;
-    for (final event in backfilled) {
-      if (event.createdAt > newest) newest = event.createdAt;
+  Duration _nextTailReconnectDelay() {
+    var multiplier = 1;
+    for (var attempt = 0; attempt < _tailReconnectAttempt; attempt++) {
+      if (_tailReconnectDelay.inMicroseconds * multiplier >=
+          _tailMaxReconnectDelay.inMicroseconds) {
+        return _tailMaxReconnectDelay;
+      }
+      multiplier *= 2;
     }
-    return newest > 0 ? newest : DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final candidate = _tailReconnectDelay * multiplier;
+    return candidate.inMicroseconds > _tailMaxReconnectDelay.inMicroseconds
+        ? _tailMaxReconnectDelay
+        : candidate;
   }
 
   /// Retry [pubkey] the next time a relay connects.
@@ -928,21 +1001,30 @@ class ModerationLabelService {
   }
 
   /// Process a Kind 1985 label event and cache its labels.
-  void _processLabelEvent(dynamic event) {
+  void _processLabelEvent(Event event) {
     try {
-      final tags = event.tags as List<dynamic>;
-      final labelerPubkey = event.pubkey as String;
-      final eventId = event.id as String;
+      final tags = event.tags;
+      final labelerPubkey = event.pubkey;
+      final eventId = event.id;
 
-      // A reconnect replays the relay's stored window, so the same label event
-      // arrives again; apply each label event at most once per labeler. Empty
-      // ids come only from test fakes on the single-shot backfill path; real
-      // wire events always carry one, so skipping dedup for them is safe. #8255.
-      if (eventId.isNotEmpty &&
-          !_appliedLabelEventIds
-              .putIfAbsent(labelerPubkey, () => <String>{})
-              .add(eventId)) {
+      if (eventId.isEmpty) {
+        Log.warning(
+          'Ignoring moderation label without a Nostr event id from '
+          '${pubkeyForLogs(labelerPubkey)}',
+          name: 'ModerationLabelService',
+          category: LogCategory.system,
+        );
         return;
+      }
+
+      final watermark = _tailWatermark[labelerPubkey];
+      if (watermark != null && event.createdAt >= watermark) {
+        final applied = _appliedLabelEventIds.putIfAbsent(
+          labelerPubkey,
+          () => <String, int>{},
+        );
+        if (applied.containsKey(eventId)) return;
+        applied[eventId] = event.createdAt;
       }
 
       final namespaces = <String>{};
@@ -953,10 +1035,9 @@ class ModerationLabelService {
       final hashes = <String>[];
 
       for (final tag in tags) {
-        if (tag is! List || tag.length < 2) continue;
+        if (tag.length < 2) continue;
         final tagName = tag[0];
         final tagValue = tag[1];
-        if (tagName is! String || tagValue is! String) continue;
 
         switch (tagName) {
           case 'L':
@@ -965,14 +1046,12 @@ class ModerationLabelService {
               namespaces.add(namespace);
             }
           case 'l':
-            final metadata = tag.length > 3 && tag[3] is String
-                ? _parseMetadata(tag[3] as String)
-                : null;
+            final metadata = tag.length > 3 ? _parseMetadata(tag[3]) : null;
             labels.add(
               _PendingModerationLabel(
                 value: tagValue,
-                namespace: tag.length > 2 && tag[2] is String
-                    ? _normalizeLabelNamespace(tag[2] as String)
+                namespace: tag.length > 2
+                    ? _normalizeLabelNamespace(tag[2])
                     : null,
                 metadata: metadata,
               ),
@@ -1113,35 +1192,35 @@ class ModerationLabelService {
         .where((pubkey) => pubkey.isNotEmpty)
         .toSet();
 
-    final toRemove = _followedLabelers.difference(normalized);
+    await _withDeferredTailRebuild(() async {
+      final toRemove = _followedLabelers.difference(normalized);
 
-    for (final pubkey in toRemove) {
-      _followedLabelers.remove(pubkey);
-      if (!_subscribedLabelers.contains(pubkey)) {
-        await _unloadLabeler(pubkey);
+      for (final pubkey in toRemove) {
+        _followedLabelers.remove(pubkey);
+        if (!_subscribedLabelers.contains(pubkey)) {
+          await _unloadLabeler(pubkey);
+        }
       }
-    }
 
-    for (final pubkey in normalized) {
-      _followedLabelers.add(pubkey);
-      if (!_subscribedLabelers.contains(pubkey) &&
-          !_loadedLabelers.contains(pubkey)) {
-        await subscribeToLabeler(pubkey);
+      for (final pubkey in normalized) {
+        _followedLabelers.add(pubkey);
+        if (!_subscribedLabelers.contains(pubkey) &&
+            !_loadedLabelers.contains(pubkey)) {
+          await subscribeToLabeler(pubkey);
+        }
       }
-    }
+    });
   }
 
   Future<void> _unloadLabeler(String pubkey) async {
     // Synchronously, before the first await: a walk in flight has to see this
     // the moment the caller decides the labeler is going away.
     _invalidateLabelerLoad(pubkey);
-    _tailReconnectTimers.remove(pubkey)?.cancel();
     _tailWatermark.remove(pubkey);
-    await _subscriptions[pubkey]?.cancel();
-    _subscriptions.remove(pubkey);
     _removePendingLabelerRetry(pubkey);
     _loadedLabelers.remove(pubkey);
     _removeLabelsForLabeler(pubkey);
+    await _requestTailRebuild();
   }
 
   void _removePendingLabelerRetry(String pubkey) {
@@ -1306,11 +1385,7 @@ class ModerationLabelService {
     await _saveSubscribedLabelers();
 
     for (final pubkey in retired) {
-      // Clean up any labels fetched from the old key
-      _invalidateLabelerLoad(pubkey);
-      _removePendingLabelerRetry(pubkey);
-      _removeLabelsForLabeler(pubkey);
-      _loadedLabelers.remove(pubkey);
+      await _unloadLabeler(pubkey);
     }
 
     Log.info(
@@ -1324,18 +1399,16 @@ class ModerationLabelService {
   /// Clean up subscriptions.
   void dispose() {
     _disposed = true;
+    _tailGeneration++;
     unawaited(_relayReadyRetrySubscription?.cancel());
     _relayReadyRetrySubscription = null;
     _labelersAwaitingRelay.clear();
     _hadConnectedRelayWhileWaiting = false;
-    for (final timer in _tailReconnectTimers.values) {
-      timer.cancel();
-    }
-    _tailReconnectTimers.clear();
-    for (final sub in _subscriptions.values) {
-      sub.cancel();
-    }
-    _subscriptions.clear();
+    _tailReconnectTimer?.cancel();
+    _tailReconnectTimer = null;
+    unawaited(_tailSubscription?.cancel());
+    _tailSubscription = null;
+    _tailAuthors = {};
   }
 }
 

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -100,13 +100,15 @@ class ModerationLabelService {
     int labelerHistoryPageSize = defaultLabelerHistoryPageSize,
     int maxLabelerHistoryPages = defaultMaxLabelerHistoryPages,
     Duration labelerHistoryBudget = defaultLabelerHistoryBudget,
+    Duration tailReconnectDelay = defaultTailReconnectDelay,
   }) : _nostrClient = nostrClient,
        _authService = authService,
        _prefs = sharedPreferences,
        _canQueryRelays = canQueryRelays ?? (() => true),
        _labelerHistoryPageSize = labelerHistoryPageSize,
        _maxLabelerHistoryPages = maxLabelerHistoryPages,
-       _labelerHistoryBudget = labelerHistoryBudget;
+       _labelerHistoryBudget = labelerHistoryBudget,
+       _tailReconnectDelay = tailReconnectDelay;
 
   final NostrClient _nostrClient;
   // ignore: unused_field
@@ -155,6 +157,12 @@ class ModerationLabelService {
   static const Duration defaultLabelerHistoryBudget = Duration(seconds: 30);
 
   final Duration _labelerHistoryBudget;
+
+  /// Delay before re-opening a live tail that dropped, mirroring
+  /// `DmRepository`'s gift-wrap reconnect. #8255.
+  static const Duration defaultTailReconnectDelay = Duration(seconds: 2);
+
+  final Duration _tailReconnectDelay;
 
   /// SharedPreferences key for subscribed labeler pubkeys.
   static const String _subscribedLabelersKey = 'subscribed_labeler_pubkeys';
@@ -265,6 +273,14 @@ class ModerationLabelService {
   /// the relay's stored window does not double-count. Cleared with a labeler's
   /// rows in [_removeLabelsForLabeler]. #8255.
   final Map<String, Set<String>> _appliedLabelEventIds = {};
+
+  /// Newest label timestamp seen per labeler. A reconnect resumes the tail from
+  /// here (dedup absorbs the overlap) rather than from now, so labels published
+  /// during the gap are not missed. #8255.
+  final Map<String, int> _tailWatermark = {};
+
+  /// Pending tail reconnect timers, one per labeler. #8255.
+  final Map<String, Timer> _tailReconnectTimers = {};
 
   /// Whether persisted settings have been loaded.
   bool _loadedPersistedState = false;
@@ -671,18 +687,65 @@ class ModerationLabelService {
   /// the service's per-pubkey state. #8255.
   void _openLiveTail(String pubkey, List<Event> backfilled) {
     if (_disposed) return;
+    _tailWatermark[pubkey] = _tailSince(backfilled);
+    _listenTail(pubkey);
+  }
+
+  /// Open (or reopen) the tail REQ for [pubkey] from its current watermark and
+  /// wire it to reconnect when it drops. #8255.
+  void _listenTail(String pubkey) {
+    if (_disposed) return;
     final stream = _nostrClient.subscribe(
       [
         Filter(
           authors: [pubkey],
           kinds: [NostrEventKinds.label],
-          since: _tailSince(backfilled),
+          since: _tailWatermark[pubkey],
         ),
       ],
       subscriptionId: _labelerTailSubscriptionId(pubkey),
     );
     unawaited(_subscriptions[pubkey]?.cancel());
-    _subscriptions[pubkey] = stream.listen(_processLabelEvent);
+    _subscriptions[pubkey] = stream.listen(
+      (event) => _onTailEvent(pubkey, event),
+      // A relay CLOSED surfaces as onError; a socket/Dart-side close as onDone.
+      // Either way the tail is dead and must be re-opened. #8255.
+      onError: (Object _) => _scheduleTailReconnect(pubkey),
+      onDone: () => _scheduleTailReconnect(pubkey),
+    );
+  }
+
+  void _onTailEvent(String pubkey, dynamic event) {
+    final createdAt = event.createdAt as int;
+    if (createdAt > (_tailWatermark[pubkey] ?? 0)) {
+      _tailWatermark[pubkey] = createdAt;
+    }
+    _processLabelEvent(event);
+  }
+
+  /// Re-open [pubkey]'s tail after a delay, mirroring `DmRepository`'s
+  /// gift-wrap reconnect. Bounded by the number of subscribed/followed labelers
+  /// and cancelled by [_unloadLabeler] / [dispose], so it cannot outlive a
+  /// labeler nothing wants any more. #8255.
+  void _scheduleTailReconnect(String pubkey) {
+    if (_disposed) return;
+    // A labeler that has since been unloaded must not reconnect.
+    if (!_subscribedLabelers.contains(pubkey) &&
+        !_followedLabelers.contains(pubkey)) {
+      return;
+    }
+    unawaited(_subscriptions[pubkey]?.cancel());
+    _subscriptions.remove(pubkey);
+    _tailReconnectTimers[pubkey]?.cancel();
+    _tailReconnectTimers[pubkey] = Timer(_tailReconnectDelay, () {
+      _tailReconnectTimers.remove(pubkey);
+      if (_disposed) return;
+      if (!_subscribedLabelers.contains(pubkey) &&
+          !_followedLabelers.contains(pubkey)) {
+        return;
+      }
+      _listenTail(pubkey);
+    });
   }
 
   /// Where the live tail starts: the newest backfilled label's timestamp, or
@@ -1072,6 +1135,8 @@ class ModerationLabelService {
     // Synchronously, before the first await: a walk in flight has to see this
     // the moment the caller decides the labeler is going away.
     _invalidateLabelerLoad(pubkey);
+    _tailReconnectTimers.remove(pubkey)?.cancel();
+    _tailWatermark.remove(pubkey);
     await _subscriptions[pubkey]?.cancel();
     _subscriptions.remove(pubkey);
     _removePendingLabelerRetry(pubkey);
@@ -1263,6 +1328,10 @@ class ModerationLabelService {
     _relayReadyRetrySubscription = null;
     _labelersAwaitingRelay.clear();
     _hadConnectedRelayWhileWaiting = false;
+    for (final timer in _tailReconnectTimers.values) {
+      timer.cancel();
+    }
+    _tailReconnectTimers.clear();
     for (final sub in _subscriptions.values) {
       sub.cancel();
     }

--- a/mobile/test/providers/moderation_label_provider_session_test.dart
+++ b/mobile/test/providers/moderation_label_provider_session_test.dart
@@ -101,7 +101,9 @@ void main() {
       final nostrClient = _MockNostrClient();
       final followRepository = _MockFollowRepository();
       final followingController = StreamController<List<String>>.broadcast();
+      final labelTail = StreamController<Event>.broadcast();
       addTearDown(followingController.close);
+      addTearDown(labelTail.close);
 
       when(() => nostrClient.hasKeys).thenReturn(true);
       when(() => nostrClient.publicKey).thenReturn(testPubkey);
@@ -113,6 +115,13 @@ void main() {
       ).thenAnswer(
         (_) async => (events: <Event>[], timedOut: false, noRelays: false),
       );
+      when(
+        () => nostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          onEose: any(named: 'onEose'),
+        ),
+      ).thenAnswer((_) => labelTail.stream);
       when(() => followRepository.followingPubkeys).thenReturn(const []);
       when(
         () => followRepository.followingStream,

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -2450,7 +2450,14 @@ void main() {
       ).thenAnswer((_) => tail.stream);
 
       await service.addLabeler(custom);
+      expect(tail.hasListener, isTrue);
+
       service.dispose();
+
+      // Assert the cancel itself. Without this, clearing _tailAuthors alone
+      // also keeps the label out of the maps, so the emptiness below passes
+      // while a live StreamSubscription leaks on a disposed service.
+      expect(tail.hasListener, isFalse);
 
       tail.add(liveLabelFrom(custom, 'post_dispose', 'disposed_tgt'));
       await pumpEventQueue();

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -2474,50 +2474,67 @@ void main() {
     });
 
     test(
-      'a reload reapplies a labelers rows instead of dropping them as '
-      'duplicates (guards the dedup clear on reprocess)',
+      'unloading a labeler clears its dedup set so a re-add reapplies its '
+      'labels',
       () async {
+        // _removeLabelsForLabeler drops the labeler's rows AND its applied-id
+        // set. Only the _unloadLabeler call site makes that load-bearing: on
+        // the backfill path no id is ever recorded (an incomplete load sets no
+        // watermark, and a latched labeler never reloads), so deleting the
+        // clear cannot be caught there. Here the tail has recorded a real id
+        // while the labeler was loaded, and the re-add must be able to apply
+        // that same event again after its rows were dropped.
         const custom =
             'd4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4';
-        // The same real-id event on two loads: an incomplete load applies it
-        // (so the dedup set holds its id) without latching, then a complete
-        // load reprocesses. _removeLabelsForLabeler must clear the dedup set so
-        // the reprocess reapplies rather than skipping every event as a dup.
-        var complete = false;
+        stubCompletedBackfill();
+        final tail = StreamController<Event>.broadcast();
+        addTearDown(() async {
+          service.dispose();
+          await tail.close();
+        });
         when(
-          () => mockNostrClient.queryEventsDetailed(
+          () => mockNostrClient.subscribe(
             any(),
-            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            subscriptionId: any(named: 'subscriptionId'),
+            onEose: any(named: 'onEose'),
           ),
-        ).thenAnswer(
-          (_) async => (
-            events: <Event>[
-              _FakeLabelEvent(
-                pubkey: custom,
-                id: 'reload_evt_1',
-                createdAt: 100,
-                tags: [
-                  ['L', 'content-warning'],
-                  ['l', 'nudity', 'content-warning'],
-                  ['e', 'reload_tgt'],
-                ],
-              ),
-            ],
-            timedOut: !complete,
-            noRelays: false,
-          ),
+        ).thenAnswer((_) => tail.stream);
+
+        // Comfortably above any watermark this test can produce, so the
+        // assertions never straddle a second boundary.
+        final label = _FakeLabelEvent(
+          pubkey: custom,
+          id: 'sticky_evt',
+          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600,
+          tags: [
+            ['L', 'content-warning'],
+            ['l', 'nudity', 'content-warning'],
+            ['e', 'sticky_tgt'],
+          ],
         );
 
         await service.addLabeler(custom);
-        expect(service.getContentWarnings('reload_tgt'), hasLength(1));
+        tail.add(label);
+        await pumpEventQueue();
+        expect(
+          service.getContentWarnings('sticky_tgt'),
+          hasLength(1),
+          reason: 'the tail applies the label and records its id',
+        );
 
-        complete = true;
-        await service.subscribeToLabeler(custom);
+        await service.removeLabeler(custom);
+        expect(service.getContentWarnings('sticky_tgt'), isEmpty);
+
+        await service.addLabeler(custom);
+        tail.add(label);
+        await pumpEventQueue();
 
         expect(
-          service.getContentWarnings('reload_tgt'),
+          service.getContentWarnings('sticky_tgt'),
           hasLength(1),
-          reason: 'a reload must reapply the labeler rows, not drop them',
+          reason:
+              'the re-added labeler must reapply the same event; without the '
+              'dedup-set clear its id is still recorded and it is skipped',
         );
       },
     );

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -2164,8 +2164,10 @@ void main() {
         // Nothing asserted `since` before, so dropping it from the filter left
         // every test in the suite green.
         expect(filter.since, isNotNull);
-        expect(filter.since, greaterThanOrEqualTo(beforeLoad));
-        expect(filter.since, lessThanOrEqualTo(afterLoad));
+        final tolerance =
+            ModerationLabelService.defaultTailReplayTolerance.inSeconds;
+        expect(filter.since, greaterThanOrEqualTo(beforeLoad - tolerance));
+        expect(filter.since, lessThanOrEqualTo(afterLoad - tolerance));
       },
     );
 
@@ -2305,7 +2307,7 @@ void main() {
     );
 
     test(
-      'an older replay is ignored after an author watermark advances',
+      'a distinct out-of-order event is applied after the watermark advances',
       () async {
         stubCompletedBackfill();
         final tail = StreamController<Event>.broadcast();
@@ -2350,9 +2352,58 @@ void main() {
         await pumpEventQueue();
 
         expect(service.getContentWarnings('newer_target'), hasLength(1));
-        expect(service.getContentWarnings('older_target'), isEmpty);
+        expect(service.getContentWarnings('older_target'), hasLength(1));
       },
     );
+
+    test('an event older than the bounded replay window is ignored', () async {
+      stubCompletedBackfill();
+      final tail = StreamController<Event>.broadcast();
+      addTearDown(() async {
+        service.dispose();
+        await tail.close();
+      });
+      when(
+        () => mockNostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          onEose: any(named: 'onEose'),
+        ),
+      ).thenAnswer((_) => tail.stream);
+
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final outsideWindow =
+          ModerationLabelService.defaultTailReplayTolerance.inSeconds + 1;
+      await service.subscribeToLabeler(service.divineModerationPubkeyHex);
+      tail.add(
+        _FakeLabelEvent(
+          pubkey: service.divineModerationPubkeyHex,
+          id: 'newest_evt',
+          createdAt: now,
+          tags: [
+            ['L', 'content-warning'],
+            ['l', 'nudity', 'content-warning'],
+            ['e', 'newest_target'],
+          ],
+        ),
+      );
+      tail.add(
+        _FakeLabelEvent(
+          pubkey: service.divineModerationPubkeyHex,
+          id: 'outside_window_evt',
+          createdAt: now - outsideWindow,
+          tags: [
+            ['L', 'content-warning'],
+            ['l', 'nudity', 'content-warning'],
+            ['e', 'outside_window_target'],
+          ],
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(service.getContentWarnings('newest_target'), hasLength(1));
+      expect(service.getContentWarnings('outside_window_target'), isEmpty);
+    });
 
     test(
       'removing a labeler cancels its live tail so later labels do not land',

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -96,13 +96,16 @@ void main() {
       (_) => const Stream<Map<String, RelayConnectionStatus>>.empty(),
     );
     // Default: the live tail (#8255) opens after a labeler latches loaded.
-    // Tests that exercise the tail override this with a controllable stream.
+    // A never-closing broadcast stream so the tail stays open (no onDone) and
+    // no reconnect timer is scheduled. Tests that exercise the tail override
+    // this with their own controllable stream.
+    final defaultTail = StreamController<Event>.broadcast();
     when(
       () => mockNostrClient.subscribe(
         any(),
         subscriptionId: any(named: 'subscriptionId'),
       ),
-    ).thenAnswer((_) => const Stream<Event>.empty());
+    ).thenAnswer((_) => defaultTail.stream);
     service = ModerationLabelService(
       nostrClient: mockNostrClient,
       authService: mockAuthService,
@@ -2074,16 +2077,20 @@ void main() {
   });
 
   group('live tail subscription (#8255)', () {
-    Event liveLabel(String id, String targetEventId) => _FakeLabelEvent(
-      pubkey: service.divineModerationPubkeyHex,
-      id: id,
-      createdAt: 1000,
-      tags: [
-        ['L', 'content-warning'],
-        ['l', 'nudity', 'content-warning'],
-        ['e', targetEventId],
-      ],
-    );
+    Event liveLabelFrom(String labeler, String id, String targetEventId) =>
+        _FakeLabelEvent(
+          pubkey: labeler,
+          id: id,
+          createdAt: 1000,
+          tags: [
+            ['L', 'content-warning'],
+            ['l', 'nudity', 'content-warning'],
+            ['e', targetEventId],
+          ],
+        );
+
+    Event liveLabel(String id, String targetEventId) =>
+        liveLabelFrom(service.divineModerationPubkeyHex, id, targetEventId);
 
     void stubCompletedBackfill() {
       when(
@@ -2149,5 +2156,100 @@ void main() {
         expect(service.getContentWarnings('dup_target'), hasLength(1));
       },
     );
+
+    test(
+      'removing a labeler cancels its live tail so later labels do not land',
+      () async {
+        const custom =
+            'a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1';
+        stubCompletedBackfill();
+        final tail = StreamController<Event>.broadcast();
+        addTearDown(tail.close);
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).thenAnswer((_) => tail.stream);
+
+        await service.addLabeler(custom);
+
+        tail.add(liveLabelFrom(custom, 'before_evt', 'before_target'));
+        await pumpEventQueue();
+        expect(service.getContentWarnings('before_target'), hasLength(1));
+
+        await service.removeLabeler(custom);
+
+        // A label published after removal must not reach the maps.
+        tail.add(liveLabelFrom(custom, 'after_evt', 'after_target'));
+        await pumpEventQueue();
+        expect(service.getContentWarnings('after_target'), isEmpty);
+      },
+    );
+
+    test(
+      'a dropped tail stream reconnects so later labels still land',
+      () async {
+        final svc = ModerationLabelService(
+          nostrClient: mockNostrClient,
+          authService: mockAuthService,
+          sharedPreferences: mockPrefs,
+          tailReconnectDelay: Duration.zero,
+        );
+        stubCompletedBackfill();
+        final first = StreamController<Event>.broadcast();
+        final second = StreamController<Event>.broadcast();
+        addTearDown(() {
+          first.close();
+          second.close();
+          svc.dispose();
+        });
+        var calls = 0;
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).thenAnswer((_) {
+          calls++;
+          return calls == 1 ? first.stream : second.stream;
+        });
+
+        const custom =
+            'b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2';
+        await svc.addLabeler(custom);
+        expect(calls, 1);
+
+        // The relay ends the subscription; the Dart stream closes.
+        await first.close();
+        await pumpEventQueue();
+
+        expect(calls, 2, reason: 'the tail should reopen after it drops');
+        second.add(liveLabelFrom(custom, 'post', 'reconnect_tgt'));
+        await pumpEventQueue();
+        expect(svc.getContentWarnings('reconnect_tgt'), hasLength(1));
+      },
+    );
+
+    test('dispose cancels the live tail so no later label lands', () async {
+      const custom =
+          'c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3';
+      stubCompletedBackfill();
+      final tail = StreamController<Event>.broadcast();
+      addTearDown(tail.close);
+      when(
+        () => mockNostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+        ),
+      ).thenAnswer((_) => tail.stream);
+
+      await service.addLabeler(custom);
+      service.dispose();
+
+      tail.add(liveLabelFrom(custom, 'post_dispose', 'disposed_tgt'));
+      await pumpEventQueue();
+      expect(service.getContentWarnings('disposed_tgt'), isEmpty);
+    });
   });
 }

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -50,14 +50,14 @@ class _FakeNip05Adapter implements HttpClientAdapter {
 
 /// Fake event for testing label processing.
 ///
-/// [id] and [createdAt] default to empty/zero because the single-page tests
-/// never read them; the paging tests (#8252) pass explicit values because the
-/// backward-`until` walk dedups on `id` and cursors on `createdAt`.
+/// [createdAt] defaults to zero because single-page tests do not page. Tests
+/// that compare event identity pass explicit ids.
 class _FakeLabelEvent extends Fake implements Event {
   _FakeLabelEvent({
     required this.pubkey,
     required this.tags,
-    this.id = '',
+    this.id =
+        '9999999999999999999999999999999999999999999999999999999999999999',
     this.createdAt = 0,
   });
 
@@ -104,6 +104,7 @@ void main() {
       () => mockNostrClient.subscribe(
         any(),
         subscriptionId: any(named: 'subscriptionId'),
+        onEose: any(named: 'onEose'),
       ),
     ).thenAnswer((_) => defaultTail.stream);
     service = ModerationLabelService(
@@ -2081,7 +2082,7 @@ void main() {
         _FakeLabelEvent(
           pubkey: labeler,
           id: id,
-          createdAt: 1000,
+          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
           tags: [
             ['L', 'content-warning'],
             ['l', 'nudity', 'content-warning'],
@@ -2104,6 +2105,130 @@ void main() {
     }
 
     test(
+      'all followed labelers share one live relay subscription',
+      () async {
+        stubCompletedBackfill();
+        final tails = <StreamController<Event>>[];
+        var activeListeners = 0;
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            onEose: any(named: 'onEose'),
+          ),
+        ).thenAnswer((_) {
+          late final StreamController<Event> tail;
+          tail = StreamController<Event>.broadcast(
+            onListen: () => activeListeners++,
+            onCancel: () => activeListeners--,
+          );
+          tails.add(tail);
+          return tail.stream;
+        });
+        addTearDown(() async {
+          service.dispose();
+          await Future.wait(tails.map((tail) => tail.close()));
+        });
+
+        const followed = [
+          '1111111111111111111111111111111111111111111111111111111111111111',
+          '2222222222222222222222222222222222222222222222222222222222222222',
+          '3333333333333333333333333333333333333333333333333333333333333333',
+        ];
+        await service.setFollowingModerationEnabled(
+          true,
+          followedPubkeys: followed,
+        );
+
+        expect(activeListeners, 1);
+        final captured = verify(
+          () => mockNostrClient.subscribe(
+            captureAny(),
+            subscriptionId: any(named: 'subscriptionId'),
+            onEose: any(named: 'onEose'),
+          ),
+        ).captured;
+        expect(captured, hasLength(1));
+        final filter = (captured.single as List<Filter>).single;
+        expect(filter.authors, unorderedEquals(followed));
+        expect(filter.kinds, [NostrEventKinds.label]);
+      },
+    );
+
+    test('changing labelers replaces the shared author filter', () async {
+      stubCompletedBackfill();
+      final tails = <StreamController<Event>>[];
+      var activeListeners = 0;
+      when(
+        () => mockNostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          onEose: any(named: 'onEose'),
+        ),
+      ).thenAnswer((_) {
+        late final StreamController<Event> tail;
+        tail = StreamController<Event>.broadcast(
+          onListen: () => activeListeners++,
+          onCancel: () => activeListeners--,
+        );
+        tails.add(tail);
+        return tail.stream;
+      });
+      addTearDown(() async {
+        service.dispose();
+        await Future.wait(tails.map((tail) => tail.close()));
+      });
+
+      const first =
+          '4444444444444444444444444444444444444444444444444444444444444444';
+      const second =
+          '5555555555555555555555555555555555555555555555555555555555555555';
+      await service.addLabeler(first);
+      await service.addLabeler(second);
+      await service.removeLabeler(first);
+
+      expect(activeListeners, 1);
+      final captured = verify(
+        () => mockNostrClient.subscribe(
+          captureAny(),
+          subscriptionId: any(named: 'subscriptionId'),
+          onEose: any(named: 'onEose'),
+        ),
+      ).captured;
+      final lastFilter = (captured.last as List<Filter>).single;
+      expect(lastFilter.authors, [second]);
+    });
+
+    test('an event without a Nostr id is rejected', () async {
+      when(
+        () => mockNostrClient.queryEventsDetailed(
+          any(),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        ),
+      ).thenAnswer(
+        (_) async => (
+          events: <Event>[
+            _FakeLabelEvent(
+              pubkey: service.divineModerationPubkeyHex,
+              id: '',
+              tags: [
+                ['L', 'content-warning'],
+                ['l', 'nudity', 'content-warning'],
+                ['e', 'invalid_id_target'],
+              ],
+            ),
+          ],
+          timedOut: false,
+          noRelays: false,
+        ),
+      );
+
+      await service.subscribeToLabeler(service.divineModerationPubkeyHex);
+
+      expect(service.getContentWarnings('invalid_id_target'), isEmpty);
+    });
+
+    test(
       'a label published after the initial load reaches the maps without a '
       'restart',
       () async {
@@ -2116,6 +2241,7 @@ void main() {
           () => mockNostrClient.subscribe(
             any(),
             subscriptionId: any(named: 'subscriptionId'),
+            onEose: any(named: 'onEose'),
           ),
         ).thenAnswer((_) => tail.stream);
 
@@ -2144,6 +2270,7 @@ void main() {
           () => mockNostrClient.subscribe(
             any(),
             subscriptionId: any(named: 'subscriptionId'),
+            onEose: any(named: 'onEose'),
           ),
         ).thenAnswer((_) => tail.stream);
 
@@ -2154,6 +2281,53 @@ void main() {
         await pumpEventQueue();
 
         expect(service.getContentWarnings('dup_target'), hasLength(1));
+      },
+    );
+
+    test(
+      'an older replay is ignored after an author watermark advances',
+      () async {
+        stubCompletedBackfill();
+        final tail = StreamController<Event>.broadcast();
+        addTearDown(tail.close);
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            onEose: any(named: 'onEose'),
+          ),
+        ).thenAnswer((_) => tail.stream);
+
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        await service.subscribeToLabeler(service.divineModerationPubkeyHex);
+        tail.add(
+          _FakeLabelEvent(
+            pubkey: service.divineModerationPubkeyHex,
+            id: 'newer_evt',
+            createdAt: now + 1,
+            tags: [
+              ['L', 'content-warning'],
+              ['l', 'nudity', 'content-warning'],
+              ['e', 'newer_target'],
+            ],
+          ),
+        );
+        tail.add(
+          _FakeLabelEvent(
+            pubkey: service.divineModerationPubkeyHex,
+            id: 'older_evt',
+            createdAt: now,
+            tags: [
+              ['L', 'content-warning'],
+              ['l', 'nudity', 'content-warning'],
+              ['e', 'older_target'],
+            ],
+          ),
+        );
+        await pumpEventQueue();
+
+        expect(service.getContentWarnings('newer_target'), hasLength(1));
+        expect(service.getContentWarnings('older_target'), isEmpty);
       },
     );
 
@@ -2169,6 +2343,7 @@ void main() {
           () => mockNostrClient.subscribe(
             any(),
             subscriptionId: any(named: 'subscriptionId'),
+            onEose: any(named: 'onEose'),
           ),
         ).thenAnswer((_) => tail.stream);
 
@@ -2209,6 +2384,7 @@ void main() {
           () => mockNostrClient.subscribe(
             any(),
             subscriptionId: any(named: 'subscriptionId'),
+            onEose: any(named: 'onEose'),
           ),
         ).thenAnswer((_) {
           calls++;
@@ -2225,6 +2401,14 @@ void main() {
         await pumpEventQueue();
 
         expect(calls, 2, reason: 'the tail should reopen after it drops');
+        final messages = LogCaptureService().getRecentLogs().map(
+          (entry) => entry.message,
+        );
+        expect(
+          messages,
+          contains('Moderation label tail dropped (stream closed)'),
+        );
+        expect(messages, contains('Re-subscribing to moderation labels in 0s'));
         second.add(liveLabelFrom(custom, 'post', 'reconnect_tgt'));
         await pumpEventQueue();
         expect(svc.getContentWarnings('reconnect_tgt'), hasLength(1));
@@ -2241,6 +2425,7 @@ void main() {
         () => mockNostrClient.subscribe(
           any(),
           subscriptionId: any(named: 'subscriptionId'),
+          onEose: any(named: 'onEose'),
         ),
       ).thenAnswer((_) => tail.stream);
 

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -95,6 +95,14 @@ void main() {
     ).thenAnswer(
       (_) => const Stream<Map<String, RelayConnectionStatus>>.empty(),
     );
+    // Default: the live tail (#8255) opens after a labeler latches loaded.
+    // Tests that exercise the tail override this with a controllable stream.
+    when(
+      () => mockNostrClient.subscribe(
+        any(),
+        subscriptionId: any(named: 'subscriptionId'),
+      ),
+    ).thenAnswer((_) => const Stream<Event>.empty());
     service = ModerationLabelService(
       nostrClient: mockNostrClient,
       authService: mockAuthService,
@@ -2063,5 +2071,58 @@ void main() {
         },
       );
     });
+  });
+
+  group('live tail subscription (#8255)', () {
+    Event liveLabel(String id, String targetEventId) => _FakeLabelEvent(
+      pubkey: service.divineModerationPubkeyHex,
+      id: id,
+      createdAt: 1000,
+      tags: [
+        ['L', 'content-warning'],
+        ['l', 'nudity', 'content-warning'],
+        ['e', targetEventId],
+      ],
+    );
+
+    void stubCompletedBackfill() {
+      when(
+        () => mockNostrClient.queryEventsDetailed(
+          any(),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        ),
+      ).thenAnswer(
+        (_) async => (events: <Event>[], timedOut: false, noRelays: false),
+      );
+    }
+
+    test(
+      'a label published after the initial load reaches the maps without a '
+      'restart',
+      () async {
+        // Backfill returns nothing and completes, so the labeler latches loaded
+        // and the service opens its live tail.
+        stubCompletedBackfill();
+        final tail = StreamController<Event>.broadcast();
+        addTearDown(tail.close);
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).thenAnswer((_) => tail.stream);
+
+        await service.subscribeToLabeler(service.divineModerationPubkeyHex);
+        expect(service.getContentWarnings('live_target'), isEmpty);
+
+        // A moderator labels a video mid-session.
+        tail.add(liveLabel('live_evt_1', 'live_target'));
+        await pumpEventQueue();
+
+        final warnings = service.getContentWarnings('live_target');
+        expect(warnings, hasLength(1));
+        expect(warnings.first.labelValue, 'nudity');
+      },
+    );
   });
 }

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -2124,5 +2124,30 @@ void main() {
         expect(warnings.first.labelValue, 'nudity');
       },
     );
+
+    test(
+      'the same tail event arriving twice produces one label row (dedup)',
+      () async {
+        // A re-issued REQ across a reconnect replays the relay's stored window,
+        // so the same kind-1985 event arrives again. It must not double-count.
+        stubCompletedBackfill();
+        final tail = StreamController<Event>.broadcast();
+        addTearDown(tail.close);
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).thenAnswer((_) => tail.stream);
+
+        await service.subscribeToLabeler(service.divineModerationPubkeyHex);
+
+        tail.add(liveLabel('dup_evt', 'dup_target'));
+        tail.add(liveLabel('dup_evt', 'dup_target'));
+        await pumpEventQueue();
+
+        expect(service.getContentWarnings('dup_target'), hasLength(1));
+      },
+    );
   });
 }

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -2441,6 +2441,70 @@ void main() {
       },
     );
 
+    test(
+      'a refused tail subscription reconnects so later labels still land',
+      () async {
+        // The sibling test drives onDone, which production cannot reach: a
+        // dead relay socket does not close the stream (the SDK retains the
+        // subscription for re-issue), and a CLOSED from some but not all
+        // serving relays is invisible to the stream. The only live drop signal
+        // is onError, once every serving relay has refused the REQ.
+        final svc = ModerationLabelService(
+          nostrClient: mockNostrClient,
+          authService: mockAuthService,
+          sharedPreferences: mockPrefs,
+          tailReconnectDelay: Duration.zero,
+        );
+        stubCompletedBackfill();
+        final first = StreamController<Event>.broadcast();
+        final second = StreamController<Event>.broadcast();
+        addTearDown(() async {
+          svc.dispose();
+          await first.close();
+          await second.close();
+        });
+        var calls = 0;
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            onEose: any(named: 'onEose'),
+          ),
+        ).thenAnswer((_) {
+          calls++;
+          return calls == 1 ? first.stream : second.stream;
+        });
+
+        const custom =
+            'e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5';
+        await svc.addLabeler(custom);
+        expect(calls, 1);
+
+        first.addError(const RelaySubscriptionRefusedException('rate-limited'));
+        await pumpEventQueue();
+
+        expect(
+          calls,
+          2,
+          reason: 'a refused subscription should reopen the tail',
+        );
+        final messages = LogCaptureService().getRecentLogs().map(
+          (entry) => entry.message,
+        );
+        expect(
+          messages,
+          contains(
+            'Moderation label tail dropped (subscription error: '
+            'RelaySubscriptionRefusedException: rate-limited)',
+          ),
+        );
+
+        second.add(liveLabelFrom(custom, 'post_refusal', 'refused_tgt'));
+        await pumpEventQueue();
+        expect(svc.getContentWarnings('refused_tgt'), hasLength(1));
+      },
+    );
+
     test('dispose cancels the live tail so no later label lands', () async {
       const custom =
           'c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3';

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -2104,6 +2104,11 @@ void main() {
       );
     }
 
+    // [LogCaptureService] is a process-wide singleton with a 50k ring buffer,
+    // so a tail drop logged by an earlier test satisfies this group's log
+    // assertions before they run. Clear it so each test only sees its own.
+    setUp(() => LogCaptureService().clearAllLogs());
+
     test(
       'all followed labelers share one live relay subscription',
       () async {
@@ -2236,7 +2241,10 @@ void main() {
         // and the service opens its live tail.
         stubCompletedBackfill();
         final tail = StreamController<Event>.broadcast();
-        addTearDown(tail.close);
+        addTearDown(() async {
+          service.dispose();
+          await tail.close();
+        });
         when(
           () => mockNostrClient.subscribe(
             any(),
@@ -2265,7 +2273,10 @@ void main() {
         // so the same kind-1985 event arrives again. It must not double-count.
         stubCompletedBackfill();
         final tail = StreamController<Event>.broadcast();
-        addTearDown(tail.close);
+        addTearDown(() async {
+          service.dispose();
+          await tail.close();
+        });
         when(
           () => mockNostrClient.subscribe(
             any(),
@@ -2289,7 +2300,10 @@ void main() {
       () async {
         stubCompletedBackfill();
         final tail = StreamController<Event>.broadcast();
-        addTearDown(tail.close);
+        addTearDown(() async {
+          service.dispose();
+          await tail.close();
+        });
         when(
           () => mockNostrClient.subscribe(
             any(),
@@ -2338,7 +2352,10 @@ void main() {
             'a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1';
         stubCompletedBackfill();
         final tail = StreamController<Event>.broadcast();
-        addTearDown(tail.close);
+        addTearDown(() async {
+          service.dispose();
+          await tail.close();
+        });
         when(
           () => mockNostrClient.subscribe(
             any(),
@@ -2374,10 +2391,10 @@ void main() {
         stubCompletedBackfill();
         final first = StreamController<Event>.broadcast();
         final second = StreamController<Event>.broadcast();
-        addTearDown(() {
-          first.close();
-          second.close();
+        addTearDown(() async {
           svc.dispose();
+          await first.close();
+          await second.close();
         });
         var calls = 0;
         when(
@@ -2420,7 +2437,10 @@ void main() {
           'c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3';
       stubCompletedBackfill();
       final tail = StreamController<Event>.broadcast();
-      addTearDown(tail.close);
+      addTearDown(() async {
+        service.dispose();
+        await tail.close();
+      });
       when(
         () => mockNostrClient.subscribe(
           any(),

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -2251,5 +2251,54 @@ void main() {
       await pumpEventQueue();
       expect(service.getContentWarnings('disposed_tgt'), isEmpty);
     });
+
+    test(
+      'a reload reapplies a labelers rows instead of dropping them as '
+      'duplicates (guards the dedup clear on reprocess)',
+      () async {
+        const custom =
+            'd4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4';
+        // The same real-id event on two loads: an incomplete load applies it
+        // (so the dedup set holds its id) without latching, then a complete
+        // load reprocesses. _removeLabelsForLabeler must clear the dedup set so
+        // the reprocess reapplies rather than skipping every event as a dup.
+        var complete = false;
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[
+              _FakeLabelEvent(
+                pubkey: custom,
+                id: 'reload_evt_1',
+                createdAt: 100,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['l', 'nudity', 'content-warning'],
+                  ['e', 'reload_tgt'],
+                ],
+              ),
+            ],
+            timedOut: !complete,
+            noRelays: false,
+          ),
+        );
+
+        await service.addLabeler(custom);
+        expect(service.getContentWarnings('reload_tgt'), hasLength(1));
+
+        complete = true;
+        await service.subscribeToLabeler(custom);
+
+        expect(
+          service.getContentWarnings('reload_tgt'),
+          hasLength(1),
+          reason: 'a reload must reapply the labeler rows, not drop them',
+        );
+      },
+    );
   });
 }

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -2140,10 +2140,12 @@ void main() {
           '2222222222222222222222222222222222222222222222222222222222222222',
           '3333333333333333333333333333333333333333333333333333333333333333',
         ];
+        final beforeLoad = DateTime.now().millisecondsSinceEpoch ~/ 1000;
         await service.setFollowingModerationEnabled(
           true,
           followedPubkeys: followed,
         );
+        final afterLoad = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
         expect(activeListeners, 1);
         final captured = verify(
@@ -2157,6 +2159,13 @@ void main() {
         final filter = (captured.single as List<Filter>).single;
         expect(filter.authors, unorderedEquals(followed));
         expect(filter.kinds, [NostrEventKinds.label]);
+        // The whole point of the watermark: the tail resumes from the oldest
+        // per-labeler boundary rather than re-requesting the stored window.
+        // Nothing asserted `since` before, so dropping it from the filter left
+        // every test in the suite green.
+        expect(filter.since, isNotNull);
+        expect(filter.since, greaterThanOrEqualTo(beforeLoad));
+        expect(filter.since, lessThanOrEqualTo(afterLoad));
       },
     );
 

--- a/mobile/test/services/nsfw_content_filter_test.dart
+++ b/mobile/test/services/nsfw_content_filter_test.dart
@@ -23,11 +23,9 @@ class _FakeFilter extends Fake implements Filter {}
 class _FakeLabelEvent extends Fake implements Event {
   _FakeLabelEvent({required this.pubkey, required this.tags});
 
-  // The live tail (#8255) reads id (dedup) and createdAt (tail watermark).
-  // These fakes model the single-shot backfill only, so fixed values suffice:
-  // an empty id skips dedup, exactly as intended for a one-page load.
   @override
-  String get id => '';
+  String get id =>
+      '8888888888888888888888888888888888888888888888888888888888888888';
 
   @override
   int get createdAt => 0;
@@ -119,6 +117,7 @@ void main() {
         () => mockNostrClient.subscribe(
           any(),
           subscriptionId: any(named: 'subscriptionId'),
+          onEose: any(named: 'onEose'),
         ),
       ).thenAnswer((_) => StreamController<Event>.broadcast().stream);
       moderationLabelService = ModerationLabelService(

--- a/mobile/test/services/nsfw_content_filter_test.dart
+++ b/mobile/test/services/nsfw_content_filter_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
@@ -20,6 +22,15 @@ class _FakeFilter extends Fake implements Filter {}
 
 class _FakeLabelEvent extends Fake implements Event {
   _FakeLabelEvent({required this.pubkey, required this.tags});
+
+  // The live tail (#8255) reads id (dedup) and createdAt (tail watermark).
+  // These fakes model the single-shot backfill only, so fixed values suffice:
+  // an empty id skips dedup, exactly as intended for a one-page load.
+  @override
+  String get id => '';
+
+  @override
+  int get createdAt => 0;
 
   @override
   final String pubkey;
@@ -103,6 +114,13 @@ void main() {
       await contentFilterService.initialize();
       mockNostrClient = _MockNostrClient();
       mockAuthService = _MockAuthService();
+      // The moderation labeler opens a live tail after its backfill (#8255).
+      when(
+        () => mockNostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+        ),
+      ).thenAnswer((_) => StreamController<Event>.broadcast().stream);
       moderationLabelService = ModerationLabelService(
         nostrClient: mockNostrClient,
         authService: mockAuthService,

--- a/mobile/test/services/video_event_service_content_filter_test.dart
+++ b/mobile/test/services/video_event_service_content_filter_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
@@ -23,6 +25,15 @@ class _FakeFilter extends Fake implements Filter {}
 
 class _FakeLabelEvent extends Fake implements Event {
   _FakeLabelEvent({required this.pubkey, required this.tags});
+
+  // The live tail (#8255) reads id (dedup) and createdAt (tail watermark).
+  // These fakes model the single-shot backfill only, so fixed values suffice:
+  // an empty id skips dedup, exactly as intended for a one-page load.
+  @override
+  String get id => '';
+
+  @override
+  int get createdAt => 0;
 
   @override
   final String pubkey;
@@ -102,6 +113,13 @@ void main() {
     when(() => mockNostrClient.publicKey).thenReturn(
       '1111111111111111111111111111111111111111111111111111111111111111',
     );
+    // The moderation labeler opens a live tail after its backfill (#8255).
+    when(
+      () => mockNostrClient.subscribe(
+        any(),
+        subscriptionId: any(named: 'subscriptionId'),
+      ),
+    ).thenAnswer((_) => StreamController<Event>.broadcast().stream);
 
     ageVerificationService = AgeVerificationService(
       preferences: prefs,

--- a/mobile/test/services/video_event_service_content_filter_test.dart
+++ b/mobile/test/services/video_event_service_content_filter_test.dart
@@ -26,11 +26,9 @@ class _FakeFilter extends Fake implements Filter {}
 class _FakeLabelEvent extends Fake implements Event {
   _FakeLabelEvent({required this.pubkey, required this.tags});
 
-  // The live tail (#8255) reads id (dedup) and createdAt (tail watermark).
-  // These fakes model the single-shot backfill only, so fixed values suffice:
-  // an empty id skips dedup, exactly as intended for a one-page load.
   @override
-  String get id => '';
+  String get id =>
+      '7777777777777777777777777777777777777777777777777777777777777777';
 
   @override
   int get createdAt => 0;
@@ -118,6 +116,7 @@ void main() {
       () => mockNostrClient.subscribe(
         any(),
         subscriptionId: any(named: 'subscriptionId'),
+        onEose: any(named: 'onEose'),
       ),
     ).thenAnswer((_) => StreamController<Event>.broadcast().stream);
 


### PR DESCRIPTION
## Problem

The app loads trusted labeler events when a labeler is added, but that history request ends at end-of-stored-events. Labels published afterward do not reach the running client's moderation maps until the app restarts or the labeler subscription is rebuilt.

Closes #8255.

## Why this fix

- Keeps the existing paged history load, then opens one shared live Nostr subscription for all trusted labelers.
- Rebuilds that subscription when the trusted-labeler set changes and cancels it when the last labeler is removed or the service is disposed.
- Reconnects with bounded exponential backoff after an unexpected stream end.
- Replays a five-minute overlap around each labeler's newest timestamp so distinct events delivered out of order across relays are not lost, while exact event-ID deduplication prevents duplicate application and bounds retained state.
- Continues routing received labels through the existing event, addressable-coordinate, and pubkey label maps.

## Deliberately unchanged

This PR does not add a separate invalidation path for feed items that have already been rendered. A newly received label is available to the next existing moderation-filter pass; forcing an immediate feed re-filter remains outside #8255's live-map subscription scope.

## Verification

- `flutter test test/services/moderation_label_service_test.dart test/services/nsfw_content_filter_test.dart test/services/video_event_service_content_filter_test.dart test/providers/moderation_label_provider_session_test.dart` — 112 tests passed
- `flutter analyze lib test integration_test` — no issues
- `flutter analyze lib/services/moderation_label_service.dart test/services/moderation_label_service_test.dart` — no issues after the final focused edit
- Production `Future.delayed`, uncancellable timer-wait, Nostr ID logging, and pubkey logging guards passed locally
- Repository pre-push analysis and affected-test gate passed
