### PR TITLE
test(e2e): reduce PR smoke to deterministic journeys

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1488,6 +1488,13 @@ workflows:
       vars:
         DEFAULT_ENV: STAGING
         BUNDLE_ID: co.openvine.app.staging
+        # Same fixture as the iOS lane, and it has to be: both workflows run
+        # the shared *run_maestro_smoke_tests script, which passes
+        # `-e QA_VIDEO_EVENT_ID`. Leaving it unset here expands to an empty
+        # string under `set -e` (no `set -u`), which fails prSeededVideoPlayback
+        # on every dispatched Android run. The contract test pins the two
+        # values as equal so they cannot drift.
+        QA_VIDEO_EVENT_ID: dd6ba512d5c3ed9490db9cd15986fb5c88347cb4aeeef6220331e8b06ca3c510
     cache:
       cache_paths:
         - $HOME/.gradle/caches

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1395,10 +1395,18 @@ workflows:
   e2e-smoke-ios:
     name: E2E Smoke Tests (iOS)
     working_directory: mobile
-    # This is a deliberately small PR signal, not the regression suite. Stop a
-    # stalled build at 18 minutes; promotion requires the p95 to remain below
-    # 15 minutes during the observation window.
-    max_build_duration: 18
+    # A hang-stopper, not a performance gate — those are separate numbers and
+    # only one of them belongs here. Two green runs of the PREVIOUS lane
+    # measured 12 min and 15m42s end to end (builds 6a7bb0d4 and 6a7d30c1),
+    # and this lane does strictly more than that one: prAuthenticateHome still
+    # runs the whole of loginFreshInstall, on top of an extra clean launch and
+    # the video journey. A cap near the slow measurement would turn cache
+    # warmth into a red PR, which is the infrastructure noise this lane exists
+    # to remove. 25 leaves that headroom while still stopping a hung Maestro
+    # driver from billing the hour the previous 60 allowed (build 6a7d2a83).
+    # Speed is governed by the promotion bar instead: p95 below 15 minutes
+    # over the observation window before this becomes a required check.
+    max_build_duration: 25
     instance_type: mac_mini_m2
     environment:
       flutter: 3.44.9

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -847,7 +847,10 @@ definitions:
         maestro "$@" test \
           --format junit \
           --output report.xml \
-          e2e/maestro/tests/loginFreshInstall.yaml \
+          -e QA_VIDEO_EVENT_ID="$QA_VIDEO_EVENT_ID" \
+          e2e/maestro/tests/prLaunchReady.yaml \
+          e2e/maestro/tests/prAuthenticateHome.yaml \
+          e2e/maestro/tests/prSeededVideoPlayback.yaml \
           e2e/maestro/tests/removeKeys.yaml
       # Script-level, not workflow-level: Codemagic rejects `test_report` as an
       # unknown workflow field ("extra fields not permitted").
@@ -1392,12 +1395,10 @@ workflows:
   e2e-smoke-ios:
     name: E2E Smoke Tests (iOS)
     working_directory: mobile
-    # Two green runs measured 12 min and 15m42s end to end (builds 6a7bb0d4
-    # and 6a7d30c1); the spread is cache warmth. 25 covers the slower one with
-    # room to spare while still stopping a hung Maestro driver from billing the
-    # hour the previous 60 allowed — a hang is what 60 actually cost us
-    # (build 6a7d2a83).
-    max_build_duration: 25
+    # This is a deliberately small PR signal, not the regression suite. Stop a
+    # stalled build at 18 minutes; promotion requires the p95 to remain below
+    # 15 minutes during the observation window.
+    max_build_duration: 18
     instance_type: mac_mini_m2
     environment:
       flutter: 3.44.9
@@ -1416,6 +1417,10 @@ workflows:
       vars:
         DEFAULT_ENV: STAGING
         BUNDLE_ID: co.openvine.app.staging
+        # Immutable public Nostr event used only to prove the detail route can
+        # resolve and render playback chrome. Never replace this with a private
+        # account credential or mutable search result.
+        QA_VIDEO_EVENT_ID: dd6ba512d5c3ed9490db9cd15986fb5c88347cb4aeeef6220331e8b06ca3c510
     cache:
       cache_paths:
         - $HOME/Library/Caches/CocoaPods
@@ -1441,6 +1446,8 @@ workflows:
       changeset:
         includes:
           - mobile/
+        excludes:
+          - mobile/**/*.md
     scripts:
       - *check_signing_endpoint
       - *check_supporters_config

--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -6,18 +6,27 @@ End-to-end UI tests written with **Maestro**, driving a real build against
 They exist for fast, high-signal regression detection on critical user flows.
 They are not a replacement for unit or widget tests.
 
-## What the smoke suite covers today
+## Pull-request smoke versus regression
 
-`suites/smoke.yaml` runs the account-management paths — `loginFreshInstall`,
-its `removeKeys` cleanup, and `loginEmailPwd` — plus all three social flows:
-`likeFlow`, `commentFlow` (post a comment, delete it) and `searchUserFlow`
-(find an account, open its profile, come back).
+The automatic PR gate is intentionally limited to three deterministic signals:
 
-The full smoke suite is the manual target. The PR gate in Codemagic runs
-`tests/loginFreshInstall.yaml` and `tests/removeKeys.yaml` as individual files so the
-JUnit report keeps per-flow names and timings. `likeFlow` and `commentFlow` stay
-off the gate: after the reduced-motion fix they still fail on Codemagic with a
-blocked main thread, as documented in
+1. `prLaunchReady` proves a clean install reaches interactive onboarding.
+2. `prAuthenticateHome` creates a throwaway local identity and proves the
+   authenticated shell can open Home.
+3. `prSeededVideoPlayback` opens one immutable public Nostr event directly and
+   proves the video route resolves to playback chrome.
+
+`removeKeys` is a teardown case, not another journey. Codemagic passes every
+file separately so JUnit preserves its name and timing. The PR suite neither
+searches mutable content nor signs into a shared account, and it does not need
+credentials. A public `QA_VIDEO_EVENT_ID` variable identifies the immutable
+fixture; changing it is a reviewed CI configuration change.
+
+The broader `suites/smoke.yaml` remains a manual regression target. It includes
+account-management and social flows that depend on credentials or mutable
+staging state. `likeFlow` and `commentFlow` remain unsuitable for the PR gate:
+after the reduced-motion fix they still fail on Codemagic with a blocked main
+thread, as documented in
 [#7204](https://github.com/divinevideo/divine-mobile/issues/7204). Restoring
 those flows is tracked by
 [#7619](https://github.com/divinevideo/divine-mobile/issues/7619) and
@@ -49,11 +58,12 @@ The lesson generalises: **before filing a Maestro failure as flaky data,
 check whether the screen is stuck in a state the app has no exit from.**
 A permanent loading placeholder looks exactly like slow live content.
 
-The `e2e-smoke-ios` Codemagic workflow is configured to run on pull requests
-that touch `mobile/`, but the webhook integration must be restored under
-[#7504](https://github.com/divinevideo/divine-mobile/issues/7504) before those
-builds can fire. It remains non-blocking until a flake baseline exists. The
-`e2e-smoke-android` workflow is a manual dispatch.
+The `e2e-smoke-ios` Codemagic workflow runs on pull requests that touch mobile
+code, excluding Markdown-only changes. It remains non-blocking for an
+observation window of at least 30 runs. Promote it to a required check only if
+at least 95% of runs are infrastructure-clean and the p95 end-to-end duration
+stays below 15 minutes; reset the observation window after a flow, runner image,
+or Maestro version change. The `e2e-smoke-android` workflow is manual.
 
 ## The recorder flows
 
@@ -480,7 +490,10 @@ runner guard keeps CI failures from looking like unrelated selector breakage.
 maestro test \
   --format junit \
   --output report.xml \
-  e2e/maestro/tests/loginFreshInstall.yaml \
+  -e QA_VIDEO_EVENT_ID=<immutable-public-event-id> \
+  e2e/maestro/tests/prLaunchReady.yaml \
+  e2e/maestro/tests/prAuthenticateHome.yaml \
+  e2e/maestro/tests/prSeededVideoPlayback.yaml \
   e2e/maestro/tests/removeKeys.yaml
 
 # The full smoke suite

--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -58,9 +58,13 @@ The lesson generalises: **before filing a Maestro failure as flaky data,
 check whether the screen is stuck in a state the app has no exit from.**
 A permanent loading placeholder looks exactly like slow live content.
 
-The `e2e-smoke-ios` Codemagic workflow runs on pull requests that touch mobile
-code, excluding Markdown-only changes. It remains non-blocking for an
-observation window of at least 30 runs. Promote it to a required check only if
+The `e2e-smoke-ios` Codemagic workflow is configured to run on pull requests
+that touch mobile code, excluding Markdown-only changes — but no build can fire
+until the Codemagic webhook subscription is restored under
+[#7504](https://github.com/divinevideo/divine-mobile/issues/7504), which is an
+external integration setting this repository cannot change. Once builds do
+fire, the check remains non-blocking for an observation window of at least 30
+runs. Promote it to a required check only if
 at least 95% of runs are infrastructure-clean and the p95 end-to-end duration
 stays below 15 minutes; reset the observation window after a flow, runner image,
 or Maestro version change. The `e2e-smoke-android` workflow is manual.

--- a/mobile/e2e/maestro/tests/loginFreshInstall.yaml
+++ b/mobile/e2e/maestro/tests/loginFreshInstall.yaml
@@ -22,8 +22,10 @@ tags:
 # written. The id is the same on both branches.
 - tapOn:
     id: "create_account_button"
-- tapOn: Use Divine with no backup
-- tapOn: Use this device only
+- tapOn:
+    id: "use_without_backup_button"
+- tapOn:
+    id: "use_device_only_button"
 
 # 3. Wait for the authenticated shell without waiting for every loading
 # animation. The empty-following redirect normally lands on Explore, but it is

--- a/mobile/e2e/maestro/tests/prAuthenticateHome.yaml
+++ b/mobile/e2e/maestro/tests/prAuthenticateHome.yaml
@@ -5,8 +5,18 @@ tags:
   - auth
 ---
 - runFlow: loginFreshInstall.yaml
+
+# loginFreshInstall leaves the app on Explore, and the bottom-nav tabs it
+# already asserted are present on every shell route -- so re-asserting them
+# after the tap cannot fail. The shell wraps every inactive branch in
+# ExcludeSemantics, so Explore's search field disappearing is the id-based
+# signal that the Home tap actually switched branch.
 - tapOn:
     id: "home_tab"
+- extendedWaitUntil:
+    notVisible:
+      id: "explore_search_bar"
+    timeout: 30000
 - assertVisible:
     id: "home_tab"
 - assertVisible:

--- a/mobile/e2e/maestro/tests/prAuthenticateHome.yaml
+++ b/mobile/e2e/maestro/tests/prAuthenticateHome.yaml
@@ -1,0 +1,13 @@
+appId: co.openvine.app.staging
+name: PR smoke - authenticated home
+tags:
+  - pr-smoke
+  - auth
+---
+- runFlow: loginFreshInstall.yaml
+- tapOn:
+    id: "home_tab"
+- assertVisible:
+    id: "home_tab"
+- assertVisible:
+    id: "profile_tab"

--- a/mobile/e2e/maestro/tests/prLaunchReady.yaml
+++ b/mobile/e2e/maestro/tests/prLaunchReady.yaml
@@ -1,0 +1,11 @@
+appId: co.openvine.app.staging
+name: PR smoke - app launch
+tags:
+  - pr-smoke
+---
+- launchApp:
+    clearState: true
+- extendedWaitUntil:
+    visible:
+      id: "create_account_button"
+    timeout: 30000

--- a/mobile/e2e/maestro/tests/prSeededVideoPlayback.yaml
+++ b/mobile/e2e/maestro/tests/prSeededVideoPlayback.yaml
@@ -11,3 +11,14 @@ tags:
       id: "video_detail_loading"
     timeout: 30000
 - runFlow: ../asserts/assertVideoPlayback.yaml
+
+# Leave the app back on the tab shell. `/video/:id` is a top-level route
+# outside the StatefulShellRoute, so while this takeover is open the bottom
+# nav is not on screen -- and removeKeys, which Codemagic runs straight after
+# this file, opens Settings by tapping profile_tab.
+- tapOn:
+    id: "back_button"
+- extendedWaitUntil:
+    visible:
+      id: "profile_tab"
+    timeout: 30000

--- a/mobile/e2e/maestro/tests/prSeededVideoPlayback.yaml
+++ b/mobile/e2e/maestro/tests/prSeededVideoPlayback.yaml
@@ -1,0 +1,13 @@
+appId: co.openvine.app.staging
+name: PR smoke - seeded video playback
+tags:
+  - pr-smoke
+  - video
+---
+- assertTrue: ${typeof QA_VIDEO_EVENT_ID !== 'undefined' && QA_VIDEO_EVENT_ID !== ''}
+- openLink: "divine:///video/${QA_VIDEO_EVENT_ID}"
+- extendedWaitUntil:
+    notVisible:
+      id: "video_detail_loading"
+    timeout: 30000
+- runFlow: ../asserts/assertVideoPlayback.yaml

--- a/mobile/lib/constants/semantic_ids.dart
+++ b/mobile/lib/constants/semantic_ids.dart
@@ -100,6 +100,8 @@ abstract class SemanticIds {
   static const String authContinueAsButton = 'continue_as_button';
   static const String authUseAnotherAccountButton =
       'use_another_account_button';
+  static const String authUseWithoutBackupButton = 'use_without_backup_button';
+  static const String authUseDeviceOnlyButton = 'use_device_only_button';
 
   /// Sign-in options screen. The info button opens the sheet explaining each
   /// sign-in method; the back control there reuses

--- a/mobile/lib/screens/auth/create_account_screen.dart
+++ b/mobile/lib/screens/auth/create_account_screen.dart
@@ -342,32 +342,40 @@ class _SkipButton extends StatelessWidget {
     return SizedBox(
       width: double.infinity,
       height: 48,
-      child: Semantics(
-        identifier: SemanticIds.authUseWithoutBackupButton,
-        child: TextButton(
-          onPressed: isDisabled ? null : onPressed,
-          style: TextButton.styleFrom(
-            foregroundColor: context.vineColors.secondaryText,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(20),
+      // MergeSemantics, not a bare Semantics wrapper: TextButton declares
+      // `container: true`, so an identifier-only annotation above it cannot
+      // merge and becomes its own node carrying no label, no button flag and
+      // no tap action. iOS exposes only focusable nodes as accessibility
+      // elements, so Maestro would not see the identifier at all. Merging
+      // puts it on the node that already announces and activates the button.
+      child: MergeSemantics(
+        child: Semantics(
+          identifier: SemanticIds.authUseWithoutBackupButton,
+          child: TextButton(
+            onPressed: isDisabled ? null : onPressed,
+            style: TextButton.styleFrom(
+              foregroundColor: context.vineColors.secondaryText,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(20),
+              ),
             ),
+            child: isSkipping
+                ? SizedBox(
+                    height: 18,
+                    width: 18,
+                    child: DivineCircularProgressIndicator(
+                      color: context.vineColors.secondaryText,
+                      strokeWidth: 2,
+                    ),
+                  )
+                : Text(
+                    context.l10n.authUseDivineNoBackup,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
           ),
-          child: isSkipping
-              ? SizedBox(
-                  height: 18,
-                  width: 18,
-                  child: DivineCircularProgressIndicator(
-                    color: context.vineColors.secondaryText,
-                    strokeWidth: 2,
-                  ),
-                )
-              : Text(
-                  context.l10n.authUseDivineNoBackup,
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
         ),
       ),
     );
@@ -465,21 +473,25 @@ class _SkipConfirmationSheet extends StatelessWidget {
           SizedBox(
             width: double.infinity,
             height: 56,
-            child: Semantics(
-              identifier: SemanticIds.authUseDeviceOnlyButton,
-              child: TextButton(
-                onPressed: () => Navigator.pop(context, true),
-                style: TextButton.styleFrom(
-                  foregroundColor: context.vineColors.secondaryText,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(20),
+            // Merged for the same reason as _SkipButton above: the identifier
+            // has to land on the node that carries the label and the tap.
+            child: MergeSemantics(
+              child: Semantics(
+                identifier: SemanticIds.authUseDeviceOnlyButton,
+                child: TextButton(
+                  onPressed: () => Navigator.pop(context, true),
+                  style: TextButton.styleFrom(
+                    foregroundColor: context.vineColors.secondaryText,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
                   ),
-                ),
-                child: Text(
-                  context.l10n.authUseThisDeviceOnly,
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
+                  child: Text(
+                    context.l10n.authUseThisDeviceOnly,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                    ),
                   ),
                 ),
               ),

--- a/mobile/lib/screens/auth/create_account_screen.dart
+++ b/mobile/lib/screens/auth/create_account_screen.dart
@@ -15,6 +15,7 @@ import 'package:invite_api_client/invite_api_client.dart';
 import 'package:openvine/blocs/divine_auth/divine_auth_cubit.dart';
 import 'package:openvine/blocs/invite_gate/invite_gate_bloc.dart';
 import 'package:openvine/blocs/invite_gate/invite_gate_event.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/generated/product_analytics.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/analytics_providers.dart';
@@ -341,30 +342,33 @@ class _SkipButton extends StatelessWidget {
     return SizedBox(
       width: double.infinity,
       height: 48,
-      child: TextButton(
-        onPressed: isDisabled ? null : onPressed,
-        style: TextButton.styleFrom(
-          foregroundColor: context.vineColors.secondaryText,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(20),
+      child: Semantics(
+        identifier: SemanticIds.authUseWithoutBackupButton,
+        child: TextButton(
+          onPressed: isDisabled ? null : onPressed,
+          style: TextButton.styleFrom(
+            foregroundColor: context.vineColors.secondaryText,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(20),
+            ),
           ),
+          child: isSkipping
+              ? SizedBox(
+                  height: 18,
+                  width: 18,
+                  child: DivineCircularProgressIndicator(
+                    color: context.vineColors.secondaryText,
+                    strokeWidth: 2,
+                  ),
+                )
+              : Text(
+                  context.l10n.authUseDivineNoBackup,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
         ),
-        child: isSkipping
-            ? SizedBox(
-                height: 18,
-                width: 18,
-                child: DivineCircularProgressIndicator(
-                  color: context.vineColors.secondaryText,
-                  strokeWidth: 2,
-                ),
-              )
-            : Text(
-                context.l10n.authUseDivineNoBackup,
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
       ),
     );
   }
@@ -461,19 +465,22 @@ class _SkipConfirmationSheet extends StatelessWidget {
           SizedBox(
             width: double.infinity,
             height: 56,
-            child: TextButton(
-              onPressed: () => Navigator.pop(context, true),
-              style: TextButton.styleFrom(
-                foregroundColor: context.vineColors.secondaryText,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(20),
+            child: Semantics(
+              identifier: SemanticIds.authUseDeviceOnlyButton,
+              child: TextButton(
+                onPressed: () => Navigator.pop(context, true),
+                style: TextButton.styleFrom(
+                  foregroundColor: context.vineColors.secondaryText,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(20),
+                  ),
                 ),
-              ),
-              child: Text(
-                context.l10n.authUseThisDeviceOnly,
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w500,
+                child: Text(
+                  context.l10n.authUseThisDeviceOnly,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                  ),
                 ),
               ),
             ),

--- a/mobile/scripts/baseline/maestro_copy_manifest.txt
+++ b/mobile/scripts/baseline/maestro_copy_manifest.txt
@@ -31,8 +31,6 @@ authSignInButton	e2e/maestro/asserts/assertSignIn.yaml	bound:Sign in
 authSignInButton	e2e/maestro/flows/loginEmailPwd.yaml	bound:Sign in
 authSignInWithAmber	e2e/maestro/asserts/assertSignIn.yaml	bound:Sign in with Amber
 authTermsOfService	e2e/maestro/asserts/assertLogin.yaml	bound:Terms of Service
-authUseDivineNoBackup	e2e/maestro/tests/loginFreshInstall.yaml	bound:Use Divine with no backup
-authUseThisDeviceOnly	e2e/maestro/tests/loginFreshInstall.yaml	bound:Use this device only
 blossomSaveTooltip	e2e/maestro/asserts/assertEditProfileModal.yaml	bound:Save
 blossomSaveTooltip	e2e/maestro/asserts/assertEditYourProfile.yaml	bound:Save
 commentOptionsTitle	e2e/maestro/asserts/assertCommentsOptions.yaml	bound:Options

--- a/mobile/test/screens/auth/create_account_screen_test.dart
+++ b/mobile/test/screens/auth/create_account_screen_test.dart
@@ -240,9 +240,21 @@ void main() {
           find.widgetWithText(TextButton, 'Use Divine with no backup'),
           findsOneWidget,
         );
+        // The identifier has to sit on the node that also announces and
+        // activates the button. A bare Semantics wrapper over a TextButton
+        // yields a separate, non-focusable node that iOS never exposes as an
+        // accessibility element, so `find.bySemanticsIdentifier` alone would
+        // stay green while Maestro's `tapOn: id:` found nothing on device.
         expect(
-          find.bySemanticsIdentifier(SemanticIds.authUseWithoutBackupButton),
-          findsOneWidget,
+          tester.getSemantics(
+            find.bySemanticsIdentifier(SemanticIds.authUseWithoutBackupButton),
+          ),
+          isSemantics(
+            identifier: SemanticIds.authUseWithoutBackupButton,
+            label: 'Use Divine with no backup',
+            isButton: true,
+            hasTapAction: true,
+          ),
         );
       });
 
@@ -280,8 +292,15 @@ void main() {
           findsOneWidget,
         );
         expect(
-          find.bySemanticsIdentifier(SemanticIds.authUseDeviceOnlyButton),
-          findsOneWidget,
+          tester.getSemantics(
+            find.bySemanticsIdentifier(SemanticIds.authUseDeviceOnlyButton),
+          ),
+          isSemantics(
+            identifier: SemanticIds.authUseDeviceOnlyButton,
+            label: 'Use this device only',
+            isButton: true,
+            hasTapAction: true,
+          ),
         );
       });
 

--- a/mobile/test/screens/auth/create_account_screen_test.dart
+++ b/mobile/test/screens/auth/create_account_screen_test.dart
@@ -18,6 +18,7 @@ import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:openvine/blocs/divine_auth/divine_auth_cubit.dart';
 import 'package:openvine/blocs/invite_gate/invite_gate_bloc.dart';
 import 'package:openvine/blocs/invite_gate/invite_gate_state.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/generated/product_analytics.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -141,10 +142,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        createTestWidget(
-          inviteAccessGrant: grant,
-          analyticsService: analytics,
-        ),
+        createTestWidget(inviteAccessGrant: grant, analyticsService: analytics),
       );
       await tester.pump();
 
@@ -242,6 +240,10 @@ void main() {
           find.widgetWithText(TextButton, 'Use Divine with no backup'),
           findsOneWidget,
         );
+        expect(
+          find.bySemanticsIdentifier(SemanticIds.authUseWithoutBackupButton),
+          findsOneWidget,
+        );
       });
 
       testWidgets('displays dog sticker', (tester) async {
@@ -275,6 +277,10 @@ void main() {
         );
         expect(
           find.widgetWithText(TextButton, 'Use this device only'),
+          findsOneWidget,
+        );
+        expect(
+          find.bySemanticsIdentifier(SemanticIds.authUseDeviceOnlyButton),
           findsOneWidget,
         );
       });
@@ -431,10 +437,7 @@ void main() {
           );
           await tester.enterText(
             find.descendant(
-              of: find.widgetWithText(
-                DivineAuthTextField,
-                'Confirm password',
-              ),
+              of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
               matching: find.byType(TextField),
             ),
             'SecurePass123!',
@@ -534,10 +537,7 @@ void main() {
           );
           await tester.enterText(
             find.descendant(
-              of: find.widgetWithText(
-                DivineAuthTextField,
-                'Confirm password',
-              ),
+              of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
               matching: find.byType(TextField),
             ),
             'SecurePass123!',

--- a/mobile/test/tools/maestro_pr_smoke_contract_test.dart
+++ b/mobile/test/tools/maestro_pr_smoke_contract_test.dart
@@ -76,7 +76,7 @@ void main() {
     });
 
     test('keeps the PR workflow bounded and docs-aware', () {
-      expect(iosWorkflow, contains('max_build_duration: 18'));
+      expect(iosWorkflow, contains('max_build_duration: 25'));
       expect(iosWorkflow, contains('- mobile/**/*.md'));
       expect(iosWorkflow, contains('cancel_previous_builds: true'));
     });

--- a/mobile/test/tools/maestro_pr_smoke_contract_test.dart
+++ b/mobile/test/tools/maestro_pr_smoke_contract_test.dart
@@ -5,54 +5,67 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+/// Every Maestro flow path the smoke command may name, in invocation order.
+final _flowInvocation = RegExp(r'e2e/maestro/\S+\.yaml');
+
 void main() {
   group('Maestro PR smoke contract', () {
     late String codemagic;
+    late String smokeCommand;
+    late String iosWorkflow;
+
+    /// Slices [source] between two anchors, failing on the anchor rather than
+    /// on a `substring` range error when one of them moves.
+    String sliceBetween(String source, String start, String end) {
+      final from = source.indexOf(start);
+      final to = source.indexOf(end);
+      expect(from, isNonNegative, reason: 'codemagic.yaml lost anchor $start');
+      expect(to, greaterThan(from), reason: 'codemagic.yaml lost anchor $end');
+      return source.substring(from, to);
+    }
 
     setUpAll(() {
       codemagic = File('../codemagic.yaml').readAsStringSync();
+      smokeCommand = sliceBetween(
+        codemagic,
+        r'maestro "$@" test',
+        'test_report: report.xml',
+      );
+      iosWorkflow = sliceBetween(
+        codemagic,
+        '  e2e-smoke-ios:',
+        '  e2e-smoke-android:',
+      );
     });
 
-    test('runs only the three PR journeys and teardown', () {
-      const expected = [
-        'prLaunchReady.yaml',
-        'prAuthenticateHome.yaml',
-        'prSeededVideoPlayback.yaml',
-        'removeKeys.yaml',
-      ];
-      final smokeBlock = codemagic.substring(
-        codemagic.indexOf(r'maestro "$@" test'),
-        codemagic.indexOf('test_report: report.xml'),
+    test('runs only the three PR journeys and teardown, in order', () {
+      // Ordered equality, not a presence loop: the lane's value is that it is
+      // bounded, so a regression flow appended to the command has to fail here.
+      expect(
+        _flowInvocation
+            .allMatches(smokeCommand)
+            .map((match) => match.group(0))
+            .toList(),
+        equals(const [
+          'e2e/maestro/tests/prLaunchReady.yaml',
+          'e2e/maestro/tests/prAuthenticateHome.yaml',
+          'e2e/maestro/tests/prSeededVideoPlayback.yaml',
+          'e2e/maestro/tests/removeKeys.yaml',
+        ]),
       );
-
-      for (final flow in expected) {
-        expect(smokeBlock, contains('e2e/maestro/tests/$flow'));
-      }
-      expect(smokeBlock, isNot(contains('suites/smoke.yaml')));
-      expect(smokeBlock, isNot(contains('fullRegression.yaml')));
     });
 
     test('keeps the PR workflow bounded and docs-aware', () {
-      final workflow = codemagic.substring(
-        codemagic.indexOf('  e2e-smoke-ios:'),
-        codemagic.indexOf('  e2e-smoke-android:'),
-      );
-
-      expect(workflow, contains('max_build_duration: 18'));
-      expect(workflow, contains('- mobile/**/*.md'));
-      expect(workflow, contains('cancel_previous_builds: true'));
+      expect(iosWorkflow, contains('max_build_duration: 18'));
+      expect(iosWorkflow, contains('- mobile/**/*.md'));
+      expect(iosWorkflow, contains('cancel_previous_builds: true'));
     });
 
     test('uses a public fixture id instead of account credentials', () {
-      final command = codemagic.substring(
-        codemagic.indexOf(r'maestro "$@" test'),
-        codemagic.indexOf('test_report: report.xml'),
-      );
-
-      expect(command, contains('-e QA_VIDEO_EVENT_ID='));
-      expect(command, isNot(contains('USER_EMAIL')));
-      expect(command, isNot(contains('USER_PWD')));
-      expect(command, isNot(contains('USER_KEYS')));
+      expect(smokeCommand, contains('-e QA_VIDEO_EVENT_ID='));
+      expect(smokeCommand, isNot(contains('USER_EMAIL')));
+      expect(smokeCommand, isNot(contains('USER_PWD')));
+      expect(smokeCommand, isNot(contains('USER_KEYS')));
     });
   });
 }

--- a/mobile/test/tools/maestro_pr_smoke_contract_test.dart
+++ b/mobile/test/tools/maestro_pr_smoke_contract_test.dart
@@ -1,0 +1,58 @@
+// ABOUTME: Pins the small, deterministic Maestro suite used on pull requests.
+// ABOUTME: Prevents broad regression flows or credential dependencies entering the gate.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Maestro PR smoke contract', () {
+    late String codemagic;
+
+    setUpAll(() {
+      codemagic = File('../codemagic.yaml').readAsStringSync();
+    });
+
+    test('runs only the three PR journeys and teardown', () {
+      const expected = [
+        'prLaunchReady.yaml',
+        'prAuthenticateHome.yaml',
+        'prSeededVideoPlayback.yaml',
+        'removeKeys.yaml',
+      ];
+      final smokeBlock = codemagic.substring(
+        codemagic.indexOf(r'maestro "$@" test'),
+        codemagic.indexOf('test_report: report.xml'),
+      );
+
+      for (final flow in expected) {
+        expect(smokeBlock, contains('e2e/maestro/tests/$flow'));
+      }
+      expect(smokeBlock, isNot(contains('suites/smoke.yaml')));
+      expect(smokeBlock, isNot(contains('fullRegression.yaml')));
+    });
+
+    test('keeps the PR workflow bounded and docs-aware', () {
+      final workflow = codemagic.substring(
+        codemagic.indexOf('  e2e-smoke-ios:'),
+        codemagic.indexOf('  e2e-smoke-android:'),
+      );
+
+      expect(workflow, contains('max_build_duration: 18'));
+      expect(workflow, contains('- mobile/**/*.md'));
+      expect(workflow, contains('cancel_previous_builds: true'));
+    });
+
+    test('uses a public fixture id instead of account credentials', () {
+      final command = codemagic.substring(
+        codemagic.indexOf(r'maestro "$@" test'),
+        codemagic.indexOf('test_report: report.xml'),
+      );
+
+      expect(command, contains('-e QA_VIDEO_EVENT_ID='));
+      expect(command, isNot(contains('USER_EMAIL')));
+      expect(command, isNot(contains('USER_PWD')));
+      expect(command, isNot(contains('USER_KEYS')));
+    });
+  });
+}

--- a/mobile/test/tools/maestro_pr_smoke_contract_test.dart
+++ b/mobile/test/tools/maestro_pr_smoke_contract_test.dart
@@ -8,11 +8,22 @@ import 'package:flutter_test/flutter_test.dart';
 /// Every Maestro flow path the smoke command may name, in invocation order.
 final _flowInvocation = RegExp(r'e2e/maestro/\S+\.yaml');
 
+/// The fixture id as a workflow assigns it, so a prose mention of the name in
+/// a comment is not mistaken for a definition.
+final _fixtureAssignment = RegExp(
+  r'^\s*QA_VIDEO_EVENT_ID:\s*(\S+)',
+  multiLine: true,
+);
+
+/// A bare 32-byte Nostr event id — the only shape this variable may carry.
+final _eventId = RegExp(r'^[0-9a-f]{64}$');
+
 void main() {
   group('Maestro PR smoke contract', () {
     late String codemagic;
     late String smokeCommand;
     late String iosWorkflow;
+    late String androidWorkflow;
 
     /// Slices [source] between two anchors, failing on the anchor rather than
     /// on a `substring` range error when one of them moves.
@@ -22,6 +33,14 @@ void main() {
       expect(from, isNonNegative, reason: 'codemagic.yaml lost anchor $start');
       expect(to, greaterThan(from), reason: 'codemagic.yaml lost anchor $end');
       return source.substring(from, to);
+    }
+
+    /// Slices [source] from [start] to end of file, for the last workflow in
+    /// the document, which has no following anchor to stop at.
+    String sliceFrom(String source, String start) {
+      final from = source.indexOf(start);
+      expect(from, isNonNegative, reason: 'codemagic.yaml lost anchor $start');
+      return source.substring(from);
     }
 
     setUpAll(() {
@@ -36,6 +55,7 @@ void main() {
         '  e2e-smoke-ios:',
         '  e2e-smoke-android:',
       );
+      androidWorkflow = sliceFrom(codemagic, '  e2e-smoke-android:');
     });
 
     test('runs only the three PR journeys and teardown, in order', () {
@@ -66,6 +86,49 @@ void main() {
       expect(smokeCommand, isNot(contains('USER_EMAIL')));
       expect(smokeCommand, isNot(contains('USER_PWD')));
       expect(smokeCommand, isNot(contains('USER_KEYS')));
+    });
+
+    test('gives every workflow on the shared script the same fixture id', () {
+      // The smoke command is a YAML anchor, so iOS and Android both inherit
+      // `-e QA_VIDEO_EVENT_ID`. A workflow that runs it without defining the
+      // variable passes an empty string — the script has `set -e` but no
+      // `set -u`, so nothing fails until prSeededVideoPlayback's own guard.
+      for (final workflow in {
+        'e2e-smoke-ios': iosWorkflow,
+        'e2e-smoke-android': androidWorkflow,
+      }.entries) {
+        expect(
+          workflow.value,
+          contains('- *run_maestro_smoke_tests'),
+          reason:
+              '${workflow.key} no longer runs the shared smoke command; '
+              'drop it from this test if that is intended',
+        );
+        final assigned = _fixtureAssignment
+            .firstMatch(workflow.value)
+            ?.group(1);
+        expect(
+          assigned,
+          isNotNull,
+          reason:
+              '${workflow.key} runs the shared smoke command but defines '
+              'no QA_VIDEO_EVENT_ID',
+        );
+        expect(
+          assigned,
+          matches(_eventId),
+          reason:
+              '${workflow.key} must carry a bare public event id, never a '
+              'credential or a secret reference',
+        );
+      }
+
+      // Pinned as equal rather than as a literal: the two lanes must prove the
+      // same fixture, and duplicating the hex is what lets them drift apart.
+      expect(
+        _fixtureAssignment.firstMatch(androidWorkflow)!.group(1),
+        equals(_fixtureAssignment.firstMatch(iosWorkflow)!.group(1)),
+      );
     });
   });
 }


### PR DESCRIPTION
## Problem

The automatic Maestro lane reused broad, mutable staging flows and produced an expensive signal that could fail for content drift rather than a product regression. Its onboarding steps also depended on English button copy.

## Why this change

The PR lane now has three explicit cases: clean launch readiness, throwaway-account authentication into Home, and direct playback of one immutable public Nostr event. A fourth case removes the throwaway keys. Each file remains a separate JUnit testcase with screenshots, hierarchy output, Maestro logs, and bounded platform logs available independently.

The account path needs no shared credentials or reset service. The video fixture is a public event ID supplied as non-secret CI configuration, and both E2E workflows carry it because they share one Maestro command. Two onboarding actions now expose semantic identifiers, removing their copy dependency. Markdown-only changes are excluded and stale builds are cancelled. The build cap stays at 25 minutes as a hang-stopper; speed is governed separately by the promotion target, a p95 below 15 minutes over at least 30 runs.

Two rows leave `mobile/scripts/baseline/maestro_copy_manifest.txt`: `authUseDivineNoBackup` and `authUseThisDeviceOnly` were bound to `loginFreshInstall`, which now taps both buttons by semantic id instead of by English copy, so the bindings have no literal left to guard.

## Deliberately unchanged

The larger manual regression suite remains available but is not a PR gate. The iOS smoke check remains non-blocking until it meets the documented observation threshold. Codemagic webhook restoration is still tracked by #7504; this repository change cannot repair the external integration setting.

## Verification

- `flutter test test/tools/maestro_pr_smoke_contract_test.dart test/screens/auth/create_account_screen_test.dart` (23 tests)
- focused `flutter analyze` on changed Dart files
- `bash mobile/e2e/maestro/scripts/check_refs.sh`
- `bash mobile/scripts/check_maestro_copy_drift.sh`
- `bash mobile/scripts/check_codemagic_groups.sh`
- parsed Codemagic and Maestro YAML files
- repository pre-push checks

A local Maestro device run was not available; the lane remains observational by design until real-run evidence reaches the promotion threshold.

Closes #8867
Related to #8864
Related to #7504
