### PR TITLE
fix(ios): stop unused device identifier access from shipping

### DIFF
--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -34,9 +34,25 @@ macOS is not listed, which is why `mobile/macos` carries no obligation here.
 | `divine_quick_actions` | `mobile/packages/divine_quick_actions/ios/Resources/PrivacyInfo.xcprivacy` | `s.resource_bundles` |
 | `LibProofMode` (vendored) | `mobile/ios/LocalPods/LibProofMode/Resources/PrivacyInfo.xcprivacy` | `s.resource_bundles` |
 
-`LibProofMode` is Guardian Project code vendored under `ios/LocalPods/`. No
-upstream release will ship a manifest into Divine's archive, so we own its
-declaration for as long as it is vendored.
+`LibProofMode` is Guardian Project code vendored under `ios/LocalPods/`. Divine
+owns the declaration in its archive for as long as it consumes the library as a
+local path pod, even if the declaration is later accepted upstream.
+
+### LibProofMode vendor delta
+
+The vendored source is based on Guardian Project's upstream `0.1.11` commit
+`1690d3a5237426ef6bd2d78dc5476325ad7a6e68`. Keep these Divine-local changes
+when refreshing it until each change is present upstream:
+
+- `Classes/MediaItem.swift` imports `UniformTypeIdentifiers` and qualifies the
+  movie and audio types as `UTType.movie` and `UTType.audio` for current Xcode.
+- `Resources/PrivacyInfo.xcprivacy` declares the required file-timestamp API,
+  and `LibProofMode.podspec` bundles that manifest.
+
+The Podfile selects LibProofMode's existing `PrivacyProtected` subspec. Divine
+sets `showDeviceIds: false`, so compiling out `AdSupport` and
+`ASIdentifierManager` keeps the archive aligned with the behavior and privacy
+declaration described below.
 
 ## What is currently declared, and why
 
@@ -112,8 +128,8 @@ bash scripts/check_privacy_manifest_coverage.sh --archive build/ios/iphoneos/Run
 ```
 
 It also fails on an invalid reason code for a category, an unknown category
-string, and a manifest that exists but is not bundled by its podspec — a
-manifest nothing ships is a manifest Apple never reads.
+string, and a manifest that exists but is not bundled by the selected podspec
+or subspec — a manifest nothing ships is a manifest Apple never reads.
 
 Behaviour is pinned by
 `mobile/test/tools/privacy_manifest_coverage_detector_test.dart`.

--- a/mobile/ios/LocalPods/LibProofMode/LibProofMode.podspec
+++ b/mobile/ios/LocalPods/LibProofMode/LibProofMode.podspec
@@ -47,6 +47,7 @@ without the need to fork it. That way, spin-offs can easily stay up to date.
 
   s.subspec 'PrivacyProtected' do |ss|
     ss.source_files = 'Classes/**/*'
+    ss.resource_bundles = {'LibProofMode_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
 
     ss.pod_target_xcconfig = {
       'SWIFT_ACTIVE_COMPILATION_CONDITIONS': '$(inherited) PRIVACY_PROTECTED'

--- a/mobile/ios/Podfile
+++ b/mobile/ios/Podfile
@@ -43,9 +43,9 @@ target 'Runner' do
   # Explicitly include pods that have given us trouble
   pod 'libwebp', '~> 1.5.0'
 
-  # ProofMode library for cryptographic proof generation
-  # Using local fork with Swift 5.x compatibility fixes
-  pod 'LibProofMode', :path => 'LocalPods/LibProofMode'
+  # ProofMode library for cryptographic proof generation. Divine disables
+  # device-ID collection, so compile out LibProofMode's AdSupport dependency.
+  pod 'LibProofMode/PrivacyProtected', :path => 'LocalPods/LibProofMode'
 
   # Zendesk Support SDK
   pod 'ZendeskSupportSDK', '~> 9.0'

--- a/mobile/scripts/lib/privacy_manifest_coverage.py
+++ b/mobile/scripts/lib/privacy_manifest_coverage.py
@@ -221,18 +221,31 @@ class Unit:
         roots: list[str],
         manifest: str,
         podspec: str | None,
+        selected_subspec: str | None = None,
         xcodeproj: str | None = None,
     ):
         self.name = name
         self.roots = roots
         self.manifest = manifest
         self.podspec = podspec
+        self.selected_subspec = selected_subspec
         self.xcodeproj = xcodeproj
 
 
 def discover(mobile: str) -> list[Unit]:
     units: list[Unit] = []
     ios = os.path.join(mobile, "ios")
+    selected_subspecs: dict[str, str] = {}
+    podfile = os.path.join(ios, "Podfile")
+    try:
+        with open(podfile, "r", encoding="utf-8") as handle:
+            podfile_text = strip_noise(handle.read())
+    except OSError:
+        podfile_text = ""
+    for pod, subspec in re.findall(
+        r"\bpod\s+['\"]([^/'\"]+)/([^'\"]+)['\"]", podfile_text
+    ):
+        selected_subspecs[pod] = subspec
 
     units.append(
         Unit(
@@ -261,7 +274,8 @@ def discover(mobile: str) -> list[Unit]:
             units.append(
                 Unit(f"localpod:{pod}", [path],
                      os.path.join(path, "Resources", "PrivacyInfo.xcprivacy"),
-                     os.path.join(path, specs[0]) if specs else None)
+                     os.path.join(path, specs[0]) if specs else None,
+                     selected_subspec=selected_subspecs.get(pod))
             )
 
     packages = os.path.join(mobile, "packages")
@@ -274,7 +288,8 @@ def discover(mobile: str) -> list[Unit]:
             units.append(
                 Unit(f"package:{pkg}", [pkg_ios],
                      os.path.join(pkg_ios, "Resources", "PrivacyInfo.xcprivacy"),
-                     os.path.join(pkg_ios, specs[0]) if specs else None)
+                     os.path.join(pkg_ios, specs[0]) if specs else None,
+                     selected_subspec=selected_subspecs.get(pkg))
             )
     return units
 
@@ -384,11 +399,29 @@ def xcode_manifest_is_runner_resource(project: str) -> bool:
     return False
 
 
-def podspec_bundles_manifest(spec: str) -> bool:
-    """Return whether a real resource_bundles assignment includes the manifest."""
+def podspec_bundles_manifest(spec: str, selected_subspec: str | None) -> bool:
+    """Return whether the selected pod specification bundles the manifest."""
     uncommented = "\n".join(
         line for line in spec.splitlines() if not line.lstrip().startswith("#")
     )
+    if selected_subspec:
+        subspec = re.search(
+            rf"\bs\.subspec\s+['\"]{re.escape(selected_subspec)}['\"]\s+do\s+"
+            r"\|(?P<var>\w+)\|(?P<body>.*?)^\s*end\b",
+            uncommented,
+            re.M | re.S,
+        )
+        if not subspec:
+            return False
+        variable = re.escape(subspec.group("var"))
+        return bool(
+            re.search(
+                rf"\b{variable}\.resource_bundles\s*=\s*"
+                r"\{[^}]*PrivacyInfo\.xcprivacy[^}]*\}",
+                subspec.group("body"),
+                re.S,
+            )
+        )
     return bool(
         re.search(
             r"\b\w+\.resource_bundles\s*=\s*\{[^}]*PrivacyInfo\.xcprivacy[^}]*\}",
@@ -450,7 +483,7 @@ def check_sources(mobile: str) -> int:
                         spec = handle.read()
                 except OSError:
                     spec = ""
-                if not podspec_bundles_manifest(spec):
+                if not podspec_bundles_manifest(spec, unit.selected_subspec):
                     failures.append(
                         f"{unit.name}: {unit.manifest} exists but "
                         f"{unit.podspec} has no resource_bundles entry for it, "

--- a/mobile/scripts/lib/privacy_manifest_coverage.py
+++ b/mobile/scripts/lib/privacy_manifest_coverage.py
@@ -239,11 +239,14 @@ def discover(mobile: str) -> list[Unit]:
     podfile = os.path.join(ios, "Podfile")
     try:
         with open(podfile, "r", encoding="utf-8") as handle:
-            podfile_text = strip_noise(handle.read())
+            podfile_text = handle.read()
     except OSError:
         podfile_text = ""
-    for pod, subspec in re.findall(
-        r"\bpod\s+['\"]([^/'\"]+)/([^'\"]+)['\"]", podfile_text
+    # Podfile declarations are Ruby: retain quoted names and ignore comment lines.
+    for _, pod, subspec in re.findall(
+        r"^[ \t]*pod[ \t]+(['\"])([^/'\"\n]+)/([^'\"\n]+)\1",
+        podfile_text,
+        re.M,
     ):
         selected_subspecs[pod] = subspec
 

--- a/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
+++ b/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
@@ -37,6 +37,7 @@ void main() {
   Directory makeTree({
     required String swift,
     String? manifest,
+    String? selectedSubspec,
     String podspec =
         "s.resource_bundles = {'p' => ['Resources/PrivacyInfo.xcprivacy']}",
   }) {
@@ -48,6 +49,11 @@ void main() {
     File('${pkg.path}/Classes/Sample.swift').writeAsStringSync(swift);
     File('${pkg.path}/sample.podspec').writeAsStringSync(podspec);
     Directory('${root.path}/ios/Runner').createSync(recursive: true);
+    if (selectedSubspec != null) {
+      File('${root.path}/ios/Podfile').writeAsStringSync(
+        "pod 'sample/$selectedSubspec', :path => '../packages/sample/ios'\n",
+      );
+    }
     if (manifest != null) {
       Directory('${pkg.path}/Resources').createSync(recursive: true);
       File(
@@ -310,6 +316,46 @@ ABC123 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo
 
         expect(result.exitCode, equals(1));
         expect(result.output, contains('never reaches the archive'));
+      });
+
+      test('rejects a manifest bundled only by an unselected root spec', () {
+        final root = makeTree(
+          swift: 'let t = ProcessInfo.processInfo.systemUptime\n',
+          manifest: manifestFor(
+            'NSPrivacyAccessedAPICategorySystemBootTime',
+            '35F9.1',
+          ),
+          selectedSubspec: 'PrivacyProtected',
+          podspec:
+              "s.resource_bundles = {'p' => "
+              "['Resources/PrivacyInfo.xcprivacy']}\n"
+              "s.subspec 'PrivacyProtected' do |ss|\n"
+              "  ss.source_files = 'Classes/**/*'\n"
+              'end\n',
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(1));
+        expect(result.output, contains('never reaches the archive'));
+      });
+
+      test('accepts a manifest bundled by the selected subspec', () {
+        final root = makeTree(
+          swift: 'let t = ProcessInfo.processInfo.systemUptime\n',
+          manifest: manifestFor(
+            'NSPrivacyAccessedAPICategorySystemBootTime',
+            '35F9.1',
+          ),
+          selectedSubspec: 'PrivacyProtected',
+          podspec:
+              "s.subspec 'PrivacyProtected' do |ss|\n"
+              "  ss.resource_bundles = {'p' => "
+              "['Resources/PrivacyInfo.xcprivacy']}\n"
+              'end\n',
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(0), reason: result.output);
       });
     });
 

--- a/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
+++ b/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
@@ -318,25 +318,48 @@ ABC123 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo
         expect(result.output, contains('never reaches the archive'));
       });
 
-      test('rejects a manifest bundled only by an unselected root spec', () {
+      for (final quote in ["'", '"']) {
+        test('rejects root-only bundling with $quote-quoted subspec', () {
+          final root = makeTree(
+            swift: 'let t = ProcessInfo.processInfo.systemUptime\n',
+            manifest: manifestFor(
+              'NSPrivacyAccessedAPICategorySystemBootTime',
+              '35F9.1',
+            ),
+            podspec:
+                "s.resource_bundles = {'p' => "
+                "['Resources/PrivacyInfo.xcprivacy']}\n"
+                "s.subspec 'PrivacyProtected' do |ss|\n"
+                "  ss.source_files = 'Classes/**/*'\n"
+                'end\n',
+          );
+          File('${root.path}/ios/Podfile').writeAsStringSync(
+            '  pod ${quote}sample/PrivacyProtected$quote, '
+            ":path => '../packages/sample/ios'\n",
+          );
+          final result = run(root: root);
+
+          expect(result.exitCode, equals(1));
+          expect(result.output, contains('never reaches the archive'));
+        });
+      }
+
+      test('ignores a commented-out Podfile subspec selection', () {
         final root = makeTree(
           swift: 'let t = ProcessInfo.processInfo.systemUptime\n',
           manifest: manifestFor(
             'NSPrivacyAccessedAPICategorySystemBootTime',
             '35F9.1',
           ),
-          selectedSubspec: 'PrivacyProtected',
-          podspec:
-              "s.resource_bundles = {'p' => "
-              "['Resources/PrivacyInfo.xcprivacy']}\n"
-              "s.subspec 'PrivacyProtected' do |ss|\n"
-              "  ss.source_files = 'Classes/**/*'\n"
-              'end\n',
         );
+        File('${root.path}/ios/Podfile').writeAsStringSync(
+          "# pod 'sample/Unused'\n"
+          "pod 'sample', :path => '../packages/sample/ios'\n",
+        );
+
         final result = run(root: root);
 
-        expect(result.exitCode, equals(1));
-        expect(result.output, contains('never reaches the archive'));
+        expect(result.exitCode, equals(0), reason: result.output);
       });
 
       test('accepts a manifest bundled by the selected subspec', () {


### PR DESCRIPTION
## Problem

Divine disables ProofMode device-ID collection at runtime, but the vendored iOS library still compiled its AdSupport and advertising-identifier code into release builds. That unnecessary binary reference can trigger additional App Store privacy scrutiny even though Divine never calls the path.

## Why this fix

This selects LibProofMode's existing PrivacyProtected subspec, which compiles the device-identifier implementation out of the library. CocoaPods does not inherit the root privacy resource bundle when this explicit subspec is selected, so the manifest is also attached directly to the subspec.

The source guard now understands explicit Podfile subspec selection. It fails before CI reaches an archive build when a manifest is attached only to an unselected root specification, the exact packaging gap found while verifying this change. It handles both single- and double-quoted pod names and ignores commented-out selections.

## Deliberately unchanged

This does not change ProofMode's media hashing or proof-generation behavior, and it does not change Divine's App Store Connect privacy answers or collected-data declarations. Upstreaming the vendor fixes remains external follow-up work in #8851.

Refs #8851

## Verification

- flutter analyze
- flutter test test/tools/privacy_manifest_coverage_detector_test.dart (20 tests)
- flutter build ios --release --no-codesign
- archive privacy-manifest validation (62 manifests; all required Divine manifests present)
- built LibProofMode framework inspected with nm, strings, and otool; no ASIdentifierManager, advertisingIdentifier, or AdSupport reference remains

The iOS build, archive and binary inspection above were performed for the original native changes. The later parser/test correction leaves those native files unchanged and passed all 20 detector tests, formatting and analysis. Its broad local test run timed out after 300 seconds; all four CI test shards subsequently passed. Native archive inspection was not repeated on Linux, and archive mode remains a manual check rather than a CI check.
