### PR TITLE
ci(ios): detect Apple required-reason API changes

### DIFF
--- a/.github/workflows/apple_required_reason_probe.yml
+++ b/.github/workflows/apple_required_reason_probe.yml
@@ -1,0 +1,117 @@
+name: Apple Required-Reason Catalogue Probe
+
+on:
+  schedule:
+    - cron: "23 9 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: apple-required-reason-catalogue-probe
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    if: >-
+      github.event_name == 'schedule' ||
+      github.ref_name == github.event.repository.default_branch
+    name: Compare Apple's required-reason catalogue
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - uses: actions/checkout@v7
+      - name: Compare Apple's catalogue with the pinned data
+        id: catalogue_probe
+        shell: bash
+        run: |
+          set +e
+          set -o pipefail
+          bash scripts/check_apple_required_reason_catalogue.sh 2>&1 \
+            | tee "$RUNNER_TEMP/apple-required-reason-probe.txt"
+          status=${PIPESTATUS[0]}
+          if (( status == 1 )); then
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          fi
+          exit "$status"
+      - name: Open or update the catalogue-drift incident
+        if: ${{ failure() && steps.catalogue_probe.outputs.drift == 'true' }}
+        uses: actions/github-script@v9
+        env:
+          PROBE_OUTPUT: ${{ runner.temp }}/apple-required-reason-probe.txt
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- apple-required-reason-catalogue-incident -->';
+            const title = 'ci(ios): Apple required-reason API catalogue changed';
+            const output = fs.readFileSync(process.env.PROBE_OUTPUT, 'utf8').trim();
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              marker,
+              "Apple's required-reason API catalogue differs from the data pinned in `mobile/scripts/data/apple_required_reason_catalogue.json`.",
+              '',
+              `Latest failed run: ${runUrl}`,
+              '',
+              '```text',
+              output.slice(-6000),
+              '```',
+              '',
+              'Review the semantic delta before updating the catalogue and detector. This issue closes automatically after the probe matches again.',
+            ].join('\n');
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all',
+              per_page: 100,
+            });
+            const existing = issues.find(issue =>
+              !issue.pull_request && issue.body && issue.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+                state: 'open',
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['bug'],
+              });
+            }
+      - name: Close the resolved catalogue-drift incident
+        if: ${{ success() }}
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const marker = '<!-- apple-required-reason-catalogue-incident -->';
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const existing = issues.find(issue =>
+              !issue.pull_request && issue.body && issue.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+            }

--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -5,9 +5,11 @@ without declaring it in a privacy manifest. This document is the ownership and
 update process for those declarations (#8803).
 
 Source of truth for the rules is Apple's
-[Describing use of required reason API][apple-rr]. The tables below were
-verified against Apple's documentation payload on 2026-09-08; re-verify them
-when Apple updates the list, which the page says happens periodically.
+[Describing use of required reason API][apple-rr]. The generated tables below
+were verified against Apple's documentation payload on 2026-09-07. A monthly
+probe compares Apple's current Swift and Objective-C variants with the
+machine-readable catalogue in
+`scripts/data/apple_required_reason_catalogue.json`.
 
 [apple-rr]: https://developer.apple.com/documentation/bundleresources/describing-use-of-required-reason-api
 
@@ -78,37 +80,37 @@ updated in the same change.**
 
 ## Apple's catalogue
 
-Symbols, verified against Apple's documentation:
-
-| Category | APIs |
-|---|---|
-| `FileTimestamp` | `FileAttributeKey.creationDate`, `FileAttributeKey.modificationDate`, `UIDocument.fileModificationDate`, `URLResourceKey.contentModificationDateKey`, `URLResourceKey.creationDateKey`, `getattrlist`, `getattrlistbulk`, `fgetattrlist`, `stat`, `fstat`, `fstatat`, `lstat`, `getattrlistat` |
-| `SystemBootTime` | `ProcessInfo.systemUptime`, `mach_absolute_time()` |
-| `DiskSpace` | `volumeAvailableCapacityKey`, `volumeAvailableCapacityForImportantUsageKey`, `volumeAvailableCapacityForOpportunisticUsageKey`, `volumeTotalCapacityKey`, `systemFreeSize`, `systemSize`, `statfs`, `statvfs`, `fstatfs`, `fstatvfs`, `getattrlist`, `fgetattrlist`, `getattrlistat` |
-| `ActiveKeyboards` | `UITextInputMode.activeInputModes` |
-| `UserDefaults` | `UserDefaults` |
+<!-- apple-required-reason-catalogue:start -->
+| Category | Swift APIs | Objective-C APIs |
+|---|---|---|
+| `FileTimestamp` | `creationDate`, `modificationDate`, `fileModificationDate`, `contentModificationDateKey`, `creationDateKey`, `getattrlist`, `getattrlistbulk`, `fgetattrlist`, `stat`, `fstat`, `fstatat`, `lstat`, `getattrlistat` | `NSFileCreationDate`, `NSFileModificationDate`, `fileModificationDate`, `NSURLContentModificationDateKey`, `NSURLCreationDateKey`, `getattrlist`, `getattrlistbulk`, `fgetattrlist`, `stat`, `fstat`, `fstatat`, `lstat`, `getattrlistat` |
+| `SystemBootTime` | `systemUptime`, `mach_absolute_time` | `systemUptime`, `mach_absolute_time` |
+| `DiskSpace` | `volumeAvailableCapacityKey`, `volumeAvailableCapacityForImportantUsageKey`, `volumeAvailableCapacityForOpportunisticUsageKey`, `volumeTotalCapacityKey`, `systemFreeSize`, `systemSize`, `statfs`, `statvfs`, `fstatfs`, `fstatvfs`, `getattrlist`, `fgetattrlist`, `getattrlistat` | `NSURLVolumeAvailableCapacityKey`, `NSURLVolumeAvailableCapacityForImportantUsageKey`, `NSURLVolumeAvailableCapacityForOpportunisticUsageKey`, `NSURLVolumeTotalCapacityKey`, `NSFileSystemFreeSize`, `NSFileSystemSize`, `statfs`, `statvfs`, `fstatfs`, `fstatvfs`, `getattrlist`, `fgetattrlist`, `getattrlistat` |
+| `ActiveKeyboards` | `activeInputModes` | `activeInputModes` |
+| `UserDefaults` | `UserDefaults` | `NSUserDefaults` |
 
 Reason codes:
 
 | Code | Category | Meaning |
 |---|---|---|
 | `DDA9.1` | FileTimestamp | display file timestamps to the user; not sent off-device |
-| `C617.1` | FileTimestamp | metadata of files in the app / app-group / CloudKit container |
-| `3B52.1` | FileTimestamp | files the user explicitly granted access to (document picker) |
+| `C617.1` | FileTimestamp | metadata of files in the app, app-group, or CloudKit container |
+| `3B52.1` | FileTimestamp | files the user explicitly granted access to |
 | `0A2A.1` | FileTimestamp | third-party SDK wrapper function only |
 | `35F9.1` | SystemBootTime | elapsed time between in-app events, or timers |
 | `8FFB.1` | SystemBootTime | absolute timestamps for in-app events |
 | `3D61.1` | SystemBootTime | user-submitted bug report |
 | `85F4.1` | DiskSpace | display disk space to the user |
-| `E174.1` | DiskSpace | check sufficient / low disk space, with observable behaviour |
+| `E174.1` | DiskSpace | check sufficient or low disk space, with observable behaviour |
 | `7D9E.1` | DiskSpace | user-submitted bug report |
 | `B728.1` | DiskSpace | health research app |
 | `3EC4.1` | ActiveKeyboards | custom keyboard app |
 | `54BD.1` | ActiveKeyboards | customize UI to the active keyboards |
 | `CA92.1` | UserDefaults | data accessible only to the app itself |
-| `1C8F.1` | UserDefaults | App Group–scoped defaults |
+| `1C8F.1` | UserDefaults | App Group-scoped defaults |
 | `C56D.1` | UserDefaults | third-party SDK wrapper function only |
 | `AC6B.1` | UserDefaults | MDM managed app configuration |
+<!-- apple-required-reason-catalogue:end -->
 
 ## The guard
 
@@ -134,6 +136,19 @@ or subspec — a manifest nothing ships is a manifest Apple never reads.
 Behaviour is pinned by
 `mobile/test/tools/privacy_manifest_coverage_detector_test.dart`.
 
+`apple_required_reason_probe.yml` runs monthly and can also be dispatched by
+hand. It retries transient fetch and parse failures without opening an issue.
+When a successfully parsed payload differs from the pinned catalogue, it opens
+or updates one marker-tagged incident issue and closes that issue after the
+catalogue matches again.
+
+When the probe reports a new category or symbol, update the catalogue and teach
+the detector how to recognize the new API before accepting uses of it. When it
+reports a new reason code, verify Apple's restrictions, add a concise meaning
+to the catalogue, and update detector tests. Run
+`python3 scripts/lib/render_required_reason_catalogue.py --check` to prove this
+document still matches the catalogue.
+
 ### Two things it deliberately does not do
 
 - **Bare `.creationDate` / `.modificationDate` are reported, never fatal.**
@@ -146,6 +161,10 @@ Behaviour is pinned by
   Release, so it needs no declaration. Any other condition
   (`#if canImport(…)`, `#if !DEBUG`) is scanned normally, so the guard errs
   toward reporting rather than hiding a use.
+- **The `getattrlist`, `fgetattrlist`, and `getattrlistat` families are review
+  findings.** Apple lists them under both file timestamps and disk space. The
+  requested attribute list decides which declaration is accurate, so the guard
+  reports both possibilities without forcing either one.
 
 ## Adding or changing a declaration
 

--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -80,6 +80,11 @@ updated in the same change.**
 
 ## Apple's catalogue
 
+The table uses Apple's short symbol titles. In Swift, `creationDate` and
+`modificationDate` here belong to `FileAttributeKey`, `fileModificationDate` to
+`UIDocument`, `systemUptime` to `ProcessInfo`, and `activeInputModes` to
+`UITextInputMode`. Identically named properties on other types are not equivalent.
+
 <!-- apple-required-reason-catalogue:start -->
 | Category | Swift APIs | Objective-C APIs |
 |---|---|---|
@@ -142,6 +147,14 @@ When a successfully parsed payload differs from the pinned catalogue, it opens
 or updates one marker-tagged incident issue and closes that issue after the
 catalogue matches again.
 
+After three failed fetch or parse attempts, the workflow stays red in Actions;
+it does not open an operational incident. Maintainers must inspect failed runs,
+repair persistent payload-shape failures, and rerun the workflow before treating
+the catalogue as current. There is no separate operational alert in this workflow.
+The comparison covers category identifiers, symbol titles, and reason codes, not
+edits to Apple's explanatory prose. The meanings above are summaries; consult
+Apple's current restrictions before choosing a reason, even when the probe passes.
+
 When the probe reports a new category or symbol, update the catalogue and teach
 the detector how to recognize the new API before accepting uses of it. When it
 reports a new reason code, verify Apple's restrictions, add a concise meaning
@@ -169,7 +182,7 @@ document still matches the catalogue.
 ## Adding or changing a declaration
 
 1. Find the call site: `bash scripts/check_privacy_manifest_coverage.sh --detail`.
-2. Pick the reason from the table above whose wording matches what the code
+2. Consult Apple's current restrictions and pick the reason whose wording matches what the code
    actually does — including its off-device restriction. If none fits, the code
    needs to change, not the manifest.
 3. Edit the owning bundle's manifest. For a pod, confirm its podspec has a

--- a/mobile/scripts/check_apple_required_reason_catalogue.sh
+++ b/mobile/scripts/check_apple_required_reason_catalogue.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+attempt=1
+while (( attempt <= 3 )); do
+  python3 "$SCRIPT_DIR/lib/apple_required_reason_probe.py" "$@"
+  status=$?
+  if (( status != 2 )); then
+    exit "$status"
+  fi
+  if (( attempt < 3 )); then
+    echo "Retrying after operational failure ($attempt/3)..." >&2
+  fi
+  ((attempt += 1))
+done
+exit 2

--- a/mobile/scripts/data/apple_required_reason_catalogue.json
+++ b/mobile/scripts/data/apple_required_reason_catalogue.json
@@ -1,0 +1,73 @@
+{
+  "source": "https://developer.apple.com/tutorials/data/documentation/bundleresources/app-privacy-configuration/nsprivacyaccessedapitypes/nsprivacyaccessedapitype.json",
+  "verified": "2026-09-07",
+  "categories": [
+    {
+      "id": "NSPrivacyAccessedAPICategoryFileTimestamp",
+      "name": "FileTimestamp",
+      "symbols": {
+        "swift": ["creationDate", "modificationDate", "fileModificationDate", "contentModificationDateKey", "creationDateKey", "getattrlist", "getattrlistbulk", "fgetattrlist", "stat", "fstat", "fstatat", "lstat", "getattrlistat"],
+        "objectiveC": ["NSFileCreationDate", "NSFileModificationDate", "fileModificationDate", "NSURLContentModificationDateKey", "NSURLCreationDateKey", "getattrlist", "getattrlistbulk", "fgetattrlist", "stat", "fstat", "fstatat", "lstat", "getattrlistat"]
+      },
+      "reasons": {
+        "DDA9.1": "display file timestamps to the user; not sent off-device",
+        "C617.1": "metadata of files in the app, app-group, or CloudKit container",
+        "3B52.1": "files the user explicitly granted access to",
+        "0A2A.1": "third-party SDK wrapper function only"
+      }
+    },
+    {
+      "id": "NSPrivacyAccessedAPICategorySystemBootTime",
+      "name": "SystemBootTime",
+      "symbols": {
+        "swift": ["systemUptime", "mach_absolute_time"],
+        "objectiveC": ["systemUptime", "mach_absolute_time"]
+      },
+      "reasons": {
+        "35F9.1": "elapsed time between in-app events, or timers",
+        "8FFB.1": "absolute timestamps for in-app events",
+        "3D61.1": "user-submitted bug report"
+      }
+    },
+    {
+      "id": "NSPrivacyAccessedAPICategoryDiskSpace",
+      "name": "DiskSpace",
+      "symbols": {
+        "swift": ["volumeAvailableCapacityKey", "volumeAvailableCapacityForImportantUsageKey", "volumeAvailableCapacityForOpportunisticUsageKey", "volumeTotalCapacityKey", "systemFreeSize", "systemSize", "statfs", "statvfs", "fstatfs", "fstatvfs", "getattrlist", "fgetattrlist", "getattrlistat"],
+        "objectiveC": ["NSURLVolumeAvailableCapacityKey", "NSURLVolumeAvailableCapacityForImportantUsageKey", "NSURLVolumeAvailableCapacityForOpportunisticUsageKey", "NSURLVolumeTotalCapacityKey", "NSFileSystemFreeSize", "NSFileSystemSize", "statfs", "statvfs", "fstatfs", "fstatvfs", "getattrlist", "fgetattrlist", "getattrlistat"]
+      },
+      "reasons": {
+        "85F4.1": "display disk space to the user",
+        "E174.1": "check sufficient or low disk space, with observable behaviour",
+        "7D9E.1": "user-submitted bug report",
+        "B728.1": "health research app"
+      }
+    },
+    {
+      "id": "NSPrivacyAccessedAPICategoryActiveKeyboards",
+      "name": "ActiveKeyboards",
+      "symbols": {
+        "swift": ["activeInputModes"],
+        "objectiveC": ["activeInputModes"]
+      },
+      "reasons": {
+        "3EC4.1": "custom keyboard app",
+        "54BD.1": "customize UI to the active keyboards"
+      }
+    },
+    {
+      "id": "NSPrivacyAccessedAPICategoryUserDefaults",
+      "name": "UserDefaults",
+      "symbols": {
+        "swift": ["UserDefaults"],
+        "objectiveC": ["NSUserDefaults"]
+      },
+      "reasons": {
+        "CA92.1": "data accessible only to the app itself",
+        "1C8F.1": "App Group-scoped defaults",
+        "C56D.1": "third-party SDK wrapper function only",
+        "AC6B.1": "MDM managed app configuration"
+      }
+    }
+  ]
+}

--- a/mobile/scripts/lib/apple_required_reason_probe.py
+++ b/mobile/scripts/lib/apple_required_reason_probe.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Compare Apple's live required-reason catalogue with the pinned catalogue."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+CATALOGUE_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    "data",
+    "apple_required_reason_catalogue.json",
+)
+
+
+class PayloadError(ValueError):
+    """Apple's payload could not be interpreted safely."""
+
+
+def _pointer_reference(path: str) -> str | None:
+    prefix = "/references/"
+    suffix = "/title"
+    if not path.startswith(prefix) or not path.endswith(suffix):
+        return None
+    encoded = path[len(prefix) : -len(suffix)]
+    return encoded.replace("~1", "/").replace("~0", "~")
+
+
+def _objective_c_titles(payload: dict) -> dict[str, str]:
+    overrides = payload.get("variantOverrides", [])
+    for override in overrides:
+        patch = override.get("patch", [])
+        if any(
+            item.get("path") == "/identifier/interfaceLanguage"
+            and item.get("value") == "occ"
+            for item in patch
+        ):
+            titles = {}
+            for item in patch:
+                reference = _pointer_reference(item.get("path", ""))
+                if reference and item.get("op") == "replace":
+                    titles[reference] = item["value"]
+            return titles
+    raise PayloadError("Objective-C (occ) variant override is missing")
+
+
+def _symbol(item: dict, references: dict, title_overrides: dict[str, str]) -> str:
+    try:
+        inline = item["content"][0]["inlineContent"][0]
+    except (KeyError, IndexError, TypeError) as error:
+        raise PayloadError("API list item has an unknown shape") from error
+    if inline.get("type") == "codeVoice":
+        return inline["code"].split("(", 1)[0]
+    if inline.get("type") != "reference":
+        raise PayloadError("API list item is neither code nor a reference")
+    identifier = inline["identifier"]
+    try:
+        return title_overrides.get(identifier, references[identifier]["title"])
+    except KeyError as error:
+        raise PayloadError(f"unresolved symbol reference: {identifier}") from error
+
+
+def extract(payload: dict) -> list[dict]:
+    """Return comparable category, symbol, and reason-code data."""
+    references = payload.get("references")
+    if not isinstance(references, dict):
+        raise PayloadError("references map is missing")
+    objective_c_titles = _objective_c_titles(payload)
+    sections = [
+        section
+        for section in payload.get("primaryContentSections", [])
+        if section.get("kind") == "possibleValues"
+    ]
+    if len(sections) != 1:
+        raise PayloadError("expected exactly one possibleValues section")
+
+    categories = []
+    for value in sections[0].get("values", []):
+        lists = {part.get("type"): part for part in value.get("content", [])}
+        try:
+            api_items = lists["unorderedList"]["items"]
+            reason_items = lists["termList"]["items"]
+            category_id = value["name"]
+        except (KeyError, TypeError) as error:
+            raise PayloadError("category content has an unknown shape") from error
+
+        swift = [_symbol(item, references, {}) for item in api_items]
+        objective_c = [
+            _symbol(item, references, objective_c_titles) for item in api_items
+        ]
+        reasons = []
+        for item in reason_items:
+            try:
+                reasons.append(item["term"]["inlineContent"][0]["code"])
+            except (KeyError, IndexError, TypeError) as error:
+                raise PayloadError("reason-code item has an unknown shape") from error
+        categories.append(
+            {
+                "id": category_id,
+                "symbols": {
+                    "swift": sorted(swift),
+                    "objectiveC": sorted(objective_c),
+                },
+                "reasons": sorted(reasons),
+            }
+        )
+    return sorted(categories, key=lambda category: category["id"])
+
+
+def expected(catalogue: dict) -> list[dict]:
+    result = []
+    for category in catalogue["categories"]:
+        result.append(
+            {
+                "id": category["id"],
+                "symbols": {
+                    "swift": sorted(category["symbols"]["swift"]),
+                    "objectiveC": sorted(category["symbols"]["objectiveC"]),
+                },
+                "reasons": sorted(category["reasons"]),
+            }
+        )
+    return sorted(result, key=lambda category: category["id"])
+
+
+def _describe_delta(pinned: list[dict], apple: list[dict]) -> None:
+    pinned_by_id = {category["id"]: category for category in pinned}
+    apple_by_id = {category["id"]: category for category in apple}
+    for category_id in sorted(set(pinned_by_id) | set(apple_by_id)):
+        if category_id not in pinned_by_id:
+            print(f"+ category {category_id}")
+            continue
+        if category_id not in apple_by_id:
+            print(f"- category {category_id}")
+            continue
+        for language in ("swift", "objectiveC"):
+            old = set(pinned_by_id[category_id]["symbols"][language])
+            new = set(apple_by_id[category_id]["symbols"][language])
+            for symbol in sorted(new - old):
+                print(f"+ {category_id} {language} symbol {symbol}")
+            for symbol in sorted(old - new):
+                print(f"- {category_id} {language} symbol {symbol}")
+        old_reasons = set(pinned_by_id[category_id]["reasons"])
+        new_reasons = set(apple_by_id[category_id]["reasons"])
+        for reason in sorted(new_reasons - old_reasons):
+            print(f"+ {category_id} reason {reason}")
+        for reason in sorted(old_reasons - new_reasons):
+            print(f"- {category_id} reason {reason}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", help="read a saved DocC payload instead of fetching")
+    args = parser.parse_args()
+    try:
+        with open(CATALOGUE_PATH, encoding="utf-8") as handle:
+            catalogue = json.load(handle)
+        if args.input:
+            with open(args.input, encoding="utf-8") as handle:
+                payload = json.load(handle)
+        else:
+            request = urllib.request.Request(
+                catalogue["source"], headers={"User-Agent": "divine-mobile-ci/1"}
+            )
+            with urllib.request.urlopen(request, timeout=30) as response:
+                payload = json.load(response)
+        pinned = expected(catalogue)
+        apple = extract(payload)
+    except (OSError, json.JSONDecodeError, PayloadError, urllib.error.URLError) as error:
+        print(f"OPERATIONAL ERROR: could not verify Apple's catalogue: {error}")
+        return 2
+
+    if apple != pinned:
+        print("CATALOGUE DRIFT: Apple's required-reason API list changed")
+        _describe_delta(pinned, apple)
+        return 1
+    print("Apple's required-reason API catalogue matches the pinned data")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mobile/scripts/lib/apple_required_reason_probe.py
+++ b/mobile/scripts/lib/apple_required_reason_probe.py
@@ -41,6 +41,10 @@ def _objective_c_titles(payload: dict) -> dict[str, str]:
         ):
             titles = {}
             for item in patch:
+                if item.get("path", "").startswith("/primaryContentSections"):
+                    raise PayloadError(
+                        "Objective-C category content patches are not supported"
+                    )
                 reference = _pointer_reference(item.get("path", ""))
                 if reference and item.get("op") == "replace":
                     titles[reference] = item["value"]

--- a/mobile/scripts/lib/apple_required_reason_probe.py
+++ b/mobile/scripts/lib/apple_required_reason_probe.py
@@ -78,8 +78,11 @@ def extract(payload: dict) -> list[dict]:
     if len(sections) != 1:
         raise PayloadError("expected exactly one possibleValues section")
 
+    values = sections[0].get("values")
+    if not isinstance(values, list):
+        raise PayloadError("category values list is missing")
     categories = []
-    for value in sections[0].get("values", []):
+    for value in values:
         lists = {part.get("type"): part for part in value.get("content", [])}
         try:
             api_items = lists["unorderedList"]["items"]
@@ -170,7 +173,11 @@ def main() -> int:
                 payload = json.load(response)
         pinned = expected(catalogue)
         apple = extract(payload)
-    except (OSError, json.JSONDecodeError, PayloadError, urllib.error.URLError) as error:
+    except (
+        OSError, json.JSONDecodeError, PayloadError, urllib.error.URLError,
+        KeyError, IndexError, TypeError, AttributeError,
+    ) as error:
+        # DocC shape changes are not evidence of a semantic catalogue delta.
         print(f"OPERATIONAL ERROR: could not verify Apple's catalogue: {error}")
         return 2
 

--- a/mobile/scripts/lib/privacy_manifest_coverage.py
+++ b/mobile/scripts/lib/privacy_manifest_coverage.py
@@ -470,7 +470,7 @@ def check_sources(mobile: str) -> int:
                         + (f" (+{len(sites) - 3} more)" if len(sites) > 3 else "")
                         + f" but {unit.manifest} does not declare it"
                     )
-            for category in sorted(set(declared) - set(definite)):
+            for category in sorted(set(declared) - set(definite) - set(ambiguous)):
                 warnings.append(
                     f"{unit.name}: {unit.manifest} declares {category} but no "
                     f"call site was detected -- confirm it is still used, or "

--- a/mobile/scripts/lib/privacy_manifest_coverage.py
+++ b/mobile/scripts/lib/privacy_manifest_coverage.py
@@ -70,7 +70,7 @@ DEFINITE = [
         re.compile(
             r"\b(?:contentModificationDateKey|NSURLContentModificationDateKey)\b"
             r"|\b(?:creationDateKey|NSURLCreationDateKey)\b"
-            r"|\b(?:NSFile)?(?:CreationDate|ModificationDate)\b"
+            r"|\bNSFile(?:CreationDate|ModificationDate)\b"
             r"|\bfileModificationDate\b"
             r"|\bFileAttributeKey\.(?:creationDate|modificationDate)\b"
             r"|\bgetattrlistbulk\s*\("
@@ -80,10 +80,10 @@ DEFINITE = [
     (
         DISK_SPACE,
         re.compile(
-            r"\b(?:NSURL)?VolumeAvailableCapacity"
+            r"\b(?:volume|NSURLVolume)AvailableCapacity"
             r"(?:ForImportantUsage|ForOpportunisticUsage)?Key\b"
-            r"|\b(?:NSURL)?VolumeTotalCapacityKey\b"
-            r"|\b(?:NSFileSystem)?FreeSize\b|\b(?:NSFileSystem)?Size\b"
+            r"|\b(?:volume|NSURLVolume)TotalCapacityKey\b"
+            r"|\bNSFileSystem(?:FreeSize|Size)\b"
             r"|\bsystemFreeSize\b|\bsystemSize\b"
             r"|\bstatfs\s*\(|\bstatvfs\s*\(|\bfstatfs\s*\(|\bfstatvfs\s*\("
         ),

--- a/mobile/scripts/lib/privacy_manifest_coverage.py
+++ b/mobile/scripts/lib/privacy_manifest_coverage.py
@@ -30,15 +30,24 @@ REVIEW (non-fatal) and never as a failure.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import plistlib
 import re
 import sys
 
 # --- Apple's required-reason API catalogue -------------------------------
-# Symbols verified against Apple's DocC payload for
-# bundleresources/app-privacy-configuration/nsprivacyaccessedapitypes/
-# nsprivacyaccessedapitype (symbol reference links resolved), 2026-09-08.
+
+CATALOGUE_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    "data",
+    "apple_required_reason_catalogue.json",
+)
+
+with open(CATALOGUE_PATH, encoding="utf-8") as catalogue_file:
+    CATALOGUE = json.load(catalogue_file)
+
+CATEGORIES = {category["id"]: category for category in CATALOGUE["categories"]}
 
 FILE_TIMESTAMP = "NSPrivacyAccessedAPICategoryFileTimestamp"
 SYSTEM_BOOT_TIME = "NSPrivacyAccessedAPICategorySystemBootTime"
@@ -46,20 +55,10 @@ DISK_SPACE = "NSPrivacyAccessedAPICategoryDiskSpace"
 ACTIVE_KEYBOARDS = "NSPrivacyAccessedAPICategoryActiveKeyboards"
 USER_DEFAULTS = "NSPrivacyAccessedAPICategoryUserDefaults"
 
-ALL_CATEGORIES = {
-    FILE_TIMESTAMP,
-    SYSTEM_BOOT_TIME,
-    DISK_SPACE,
-    ACTIVE_KEYBOARDS,
-    USER_DEFAULTS,
-}
-
+ALL_CATEGORIES = set(CATEGORIES)
 VALID_REASONS = {
-    FILE_TIMESTAMP: {"DDA9.1", "C617.1", "3B52.1", "0A2A.1"},
-    SYSTEM_BOOT_TIME: {"35F9.1", "8FFB.1", "3D61.1"},
-    DISK_SPACE: {"85F4.1", "E174.1", "7D9E.1", "B728.1"},
-    ACTIVE_KEYBOARDS: {"3EC4.1", "54BD.1"},
-    USER_DEFAULTS: {"CA92.1", "1C8F.1", "C56D.1", "AC6B.1"},
+    category_id: set(category["reasons"])
+    for category_id, category in CATEGORIES.items()
 }
 
 # Unambiguous: each pattern can only mean the required-reason API.
@@ -69,18 +68,23 @@ DEFINITE = [
     (
         FILE_TIMESTAMP,
         re.compile(
-            r"\bcontentModificationDateKey\b|\bcreationDateKey\b"
+            r"\b(?:contentModificationDateKey|NSURLContentModificationDateKey)\b"
+            r"|\b(?:creationDateKey|NSURLCreationDateKey)\b"
+            r"|\b(?:NSFile)?(?:CreationDate|ModificationDate)\b"
             r"|\bfileModificationDate\b"
             r"|\bFileAttributeKey\.(?:creationDate|modificationDate)\b"
-            r"|\bgetattrlist(?:bulk|at)?\s*\(|\bfgetattrlist\s*\("
+            r"|\bgetattrlistbulk\s*\("
             r"|\bfstatat\s*\(|\blstat\s*\(|\bfstat\s*\(|(?<![\w.])stat\s*\("
         ),
     ),
     (
         DISK_SPACE,
         re.compile(
-            r"\bvolumeAvailableCapacity(?:ForImportantUsage|ForOpportunisticUsage)?Key\b"
-            r"|\bvolumeTotalCapacityKey\b|\bsystemFreeSize\b|\bsystemSize\b"
+            r"\b(?:NSURL)?VolumeAvailableCapacity"
+            r"(?:ForImportantUsage|ForOpportunisticUsage)?Key\b"
+            r"|\b(?:NSURL)?VolumeTotalCapacityKey\b"
+            r"|\b(?:NSFileSystem)?FreeSize\b|\b(?:NSFileSystem)?Size\b"
+            r"|\bsystemFreeSize\b|\bsystemSize\b"
             r"|\bstatfs\s*\(|\bstatvfs\s*\(|\bfstatfs\s*\(|\bfstatvfs\s*\("
         ),
     ),
@@ -93,6 +97,14 @@ AMBIGUOUS = [
     (
         FILE_TIMESTAMP,
         re.compile(r"\battributesOfItem\b|\.(?:creationDate|modificationDate)\b"),
+    ),
+    (
+        FILE_TIMESTAMP,
+        re.compile(r"\b(?:f?getattrlist|getattrlistat)\s*\("),
+    ),
+    (
+        DISK_SPACE,
+        re.compile(r"\b(?:f?getattrlist|getattrlistat)\s*\("),
     ),
 ]
 
@@ -497,11 +509,11 @@ def check_sources(mobile: str) -> int:
             if declared and category in declared:
                 continue
             warnings.append(
-                f"{unit.name}: possible {category} use (ambiguous accessor) at "
+                f"{unit.name}: possible {category} use (review required) at "
                 + ", ".join(sites[:3])
                 + (f" (+{len(sites) - 3} more)" if len(sites) > 3 else "")
-                + " -- confirm whether this is FileAttributeKey/URLResourceKey "
-                  "(declare it) or unrelated metadata such as PHAsset (ignore)"
+                + " -- inspect the concrete type or requested attributes, then "
+                  "declare only the category actually accessed"
             )
 
     for warning in warnings:

--- a/mobile/scripts/lib/render_required_reason_catalogue.py
+++ b/mobile/scripts/lib/render_required_reason_catalogue.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Verify the generated catalogue tables in IOS_PRIVACY_MANIFESTS.md."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.dirname(__file__))
+CATALOGUE_PATH = os.path.join(
+    SCRIPT_DIR, "data", "apple_required_reason_catalogue.json"
+)
+DOC_PATH = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "docs", "IOS_PRIVACY_MANIFESTS.md"))
+START = "<!-- apple-required-reason-catalogue:start -->"
+END = "<!-- apple-required-reason-catalogue:end -->"
+
+
+def render(catalogue: dict) -> str:
+    lines = [
+        START,
+        "| Category | Swift APIs | Objective-C APIs |",
+        "|---|---|---|",
+    ]
+    for category in catalogue["categories"]:
+        swift = ", ".join(f"`{symbol}`" for symbol in category["symbols"]["swift"])
+        objective_c = ", ".join(
+            f"`{symbol}`" for symbol in category["symbols"]["objectiveC"]
+        )
+        lines.append(f"| `{category['name']}` | {swift} | {objective_c} |")
+    lines.extend(["", "Reason codes:", "", "| Code | Category | Meaning |", "|---|---|---|"])
+    for category in catalogue["categories"]:
+        for code, meaning in category["reasons"].items():
+            lines.append(f"| `{code}` | {category['name']} | {meaning} |")
+    lines.append(END)
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail instead of printing")
+    args = parser.parse_args()
+    with open(CATALOGUE_PATH, encoding="utf-8") as handle:
+        generated = render(json.load(handle))
+    with open(DOC_PATH, encoding="utf-8") as handle:
+        document = handle.read()
+    try:
+        current = START + document.split(START, 1)[1].split(END, 1)[0] + END
+    except IndexError:
+        if args.check:
+            print("catalogue markers are missing from IOS_PRIVACY_MANIFESTS.md")
+            return 1
+        print(generated)
+        return 0
+    if current != generated:
+        if args.check:
+            print("IOS_PRIVACY_MANIFESTS.md catalogue tables are stale")
+            return 1
+        print(generated)
+        return 0
+    print("IOS_PRIVACY_MANIFESTS.md matches the pinned catalogue")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mobile/test/tools/apple_required_reason_probe_test.dart
+++ b/mobile/test/tools/apple_required_reason_probe_test.dart
@@ -171,6 +171,21 @@ void main() {
       expect(result.output, contains('OPERATIONAL ERROR'));
     });
 
+    test('does not silently ignore Objective-C category content patches', () {
+      final payload = payloadForCatalogue();
+      final overrides = payload['variantOverrides']! as List<dynamic>;
+      final override = overrides.single! as Map<String, dynamic>;
+      final patches = override['patch']! as List<dynamic>;
+      patches.add({
+        'op': 'remove',
+        'path': '/primaryContentSections/0/values/0',
+      });
+      final result = run(payload);
+
+      expect(result.exitCode, equals(2), reason: result.output);
+      expect(result.output, contains('OPERATIONAL ERROR'));
+    });
+
     test('documentation tables match the catalogue', () {
       final result = Process.runSync('python3', [
         'scripts/lib/render_required_reason_catalogue.py',

--- a/mobile/test/tools/apple_required_reason_probe_test.dart
+++ b/mobile/test/tools/apple_required_reason_probe_test.dart
@@ -1,0 +1,165 @@
+// ABOUTME: Pins semantic extraction of Apple's required-reason DocC payload.
+// ABOUTME: Covers Swift references, Objective-C overrides, and drift reporting.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  final probe = File(
+    'scripts/lib/apple_required_reason_probe.py',
+  ).absolute.path;
+  final catalogue =
+      jsonDecode(
+            File(
+              'scripts/data/apple_required_reason_catalogue.json',
+            ).readAsStringSync(),
+          )
+          as Map<String, dynamic>;
+
+  Map<String, dynamic> payloadForCatalogue() {
+    final references = <String, dynamic>{};
+    final titlePatches = <Map<String, dynamic>>[];
+    final values = <Map<String, dynamic>>[];
+    final categories = catalogue['categories']! as List<dynamic>;
+    for (final rawCategory in categories) {
+      final category = rawCategory! as Map<String, dynamic>;
+      final symbols = category['symbols']! as Map<String, dynamic>;
+      final swift = symbols['swift']! as List<dynamic>;
+      final objectiveC = symbols['objectiveC']! as List<dynamic>;
+      final apiItems = <Map<String, dynamic>>[];
+      for (var index = 0; index < swift.length; index += 1) {
+        final swiftName = swift[index]! as String;
+        final objectiveCName = objectiveC[index]! as String;
+        Map<String, dynamic> inline;
+        if (swiftName == objectiveCName) {
+          inline = {'type': 'codeVoice', 'code': '$swiftName()'};
+        } else {
+          final reference = 'doc://test/${category['name']}/$index';
+          references[reference] = {'title': swiftName};
+          final pointer = reference.replaceAll('~', '~0').replaceAll('/', '~1');
+          titlePatches.add({
+            'op': 'replace',
+            'path': '/references/$pointer/title',
+            'value': objectiveCName,
+          });
+          inline = {'type': 'reference', 'identifier': reference};
+        }
+        apiItems.add({
+          'content': [
+            {
+              'inlineContent': [inline],
+            },
+          ],
+        });
+      }
+      final reasons = category['reasons']! as Map<String, dynamic>;
+      values.add({
+        'name': category['id'],
+        'content': [
+          {'type': 'unorderedList', 'items': apiItems},
+          {
+            'type': 'termList',
+            'items': [
+              for (final code in reasons.keys)
+                {
+                  'term': {
+                    'inlineContent': [
+                      {'type': 'codeVoice', 'code': code},
+                    ],
+                  },
+                },
+            ],
+          },
+        ],
+      });
+    }
+    return {
+      'references': references,
+      'primaryContentSections': [
+        {'kind': 'possibleValues', 'values': values},
+      ],
+      'variantOverrides': [
+        {
+          'patch': [
+            {
+              'op': 'replace',
+              'path': '/identifier/interfaceLanguage',
+              'value': 'occ',
+            },
+            ...titlePatches,
+          ],
+        },
+      ],
+    };
+  }
+
+  ({int exitCode, String output}) run(Map<String, dynamic> payload) {
+    final directory = Directory.systemTemp.createTempSync('apple_docc_test');
+    addTearDown(() => directory.deleteSync(recursive: true));
+    final input = File('${directory.path}/payload.json')
+      ..writeAsStringSync(jsonEncode(payload));
+    final result = Process.runSync('python3', [probe, '--input', input.path]);
+    return (
+      exitCode: result.exitCode,
+      output: '${result.stdout}${result.stderr}',
+    );
+  }
+
+  test('accepts a matching Swift and Objective-C catalogue', () {
+    final result = run(payloadForCatalogue());
+
+    expect(result.exitCode, equals(0), reason: result.output);
+    expect(result.output, contains('matches the pinned data'));
+  });
+
+  test('reports a semantic reason-code delta', () {
+    final payload = payloadForCatalogue();
+    final sections = payload['primaryContentSections']! as List<dynamic>;
+    final section = sections.single! as Map<String, dynamic>;
+    final values = section['values']! as List<dynamic>;
+    final category = values.first! as Map<String, dynamic>;
+    final content = category['content']! as List<dynamic>;
+    final termList = content.last! as Map<String, dynamic>;
+    final items = termList['items']! as List<dynamic>;
+    items.add({
+      'term': {
+        'inlineContent': [
+          {'type': 'codeVoice', 'code': 'NEW1.1'},
+        ],
+      },
+    });
+
+    final result = run(payload);
+
+    expect(result.exitCode, equals(1), reason: result.output);
+    expect(result.output, contains('CATALOGUE DRIFT'));
+    expect(
+      result.output,
+      contains('+ NSPrivacyAccessedAPICategoryFileTimestamp reason NEW1.1'),
+    );
+  });
+
+  test('classifies a missing Objective-C variant as operational', () {
+    final payload = payloadForCatalogue()..['variantOverrides'] = <dynamic>[];
+
+    final result = run(payload);
+
+    expect(result.exitCode, equals(2), reason: result.output);
+    expect(result.output, contains('OPERATIONAL ERROR'));
+  });
+
+  test('documentation tables match the catalogue', () {
+    final result = Process.runSync('python3', [
+      'scripts/lib/render_required_reason_catalogue.py',
+      '--check',
+    ]);
+
+    expect(
+      result.exitCode,
+      equals(0),
+      reason: '${result.stdout}${result.stderr}',
+    );
+  });
+}

--- a/mobile/test/tools/apple_required_reason_probe_test.dart
+++ b/mobile/test/tools/apple_required_reason_probe_test.dart
@@ -107,59 +107,61 @@ void main() {
     );
   }
 
-  test('accepts a matching Swift and Objective-C catalogue', () {
-    final result = run(payloadForCatalogue());
+  group('Apple required-reason catalogue probe', () {
+    test('accepts a matching Swift and Objective-C catalogue', () {
+      final result = run(payloadForCatalogue());
 
-    expect(result.exitCode, equals(0), reason: result.output);
-    expect(result.output, contains('matches the pinned data'));
-  });
-
-  test('reports a semantic reason-code delta', () {
-    final payload = payloadForCatalogue();
-    final sections = payload['primaryContentSections']! as List<dynamic>;
-    final section = sections.single! as Map<String, dynamic>;
-    final values = section['values']! as List<dynamic>;
-    final category = values.first! as Map<String, dynamic>;
-    final content = category['content']! as List<dynamic>;
-    final termList = content.last! as Map<String, dynamic>;
-    final items = termList['items']! as List<dynamic>;
-    items.add({
-      'term': {
-        'inlineContent': [
-          {'type': 'codeVoice', 'code': 'NEW1.1'},
-        ],
-      },
+      expect(result.exitCode, equals(0), reason: result.output);
+      expect(result.output, contains('matches the pinned data'));
     });
 
-    final result = run(payload);
+    test('reports a semantic reason-code delta', () {
+      final payload = payloadForCatalogue();
+      final sections = payload['primaryContentSections']! as List<dynamic>;
+      final section = sections.single! as Map<String, dynamic>;
+      final values = section['values']! as List<dynamic>;
+      final category = values.first! as Map<String, dynamic>;
+      final content = category['content']! as List<dynamic>;
+      final termList = content.last! as Map<String, dynamic>;
+      final items = termList['items']! as List<dynamic>;
+      items.add({
+        'term': {
+          'inlineContent': [
+            {'type': 'codeVoice', 'code': 'NEW1.1'},
+          ],
+        },
+      });
 
-    expect(result.exitCode, equals(1), reason: result.output);
-    expect(result.output, contains('CATALOGUE DRIFT'));
-    expect(
-      result.output,
-      contains('+ NSPrivacyAccessedAPICategoryFileTimestamp reason NEW1.1'),
-    );
-  });
+      final result = run(payload);
 
-  test('classifies a missing Objective-C variant as operational', () {
-    final payload = payloadForCatalogue()..['variantOverrides'] = <dynamic>[];
+      expect(result.exitCode, equals(1), reason: result.output);
+      expect(result.output, contains('CATALOGUE DRIFT'));
+      expect(
+        result.output,
+        contains('+ NSPrivacyAccessedAPICategoryFileTimestamp reason NEW1.1'),
+      );
+    });
 
-    final result = run(payload);
+    test('classifies a missing Objective-C variant as operational', () {
+      final payload = payloadForCatalogue()..['variantOverrides'] = <dynamic>[];
 
-    expect(result.exitCode, equals(2), reason: result.output);
-    expect(result.output, contains('OPERATIONAL ERROR'));
-  });
+      final result = run(payload);
 
-  test('documentation tables match the catalogue', () {
-    final result = Process.runSync('python3', [
-      'scripts/lib/render_required_reason_catalogue.py',
-      '--check',
-    ]);
+      expect(result.exitCode, equals(2), reason: result.output);
+      expect(result.output, contains('OPERATIONAL ERROR'));
+    });
 
-    expect(
-      result.exitCode,
-      equals(0),
-      reason: '${result.stdout}${result.stderr}',
-    );
+    test('documentation tables match the catalogue', () {
+      final result = Process.runSync('python3', [
+        'scripts/lib/render_required_reason_catalogue.py',
+        '--check',
+      ]);
+
+      expect(
+        result.exitCode,
+        equals(0),
+        reason: '${result.stdout}${result.stderr}',
+      );
+    });
   });
 }

--- a/mobile/test/tools/apple_required_reason_probe_test.dart
+++ b/mobile/test/tools/apple_required_reason_probe_test.dart
@@ -151,6 +151,26 @@ void main() {
       expect(result.output, contains('OPERATIONAL ERROR'));
     });
 
+    test('classifies a malformed variant as operational rather than drift', () {
+      final payload = payloadForCatalogue()..['variantOverrides'] = null;
+      final result = run(payload);
+
+      expect(result.exitCode, equals(2), reason: result.output);
+      expect(result.output, contains('OPERATIONAL ERROR'));
+      expect(result.output, isNot(contains('CATALOGUE DRIFT')));
+    });
+
+    test('classifies missing category values as an operational failure', () {
+      final payload = payloadForCatalogue()
+        ..['primaryContentSections'] = [
+          {'kind': 'possibleValues'},
+        ];
+      final result = run(payload);
+
+      expect(result.exitCode, equals(2), reason: result.output);
+      expect(result.output, contains('OPERATIONAL ERROR'));
+    });
+
     test('documentation tables match the catalogue', () {
       final result = Process.runSync('python3', [
         'scripts/lib/render_required_reason_catalogue.py',

--- a/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
+++ b/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
@@ -36,6 +36,7 @@ void main() {
 
   Directory makeTree({
     required String swift,
+    String? objectiveC,
     String? manifest,
     String? selectedSubspec,
     String podspec =
@@ -47,6 +48,9 @@ void main() {
       ..createSync(recursive: true);
     Directory('${pkg.path}/Classes').createSync(recursive: true);
     File('${pkg.path}/Classes/Sample.swift').writeAsStringSync(swift);
+    if (objectiveC != null) {
+      File('${pkg.path}/Classes/Sample.m').writeAsStringSync(objectiveC);
+    }
     File('${pkg.path}/sample.podspec').writeAsStringSync(podspec);
     Directory('${root.path}/ios/Runner').createSync(recursive: true);
     if (selectedSubspec != null) {
@@ -138,7 +142,7 @@ void main() {
         // Reported for a human to judge, never fatal: PHAsset metadata carries
         // no declaration duty, and over-declaring is itself inaccurate.
         expect(result.exitCode, equals(0), reason: result.output);
-        expect(result.output, contains('ambiguous accessor'));
+        expect(result.output, contains('review required'));
       });
 
       test('does fail on the unambiguous URLResourceKey form', () {
@@ -155,6 +159,46 @@ void main() {
           contains('NSPrivacyAccessedAPICategoryFileTimestamp'),
         );
       });
+
+      test('detects Objective-C timestamp and disk-space constants', () {
+        final root = makeTree(
+          swift: '',
+          objectiveC:
+              'id timestamp = NSURLContentModificationDateKey;\n'
+              'id capacity = NSURLVolumeTotalCapacityKey;\n',
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(1));
+        expect(
+          result.output,
+          contains('NSPrivacyAccessedAPICategoryFileTimestamp'),
+        );
+        expect(
+          result.output,
+          contains('NSPrivacyAccessedAPICategoryDiskSpace'),
+        );
+      });
+
+      test(
+        'reports cross-category getattrlist calls without forcing either',
+        () {
+          final root = makeTree(
+            swift: 'getattrlist(path, &attributes, &buffer, size, 0)\n',
+          );
+          final result = run(root: root);
+
+          expect(result.exitCode, equals(0), reason: result.output);
+          expect(
+            result.output,
+            contains('possible NSPrivacyAccessedAPICategoryFileTimestamp use'),
+          );
+          expect(
+            result.output,
+            contains('possible NSPrivacyAccessedAPICategoryDiskSpace use'),
+          );
+        },
+      );
 
       test('ignores an API named only in a comment or string literal', () {
         final root = makeTree(

--- a/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
+++ b/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
@@ -231,6 +231,20 @@ void main() {
         },
       );
 
+      test('does not suggest removing a declaration with an ambiguous use', () {
+        final root = makeTree(
+          swift: 'getattrlist(path, &attributes, &buffer, size, 0)\n',
+          manifest: manifestFor(
+            'NSPrivacyAccessedAPICategoryFileTimestamp',
+            'C617.1',
+          ),
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(0), reason: result.output);
+        expect(result.output, isNot(contains('no call site was detected')));
+      });
+
       test('ignores an API named only in a comment or string literal', () {
         final root = makeTree(
           swift:

--- a/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
+++ b/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
@@ -131,6 +131,37 @@ void main() {
     });
 
     group('false-positive guards', () {
+      for (final symbol in [
+        'volumeAvailableCapacityKey',
+        'volumeAvailableCapacityForImportantUsageKey',
+        'volumeAvailableCapacityForOpportunisticUsageKey',
+        'volumeTotalCapacityKey',
+      ]) {
+        test('detects Swift disk-space key $symbol', () {
+          final root = makeTree(swift: 'let key = URLResourceKey.$symbol\n');
+          final result = run(root: root);
+
+          expect(result.exitCode, equals(1), reason: result.output);
+          expect(
+            result.output,
+            contains('NSPrivacyAccessedAPICategoryDiskSpace'),
+          );
+        });
+      }
+
+      test('ignores unrelated capitalized type names', () {
+        final root = makeTree(
+          swift:
+              'let size = Size(width: 1, height: 2)\n'
+              'let free = FreeSize()\n'
+              'let creation = CreationDate()\n'
+              'let modification = ModificationDate()\n',
+        );
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(0), reason: result.output);
+      });
+
       test('does not fail on a bare PHAsset-style .creationDate accessor', () {
         final root = makeTree(
           swift:


### PR DESCRIPTION
## Problem

The privacy-manifest guard pins Apple required-reason categories, symbols, and reason codes, but it could not notice when Apple changed that catalogue. Its Swift-only extraction also left Objective-C constants undetected even though the scanner covers Objective-C source files.

## Why this fix

This change moves the catalogue into one machine-readable JSON source used by the detector and generated documentation tables. A monthly workflow semantically compares Apple DocC data for both Swift and Objective-C variants, opens one incident issue only for confirmed catalogue drift, and closes it after recovery. Transient fetch or payload-shape failures are retried and remain operational failures rather than false drift incidents.

The detector now recognizes the ten previously missed Objective-C constants. Shared getattrlist-family APIs remain review findings for both possible categories because their requested attributes determine whether FileTimestamp or DiskSpace is accurate; the guard does not force an over-declaration.

## Deliberately unchanged

The existing privacy guard remains offline and continues running in normal Mobile CI. Pull requests do not depend on developer.apple.com, and current source declarations do not change.

## Verification

- actionlint .github/workflows/apple_required_reason_probe.yml
- flutter test test/tools/privacy_manifest_coverage_detector_test.dart test/tools/apple_required_reason_probe_test.dart
- bash scripts/check_privacy_manifest_coverage.sh
- bash scripts/check_apple_required_reason_catalogue.sh
- python3 scripts/lib/render_required_reason_catalogue.py --check
- flutter analyze
- env -u TMPDIR .codex/scripts/test-config.sh

Closes #8852