### PR TITLE
test(video): restore subscription deduplication coverage

### DIFF
--- a/mobile/scripts/baseline/future_delayed_test_counts.txt
+++ b/mobile/scripts/baseline/future_delayed_test_counts.txt
@@ -155,7 +155,6 @@ test/services/video_editor/video_editor_render_service_progress_test.dart	1
 test/services/video_editor/video_editor_split_service_test.dart	1
 test/services/video_event_publisher_retry_test.dart	1
 test/services/video_event_service_blocklist_sweep_test.dart	7
-test/services/video_event_service_deduplication_test.dart	1
 test/services/video_event_service_deletion_test.dart	9
 test/services/video_event_service_event_deduplication_test.dart	24
 test/services/video_event_service_initial_page_pagination_test.dart	2

--- a/mobile/scripts/baseline/skip_test_ceilings.txt
+++ b/mobile/scripts/baseline/skip_test_ceilings.txt
@@ -52,7 +52,6 @@ test/services/hashtag_service_test.dart	1 # delete: empty body for a feature nev
 test/services/m3u8_resolver_service_test.dart	1 # quarantine: real http to stream.divine.video playlist (#4836)
 test/services/profile_editing_test.dart	1 # delete: asserts its own for-loop; no retry logic exists (#4836)
 test/services/upload_manager_thumbnail_test.dart	2 # delete: assert the mock's own return; one is self-contradictory (#4836)
-test/services/video_event_service_deduplication_test.dart	7 # rewrite: verify() misses subscribe's oneose/subscriptionid args (#4836)
 test/services/video_event_service_replaceable_test.dart	1 # delete: kind 22 rejected: isvideokind() is 34236-only (#4836)
 test/services/video_event_service_repost_test.dart	1 # rewrite: uses kind 6 reposts and kind 22 originals; both dropped (#4836)
 test/tools/naming_convention_test.dart	2 # delete: 147 of 238 lib/screens files break the asserted rule (#4836)

--- a/mobile/test/services/video_event_service_deduplication_test.dart
+++ b/mobile/test/services/video_event_service_deduplication_test.dart
@@ -36,7 +36,7 @@ void main() {
       when(() => mockNostrService.isInitialized).thenReturn(true);
       when(() => mockNostrService.connectedRelayCount).thenReturn(1);
       when(
-        () => mockNostrService.subscribe(any()),
+        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
       ).thenAnswer((_) => const Stream<Event>.empty());
 
       videoEventService = VideoEventService(
@@ -59,7 +59,9 @@ void main() {
         videoEventService.subscribeToDiscovery();
 
         // Verify NostrService was only called once (reused existing)
-        verify(() => mockNostrService.subscribe(any())).called(1);
+        verify(
+          () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+        ).called(1);
       });
     });
 
@@ -73,10 +75,10 @@ void main() {
         await videoEventService.subscribeToHomeFeed(['author1']);
 
         // Both should create separate subscriptions
-        verify(() => mockNostrService.subscribe(any())).called(2);
+        verify(
+          () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+        ).called(2);
       },
-      // TODO(any): Fix and re-enable this test
-      skip: true,
     );
 
     test('should generate different IDs for different authors', () async {
@@ -87,9 +89,10 @@ void main() {
       await videoEventService.subscribeToHomeFeed(['author3', 'author4']);
 
       // Both should create separate subscriptions
-      verify(() => mockNostrService.subscribe(any())).called(2);
-      // TODO(any): Fix and re-enable this test
-    }, skip: true);
+      verify(
+        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+      ).called(2);
+    });
 
     test('should generate same ID regardless of author order', () async {
       // Subscribe with authors in one order
@@ -108,9 +111,10 @@ void main() {
       ]);
 
       // Should reuse the subscription pattern (2 calls total, not 3)
-      verify(() => mockNostrService.subscribe(any())).called(2);
-      // TODO(any): Fix and re-enable this test
-    }, skip: true);
+      verify(
+        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+      ).called(2);
+    });
 
     test('should generate different IDs for different hashtags', () async {
       // Subscribe with first hashtag
@@ -120,9 +124,10 @@ void main() {
       await videoEventService.subscribeToHashtagVideos(['music']);
 
       // Both should create separate subscriptions
-      verify(() => mockNostrService.subscribe(any())).called(2);
-      // TODO(any): Fix and re-enable this test
-    }, skip: true);
+      verify(
+        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+      ).called(2);
+    });
 
     test('should not create duplicate subscriptions for rapid calls', () async {
       // Simulate rapid subscription calls (like from multiple UI components)
@@ -135,9 +140,10 @@ void main() {
       await Future.wait(futures);
 
       // Should only create one subscription despite 5 calls
-      verify(() => mockNostrService.subscribe(any())).called(1);
-      // TODO(any): Fix and re-enable this test
-    }, skip: true);
+      verify(
+        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+      ).called(1);
+    });
 
     test('subscription count should stay reasonable', () async {
       // Create various subscription types
@@ -154,8 +160,7 @@ void main() {
       expect(activeSubscriptions, contains('discovery'));
       expect(activeSubscriptions, contains('homeFeed'));
       expect(activeSubscriptions, contains('hashtag'));
-      // TODO(any): Fix and re-enable this test
-    }, skip: true);
+    });
 
     test('should handle subscription replacement correctly', () async {
       // First subscription
@@ -165,13 +170,14 @@ void main() {
       await videoEventService.subscribeToDiscovery();
 
       // Should create two subscriptions (old one cancelled, new one created)
-      verify(() => mockNostrService.subscribe(any())).called(2);
+      verify(
+        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+      ).called(2);
 
       // But only one should be active
       final status = videoEventService.getConnectionStatus();
       final activeSubscriptions = status['activeSubscriptions'] as List;
       expect(activeSubscriptions.length, equals(1));
-      // TODO(any): Fix and re-enable this test
-    }, skip: true);
+    });
   });
 }

--- a/mobile/test/services/video_event_service_deduplication_test.dart
+++ b/mobile/test/services/video_event_service_deduplication_test.dart
@@ -1,9 +1,4 @@
-// Permanent: existing active and skipped assertions depend on
-// VideoEventService subscription lifecycle timing; keep isolated until the
-// subscription dedupe tests use non-completing streams and layer-correct
-// assertions.
-@Tags(['skip_very_good_optimization'])
-library;
+import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -24,19 +19,40 @@ void main() {
   });
 
   group('VideoEventService Subscription Deduplication', () {
+    final author1 = '1' * 64;
+    final author2 = '2' * 64;
+    final author3 = '3' * 64;
+    final author4 = '4' * 64;
     late VideoEventService videoEventService;
     late _MockNostrClient mockNostrService;
     late _MockSubscriptionManager mockSubscriptionManager;
+    late List<StreamController<Event>> streams;
 
     setUp(() {
       mockNostrService = _MockNostrClient();
       mockSubscriptionManager = _MockSubscriptionManager();
+      streams = [];
 
       // Setup mock NostrService
       when(() => mockNostrService.isInitialized).thenReturn(true);
       when(() => mockNostrService.connectedRelayCount).thenReturn(1);
       when(
         () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+      ).thenAnswer((_) {
+        final controller = StreamController<Event>();
+        streams.add(controller);
+        return controller.stream;
+      });
+      // Home-feed backfill is separate from the persistent subscription.
+      when(
+        () => mockNostrService.subscribe(
+          any(),
+          subscriptionId: any(
+            named: 'subscriptionId',
+            that: startsWith('seed_home_'),
+          ),
+          onEose: any(named: 'onEose'),
+        ),
       ).thenAnswer((_) => const Stream<Event>.empty());
 
       videoEventService = VideoEventService(
@@ -46,77 +62,85 @@ void main() {
       );
     });
 
-    test('should generate same subscription ID for identical parameters', () {
-      // Access the private method through reflection for testing
-      // Note: In production, we'd test this indirectly through behavior
+    tearDown(() async {
+      await videoEventService.unsubscribeFromVideoFeed();
+      videoEventService.dispose();
+      for (final controller in streams) {
+        await controller.close();
+      }
+    });
 
-      // First subscription
-      videoEventService.subscribeToDiscovery();
+    test('reuses a live subscription for identical parameters', () async {
+      await videoEventService.subscribeToDiscovery();
+      expect(streams.single.hasListener, isTrue);
 
-      // Give it a moment to process
-      Future.delayed(const Duration(milliseconds: 100), () {
-        // Second identical subscription
-        videoEventService.subscribeToDiscovery();
+      await videoEventService.subscribeToDiscovery();
 
-        // Verify NostrService was only called once (reused existing)
-        verify(
-          () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
-        ).called(1);
-      });
+      verify(
+        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+      ).called(1);
+      expect(streams.single.hasListener, isTrue);
     });
 
     test(
-      'should generate different IDs for different subscription types',
+      'keeps different subscription types active independently',
       () async {
         // Subscribe to discovery
         await videoEventService.subscribeToDiscovery();
 
         // Subscribe to home feed with same limit
-        await videoEventService.subscribeToHomeFeed(['author1']);
+        await videoEventService.subscribeToHomeFeed([author1]);
 
         // Both should create separate subscriptions
         verify(
           () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
         ).called(2);
+        expect(streams.every((stream) => stream.hasListener), isTrue);
       },
     );
 
-    test('should generate different IDs for different authors', () async {
+    test('replaces the subscription when authors change', () async {
       // Subscribe with first set of authors
-      await videoEventService.subscribeToHomeFeed(['author1', 'author2']);
+      await videoEventService.subscribeToHomeFeed([author1, author2]);
 
       // Subscribe with different authors
-      await videoEventService.subscribeToHomeFeed(['author3', 'author4']);
+      await videoEventService.subscribeToHomeFeed([author3, author4]);
 
       // Both should create separate subscriptions
       verify(
         () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
       ).called(2);
+      expect(streams.first.hasListener, isFalse);
+      expect(streams.last.hasListener, isTrue);
     });
 
-    test('should generate same ID regardless of author order', () async {
-      // Subscribe with authors in one order
-      await videoEventService.subscribeToHomeFeed([
-        'author1',
-        'author2',
-        'author3',
-      ]);
+    test(
+      'reuses the same ID for reordered authors without replacement',
+      () async {
+        // Subscribe with authors in one order
+        await videoEventService.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.homeFeed,
+          authors: [author1, author2, author3],
+          replace: false,
+        );
+        expect(streams.single.hasListener, isTrue);
 
-      // Clear and subscribe with authors in different order
-      await videoEventService.unsubscribeFromVideoFeed();
-      await videoEventService.subscribeToHomeFeed([
-        'author3',
-        'author1',
-        'author2',
-      ]);
+        // Keep the existing subscription so this reaches ID-based reuse rather
+        // than the default replacement path's order-sensitive parameter check.
+        await videoEventService.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.homeFeed,
+          authors: [author3, author1, author2],
+          replace: false,
+        );
 
-      // Should reuse the subscription pattern (2 calls total, not 3)
-      verify(
-        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
-      ).called(2);
-    });
+        verify(
+          () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+        ).called(1);
+        expect(streams.single.hasListener, isTrue);
+      },
+    );
 
-    test('should generate different IDs for different hashtags', () async {
+    test('replaces the subscription when hashtags change', () async {
       // Subscribe with first hashtag
       await videoEventService.subscribeToHashtagVideos(['funny']);
 
@@ -127,6 +151,8 @@ void main() {
       verify(
         () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
       ).called(2);
+      expect(streams.first.hasListener, isFalse);
+      expect(streams.last.hasListener, isTrue);
     });
 
     test('should not create duplicate subscriptions for rapid calls', () async {
@@ -148,7 +174,7 @@ void main() {
     test('subscription count should stay reasonable', () async {
       // Create various subscription types
       await videoEventService.subscribeToDiscovery();
-      await videoEventService.subscribeToHomeFeed(['author1']);
+      await videoEventService.subscribeToHomeFeed([author1]);
       await videoEventService.subscribeToHashtagVideos(['funny']);
 
       // Get connection status to check subscription count
@@ -173,6 +199,8 @@ void main() {
       verify(
         () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
       ).called(2);
+      expect(streams.first.hasListener, isFalse);
+      expect(streams.last.hasListener, isTrue);
 
       // But only one should be active
       final status = videoEventService.getConnectionStatus();


### PR DESCRIPTION
## Problem

Seven subscription-deduplication tests in #4836 were frozen because their Nostr client mock still matched the old one-argument call.
`VideoEventService` now supplies an `onEose` callback, so Mocktail returned no matching stream and the tests could not exercise the service.

## Why this fix

The mock and its call-count verifications now match the current `subscribe(filters, onEose:)` boundary.
The tests also own non-completing streams and assert that reused subscriptions stay live and replaced listeners are canceled.
Assertions are awaited rather than detached behind a delay, and home-feed backfill has a separate mock response.

The eight tests cover subscription type, author and hashtag identities, rapid duplicate calls, active counts, and replacement.
The author-order test now proves deterministic subscription-ID reuse with `replace: false`, rather than unsubscribing before the second call.

This removes all seven skip declarations, the file's skip-ceiling and Future.delayed rows, and its standalone-isolation tag.

## Deliberately unchanged

No production code changes.
The default home-feed replacement path still compares author lists in order; this change does not make reordered lists deduplicate through that path.
The separate legacy `video_events_provider_test.dart` row needs a broader provider-harness rewrite and is not bundled into this test-harness fix.

## Verification

- `flutter test --no-pub --dart-define=DIVINE_STRICT_CHANNELS=true test/services/video_event_service_deduplication_test.dart` (8 tests pass)
- Broad Flutter analysis and formatting over `lib test integration_test tools`
- `bash scripts/check_skip_ceiling.sh`
- `bash scripts/check_future_delayed_ceiling.sh`
- Repository pre-push checks passed.
- All four optimized CI test shards, Generated Files, analysis, formatting, Goldens, and aggregate Mobile CI passed on `3f68582dd` ([run](https://github.com/divinevideo/divine-mobile/actions/runs/34185192356)).
- Full-shard validation ran in CI, not locally. The separately scoped service-integration workflow skipped this test-only change.

Closes part of #4836.
