### PR TITLE
test(router): restore location stream coverage

### DIFF
--- a/mobile/scripts/baseline/skip_test_ceilings.txt
+++ b/mobile/scripts/baseline/skip_test_ceilings.txt
@@ -32,7 +32,6 @@ test/router/navigation_scenarios_test.dart	1 # rewrite: no overrides, sharedpref
 test/router/page_context_provider_test.dart	1 # rewrite: bare ProviderContainer, sharedPreferences unoverridden (#4836)
 test/router/profile_me_redirect_integration_test.dart	1 # rewrite: same authStateStream mock gap; overlaps unit variant (#4836)
 test/router/profile_me_redirect_test.dart	1 # rewrite: _MockAuthService lacks authStateStream goRouter reads (#4836)
-test/router/router_location_provider_test.dart	1 # rewrite: bare ProviderContainer, sharedPreferences unoverridden (#4836)
 test/screens/explore_screen_pure_test.dart	1 # delete: tdd stub file; 'Popular Now' tab no longer exists (#4836)
 test/screens/explore_screen_router_test.dart	2 # delete: ExploreScreenRouter is unrouted dead poc code (#4836)
 test/screens/explore_screen_video_display_test.dart	1 # rewrite: tabs now l10n featured/new, not 'Popular Now' (#4836)

--- a/mobile/test/router/router_location_provider_test.dart
+++ b/mobile/test/router/router_location_provider_test.dart
@@ -113,7 +113,7 @@ void main() {
       final router = _MockGoRouter();
       final delegate = _MockGoRouterDelegate();
       final routeInformation = GoRouteInformationProvider(
-        initialLocation: WelcomeScreen.path,
+        initialLocation: '/sentinel-location',
         initialExtra: null,
       );
       addTearDown(routeInformation.dispose);
@@ -125,22 +125,29 @@ void main() {
       addTearDown(container.dispose);
 
       final stream = container.read(routerLocationStreamProvider);
-      final queue = StreamQueue(stream);
-      addTearDown(queue.cancel);
+      final locations = <String>[];
+      var isDone = false;
+      final subscription = stream.listen(
+        locations.add,
+        onDone: () => isDone = true,
+      );
+      addTearDown(subscription.cancel);
       final listener =
           verify(
                 () => delegate.addListener(captureAny()),
               ).captured.single
               as VoidCallback;
 
-      final initial = await queue.next;
-      expect(initial, WelcomeScreen.path);
+      await pumpEventQueue();
+      expect(locations, ['/sentinel-location']);
+      expect(isDone, isFalse);
 
       // Keep the subscription active so cancellation cannot hide a leaked
       // controller. The router remains alive independently of this container.
       container.dispose();
       verify(() => delegate.removeListener(listener)).called(1);
-      expect(await queue.hasNext, isFalse);
+      await pumpEventQueue();
+      expect(isDone, isTrue);
     });
   });
 }

--- a/mobile/test/router/router_location_provider_test.dart
+++ b/mobile/test/router/router_location_provider_test.dart
@@ -26,7 +26,7 @@ void main() {
             authState: AuthState.authenticated,
             currentPublicKeyHex: syntheticTestPubkey,
           ),
-        ).cast(),
+        ),
         currentMinorAccountReviewStatusProvider.overrideWith(
           (ref) async => MinorAccountReviewStatus.active(),
         ),

--- a/mobile/test/router/router_location_provider_test.dart
+++ b/mobile/test/router/router_location_provider_test.dart
@@ -6,17 +6,39 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/minor_account_review_status.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/router.dart';
-import 'package:openvine/screens/explore/explore_screen.dart';
-import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:openvine/screens/auth/welcome_screen.dart';
+import 'package:openvine/services/auth_service.dart';
+
+import '../helpers/test_provider_overrides.dart';
+import '../helpers/test_pubkeys.dart';
 
 void main() {
+  Future<ProviderContainer> createContainer() async {
+    final container = ProviderContainer(
+      overrides: [
+        ...getStandardTestOverrides(
+          mockAuthService: createMockAuthService(
+            authState: AuthState.authenticated,
+            currentPublicKeyHex: syntheticTestPubkey,
+          ),
+        ).cast(),
+        currentMinorAccountReviewStatusProvider.overrideWith(
+          (ref) async => MinorAccountReviewStatus.active(),
+        ),
+        currentAccountDeletionAttemptProvider.overrideWith((ref) async => null),
+      ],
+    );
+    await container.read(currentMinorAccountReviewStatusProvider.future);
+    await container.read(currentAccountDeletionAttemptProvider.future);
+    return container;
+  }
+
   group('Router Location Provider', () {
     testWidgets('emits initial location immediately', (tester) async {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
-
-      // Build minimal widget tree with GoRouter
+      final container = await createContainer();
       await tester.pumpWidget(
         UncontrolledProviderScope(
           container: container,
@@ -30,18 +52,19 @@ void main() {
 
       final stream = container.read(routerLocationStreamProvider);
       final queue = StreamQueue(stream);
-      addTearDown(() async => queue.cancel());
 
       // Get initial location
       final initial = await queue.next;
-      expect(initial, VideoFeedPage.pathForIndex(0));
+      expect(initial, WelcomeScreen.path);
+
+      await queue.cancel();
+      await tester.pumpWidget(const SizedBox.shrink());
+      container.dispose();
+      await tester.pump();
     });
 
     testWidgets('emits new location when router navigates', (tester) async {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
-
-      // Build minimal widget tree with GoRouter
+      final container = await createContainer();
       await tester.pumpWidget(
         UncontrolledProviderScope(
           container: container,
@@ -56,31 +79,33 @@ void main() {
       // Listen to the raw stream for deterministic events
       final stream = container.read(routerLocationStreamProvider);
       final queue = StreamQueue(stream);
-      addTearDown(() async => queue.cancel());
 
       // 1) Initial location
       final initial = await queue.next;
-      expect(initial, VideoFeedPage.pathForIndex(0));
+      expect(initial, WelcomeScreen.path);
 
-      // 2) Navigate to explore
-      container.read(goRouterProvider).go(ExploreScreen.pathForIndex(0));
-      await tester.pump(); // Flush delegate change notification
+      // Use error routes so this provider test does not initialize unrelated
+      // app-shell side effects.
+      container.read(goRouterProvider).go('/unknown-one');
+      await tester.pump();
 
       final next1 = await queue.next;
-      expect(next1, ExploreScreen.pathForIndex(0));
+      expect(next1, '/unknown-one');
 
-      // 3) Navigate to explore page 5
-      container.read(goRouterProvider).go(ExploreScreen.pathForIndex(5));
+      container.read(goRouterProvider).go('/unknown-two');
       await tester.pump();
 
       final next2 = await queue.next;
-      expect(next2, ExploreScreen.pathForIndex(5));
+      expect(next2, '/unknown-two');
+
+      await queue.cancel();
+      await tester.pumpWidget(const SizedBox.shrink());
+      container.dispose();
+      await tester.pump();
     });
 
     testWidgets('cleans up listener on dispose', (tester) async {
-      final container = ProviderContainer();
-
-      // Build minimal widget tree
+      final container = await createContainer();
       await tester.pumpWidget(
         UncontrolledProviderScope(
           container: container,
@@ -101,11 +126,12 @@ void main() {
 
       // Cancel and dispose
       await queue.cancel();
+      await tester.pumpWidget(const SizedBox.shrink());
       container.dispose();
+      await tester.pump();
 
       // If this completes without error, cleanup worked
       expect(true, isTrue);
     });
-    // TODO(Any): Fix and re-enable these tests
-  }, skip: true);
+  });
 }

--- a/mobile/test/router/router_location_provider_test.dart
+++ b/mobile/test/router/router_location_provider_test.dart
@@ -109,7 +109,6 @@ void main() {
     });
 
     test('removes its listener and closes the stream on dispose', () async {
-      registerFallbackValue(() {});
       final router = _MockGoRouter();
       final delegate = _MockGoRouterDelegate();
       final routeInformation = GoRouteInformationProvider(

--- a/mobile/test/router/router_location_provider_test.dart
+++ b/mobile/test/router/router_location_provider_test.dart
@@ -5,6 +5,8 @@ import 'package:async/async.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/minor_account_review_status.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -39,6 +41,7 @@ void main() {
   group('Router Location Provider', () {
     testWidgets('emits initial location immediately', (tester) async {
       final container = await createContainer();
+      addTearDown(container.dispose);
       await tester.pumpWidget(
         UncontrolledProviderScope(
           container: container,
@@ -65,6 +68,7 @@ void main() {
 
     testWidgets('emits new location when router navigates', (tester) async {
       final container = await createContainer();
+      addTearDown(container.dispose);
       await tester.pumpWidget(
         UncontrolledProviderScope(
           container: container,
@@ -104,34 +108,43 @@ void main() {
       await tester.pump();
     });
 
-    testWidgets('cleans up listener on dispose', (tester) async {
-      final container = await createContainer();
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: MaterialApp.router(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            routerConfig: container.read(goRouterProvider),
-          ),
-        ),
+    test('removes its listener and closes the stream on dispose', () async {
+      registerFallbackValue(() {});
+      final router = _MockGoRouter();
+      final delegate = _MockGoRouterDelegate();
+      final routeInformation = GoRouteInformationProvider(
+        initialLocation: WelcomeScreen.path,
+        initialExtra: null,
       );
+      addTearDown(routeInformation.dispose);
+      when(() => router.routerDelegate).thenReturn(delegate);
+      when(() => router.routeInformationProvider).thenReturn(routeInformation);
+      final container = ProviderContainer(
+        overrides: [goRouterProvider.overrideWithValue(router)],
+      );
+      addTearDown(container.dispose);
 
       final stream = container.read(routerLocationStreamProvider);
       final queue = StreamQueue(stream);
+      addTearDown(queue.cancel);
+      final listener =
+          verify(
+                () => delegate.addListener(captureAny()),
+              ).captured.single
+              as VoidCallback;
 
-      // Get initial value to confirm stream is working
       final initial = await queue.next;
-      expect(initial, isNotEmpty);
+      expect(initial, WelcomeScreen.path);
 
-      // Cancel and dispose
-      await queue.cancel();
-      await tester.pumpWidget(const SizedBox.shrink());
+      // Keep the subscription active so cancellation cannot hide a leaked
+      // controller. The router remains alive independently of this container.
       container.dispose();
-      await tester.pump();
-
-      // If this completes without error, cleanup worked
-      expect(true, isTrue);
+      verify(() => delegate.removeListener(listener)).called(1);
+      expect(await queue.hasNext, isFalse);
     });
   });
 }
+
+class _MockGoRouter extends Mock implements GoRouter {}
+
+class _MockGoRouterDelegate extends Mock implements GoRouterDelegate {}


### PR DESCRIPTION
## Description

Restores the router location stream tests against the current router bootstrap contract. The widget tests use the standard provider harness, assert the current welcome initial location, and exercise subsequent notifications through isolated error routes without initializing unrelated app-shell behavior. An isolated lifecycle test verifies that provider disposal removes its registered listener and closes an active stream.

This is test-only and does not change app behavior.

Refs #4836 (one router-coverage slice; the remaining skip work stays open).

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore

## Verification

- `flutter test --no-pub --dart-define=DIVINE_STRICT_CHANNELS=true test/router/router_location_provider_test.dart`: three tests passed.
- `flutter analyze --no-pub lib test integration_test tools`: no issues.
- `dart format --output=none --set-exit-if-changed lib test integration_test tools`: no changes.
- Skip, placeholder, unpinned-assertion, ungrouped-test and localization-delegate ratchets passed against the rebased main commit.

The skip baseline drops by one file and one skip declaration, restoring three tests. The full randomized/sharded and service-integration suites were not run locally; remaining CI checks are not represented by these focused results.
