### PR TITLE
test(relays): restore NIP-11 settings coverage

### DIFF
--- a/mobile/scripts/baseline/skip_test_ceilings.txt
+++ b/mobile/scripts/baseline/skip_test_ceilings.txt
@@ -44,7 +44,6 @@ test/screens/hashtag_feed_screen_tdd_test.dart	1 # delete: dupe of test/widget s
 test/screens/hashtag_grid_view_simple_test.dart	1 # rewrite: mock lacks filterVideoList; needs prefs override (#4836)
 test/screens/profile_menu_drafts_navigation_test.dart	1 # rewrite: fixture pubkey 'currentuser1111' is non-hex, throws (#4836)
 test/screens/profile_share_edit_buttons_test.dart	1 # delete: own-profile asserts inside if(); findsNothing vacuous (#4836)
-test/screens/relay_settings_nip11_info_test.dart	1 # rewrite: needs sharedPreferencesProvider override, ui intact (#4836)
 test/screens/video_editor/video_text_editor_screen_test.dart	3 # rewrite: layer path fetches anonymouspro via google_fonts (#4836)
 test/services/account_deletion_flow_test.dart	1 # rewrite: delete entry moved from Settings to NostrSettings (#4836)
 test/services/feature_flag_service_test.dart	1 # rewrite: empty body; skip comment's riverpod claim is false (#4836)

--- a/mobile/test/screens/relay_settings_nip11_info_test.dart
+++ b/mobile/test/screens/relay_settings_nip11_info_test.dart
@@ -12,9 +12,12 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/screens/relay_settings_screen.dart';
 import 'package:openvine/services/relay_capability_service.dart';
 import 'package:openvine/services/relay_statistics_service.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class MockNostrService extends Mock implements NostrClient {}
@@ -25,17 +28,23 @@ class MockRelayCapabilityService extends Mock
 class MockRelayStatisticsService extends Mock
     implements RelayStatisticsService {}
 
+class MockVideoEventService extends Mock implements VideoEventService {}
+
 void main() {
   group('RelaySettingsScreen NIP-11 Info', () {
     late MockNostrService mockNostrService;
     late MockRelayCapabilityService mockCapabilityService;
     late MockRelayStatisticsService mockStatsService;
+    late MockVideoEventService mockVideoEventService;
+    late SharedPreferences sharedPreferences;
 
-    setUp(() {
+    setUp(() async {
       mockNostrService = MockNostrService();
       mockCapabilityService = MockRelayCapabilityService();
       mockStatsService = MockRelayStatisticsService();
+      mockVideoEventService = MockVideoEventService();
       SharedPreferences.setMockInitialValues({});
+      sharedPreferences = await SharedPreferences.getInstance();
     });
 
     Widget createTestWidget(
@@ -53,6 +62,7 @@ void main() {
       final relayUrl = configuredRelays.isNotEmpty
           ? configuredRelays.first
           : 'wss://test.relay';
+      when(() => mockNostrService.defaultRelayUrl).thenReturn(relayUrl);
       final stats = RelayStatistics(relayUrl: relayUrl);
       stats.isConnected = true;
       when(() => mockStatsService.getStatistics(any())).thenReturn(stats);
@@ -76,7 +86,9 @@ void main() {
 
       final container = ProviderContainer(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(sharedPreferences),
           nostrServiceProvider.overrideWithValue(mockNostrService),
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
           relayCapabilityServiceProvider.overrideWithValue(
             mockCapabilityService,
           ),
@@ -86,6 +98,7 @@ void main() {
           ),
         ],
       );
+      addTearDown(container.dispose);
 
       return UncontrolledProviderScope(
         container: container,
@@ -224,7 +237,10 @@ void main() {
 
       // Should show "View Website" button
       expect(find.text('View Website'), findsOneWidget);
-      expect(find.byIcon(Icons.open_in_new), findsWidgets);
+      final websiteButton = tester.widget<DivineButton>(
+        find.widgetWithText(DivineButton, 'View Website'),
+      );
+      expect(websiteButton.leadingIcon, DivineIconName.arrowUpRight);
     });
 
     testWidgets('shows software info when available', (tester) async {
@@ -279,6 +295,9 @@ void main() {
       when(
         () => mockNostrService.configuredRelays,
       ).thenReturn(['wss://relay.divine.video']);
+      when(
+        () => mockNostrService.defaultRelayUrl,
+      ).thenReturn('wss://relay.divine.video');
       when(() => mockNostrService.connectedRelayCount).thenReturn(1);
       final loadingStats = RelayStatistics(
         relayUrl: 'wss://relay.divine.video',
@@ -298,7 +317,9 @@ void main() {
 
       final container = ProviderContainer(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(sharedPreferences),
           nostrServiceProvider.overrideWithValue(mockNostrService),
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
           relayCapabilityServiceProvider.overrideWithValue(
             mockCapabilityService,
           ),
@@ -308,6 +329,7 @@ void main() {
           ),
         ],
       );
+      addTearDown(container.dispose);
 
       await tester.pumpWidget(
         UncontrolledProviderScope(
@@ -327,7 +349,7 @@ void main() {
       await tester.pump();
 
       // Should show loading indicator while fetching
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
 
       // Complete the future to avoid pending timer error
       completer.complete(
@@ -339,6 +361,5 @@ void main() {
       );
       await tester.pumpAndSettle();
     });
-    // TODO(any): Fix and enable this test
-  }, skip: true);
+  });
 }

--- a/mobile/test/screens/relay_settings_nip11_info_test.dart
+++ b/mobile/test/screens/relay_settings_nip11_info_test.dart
@@ -31,6 +31,8 @@ class MockRelayStatisticsService extends Mock
 class MockVideoEventService extends Mock implements VideoEventService {}
 
 void main() {
+  final l10n = lookupAppLocalizations(const Locale('en'));
+
   group('RelaySettingsScreen NIP-11 Info', () {
     late MockNostrService mockNostrService;
     late MockRelayCapabilityService mockCapabilityService;
@@ -137,7 +139,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Should show "About Relay" section header
-      expect(find.text('About Relay'), findsOneWidget);
+      expect(find.text(l10n.relaySettingsAboutRelay), findsOneWidget);
     });
 
     testWidgets('displays relay name from NIP-11', (tester) async {
@@ -210,7 +212,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Should show "Supported NIPs" label
-      expect(find.text('Supported NIPs'), findsOneWidget);
+      expect(find.text(l10n.relaySettingsSupportedNips), findsOneWidget);
       // Should show the NIPs as a formatted string
       expect(find.text('1, 2, 9, 11, 12, 71'), findsOneWidget);
     });
@@ -236,9 +238,9 @@ void main() {
       await tester.pumpAndSettle();
 
       // Should show "View Website" button
-      expect(find.text('View Website'), findsOneWidget);
+      expect(find.text(l10n.relaySettingsViewWebsite), findsOneWidget);
       final websiteButton = tester.widget<DivineButton>(
-        find.widgetWithText(DivineButton, 'View Website'),
+        find.widgetWithText(DivineButton, l10n.relaySettingsViewWebsite),
       );
       expect(websiteButton.leadingIcon, DivineIconName.arrowUpRight);
     });
@@ -264,7 +266,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Should show software info
-      expect(find.text('Software'), findsOneWidget);
+      expect(find.text(l10n.relaySettingsSoftware), findsOneWidget);
       expect(find.text('nosflare v0.3.0'), findsOneWidget);
     });
 
@@ -278,7 +280,8 @@ void main() {
 
       // Should not crash, and should not show "About Relay" if no info
       // The screen should still be functional
-      expect(find.text('Connection'), findsOneWidget);
+      expect(find.text(l10n.relaySettingsConnection), findsOneWidget);
+      expect(find.text(l10n.relaySettingsAboutRelay), findsNothing);
     });
 
     testWidgets('shows loading indicator while fetching NIP-11', (


### PR DESCRIPTION
## Problem

The eight NIP-11 relay-settings widget tests are disabled by one frozen group skip. The suite omitted the required shared-preferences provider, then accumulated additional harness and design-system drift while frozen.

## Why this change

Restore the suite with the smallest current harness:

- supply initialized shared preferences and the relay client default URL
- isolate the screen from unrelated video-service construction
- assert the current Divine website icon and branded loading indicator
- dispose every test provider container
- resolve UI-label assertions through localization and check that missing metadata hides the relay-info header

The production UI remains intact, matching the baseline annotation. Regenerating the skip baseline removes one skip declaration and re-enables all eight tests.

## Deliberately unchanged

No production relay behavior, copy, localization resources, or service implementation changes.

## Verification

- `flutter test --no-pub test/screens/relay_settings_nip11_info_test.dart` (8 passed)
- `flutter analyze test/screens/relay_settings_nip11_info_test.dart`
- `bash scripts/check_skip_ceiling.sh`
- `git diff --check`
- pre-push analyze and affected-test hook

Relates to #4836
