### PR TITLE
test(seen-videos): synchronize persistence hydration

### DIFF
--- a/mobile/scripts/baseline/future_delayed_test_counts.txt
+++ b/mobile/scripts/baseline/future_delayed_test_counts.txt
@@ -92,7 +92,6 @@ test/providers/list_providers_test.dart	17
 test/providers/moderation_label_provider_session_test.dart	3
 test/providers/moderation_providers_blocked_follow_reconciler_test.dart	19
 test/providers/provider_identity_stream_test.dart	10
-test/providers/seen_videos_notifier_test.dart	8
 test/providers/sounds_providers_test.dart	2
 test/providers/supporter_providers_test.dart	1
 test/providers/user_profile_providers_test.dart	31

--- a/mobile/scripts/baseline/skip_test_ceilings.txt
+++ b/mobile/scripts/baseline/skip_test_ceilings.txt
@@ -19,7 +19,6 @@ test/infrastructure/drift_setup_test.dart	1 # delete: asserts schemaVersion 6, n
 test/providers/curation_provider_lifecycle_test.dart	2 # rewrite: mock authservice lacks authstatestream, init errors out (#4836)
 test/providers/curation_provider_tab_refresh_test.dart	1 # rewrite: unstubbed authstatestream, no videoevent fallback value (#4836)
 test/providers/readiness_gate_providers_test.dart	1 # delete: appready no longer gates on nostr, only on foreground (#4836)
-test/providers/seen_videos_notifier_test.dart	1 # rewrite: races hydration, load lands after the 100ms expect (#4836)
 test/providers/video_events_provider_fresh_test.dart	1 # quarantine: real relay via realintegrationtesthelper, 40s timeout (#4836)
 test/providers/video_events_provider_test.dart	1 # rewrite: stubs subscribe(named filters:), now a positional param (#4836)
 test/repositories/profile_cache_sync_test.dart	1 # delete: pure mocktail tautology, asserts only values it stubbed (#4836)

--- a/mobile/test/providers/seen_videos_notifier_test.dart
+++ b/mobile/test/providers/seen_videos_notifier_test.dart
@@ -1,10 +1,25 @@
 // ABOUTME: Tests for SeenVideosNotifier Riverpod state management
 // ABOUTME: Validates reactive state updates and provider integration
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/providers/seen_videos_notifier.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+Future<void> _waitUntilInitialized(ProviderContainer container) async {
+  if (container.read(seenVideosProvider).isInitialized) return;
+
+  final initialized = Completer<void>();
+  final subscription = container.listen(seenVideosProvider, (_, state) {
+    if (state.isInitialized && !initialized.isCompleted) {
+      initialized.complete();
+    }
+  }, fireImmediately: true);
+  await initialized.future;
+  subscription.close();
+}
 
 void main() {
   group('SeenVideosNotifier', () {
@@ -20,8 +35,7 @@ void main() {
       expect(initialState.seenVideoIds, isEmpty);
       expect(initialState.isInitialized, isFalse);
 
-      // Wait for initialization
-      await Future.delayed(const Duration(milliseconds: 100));
+      await _waitUntilInitialized(container);
 
       final state = container.read(seenVideosProvider);
       expect(state.isInitialized, isTrue);
@@ -34,8 +48,7 @@ void main() {
 
       final notifier = container.read(seenVideosProvider.notifier);
 
-      // Wait for initialization
-      await Future.delayed(const Duration(milliseconds: 100));
+      await _waitUntilInitialized(container);
 
       const videoId = 'test_video_123';
       await notifier.markVideoAsSeen(videoId);
@@ -51,8 +64,7 @@ void main() {
 
       final notifier = container.read(seenVideosProvider.notifier);
 
-      // Wait for initialization
-      await Future.delayed(const Duration(milliseconds: 100));
+      await _waitUntilInitialized(container);
 
       const videoId = 'test_video_456';
 
@@ -70,8 +82,7 @@ void main() {
 
       final notifier = container.read(seenVideosProvider.notifier);
 
-      // Wait for initialization
-      await Future.delayed(const Duration(milliseconds: 100));
+      await _waitUntilInitialized(container);
 
       const videoId = 'test_video_789';
 
@@ -94,8 +105,7 @@ void main() {
 
       final notifier = container.read(seenVideosProvider.notifier);
 
-      // Wait for initialization
-      await Future.delayed(const Duration(milliseconds: 100));
+      await _waitUntilInitialized(container);
 
       const videoId = 'duplicate_video';
 
@@ -114,8 +124,7 @@ void main() {
 
       final notifier = container.read(seenVideosProvider.notifier);
 
-      // Wait for initialization
-      await Future.delayed(const Duration(milliseconds: 100));
+      await _waitUntilInitialized(container);
 
       var listenerCallCount = 0;
       container.listen(seenVideosProvider, (_, _) => listenerCallCount++);
@@ -133,8 +142,7 @@ void main() {
       final container1 = ProviderContainer();
       final notifier1 = container1.read(seenVideosProvider.notifier);
 
-      // Wait for initialization
-      await Future.delayed(const Duration(milliseconds: 100));
+      await _waitUntilInitialized(container1);
 
       const videoId = 'persistent_video';
       await notifier1.markVideoAsSeen(videoId);
@@ -144,14 +152,12 @@ void main() {
       // Second container
       final container2 = ProviderContainer();
 
-      // Wait for initialization
-      await Future.delayed(const Duration(milliseconds: 100));
+      await _waitUntilInitialized(container2);
 
       final notifier2 = container2.read(seenVideosProvider.notifier);
       expect(notifier2.hasSeenVideo(videoId), isTrue);
 
       container2.dispose();
-      // TODO(any): Fix and re-enable tests
-    }, skip: true);
+    });
   });
 }


### PR DESCRIPTION
## Problem

The persistence test in `seen_videos_notifier_test.dart` is frozen because it races asynchronous service hydration behind fixed 100 ms sleeps. The same timing guess appears throughout the suite and is separately tracked by the `Future.delayed` test ratchet.

## Why this change

Synchronize every test on the provider’s real `isInitialized` state transition through a temporary Riverpod listener. This restores the persistence case, removes all fixed initialization sleeps from the file, and makes the suite wait for the boundary it actually depends on.

Both shrink-only baselines are regenerated:

- one fewer unconditional skip
- one fewer file carrying executable `Future.delayed` calls

## Deliberately unchanged

No production persistence, hydration, database, or provider behavior changes.

## Verification

- `flutter test --no-pub test/providers/seen_videos_notifier_test.dart` (7 passed, including persistence across containers)
- `bash scripts/check_skip_ceiling.sh`
- `bash scripts/check_future_delayed_ceiling.sh`
- pre-push analyze and affected-test hook

Part of #4836