### PR TITLE
fix(tooling): stop reporting a shallow clone as a merge conflict

### DIFF
--- a/.claude/rules/git_hooks.md
+++ b/.claude/rules/git_hooks.md
@@ -10,7 +10,9 @@ cd mobile && mise run setup_hooks
 
 The hooks are **generated copies**, not symlinks — editing `scripts/install-hooks.sh` does nothing until each developer re-runs the command above. When a PR changes hook behaviour, say so in its description, because an already-installed hook keeps the old behaviour silently.
 
-Most recent change: the pre-push hook now skips changed files under `mobile/test/goldens/`. Without re-running `mise run setup_hooks`, a golden change is unpushable on macOS — the stale hook runs the image goldens against Ubuntu-rendered references and fails every time.
+Most recent change: the pre-push merge-conflict check moved into `scripts/check_branch_mergeable.sh`, so future fixes to it apply without re-running `mise run setup_hooks`. Re-run it once to pick up the delegation; a stale hook keeps reporting a shallow clone as a merge conflict (see below).
+
+Before that: the pre-push hook skips changed files under `mobile/test/goldens/`. Without re-running `mise run setup_hooks`, a golden change is unpushable on macOS — the stale hook runs the image goldens against Ubuntu-rendered references and fails every time.
 
 When a developer reports CI failures on format, analyze, or codegen that they didn't catch locally, FIRST check whether hooks are installed (`ls .git/hooks/pre-commit .git/hooks/pre-push`) before analyzing the failure itself. If hooks are missing, that is likely the root cause — suggest `mise run setup_hooks`. Do not skip this check.
 
@@ -22,7 +24,32 @@ When a developer reports CI failures on format, analyze, or codegen that they di
 - build_runner codegen verification (if codegen inputs changed)
 
 **Pre-push**:
-- Merge conflict check against `origin/main`
+- Merge conflict check against `origin/main` (`scripts/check_branch_mergeable.sh`)
 - `flutter analyze lib test integration_test`
 - build_runner codegen verification
 - Runs tests for changed files
+
+## The merge-conflict check cannot always answer
+
+`git merge-tree --write-tree` reports three outcomes, not two: exit 0 clean,
+exit 1 conflicts, and exit 128 a fatal error. The hook used to treat every
+non-zero exit as conflicts, which mislabels the third case.
+
+The third case is mostly **shallow clones**. With `origin/main` and the branch
+grafted at different boundaries there is no common ancestor, so merge-tree
+exits 128 with `refusing to merge unrelated histories`. That is not a conflict,
+and the advice for one — merge or rebase — cannot fix it. Deepen instead:
+
+```bash
+git fetch --deepen=500 origin main
+```
+
+`git fetch --unshallow` also works but downloads the entire history, and on a
+repo this size it can run for many minutes and die on a connection reset.
+Watch its exit code rather than its output: piping it (`git fetch --unshallow |
+tail`) reports the *pipe's* status, so a failed fetch looks like success.
+
+An unanswerable check now warns and continues rather than blocking, since it is
+not evidence of a conflict and GitHub reports mergeability on the pull request.
+The surrounding hook already takes that stance for a failed `git fetch`.
+Genuine conflicts still block.

--- a/.github/scripts/tests/test_branch_mergeable_check.py
+++ b/.github/scripts/tests/test_branch_mergeable_check.py
@@ -1,0 +1,137 @@
+"""Behavioural tests for scripts/check_branch_mergeable.sh.
+
+The script exists because `git merge-tree --write-tree` reports three outcomes
+through its exit code — clean, conflicted, and could-not-compute — and the
+pre-push hook used to collapse the last two into "Branch has merge conflicts
+with main!". On a shallow clone that message is wrong and its advice (merge or
+rebase) cannot help, so the third case is covered here explicitly.
+"""
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).resolve().parents[3] / "scripts" / "check_branch_mergeable.sh"
+)
+
+
+def git(repo, *args):
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def commit(repo, name, body):
+    (repo / name).write_text(body)
+    git(repo, "add", name)
+    git(repo, "commit", "-m", f"add {name}")
+
+
+class CheckBranchMergeableTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmp.name) / "repo"
+        self.repo.mkdir()
+        git(self.repo, "init", "-q", "-b", "main")
+        git(self.repo, "config", "user.email", "t@example.com")
+        git(self.repo, "config", "user.name", "T")
+        commit(self.repo, "shared.txt", "base\n")
+        git(self.repo, "branch", "base")
+        self.addCleanup(self._tmp.cleanup)
+
+    def run_check(self, base="base"):
+        return subprocess.run(
+            ["bash", str(SCRIPT), base],
+            cwd=self.repo,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_clean_merge_passes(self):
+        git(self.repo, "checkout", "-q", "-b", "feature")
+        commit(self.repo, "feature.txt", "new file, no overlap\n")
+
+        result = self.run_check()
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("No merge conflicts", result.stdout)
+
+    def test_real_conflict_blocks(self):
+        git(self.repo, "checkout", "-q", "-b", "feature")
+        commit(self.repo, "shared.txt", "feature edit\n")
+        git(self.repo, "checkout", "-q", "base")
+        commit(self.repo, "shared.txt", "base edit\n")
+        git(self.repo, "checkout", "-q", "feature")
+
+        result = self.run_check()
+
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("merge conflicts", result.stdout)
+        self.assertIn("git rebase", result.stdout)
+
+    def test_unrelated_histories_warn_but_do_not_report_a_conflict(self):
+        # An orphan branch shares no ancestor with base, which is the shape a
+        # shallow clone produces once the graft boundaries differ. merge-tree
+        # exits 128 here rather than 0 or 1.
+        git(self.repo, "checkout", "-q", "--orphan", "detached-history")
+        git(self.repo, "rm", "-q", "-rf", ".")
+        commit(self.repo, "other.txt", "unrelated root\n")
+
+        result = self.run_check()
+
+        combined = result.stdout + result.stderr
+        self.assertEqual(result.returncode, 0, combined)
+        self.assertIn("Could not check for merge conflicts", result.stdout)
+        self.assertIn("Continuing", result.stdout)
+        # The old hook's wording is what this script exists to avoid.
+        self.assertNotIn("Branch has merge conflicts", result.stdout)
+
+    def test_shallow_clone_is_named_as_the_likely_cause(self):
+        commit(self.repo, "second.txt", "second\n")
+        commit(self.repo, "third.txt", "third\n")
+        shallow = Path(self._tmp.name) / "shallow"
+        subprocess.run(
+            ["git", "clone", "-q", "--depth", "1", f"file://{self.repo}", str(shallow)],
+            check=True,
+            capture_output=True,
+        )
+        git(shallow, "config", "user.email", "t@example.com")
+        git(shallow, "config", "user.name", "T")
+        git(shallow, "checkout", "-q", "--orphan", "detached-history")
+        git(shallow, "rm", "-q", "-rf", ".")
+        commit(shallow, "other.txt", "unrelated root\n")
+
+        result = subprocess.run(
+            ["bash", str(SCRIPT), "origin/main"],
+            cwd=shallow,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("clone is shallow", result.stdout)
+        self.assertIn("--deepen", result.stdout)
+
+
+class InstallHooksWiringTest(unittest.TestCase):
+    def test_pre_push_delegates_to_the_script(self):
+        source = (
+            Path(__file__).resolve().parents[3] / "scripts" / "install-hooks.sh"
+        ).read_text()
+
+        self.assertIn("check_branch_mergeable.sh", source)
+        # Collapsing every non-zero exit into "conflicts" is the bug; make sure
+        # the inline form does not come back.
+        self.assertNotIn(
+            'if ! git -C "$REPO_ROOT" merge-tree --write-tree "$BASE_BRANCH" HEAD',
+            source,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_branch_mergeable_check.py
+++ b/.github/scripts/tests/test_branch_mergeable_check.py
@@ -132,6 +132,19 @@ class InstallHooksWiringTest(unittest.TestCase):
             source,
         )
 
+    def test_pre_push_delegation_does_not_gate_on_the_execute_bit(self):
+        source = (
+            Path(__file__).resolve().parents[3] / "scripts" / "install-hooks.sh"
+        ).read_text()
+
+        # The check is run through `bash "$MERGEABLE_CHECK"`, which needs the
+        # file readable, not executable. Gating on `-x` skips the whole
+        # merge-conflict check on any checkout that lost the +x bit (Windows, a
+        # mode-stripped copy), so a genuine conflict stops blocking the push —
+        # a safety gate failing open. Guard on presence instead.
+        self.assertIn('bash "$MERGEABLE_CHECK"', source)
+        self.assertNotIn('[ -x "$MERGEABLE_CHECK" ]', source)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/tests/test_branch_mergeable_check.py
+++ b/.github/scripts/tests/test_branch_mergeable_check.py
@@ -118,6 +118,18 @@ class CheckBranchMergeableTest(unittest.TestCase):
         self.assertIn("--deepen", result.stdout)
 
 
+    def test_missing_base_ref_warns_but_does_not_report_a_conflict(self):
+        # origin/main renamed, deleted, or never fetched: merge-tree exits 1
+        # here ("not something we can merge"), the same code as a real
+        # conflict, so an unchecked ref would be misreported as one.
+        result = self.run_check(base="origin/does-not-exist-ref")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("does not resolve to a", result.stdout)
+        self.assertIn("Continuing", result.stdout)
+        self.assertNotIn("Branch has merge conflicts", result.stdout)
+
+
 class InstallHooksWiringTest(unittest.TestCase):
     def test_pre_push_delegates_to_the_script(self):
         source = (

--- a/scripts/check_branch_mergeable.sh
+++ b/scripts/check_branch_mergeable.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Reports whether HEAD merges into a base ref without conflicts.
+#
+#   exit 0 — merges cleanly, or the question could not be answered
+#   exit 1 — genuine merge conflicts
+#
+# `git merge-tree --write-tree` answers with three distinct exit codes: 0 for a
+# clean merge, 1 for conflicts, and 128 for a fatal error. Treating "not 0" as
+# "conflicts" mislabels the third case, and the usual third case is a shallow
+# clone: with the base and the branch grafted at different boundaries there is
+# no common ancestor, so merge-tree exits 128 with "refusing to merge unrelated
+# histories". That is not a conflict, and the advice for a conflict — merge or
+# rebase — cannot fix it.
+#
+# An unanswerable check is not evidence of a problem, so it warns rather than
+# blocks: GitHub's own mergeability status and CI remain authoritative. This
+# mirrors the surrounding hook, which already tolerates a failed `git fetch`.
+set -uo pipefail
+
+BASE_REF="${1:-origin/main}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+stderr=$(git -C "$REPO_ROOT" merge-tree --write-tree "$BASE_REF" HEAD 2>&1 >/dev/null)
+status=$?
+
+case "$status" in
+    0)
+        echo "No merge conflicts with ${BASE_REF#origin/}"
+        ;;
+    1)
+        echo ""
+        echo "Branch has merge conflicts with ${BASE_REF#origin/}!"
+        echo ""
+        echo "Resolve conflicts before pushing:"
+        echo "  git fetch origin ${BASE_REF#origin/}"
+        echo "  git rebase $BASE_REF   # or: git merge $BASE_REF"
+        exit 1
+        ;;
+    *)
+        echo ""
+        echo "Could not check for merge conflicts (git exit $status)."
+        [ -n "$stderr" ] && echo "  $stderr"
+        if [ "$(git -C "$REPO_ROOT" rev-parse --is-shallow-repository)" = "true" ]; then
+            echo ""
+            echo "This clone is shallow, so $BASE_REF and HEAD may share no visible"
+            echo "ancestor. Deepen it to restore the check:"
+            echo "  git fetch --deepen=500 origin ${BASE_REF#origin/}"
+        fi
+        echo ""
+        echo "Continuing; GitHub reports mergeability on the pull request."
+        ;;
+esac

--- a/scripts/check_branch_mergeable.sh
+++ b/scripts/check_branch_mergeable.sh
@@ -13,6 +13,11 @@
 # histories". That is not a conflict, and the advice for a conflict — merge or
 # rebase — cannot fix it.
 #
+# A base ref that does not resolve at all is a fourth case merge-tree does not
+# separate from a real conflict: it exits 1 with "not something we can merge",
+# not 128, so it is checked before merge-tree ever runs rather than folded
+# into the exit-code switch below.
+#
 # An unanswerable check is not evidence of a problem, so it warns rather than
 # blocks: GitHub's own mergeability status and CI remain authoritative. This
 # mirrors the surrounding hook, which already tolerates a failed `git fetch`.
@@ -20,6 +25,20 @@ set -uo pipefail
 
 BASE_REF="${1:-origin/main}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# A base ref that does not resolve at all — origin/main renamed, deleted, or
+# never fetched — is a fourth unanswerable case merge-tree does not surface as
+# 128. It fails as exit 1 with "not something we can merge", indistinguishable
+# from a real conflict unless checked first. Absence is not conflict evidence
+# either, so this gets the same warn-and-continue treatment as exit 128.
+if ! git -C "$REPO_ROOT" rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
+    echo ""
+    echo "Could not check for merge conflicts: '$BASE_REF' does not resolve to a"
+    echo "commit (renamed, deleted, or never fetched)."
+    echo ""
+    echo "Continuing; GitHub reports mergeability on the pull request."
+    exit 0
+fi
 
 stderr=$(git -C "$REPO_ROOT" merge-tree --write-tree "$BASE_REF" HEAD 2>&1 >/dev/null)
 status=$?

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -170,16 +170,15 @@ git -C "$REPO_ROOT" fetch origin main --quiet 2>/dev/null || true
 CURRENT_BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
 if [ "$CURRENT_BRANCH" != "main" ]; then
     echo "Checking for merge conflicts with main..."
-    if ! git -C "$REPO_ROOT" merge-tree --write-tree "$BASE_BRANCH" HEAD >/dev/null 2>&1; then
-        echo ""
-        echo "Branch has merge conflicts with main!"
-        echo ""
-        echo "Resolve conflicts before pushing:"
-        echo "  git fetch origin main"
-        echo "  git merge origin/main   # or: git rebase origin/main"
-        exit 1
+    # Lives in the repo rather than inline so it is testable, and so a fix to
+    # it reaches everyone without a re-run of `mise run setup_hooks`. Skipped
+    # when absent, e.g. on a branch predating it.
+    MERGEABLE_CHECK="$REPO_ROOT/scripts/check_branch_mergeable.sh"
+    if [ -x "$MERGEABLE_CHECK" ]; then
+        bash "$MERGEABLE_CHECK" "$BASE_BRANCH" || exit 1
+    else
+        echo "Skipped: scripts/check_branch_mergeable.sh not present"
     fi
-    echo "No merge conflicts with main"
     echo ""
 
     # Validate branch name matches semantic PR title convention

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -174,7 +174,11 @@ if [ "$CURRENT_BRANCH" != "main" ]; then
     # it reaches everyone without a re-run of `mise run setup_hooks`. Skipped
     # when absent, e.g. on a branch predating it.
     MERGEABLE_CHECK="$REPO_ROOT/scripts/check_branch_mergeable.sh"
-    if [ -x "$MERGEABLE_CHECK" ]; then
+    # Invoked through `bash`, so it needs to be present and readable, not
+    # executable. Testing `-x` would skip the whole check on a checkout that
+    # lost the +x bit (Windows, a mode-stripped copy) and let a genuine
+    # conflict through — the check must fail closed, not open.
+    if [ -f "$MERGEABLE_CHECK" ]; then
         bash "$MERGEABLE_CHECK" "$BASE_BRANCH" || exit 1
     else
         echo "Skipped: scripts/check_branch_mergeable.sh not present"


### PR DESCRIPTION
## Description

Pushing from a shallow clone failed with **"Branch has merge conflicts with main!"** when there were no conflicts at all, and the remedy it printed could not have helped.

The pre-push hook asked `git merge-tree --write-tree` and treated any non-zero exit as conflicts. That command actually reports three outcomes:

| exit | meaning |
|---|---|
| 0 | merges cleanly |
| 1 | genuine conflicts |
| 128 | fatal — it could not answer |

In a shallow clone `origin/main` and the branch are grafted at different boundaries, so they share no visible ancestor and merge-tree exits **128** with `refusing to merge unrelated histories`. That is not a conflict, and the advice the hook printed — merge or rebase — cannot fix it. Deepening can.

This branches on the exit code. A genuine conflict still blocks and still says so.

**The one judgment call.** An unanswerable check now *warns and continues* instead of blocking. Three reasons: it is not evidence of a conflict, GitHub reports mergeability on the pull request anyway, and the surrounding hook already takes exactly this stance for a failed `git fetch` (`fetch origin main --quiet 2>/dev/null || true`). If you would rather it keep blocking, that is a one-line change and I am happy to make it — the important half is that the message is now true and the remedy usable.

The check moves into `scripts/check_branch_mergeable.sh` for two reasons: it can be tested against real repositories, and a later fix to it reaches everyone without another `mise run setup_hooks`. Hooks are generated copies, so inline logic goes stale silently. The hook skips the check when the script is absent, which is what a branch predating this sees.

**⚠️ This changes hook behaviour, so re-run `cd mobile && mise run setup_hooks`.** Until you do, a stale hook keeps reporting a shallow clone as a merge conflict.

**Related Issue:** Relates to #8724 — found while pushing a review fix there, where this blocked the push for ~15 minutes.

## Out of Scope

The `document_ignores` and rebase work from #8724 stays on that branch. This PR touches only the hook, its new script, its tests, and the doc.

Not addressed here: `git fetch --unshallow` on this repo is slow enough to die on a connection reset (11 minutes, `RPC failed; curl 56`). `--deepen` is the practical remedy and is what the hook now suggests. Whether the repo should be cloned deeper by default is a separate question.

## Verification

- `python3 -m unittest discover -s .github/scripts/tests` — 86 tests, all pass (5 new).
- **Mutation-checked**: reverting `check_branch_mergeable.sh` to the old any-non-zero-is-a-conflict form turns 3 of the 5 new tests red, so they pin the behaviour rather than restating it.
- Generated-hook check: ran `install-hooks.sh` in a throwaway clone, confirmed `bash -n .git/hooks/pre-push` is clean and the delegation is present.
- `bash -n` on both shell scripts.
- No Dart touched, so `flutter analyze` is not implicated; the pre-push hook agreed and skipped its Dart checks.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Build configuration change
- [x] 📝 Documentation
