### PR TITLE
test(video-player): stop one test file's fake video player answering the next file's calls

### DIFF
--- a/mobile/test/helpers/divine_video_player_channel.dart
+++ b/mobile/test/helpers/divine_video_player_channel.dart
@@ -1,0 +1,48 @@
+// ABOUTME: Installs paired method and event mocks for a native video player.
+// ABOUTME: Keeps per-player channel setup and teardown atomic across tests.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Installs the method and event channels for one mocked native video player.
+///
+/// Both handlers are cleared automatically when the current test scope ends.
+void installMockDivineVideoPlayer({
+  int playerId = 0,
+  Future<Object?> Function(MethodCall call)? onMethodCall,
+  MockStreamHandler? streamHandler,
+}) {
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  final methodChannel = MethodChannel(
+    'divine_video_player/player_$playerId',
+  );
+  final eventChannel = EventChannel(
+    'divine_video_player/player_$playerId/events',
+  );
+
+  messenger
+    ..setMockMethodCallHandler(
+      methodChannel,
+      onMethodCall ?? (_) async => null,
+    )
+    ..setMockStreamHandler(
+      eventChannel,
+      streamHandler ?? EmptyPlayerStreamHandler(),
+    );
+
+  addTearDown(() {
+    messenger
+      ..setMockMethodCallHandler(methodChannel, null)
+      ..setMockStreamHandler(eventChannel, null);
+  });
+}
+
+/// An event handler for player tests that do not need native state updates.
+class EmptyPlayerStreamHandler extends MockStreamHandler {
+  @override
+  void onListen(Object? arguments, MockStreamHandlerEventSink events) {}
+
+  @override
+  void onCancel(Object? arguments) {}
+}

--- a/mobile/test/helpers/divine_video_player_channel_test.dart
+++ b/mobile/test/helpers/divine_video_player_channel_test.dart
@@ -12,31 +12,33 @@ void main() {
   const methodChannel = MethodChannel('divine_video_player/player_7');
   const eventChannel = EventChannel('divine_video_player/player_7/events');
 
-  test('installs the method and event handlers together', () {
-    installMockDivineVideoPlayer(playerId: 7);
+  group('installMockDivineVideoPlayer', () {
+    test('installs the method and event handlers together', () {
+      installMockDivineVideoPlayer(playerId: 7);
 
-    final messenger =
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
-    expect(
-      messenger.checkMockMessageHandler(methodChannel.name, null),
-      isFalse,
-    );
-    expect(
-      messenger.checkMockMessageHandler(eventChannel.name, null),
-      isFalse,
-    );
-  });
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      expect(
+        messenger.checkMockMessageHandler(methodChannel.name, null),
+        isFalse,
+      );
+      expect(
+        messenger.checkMockMessageHandler(eventChannel.name, null),
+        isFalse,
+      );
+    });
 
-  test('clears both handlers after the prior test', () {
-    final messenger =
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
-    expect(
-      messenger.checkMockMessageHandler(methodChannel.name, null),
-      isTrue,
-    );
-    expect(
-      messenger.checkMockMessageHandler(eventChannel.name, null),
-      isTrue,
-    );
+    test('clears both handlers after the prior test', () {
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      expect(
+        messenger.checkMockMessageHandler(methodChannel.name, null),
+        isTrue,
+      );
+      expect(
+        messenger.checkMockMessageHandler(eventChannel.name, null),
+        isTrue,
+      );
+    });
   });
 }

--- a/mobile/test/helpers/divine_video_player_channel_test.dart
+++ b/mobile/test/helpers/divine_video_player_channel_test.dart
@@ -1,0 +1,42 @@
+// ABOUTME: Verifies paired native video player mocks cannot leak across tests.
+// ABOUTME: Covers both method and event channel teardown in the shared helper.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'divine_video_player_channel.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const methodChannel = MethodChannel('divine_video_player/player_7');
+  const eventChannel = EventChannel('divine_video_player/player_7/events');
+
+  test('installs the method and event handlers together', () {
+    installMockDivineVideoPlayer(playerId: 7);
+
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    expect(
+      messenger.checkMockMessageHandler(methodChannel.name, null),
+      isFalse,
+    );
+    expect(
+      messenger.checkMockMessageHandler(eventChannel.name, null),
+      isFalse,
+    );
+  });
+
+  test('clears both handlers after the prior test', () {
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    expect(
+      messenger.checkMockMessageHandler(methodChannel.name, null),
+      isTrue,
+    );
+    expect(
+      messenger.checkMockMessageHandler(eventChannel.name, null),
+      isTrue,
+    );
+  });
+}

--- a/mobile/test/screens/video_metadata/video_metadata_preview_screen_test.dart
+++ b/mobile/test/screens/video_metadata/video_metadata_preview_screen_test.dart
@@ -118,7 +118,10 @@ void main() {
   late _PlayerEventsStreamHandler playerEvents;
   late List<Map<Object?, Object?>> setClipsArguments;
 
+  final createdPlayerIds = <int>{};
+
   setUp(() async {
+    createdPlayerIds.clear();
     SharedPreferences.setMockInitialValues({});
     prefs = await SharedPreferences.getInstance();
     playerEvents = _PlayerEventsStreamHandler();
@@ -131,6 +134,7 @@ void main() {
           if (call.method == 'create') {
             final args = call.arguments! as Map<Object?, Object?>;
             final id = args['id']! as int;
+            createdPlayerIds.add(id);
             TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
                 .setMockMethodCallHandler(
                   MethodChannel('divine_video_player/player_$id'),
@@ -155,21 +159,27 @@ void main() {
   });
 
   tearDown(() async {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(
-          const MethodChannel('divine_video_player'),
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          ..setMockMethodCallHandler(
+            const MethodChannel('divine_video_player'),
+            null,
+          );
+    // Clear exactly what `create` installed. Clearing `player_0` alone stayed
+    // matched only while every test created a single controller; a second one
+    // would leave `player_1` installed for the rest of the isolate.
+    for (final id in createdPlayerIds) {
+      messenger
+        ..setMockMethodCallHandler(
+          MethodChannel('divine_video_player/player_$id'),
+          null,
+        )
+        ..setMockStreamHandler(
+          EventChannel('divine_video_player/player_$id/events'),
           null,
         );
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(
-          const MethodChannel('divine_video_player/player_0'),
-          null,
-        );
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockStreamHandler(
-          const EventChannel('divine_video_player/player_0/events'),
-          null,
-        );
+    }
+    createdPlayerIds.clear();
   });
 
   group(VideoMetadataPreviewScreen, () {

--- a/mobile/test/widgets/library/clips_tab_test.dart
+++ b/mobile/test/widgets/library/clips_tab_test.dart
@@ -858,6 +858,13 @@ void main() {
             const MethodChannel('divine_video_player/player_0'),
             (call) async => null,
           );
+          // initialize() subscribes unconditionally, so mock the event channel
+          // rather than leaving the subscription's teardown to a
+          // fire-and-forget dispose that races the end of the test.
+          messenger.setMockStreamHandler(
+            const EventChannel('divine_video_player/player_0/events'),
+            _EmptyPlayerStreamHandler(),
+          );
           addTearDown(() {
             messenger
               ..setMockMethodCallHandler(
@@ -866,6 +873,10 @@ void main() {
               )
               ..setMockMethodCallHandler(
                 const MethodChannel('divine_video_player/player_0'),
+                null,
+              )
+              ..setMockStreamHandler(
+                const EventChannel('divine_video_player/player_0/events'),
                 null,
               );
           });
@@ -977,4 +988,12 @@ void main() {
       expect(created, isFalse);
     });
   });
+}
+
+class _EmptyPlayerStreamHandler extends MockStreamHandler {
+  @override
+  void onListen(dynamic arguments, MockStreamHandlerEventSink events) {}
+
+  @override
+  void onCancel(dynamic arguments) {}
 }

--- a/mobile/test/widgets/library/clips_tab_test.dart
+++ b/mobile/test/widgets/library/clips_tab_test.dart
@@ -27,6 +27,7 @@ import 'package:openvine/widgets/video_clip/video_clip_preview.dart';
 import 'package:openvine/widgets/video_clip/video_clip_thumbnail_card.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
+import '../../helpers/divine_video_player_channel.dart';
 import '../../helpers/go_router.dart';
 
 class _MockClipsLibraryBloc
@@ -854,31 +855,12 @@ void main() {
               return null;
             },
           );
-          messenger.setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            (call) async => null,
-          );
-          // initialize() subscribes unconditionally, so mock the event channel
-          // rather than leaving the subscription's teardown to a
-          // fire-and-forget dispose that races the end of the test.
-          messenger.setMockStreamHandler(
-            const EventChannel('divine_video_player/player_0/events'),
-            _EmptyPlayerStreamHandler(),
-          );
+          installMockDivineVideoPlayer();
           addTearDown(() {
-            messenger
-              ..setMockMethodCallHandler(
-                const MethodChannel('divine_video_player'),
-                null,
-              )
-              ..setMockMethodCallHandler(
-                const MethodChannel('divine_video_player/player_0'),
-                null,
-              )
-              ..setMockStreamHandler(
-                const EventChannel('divine_video_player/player_0/events'),
-                null,
-              );
+            messenger.setMockMethodCallHandler(
+              const MethodChannel('divine_video_player'),
+              null,
+            );
           });
 
           final mockGoRouter = MockGoRouter();
@@ -988,12 +970,4 @@ void main() {
       expect(created, isFalse);
     });
   });
-}
-
-class _EmptyPlayerStreamHandler extends MockStreamHandler {
-  @override
-  void onListen(dynamic arguments, MockStreamHandlerEventSink events) {}
-
-  @override
-  void onCancel(dynamic arguments) {}
 }

--- a/mobile/test/widgets/video_clip/video_clip_preview_test.dart
+++ b/mobile/test/widgets/video_clip/video_clip_preview_test.dart
@@ -23,6 +23,7 @@ import 'package:openvine/widgets/video_clip/video_clip_preview.dart';
 import 'package:openvine/widgets/video_clip/video_clip_thumbnail_card.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
+import '../../helpers/divine_video_player_channel.dart';
 import '../../helpers/go_router.dart';
 
 class _MockGallerySaveService extends Mock implements GallerySaveService {}
@@ -138,18 +139,7 @@ void main() {
     });
 
     testWidgets('exposes an action to close the video preview', (tester) async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            (call) async => null,
-          );
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              null,
-            );
-      });
+      installMockDivineVideoPlayer();
 
       await tester.pumpWidget(buildTestWidget());
       final l10n = lookupAppLocalizations(const Locale('en'));
@@ -169,18 +159,7 @@ void main() {
     });
 
     testWidgets('renders $DivineVideoPlayer and save button', (tester) async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            (call) async => null,
-          );
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              null,
-            );
-      });
+      installMockDivineVideoPlayer();
 
       await tester.pumpWidget(buildTestWidget());
       await tester.pump(const Duration(milliseconds: 100));
@@ -205,36 +184,14 @@ void main() {
       final videoFile = File('${tempDir.path}/video.mp4')
         ..writeAsBytesSync(const [0]);
       Map<Object?, Object?>? setClipsArguments;
-      final messenger =
-          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            ..setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              (call) async {
-                if (call.method == 'setClips') {
-                  setClipsArguments = call.arguments! as Map<Object?, Object?>;
-                }
-                return null;
-              },
-            )
-            // initialize() subscribes unconditionally, so mock the event
-            // channel the way the sibling hero test below does rather than
-            // leaving the subscription's teardown to a fire-and-forget
-            // dispose that races the end of the test.
-            ..setMockStreamHandler(
-              const EventChannel('divine_video_player/player_0/events'),
-              _EmptyPlayerStreamHandler(),
-            );
-      addTearDown(() {
-        messenger
-          ..setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            null,
-          )
-          ..setMockStreamHandler(
-            const EventChannel('divine_video_player/player_0/events'),
-            null,
-          );
-      });
+      installMockDivineVideoPlayer(
+        onMethodCall: (call) async {
+          if (call.method == 'setClips') {
+            setClipsArguments = call.arguments! as Map<Object?, Object?>;
+          }
+          return null;
+        },
+      );
 
       await tester.pumpWidget(
         buildTestWidget(
@@ -251,18 +208,7 @@ void main() {
     testWidgets('renders delete button when onDelete is provided', (
       tester,
     ) async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            (call) async => null,
-          );
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              null,
-            );
-      });
+      installMockDivineVideoPlayer();
 
       await tester.pumpWidget(buildTestWidget(onDelete: () {}));
       await tester.pump(const Duration(milliseconds: 100));
@@ -276,18 +222,7 @@ void main() {
     });
 
     testWidgets('hides delete button when onDelete is null', (tester) async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            (call) async => null,
-          );
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              null,
-            );
-      });
+      installMockDivineVideoPlayer();
 
       await tester.pumpWidget(buildTestWidget());
       await tester.pump(const Duration(milliseconds: 100));
@@ -301,18 +236,7 @@ void main() {
     });
 
     testWidgets('renders placeholder with progress indicator', (tester) async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            (call) async => null,
-          );
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              null,
-            );
-      });
+      installMockDivineVideoPlayer();
 
       await tester.pumpWidget(buildTestWidget());
       await tester.pump(const Duration(milliseconds: 100));
@@ -329,27 +253,9 @@ void main() {
       final thumbnailFile = File('${tempDir.path}/thumbnail.jpg')
         ..writeAsBytesSync(_transparentPngBytes);
 
-      final messenger =
-          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            ..setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              (call) async => null,
-            )
-            ..setMockStreamHandler(
-              const EventChannel('divine_video_player/player_0/events'),
-              _FirstFrameStreamHandler(),
-            );
-      addTearDown(() {
-        messenger
-          ..setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            null,
-          )
-          ..setMockStreamHandler(
-            const EventChannel('divine_video_player/player_0/events'),
-            null,
-          );
-      });
+      installMockDivineVideoPlayer(
+        streamHandler: _FirstFrameStreamHandler(),
+      );
 
       final clip = testClip.copyWith(
         video: EditorVideo.file(videoFile.path),
@@ -613,18 +519,7 @@ void main() {
         WidgetTester tester,
         GallerySaveResult result,
       ) async {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              (call) async => null,
-            );
-        addTearDown(() {
-          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-              .setMockMethodCallHandler(
-                const MethodChannel('divine_video_player/player_0'),
-                null,
-              );
-        });
+        installMockDivineVideoPlayer();
 
         when(
           () => mockGallerySaveService.saveVideoToGallery(any()),
@@ -767,11 +662,3 @@ const _transparentPngBytes = <int>[
   0x60,
   0x82,
 ];
-
-class _EmptyPlayerStreamHandler extends MockStreamHandler {
-  @override
-  void onListen(dynamic arguments, MockStreamHandlerEventSink events) {}
-
-  @override
-  void onCancel(dynamic arguments) {}
-}

--- a/mobile/test/widgets/video_clip/video_clip_preview_test.dart
+++ b/mobile/test/widgets/video_clip/video_clip_preview_test.dart
@@ -205,22 +205,35 @@ void main() {
       final videoFile = File('${tempDir.path}/video.mp4')
         ..writeAsBytesSync(const [0]);
       Map<Object?, Object?>? setClipsArguments;
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            (call) async {
-              if (call.method == 'setClips') {
-                setClipsArguments = call.arguments! as Map<Object?, Object?>;
-              }
-              return null;
-            },
-          );
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            ..setMockMethodCallHandler(
               const MethodChannel('divine_video_player/player_0'),
-              null,
+              (call) async {
+                if (call.method == 'setClips') {
+                  setClipsArguments = call.arguments! as Map<Object?, Object?>;
+                }
+                return null;
+              },
+            )
+            // initialize() subscribes unconditionally, so mock the event
+            // channel the way the sibling hero test below does rather than
+            // leaving the subscription's teardown to a fire-and-forget
+            // dispose that races the end of the test.
+            ..setMockStreamHandler(
+              const EventChannel('divine_video_player/player_0/events'),
+              _EmptyPlayerStreamHandler(),
             );
+      addTearDown(() {
+        messenger
+          ..setMockMethodCallHandler(
+            const MethodChannel('divine_video_player/player_0'),
+            null,
+          )
+          ..setMockStreamHandler(
+            const EventChannel('divine_video_player/player_0/events'),
+            null,
+          );
       });
 
       await tester.pumpWidget(
@@ -754,3 +767,11 @@ const _transparentPngBytes = <int>[
   0x60,
   0x82,
 ];
+
+class _EmptyPlayerStreamHandler extends MockStreamHandler {
+  @override
+  void onListen(dynamic arguments, MockStreamHandlerEventSink events) {}
+
+  @override
+  void onCancel(dynamic arguments) {}
+}

--- a/mobile/test/widgets/video_editor/chroma_key/chroma_key_backdrop_test.dart
+++ b/mobile/test/widgets/video_editor/chroma_key/chroma_key_backdrop_test.dart
@@ -84,6 +84,14 @@ void main() {
                 return null;
               },
             );
+            // initialize() subscribes unconditionally, so mock the event
+            // channel the way every sibling test does rather than leaving the
+            // subscription's teardown to a fire-and-forget dispose that races
+            // the end of the test.
+            messenger.setMockStreamHandler(
+              const EventChannel('divine_video_player/player_0/events'),
+              _EmptyPlayerStreamHandler(),
+            );
             return <String, Object?>{'textureId': 1};
           }
           return null;
@@ -97,6 +105,10 @@ void main() {
           )
           ..setMockMethodCallHandler(
             const MethodChannel('divine_video_player/player_0'),
+            null,
+          )
+          ..setMockStreamHandler(
+            const EventChannel('divine_video_player/player_0/events'),
             null,
           );
       });
@@ -119,4 +131,12 @@ void main() {
       );
     });
   });
+}
+
+class _EmptyPlayerStreamHandler extends MockStreamHandler {
+  @override
+  void onListen(dynamic arguments, MockStreamHandlerEventSink events) {}
+
+  @override
+  void onCancel(dynamic arguments) {}
 }

--- a/mobile/test/widgets/video_editor/chroma_key/chroma_key_backdrop_test.dart
+++ b/mobile/test/widgets/video_editor/chroma_key/chroma_key_backdrop_test.dart
@@ -10,6 +10,8 @@ import 'package:openvine/widgets/video_editor/chroma_key/chroma_key_backdrop.dar
 import 'package:pro_video_editor/pro_video_editor.dart'
     show ChromaKey, EditorLayerImage;
 
+import '../../../helpers/divine_video_player_channel.dart';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -69,48 +71,30 @@ void main() {
     ) async {
       DivineVideoPlayerController.resetIdCounterForTesting();
       Map<Object?, Object?>? setClipsArguments;
+      installMockDivineVideoPlayer(
+        onMethodCall: (call) async {
+          if (call.method == 'setClips') {
+            setClipsArguments = call.arguments! as Map<Object?, Object?>;
+          }
+          return null;
+        },
+      );
       final messenger =
           TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
       messenger.setMockMethodCallHandler(
         const MethodChannel('divine_video_player'),
         (call) async {
           if (call.method == 'create') {
-            messenger.setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              (call) async {
-                if (call.method == 'setClips') {
-                  setClipsArguments = call.arguments! as Map<Object?, Object?>;
-                }
-                return null;
-              },
-            );
-            // initialize() subscribes unconditionally, so mock the event
-            // channel the way every sibling test does rather than leaving the
-            // subscription's teardown to a fire-and-forget dispose that races
-            // the end of the test.
-            messenger.setMockStreamHandler(
-              const EventChannel('divine_video_player/player_0/events'),
-              _EmptyPlayerStreamHandler(),
-            );
             return <String, Object?>{'textureId': 1};
           }
           return null;
         },
       );
       addTearDown(() {
-        messenger
-          ..setMockMethodCallHandler(
-            const MethodChannel('divine_video_player'),
-            null,
-          )
-          ..setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            null,
-          )
-          ..setMockStreamHandler(
-            const EventChannel('divine_video_player/player_0/events'),
-            null,
-          );
+        messenger.setMockMethodCallHandler(
+          const MethodChannel('divine_video_player'),
+          null,
+        );
       });
 
       await pump(
@@ -131,12 +115,4 @@ void main() {
       );
     });
   });
-}
-
-class _EmptyPlayerStreamHandler extends MockStreamHandler {
-  @override
-  void onListen(dynamic arguments, MockStreamHandlerEventSink events) {}
-
-  @override
-  void onCancel(dynamic arguments) {}
 }

--- a/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail_test.dart
@@ -22,6 +22,8 @@ import 'package:openvine/widgets/video_metadata/modes/classic/video_metadata_cla
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../../../helpers/divine_video_player_channel.dart';
+
 void main() {
   group(VideoMetadataClassicPreviewThumbnail, () {
     late DivineVideoClip testClip;
@@ -320,47 +322,32 @@ void _registerMockPlayerChannel(
   List<Map<Object?, Object?>>? setClipsArguments,
 }) {
   const globalChannel = MethodChannel('divine_video_player');
-  // Player ID resets via resetIdCounterForTesting in setUp, so first is 0.
-  const playerChannel = MethodChannel('divine_video_player/player_0');
   final messenger =
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  // Player ID resets via resetIdCounterForTesting in setUp, so first is 0.
+  installMockDivineVideoPlayer(
+    onMethodCall: (call) async {
+      methodCalls.add(call.method);
+      if (call.method == 'setClips') {
+        setClipsArguments?.add(
+          call.arguments! as Map<Object?, Object?>,
+        );
+      }
+      return null;
+    },
+  );
 
   messenger.setMockMethodCallHandler(globalChannel, (call) async {
     methodCalls.add(call.method);
     if (call.method == 'create') {
-      // Register the per-player channel on first create.
-      messenger.setMockMethodCallHandler(playerChannel, (call) async {
-        methodCalls.add(call.method);
-        if (call.method == 'setClips') {
-          setClipsArguments?.add(
-            call.arguments! as Map<Object?, Object?>,
-          );
-        }
-        return null;
-      });
-
-      // Also register an empty event channel so the player stream works.
-      messenger.setMockStreamHandler(
-        const EventChannel('divine_video_player/player_0/events'),
-        _EmptyStreamHandler(),
-      );
       return <String, dynamic>{'textureId': 1};
     }
     return null;
   });
 
-  // The whole app suite runs in one isolate, so a handler left installed here
-  // is live for every file that runs afterwards — and this one appends into a
-  // per-test list captured by the closure above, so a leaked handler writes
-  // into a stale list instead of returning null.
   addTearDown(() {
-    messenger
-      ..setMockMethodCallHandler(globalChannel, null)
-      ..setMockMethodCallHandler(playerChannel, null)
-      ..setMockStreamHandler(
-        const EventChannel('divine_video_player/player_0/events'),
-        null,
-      );
+    messenger.setMockMethodCallHandler(globalChannel, null);
   });
 }
 
@@ -380,12 +367,4 @@ class _MockVideoEditorNotifier extends VideoEditorNotifier {
 
   @override
   VideoEditorProviderState build() => _state;
-}
-
-class _EmptyStreamHandler extends MockStreamHandler {
-  @override
-  void onListen(dynamic arguments, MockStreamHandlerEventSink events) {}
-
-  @override
-  void onCancel(dynamic arguments) {}
 }

--- a/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail_test.dart
@@ -348,6 +348,20 @@ void _registerMockPlayerChannel(
     }
     return null;
   });
+
+  // The whole app suite runs in one isolate, so a handler left installed here
+  // is live for every file that runs afterwards — and this one appends into a
+  // per-test list captured by the closure above, so a leaked handler writes
+  // into a stale list instead of returning null.
+  addTearDown(() {
+    messenger
+      ..setMockMethodCallHandler(globalChannel, null)
+      ..setMockMethodCallHandler(playerChannel, null)
+      ..setMockStreamHandler(
+        const EventChannel('divine_video_player/player_0/events'),
+        null,
+      );
+  });
 }
 
 class _MockClipManagerNotifier extends ClipManagerNotifier {


### PR DESCRIPTION
## Problem

Under `very_good test --optimization`, app tests in each shard share one isolate. A mock `divine_video_player` handler left installed by one test therefore remains live for later files. One classic-thumbnail helper demonstrably leaked its global, per-player, and event handlers; several other tests installed only half of the per-player channel pair, and one preview-screen teardown assumed only `player_0` could exist.

This is test-only and does not change app behavior.

## Why this fix

- The classic-thumbnail helper now tears down everything it installs.
- Preview-screen teardown records every player id returned by `create` and clears the matching method and event channels.
- A shared test helper installs each per-player MethodChannel and EventChannel together and registers their teardown together.
- All affected controller-building tests use that helper, including every matching site in `video_clip_preview_test.dart`.
- A regression test proves both handlers are removed before the next test runs.

This makes the previously inconsistent setup atomic instead of relying on fire-and-forget controller disposal to win a race at test end.

**Related issue:** Closes #8900

## Deliberately unchanged

The merged-isolate guard does not yet discover dynamically named `divine_video_player/player_<id>` channels because they have no canonical app-wide handler to restore. Follow-up #8925 tracks that guard design and regression coverage.

## Verification

- `flutter test` across the new helper test and all five affected suites: 76 tests passed
- Regression test red/green check: fails when helper teardown is removed, passes when restored
- `flutter analyze test`
- `bash scripts/check_process_global_mutations.sh`
- `bash scripts/check_shared_channel_overrides.sh`
- Pinned formatter and pre-push checks

## Type of Change

- [x] 🛠️ Bug fix (non-breaking test change)