### PR TITLE
fix(video-editor): stop the export progress bar reading 0% through a healthy render

### DIFF
--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -88,10 +88,14 @@ final videoEditorProvider =
 /// [VideoEditorRenderService] directly, keeping the UI/service boundary clean.
 final StreamProvider<ProgressModel> videoEditorCompositeProgressProvider =
     StreamProvider.autoDispose<ProgressModel>((ref) {
-      // draftId is set once during initialization and does not change within a
-      // session, so a one-time read is sufficient.
-      final draftId = ref.read(videoEditorProvider.notifier).draftId;
-      return VideoEditorRenderService.compositeProgressStreamById(draftId);
+      // draftId is NOT fixed for the session: it has a setter and is
+      // reassigned at three sites in this file. Hand the stream a callback so
+      // the filter follows the current id instead of the one this provider
+      // happened to see first (#8796).
+      final notifier = ref.read(videoEditorProvider.notifier);
+      return VideoEditorRenderService.compositeProgressStreamById(
+        () => notifier.draftId,
+      );
     });
 
 /// Manages video editor state and operations.

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -151,9 +151,18 @@ class VideoEditorRenderService {
     return (normalizedClipCount * 0.01).clamp(0.05, 0.10);
   }
 
-  static Stream<ProgressModel> compositeProgressStreamById(String taskId) {
+  /// Composite render + proof progress for whatever [taskId] resolves to.
+  ///
+  /// [taskId] is a callback re-read per event rather than a value captured
+  /// once, because a draft id can be reassigned mid-session. A filter pinned
+  /// to the id the caller first saw goes silent while the export publishes
+  /// under the new one, which reads as a steady 0% through a healthy render
+  /// (#8796).
+  static Stream<ProgressModel> compositeProgressStreamById(
+    String Function() taskId,
+  ) {
     return _compositeProgressController.stream.where(
-      (progress) => progress.id == taskId,
+      (progress) => progress.id == taskId(),
     );
   }
 

--- a/mobile/lib/widgets/video_editor/video_editor_processing_overlay.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_processing_overlay.dart
@@ -59,15 +59,19 @@ class VideoEditorProcessingOverlay extends StatelessWidget {
               RepaintBoundary(
                 child: Consumer(
                   builder: (context, ref, _) {
-                    final progress =
-                        (ref
-                                    .watch(videoEditorCompositeProgressProvider)
-                                    .asData
-                                    ?.value
-                                    .progress ??
-                                0)
-                            .clamp(0.0, 1.0);
-                    return PartialCircleSpinner(progress: progress);
+                    // No reading yet is not 0% — collapsing the two is what
+                    // made a healthy export read as a hang (#8796). The
+                    // indicator above already says work is in flight, so show
+                    // the ring only once there is a real value to draw.
+                    final reading = ref
+                        .watch(videoEditorCompositeProgressProvider)
+                        .asData
+                        ?.value
+                        .progress;
+                    if (reading == null) return const SizedBox.shrink();
+                    return PartialCircleSpinner(
+                      progress: reading.clamp(0.0, 1.0),
+                    );
                   },
                 ),
               ),

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -1696,6 +1696,92 @@ void main() {
     });
   });
 
+  group('videoEditorCompositeProgressProvider', () {
+    late ProviderContainer container;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('keeps reporting progress after the draft id is reassigned', () async {
+      final notifier = container.read(videoEditorProvider.notifier)
+        ..setDraftId('draft-before');
+
+      final readings = <double>[];
+      final subscription = container.listen(
+        videoEditorCompositeProgressProvider,
+        (_, next) {
+          final value = next.asData?.value;
+          if (value != null) readings.add(value.progress);
+        },
+      );
+      addTearDown(subscription.close);
+
+      VideoEditorRenderService.emitCompositeProgressForTesting(
+        taskId: 'draft-before',
+        progress: 0.25,
+      );
+      await pumpEventQueue();
+      expect(
+        readings,
+        equals([0.25]),
+        reason:
+            'Without a first reading under the original id the assertion '
+            'below could pass on an provider that reports nothing at all.',
+      );
+
+      notifier.setDraftId('draft-after');
+      VideoEditorRenderService.emitCompositeProgressForTesting(
+        taskId: 'draft-after',
+        progress: 0.5,
+      );
+      await pumpEventQueue();
+
+      expect(
+        readings,
+        equals([0.25, 0.5]),
+        reason:
+            'A filter pinned to the id this provider first saw goes silent '
+            'when the export publishes under a new draft id, which the '
+            'overlay cannot tell apart from a genuine 0% (#8796).',
+      );
+    });
+
+    test('ignores progress published under a different draft id', () async {
+      container.read(videoEditorProvider.notifier).setDraftId('mine');
+
+      final readings = <double>[];
+      final subscription = container.listen(
+        videoEditorCompositeProgressProvider,
+        (_, next) {
+          final value = next.asData?.value;
+          if (value != null) readings.add(value.progress);
+        },
+      );
+      addTearDown(subscription.close);
+
+      VideoEditorRenderService.emitCompositeProgressForTesting(
+        taskId: 'someone-elses-draft',
+        progress: 0.9,
+      );
+      VideoEditorRenderService.emitCompositeProgressForTesting(
+        taskId: 'mine',
+        progress: 0.1,
+      );
+      await pumpEventQueue();
+
+      expect(readings, equals([0.1]));
+    });
+  });
+
   group('getActiveDraft', () {
     late ProviderContainer container;
 

--- a/mobile/test/services/video_editor/video_editor_render_service_progress_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_progress_test.dart
@@ -208,7 +208,7 @@ void main() {
 
         final progressSubscription =
             VideoEditorRenderService.compositeProgressStreamById(
-              taskId,
+              () => taskId,
             ).listen((progress) => progressValues.add(progress.progress));
         addTearDown(progressSubscription.cancel);
 
@@ -314,7 +314,7 @@ void main() {
 
         final progressSubscription =
             VideoEditorRenderService.compositeProgressStreamById(
-              taskId,
+              () => taskId,
             ).listen((progress) => progressValues.add(progress.progress));
         addTearDown(progressSubscription.cancel);
 

--- a/mobile/test/widgets/video_editor/video_editor_processing_overlay_test.dart
+++ b/mobile/test/widgets/video_editor/video_editor_processing_overlay_test.dart
@@ -1,0 +1,74 @@
+// ABOUTME: Widget tests for VideoEditorProcessingOverlay's progress reading.
+// ABOUTME: Pins that "no reading yet" is not rendered as a genuine 0%.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
+import 'package:openvine/widgets/video_editor/video_editor_processing_overlay.dart';
+import 'package:pro_video_editor/pro_video_editor.dart' show EditorVideo;
+
+import '../../helpers/test_provider_overrides.dart';
+
+void main() {
+  final clip = DivineVideoClip(
+    id: 'clip-1',
+    video: EditorVideo.file('/tmp/clip.mp4'),
+    duration: const Duration(seconds: 3),
+    recordedAt: DateTime(2026),
+    targetAspectRatio: model.AspectRatio.vertical,
+    originalAspectRatio: 9 / 16,
+  );
+
+  group(VideoEditorProcessingOverlay, () {
+    group('progress reading', () {
+      testWidgets('draws no progress ring before the first reading arrives', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          testMaterialApp(
+            home: VideoEditorProcessingOverlay(clip: clip, isProcessing: true),
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          find.byType(BrandedLoadingIndicator),
+          findsOneWidget,
+          reason: 'The overlay must still say work is in flight.',
+        );
+        expect(
+          find.byType(PartialCircleSpinner),
+          findsNothing,
+          reason:
+              'A ring drawn at 0% before any reading exists is what made a '
+              'healthy export read as a hang (#8796).',
+        );
+      });
+
+      testWidgets('draws the ring once a reading arrives', (tester) async {
+        await tester.pumpWidget(
+          testMaterialApp(
+            home: VideoEditorProcessingOverlay(clip: clip, isProcessing: true),
+          ),
+        );
+        await tester.pump();
+
+        VideoEditorRenderService.emitCompositeProgressForTesting(
+          taskId: VideoEditorConstants.autoSaveId,
+          progress: 0.4,
+        );
+        await tester.pump();
+        await tester.pump();
+
+        final spinner = tester.widget<PartialCircleSpinner>(
+          find.byType(PartialCircleSpinner),
+        );
+        expect(spinner.progress, closeTo(0.4, 1e-9));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

The processing overlay could sit at a steady 0% for the whole of an export that was running perfectly normally. That is not cosmetic. It is what sent the first diagnosis of #8488 looking for a blocking `await` that did not exist, and it would mislead the next investigation the same way.

Two things combined to produce it.

`videoEditorCompositeProgressProvider` read the draft id once and filtered the progress stream on that value, under a comment claiming the id "is set once during initialization and does not change within a session". The comment was wrong: `draftId` has a setter and is reassigned at three sites in the same file. Once it changed, the filter stayed pinned to the old id while the export published under the new one, and the provider went silent. The stream now takes a callback and re-reads the id per event, so the filter follows the draft rather than a snapshot of it.

The overlay then could not tell that apart from real progress, because it collapsed "no reading" and "zero" into the same render with `?? 0`. It now draws the ring only once a reading exists. Nothing is lost while the first value is on its way — the branded indicator directly above it already says work is in flight.

**Related Issue:** Closes #8796

## Out of Scope

The two other paths the issue names as legitimately reading 0% — `_analyzeClips` running before any encode starts, and `_renderNormalizedClip` reporting under a different task id. Both are real, but each is a change to what the export emits rather than to how the reading is resolved, and `video_editor_render_service.dart` is 40 lines under the 1500-line service ceiling.

## Verification

- Provider test that reassigns the draft id mid-stream: red on the old implementation, where progress stops at the first reading
- Widget test that no ring is drawn before the first reading, and that it appears with the right value after: red when the `?? 0` is restored
- `flutter test test/providers/video_editor_provider_test.dart` (134 pass), plus the render-service progress suite and the new overlay suite
- `bash scripts/check_service_god_file_ceiling.sh` OK
- `flutter analyze lib test` clean, `dart format` clean


## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
