### PR TITLE
fix(proof): stop backfilling clip proofs nothing reads yet

### DIFF
--- a/mobile/lib/services/native_proofmode_service.dart
+++ b/mobile/lib/services/native_proofmode_service.dart
@@ -37,6 +37,29 @@ class NativeProofModeService {
   @visibleForTesting
   static C2paSigningService Function()? c2paSigningServiceFactoryOverride;
 
+  /// Whether a clip that arrives without its own attestation gets one
+  /// generated before the final combined proof is built.
+  ///
+  /// **Temporarily off** while the combined proof described in [proofFile]'s
+  /// TODO is being implemented. Until that lands, each backfill costs a
+  /// full-file SHA-256, a full C2PA re-sign and a native ProofMode pass for a
+  /// result nothing reads.
+  ///
+  /// Switching it off costs almost nothing: a recorded clip is already
+  /// attested at record time, so the per-clip data a combined proof will read
+  /// is present either way. Only the gap case loses something — a clip that
+  /// reaches render without proof cannot be referenced by a later ingredient
+  /// chain.
+  ///
+  /// Keeping that gap-fill is not free either: it runs through the C2PA
+  /// re-sign, which replaces the user's original recording on disk (#8799).
+  /// Resolve that first, then flip this to `true` and delete the constant in
+  /// the same change that starts reading the per-clip data (#8798).
+  ///
+  /// The [proofFile] `clips` and `editorStateHistory` parameters stay as they
+  /// are: `clips` is exactly the list a combined proof draws from.
+  static const bool clipLevelProofGenerationEnabled = false;
+
   /// Generate native ProofMode proof for a video file.
   ///
   /// Returns [NativeProofData] if proof generation succeeds, null otherwise.
@@ -70,7 +93,13 @@ class NativeProofModeService {
 
     try {
       // TODO(n8fr8): Incorporate clip-level proof data into the final
-      // combined proof. Each clip now carries its own attestation:
+      // combined proof. Each clip now carries its own attestation.
+      //
+      // Until this lands, [clipLevelProofGenerationEnabled] is false, so a
+      // clip arriving here without proof is not backfilled (#8798). Recorded
+      // clips are unaffected — they are attested at record time — but a clip
+      // that slipped through unattested has nothing to reference, so see
+      // #8799 before flipping that constant back.
       //
       // Access per-clip data via the [clips] parameter:
       //   for (final clip in clips ?? []) {

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -486,17 +486,32 @@ class VideoEditorRenderService {
     return proofData != null ? jsonEncode(proofData) : null;
   }
 
-  /// Ensures every clip has a [proofManifestJson].
+  /// Fills in a [proofManifestJson] for clips that arrived without one.
   ///
   /// Clips that already have proof data are returned as-is. For clips without
   /// proof, [NativeProofModeService.proofFile] is called on the clip's video
   /// file and the clip is updated with the result.
+  ///
+  /// **Currently a pass-through.**
+  /// [NativeProofModeService.clipLevelProofGenerationEnabled] is `false`, so
+  /// nothing is generated and every clip is returned unchanged. A recorded
+  /// clip is attested at record time, so in the normal case the list handed to
+  /// `proofFile` is exactly what it would have been; only a clip that reached
+  /// render unattested stays that way. The per-clip progress tick runs either
+  /// way, so the export's proof-phase budget resolves in the same number of
+  /// steps. See that constant for why, and for what has to be resolved before
+  /// it flips back.
   static Future<List<DivineVideoClip>> _ensureClipProofs(
     List<DivineVideoClip> clips, {
     VoidCallback? onClipProcessed,
   }) async {
     final result = <DivineVideoClip>[];
     for (final clip in clips) {
+      if (!NativeProofModeService.clipLevelProofGenerationEnabled) {
+        result.add(clip);
+        onClipProcessed?.call();
+        continue;
+      }
       if (clip.proofManifestJson != null) {
         result.add(clip);
         onClipProcessed?.call();

--- a/mobile/test/services/video_editor/ensure_clip_proofs_test.dart
+++ b/mobile/test/services/video_editor/ensure_clip_proofs_test.dart
@@ -1,244 +1,144 @@
-// ABOUTME: Tests for the clip proof backfill logic used by render service
-// ABOUTME: Validates the proof attestation contract for clip collections
+// ABOUTME: Tests the clip proof pass-through in VideoEditorRenderService
+// ABOUTME: Pins that every clip still reaches the combined proof unchanged
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model;
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/services/native_proofmode_service.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
-/// Replicates the _ensureClipProofs logic for testable unit verification.
-///
-/// In production, [NativeProofModeService.proofFile] is called for clips
-/// missing proof. Here we simulate the outcome to validate the contract:
-/// - Clips with existing proof are passed through unchanged.
-/// - Clips without proof receive generated attestation data.
-/// - Clips without a video file are passed through unchanged.
-List<DivineVideoClip> ensureClipProofsSimulated(
-  List<DivineVideoClip> clips, {
-  required Map<String, dynamic> Function(String clipId) proofGenerator,
-}) {
-  final result = <DivineVideoClip>[];
-  for (final clip in clips) {
-    if (clip.proofManifestJson != null) {
-      result.add(clip);
-      continue;
-    }
-
-    final videoFile = clip.requireVideo.file;
-    if (videoFile == null) {
-      result.add(clip);
-      continue;
-    }
-
-    final proofData = proofGenerator(clip.id);
-    result.add(clip.copyWith(proofManifestJson: jsonEncode(proofData)));
-  }
-  return result;
+DivineVideoClip _createClip(int index, {String? proofManifestJson}) {
+  return DivineVideoClip(
+    id: 'clip-$index',
+    video: EditorVideo.file('${Directory.systemTemp.path}/clip-$index.mp4'),
+    duration: const Duration(seconds: 2),
+    recordedAt: DateTime(2026, 6, 5, 12, index),
+    targetAspectRatio: model.AspectRatio.vertical,
+    originalAspectRatio: 9 / 16,
+    proofManifestJson: proofManifestJson,
+  );
 }
 
 void main() {
-  group('ensureClipProofs contract', () {
-    DivineVideoClip createClip({
-      required String id,
-      String? proofManifestJson,
-      String filePath = '/path/to/video.mp4',
-    }) {
-      return DivineVideoClip(
-        id: id,
-        video: EditorVideo.file(filePath),
-        duration: const Duration(seconds: 2),
-        recordedAt: DateTime(2025, 12, 13, 10),
-        targetAspectRatio: .vertical,
-        originalAspectRatio: 9 / 16,
-        proofManifestJson: proofManifestJson,
-      );
-    }
+  group('VideoEditorRenderService.reproofRenderedClip', () {
+    late List<List<DivineVideoClip>?> proofCallClips;
 
-    test('passes through clips that already have proof', () {
-      final clips = [
-        createClip(id: 'clip_1', proofManifestJson: '{"hash":"existing"}'),
-        createClip(id: 'clip_2', proofManifestJson: '{"hash":"also_exists"}'),
-      ];
-
-      var generatorCalled = false;
-      final result = ensureClipProofsSimulated(
-        clips,
-        proofGenerator: (_) {
-          generatorCalled = true;
-          return {'hash': 'should_not_be_used'};
-        },
-      );
-
-      expect(generatorCalled, isFalse);
-      expect(result.length, equals(2));
-      expect(result[0].proofManifestJson, equals('{"hash":"existing"}'));
-      expect(result[1].proofManifestJson, equals('{"hash":"also_exists"}'));
+    setUp(() {
+      proofCallClips = <List<DivineVideoClip>?>[];
+      NativeProofModeService.proofFileOverride =
+          (
+            File videoFile, {
+            required bool enableAdvancedCawgEmbedding,
+            creatorBindingAssertion,
+            cawgIdentityAssertion,
+            verifiedIdentityBundle,
+            clips,
+            editorStateHistory,
+          }) async {
+            proofCallClips.add(clips);
+            return const model.NativeProofData(videoHash: 'combined-hash');
+          };
     });
 
-    test('generates proof for clips missing attestation', () {
-      final clips = [createClip(id: 'clip_1'), createClip(id: 'clip_2')];
-
-      final generatedIds = <String>[];
-      final result = ensureClipProofsSimulated(
-        clips,
-        proofGenerator: (clipId) {
-          generatedIds.add(clipId);
-          return {'hash': 'generated_$clipId'};
-        },
-      );
-
-      expect(generatedIds, equals(['clip_1', 'clip_2']));
-      expect(result.length, equals(2));
-      expect(
-        result[0].proofManifestJson,
-        equals('{"hash":"generated_clip_1"}'),
-      );
-      expect(
-        result[1].proofManifestJson,
-        equals('{"hash":"generated_clip_2"}'),
-      );
+    tearDown(() {
+      NativeProofModeService.proofFileOverride = null;
     });
 
-    test('only generates proof for clips that need it', () {
-      final clips = [
-        createClip(id: 'clip_1', proofManifestJson: '{"hash":"existing"}'),
-        createClip(id: 'clip_2'),
-        createClip(id: 'clip_3', proofManifestJson: '{"hash":"also_exists"}'),
-        createClip(id: 'clip_4'),
-      ];
+    test(
+      'hands every clip to the combined proof without generating any',
+      () async {
+        // The clip-level backfill is switched off (#8798), so an unattested
+        // clip must still travel to the combined call rather than triggering
+        // a proof generation of its own.
+        final clips = [
+          _createClip(0, proofManifestJson: '{"videoHash":"clip-0-hash"}'),
+          _createClip(1),
+          _createClip(2),
+        ];
 
-      final generatedIds = <String>[];
-      final result = ensureClipProofsSimulated(
-        clips,
-        proofGenerator: (clipId) {
-          generatedIds.add(clipId);
-          return {'hash': 'backfilled_$clipId'};
-        },
+        final result = await VideoEditorRenderService.reproofRenderedClip(
+          clip: _createClip(9),
+          clips: clips,
+          editorStateHistory: const {'clips': 3},
+        );
+
+        expect(
+          NativeProofModeService.clipLevelProofGenerationEnabled,
+          isFalse,
+          reason: 'this test pins the switched-off behaviour',
+        );
+        expect(
+          proofCallClips,
+          hasLength(1),
+          reason: 'only the combined proof runs; no per-clip backfill',
+        );
+        expect(proofCallClips.single, hasLength(3));
+        expect(
+          proofCallClips.single!.map((c) => c.id),
+          equals(['clip-0', 'clip-1', 'clip-2']),
+        );
+        expect(
+          proofCallClips.single!.map((c) => c.proofManifestJson),
+          equals(['{"videoHash":"clip-0-hash"}', null, null]),
+          reason: 'clips are passed through untouched, gaps included',
+        );
+        expect(
+          result,
+          equals(
+            jsonEncode(
+              const model.NativeProofData(
+                videoHash: 'combined-hash',
+              ),
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'returns null without proofing when the clip has no video file',
+      () async {
+        final result = await VideoEditorRenderService.reproofRenderedClip(
+          clip: DivineVideoClip(
+            id: 'no-file',
+            video: EditorVideo.network('https://example.com/clip.mp4'),
+            duration: const Duration(seconds: 2),
+            recordedAt: DateTime(2026, 6, 5, 12),
+            targetAspectRatio: model.AspectRatio.vertical,
+            originalAspectRatio: 9 / 16,
+          ),
+          clips: [_createClip(0)],
+          editorStateHistory: const {},
+        );
+
+        expect(result, isNull);
+        expect(proofCallClips, isEmpty);
+      },
+    );
+
+    test('returns null when the combined proof yields nothing', () async {
+      NativeProofModeService.proofFileOverride =
+          (
+            File videoFile, {
+            required bool enableAdvancedCawgEmbedding,
+            creatorBindingAssertion,
+            cawgIdentityAssertion,
+            verifiedIdentityBundle,
+            clips,
+            editorStateHistory,
+          }) async => null;
+
+      final result = await VideoEditorRenderService.reproofRenderedClip(
+        clip: _createClip(0),
+        clips: [_createClip(0)],
+        editorStateHistory: const {},
       );
 
-      expect(generatedIds, equals(['clip_2', 'clip_4']));
-      expect(result.length, equals(4));
-      expect(result[0].proofManifestJson, equals('{"hash":"existing"}'));
-      expect(
-        result[1].proofManifestJson,
-        equals('{"hash":"backfilled_clip_2"}'),
-      );
-      expect(result[2].proofManifestJson, equals('{"hash":"also_exists"}'));
-      expect(
-        result[3].proofManifestJson,
-        equals('{"hash":"backfilled_clip_4"}'),
-      );
-    });
-
-    test('handles empty clip list', () {
-      final result = ensureClipProofsSimulated(
-        [],
-        proofGenerator: (_) => {'hash': 'unused'},
-      );
-
-      expect(result, isEmpty);
-    });
-
-    test('preserves clip order', () {
-      final clips = [
-        createClip(id: 'clip_a'),
-        createClip(id: 'clip_b', proofManifestJson: '{"hash":"b"}'),
-        createClip(id: 'clip_c'),
-      ];
-
-      final result = ensureClipProofsSimulated(
-        clips,
-        proofGenerator: (clipId) => {'hash': 'gen_$clipId'},
-      );
-
-      expect(result[0].id, equals('clip_a'));
-      expect(result[1].id, equals('clip_b'));
-      expect(result[2].id, equals('clip_c'));
-    });
-
-    test('preserves all clip metadata when adding proof', () {
-      final clip = DivineVideoClip(
-        id: 'clip_full',
-        video: EditorVideo.file('/path/to/video.mp4'),
-        duration: const Duration(seconds: 5),
-        recordedAt: DateTime(2025, 12, 13, 10),
-        targetAspectRatio: .square,
-        originalAspectRatio: 1,
-        thumbnailPath: '/path/to/thumb.jpg',
-      );
-
-      final result = ensureClipProofsSimulated([
-        clip,
-      ], proofGenerator: (_) => {'hash': 'abc123'});
-
-      final attested = result.first;
-      expect(attested.id, equals('clip_full'));
-      expect(attested.duration, equals(const Duration(seconds: 5)));
-      expect(attested.recordedAt, equals(DateTime(2025, 12, 13, 10)));
-      expect(attested.targetAspectRatio, equals(model.AspectRatio.square));
-      expect(attested.thumbnailPath, equals('/path/to/thumb.jpg'));
-      expect(attested.proofManifestJson, equals('{"hash":"abc123"}'));
-    });
-
-    test('single clip list with proof is returned unchanged', () {
-      final clip = createClip(
-        id: 'solo',
-        proofManifestJson: '{"hash":"solo_proof"}',
-      );
-
-      var called = false;
-      final result = ensureClipProofsSimulated(
-        [clip],
-        proofGenerator: (_) {
-          called = true;
-          return {};
-        },
-      );
-
-      expect(called, isFalse);
-      expect(result.length, equals(1));
-      expect(result.first.proofManifestJson, equals('{"hash":"solo_proof"}'));
-    });
-
-    test('single clip list without proof gets attested', () {
-      final clip = createClip(id: 'solo');
-
-      final result = ensureClipProofsSimulated([
-        clip,
-      ], proofGenerator: (_) => {'hash': 'attested'});
-
-      expect(result.length, equals(1));
-      expect(result.first.proofManifestJson, equals('{"hash":"attested"}'));
-    });
-
-    test('generated proof JSON is valid and decodable', () {
-      final clip = createClip(id: 'clip_json');
-
-      final result = ensureClipProofsSimulated(
-        [clip],
-        proofGenerator: (_) => {
-          'manifest': {'alg': 'sha256', 'hash': 'abc123'},
-          'assertions': [
-            {
-              'label': 'c2pa.actions',
-              'data': {
-                'actions': [
-                  {'action': 'c2pa.created'},
-                ],
-              },
-            },
-          ],
-          'claim_generator': 'divine/1.0',
-        },
-      );
-
-      final json = result.first.proofManifestJson!;
-      final decoded = jsonDecode(json) as Map<String, dynamic>;
-      expect(decoded, containsPair('claim_generator', 'divine/1.0'));
-      expect(decoded['manifest'], isA<Map<String, dynamic>>());
-      expect(decoded['assertions'], isA<List<dynamic>>());
+      expect(result, isNull);
     });
   });
 }

--- a/mobile/test/services/video_editor/video_editor_render_service_progress_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_progress_test.dart
@@ -271,11 +271,21 @@ void main() {
           result.$1.thumbnailPath,
           equals('${Directory.systemTemp.path}/clip-0-thumb.jpg'),
         );
+        // With clip-level generation switched off (#8798) the three per-clip
+        // backfill calls are gone, but the combined call still receives all
+        // three clips: the switch removes generated data, not the plumbing
+        // that carries it. Derived from the constant rather than hardcoded, so
+        // this stays right on the day the combination lands and it flips.
+        final expectedProofCallClipCounts =
+            NativeProofModeService.clipLevelProofGenerationEnabled
+            ? [null, null, null, 3]
+            : [3];
         expect(
           proofCallClipCounts,
-          equals([null, null, null, 3]),
+          equals(expectedProofCallClipCounts),
           reason:
-              'three clip-proof steps plus the final combined proofFile step',
+              'The final combined proofFile call must still be handed every '
+              'clip, whether or not the missing ones were backfilled first.',
         );
 
         const renderBudget = 0.95;


### PR DESCRIPTION
## Description

When a clip reaches render without its own attestation, `_ensureClipProofs` generates one — a full-file SHA-256, a full C2PA re-sign and a native ProofMode pass, per clip. The combined proof does not read per-clip data yet, so all of that is paid for a result that is discarded. The re-sign also replaces the user's original recording on disk on its way past, which is the separate defect in #8799.

`NativeProofModeService.clipLevelProofGenerationEnabled` switches the generation off while the combination described in `proofFile`'s TODO is being implemented.

## What switching it off costs

In the normal case, nothing. A recorded clip is already attested at record time by `ClipManagerNotifier`, so the per-clip data a combined proof will read — the video hash and the C2PA manifest id — is present either way. Only the gap case loses something: a clip that reaches render unattested cannot be referenced by a later ingredient chain.

Keeping that gap-fill is not free either. It runs through the C2PA re-sign that overwrites the user's original recording, so **#8799 should be resolved before the constant flips back**. The constant's doc says so at the point where someone would flip it.

This is worth knowing for whoever implements the combination: after this change, a clip can reach the combined proof unattested, so an implementation that assumes every clip carries a manifest would silently produce incomplete chains for that case.

**Nothing else changes.** The `clips` and `editorStateHistory` parameters and the plumbing that carries them through `renderVideoToClip` and `reproofRenderedClip` stay exactly as they are — `clips` is exactly the list a combined proof draws from. Clips that already carry proof still flow into the combined call, so the switch removes generated data, not the data path.

The per-clip progress tick runs either way, so the export's proof-phase budget resolves in the same number of steps and the progress bar behaves identically.

## Test change

`ensure_clip_proofs_test.dart` tested `ensureClipProofsSimulated` — a copy of the backfill logic reimplemented inside the test file. It could never fail for a production regression, and after this change it asserted behaviour the code no longer has, while staying green. It now drives the real `reproofRenderedClip` and pins that every clip still reaches the combined proof untouched, gaps included. Verified by mutation: dropping a clip from the pass-through turns it red.

## Out of Scope

Implementing the combined proof itself — that is the TODO, and it stays open as #8798. This PR references that issue rather than closing it, so the tracker for that work survives.

The signing side effect on the user's original recording is #8799; switching the backfill off stops triggering it, but the underlying replace-in-place behaviour is untouched.

**Related Issue:** Refs #8798

## Verification

- `flutter test test/services/video_editor/ test/services/native_proofmode_service_test.dart` — 330 pass
- The composite-progress test derives its expectation from the constant rather than hardcoding it. With the switch off the three per-clip backfill calls are gone **and the combined call still receives all three clips**, which is what pins that the plumbing survived
- Progress-value expectations are unchanged, which is the evidence that gating the backfill left the proof-phase budget alone
- `flutter analyze lib test` clean, `dart format` clean
- No device testing needed: no user-visible behaviour changes on the ordinary editor path, since the backfill does not fire there

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
