### PR TITLE
fix(video-editor): take the plugin release that stops a drawing killing the app

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1817,18 +1817,18 @@ packages:
     dependency: "direct main"
     description:
       name: pro_image_editor
-      sha256: "5db82a3570b8c56e13fe87041ca17aedc1a64e855e1f6c3c698456fd5c6b1082"
+      sha256: "573b441ebfc51891e477dfb2dc629d76c83079cbd4002295b506cf1526e1cefc"
       url: "https://pub.dev"
     source: hosted
-    version: "13.3.1"
+    version: "13.5.0"
   pro_video_editor:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: "2c2ab71dc8d34e4554ad9c64f5bfb774853a4111542ff21f9d886c55bc556103"
+      sha256: ca5d74b98edf8dbf15dc767903f5bdc36c77712f48eacc12ff618978c3dbc388
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.3"
+    version: "2.11.4"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -374,8 +374,8 @@ dependencies:
   # extra Flutter-specific native SQLite providers can make plain SQLite win.
   sqlite3: ^3.3.3
   audio_session: ^0.2.2
-  pro_video_editor: ^2.11.3
-  pro_image_editor: ^13.3.1
+  pro_video_editor: ^2.11.4
+  pro_image_editor: ^13.5.0
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7
   sensors_plus: ^7.0.0


### PR DESCRIPTION
## Description

Picks up `pro_video_editor` **2.11.4** and `pro_image_editor` **13.5.0**.

### Why 2.11.4 matters

It fixes the fatal `java.lang.OutOfMemoryError` that killed the app while the metadata screen rendered a video carrying a drawing, sticker, text or caption. Worth being precise about where that happens, because the issue originally described it as an export failure and it is not: `_handleDone` navigates to the metadata screen **first** and starts `startRenderVideo()` after, so the render runs behind the preview while `VideoEditorProcessingOverlay` shows its spinner. Nobody has to tap Post to hit it. Crashlytics breadcrumbs put `video_metadata` as the last screen in all six of the most recent events.

The mechanism: overlays are laid out in the composition's pixel space, which is the source clip's own resolution, while a `Presentation` effect scales each clip to the export resolution **after** them. A source above 1080p therefore had every layer rastered at several times the pixels the encode could show — and thrown away by the very next effect. Each one cost two full-frame Java-heap buffers in `unpremultiplyAlpha`, both counted against Android's 256 MiB per-app growth limit, once per layer. A drawing produces one layer per stroke.

2.11.4 rasters each overlay at the size that survives to the encoded frame and hands the shortfall to the compositor as an overlay scale, and converts premultiplied alpha through a 64 KiB scratch band instead of a second full-frame buffer.

### Why 13.5.0 is safe

A straight catch-up over 13.3.1. 13.4.0 and 13.5.0 add only **opt-in** paint-editor and helper-line features — `enableZoomWhileDrawing`, `enableSmartAlignment`, `enableEdgeSnapping`, `enablePaintLayerSnapping` — none of which this app enables. Nothing changes without a call site asking for it.

13.6.0 and 14.0.0 exist in that package's changelog but are **not published**; 14.0.0 is a breaking migration to the standalone `material_ui` / `cupertino_ui` packages and is deliberately not taken here.

## Out of Scope

- **This does not fix the crash for a 1080p source.** `overlayRasterScale` returns exactly `1f` when the output resolution matches the composition, so a clip recorded by the in-app camera at fhd is untouched by the raster cap. It still benefits from the halved conversion peak, but if the crash also occurs on pure camera footage, the remaining driver is the number of layers a drawing produces and that needs separate work.
- Freeing overlay bitmaps between layers, which would be the other half of the resident-memory problem, is not implementable: `BitmapOverlay` hands the bitmap back from `getBitmap(long)` on every frame and caches its texture against it, so none can be released early.
- No app-side code changes. The oversized `width`/`height` this app computes in `buildImageLayers` from the source clip's resolution are still what the plugin receives; 2.11.4 now bounds what it allocates for them.

## Verification

- `flutter analyze lib test integration_test` — no issues (this is what would catch an API break across the two-minor `pro_image_editor` jump).
- `flutter test test/services/video_editor test/blocs/video_editor test/providers/video_editor_provider_test.dart test/extensions` — 1169 passed.
- `flutter test test/widgets/video_editor test/screens/video_editor` — passed.
- `bash scripts/check_dependency_provenance.sh` — no new entries.
- Resolved with the pinned toolchain (`mise exec -- flutter`, 3.44.9). A first attempt on a local 3.44.0 rewrote ~8 unrelated transitive pins and 20 `analysis_options.yaml` files; that was discarded, so the lockfile diff is exactly the two packages.
- `flutter test test/goldens` fails on 3 `divine_ui` goldens at 2.67% / 2.79% / 3.65%. Those are the macOS-vs-Ubuntu font antialiasing drift AGENTS.md documents at 2.7% / 2.8% / 3.7%, on design-system goldens with no editor involvement. CI's Ubuntu `Goldens` job is authoritative.

**Not device-verified yet — this is why it is a draft.** What needs a run on hardware: a video with a drawing over a **higher-than-1080p source** (a gallery import), exported to completion, checking the drawing lands in the same place and at the same size, plus the same with a rotated layer. That confirms Media3 applies the compensating `setScale` about the overlay centre, which is read off the 1.10.1 bytecode rather than observed. A 1080p camera clip should be pixel-identical to before by construction.

**Related Issue:** Relates to #8599 — it can be closed once the device run above confirms the fix and establishes whether the 1080p shape is also gone.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
