### PR TITLE
test(account): make the account-deletion tests catch an unwanted sign-out

### DIFF
--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -266,6 +266,20 @@ List<Object?> _captureAnnouncements(WidgetTester tester) {
   return announced;
 }
 
+/// Asserts the flow signed the user out with no argument shape at all.
+///
+/// Matching exact flags would miss the bare `signOut()` the processing branch
+/// makes, so a path that must not sign out has to reject every call.
+void _verifyNeverSignedOut(_MockAuthService authService) {
+  verifyNever(
+    () => authService.signOut(
+      deleteKeys: any(named: 'deleteKeys'),
+      abortOnKeyDeletionFailure: any(named: 'abortOnKeyDeletionFailure'),
+      deleteLocalUserData: any(named: 'deleteLocalUserData'),
+    ),
+  );
+}
+
 void main() {
   group('showRemoveKeysWarningSheet', () {
     // Written by the sheet's future, which only completes after the sheet
@@ -770,10 +784,7 @@ void main() {
           find.text(_englishL10n().accountDeletionCancelAttemptBody),
           findsOneWidget,
         );
-        verifyNever(
-          () =>
-              authService.signOut(deleteKeys: true, deleteLocalUserData: true),
-        );
+        _verifyNeverSignedOut(authService);
       },
     );
 
@@ -1165,9 +1176,7 @@ void main() {
         ),
         findsOneWidget,
       );
-      verifyNever(
-        () => authService.signOut(deleteKeys: true, deleteLocalUserData: true),
-      );
+      _verifyNeverSignedOut(authService);
     });
 
     testWidgets(
@@ -1319,7 +1328,7 @@ void main() {
           vanishEventId: any(named: 'vanishEventId'),
         ),
       );
-      verifyNever(authService.signOut);
+      _verifyNeverSignedOut(authService);
     });
 
     testWidgets('username preparation failure keeps neutral guidance', (
@@ -1772,10 +1781,7 @@ void main() {
           find.text(l10n.accountDeletionCancelAttemptBody),
           findsOneWidget,
         );
-        verifyNever(
-          () =>
-              authService.signOut(deleteKeys: true, deleteLocalUserData: true),
-        );
+        _verifyNeverSignedOut(authService);
       },
     );
 
@@ -1823,9 +1829,7 @@ void main() {
           expectedPubkey: any(named: 'expectedPubkey'),
         ),
       );
-      verifyNever(
-        () => authService.signOut(deleteKeys: true, deleteLocalUserData: true),
-      );
+      _verifyNeverSignedOut(authService);
 
       // The user is told to sign in again, and never the post-publish copy that
       // reports deletion requests as already sent.

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -266,7 +266,7 @@ List<Object?> _captureAnnouncements(WidgetTester tester) {
   return announced;
 }
 
-/// Asserts the flow signed the user out with no argument shape at all.
+/// Asserts the flow did not sign the user out, under any argument shape.
 ///
 /// Matching exact flags would miss the bare `signOut()` the processing branch
 /// makes, so a path that must not sign out has to reject every call.


### PR DESCRIPTION
## Description

Five tests in `delete_account_dialog_test.dart` assert that a given deletion path must **not** sign the user out. All five matched one exact argument shape, so none of them could actually catch a sign-out that used a different one.

`AuthService.signOut` takes three defaulted named parameters, and `delete_account_dialog.dart` calls it two different ways — a bare `await authService.signOut()` on the processing branch (`:847`) and `signOut(deleteKeys: true, deleteLocalUserData: true)` for the terminal cleanup (`:863`). Mocktail matches named arguments exactly, so the guards were each blind in one direction: `verifyNever(() => authService.signOut(deleteKeys: true, deleteLocalUserData: true))` cannot see the bare call, and `verifyNever(authService.signOut)` is invoked with defaults, so it matches only the all-defaults call and cannot see the flagged one.

They do fail today, but by accident rather than by assertion: no test stubs `signOut`, so an unexpected call returns null and dies on `type 'Null' is not a subtype of type 'Future<void>'`. That protection disappears the moment a `signOut` stub is added — and a sibling group in the same file already installs exactly that line.

The failure being guarded against is a real one: a user whose vanish event never confirmed gets signed out to `/welcome` with their account still live, never seeing the `accountDeletionRecoveryBody` recovery sheet.

The fix matches any argument shape via `any(named: ...)` on all three parameters, behind one named helper (`_verifyNeverSignedOut`) so the next guard someone writes is correct by construction rather than correct by luck.

**Related Issue:** Closes #8917

## Out of Scope

- **No production code changes.** `delete_account_dialog.dart` is untouched; there is no bug in it today. This closes the gap that would let one land unnoticed.
- **Positive assertions and `when(...)` stubs stay argument-exact.** Those legitimately pin the specific cleanup call, and widening them would weaken real coverage.
- Found while reviewing #8888, which removes an obsolete suite and leans on these guards as the surviving coverage. That PR is correct and independent of this one — no changes are needed there.

## Verification

Mutation-tested rather than assumed. Adding `await authService.signOut();` to the content-deletion failure branch of `executeAccountDeletion`:

| Setup | Result |
|---|---|
| old guard, no `signOut` stub | fails — but on `type 'Null' is not a subtype of type 'Future<void>'`, not the assertion |
| old guard + `signOut` stub | **passes** — the regression is invisible |
| new guard + `signOut` stub | fails, naming `signOut({deleteKeys: false, ...})` |

The mutation was reverted before committing; the diff is test-only.

- `flutter test test/widgets/delete_account_dialog_test.dart` — 44/44 pass
- `flutter analyze lib test integration_test` — no issues
- `dart format` — clean
- Ratchets: `check_shared_setup_stubs.sh`, `check_placeholder_tests.sh`, `check_unpinned_unchanged_assertions.sh`, `check_ungrouped_tests.sh`, `check_test_unit_structure.sh`, `check_skip_ceiling.sh` — all pass

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
