### PR TITLE
perf(privacy): move diagnostic sanitization off the main isolate (#7080)

### DIFF
--- a/docs/superpowers/specs/2026-09-08-sanitize-off-isolate-design.md
+++ b/docs/superpowers/specs/2026-09-08-sanitize-off-isolate-design.md
@@ -6,11 +6,13 @@ messages, errors, and stack traces. #6909 bounded typed fields, but the log corp
 app-generated and the largest uncapped sanitization workload, so submitting a report
 can still stall the UI.
 
-**Serializability (verified).** `BugReportData` and `LogEntry` are immutable data
-classes of only `String`/`DateTime`/enum fields (`error`/`stackTrace` are Strings), so
-they copy cleanly across a `compute()` boundary. Established codebase pattern:
-`compute(_topLevelFn, arg)` — `signer_factory._verifyEventSignature`,
-`seed_data_preload_service._decodeBundle`.
+**Serializability (verified).** `LogEntry` is an immutable data class containing
+`String`/`DateTime`/enum fields (`error`/`stackTrace` are Strings). `BugReportData`
+also carries dynamic diagnostic maps, so the real-`compute` test sends the current
+production shapes—nested device data, populated logs, and error counts—across the
+boundary rather than assuming every future dynamic value is sendable. Established
+codebase pattern: `compute(_topLevelFn, arg)` —
+`signer_factory._verifyEventSignature`, `seed_data_preload_service._decodeBundle`.
 
 ## Approved design (mirrors `signer_factory`)
 
@@ -34,6 +36,16 @@ they copy cleanly across a `compute()` boundary. Established codebase pattern:
    If the worker isolate cannot spawn, sanitize inline rather than transmit
    unsanitized diagnostics. Sanitization must never be skipped — this serves the AC
    "keep public-support payloads sanitized before public projections."
+5. **Build the bounded Zendesk log summary through `compute` too.** Its
+   defense-in-depth sanitizer runs over each formatted entry before truncation, so
+   leaving summary construction in `BugReportCubit` would retain a pathological
+   main-isolate scan for one oversized entry. Await an async summary seam before
+   submission and use the same privacy-preserving inline fallback if its worker cannot
+   start.
+
+On Flutter web, `compute` runs on the current event loop rather than a separate
+isolate. The off-main performance benefit therefore applies to the native builds; the
+same API preserves behavior on web.
 
 ## Tests (TDD)
 
@@ -41,10 +53,14 @@ they copy cleanly across a `compute()` boundary. Established codebase pattern:
   (now exercising the moved top-level fn via the delegate) must stay green.
 - The seam's job: inject a throwing `_sanitizeOffMain`, assert the report still comes
   back fully sanitized (the inline fallback). Mutation-checkable.
-- One real-`compute` happy-path test proving the serialization shape end-to-end.
+- Real-`compute` happy-path tests proving the populated report and summary
+  serialization shapes end-to-end.
+- The Cubit awaits asynchronous summary construction before submission.
 - `flutter analyze` + the bug-report/privacy tests.
 
 ## Files
 
 `mobile/lib/services/bug_report_service.dart` (extract + delegate + seam + fallback),
-`mobile/test/services/bug_report_service_test.dart` (seam/fallback + real-compute).
+`mobile/lib/services/bug_report_log_summary.dart` and
+`mobile/lib/blocs/bug_report/bug_report_cubit.dart` (off-main summary), plus their
+focused tests.

--- a/docs/superpowers/specs/2026-09-08-sanitize-off-isolate-design.md
+++ b/docs/superpowers/specs/2026-09-08-sanitize-off-isolate-design.md
@@ -1,0 +1,50 @@
+# Move diagnostic sanitization off the main isolate (#7080) — design
+
+**Problem.** `BugReportService.sanitizeSensitiveData` runs synchronously on the main
+isolate over up to `BugReportConfig.maxLogEntries` (5000) log entries, sanitizing
+messages, errors, and stack traces. #6909 bounded typed fields, but the log corpus is
+app-generated and the largest uncapped sanitization workload, so submitting a report
+can still stall the UI.
+
+**Serializability (verified).** `BugReportData` and `LogEntry` are immutable data
+classes of only `String`/`DateTime`/enum fields (`error`/`stackTrace` are Strings), so
+they copy cleanly across a `compute()` boundary. Established codebase pattern:
+`compute(_topLevelFn, arg)` — `signer_factory._verifyEventSignature`,
+`seed_data_preload_service._decodeBundle`.
+
+## Approved design (mirrors `signer_factory`)
+
+1. **Move** the report-sanitize graph to top-level pure functions:
+   `sanitizeBugReportData(BugReportData) -> BugReportData` plus the map/list/
+   device-info/error-count helpers it needs, all bottoming out in the existing
+   top-level `sanitizeDiagnosticText`. Redaction logic is relocated verbatim (single
+   implementation, no duplication); no logging inside the isolate entrypoint.
+2. **Keep** the sync instance `sanitizeSensitiveData(data)` as a one-line delegate to
+   `sanitizeBugReportData`, preserving behavior/idempotency and the existing ~15 sync
+   redaction tests (the deterministic oracle). Keep instance `_sanitizeString` for the
+   log-export callback path.
+3. **Add** an injectable seam, exactly like `signer_factory._verifyOffMain`:
+   `_sanitizeOffMain` field defaulting to `(d) => compute(sanitizeBugReportData, d)`,
+   settable via a constructor param so tests can force isolate-spawn failure.
+4. **Fallback (privacy-critical).** The production collection path becomes:
+   ```dart
+   try { return await _sanitizeOffMain(reportData); }
+   on Object { return sanitizeBugReportData(reportData); } // inline
+   ```
+   If the worker isolate cannot spawn, sanitize inline rather than transmit
+   unsanitized diagnostics. Sanitization must never be skipped — this serves the AC
+   "keep public-support payloads sanitized before public projections."
+
+## Tests (TDD)
+
+- Behavior/idempotency/redaction: the existing sync `sanitizeSensitiveData` tests
+  (now exercising the moved top-level fn via the delegate) must stay green.
+- The seam's job: inject a throwing `_sanitizeOffMain`, assert the report still comes
+  back fully sanitized (the inline fallback). Mutation-checkable.
+- One real-`compute` happy-path test proving the serialization shape end-to-end.
+- `flutter analyze` + the bug-report/privacy tests.
+
+## Files
+
+`mobile/lib/services/bug_report_service.dart` (extract + delegate + seam + fallback),
+`mobile/test/services/bug_report_service_test.dart` (seam/fallback + real-compute).

--- a/mobile/lib/blocs/bug_report/bug_report_cubit.dart
+++ b/mobile/lib/blocs/bug_report/bug_report_cubit.dart
@@ -28,7 +28,7 @@ typedef SubmitBugReportAction =
     });
 
 /// Builds the logs summary string the cubit passes to Zendesk.
-typedef BuildLogsSummary = String? Function(List<LogEntry> logs);
+typedef BuildLogsSummary = Future<String?> Function(List<LogEntry> logs);
 
 /// Cubit backing the bug report flow. Owns the submission lifecycle plus
 /// the `BugReportFailureKey` that distinguishes attachment-upload
@@ -87,7 +87,7 @@ class BugReportCubit extends Cubit<BugReportState> {
         currentScreen: currentScreen,
         userPubkey: userPubkey,
         errorCounts: reportData.errorCounts,
-        logsSummary: _buildLogsSummary(reportData.recentLogs),
+        logsSummary: await _buildLogsSummary(reportData.recentLogs),
         attachmentPaths: attachments.map((f) => f.path).toList(),
       );
       if (isClosed) return;

--- a/mobile/lib/services/bug_report_log_summary.dart
+++ b/mobile/lib/services/bug_report_log_summary.dart
@@ -1,8 +1,29 @@
 // ABOUTME: Formats sanitized bug report logs for public support submissions
 // ABOUTME: Keeps diagnostic transformation out of the bug report UI layer
 
-import 'package:models/models.dart' show LogEntry, LogLevel;
+import 'package:flutter/foundation.dart' show compute;
 import 'package:openvine/config/bug_report_config.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Builds the public-support log summary outside the main isolate.
+///
+/// Production input logs have already been sanitized field by field, while
+/// [buildLogsSummary] also guarantees sanitized output for any other caller.
+/// Keep that potentially expensive pre-truncation scan off the UI isolate. If
+/// a worker cannot start, fall back inline rather than risk transmitting an
+/// unsanitized summary.
+Future<String?> buildLogsSummaryOffMain(List<LogEntry> logs) async {
+  try {
+    return await compute(buildLogsSummary, logs);
+  } on Object catch (error) {
+    Log.warning(
+      'Off-main bug report summary failed ($error); building inline so the '
+      'report remains sanitized',
+      category: LogCategory.system,
+    );
+    return buildLogsSummary(logs);
+  }
+}
 
 /// Build a log summary prioritizing errors/warnings with recent context.
 ///

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -75,6 +75,7 @@ class BugReportService {
     ui.Locale Function()? resolvedUiLocaleLoader,
     List<ui.Locale> Function()? deviceLocalesLoader,
     bool Function()? hasLocaleOverrideLoader,
+    Future<BugReportData> Function(BugReportData)? sanitizeOffMain,
   }) : _errorTracker = errorTracker ?? ErrorAnalyticsTracker(),
        _storageManagementService = storageManagementService,
        _supportDiagnosticsLoader = supportDiagnosticsLoader,
@@ -91,7 +92,11 @@ class BugReportService {
        _deviceLocalesLoader =
            deviceLocalesLoader ??
            (() => ui.PlatformDispatcher.instance.locales),
-       _hasLocaleOverrideLoader = hasLocaleOverrideLoader ?? (() => false);
+       _hasLocaleOverrideLoader = hasLocaleOverrideLoader ?? (() => false),
+       // Runs the sanitizer in a background isolate; injectable so tests can
+       // force the isolate-spawn-failure fallback. #7080.
+       _sanitizeOffMain =
+           sanitizeOffMain ?? ((data) => compute(sanitizeBugReportData, data));
 
   static const _uuid = Uuid();
 
@@ -111,6 +116,7 @@ class BugReportService {
   final ui.Locale Function() _resolvedUiLocaleLoader;
   final List<ui.Locale> Function() _deviceLocalesLoader;
   final bool Function() _hasLocaleOverrideLoader;
+  final Future<BugReportData> Function(BugReportData) _sanitizeOffMain;
 
   /// Language codes the app ships a translation for. A device language outside
   /// this set cannot be matched during device locale resolution.
@@ -270,7 +276,7 @@ class BugReportService {
         category: LogCategory.system,
       );
 
-      return sanitizeSensitiveData(reportData);
+      return await sanitizeSensitiveDataInBackground(reportData);
     } catch (e) {
       Log.error(
         'Failed to collect diagnostics: $e',
@@ -280,64 +286,41 @@ class BugReportService {
     }
   }
 
-  /// Sanitize sensitive data from bug report
+  /// Sanitize sensitive data from a bug report, synchronously on the calling
+  /// isolate.
+  ///
+  /// Retained for callers and tests that need deterministic in-process
+  /// sanitization. The production collection path uses
+  /// [sanitizeSensitiveDataInBackground] to keep the bulk log work off the main
+  /// isolate; both share the top-level [sanitizeBugReportData]. #7080.
   BugReportData sanitizeSensitiveData(BugReportData data) {
     Log.debug(
       'Sanitizing sensitive data from bug report',
       category: LogCategory.system,
     );
-
-    // Sanitize user description
-    final sanitizedDescription = _sanitizeString(data.userDescription);
-
-    // Sanitize logs
-    final sanitizedLogs = data.recentLogs.map((log) {
-      return LogEntry(
-        timestamp: log.timestamp,
-        level: log.level,
-        message: _sanitizeString(log.message),
-        category: log.category,
-        name: log.name,
-        error: log.error != null ? _sanitizeString(log.error!) : null,
-        stackTrace: log.stackTrace != null
-            ? _sanitizeString(log.stackTrace!)
-            : null,
-      );
-    }).toList();
-
-    // Sanitize additional context if present
-    Map<String, dynamic>? sanitizedContext;
-    if (data.additionalContext != null) {
-      sanitizedContext = _sanitizeMap(data.additionalContext!);
-    }
-
-    return data.copyWith(
-      userDescription: sanitizedDescription,
-      deviceInfo: _sanitizeDeviceInfo(data.deviceInfo),
-      recentLogs: sanitizedLogs,
-      additionalContext: sanitizedContext,
-      errorCounts: _sanitizeErrorCounts(data.errorCounts),
-    );
+    return sanitizeBugReportData(data);
   }
 
-  /// Sanitize error-count keys, which are `'<location>:<errorType>'` strings
-  /// and so can carry a credential-shaped name.
+  /// Sanitize [data] off the main isolate via [compute].
   ///
-  /// Done here rather than only where the counts are rendered, so every
-  /// consumer of the sanitized report inherits it.
-  Map<String, int> _sanitizeErrorCounts(Map<String, int> input) {
-    final sanitized = <String, int>{};
-    input.forEach((key, value) {
-      final composed = '$key: $value';
-      final safeKey = sanitizeDiagnosticText(composed) == composed
-          ? key
-          : '[REDACTED]';
-      // Summed rather than overwritten: two credential-shaped keys both
-      // collapse to the same placeholder, and silently dropping one of the
-      // counts is the kind of quiet loss this sanitizer exists to avoid.
-      sanitized[safeKey] = (sanitized[safeKey] ?? 0) + value;
-    });
-    return sanitized;
+  /// Falls back to inline sanitization if the worker isolate cannot spawn: a
+  /// report must never be transmitted unsanitized, so a spawn failure costs a
+  /// main-thread stall (the pre-#7080 behavior) rather than leaking
+  /// diagnostics. The off-main runner is injectable so tests can force that
+  /// fallback. Mirrors `signer_factory`'s `_verifyOffMain`. #7080.
+  Future<BugReportData> sanitizeSensitiveDataInBackground(
+    BugReportData data,
+  ) async {
+    try {
+      return await _sanitizeOffMain(data);
+    } on Object catch (e) {
+      Log.warning(
+        'Off-main sanitization failed ($e); sanitizing inline so the report '
+        'is never transmitted unsanitized',
+        category: LogCategory.system,
+      );
+      return sanitizeBugReportData(data);
+    }
   }
 
   /// Export logs to a file.
@@ -943,78 +926,119 @@ class BugReportService {
   String _sanitizeString(String input) {
     return sanitizeDiagnosticText(input);
   }
+}
 
-  /// Sanitize a map by removing sensitive values.
-  ///
-  /// Sensitivity is decided on the `key: value` pair, not on the value alone.
-  /// The rules match a credential *key* next to its value, so a value handed
-  /// over on its own arrives with no key attached and survives:
-  /// `{'sessionKey': '<secret>'}` came back unchanged before this, into an
-  /// export the user can share anywhere.
-  ///
-  /// A credential-shaped key redacts its whole value regardless of type. A
-  /// secret is just as exposed as `{'sessionKey': ['<secret>']}` or
-  /// `{'apiKey': {'value': '<secret>'}}`, and recursing into those loses the
-  /// key that identifies them.
-  Map<String, dynamic> _sanitizeMap(Map<String, dynamic> input) {
-    final Map<String, dynamic> sanitized = {};
+/// Sanitizes a [BugReportData] for transmission, redacting sensitive patterns
+/// from the description, logs, device info, additional context, and error
+/// counts.
+///
+/// Top-level (not an instance method) so it can run inside a `compute` worker
+/// isolate — see [BugReportService.sanitizeSensitiveDataInBackground]. Pure:
+/// it depends only on the top-level [sanitizeDiagnosticText], so both it and
+/// its input/output copy safely across the isolate boundary. #7080.
+BugReportData sanitizeBugReportData(BugReportData data) {
+  final sanitizedLogs = data.recentLogs.map((log) {
+    return LogEntry(
+      timestamp: log.timestamp,
+      level: log.level,
+      message: sanitizeDiagnosticText(log.message),
+      category: log.category,
+      name: log.name,
+      error: log.error != null ? sanitizeDiagnosticText(log.error!) : null,
+      stackTrace: log.stackTrace != null
+          ? sanitizeDiagnosticText(log.stackTrace!)
+          : null,
+    );
+  }).toList();
 
-    input.forEach((key, value) {
-      if (_isCredentialKey(key)) {
-        // The whole subtree, whatever shape it is. Recursing would hand the
-        // rules a bare value with no key attached, which is how
-        // `{'apiKey': ['<secret>']}` used to survive.
-        sanitized[key] = '[REDACTED]';
-      } else if (value is String) {
-        sanitized[key] = _sanitizeString(value);
-      } else if (value is Map<String, dynamic>) {
-        sanitized[key] = _sanitizeMap(value);
-      } else if (value is List) {
-        sanitized[key] = _sanitizeList(value);
-      } else {
-        sanitized[key] = value;
-      }
-    });
+  return data.copyWith(
+    userDescription: sanitizeDiagnosticText(data.userDescription),
+    deviceInfo: _sanitizeReportDeviceInfo(data.deviceInfo),
+    recentLogs: sanitizedLogs,
+    additionalContext: data.additionalContext != null
+        ? _sanitizeReportMap(data.additionalContext!)
+        : null,
+    errorCounts: _sanitizeReportErrorCounts(data.errorCounts),
+  );
+}
 
-    return sanitized;
-  }
+/// Sanitize error-count keys, which are `'<location>:<errorType>'` strings and
+/// so can carry a credential-shaped name.
+///
+/// Done here rather than only where the counts are rendered, so every consumer
+/// of the sanitized report inherits it.
+Map<String, int> _sanitizeReportErrorCounts(Map<String, int> input) {
+  final sanitized = <String, int>{};
+  input.forEach((key, value) {
+    final composed = '$key: $value';
+    final safeKey = sanitizeDiagnosticText(composed) == composed
+        ? key
+        : '[REDACTED]';
+    // Summed rather than overwritten: two credential-shaped keys both collapse
+    // to the same placeholder, and silently dropping one of the counts is the
+    // kind of quiet loss this sanitizer exists to avoid.
+    sanitized[safeKey] = (sanitized[safeKey] ?? 0) + value;
+  });
+  return sanitized;
+}
 
-  /// Whether [key] alone reads as a credential key.
-  ///
-  /// Tested with a placeholder value rather than the real one, so the answer
-  /// does not depend on what the value happens to contain: the point is that
-  /// `sessionKey` identifies a credential no matter whether its value is a
-  /// string, a list or a nested map.
-  bool _isCredentialKey(String key) {
-    const probe = 'x';
-    final composed = '$key: $probe';
-    return sanitizeDiagnosticText(composed) != composed;
-  }
-
-  Map<String, dynamic> _sanitizeDeviceInfo(Map<String, dynamic> input) {
-    final sanitized = _sanitizeMap(input);
-    for (final key in const ['name', 'hostName', 'computerName']) {
-      if (sanitized.containsKey(key)) {
-        sanitized[key] = '[REDACTED]';
-      }
+/// Sanitize a map by removing sensitive values.
+///
+/// Sensitivity is decided on the `key: value` pair, not on the value alone. A
+/// credential-shaped key redacts its whole value regardless of type, because a
+/// secret is just as exposed as `{'apiKey': ['<secret>']}` or
+/// `{'apiKey': {'value': '<secret>'}}`, and recursing into those loses the key
+/// that identifies them.
+Map<String, dynamic> _sanitizeReportMap(Map<String, dynamic> input) {
+  final Map<String, dynamic> sanitized = {};
+  input.forEach((key, value) {
+    if (_isReportCredentialKey(key)) {
+      sanitized[key] = '[REDACTED]';
+    } else if (value is String) {
+      sanitized[key] = sanitizeDiagnosticText(value);
+    } else if (value is Map<String, dynamic>) {
+      sanitized[key] = _sanitizeReportMap(value);
+    } else if (value is List) {
+      sanitized[key] = _sanitizeReportList(value);
+    } else {
+      sanitized[key] = value;
     }
-    return sanitized;
-  }
+  });
+  return sanitized;
+}
 
-  /// Sanitize a list by removing sensitive values
-  List<dynamic> _sanitizeList(List<dynamic> input) {
-    return input.map((item) {
-      if (item is String) {
-        return _sanitizeString(item);
-      } else if (item is Map<String, dynamic>) {
-        return _sanitizeMap(item);
-      } else if (item is List) {
-        return _sanitizeList(item);
-      } else {
-        return item;
-      }
-    }).toList();
+/// Whether [key] alone reads as a credential key.
+///
+/// Tested with a placeholder value rather than the real one, so the answer does
+/// not depend on what the value happens to contain.
+bool _isReportCredentialKey(String key) {
+  const probe = 'x';
+  final composed = '$key: $probe';
+  return sanitizeDiagnosticText(composed) != composed;
+}
+
+Map<String, dynamic> _sanitizeReportDeviceInfo(Map<String, dynamic> input) {
+  final sanitized = _sanitizeReportMap(input);
+  for (final key in const ['name', 'hostName', 'computerName']) {
+    if (sanitized.containsKey(key)) {
+      sanitized[key] = '[REDACTED]';
+    }
   }
+  return sanitized;
+}
+
+List<dynamic> _sanitizeReportList(List<dynamic> input) {
+  return input.map((item) {
+    if (item is String) {
+      return sanitizeDiagnosticText(item);
+    } else if (item is Map<String, dynamic>) {
+      return _sanitizeReportMap(item);
+    } else if (item is List) {
+      return _sanitizeReportList(item);
+    } else {
+      return item;
+    }
+  }).toList();
 }
 
 /// Outcome of [BugReportService.exportLogsToFile].

--- a/mobile/lib/widgets/bug_report_dialog.dart
+++ b/mobile/lib/widgets/bug_report_dialog.dart
@@ -30,6 +30,7 @@ class BugReportScreen extends StatefulWidget {
     this.currentScreen,
     this.userPubkey,
     this.submitBugReport,
+    this.buildLogsSummary = buildLogsSummaryOffMain,
   });
 
   static const routeName = 'support-report-bug';
@@ -39,6 +40,7 @@ class BugReportScreen extends StatefulWidget {
   final String? currentScreen;
   final String? userPubkey;
   final SubmitBugReportAction? submitBugReport;
+  final BuildLogsSummary buildLogsSummary;
 
   @override
   State<BugReportScreen> createState() => _BugReportScreenState();
@@ -58,7 +60,7 @@ class _BugReportScreenState extends State<BugReportScreen> {
     return BlocProvider(
       create: (_) => BugReportCubit(
         bugReportService: widget.bugReportService,
-        buildLogsSummary: buildLogsSummaryOffMain,
+        buildLogsSummary: widget.buildLogsSummary,
         submitBugReport:
             widget.submitBugReport ??
             ZendeskSupportService.createStructuredBugReport,

--- a/mobile/lib/widgets/bug_report_dialog.dart
+++ b/mobile/lib/widgets/bug_report_dialog.dart
@@ -58,7 +58,7 @@ class _BugReportScreenState extends State<BugReportScreen> {
     return BlocProvider(
       create: (_) => BugReportCubit(
         bugReportService: widget.bugReportService,
-        buildLogsSummary: buildLogsSummary,
+        buildLogsSummary: buildLogsSummaryOffMain,
         submitBugReport:
             widget.submitBugReport ??
             ZendeskSupportService.createStructuredBugReport,

--- a/mobile/test/blocs/bug_report/bug_report_cubit_test.dart
+++ b/mobile/test/blocs/bug_report/bug_report_cubit_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: lifecycle, with the typed failure-key distinguishing
 // ABOUTME: attachment-upload errors from generic failures.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker/image_picker.dart';
@@ -78,7 +80,7 @@ void main() {
     }) {
       return BugReportCubit(
         bugReportService: service,
-        buildLogsSummary: buildLogsSummary ?? (_) => null,
+        buildLogsSummary: buildLogsSummary ?? (_) async => null,
         submitBugReport:
             submitBugReport ??
             buildSubmit(returnValue: returnValue, throwError: throwError),
@@ -99,6 +101,54 @@ void main() {
         const BugReportState(status: BugReportStatus.submitting),
         const BugReportState(status: BugReportStatus.success),
       ],
+    );
+
+    test(
+      'awaits off-main log summary construction before submitting',
+      () async {
+        final summaryCompleter = Completer<String?>();
+        var submitCalls = 0;
+        String? submittedSummary;
+        final cubit = buildCubit(
+          buildLogsSummary: (_) => summaryCompleter.future,
+          submitBugReport:
+              ({
+                required String subject,
+                required String description,
+                required String reportId,
+                required String appVersion,
+                required Map<String, dynamic> deviceInfo,
+                String? stepsToReproduce,
+                String? expectedBehavior,
+                String? currentScreen,
+                String? userPubkey,
+                Map<String, int>? errorCounts,
+                String? logsSummary,
+                List<String>? attachmentPaths,
+              }) async {
+                submitCalls++;
+                submittedSummary = logsSummary;
+                return true;
+              },
+        );
+
+        final submission = cubit.submit(
+          subject: 'Crash',
+          description: 'It crashed',
+          stepsToReproduce: '',
+          expectedBehavior: '',
+          attachments: const [],
+        );
+        await pumpEventQueue();
+
+        expect(submitCalls, 0);
+        summaryCompleter.complete('off-main summary');
+        await submission;
+
+        expect(submitCalls, 1);
+        expect(submittedSummary, 'off-main summary');
+        await cubit.close();
+      },
     );
 
     blocTest<BugReportCubit, BugReportState>(
@@ -201,7 +251,7 @@ void main() {
       },
       build: () {
         return buildCubit(
-          buildLogsSummary: (logs) => logs
+          buildLogsSummary: (logs) async => logs
               .map((log) => '${log.message}\n${log.error}\n${log.stackTrace}')
               .join('\n'),
           submitBugReport:
@@ -219,10 +269,7 @@ void main() {
                 String? logsSummary,
                 List<String>? attachmentPaths,
               }) async {
-                final submitted = [
-                  description,
-                  logsSummary,
-                ].join('\n');
+                final submitted = [description, logsSummary].join('\n');
                 expect(submitted, isNot(contains(_rawNsec)));
                 expect(submitted, isNot(contains(_rawEmail)));
                 expect(submitted, contains('[REDACTED]'));

--- a/mobile/test/services/bug_report_log_summary_test.dart
+++ b/mobile/test/services/bug_report_log_summary_test.dart
@@ -2,7 +2,7 @@
 // ABOUTME: Verifies error/warning prioritization, dedup, chronological ordering
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:models/models.dart' show LogEntry, LogLevel;
+import 'package:models/models.dart' show LogCategory, LogEntry, LogLevel;
 import 'package:openvine/services/bug_report_log_summary.dart';
 
 LogEntry _log(int minute, LogLevel level, String msg) => LogEntry(
@@ -138,6 +138,24 @@ void main() {
 
       expect(result, contains('[REDACTED]'));
       expect(result, isNot(contains('hunter2')));
+    });
+
+    test('builds a production-shaped summary via real compute', () async {
+      final result = await buildLogsSummaryOffMain([
+        LogEntry(
+          timestamp: DateTime.fromMillisecondsSinceEpoch(7080),
+          level: LogLevel.error,
+          category: LogCategory.api,
+          name: 'request',
+          message: 'token: summary-secret',
+          error: 'network error',
+          stackTrace: 'stack trace',
+        ),
+      ]);
+
+      expect(result, contains('[REDACTED]'));
+      expect(result, isNot(contains('summary-secret')));
+      expect(result, contains('[API]'));
     });
 
     test('a credential in one entry cannot consume the next entry', () {

--- a/mobile/test/services/bug_report_service_test.dart
+++ b/mobile/test/services/bug_report_service_test.dart
@@ -612,5 +612,73 @@ void main() {
         expect(capture.isEmpty, isTrue);
       });
     });
+
+    group('off-main sanitization (#7080)', () {
+      BugReportData reportWith(String description) => BugReportData(
+        reportId: 'test-7080',
+        timestamp: DateTime.now(),
+        userDescription: description,
+        deviceInfo: const {},
+        appVersion: '1.0.0',
+        recentLogs: const [],
+        errorCounts: const {},
+      );
+
+      test('the top-level entrypoint matches the sync sanitizer', () {
+        final input = reportWith('My nsec is $_rawNsec');
+        final viaTopLevel = sanitizeBugReportData(input);
+        final viaSync = BugReportService().sanitizeSensitiveData(input);
+        expect(viaTopLevel.userDescription, viaSync.userDescription);
+        expect(viaTopLevel.userDescription, isNot(contains('nsec1')));
+        expect(viaTopLevel.userDescription, contains('[REDACTED]'));
+      });
+
+      test('runs sanitization through the injected off-main runner', () async {
+        var offMainCalls = 0;
+        final service = BugReportService(
+          sanitizeOffMain: (data) async {
+            offMainCalls++;
+            return sanitizeBugReportData(data);
+          },
+        );
+
+        final sanitized = await service.sanitizeSensitiveDataInBackground(
+          reportWith('My nsec is $_rawNsec'),
+        );
+
+        expect(offMainCalls, 1);
+        expect(sanitized.userDescription, isNot(contains('nsec1')));
+        expect(sanitized.userDescription, contains('[REDACTED]'));
+      });
+
+      test(
+        'falls back to inline sanitization when the isolate cannot spawn',
+        () async {
+          final service = BugReportService(
+            sanitizeOffMain: (_) async =>
+                throw StateError('isolate spawn failed'),
+          );
+
+          final sanitized = await service.sanitizeSensitiveDataInBackground(
+            reportWith('My nsec is $_rawNsec'),
+          );
+
+          // Never transmit unsanitized diagnostics: the fallback still redacts.
+          expect(sanitized.userDescription, isNot(contains('nsec1')));
+          expect(sanitized.userDescription, contains('[REDACTED]'));
+        },
+      );
+
+      test('sanitizes off the real isolate via compute', () async {
+        final service = BugReportService();
+
+        final sanitized = await service.sanitizeSensitiveDataInBackground(
+          reportWith('My nsec is $_rawNsec'),
+        );
+
+        expect(sanitized.userDescription, isNot(contains('nsec1')));
+        expect(sanitized.userDescription, contains('[REDACTED]'));
+      });
+    });
   });
 }

--- a/mobile/test/services/bug_report_service_test.dart
+++ b/mobile/test/services/bug_report_service_test.dart
@@ -669,15 +669,52 @@ void main() {
         },
       );
 
-      test('sanitizes off the real isolate via compute', () async {
+      test('sanitizes a production-shaped report via real compute', () async {
         final service = BugReportService();
+        final input = BugReportData(
+          reportId: 'test-7080',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(7080),
+          userDescription: 'My nsec is $_rawNsec',
+          deviceInfo: {
+            'platform': 'test',
+            'localStorage': {
+              'sessionKey': 'device-secret',
+              'counts': [1, 2],
+            },
+          },
+          appVersion: '1.0.0',
+          recentLogs: [
+            LogEntry(
+              timestamp: DateTime.fromMillisecondsSinceEpoch(7081),
+              level: LogLevel.error,
+              category: LogCategory.api,
+              name: 'request',
+              message: 'token: message-secret',
+              error: 'password: error-secret',
+              stackTrace: 'authorization: bearer stack-secret',
+            ),
+          ],
+          errorCounts: const {'password: count-secret': 2},
+        );
 
         final sanitized = await service.sanitizeSensitiveDataInBackground(
-          reportWith('My nsec is $_rawNsec'),
+          input,
         );
 
         expect(sanitized.userDescription, isNot(contains('nsec1')));
         expect(sanitized.userDescription, contains('[REDACTED]'));
+        expect(sanitized.timestamp, input.timestamp);
+        expect(sanitized.recentLogs.single.level, LogLevel.error);
+        expect(sanitized.recentLogs.single.category, LogCategory.api);
+        expect(sanitized.recentLogs.single.message, contains('[REDACTED]'));
+        expect(sanitized.recentLogs.single.error, contains('[REDACTED]'));
+        expect(sanitized.recentLogs.single.stackTrace, contains('[REDACTED]'));
+        expect(
+          (sanitized.deviceInfo['localStorage']
+              as Map<String, dynamic>)['sessionKey'],
+          '[REDACTED]',
+        );
+        expect(sanitized.errorCounts, {'[REDACTED]': 2});
       });
     });
   });

--- a/mobile/test/widgets/bug_report_dialog_test.dart
+++ b/mobile/test/widgets/bug_report_dialog_test.dart
@@ -94,6 +94,7 @@ void main() {
               currentScreen: 'SupportCenterScreen',
               userPubkey: _pubkeyHex,
               submitBugReport: submitBugReport,
+              buildLogsSummary: (_) async => null,
             ),
           ),
         ],


### PR DESCRIPTION
## Problem

Bug-report submission sanitized as many as 5,000 captured log entries synchronously on the main isolate. The final Zendesk log-summary builder also sanitized each fully formatted entry before truncating it, so one oversized entry could still stall the UI even after moving the bulk report pass.

## Why this fix

- Moves the report-sanitization graph into a top-level pure function and runs it through Flutter's `compute` API.
- Runs the pre-truncation log-summary sanitizer through `compute` as well, and makes the Cubit await that asynchronous result before submission.
- Preserves privacy-first inline fallbacks: if either worker cannot start, the report is sanitized on the calling isolate instead of transmitting unsanitized diagnostics.
- Keeps the synchronous sanitizer as the deterministic entry point used by existing redaction tests.

The real-isolate tests now send populated `LogEntry` objects, enums, dates, nested device diagnostics, and error counts across the boundary. Cubit and widget tests use injected async seams so they verify ordering without depending on isolate scheduling.

## Deliberately unchanged

Redaction behavior, idempotency, report size caps, log prioritization, and Zendesk payload shape are unchanged. On Flutter web, `compute` runs on the current event loop, so this change preserves behavior there but only native builds receive the off-main-isolate performance benefit.

## Verification

- `flutter test test/blocs/bug_report/bug_report_cubit_test.dart test/services/bug_report_service_test.dart test/services/bug_report_log_summary_test.dart`
- Pre-push changed-file analysis: clean
- Pre-push changed-file tests: 69 passed, 2 platform skips

Closes #7080
