### PR TITLE
fix(crossposting): bind the ATProto crosspost token and keep secrets out of its errors (#8825)

### DIFF
--- a/docs/superpowers/specs/2026-09-08-crosspost-token-bind-design.md
+++ b/docs/superpowers/specs/2026-09-08-crosspost-token-bind-design.md
@@ -1,0 +1,28 @@
+# Bind the ATProto crosspost client token; keep secrets out of errors (#8825) — design
+
+**Problem.** `CrosspostApiClient` (the Keycast ATProto/Bluesky client) read its bearer
+token straight from the OAuth session (`_oauthClient.getSession().accessToken`) — an
+unbound token, not re-validated against the active account across the await, so an
+account switch mid-flight could authenticate a request as the wrong account. Its
+exception `toString()` also emitted the raw message, which can carry a connection URL
+or token into logs. Same latent gaps #8705 fixed for the sibling `CrosspostingApiClient`.
+
+## Approach (mirrors the merged #8705 sibling)
+
+1. **Bind the token.** Replace the `KeycastOAuth oauthClient` dependency (used only for
+   the token) with an injected `CrosspostAccessTokenReader = Future<String?> Function()`.
+   `_authHeaders` awaits the reader instead of `getSession().accessToken`. The provider
+   passes `authService.getBoundDivineAccessToken`, which captures the owner pubkey
+   before the await and re-checks it after, refusing on mismatch — closing the
+   account-switch TOCTOU.
+2. **Scrub the exception.** `CrosspostApiException.toString()` now omits the raw
+   `message` (keeps `statusCode` + `kind`), mirroring `CrosspostingApiException`.
+3. **Tests (TDD):** a spy reader pinned as the token source (goes red if reverted to an
+   unbound `getSession()` read — the AC's mutation check); a test that `toString()`
+   does not leak the message.
+
+## Files
+
+`mobile/lib/services/crosspost_api_client.dart` (typedef + constructor + `_authHeaders`
++ exception `toString`), `mobile/lib/providers/upload_media_providers.dart` (wire the
+bound reader), `mobile/test/services/crosspost_api_client_test.dart`.

--- a/mobile/lib/providers/upload_media_providers.dart
+++ b/mobile/lib/providers/upload_media_providers.dart
@@ -333,12 +333,12 @@ ApiService apiService(Ref ref) {
 /// Crosspost API client for Bluesky toggle settings
 @riverpod
 CrosspostApiClient crosspostApiClient(Ref ref) {
-  final oauthClient = ref.watch(oauthClientProvider);
+  final authService = ref.watch(authServiceProvider);
   final config = ref.watch(oauthConfigProvider);
   final httpClient = ref.watch(instrumentedHttpClientFactoryProvider)();
   ref.onDispose(httpClient.close);
   return CrosspostApiClient(
-    oauthClient: oauthClient,
+    accessTokenReader: authService.getBoundDivineAccessToken,
     serverUrl: config.serverUrl,
     httpClient: httpClient,
   );

--- a/mobile/lib/providers/upload_media_providers.g.dart
+++ b/mobile/lib/providers/upload_media_providers.g.dart
@@ -313,7 +313,7 @@ final class CrosspostApiClientProvider
 }
 
 String _$crosspostApiClientHash() =>
-    r'3c3771a323baade67d52ed7de2882fb42406ba56';
+    r'8c4a25641f2a497b44505baaa50ce56c95c3dd21';
 
 /// Repository for Bluesky toggle settings
 

--- a/mobile/lib/services/crosspost_api_client.dart
+++ b/mobile/lib/services/crosspost_api_client.dart
@@ -4,7 +4,6 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
-import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:openvine/models/atproto_provisioning_state.dart';
 
 /// Response model for crosspost status from keycast's `AtprotoStatusResponse`.
@@ -51,23 +50,28 @@ class CrosspostStatus {
   final String? provisioningError;
 }
 
+/// Reads the active account's bound access token, re-validating the owner
+/// pubkey across the await so a request cannot authenticate as the wrong
+/// account after a mid-flight switch. See
+/// [AuthService.getBoundDivineAccessToken]. #8825.
+typedef CrosspostAccessTokenReader = Future<String?> Function();
+
 /// Client for keycast crosspost API endpoints.
 class CrosspostApiClient {
   CrosspostApiClient({
-    required KeycastOAuth oauthClient,
+    required CrosspostAccessTokenReader accessTokenReader,
     required String serverUrl,
     http.Client? httpClient,
-  }) : _oauthClient = oauthClient,
+  }) : _accessTokenReader = accessTokenReader,
        _serverUrl = serverUrl,
        _httpClient = httpClient ?? http.Client();
 
-  final KeycastOAuth _oauthClient;
+  final CrosspostAccessTokenReader _accessTokenReader;
   final String _serverUrl;
   final http.Client _httpClient;
 
   Future<Map<String, String>> _authHeaders() async {
-    final session = await _oauthClient.getSession();
-    final token = session?.accessToken;
+    final token = await _accessTokenReader();
     if (token == null) {
       throw const CrosspostApiException('Not authenticated', statusCode: 401);
     }
@@ -174,7 +178,11 @@ class CrosspostApiException implements Exception {
   final int? statusCode;
   final CrosspostApiErrorKind kind;
 
+  /// Deliberately omits [message]: it can carry a connection URL or a bearer
+  /// token, and this text reaches logs. Mirrors the sibling
+  /// CrosspostingApiException. #8825.
   @override
   String toString() =>
-      'CrosspostApiException: $message (${statusCode ?? 'no status'})';
+      'CrosspostApiException(status: ${statusCode ?? 'none'}, '
+      'kind: ${kind.name})';
 }

--- a/mobile/test/providers/crosspost_job_client_auth_test.dart
+++ b/mobile/test/providers/crosspost_job_client_auth_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Pins the crosspost job client to the account-bound Divine token
-// ABOUTME: Guards against regressing to a raw, unbound Keycast session read
+// ABOUTME: Pins crosspost API providers to the account-bound Divine token
+// ABOUTME: Guards provider wiring against raw, unbound Keycast session reads
 
 import 'dart:convert';
 
@@ -11,6 +11,7 @@ import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/upload_media_providers.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/crosspost_api_client.dart';
 import 'package:openvine/services/crossposting_api_client.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
@@ -58,13 +59,13 @@ void main() {
     // Keycast's rotating refresh (#7802).
     test('authenticates with the account-bound Divine token', () async {
       when(
-        () => auth.getBoundDivineAccessToken(),
+        auth.getBoundDivineAccessToken,
       ).thenAnswer((_) async => 'owner-bound-token');
 
       final client = buildContainer().read(crossposterApiClientProvider);
       await client.getCrossposts(eventId: eventId);
 
-      verify(() => auth.getBoundDivineAccessToken()).called(1);
+      verify(auth.getBoundDivineAccessToken).called(1);
       final headers =
           verify(
                 () => httpClient.get(
@@ -98,5 +99,45 @@ void main() {
         );
       },
     );
+  });
+
+  group('crosspostApiClientProvider', () {
+    test('authenticates with the account-bound Divine token', () async {
+      final auth = _MockAuthService();
+      final httpClient = _MockHttpClient();
+      when(
+        auth.getBoundDivineAccessToken,
+      ).thenAnswer((_) async => 'owner-bound-token');
+      when(
+        () => httpClient.get(any(), headers: any(named: 'headers')),
+      ).thenAnswer(
+        (_) async =>
+            http.Response(jsonEncode({'enabled': false, 'state': null}), 200),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          authServiceProvider.overrideWithValue(auth),
+          instrumentedHttpClientFactoryProvider.overrideWithValue(
+            () => httpClient,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final client = container.read(crosspostApiClientProvider);
+      expect(client, isA<CrosspostApiClient>());
+      await client.getStatus();
+
+      verify(auth.getBoundDivineAccessToken).called(1);
+      final headers =
+          verify(
+                () => httpClient.get(
+                  any(),
+                  headers: captureAny(named: 'headers'),
+                ),
+              ).captured.single
+              as Map<String, String>;
+      expect(headers['Authorization'], equals('Bearer owner-bound-token'));
+    });
   });
 }

--- a/mobile/test/services/crosspost_api_client_test.dart
+++ b/mobile/test/services/crosspost_api_client_test.dart
@@ -2,20 +2,21 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/models/atproto_provisioning_state.dart';
 import 'package:openvine/services/crosspost_api_client.dart';
-
-class _MockKeycastOAuth extends Mock implements KeycastOAuth {}
 
 class _MockHttpClient extends Mock implements http.Client {}
 
 void main() {
   group(CrosspostApiClient, () {
-    late _MockKeycastOAuth oauthClient;
     late _MockHttpClient httpClient;
     late CrosspostApiClient client;
+
+    // The token the injected account-bound reader returns, and how many times
+    // it was consulted. #8825.
+    String? boundToken;
+    var readerCalls = 0;
 
     const serverUrl = 'https://login.divine.video';
     const pubkey = 'abc123def456';
@@ -34,18 +35,16 @@ void main() {
     });
 
     setUp(() {
-      oauthClient = _MockKeycastOAuth();
       httpClient = _MockHttpClient();
+      boundToken = accessToken;
+      readerCalls = 0;
       client = CrosspostApiClient(
-        oauthClient: oauthClient,
+        accessTokenReader: () async {
+          readerCalls++;
+          return boundToken;
+        },
         serverUrl: serverUrl,
         httpClient: httpClient,
-      );
-      when(() => oauthClient.getSession()).thenAnswer(
-        (_) async => const KeycastSession(
-          bunkerUrl: 'bunker://test',
-          accessToken: accessToken,
-        ),
       );
     });
 
@@ -155,7 +154,7 @@ void main() {
       });
 
       test('throws CrosspostApiException when no session token', () async {
-        when(() => oauthClient.getSession()).thenAnswer((_) async => null);
+        boundToken = null;
 
         expect(
           () => client.getStatus(),
@@ -336,6 +335,46 @@ void main() {
 
         expect(status.username, isNull);
         expect(status.handle, isNull);
+      });
+    });
+
+    group('account-bound token (#8825)', () {
+      test(
+        'authenticates with the token from the injected bound reader',
+        () async {
+          // Pins the account-bound reader as the token source. Goes red if the
+          // client reverts to an unbound session read (the header would then
+          // carry the session token, not the bound reader's).
+          boundToken = 'bound-token-xyz';
+          when(
+            () => httpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer((_) async => http.Response(jsonEncode(statusJson), 200));
+
+          await client.getStatus();
+
+          final headers =
+              verify(
+                    () => httpClient.get(
+                      any(),
+                      headers: captureAny(named: 'headers'),
+                    ),
+                  ).captured.single
+                  as Map<String, String>;
+          expect(readerCalls, 1);
+          expect(headers['Authorization'], 'Bearer bound-token-xyz');
+        },
+      );
+
+      test('exception diagnostics omit the raw message', () {
+        const e = CrosspostApiException(
+          'connect failed for https://host?token=SECRETVALUE',
+          statusCode: 500,
+        );
+
+        final text = e.toString();
+        expect(text, isNot(contains('SECRETVALUE')));
+        expect(text, isNot(contains('https://host')));
+        expect(text, contains('500'));
       });
     });
   });


### PR DESCRIPTION
## What and why

`CrosspostApiClient` (the Keycast ATProto/Bluesky client) read its bearer token straight from the OAuth session (`getSession().accessToken`) — an **unbound** token, not re-validated against the active account across the await, so an account switch mid-flight could authenticate a request as the wrong account. Its exception `toString()` also emitted the raw message, which can carry a connection URL or token into logs. These are the same latent auth-binding and secret-in-logs gaps #8705 fixed for the sibling `CrosspostingApiClient`.

## Approach (mirrors the merged #8705)

- **Bind the token:** replace the `KeycastOAuth` dependency (used only for the token) with an injected `CrosspostAccessTokenReader = Future<String?> Function()`; wire the provider to `authService.getBoundDivineAccessToken`, which captures the owner pubkey before the await and re-checks it after, refusing on mismatch. Closes the account-switch TOCTOU.
- **Scrub the exception:** `CrosspostApiException.toString()` now omits the raw message (keeps status + kind), like the sibling exception.
- **Tests:** a client-level spy pins the injected token reader as the request's token source; a provider-level test proves production wiring calls `AuthService.getBoundDivineAccessToken`; and an exception test proves `toString()` does not leak the raw message.

Design detail: `docs/superpowers/specs/2026-09-08-crosspost-token-bind-design.md`.

Closes #8825
