### PR TITLE
fix(blocklist): surface the mute-list publish result from block/unblock

### DIFF
--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -1228,7 +1228,14 @@ class ContentBlocklistRepository {
   /// If [ourPubkey] is provided, it will be used to prevent self-blocking.
   /// Otherwise falls back to [_ourPubkey] set during
   /// [syncMuteListsInBackground].
-  Future<void> blockUser(String pubkey, {String? ourPubkey}) {
+  ///
+  /// Returns whether the kind 10000 mute-list publish was confirmed: `true`
+  /// when it landed or nothing needed publishing, `false` when it is
+  /// unconfirmed. An unconfirmed publish is reconciled on its own later (the
+  /// pending-publish retry and the reconcile-on-read), so callers may ignore
+  /// this; it lets a surface distinguish confirmed from pending and does not by
+  /// itself drive any user-facing message.
+  Future<bool> blockUser(String pubkey, {String? ourPubkey}) {
     return blockUsers([pubkey], ourPubkey: ourPubkey);
   }
 
@@ -1239,13 +1246,18 @@ class ContentBlocklistRepository {
   /// [BlocklistChange] per newly-blocked pubkey because downstream feed
   /// cleanup reacts per author. An idempotent re-block also flushes a pending
   /// mute-list publish without producing another local change event.
-  Future<void> blockUsers(Iterable<String> pubkeys, {String? ourPubkey}) async {
+  ///
+  /// Returns whether the publish was confirmed (see [blockUser]); a batch with
+  /// nothing new to block returns the current publish status.
+  Future<bool> blockUsers(Iterable<String> pubkeys, {String? ourPubkey}) async {
     final selfPubkey = ourPubkey ?? _ourPubkey;
     var skippedSelf = false;
     var hasEligibleTarget = false;
     final newlyBlocked = <String>[];
     final newlySeveredFollowers = <String>[];
     var retiredPendingUnblock = false;
+    // Confirmed unless a publish is attempted and comes back unconfirmed.
+    var published = true;
 
     for (final pubkey in pubkeys) {
       if (pubkey.isEmpty) continue;
@@ -1287,7 +1299,7 @@ class ContentBlocklistRepository {
     // affordance in the app can reach.
     if (retiredPendingUnblock) await _savePendingUnblocks();
     if (newlyBlocked.isNotEmpty) {
-      await _publishMuteListToNostr();
+      published = await _publishMuteListToNostr();
 
       Log.debug(
         'Added ${newlyBlocked.length} users to blocklist',
@@ -1295,8 +1307,8 @@ class ContentBlocklistRepository {
         category: LogCategory.system,
       );
     }
-    if (newlyBlocked.isEmpty && hasEligibleTarget) {
-      await retryPendingMuteListPublish();
+    if (newlyBlocked.isEmpty && hasEligibleTarget && _muteListPublishPending) {
+      published = await retryPendingMuteListPublish();
     }
 
     // Track as severed follower so they stay hidden from our followers
@@ -1305,6 +1317,8 @@ class ContentBlocklistRepository {
       _severedFollowers.addAll(newlySeveredFollowers);
       await _saveSeveredFollowers();
     }
+
+    return published;
   }
 
   /// Stop hiding a public key through this account's own mute list.
@@ -1313,10 +1327,13 @@ class ContentBlocklistRepository {
   /// client, then republishes the updated kind 10000 mute list to Nostr.
   /// Awaits the local write so the change survives an immediate app kill.
   /// Note: Cannot remove users from internal blocklist.
-  Future<void> unblockUser(String pubkey) async {
+  ///
+  /// Returns whether the publish was confirmed (see [blockUser]); a no-op
+  /// returns the current publish status.
+  Future<bool> unblockUser(String pubkey) async {
     // DM surfaces fall back to an empty counterparty when a conversation
     // carries no participants; [blockUsers] already skips it.
-    if (pubkey.isEmpty) return;
+    if (pubkey.isEmpty) return !_muteListPublishPending;
     // coverage:ignore-start
     if (_internalBlocklist.contains(pubkey)) {
       // Internal blocklist is intentionally empty; this branch is
@@ -1327,7 +1344,7 @@ class ContentBlocklistRepository {
         name: 'ContentBlocklistRepository',
         category: LogCategory.system,
       );
-      return;
+      return false;
     }
     // coverage:ignore-end
 
@@ -1342,8 +1359,8 @@ class ContentBlocklistRepository {
         publishedListCarries;
 
     if (!hasExplicitUnblock) {
-      await retryPendingMuteListPublish();
-      return;
+      if (!_muteListPublishPending) return true;
+      return retryPendingMuteListPublish();
     }
 
     // Recorded BEFORE the local removals are persisted, and so before the
@@ -1376,13 +1393,14 @@ class ContentBlocklistRepository {
       _notifyChanged();
     }
 
-    await _publishMuteListToNostr();
+    final published = await _publishMuteListToNostr();
 
     Log.info(
       'Stopped hiding user: ${pubkeyForLogs(pubkey)}',
       name: 'ContentBlocklistRepository',
       category: LogCategory.system,
     );
+    return published;
   }
 
   /// Get all blocked public keys (for debugging)

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -4874,6 +4874,110 @@ void main() {
         });
       });
     });
+
+    group('publish result propagation (#6436)', () {
+      // The repository knows whether the kind 10000 mute-list publish landed
+      // (_publishMuteListToNostr returns a bool), but before #6436 that result
+      // was dropped at the blockUser/blockUsers/unblockUser boundary, so no
+      // caller could tell a confirmed change from one still pending on the
+      // relay. These pin that the result now reaches the caller. User-facing
+      // messaging is left alone: an unconfirmed publish is pending, not
+      // failed, and the retry-on-next-launch path (#8263) recovers it.
+      void armAuthenticatedSigner() {
+        when(() => mockSigner.isAuthenticated).thenReturn(true);
+        when(
+          () => mockSigner.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((inv) async => signedEventFromInvocation(inv));
+      }
+
+      void armPublish(PublishResult result) {
+        when(
+          () => mockClient.publishEvent(any()),
+        ).thenAnswer((_) async => result);
+      }
+
+      Future<ContentBlocklistRepository> readyService() async {
+        final service = ContentBlocklistRepository();
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        return service;
+      }
+
+      test('blockUser returns true when the publish is confirmed', () async {
+        armAuthenticatedSigner();
+        armPublish(PublishSuccess(event: buildEvent(kind: 10000)));
+        final service = await readyService();
+
+        expect(await service.blockUser('pubkey1'), isTrue);
+      });
+
+      test(
+        'blockUser returns false when the publish is not confirmed',
+        () async {
+          armAuthenticatedSigner();
+          armPublish(const PublishFailed());
+          final service = await readyService();
+
+          expect(await service.blockUser('pubkey1'), isFalse);
+        },
+      );
+
+      test(
+        'blockUser returns true for an already-blocked pubkey without '
+        'republishing',
+        () async {
+          armAuthenticatedSigner();
+          armPublish(PublishSuccess(event: buildEvent(kind: 10000)));
+          final service = await readyService();
+
+          expect(await service.blockUser('pubkey1'), isTrue);
+          // No new pubkey, so nothing to publish: the state is already
+          // confirmed and the relay is not touched again.
+          expect(await service.blockUser('pubkey1'), isTrue);
+          verify(() => mockClient.publishEvent(any())).called(1);
+        },
+      );
+
+      test(
+        'blockUsers returns false when the batch publish is not confirmed',
+        () async {
+          armAuthenticatedSigner();
+          armPublish(const PublishFailed());
+          final service = await readyService();
+
+          expect(await service.blockUsers(['pubkey1', 'pubkey2']), isFalse);
+        },
+      );
+
+      test('unblockUser returns true when the publish is confirmed', () async {
+        armAuthenticatedSigner();
+        armPublish(PublishSuccess(event: buildEvent(kind: 10000)));
+        final service = await readyService();
+        await service.blockUser('pubkey1');
+
+        expect(await service.unblockUser('pubkey1'), isTrue);
+      });
+
+      test(
+        'unblockUser returns false when the publish is not confirmed',
+        () async {
+          armAuthenticatedSigner();
+          armPublish(PublishSuccess(event: buildEvent(kind: 10000)));
+          final service = await readyService();
+          await service.blockUser('pubkey1');
+
+          armPublish(const PublishFailed());
+          expect(await service.unblockUser('pubkey1'), isFalse);
+        },
+      );
+    });
   });
 
   group('ContentBlocklistRepository - legacy block list migration', () {

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -4930,6 +4930,19 @@ void main() {
       );
 
       test(
+        'blockUser returns the retry result when the block is already local',
+        () async {
+          armAuthenticatedSigner();
+          armPublish(const PublishFailed());
+          final service = await readyService();
+
+          expect(await service.blockUser('pubkey1'), isFalse);
+          expect(await service.blockUser('pubkey1'), isFalse);
+          verify(() => mockClient.publishEvent(any())).called(2);
+        },
+      );
+
+      test(
         'blockUser returns true for an already-blocked pubkey without '
         'republishing',
         () async {
@@ -4977,6 +4990,31 @@ void main() {
           expect(await service.unblockUser('pubkey1'), isFalse);
         },
       );
+
+      test(
+        'unblockUser returns the retry result when the unblock is already '
+        'local',
+        () async {
+          armAuthenticatedSigner();
+          armPublish(PublishSuccess(event: buildEvent(kind: 10000)));
+          final service = await readyService();
+          await service.blockUser('pubkey1');
+
+          armPublish(const PublishFailed());
+          expect(await service.unblockUser('pubkey1'), isFalse);
+          expect(await service.unblockUser('pubkey1'), isFalse);
+          verify(() => mockClient.publishEvent(any())).called(3);
+        },
+      );
+
+      test('unblockUser returns true for a clean no-op', () async {
+        armAuthenticatedSigner();
+        armPublish(PublishSuccess(event: buildEvent(kind: 10000)));
+        final service = await readyService();
+
+        expect(await service.unblockUser('pubkey1'), isTrue);
+        verifyNever(() => mockClient.publishEvent(any()));
+      });
     });
   });
 

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -5015,6 +5015,19 @@ void main() {
         expect(await service.unblockUser('pubkey1'), isTrue);
         verifyNever(() => mockClient.publishEvent(any()));
       });
+
+      test(
+        'unblockUser returns the pending retry result for a no-op',
+        () async {
+          armAuthenticatedSigner();
+          armPublish(const PublishFailed());
+          final service = await readyService();
+          expect(await service.blockUser('pubkey1'), isFalse);
+
+          expect(await service.unblockUser('pubkey2'), isFalse);
+          verify(() => mockClient.publishEvent(any())).called(2);
+        },
+      );
     });
   });
 

--- a/mobile/test/blocs/badges/badge_detail_cubit_test.dart
+++ b/mobile/test/blocs/badges/badge_detail_cubit_test.dart
@@ -395,7 +395,7 @@ void main() {
       setUp: () {
         when(
           () => contentBlocklistRepository.blockUsers(any()),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => true);
       },
       build: buildCubit,
       act: (cubit) => cubit.blockClaimants({_pubkey(2), _pubkey(3)}),

--- a/mobile/test/blocs/comments/comment_reactions/comment_reactions_bloc_test.dart
+++ b/mobile/test/blocs/comments/comment_reactions/comment_reactions_bloc_test.dart
@@ -696,7 +696,7 @@ void main() {
         setUp: () {
           when(
             () => mockContentBlocklistRepository.blockUser(any()),
-          ).thenAnswer((_) async {});
+          ).thenAnswer((_) async => true);
         },
         build: createBloc,
         act: (b) => b.add(CommentBlockUserRequested(validId('blocked'))),

--- a/mobile/test/blocs/dm/conversation_actions/conversation_actions_cubit_test.dart
+++ b/mobile/test/blocs/dm/conversation_actions/conversation_actions_cubit_test.dart
@@ -51,7 +51,7 @@ void main() {
     );
 
     test('does not emit or throw when closed mid-block', () async {
-      final completer = Completer<void>();
+      final completer = Completer<bool>();
       when(
         () => mockBlocklistRepository.blockUser(
           pubkey,
@@ -63,7 +63,7 @@ void main() {
       final future = cubit.blockUser(pubkey);
       // processing emitted synchronously; close before the block resolves.
       await cubit.close();
-      completer.complete();
+      completer.complete(true);
       await expectLater(future, completes);
 
       expect(cubit.state.status, ConversationActionsStatus.processing);
@@ -244,7 +244,7 @@ void main() {
               pubkey,
               ourPubkey: currentUserPubkey,
             ),
-          ).thenAnswer((_) async {});
+          ).thenAnswer((_) async => true);
         },
         build: createCubit,
         act: (cubit) => cubit.blockUser(pubkey),
@@ -296,7 +296,7 @@ void main() {
         setUp: () {
           when(
             () => mockBlocklistRepository.unblockUser(pubkey),
-          ).thenAnswer((_) async {});
+          ).thenAnswer((_) async => true);
         },
         build: createCubit,
         act: (cubit) => cubit.unblockUser(pubkey),

--- a/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
+++ b/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
@@ -752,7 +752,7 @@ void main() {
             any(),
             ourPubkey: any(named: 'ourPubkey'),
           ),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => true);
       });
 
       blocTest<OtherProfileBloc, OtherProfileState>(
@@ -800,7 +800,7 @@ void main() {
       setUp(() {
         when(
           () => mockBlocklistRepository.unblockUser(any()),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => true);
       });
 
       blocTest<OtherProfileBloc, OtherProfileState>(

--- a/mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart
+++ b/mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart
@@ -113,7 +113,7 @@ void main() {
       ).thenAnswer((_) => blocklistStream.stream);
       when(
         () => blocklistRepository.unblockUser(any()),
-      ).thenAnswer((_) async {});
+      ).thenAnswer((_) async => true);
     });
 
     tearDown(() async {
@@ -497,7 +497,7 @@ void main() {
       });
 
       test('unblockUser drops its refresh after close', () async {
-        final unblock = Completer<void>();
+        final unblock = Completer<bool>();
         when(
           () => blocklistRepository.unblockUser(any()),
         ).thenAnswer((_) => unblock.future);
@@ -505,7 +505,7 @@ void main() {
         final cubit = buildCubit();
         final unblocking = cubit.unblockUser('blocked_pubkey');
         await cubit.close();
-        unblock.complete();
+        unblock.complete(true);
 
         await expectLater(unblocking, completes);
       });

--- a/mobile/test/screens/badges/badge_detail_screen_test.dart
+++ b/mobile/test/screens/badges/badge_detail_screen_test.dart
@@ -151,7 +151,7 @@ void main() {
       ).thenAnswer((_) async => claimants);
       when(
         () => contentBlocklistRepository.blockUsers(any()),
-      ).thenAnswer((_) async {});
+      ).thenAnswer((_) async => true);
 
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();

--- a/mobile/test/screens/safety_settings_screen_test.dart
+++ b/mobile/test/screens/safety_settings_screen_test.dart
@@ -42,13 +42,15 @@ class _MockContentBlocklistRepository extends Mock
       const Stream<ContentPolicyState>.empty();
 
   @override
-  Future<void> blockUser(String pubkey, {String? ourPubkey}) async {
+  Future<bool> blockUser(String pubkey, {String? ourPubkey}) async {
     _runtimeBlocklist.add(pubkey);
+    return true;
   }
 
   @override
-  Future<void> unblockUser(String pubkey) async {
+  Future<bool> unblockUser(String pubkey) async {
     _runtimeBlocklist.remove(pubkey);
+    return true;
   }
 
   @override

--- a/mobile/test/widgets/profile/unavailable_profile_actions_test.dart
+++ b/mobile/test/widgets/profile/unavailable_profile_actions_test.dart
@@ -95,7 +95,7 @@ void main() {
     ) async {
       when(
         () => blocklistRepository.blockUser(_userIdHex),
-      ).thenAnswer((_) async {});
+      ).thenAnswer((_) async => true);
 
       await tester.pumpWidget(
         buildSubject(isFollowing: false, isBlocked: false),
@@ -126,7 +126,7 @@ void main() {
     ) async {
       when(
         () => blocklistRepository.unblockUser(_userIdHex),
-      ).thenAnswer((_) async {});
+      ).thenAnswer((_) async => true);
 
       await tester.pumpWidget(
         buildSubject(isFollowing: false, isBlocked: true),


### PR DESCRIPTION
## What this fixes

Blocking or unblocking someone is a safety action, but the repository could not tell its callers whether the change reached the relay. `_publishMuteListToNostr` already computes whether the kind 10000 mute-list publish landed, yet `blockUser`, `blockUsers`, and `unblockUser` returned `void` and dropped that result. Callers therefore had no way to distinguish a confirmed change from one still pending on the relay.

The issue was rescoped by Liz during the 2026-08-28 backlog triage: the outbox, retry timer, and pending-publish recovery it originally asked for have since shipped (#8263/#8264, #8260), so the remaining task is narrow — stop discarding the result the repository already computes.

## The change

`blockUser`, `blockUsers`, and `unblockUser` now return `Future<bool>`: `true` when the publish is confirmed or the requested state is already clean, and `false` when the publish remains unconfirmed or an internal block explicitly refuses removal.

The branch was rebased over the current idempotent retry behavior. Repeating a block or unblock while a mute-list publish is pending retries that publish and surfaces the retry result instead of reporting a stale success. Existing callers remain source-compatible and may continue ignoring the result.

## What this deliberately does not change

No user-facing messaging. An unconfirmed publish is pending, not failed: the intent is recorded before the publish and the recovery path reconciles local state with the relay on its own. A "couldn't reach the relay" message on a change that lands seconds later would be worse than saying nothing.

## Note for reviewers

The production change is confined to `content_blocklist_repository.dart`. The remaining app diff updates one hand-written fake and the relevant `mocktail` stubs to match the widened return types. The `Future<void>` stubs on the `ConversationActionsCubit` mock intentionally remain `Future<void>` because those are cubit methods, not repository methods.

## Verification

- The full `content_blocklist_repository` package suite passes: 188 tests at 100% coverage.
- The pre-push hook passed analysis and all 359 affected tests.
- Pending block retry coverage was mutation-checked: discarding the retry result makes the new regression test fail.
- Clean no-op, pending no-op, and repeated-unblock result behavior are pinned alongside the confirmed and unconfirmed publish cases.
- All 21 pull-request checks pass.

Closes #6436
