### PR TITLE
test(settings): verify Blossom AppBar follows the appearance theme

### DIFF
--- a/mobile/test/screens/settings/blossom_settings_screen_test.dart
+++ b/mobile/test/screens/settings/blossom_settings_screen_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies https-only enforcement with loopback carve-outs (#3837).
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -79,6 +80,21 @@ void main() {
       await tester.tap(find.byTooltip('Save'));
       await tester.pumpAndSettle();
     }
+
+    testWidgets('has nav green AppBar', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      final appBarFinder = find.byType(AppBar);
+      expect(appBarFinder, findsOneWidget);
+
+      final appBar = tester.widget<AppBar>(appBarFinder);
+      expect(
+        appBar.backgroundColor,
+        equals(VineTheme.navGreen),
+        reason: 'BlossomSettingsScreen AppBar should be nav green',
+      );
+    });
 
     testWidgets('saves valid https:// URL', (tester) async {
       await pumpAndSave(tester, 'https://blossom.band');

--- a/mobile/test/screens/settings/blossom_settings_screen_test.dart
+++ b/mobile/test/screens/settings/blossom_settings_screen_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Widget tests for BlossomSettingsScreen URL validation.
-// ABOUTME: Verifies https-only enforcement with loopback carve-outs (#3837).
+// ABOUTME: Widget tests for BlossomSettingsScreen behavior and theming.
+// ABOUTME: Verifies adaptive colors and https-only URL enforcement (#3837).
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:divine_ui/divine_ui.dart';
@@ -26,18 +26,17 @@ void main() {
     });
 
     setUp(() {
+      VineThemeColors.debugFallbackCount = 0;
       mockService = _MockBlossomUploadService();
       // Loaded state: blossom enabled, no server configured yet, so the
       // TextField is rendered and the controller starts empty.
       when(() => mockService.isBlossomEnabled()).thenAnswer((_) async => true);
       when(() => mockService.getBlossomServer()).thenAnswer((_) async => null);
-      when(
-        () => mockService.setBlossomEnabled(any()),
-      ).thenAnswer((_) async {});
-      when(
-        () => mockService.setBlossomServer(any()),
-      ).thenAnswer((_) async {});
+      when(() => mockService.setBlossomEnabled(any())).thenAnswer((_) async {});
+      when(() => mockService.setBlossomServer(any())).thenAnswer((_) async {});
     });
+
+    tearDown(() => VineThemeColors.debugFallbackCount = 0);
 
     Widget buildSubject() {
       // Minimal GoRouter so the screen's `context.pop()` on save success
@@ -66,7 +65,7 @@ void main() {
         child: MaterialApp.router(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          theme: ThemeData.dark(),
+          theme: VineTheme.lightTheme,
           routerConfig: router,
         ),
       );
@@ -81,7 +80,7 @@ void main() {
       await tester.pumpAndSettle();
     }
 
-    testWidgets('has nav green AppBar', (tester) async {
+    testWidgets('uses the active theme for its AppBar', (tester) async {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
@@ -91,9 +90,10 @@ void main() {
       final appBar = tester.widget<AppBar>(appBarFinder);
       expect(
         appBar.backgroundColor,
-        equals(VineTheme.navGreen),
-        reason: 'BlossomSettingsScreen AppBar should be nav green',
+        VineTheme.lightColors.nav,
+        reason: 'BlossomSettingsScreen AppBar should use the theme nav token',
       );
+      expect(VineThemeColors.debugFallbackCount, 0);
     });
 
     testWidgets('saves valid https:// URL', (tester) async {
@@ -133,25 +133,23 @@ void main() {
       expect(find.text(l10n.blossomServerUrlMustUseHttps), findsNothing);
     });
 
-    testWidgets(
-      'rejects non-loopback http:// URL with localized snackbar',
-      (tester) async {
-        await pumpAndSave(tester, 'http://example.com/blossom');
+    testWidgets('rejects non-loopback http:// URL with localized snackbar', (
+      tester,
+    ) async {
+      await pumpAndSave(tester, 'http://example.com/blossom');
 
-        expect(find.text(l10n.blossomServerUrlMustUseHttps), findsOneWidget);
-        verifyNever(() => mockService.setBlossomServer(any()));
-      },
-    );
+      expect(find.text(l10n.blossomServerUrlMustUseHttps), findsOneWidget);
+      verifyNever(() => mockService.setBlossomServer(any()));
+    });
 
-    testWidgets(
-      'rejects spoofed loopback hostname with localized snackbar',
-      (tester) async {
-        await pumpAndSave(tester, 'http://localhost.evil.com/blossom');
+    testWidgets('rejects spoofed loopback hostname with localized snackbar', (
+      tester,
+    ) async {
+      await pumpAndSave(tester, 'http://localhost.evil.com/blossom');
 
-        expect(find.text(l10n.blossomServerUrlMustUseHttps), findsOneWidget);
-        verifyNever(() => mockService.setBlossomServer(any()));
-      },
-    );
+      expect(find.text(l10n.blossomServerUrlMustUseHttps), findsOneWidget);
+      verifyNever(() => mockService.setBlossomServer(any()));
+    });
 
     testWidgets('rejects unparseable URL with localized snackbar', (
       tester,
@@ -184,40 +182,36 @@ void main() {
       },
     );
 
-    testWidgets(
-      'seeds the server-URL field exactly once; later '
-      'initialServerUrl emissions do not overwrite user input',
-      (tester) async {
-        // First load() seeds the field with the persisted '' (setUp stub).
-        await tester.pumpWidget(buildSubject());
-        await tester.pumpAndSettle();
+    testWidgets('seeds the server-URL field exactly once; later '
+        'initialServerUrl emissions do not overwrite user input', (
+      tester,
+    ) async {
+      // First load() seeds the field with the persisted '' (setUp stub).
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
 
-        // User edits the field — the controller is now the source of truth.
-        const userInput = 'https://typed-by-user.example';
-        await tester.enterText(find.byType(TextField), userInput);
-        await tester.pumpAndSettle();
+      // User edits the field — the controller is now the source of truth.
+      const userInput = 'https://typed-by-user.example';
+      await tester.enterText(find.byType(TextField), userInput);
+      await tester.pumpAndSettle();
 
-        // Re-stub the service so the next load() snapshots a *different*
-        // initialServerUrl, then drive a second load() through the live
-        // cubit to emit a fresh `ready` state with that value.
-        when(
-          () => mockService.getBlossomServer(),
-        ).thenAnswer((_) async => 'https://persisted-elsewhere.example');
-        final cubit = BlocProvider.of<BlossomSettingsCubit>(
-          tester.element(find.byType(BlossomSettingsView)),
-        );
-        await cubit.load();
-        await tester.pumpAndSettle();
+      // Re-stub the service so the next load() snapshots a *different*
+      // initialServerUrl, then drive a second load() through the live
+      // cubit to emit a fresh `ready` state with that value.
+      when(
+        () => mockService.getBlossomServer(),
+      ).thenAnswer((_) async => 'https://persisted-elsewhere.example');
+      final cubit = BlocProvider.of<BlossomSettingsCubit>(
+        tester.element(find.byType(BlossomSettingsView)),
+      );
+      await cubit.load();
+      await tester.pumpAndSettle();
 
-        // The one-shot seed contract: the second emission must NOT clobber
-        // the user's typed value.
-        expect(find.text(userInput), findsOneWidget);
-        expect(
-          find.text('https://persisted-elsewhere.example'),
-          findsNothing,
-        );
-      },
-    );
+      // The one-shot seed contract: the second emission must NOT clobber
+      // the user's typed value.
+      expect(find.text(userInput), findsOneWidget);
+      expect(find.text('https://persisted-elsewhere.example'), findsNothing);
+    });
 
     testWidgets(
       'generic save failure renders complete copy, not a dangling separator',


### PR DESCRIPTION
Closes #8924

## Problem

Removing the obsolete settings scaffold suite also removed the only live assertion covering the Blossom settings AppBar. Without focused coverage, the screen could stop using the active appearance palette without a test noticing.

## Why this is the right fix

The existing Blossom settings widget fixture now pumps the real Divine light theme and verifies that the AppBar resolves the semantic nav token. The test also asserts that no widget used the silent dark fallback, so losing the VineThemeColors extension is observable.

## What this deliberately does not change

This is test-only. It does not change Blossom settings behavior or restore the obsolete skipped Relay settings scaffold tests.

## Verification

- flutter test test/screens/settings/blossom_settings_screen_test.dart
- flutter analyze test/screens/settings/blossom_settings_screen_test.dart
- pre-push changed-file analysis and tests