### PR TITLE
fix(support): open support chat during startup

### DIFF
--- a/mobile/lib/blocs/support_contact/support_contact_cubit.dart
+++ b/mobile/lib/blocs/support_contact/support_contact_cubit.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/close_guard.dart';
 import 'package:openvine/blocs/support_contact/support_contact_state.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 export 'package:openvine/blocs/support_contact/support_contact_state.dart';
 
@@ -25,7 +26,25 @@ class SupportContactCubit extends Cubit<SupportContactState>
       const SupportContactState(status: SupportContactStatus.opening),
     );
 
-    final opened = await _openSupportMessages();
+    bool opened;
+    try {
+      opened = await _openSupportMessages();
+    } catch (error) {
+      // A throwing opener must not strand the tile on `opening` (spinner up,
+      // tap disabled, and the fallback listener never sees `unavailable`) —
+      // that is the #8921 failure this cubit exists to prevent. Treat a throw
+      // as unavailable so the email fallback fires.
+      Log.warning(
+        'SupportContactCubit: opening support threw, using email fallback: '
+        '$error',
+        category: LogCategory.system,
+      );
+      emitIfOpen(
+        const SupportContactState(status: SupportContactStatus.unavailable),
+      );
+      return;
+    }
+
     emitIfOpen(
       SupportContactState(
         status: opened

--- a/mobile/lib/blocs/support_contact/support_contact_cubit.dart
+++ b/mobile/lib/blocs/support_contact/support_contact_cubit.dart
@@ -1,0 +1,37 @@
+// ABOUTME: Coordinates opening native support and reports when email fallback is needed
+// ABOUTME: Keeps asynchronous support orchestration out of the widget layer
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/close_guard.dart';
+import 'package:openvine/blocs/support_contact/support_contact_state.dart';
+import 'package:openvine/services/zendesk_support_service.dart';
+
+export 'package:openvine/blocs/support_contact/support_contact_state.dart';
+
+typedef OpenSupportMessages = Future<bool> Function();
+
+class SupportContactCubit extends Cubit<SupportContactState>
+    with CloseGuardedEmit<SupportContactState> {
+  SupportContactCubit({OpenSupportMessages? openSupportMessages})
+    : _openSupportMessages =
+          openSupportMessages ?? ZendeskSupportService.showTicketListScreen,
+      super(const SupportContactState());
+
+  final OpenSupportMessages _openSupportMessages;
+
+  Future<void> open() async {
+    if (state.status == SupportContactStatus.opening) return;
+    emitIfOpen(
+      const SupportContactState(status: SupportContactStatus.opening),
+    );
+
+    final opened = await _openSupportMessages();
+    emitIfOpen(
+      SupportContactState(
+        status: opened
+            ? SupportContactStatus.opened
+            : SupportContactStatus.unavailable,
+      ),
+    );
+  }
+}

--- a/mobile/lib/blocs/support_contact/support_contact_state.dart
+++ b/mobile/lib/blocs/support_contact/support_contact_state.dart
@@ -1,0 +1,15 @@
+// ABOUTME: State for opening the native support conversation from Support Center
+// ABOUTME: Exposes loading and fallback outcomes without leaking services into UI
+
+import 'package:equatable/equatable.dart';
+
+enum SupportContactStatus { idle, opening, opened, unavailable }
+
+class SupportContactState extends Equatable {
+  const SupportContactState({this.status = SupportContactStatus.idle});
+
+  final SupportContactStatus status;
+
+  @override
+  List<Object?> get props => [status];
+}

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -1984,7 +1984,6 @@
     "supportLoginRequired": "ድጋፍን ለማግኘት ይግቡ",
     "supportExportingLogs": "ምዝግብ ማስታወሻዎችን በመላክ ላይ...",
     "supportExportLogsFailed": "ምዝግብ ማስታወሻዎችን ወደ ውጭ መላክ አልተሳካም።",
-    "supportChatNotAvailable": "የድጋፍ ውይይት አይገኝም",
     "supportCouldNotOpenMessages": "የድጋፍ መልዕክቶችን መክፈት አልተቻለም",
     "supportCouldNotOpenPage": "{pageName} መክፈት አልተቻለም",
     "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1581,7 +1581,6 @@
     "supportLoginRequired": "سجِّل الدخول للتواصل مع الدعم",
     "supportExportingLogs": "جارٍ تصدير السجلات...",
     "supportExportLogsFailed": "تعذر تصدير السجلات",
-    "supportChatNotAvailable": "محادثة الدعم غير متاحة",
     "supportCouldNotOpenMessages": "تعذر فتح رسائل الدعم",
     "supportCouldNotOpenPage": "تعذر فتح {pageName}",
     "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1798,7 +1798,6 @@
     "supportLoginRequired": "Влез, за да се свържеш с поддръжката",
     "supportExportingLogs": "Логовете се експортират...",
     "supportExportLogsFailed": "Не успяхме да експортираме логовете",
-    "supportChatNotAvailable": "Чатът за поддръжка не е наличен",
     "supportCouldNotOpenMessages": "Не можах да отворя съобщения за поддръжка",
     "supportCouldNotOpenPage": "Не може да се отвори {pageName}",
     "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1591,7 +1591,6 @@
     "supportLoginRequired": "Melde dich an, um den Support zu kontaktieren",
     "supportExportingLogs": "Logs werden exportiert...",
     "supportExportLogsFailed": "Logs konnten nicht exportiert werden",
-    "supportChatNotAvailable": "Support-Chat nicht verfügbar",
     "supportCouldNotOpenMessages": "Support-Nachrichten konnten nicht geöffnet werden",
     "supportCouldNotOpenPage": "{pageName} konnte nicht geöffnet werden",
     "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2910,7 +2910,6 @@
   "@supportRevealLogsAction": {
     "description": "SnackBar action label that opens the folder containing the just-saved log file. Desktop platforms only."
   },
-  "supportChatNotAvailable": "Support chat not available",
   "supportCouldNotOpenMessages": "Could not open support messages",
   "supportCouldNotOpenPage": "Could not open {pageName}",
   "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1595,7 +1595,6 @@
     "supportLoginRequired": "Iniciá sesión para contactar a soporte",
     "supportExportingLogs": "Exportando logs...",
     "supportExportLogsFailed": "No se pudieron exportar los logs",
-    "supportChatNotAvailable": "El chat de soporte no está disponible",
     "supportCouldNotOpenMessages": "No se pudieron abrir los mensajes de soporte",
     "supportCouldNotOpenPage": "No se pudo abrir {pageName}",
     "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1161,7 +1161,6 @@
     "supportLoginRequired": "Mag-log in para makipag-ugnayan sa support",
     "supportExportingLogs": "Nag-e-export ng logs...",
     "supportExportLogsFailed": "Hindi na-export ang logs",
-    "supportChatNotAvailable": "Hindi available ang support chat",
     "supportCouldNotOpenMessages": "Hindi nabuksan ang support messages",
     "supportCouldNotOpenPage": "Hindi nabuksan ang {pageName}",
     "reportWhyReporting": "Bakit mo rine-report ang content na ito?",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1591,7 +1591,6 @@
     "supportLoginRequired": "Connecte-toi pour contacter le support",
     "supportExportingLogs": "Exportation des logs...",
     "supportExportLogsFailed": "Échec de l'exportation des logs",
-    "supportChatNotAvailable": "Chat du support indisponible",
     "supportCouldNotOpenMessages": "Impossible d'ouvrir les messages du support",
     "supportCouldNotOpenPage": "Impossible d'ouvrir {pageName}",
     "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1588,7 +1588,6 @@
     "supportLoginRequired": "Login untuk menghubungi dukungan",
     "supportExportingLogs": "Mengekspor log...",
     "supportExportLogsFailed": "Gagal mengekspor log",
-    "supportChatNotAvailable": "Chat dukungan tidak tersedia",
     "supportCouldNotOpenMessages": "Tidak bisa membuka pesan dukungan",
     "supportCouldNotOpenPage": "Tidak bisa membuka {pageName}",
     "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1591,7 +1591,6 @@
     "supportLoginRequired": "Accedi per contattare l'assistenza",
     "supportExportingLogs": "Esportazione log...",
     "supportExportLogsFailed": "Esportazione log fallita",
-    "supportChatNotAvailable": "Chat di assistenza non disponibile",
     "supportCouldNotOpenMessages": "Impossibile aprire i messaggi di assistenza",
     "supportCouldNotOpenPage": "Impossibile aprire {pageName}",
     "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1581,7 +1581,6 @@
     "supportLoginRequired": "サポートに連絡するにはログインしてね",
     "supportExportingLogs": "ログをエクスポート中...",
     "supportExportLogsFailed": "ログのエクスポートがうまくいかなかった",
-    "supportChatNotAvailable": "サポートチャットは今使えないよ",
     "supportCouldNotOpenMessages": "サポートメッセージが開けなかった",
     "supportCouldNotOpenPage": "{pageName}が開けなかった",
     "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1119,7 +1119,6 @@
     "supportLoginRequired": "지원팀에 문의하려면 로그인해 주세요",
     "supportExportingLogs": "로그 내보내는 중...",
     "supportExportLogsFailed": "로그 내보내기에 실패했어요",
-    "supportChatNotAvailable": "지원 채팅을 사용할 수 없어요",
     "supportCouldNotOpenMessages": "지원 메시지를 열 수 없어요",
     "supportCouldNotOpenPage": "{pageName}을(를) 열 수 없어요",
     "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -2352,7 +2352,6 @@
   "@supportRevealLogsAction": {
     "description": "SnackBar action label that opens the folder containing the just-saved log file. Desktop platforms only."
   },
-  "supportChatNotAvailable": "Sembang sokongan tidak tersedia",
   "supportCouldNotOpenMessages": "Tidak dapat membuka mesej sokongan",
   "supportCouldNotOpenPage": "Tidak dapat membuka {pageName}",
   "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1591,7 +1591,6 @@
     "supportLoginRequired": "Log in om contact op te nemen met support",
     "supportExportingLogs": "Logs exporteren...",
     "supportExportLogsFailed": "Logs exporteren mislukt",
-    "supportChatNotAvailable": "Supportchat niet beschikbaar",
     "supportCouldNotOpenMessages": "Supportberichten openen mislukt",
     "supportCouldNotOpenPage": "{pageName} openen mislukt",
     "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1591,7 +1591,6 @@
     "supportLoginRequired": "Zaloguj się, żeby skontaktować się z pomocą",
     "supportExportingLogs": "Eksportowanie logów...",
     "supportExportLogsFailed": "Nie udało się wyeksportować logów",
-    "supportChatNotAvailable": "Czat z pomocą niedostępny",
     "supportCouldNotOpenMessages": "Nie można otworzyć wiadomości pomocy",
     "supportCouldNotOpenPage": "Nie można otworzyć {pageName}",
     "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1591,7 +1591,6 @@
     "supportLoginRequired": "Entre para contatar o suporte",
     "supportExportingLogs": "Exportando logs...",
     "supportExportLogsFailed": "Falha ao exportar logs",
-    "supportChatNotAvailable": "Chat de suporte indisponível",
     "supportCouldNotOpenMessages": "Não foi possível abrir as mensagens de suporte",
     "supportCouldNotOpenPage": "Não foi possível abrir {pageName}",
     "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1591,7 +1591,6 @@
     "supportLoginRequired": "Autentifică-te ca să contactezi asistența",
     "supportExportingLogs": "Se exportă jurnalele...",
     "supportExportLogsFailed": "N-am putut exporta jurnalele",
-    "supportChatNotAvailable": "Chatul de asistență nu e disponibil",
     "supportCouldNotOpenMessages": "N-am putut deschide mesajele de asistență",
     "supportCouldNotOpenPage": "N-am putut deschide {pageName}",
     "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1591,7 +1591,6 @@
     "supportLoginRequired": "Logga in för att kontakta supporten",
     "supportExportingLogs": "Exporterar loggar...",
     "supportExportLogsFailed": "Kunde inte exportera loggar",
-    "supportChatNotAvailable": "Supportchatten är inte tillgänglig",
     "supportCouldNotOpenMessages": "Kunde inte öppna supportmeddelanden",
     "supportCouldNotOpenPage": "Kunde inte öppna {pageName}",
     "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_te.arb
+++ b/mobile/lib/l10n/app_te.arb
@@ -2869,7 +2869,6 @@
   "@supportRevealLogsAction": {
     "description": "SnackBar action label that opens the folder containing the just-saved log file. Desktop platforms only."
   },
-  "supportChatNotAvailable": "మద్దతు చాట్ అందుబాటులో లేదు",
   "supportCouldNotOpenMessages": "మద్దతు సందేశాలను తెరవడం సాధ్యపడలేదు",
   "supportCouldNotOpenPage": "తెరవడం సాధ్యపడలేదు {pageName}",
   "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1588,7 +1588,6 @@
     "supportLoginRequired": "Destekle iletişime geçmek için giriş yap",
     "supportExportingLogs": "Günlükler dışa aktarılıyor...",
     "supportExportLogsFailed": "Günlükler dışa aktarılamadı",
-    "supportChatNotAvailable": "Destek sohbeti kullanılamıyor",
     "supportCouldNotOpenMessages": "Destek mesajları açılamadı",
     "supportCouldNotOpenPage": "{pageName} açılamadı",
     "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -2352,7 +2352,6 @@
   "@supportRevealLogsAction": {
     "description": "SnackBar action label that opens the folder containing the just-saved log file. Desktop platforms only."
   },
-  "supportChatNotAvailable": "سپورٹ چیٹ دستیاب نہیں",
   "supportCouldNotOpenMessages": "سپورٹ پیغامات نہیں کھل سکے",
   "supportCouldNotOpenPage": "{pageName} نہیں کھل سکا",
   "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -2352,7 +2352,6 @@
   "@supportRevealLogsAction": {
     "description": "SnackBar action label that opens the folder containing the just-saved log file. Desktop platforms only."
   },
-  "supportChatNotAvailable": "Chat hỗ trợ không khả dụng",
   "supportCouldNotOpenMessages": "Không mở được tin nhắn hỗ trợ",
   "supportCouldNotOpenPage": "Không mở được {pageName}",
   "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -2352,7 +2352,6 @@
   "@supportRevealLogsAction": {
     "description": "SnackBar action label that opens the folder containing the just-saved log file. Desktop platforms only."
   },
-  "supportChatNotAvailable": "客服聊天不可用",
   "supportCouldNotOpenMessages": "无法打开客服消息",
   "supportCouldNotOpenPage": "无法打开{pageName}",
   "@supportCouldNotOpenPage": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7933,12 +7933,6 @@ abstract class AppLocalizations {
   /// **'Show in folder'**
   String get supportRevealLogsAction;
 
-  /// No description provided for @supportChatNotAvailable.
-  ///
-  /// In en, this message translates to:
-  /// **'Support chat not available'**
-  String get supportChatNotAvailable;
-
   /// No description provided for @supportCouldNotOpenMessages.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4518,9 +4518,6 @@ class AppLocalizationsAm extends AppLocalizations {
   String get supportRevealLogsAction => 'በአቃፊ ውስጥ አሳይ';
 
   @override
-  String get supportChatNotAvailable => 'የድጋፍ ውይይት አይገኝም';
-
-  @override
   String get supportCouldNotOpenMessages => 'የድጋፍ መልዕክቶችን መክፈት አልተቻለም';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4587,9 +4587,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get supportRevealLogsAction => 'إظهار في المجلد';
 
   @override
-  String get supportChatNotAvailable => 'محادثة الدعم غير متاحة';
-
-  @override
   String get supportCouldNotOpenMessages => 'تعذر فتح رسائل الدعم';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4676,9 +4676,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get supportRevealLogsAction => 'Покажи в папка';
 
   @override
-  String get supportChatNotAvailable => 'Чатът за поддръжка не е наличен';
-
-  @override
   String get supportCouldNotOpenMessages =>
       'Не можах да отворя съобщения за поддръжка';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4685,9 +4685,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get supportRevealLogsAction => 'Im Ordner anzeigen';
 
   @override
-  String get supportChatNotAvailable => 'Support-Chat nicht verfügbar';
-
-  @override
   String get supportCouldNotOpenMessages =>
       'Support-Nachrichten konnten nicht geöffnet werden';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4714,9 +4714,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get supportRevealLogsAction => 'Show in folder';
 
   @override
-  String get supportChatNotAvailable => 'Support chat not available';
-
-  @override
   String get supportCouldNotOpenMessages => 'Could not open support messages';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4674,9 +4674,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get supportRevealLogsAction => 'Mostrar en carpeta';
 
   @override
-  String get supportChatNotAvailable => 'El chat de soporte no está disponible';
-
-  @override
   String get supportCouldNotOpenMessages =>
       'No se pudieron abrir los mensajes de soporte';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4659,9 +4659,6 @@ class AppLocalizationsFil extends AppLocalizations {
   String get supportRevealLogsAction => 'Ipakita sa folder';
 
   @override
-  String get supportChatNotAvailable => 'Hindi available ang support chat';
-
-  @override
   String get supportCouldNotOpenMessages =>
       'Hindi nabuksan ang support messages';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4693,9 +4693,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get supportRevealLogsAction => 'Afficher dans le dossier';
 
   @override
-  String get supportChatNotAvailable => 'Chat du support indisponible';
-
-  @override
   String get supportCouldNotOpenMessages =>
       'Impossible d\'ouvrir les messages du support';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4559,9 +4559,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get supportRevealLogsAction => 'Tampilkan di folder';
 
   @override
-  String get supportChatNotAvailable => 'Chat dukungan tidak tersedia';
-
-  @override
   String get supportCouldNotOpenMessages => 'Tidak bisa membuka pesan dukungan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4679,9 +4679,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get supportRevealLogsAction => 'Mostra nella cartella';
 
   @override
-  String get supportChatNotAvailable => 'Chat di assistenza non disponibile';
-
-  @override
   String get supportCouldNotOpenMessages =>
       'Impossibile aprire i messaggi di assistenza';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4351,9 +4351,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get supportRevealLogsAction => 'フォルダで表示';
 
   @override
-  String get supportChatNotAvailable => 'サポートチャットは今使えないよ';
-
-  @override
   String get supportCouldNotOpenMessages => 'サポートメッセージが開けなかった';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4365,9 +4365,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get supportRevealLogsAction => '폴더에서 보기';
 
   @override
-  String get supportChatNotAvailable => '지원 채팅을 사용할 수 없어요';
-
-  @override
   String get supportCouldNotOpenMessages => '지원 메시지를 열 수 없어요';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -4626,9 +4626,6 @@ class AppLocalizationsMs extends AppLocalizations {
   String get supportRevealLogsAction => 'Tunjuk dalam folder';
 
   @override
-  String get supportChatNotAvailable => 'Sembang sokongan tidak tersedia';
-
-  @override
   String get supportCouldNotOpenMessages =>
       'Tidak dapat membuka mesej sokongan';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4645,9 +4645,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get supportRevealLogsAction => 'Tonen in map';
 
   @override
-  String get supportChatNotAvailable => 'Supportchat niet beschikbaar';
-
-  @override
   String get supportCouldNotOpenMessages => 'Supportberichten openen mislukt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4749,9 +4749,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get supportRevealLogsAction => 'Pokaż w folderze';
 
   @override
-  String get supportChatNotAvailable => 'Czat z pomocą niedostępny';
-
-  @override
   String get supportCouldNotOpenMessages =>
       'Nie można otworzyć wiadomości pomocy';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4657,9 +4657,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get supportRevealLogsAction => 'Mostrar na pasta';
 
   @override
-  String get supportChatNotAvailable => 'Chat de suporte indisponível';
-
-  @override
   String get supportCouldNotOpenMessages =>
       'Não foi possível abrir as mensagens de suporte';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4764,9 +4764,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get supportRevealLogsAction => 'Arată în dosar';
 
   @override
-  String get supportChatNotAvailable => 'Chatul de asistență nu e disponibil';
-
-  @override
   String get supportCouldNotOpenMessages =>
       'N-am putut deschide mesajele de asistență';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4623,9 +4623,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get supportRevealLogsAction => 'Visa i mapp';
 
   @override
-  String get supportChatNotAvailable => 'Supportchatten är inte tillgänglig';
-
-  @override
   String get supportCouldNotOpenMessages =>
       'Kunde inte öppna supportmeddelanden';
 

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -4797,9 +4797,6 @@ class AppLocalizationsTe extends AppLocalizations {
   String get supportRevealLogsAction => 'ఫోల్డర్‌లో చూపించు';
 
   @override
-  String get supportChatNotAvailable => 'మద్దతు చాట్ అందుబాటులో లేదు';
-
-  @override
   String get supportCouldNotOpenMessages =>
       'మద్దతు సందేశాలను తెరవడం సాధ్యపడలేదు';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4567,9 +4567,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get supportRevealLogsAction => 'Klasörde göster';
 
   @override
-  String get supportChatNotAvailable => 'Destek sohbeti kullanılamıyor';
-
-  @override
   String get supportCouldNotOpenMessages => 'Destek mesajları açılamadı';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -4636,9 +4636,6 @@ class AppLocalizationsUr extends AppLocalizations {
   String get supportRevealLogsAction => 'فولڈر میں دکھائیں';
 
   @override
-  String get supportChatNotAvailable => 'سپورٹ چیٹ دستیاب نہیں';
-
-  @override
   String get supportCouldNotOpenMessages => 'سپورٹ پیغامات نہیں کھل سکے';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -4594,9 +4594,6 @@ class AppLocalizationsVi extends AppLocalizations {
   String get supportRevealLogsAction => 'Hiện trong thư mục';
 
   @override
-  String get supportChatNotAvailable => 'Chat hỗ trợ không khả dụng';
-
-  @override
   String get supportCouldNotOpenMessages => 'Không mở được tin nhắn hỗ trợ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -4330,9 +4330,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get supportRevealLogsAction => '在文件夹中显示';
 
   @override
-  String get supportChatNotAvailable => '客服聊天不可用';
-
-  @override
   String get supportCouldNotOpenMessages => '无法打开客服消息';
 
   @override

--- a/mobile/lib/screens/settings/support_center_screen.dart
+++ b/mobile/lib/screens/settings/support_center_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/clear_logs/clear_logs_cubit.dart';
 import 'package:openvine/blocs/export_logs/export_logs_cubit.dart';
+import 'package:openvine/blocs/support_contact/support_contact_cubit.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
@@ -16,7 +17,6 @@ import 'package:openvine/router/route_paths.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/support_email_composer.dart';
-import 'package:openvine/services/zendesk_support_service.dart';
 import 'package:openvine/utils/share_position_origin.dart';
 import 'package:openvine/widgets/bug_report_dialog.dart';
 import 'package:openvine/widgets/clear_logs_confirmation_sheet.dart';
@@ -59,11 +59,9 @@ class SupportCenterScreen extends ConsumerWidget {
           constraints: const BoxConstraints(maxWidth: 600),
           child: ListView(
             children: [
-              _SupportTile(
-                icon: DivineIconName.chat,
-                title: l10n.supportContactSupport,
-                subtitle: l10n.supportContactSupportSubtitle,
-                onTap: () => _contactSupport(context),
+              _SupportContactTile(
+                openSupportMessages: openZendeskSupport,
+                composeEmail: composeEmail,
               ),
               if (isAuthenticated)
                 _SupportTile(
@@ -164,44 +162,6 @@ class SupportCenterScreen extends ConsumerWidget {
     context.push(FeatureRequestScreen.path);
   }
 
-  Future<bool> _viewSupportMessages() async {
-    // JWT refresh is handled internally by showTicketListScreen via _ensureFreshJwt
-    return ZendeskSupportService.showTicketListScreen();
-  }
-
-  Future<void> _contactSupport(BuildContext context) async {
-    final l10n = context.l10n;
-    var emailBody = l10n.supportContactSupportSubtitle;
-    final openZendesk =
-        openZendeskSupport ??
-        (ZendeskSupportService.isAvailable ? _viewSupportMessages : null);
-    if (openZendesk != null) {
-      if (await openZendesk()) return;
-      emailBody = '${l10n.supportCouldNotOpenMessages}\n\n$emailBody';
-    } else {
-      emailBody = '${l10n.supportChatNotAvailable}\n\n$emailBody';
-    }
-    if (!context.mounted) return;
-
-    final sharePositionOrigin = shareAnchorForContext(context);
-    try {
-      await (composeEmail ?? SupportEmailComposer().compose)(
-        toEmail: AppConstants.supportEmail,
-        subject: l10n.supportContactSupport,
-        body: emailBody,
-        sharePositionOrigin: sharePositionOrigin,
-      );
-    } catch (_) {
-      if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        DivineSnackbarContainer.snackBar(
-          l10n.authCouldNotOpenEmail(AppConstants.supportEmail),
-          error: true,
-        ),
-      );
-    }
-  }
-
   Future<void> _launchUrl(
     BuildContext context,
     String urlString,
@@ -248,6 +208,7 @@ class _SupportTile extends StatelessWidget {
     this.iconColor,
     this.titleColor,
     this.trailingColor,
+    this.trailing,
   });
 
   final DivineIconName icon;
@@ -256,9 +217,10 @@ class _SupportTile extends StatelessWidget {
   /// Overrides the title colour, for destructive entries.
   final Color? titleColor;
   final Color? trailingColor;
+  final Widget? trailing;
   final String title;
   final String subtitle;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -277,12 +239,91 @@ class _SupportTile extends StatelessWidget {
         subtitle,
         style: VineTheme.bodyMediumFont(color: context.vineColors.mutedText),
       ),
-      trailing: DivineIcon(
-        icon: DivineIconName.caretRight,
-        color: trailingColor ?? context.vineColors.mutedText,
-      ),
+      trailing:
+          trailing ??
+          DivineIcon(
+            icon: DivineIconName.caretRight,
+            color: trailingColor ?? context.vineColors.mutedText,
+          ),
       onTap: onTap,
     );
+  }
+}
+
+class _SupportContactTile extends StatelessWidget {
+  const _SupportContactTile({
+    this.openSupportMessages,
+    this.composeEmail,
+  });
+
+  final OpenSupportMessages? openSupportMessages;
+  final SupportEmailCompose? composeEmail;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => SupportContactCubit(
+        openSupportMessages: openSupportMessages,
+      ),
+      child: _SupportContactTileView(composeEmail: composeEmail),
+    );
+  }
+}
+
+class _SupportContactTileView extends StatelessWidget {
+  const _SupportContactTileView({this.composeEmail});
+
+  final SupportEmailCompose? composeEmail;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return BlocConsumer<SupportContactCubit, SupportContactState>(
+      listenWhen: (previous, current) =>
+          previous.status != current.status &&
+          current.status == SupportContactStatus.unavailable,
+      listener: (context, _) => _composeSupportEmail(context),
+      builder: (context, state) {
+        final isOpening = state.status == SupportContactStatus.opening;
+        return _SupportTile(
+          icon: DivineIconName.chat,
+          title: l10n.supportContactSupport,
+          subtitle: l10n.supportContactSupportSubtitle,
+          onTap: isOpening
+              ? null
+              : () => context.read<SupportContactCubit>().open(),
+          trailing: isOpening
+              ? const SizedBox.square(
+                  dimension: 20,
+                  child: DivineCircularProgressIndicator(strokeWidth: 2),
+                )
+              : null,
+        );
+      },
+    );
+  }
+
+  Future<void> _composeSupportEmail(BuildContext context) async {
+    final l10n = context.l10n;
+    final sharePositionOrigin = shareAnchorForContext(context);
+    try {
+      await (composeEmail ?? SupportEmailComposer().compose)(
+        toEmail: AppConstants.supportEmail,
+        subject: l10n.supportContactSupport,
+        body:
+            '${l10n.supportCouldNotOpenMessages}\n\n'
+            '${l10n.supportContactSupportSubtitle}',
+        sharePositionOrigin: sharePositionOrigin,
+      );
+    } catch (_) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        DivineSnackbarContainer.snackBar(
+          l10n.authCouldNotOpenEmail(AppConstants.supportEmail),
+          error: true,
+        ),
+      );
+    }
   }
 }
 

--- a/mobile/lib/services/zendesk_support_service.dart
+++ b/mobile/lib/services/zendesk_support_service.dart
@@ -511,6 +511,7 @@ class ZendeskSupportService {
     String? description,
     List<String>? tags,
   }) async {
+    await _awaitInitialization();
     if (!_initialized) {
       Log.warning(
         'Zendesk not initialized - cannot show ticket screen',
@@ -583,6 +584,7 @@ class ZendeskSupportService {
   /// If the native SDK returns a `NO_IDENTITY` error, this method
   /// automatically falls back to anonymous identity and retries once.
   static Future<bool> showTicketListScreen() async {
+    await _awaitInitialization();
     if (!_initialized) {
       Log.warning(
         'Zendesk not initialized - cannot show ticket list',
@@ -656,6 +658,7 @@ class ZendeskSupportService {
     List<Map<String, dynamic>>? customFields,
     List<String>? attachmentPaths,
   }) async {
+    await _awaitInitialization();
     if (!_initialized) {
       Log.warning(
         'Zendesk not initialized - cannot create ticket',

--- a/mobile/test/blocs/support_contact/support_contact_cubit_test.dart
+++ b/mobile/test/blocs/support_contact/support_contact_cubit_test.dart
@@ -1,0 +1,52 @@
+// ABOUTME: Tests support-chat opening outcomes and duplicate-tap suppression
+// ABOUTME: Pins the loading state used while deferred SDK startup settles
+
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/support_contact/support_contact_cubit.dart';
+
+void main() {
+  group(SupportContactCubit, () {
+    blocTest<SupportContactCubit, SupportContactState>(
+      'reports opened when native support opens',
+      build: () => SupportContactCubit(openSupportMessages: () async => true),
+      act: (cubit) => cubit.open(),
+      expect: () => const [
+        SupportContactState(status: SupportContactStatus.opening),
+        SupportContactState(status: SupportContactStatus.opened),
+      ],
+    );
+
+    blocTest<SupportContactCubit, SupportContactState>(
+      'requests fallback when native support is unavailable',
+      build: () => SupportContactCubit(openSupportMessages: () async => false),
+      act: (cubit) => cubit.open(),
+      expect: () => const [
+        SupportContactState(status: SupportContactStatus.opening),
+        SupportContactState(status: SupportContactStatus.unavailable),
+      ],
+    );
+
+    test('ignores a second open while the first is in flight', () async {
+      final gate = Completer<bool>();
+      var calls = 0;
+      final cubit = SupportContactCubit(
+        openSupportMessages: () {
+          calls++;
+          return gate.future;
+        },
+      );
+
+      final first = cubit.open();
+      final second = cubit.open();
+      expect(calls, 1);
+
+      gate.complete(true);
+      await Future.wait([first, second]);
+      expect(calls, 1);
+      await cubit.close();
+    });
+  });
+}

--- a/mobile/test/blocs/support_contact/support_contact_cubit_test.dart
+++ b/mobile/test/blocs/support_contact/support_contact_cubit_test.dart
@@ -29,6 +29,21 @@ void main() {
       ],
     );
 
+    blocTest<SupportContactCubit, SupportContactState>(
+      'requests fallback when the opener throws instead of returning',
+      // A throwing opener must not strand the tile on `opening` with the tap
+      // disabled and no email fallback — that is the #8921 failure this cubit
+      // exists to prevent.
+      build: () => SupportContactCubit(
+        openSupportMessages: () async => throw Exception('native crash'),
+      ),
+      act: (cubit) => cubit.open(),
+      expect: () => const [
+        SupportContactState(status: SupportContactStatus.opening),
+        SupportContactState(status: SupportContactStatus.unavailable),
+      ],
+    );
+
     test('ignores a second open while the first is in flight', () async {
       final gate = Completer<bool>();
       var calls = 0;

--- a/mobile/test/screens/settings/support_center_screen_test.dart
+++ b/mobile/test/screens/settings/support_center_screen_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -342,7 +343,7 @@ void main() {
       expect(find.text(en.supportRequestFeature), findsNothing);
     });
 
-    testWidgets('opens email support when Zendesk is unavailable', (
+    testWidgets('opens email support when native support is unavailable', (
       tester,
     ) async {
       String? capturedToEmail;
@@ -351,6 +352,7 @@ void main() {
       await pump(
         tester,
         authState: AuthState.unauthenticated,
+        openZendeskSupport: () async => false,
         composeEmail:
             ({
               required String toEmail,
@@ -369,8 +371,45 @@ void main() {
 
       expect(capturedToEmail, AppConstants.supportEmail);
       expect(capturedSubject, en.supportContactSupport);
-      expect(capturedBody, contains(en.supportChatNotAvailable));
+      expect(capturedBody, contains(en.supportCouldNotOpenMessages));
       expect(capturedBody, contains(en.supportContactSupportSubtitle));
+    });
+
+    testWidgets('shows progress and suppresses repeat taps while opening', (
+      tester,
+    ) async {
+      final opening = Completer<bool>();
+      var openCalls = 0;
+      var composed = false;
+      await pump(
+        tester,
+        openZendeskSupport: () {
+          openCalls++;
+          return opening.future;
+        },
+        composeEmail:
+            ({
+              required String toEmail,
+              required String subject,
+              required String body,
+              Rect? sharePositionOrigin,
+            }) async {
+              composed = true;
+            },
+      );
+
+      await tester.tap(find.text(en.supportContactSupport));
+      await tester.pump();
+
+      expect(find.byType(DivineCircularProgressIndicator), findsOneWidget);
+      await tester.tap(find.text(en.supportContactSupport));
+      expect(openCalls, 1);
+
+      opening.complete(true);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DivineCircularProgressIndicator), findsNothing);
+      expect(composed, isFalse);
     });
 
     testWidgets('falls back to email when Zendesk cannot open messages', (
@@ -404,6 +443,7 @@ void main() {
       await pump(
         tester,
         authState: AuthState.unauthenticated,
+        openZendeskSupport: () async => false,
         composeEmail:
             ({
               required String toEmail,

--- a/mobile/test/services/zendesk_support_service_test.dart
+++ b/mobile/test/services/zendesk_support_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:clock/clock.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -221,6 +223,11 @@ void main() {
 
   group('ZendeskSupportService.showNewTicketScreen', () {
     test('returns false when not initialized', () async {
+      await ZendeskSupportService.initialize(
+        appId: '',
+        clientId: '',
+        zendeskUrl: '',
+      );
       final result = await ZendeskSupportService.showNewTicketScreen();
 
       expect(result, false);
@@ -353,8 +360,111 @@ void main() {
     });
   });
 
+  group('ZendeskSupportService user-facing initialization gate', () {
+    test('showNewTicketScreen waits for an in-flight initialization', () async {
+      final initializationRelease = Completer<void>();
+      var showNewTicketCalls = 0;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+            if (call.method == 'initialize') {
+              await initializationRelease.future;
+              return true;
+            }
+            if (call.method == 'showNewTicket') showNewTicketCalls++;
+            return null;
+          });
+
+      final initialization = ZendeskSupportService.initialize(
+        appId: 'test',
+        clientId: 'test',
+        zendeskUrl: 'https://test.zendesk.com',
+      );
+      final opening = ZendeskSupportService.showNewTicketScreen();
+      await pumpEventQueue();
+
+      expect(showNewTicketCalls, 0);
+      initializationRelease.complete();
+
+      expect(await opening, isTrue);
+      await initialization;
+      expect(showNewTicketCalls, 1);
+    });
+
+    test(
+      'showTicketListScreen waits for an in-flight initialization',
+      () async {
+        final initializationRelease = Completer<void>();
+        var showTicketListCalls = 0;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (MethodCall call) async {
+              if (call.method == 'initialize') {
+                await initializationRelease.future;
+                return true;
+              }
+              if (call.method == 'showTicketList') showTicketListCalls++;
+              return null;
+            });
+
+        final initialization = ZendeskSupportService.initialize(
+          appId: 'test',
+          clientId: 'test',
+          zendeskUrl: 'https://test.zendesk.com',
+        );
+        final opening = ZendeskSupportService.showTicketListScreen();
+        await pumpEventQueue();
+
+        expect(showTicketListCalls, 0);
+        initializationRelease.complete();
+
+        expect(await opening, isTrue);
+        await initialization;
+        expect(showTicketListCalls, 1);
+      },
+    );
+
+    test('createTicket waits for an in-flight initialization', () async {
+      final initializationRelease = Completer<void>();
+      var createTicketCalls = 0;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+            if (call.method == 'initialize') {
+              await initializationRelease.future;
+              return true;
+            }
+            if (call.method == 'createTicket') {
+              createTicketCalls++;
+              return true;
+            }
+            return null;
+          });
+
+      final initialization = ZendeskSupportService.initialize(
+        appId: 'test',
+        clientId: 'test',
+        zendeskUrl: 'https://test.zendesk.com',
+      );
+      final creation = ZendeskSupportService.createTicket(
+        subject: 'Subject',
+        description: 'Description',
+      );
+      await pumpEventQueue();
+
+      expect(createTicketCalls, 0);
+      initializationRelease.complete();
+
+      expect(await creation, isTrue);
+      await initialization;
+      expect(createTicketCalls, 1);
+    });
+  });
+
   group('ZendeskSupportService.showTicketListScreen', () {
     test('returns false when not initialized', () async {
+      await ZendeskSupportService.initialize(
+        appId: '',
+        clientId: '',
+        zendeskUrl: '',
+      );
       final result = await ZendeskSupportService.showTicketListScreen();
 
       expect(result, false);
@@ -567,6 +677,11 @@ void main() {
 
   group('ZendeskSupportService.createTicket', () {
     test('returns false when not initialized', () async {
+      await ZendeskSupportService.initialize(
+        appId: '',
+        clientId: '',
+        zendeskUrl: '',
+      );
       final result = await ZendeskSupportService.createTicket(
         subject: 'Test',
         description: 'Test description',


### PR DESCRIPTION
## Problem

The Support Center can be opened before deferred Zendesk initialization settles. The user-facing methods checked initialization synchronously, so a cold-start tap could skip native support and fall back to email even though the SDK became ready moments later.

## Why this fix

The three user-facing Zendesk entry points now await the service’s existing bounded initialization gate before deciding that native support is unavailable. A small SupportContactCubit owns the opening state, disables repeat taps, displays progress, and preserves the email fallback for genuine initialization or platform failures.

The obsolete synchronous availability branch and its unused localization key are removed.

## Deliberately unchanged

- Genuine Zendesk initialization and presentation failures still fall back to email.
- The process-global isAvailable API is not made reactive; callers that still use it are outside this focused fix.

## Verification

- Service regression tests for ticket list, new ticket, and ticket creation during late initialization
- Cubit tests for success, fallback, and duplicate-tap suppression
- Support Center widget tests for progress and email fallback
- Localization consistency and orphan-key checks
- Changed-file Flutter analysis and repository pre-push checks

Closes #8921