### PR TITLE
test(feature-flags): remove a permanently disabled screen test

### DIFF
--- a/mobile/scripts/baseline/skip_test_ceilings.txt
+++ b/mobile/scripts/baseline/skip_test_ceilings.txt
@@ -24,7 +24,6 @@ test/router/navigation_scenarios_test.dart	1 # rewrite: no overrides, sharedpref
 test/router/page_context_provider_test.dart	1 # rewrite: bare ProviderContainer, sharedPreferences unoverridden (#4836)
 test/router/profile_me_redirect_integration_test.dart	1 # rewrite: same authStateStream mock gap; overlaps unit variant (#4836)
 test/router/profile_me_redirect_test.dart	1 # rewrite: _MockAuthService lacks authStateStream goRouter reads (#4836)
-test/screens/feature_flag_screen_test.dart	1 # rewrite: screen hides internal flags, renders 7 of 18 (#4836)
 test/screens/video_editor/video_text_editor_screen_test.dart	3 # rewrite: layer path fetches anonymouspro via google_fonts (#4836)
 test/services/m3u8_resolver_service_test.dart	1 # quarantine: real http to stream.divine.video playlist (#4836)
 test/services/video_event_service_repost_test.dart	1 # rewrite: uses kind 6 reposts and kind 22 originals; both dropped (#4836)

--- a/mobile/test/screens/feature_flag_screen_test.dart
+++ b/mobile/test/screens/feature_flag_screen_test.dart
@@ -289,41 +289,6 @@ void main() {
       }
     });
 
-    testWidgets('should show flag states correctly', (tester) async {
-      // Set up mixed flag states
-      when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
-      when(
-        () => mockPrefs.containsKey('ff_enhancedAnalytics'),
-      ).thenReturn(true);
-
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [sharedPreferencesProvider.overrideWithValue(mockPrefs)],
-          child: const MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: FeatureFlagScreen(),
-          ),
-        ),
-      );
-
-      // Initialize service
-      final container = ProviderScope.containerOf(
-        tester.element(find.byType(FeatureFlagScreen)),
-      );
-      final service = container.read(featureFlagServiceProvider);
-      await service.initialize();
-      await tester.pumpAndSettle();
-
-      // Check that switches reflect the flag states
-      final switches = tester.widgetList<Switch>(find.byType(Switch));
-      expect(switches, hasLength(FeatureFlag.values.length));
-
-      // Find switches by looking for the flag display names
-      expect(find.text('Enhanced Analytics'), findsOneWidget);
-      // TOOD(any): Fix and re-enable these tests
-    }, skip: true);
-
     testWidgets('should handle individual flag reset', (tester) async {
       // Set up a flag with user override
       when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);


### PR DESCRIPTION
## Description

The final skipped feature-flag screen test expected every flag to render even though the screen intentionally hides internal flags and lazily builds only visible rows. Its only valid assertion duplicated the live override-indicator test, so removing it eliminates a permanent skip without reducing behavioral coverage or changing the app.

Part of #4836

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [x] Chore

## Verification

- `flutter test --no-pub test/screens/feature_flag_screen_test.dart` — 10 passed
- `flutter analyze --no-pub test/screens/feature_flag_screen_test.dart`
- `bash scripts/check_skip_ceiling.sh`
- pre-push analyzer and affected test suite

The skip baseline drops by one file and one skip declaration.