### PR TITLE
test(e2e): keep Maestro coverage tiers from drifting

### DIFF
--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -6,9 +6,34 @@ End-to-end UI tests written with **Maestro**, driving a real build against
 They exist for fast, high-signal regression detection on critical user flows.
 They are not a replacement for unit or widget tests.
 
-## Pull-request smoke versus regression
+## Supported entry points and execution tiers
 
-The automatic PR gate is intentionally limited to three deterministic signals:
+[`tiers.txt`](tiers.txt) is the source of truth for supported Maestro entry
+points. An entry point is either a test, flow, or suite nothing else invokes,
+or a file an automation runner invokes directly. Assertions, utilities, and
+nested journey files inherit the tier of the entry point that reaches them.
+
+| Tier | Runs | Requirements and cost |
+|---|---|---|
+| `pr` | Codemagic's shared iOS/Android smoke command | iOS uses `mac_mini_m2` with a 25-minute cap; manually dispatched Android uses `linux_x2` with a 60-minute cap; promotion target is p95 below 15 minutes over at least 30 comparable iOS runs |
+| `manual-regression` | Operator invokes `smoke.yaml` or `fullRegression.yaml` | Simulator and staging fixture variables; runtime is not yet measured |
+| `manual-hardware` | Operator invokes one recorder flow | Camera-capable Android emulator or physical device with an English system UI; runtime is not yet measured |
+| `scheduled` | No entry points currently | Reserved for a journey connected to a real scheduled runner |
+
+The registry records the runner, prerequisites, and reason for every supported
+entry point. `maestro_pr_smoke_contract_test.dart` checks that the registry
+covers the live flow graph, paths resolve with exact case, PR rows match the
+Codemagic command in order, and manual rows cannot drift into CI. Add or remove
+the registry row in the same change that adds, nests, retires, or automates an
+entry point.
+
+There is currently no scheduled Maestro device regression. The daily workflow
+described in `docs/AUTOMATED_QA.md` runs deterministic headless service tests;
+it does not run these Maestro suites.
+
+## Pull-request smoke
+
+The intended automatic PR lane is limited to three deterministic signals:
 
 1. `prLaunchReady` proves a clean install reaches interactive onboarding.
 2. `prAuthenticateHome` creates a throwaway local identity and proves the
@@ -541,7 +566,8 @@ e2e/maestro
 ├── tests/     single scenarios
 ├── asserts/   reusable screen assertions
 ├── utils/     navigation helpers
-└── scripts/   runners and checks
+├── scripts/   runners and checks
+└── tiers.txt  supported entry points and execution policy
 ```
 
 `scripts/check_refs.sh` verifies every `runFlow:` path resolves,

--- a/mobile/e2e/maestro/tiers.txt
+++ b/mobile/e2e/maestro/tiers.txt
@@ -1,0 +1,11 @@
+# path	tier	runner	requirements	rationale
+tests/prLaunchReady.yaml	pr	codemagic:e2e-smoke-ios,codemagic:e2e-smoke-android	simulator-or-emulator	Clean-install launch readiness
+tests/prAuthenticateHome.yaml	pr	codemagic:e2e-smoke-ios,codemagic:e2e-smoke-android	simulator-or-emulator	Throwaway-account authentication into Home
+tests/prSeededVideoPlayback.yaml	pr	codemagic:e2e-smoke-ios,codemagic:e2e-smoke-android	simulator-or-emulator,QA_VIDEO_EVENT_ID	Immutable public-event playback
+tests/removeKeys.yaml	pr	codemagic:e2e-smoke-ios,codemagic:e2e-smoke-android	simulator-or-emulator	Remove the throwaway account after PR smoke
+suites/smoke.yaml	manual-regression	operator	simulator,USER_EMAIL,USER_PWD,SEARCH_USER	Account and social regression against staging
+suites/fullRegression.yaml	manual-regression	operator	simulator,USER_KEYS,SEARCH_USER,SEARCH_USER_ID,VIDEO_USER,VIDEO_DESCRIPTION,VIDEO_DATA,EXISTING_USERNAME	Broader staging regression with mutable fixtures
+flows/captureModeFlow.yaml	manual-hardware	operator	camera-capable-android,english-system-ui	Capture-mode controls and recording
+flows/classicModeFlow.yaml	manual-hardware	operator	camera-capable-android,english-system-ui	Classic-mode controls and recording limit
+flows/lipSyncModeFlow.yaml	manual-hardware	operator	camera-capable-android,english-system-ui	Lip-sync audio gate and recording
+flows/stopMotionModeFlow.yaml	manual-hardware	operator	camera-capable-android,english-system-ui	Stop-motion capture and undo

--- a/mobile/test/tools/maestro_pr_smoke_contract_test.dart
+++ b/mobile/test/tools/maestro_pr_smoke_contract_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Pins the small, deterministic Maestro suite used on pull requests.
-// ABOUTME: Prevents broad regression flows or credential dependencies entering the gate.
+// ABOUTME: Pins Maestro entry-point tiers and the deterministic PR smoke lane.
+// ABOUTME: Prevents supported journeys and their automation policy from drifting.
 
 import 'dart:io';
 
@@ -18,12 +18,140 @@ final _fixtureAssignment = RegExp(
 /// A bare 32-byte Nostr event id — the only shape this variable may carry.
 final _eventId = RegExp(r'^[0-9a-f]{64}$');
 
+final _flowReference = RegExp(
+  r'''(?:runFlow:|file:)\s*["']?([A-Za-z0-9_/&.-]+\.yaml)''',
+);
+
+const _tiers = {
+  'pr',
+  'scheduled',
+  'manual-regression',
+  'manual-hardware',
+};
+
+final class _TierEntry {
+  const _TierEntry({
+    required this.path,
+    required this.tier,
+    required this.runners,
+    required this.requirements,
+    required this.rationale,
+  });
+
+  final String path;
+  final String tier;
+  final List<String> runners;
+  final List<String> requirements;
+  final String rationale;
+}
+
+List<_TierEntry> _parseTierRegistry(String source) {
+  final entries = <_TierEntry>[];
+  final seenPaths = <String>{};
+
+  for (final (index, rawLine) in source.split('\n').indexed) {
+    final line = rawLine.trim();
+    if (line.isEmpty || line.startsWith('#')) continue;
+
+    final columns = rawLine.split('\t');
+    if (columns.length != 5 || columns.any((column) => column.trim().isEmpty)) {
+      throw FormatException(
+        'tiers.txt:${index + 1} must contain five non-empty TSV columns',
+      );
+    }
+
+    final [path, tier, runners, requirements, rationale] = columns;
+    if (!_tiers.contains(tier)) {
+      throw FormatException('tiers.txt:${index + 1} has unknown tier $tier');
+    }
+    if (path.startsWith('/') || path.split('/').contains('..')) {
+      throw FormatException('tiers.txt:${index + 1} has unsafe path $path');
+    }
+    if (!seenPaths.add(path)) {
+      throw FormatException('tiers.txt:${index + 1} duplicates $path');
+    }
+
+    entries.add(
+      _TierEntry(
+        path: path,
+        tier: tier,
+        runners: runners.split(','),
+        requirements: requirements.split(','),
+        rationale: rationale,
+      ),
+    );
+  }
+
+  return entries;
+}
+
+bool _existsCaseSensitively(Directory root, String relativePath) {
+  var directory = root;
+  final segments = relativePath.split('/');
+
+  for (final (index, segment) in segments.indexed) {
+    final matches = directory.listSync().where(
+      (entity) =>
+          entity.uri.pathSegments.lastWhere((part) => part.isNotEmpty) ==
+          segment,
+    );
+    if (matches.length != 1) return false;
+
+    final match = matches.single;
+    if (index == segments.length - 1) return match is File;
+    if (match is! Directory) return false;
+    directory = match;
+  }
+
+  return false;
+}
+
+Set<String> _graphEntryPoints(Directory maestroDirectory) {
+  final candidates = <String>{};
+  final referenced = <String>{};
+
+  for (final entity in maestroDirectory.listSync(recursive: true)) {
+    if (entity is! File || !entity.path.endsWith('.yaml')) continue;
+
+    final relativePath = entity.uri.path.substring(
+      maestroDirectory.uri.path.length,
+    );
+    if (const ['tests/', 'flows/', 'suites/'].any(relativePath.startsWith)) {
+      candidates.add(relativePath);
+    }
+
+    for (final rawLine in entity.readAsLinesSync()) {
+      final line = rawLine.split('#').first;
+      for (final match in _flowReference.allMatches(line)) {
+        final reference = match.group(1)!;
+        final resolved = entity.parent.uri.resolve(reference).normalizePath();
+        if (resolved.path.startsWith(maestroDirectory.uri.path)) {
+          referenced.add(
+            resolved.path.substring(maestroDirectory.uri.path.length),
+          );
+        }
+      }
+    }
+  }
+
+  return candidates.difference(referenced);
+}
+
+List<String> _maestroInvocations(String source) => _flowInvocation
+    .allMatches(
+      source.split('\n').map((line) => line.split('#').first).join('\n'),
+    )
+    .map((match) => match.group(0)!.replaceFirst('e2e/maestro/', ''))
+    .toList();
+
 void main() {
   group('Maestro PR smoke contract', () {
     late String codemagic;
     late String smokeCommand;
     late String iosWorkflow;
     late String androidWorkflow;
+    late Directory maestroDirectory;
+    late List<_TierEntry> registry;
 
     /// Slices [source] between two anchors, failing on the anchor rather than
     /// on a `substring` range error when one of them moves.
@@ -56,22 +184,94 @@ void main() {
         '  e2e-smoke-android:',
       );
       androidWorkflow = sliceFrom(codemagic, '  e2e-smoke-android:');
+      maestroDirectory = Directory('e2e/maestro').absolute;
+      registry = _parseTierRegistry(
+        File('e2e/maestro/tiers.txt').readAsStringSync(),
+      );
     });
 
-    test('runs only the three PR journeys and teardown, in order', () {
-      // Ordered equality, not a presence loop: the lane's value is that it is
-      // bounded, so a regression flow appended to the command has to fail here.
+    test('registry covers every supported entry point exactly once', () {
+      final invoked = _maestroInvocations(codemagic).toSet();
+      final supported = _graphEntryPoints(maestroDirectory)..addAll(invoked);
+
       expect(
-        _flowInvocation
-            .allMatches(smokeCommand)
-            .map((match) => match.group(0))
-            .toList(),
-        equals(const [
-          'e2e/maestro/tests/prLaunchReady.yaml',
-          'e2e/maestro/tests/prAuthenticateHome.yaml',
-          'e2e/maestro/tests/prSeededVideoPlayback.yaml',
-          'e2e/maestro/tests/removeKeys.yaml',
-        ]),
+        registry.map((entry) => entry.path).toSet(),
+        equals(supported),
+      );
+    });
+
+    test('registry paths resolve with exact case', () {
+      for (final entry in registry) {
+        expect(
+          _existsCaseSensitively(maestroDirectory, entry.path),
+          isTrue,
+          reason: '${entry.path} does not resolve case-sensitively',
+        );
+      }
+      expect(
+        _existsCaseSensitively(maestroDirectory, 'suites/Smoke.yaml'),
+        isFalse,
+      );
+    });
+
+    test('PR rows exactly match the smoke command in order', () {
+      expect(
+        _maestroInvocations(smokeCommand),
+        equals(
+          registry
+              .where((entry) => entry.tier == 'pr')
+              .map((entry) => entry.path)
+              .toList(),
+        ),
+      );
+    });
+
+    test('manual rows have requirements and are absent from CI', () {
+      final invoked = _maestroInvocations(codemagic).toSet();
+      for (final entry in registry.where(
+        (entry) => entry.tier.startsWith('manual-'),
+      )) {
+        expect(entry.requirements, isNotEmpty, reason: entry.path);
+        expect(entry.runners, equals(const ['operator']), reason: entry.path);
+        expect(invoked, isNot(contains(entry.path)), reason: entry.path);
+      }
+    });
+
+    test('automated rows name existing Codemagic workflows', () {
+      final invoked = _maestroInvocations(codemagic).toSet();
+      for (final entry in registry.where(
+        (entry) => entry.tier == 'pr' || entry.tier == 'scheduled',
+      )) {
+        expect(invoked, contains(entry.path), reason: entry.path);
+        for (final runner in entry.runners) {
+          expect(runner, startsWith('codemagic:'), reason: entry.path);
+          final workflow = runner.substring('codemagic:'.length);
+          expect(
+            codemagic,
+            contains('  $workflow:'),
+            reason: '${entry.path} names missing runner $runner',
+          );
+        }
+      }
+    });
+
+    test('registry parser rejects malformed policy', () {
+      expect(
+        () => _parseTierRegistry('tests/example.yaml\tpr\toperator\tsimulator'),
+        throwsFormatException,
+      );
+      expect(
+        () => _parseTierRegistry(
+          'tests/example.yaml\tunknown\toperator\tsimulator\tReason',
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => _parseTierRegistry(
+          'tests/example.yaml\tpr\toperator\tsimulator\tReason\n'
+          'tests/example.yaml\tpr\toperator\tsimulator\tReason',
+        ),
+        throwsFormatException,
       );
     });
 


### PR DESCRIPTION
## Problem

The Maestro collection has pull-request, broad regression, and camera-dependent entry points, but no enforced policy says which paths are supported in each context. A journey can become an unreferenced entry point or drift into CI without any check requiring its prerequisites and execution cost to be documented.

## Why this change

This adds one tab-separated registry for the ten supported entry points: four PR command entries, two operator-run regression suites, and four camera-dependent recorder flows. The existing smoke contract now derives entry points from the live `runFlow` graph, verifies paths case-sensitively, pins PR rows to the Codemagic command in order, keeps manual rows out of CI, and rejects automated tiers without a real runner.

The README defines each tier, records the known runner caps and hardware or fixture requirements, and states explicitly that no scheduled Maestro device regression exists today. Nested tests, assertions, and utilities inherit their entry point tier instead of being mislabeled as independent manual journeys.

## Deliberately unchanged

Functional Maestro tags such as `auth`, `video`, and `recorder` remain functional selectors rather than duplicating the execution tier in every YAML file. This does not activate Codemagic webhooks or add scheduled device execution; #7504 still owns the inactive pull-request delivery setting. No journeys or selectors change.

## Verification

- `flutter test test/tools/maestro_pr_smoke_contract_test.dart` — 9 tests passed
- `flutter analyze lib test integration_test`
- `bash e2e/maestro/scripts/check_refs.sh`
- `bash scripts/check_maestro_copy_drift.sh`
- `env TMPDIR=/private/tmp ../.codex/scripts/test-config.sh`
- repository pre-push analysis and focused tests

Closes #8863
Related to #7504
Related to #8864