### PR TITLE
fix(logging): include relay activity in support exports

### DIFF
--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
 import 'package:nostr_client/src/models/models.dart';
 import 'package:nostr_client/src/nip89_client_tag.dart';
 import 'package:nostr_client/src/publish_result.dart';
+import 'package:nostr_client/src/relay_diagnostics_adapter.dart';
 import 'package:nostr_client/src/relay_manager.dart';
 import 'package:nostr_client/src/relay_rejection_classifier.dart';
 import 'package:nostr_client/src/social_publish_result.dart';
@@ -93,10 +94,12 @@ class NostrClient {
     required RelayManagerConfig relayManagerConfig,
     AppDbClient? dbClient,
   }) {
-    final nostr = _createNostr(config);
+    final relayDiagnostics = RelayDiagnosticsAdapter();
+    final nostr = _createNostr(config, relayDiagnostics.call);
     final relayManager = RelayManager(
       config: relayManagerConfig,
       relayPool: nostr.relayPool,
+      diagnosticsSink: relayDiagnostics.call,
     );
     return NostrClient._internal(
       nostr: nostr,
@@ -129,17 +132,22 @@ class NostrClient {
        _dbClient = dbClient,
        _eventVerifyWorkerSpawner = eventVerifyWorkerSpawner;
 
-  static Nostr _createNostr(NostrClientConfig config) {
+  static Nostr _createNostr(
+    NostrClientConfig config,
+    RelayDiagnosticsSink diagnosticsSink,
+  ) {
     RelayBase tempRelayGenerator(String url) => RelayBase(
       url,
       RelayStatus(url),
       channelFactory: config.webSocketChannelFactory,
+      diagnosticsSink: diagnosticsSink,
     );
     return Nostr(
       config.signer,
       config.eventFilters,
       tempRelayGenerator,
       onNotice: config.onNotice,
+      diagnosticsSink: diagnosticsSink,
       channelFactory: config.webSocketChannelFactory,
       signatureVerificationPolicy: config.signatureVerificationPolicy,
     );

--- a/mobile/packages/nostr_client/lib/src/relay_diagnostics_adapter.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_diagnostics_adapter.dart
@@ -1,0 +1,125 @@
+// ABOUTME: Bounds relay diagnostics before forwarding them to support logs.
+// ABOUTME: Adapts nostr_sdk's logging port to the shared UnifiedLogger.
+
+import 'dart:collection';
+
+import 'package:meta/meta.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Supplies the current time for deterministic diagnostic-window tests.
+typedef RelayDiagnosticsClock = DateTime Function();
+
+/// Bounds structured relay diagnostics and forwards them to support logs.
+class RelayDiagnosticsAdapter {
+  /// Creates a relay diagnostics adapter.
+  RelayDiagnosticsAdapter({
+    this.maxEventsPerWindow = 3,
+    this.window = const Duration(minutes: 1),
+    this.maxTrackedKeys = 256,
+    RelayDiagnosticsClock? clock,
+  }) : _clock = clock ?? DateTime.now;
+
+  /// Maximum entries emitted for one relay and site in a window.
+  final int maxEventsPerWindow;
+
+  /// Duration of one suppression window.
+  final Duration window;
+
+  /// Maximum relay/site keys retained by the limiter.
+  final int maxTrackedKeys;
+  final RelayDiagnosticsClock _clock;
+  final LinkedHashMap<_DiagnosticKey, _DiagnosticWindow> _windows =
+      LinkedHashMap<_DiagnosticKey, _DiagnosticWindow>();
+
+  /// Accepts one structured relay diagnostic.
+  void call(RelayDiagnostic diagnostic) {
+    final now = _clock();
+    final key = _DiagnosticKey(diagnostic.relayUrl, diagnostic.site);
+    var state = _windows.remove(key);
+
+    if (state == null || now.difference(state.startedAt) >= window) {
+      if (state != null && state.suppressed > 0) {
+        _write(
+          RelayDiagnostic(
+            site: diagnostic.site,
+            level: RelayDiagnosticLevel.info,
+            relayUrl: diagnostic.relayUrl,
+            message:
+                'Suppressed ${state.suppressed} repeated '
+                '${diagnostic.site.name} diagnostics during the previous '
+                '${window.inSeconds} seconds',
+          ),
+        );
+      }
+      state = _DiagnosticWindow(startedAt: now);
+    }
+
+    _windows[key] = state;
+    while (_windows.length > maxTrackedKeys) {
+      _windows.remove(_windows.keys.first);
+    }
+
+    if (state.emitted >= maxEventsPerWindow) {
+      state.suppressed++;
+      return;
+    }
+    state.emitted++;
+    _write(diagnostic);
+  }
+
+  void _write(RelayDiagnostic diagnostic) {
+    final message = '[${diagnostic.relayUrl}] ${diagnostic.message}';
+    switch (diagnostic.level) {
+      case RelayDiagnosticLevel.debug:
+        Log.debug(
+          message,
+          name: 'RelayDiagnostics',
+          category: LogCategory.relay,
+        );
+      case RelayDiagnosticLevel.info:
+        Log.info(
+          message,
+          name: 'RelayDiagnostics',
+          category: LogCategory.relay,
+        );
+      case RelayDiagnosticLevel.warning:
+        Log.warning(
+          message,
+          name: 'RelayDiagnostics',
+          category: LogCategory.relay,
+        );
+      case RelayDiagnosticLevel.error:
+        Log.error(
+          message,
+          name: 'RelayDiagnostics',
+          category: LogCategory.relay,
+        );
+    }
+  }
+}
+
+@immutable
+class _DiagnosticKey {
+  const _DiagnosticKey(this.relayUrl, this.site);
+
+  final String relayUrl;
+  final RelayDiagnosticSite site;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _DiagnosticKey &&
+      relayUrl == other.relayUrl &&
+      site == other.site;
+
+  @override
+  int get hashCode => Object.hash(relayUrl, site);
+}
+
+class _DiagnosticWindow {
+  _DiagnosticWindow({required this.startedAt});
+
+  final DateTime startedAt;
+  int emitted = 0;
+  int suppressed = 0;
+}

--- a/mobile/packages/nostr_client/lib/src/relay_diagnostics_adapter.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_diagnostics_adapter.dart
@@ -38,7 +38,11 @@ class RelayDiagnosticsAdapter {
     final key = _DiagnosticKey(diagnostic.relayUrl, diagnostic.site);
     var state = _windows.remove(key);
 
-    if (state == null || now.difference(state.startedAt) >= window) {
+    final elapsed = state == null
+        ? Duration.zero
+        : now.difference(state.startedAt);
+
+    if (state == null || elapsed >= window) {
       if (state != null && state.suppressed > 0) {
         _write(
           RelayDiagnostic(
@@ -47,8 +51,9 @@ class RelayDiagnosticsAdapter {
             relayUrl: diagnostic.relayUrl,
             message:
                 'Suppressed ${state.suppressed} repeated '
-                '${diagnostic.site.name} diagnostics during the previous '
-                '${window.inSeconds} seconds',
+                '${diagnostic.site.name} diagnostics in the '
+                '${elapsed.inSeconds} seconds since '
+                '${state.startedAt.toUtc().toIso8601String()}',
           ),
         );
       }

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -67,9 +67,11 @@ class RelayManager {
     required RelayManagerConfig config,
     required RelayPool relayPool,
     @visibleForTesting Relay Function(String url)? relayFactory,
+    RelayDiagnosticsSink? diagnosticsSink,
   }) : _config = config,
        _relayPool = relayPool,
-       _relayFactory = relayFactory;
+       _relayFactory = relayFactory,
+       _diagnosticsSink = diagnosticsSink;
 
   /// Known-dead relays that should never be added.
   ///
@@ -108,6 +110,7 @@ class RelayManager {
   final RelayManagerConfig _config;
   final RelayPool _relayPool;
   final Relay Function(String url)? _relayFactory;
+  final RelayDiagnosticsSink? _diagnosticsSink;
 
   /// Configured relay URLs (user's list, persisted)
   final List<String> _configuredRelays = [];
@@ -707,6 +710,7 @@ class RelayManager {
           url,
           RelayStatus(url),
           channelFactory: _config.webSocketChannelFactory,
+          diagnosticsSink: _diagnosticsSink,
         );
       }
 
@@ -880,5 +884,15 @@ class RelayManager {
 
   void _log(String message) {
     developer.log('[RelayManager] $message');
+    if (_diagnosticsSink == null) return;
+    emitRelayDiagnostic(
+      _diagnosticsSink,
+      RelayDiagnostic(
+        site: RelayDiagnosticSite.connectionLifecycle,
+        level: RelayDiagnosticLevel.info,
+        relayUrl: 'relay-manager',
+        message: message,
+      ),
+    );
   }
 }

--- a/mobile/packages/nostr_client/pubspec.yaml
+++ b/mobile/packages/nostr_client/pubspec.yaml
@@ -18,6 +18,8 @@ dependencies:
     path: ../nostr_sdk
   pool: ^1.5.1
   shared_preferences: ^2.5.3
+  unified_logger:
+    path: ../unified_logger
 
 dev_dependencies:
   flutter_test:

--- a/mobile/packages/nostr_client/test/src/relay_diagnostics_adapter_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_diagnostics_adapter_test.dart
@@ -65,6 +65,28 @@ void main() {
       expect(messages.last, contains('after rollover'));
     });
 
+    test('the suppression summary reports the span it actually covers', () {
+      final adapter = RelayDiagnosticsAdapter(
+        maxEventsPerWindow: 1,
+        clock: () => now,
+      );
+      final windowStart = now;
+
+      adapter(diagnostic(message: 'emitted'));
+      adapter(diagnostic(message: 'suppressed'));
+
+      // The storm stops, and the next diagnostic for this key only arrives
+      // ten minutes later. Its summary is timestamped now, so it has to name
+      // when the suppressed traffic actually happened.
+      now = now.add(const Duration(minutes: 10));
+      adapter(diagnostic(message: 'much later'));
+
+      final summary = capture.getRecentLogs().elementAt(1).message;
+      expect(summary, contains('Suppressed 1 repeated'));
+      expect(summary, contains('in the 600 seconds'));
+      expect(summary, contains(windowStart.toUtc().toIso8601String()));
+    });
+
     test('bounds limiter keys and treats separate sites independently', () {
       final adapter = RelayDiagnosticsAdapter(
         maxEventsPerWindow: 1,

--- a/mobile/packages/nostr_client/test/src/relay_diagnostics_adapter_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_diagnostics_adapter_test.dart
@@ -1,0 +1,119 @@
+// ABOUTME: Tests relay diagnostic capture and deterministic volume bounding.
+// ABOUTME: Verifies the nostr_sdk port reaches the shared support-log buffer.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_client/src/relay_diagnostics_adapter.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+void main() {
+  group('RelayDiagnosticsAdapter', () {
+    late DateTime now;
+    late LogCaptureService capture;
+
+    setUp(() async {
+      now = DateTime.utc(2026, 9, 8, 12);
+      capture = LogCaptureService();
+      await capture.clearAllLogs();
+    });
+
+    tearDown(() => capture.clearAllLogs());
+
+    RelayDiagnostic diagnostic({
+      String relayUrl = 'wss://relay.example',
+      RelayDiagnosticSite site = RelayDiagnosticSite.connectionLifecycle,
+      String message = 'Relay connection succeeded',
+      RelayDiagnosticLevel level = RelayDiagnosticLevel.info,
+    }) => RelayDiagnostic(
+      site: site,
+      level: level,
+      relayUrl: relayUrl,
+      message: message,
+    );
+
+    test('writes relay diagnostics to the support-log buffer', () {
+      final adapter = RelayDiagnosticsAdapter(clock: () => now);
+
+      adapter(diagnostic());
+
+      final entry = capture.getRecentLogs().single;
+      expect(entry.message, contains('wss://relay.example'));
+      expect(entry.message, contains('Relay connection succeeded'));
+      expect(entry.name, 'RelayDiagnostics');
+      expect(entry.category, LogCategory.relay);
+      expect(entry.level, LogLevel.info);
+    });
+
+    test('bounds repeated relay and site diagnostics', () {
+      final adapter = RelayDiagnosticsAdapter(
+        maxEventsPerWindow: 2,
+        clock: () => now,
+      );
+
+      adapter(diagnostic(message: 'first'));
+      adapter(diagnostic(message: 'second'));
+      adapter(diagnostic(message: 'third'));
+
+      expect(capture.getRecentLogs(), hasLength(2));
+
+      now = now.add(const Duration(minutes: 1));
+      adapter(diagnostic(message: 'after rollover'));
+
+      final messages = capture.getRecentLogs().map((entry) => entry.message);
+      expect(messages, hasLength(4));
+      expect(messages.elementAt(2), contains('Suppressed 1 repeated'));
+      expect(messages.last, contains('after rollover'));
+    });
+
+    test('bounds limiter keys and treats separate sites independently', () {
+      final adapter = RelayDiagnosticsAdapter(
+        maxEventsPerWindow: 1,
+        maxTrackedKeys: 1,
+        clock: () => now,
+      );
+
+      adapter(diagnostic(message: 'first relay'));
+      adapter(diagnostic(message: 'suppressed'));
+      adapter(
+        diagnostic(
+          relayUrl: 'wss://other.example',
+          site: RelayDiagnosticSite.queryDispatch,
+          message: 'other key',
+        ),
+      );
+      adapter(diagnostic(message: 'first key after eviction'));
+
+      final messages = capture.getRecentLogs().map((entry) => entry.message);
+      expect(messages, hasLength(3));
+      expect(messages.last, contains('first key after eviction'));
+    });
+
+    test(
+      'maps warning and error diagnostics without copying error objects',
+      () {
+        final adapter = RelayDiagnosticsAdapter(clock: () => now);
+
+        adapter(
+          diagnostic(
+            level: RelayDiagnosticLevel.warning,
+            message: 'warning',
+          ),
+        );
+        adapter(
+          diagnostic(
+            site: RelayDiagnosticSite.authentication,
+            level: RelayDiagnosticLevel.error,
+            message: 'authentication failed',
+          ),
+        );
+
+        final entries = capture.getRecentLogs();
+        expect(entries.map((entry) => entry.level), [
+          LogLevel.warning,
+          LogLevel.error,
+        ]);
+        expect(entries.every((entry) => entry.error == null), isTrue);
+      },
+    );
+  });
+}

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -9,6 +9,7 @@ import 'nip02/contact_list.dart';
 import 'relay/event_filter.dart';
 import 'relay/publish_outcome.dart';
 import 'relay/relay.dart';
+import 'relay/relay_diagnostics.dart';
 import 'relay/relay_pool.dart';
 import 'relay/relay_type.dart';
 import 'relay/signature_verification_policy.dart';
@@ -34,6 +35,7 @@ class Nostr {
     this.tempRelayGener, {
     this.onNotice,
     WebSocketChannelFactory? channelFactory,
+    RelayDiagnosticsSink? diagnosticsSink,
     SignatureVerificationPolicy signatureVerificationPolicy =
         SignatureVerificationPolicy.all,
   }) {
@@ -44,6 +46,7 @@ class Nostr {
       eventFilters,
       tempRelayGener,
       onNotice: onNotice,
+      diagnosticsSink: diagnosticsSink,
       signatureVerificationPolicy: signatureVerificationPolicy,
     );
   }

--- a/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
@@ -52,6 +52,7 @@ export 'relay/event_filter.dart';
 export 'relay/relay_mode.dart';
 export 'relay/relay.dart';
 export 'relay/relay_base.dart';
+export 'relay/relay_diagnostics.dart';
 export 'relay/publish_outcome.dart';
 export 'relay/event_verify_isolate.dart';
 export 'relay/relay_pool.dart';

--- a/mobile/packages/nostr_sdk/lib/relay/relay.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay.dart
@@ -9,6 +9,7 @@ import '../subscription.dart';
 import 'client_connected.dart';
 import 'relay_info.dart';
 import 'relay_info_util.dart';
+import 'relay_diagnostics.dart';
 import 'relay_status.dart';
 
 enum WriteAccess { readOnly, writeOnly, readWrite, nothing }
@@ -47,7 +48,27 @@ abstract class Relay {
   // NIP-45 COUNT queries
   final Map<String, Completer<CountResponse>> _countQueries = {};
 
-  Relay(this.url, this.relayStatus);
+  Relay(this.url, this.relayStatus, {this.diagnosticsSink});
+
+  final RelayDiagnosticsSink? diagnosticsSink;
+
+  void diagnose(
+    RelayDiagnosticSite site,
+    RelayDiagnosticLevel level,
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+  }) => emitRelayDiagnostic(
+    diagnosticsSink,
+    RelayDiagnostic(
+      site: site,
+      level: level,
+      relayUrl: url,
+      message: message,
+      error: error,
+      stackTrace: stackTrace,
+    ),
+  );
 
   /// The method to call connect function by framework.
   Future<bool> connect() async {
@@ -184,13 +205,33 @@ abstract class Relay {
     List<Subscription> saved,
   ) async {
     if (saved.isEmpty) return;
+    diagnose(
+      RelayDiagnosticSite.subscriptionReplay,
+      RelayDiagnosticLevel.info,
+      'Re-issuing ${saved.length} saved relay requests '
+      '(source=${source ?? "unknown"})',
+    );
     log(
       '[Relay] onConnected[${source ?? "unknown"}]: ${relayStatus.addr} - re-issuing ${saved.length} saved REQs',
     );
     for (final subscription in saved) {
       try {
-        await send(subscription.toJson(), skipReconnect: true);
-      } catch (e) {
+        final sent = await send(subscription.toJson(), skipReconnect: true);
+        if (!sent) {
+          diagnose(
+            RelayDiagnosticSite.subscriptionReplay,
+            RelayDiagnosticLevel.warning,
+            'Saved relay request ${subscription.id} was not sent',
+          );
+        }
+      } catch (e, stackTrace) {
+        diagnose(
+          RelayDiagnosticSite.subscriptionReplay,
+          RelayDiagnosticLevel.error,
+          'Saved relay request ${subscription.id} threw while replaying',
+          error: e,
+          stackTrace: stackTrace,
+        );
         log('subscription re-issue exception onConnected');
         log('$e');
       }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_base.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_base.dart
@@ -10,6 +10,7 @@ import 'package:flutter/foundation.dart';
 import 'client_connected.dart';
 import 'platform_websocket_factory.dart';
 import 'relay.dart';
+import 'relay_diagnostics.dart';
 import 'web_socket_connection_manager.dart';
 
 class RelayBase extends Relay {
@@ -23,6 +24,7 @@ class RelayBase extends Relay {
     super.url,
     super.relayStatus, {
     WebSocketChannelFactory? channelFactory,
+    super.diagnosticsSink,
   }) : _channelFactory = channelFactory;
 
   /// Tracks whether doConnect is in progress to avoid duplicate onConnected calls
@@ -67,7 +69,14 @@ class RelayBase extends Relay {
         url: url,
         channelFactory:
             _channelFactory ?? const PlatformWebSocketChannelFactory(),
-        logger: (msg) => log("[$url] $msg"),
+        logger: (msg) {
+          log("[$url] $msg");
+          diagnose(
+            RelayDiagnosticSite.connectionLifecycle,
+            _connectionDiagnosticLevel(msg),
+            msg,
+          );
+        },
       );
 
       // Set up stream listeners
@@ -91,6 +100,17 @@ class RelayBase extends Relay {
       onError(e.toString(), reconnect: true);
       return false;
     }
+  }
+
+  RelayDiagnosticLevel _connectionDiagnosticLevel(String message) {
+    final normalized = message.toLowerCase();
+    if (normalized.contains('error') ||
+        normalized.contains('failed') ||
+        normalized.contains('timeout') ||
+        normalized.contains('exhausted')) {
+      return RelayDiagnosticLevel.warning;
+    }
+    return RelayDiagnosticLevel.info;
   }
 
   void _setupStreamListeners() {

--- a/mobile/packages/nostr_sdk/lib/relay/relay_base.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_base.dart
@@ -73,7 +73,7 @@ class RelayBase extends Relay {
           log("[$url] $msg");
           diagnose(
             RelayDiagnosticSite.connectionLifecycle,
-            _connectionDiagnosticLevel(msg),
+            connectionDiagnosticLevelFor(msg),
             msg,
           );
         },
@@ -102,13 +102,35 @@ class RelayBase extends Relay {
     }
   }
 
-  RelayDiagnosticLevel _connectionDiagnosticLevel(String message) {
+  /// Phrases [WebSocketConnectionManager] uses when a connection attempt
+  /// did not succeed.
+  ///
+  /// The manager reports its outcome in prose, so this list has to track the
+  /// wording it actually emits. `timed out` is the one that reads like a
+  /// duplicate and is not: the manager renders a `Duration` after
+  /// `Connection timed out after`, so that line carries no `timeout`
+  /// substring, and the same holds for `Max reconnect attempts reached`,
+  /// `Connect abandoned` and `stopping before attempt`. Those four are how a
+  /// relay actually gives up, so without them a relay that timed out on every
+  /// handshake and then spent its reconnect budget reaches a support export
+  /// at the same severity as an ordinary `Connecting to` line.
+  static const List<String> _connectionFailurePhrases = [
+    'error',
+    'failed',
+    'timeout',
+    'timed out',
+    'abandoned',
+    'exhausted',
+    'max reconnect attempts',
+    'stopping before attempt',
+  ];
+
+  /// Severity for a [WebSocketConnectionManager] log line.
+  @visibleForTesting
+  static RelayDiagnosticLevel connectionDiagnosticLevelFor(String message) {
     final normalized = message.toLowerCase();
-    if (normalized.contains('error') ||
-        normalized.contains('failed') ||
-        normalized.contains('timeout') ||
-        normalized.contains('exhausted')) {
-      return RelayDiagnosticLevel.warning;
+    for (final phrase in _connectionFailurePhrases) {
+      if (normalized.contains(phrase)) return RelayDiagnosticLevel.warning;
     }
     return RelayDiagnosticLevel.info;
   }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_diagnostics.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_diagnostics.dart
@@ -1,0 +1,60 @@
+// ABOUTME: Structured, injectable relay diagnostics for SDK consumers.
+// ABOUTME: Keeps support logging policy outside nostr_sdk's dependency graph.
+
+import 'dart:developer' as developer;
+
+/// Severity of a relay diagnostic.
+enum RelayDiagnosticLevel { debug, info, warning, error }
+
+/// Stable diagnostic shapes used for volume bounding and support triage.
+enum RelayDiagnosticSite {
+  connectionLifecycle,
+  subscriptionReplay,
+  queryDispatch,
+  requestSettlement,
+  authentication,
+  notice,
+}
+
+/// A safe, structured description of relay activity.
+class RelayDiagnostic {
+  const RelayDiagnostic({
+    required this.site,
+    required this.level,
+    required this.relayUrl,
+    required this.message,
+    this.error,
+    this.stackTrace,
+  });
+
+  final RelayDiagnosticSite site;
+  final RelayDiagnosticLevel level;
+  final String relayUrl;
+  final String message;
+  final Object? error;
+  final StackTrace? stackTrace;
+}
+
+/// Receives structured relay diagnostics from nostr_sdk.
+typedef RelayDiagnosticsSink = void Function(RelayDiagnostic diagnostic);
+
+/// Emits [diagnostic] without allowing observability failures to affect I/O.
+void emitRelayDiagnostic(
+  RelayDiagnosticsSink? sink,
+  RelayDiagnostic diagnostic,
+) {
+  try {
+    if (sink != null) {
+      sink(diagnostic);
+      return;
+    }
+    developer.log(
+      diagnostic.message,
+      name: 'RelayDiagnostics',
+      error: diagnostic.error,
+      stackTrace: diagnostic.stackTrace,
+    );
+  } on Object catch (_) {
+    // Diagnostics are best-effort and must never change relay behavior.
+  }
+}

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -22,6 +22,7 @@ import 'publish_outcome.dart';
 import 'relay.dart';
 import 'relay_base.dart';
 import 'relay_type.dart';
+import 'relay_diagnostics.dart';
 import 'signature_verification_policy.dart';
 
 class _AuthRequiredPublishRetry {
@@ -251,6 +252,7 @@ class RelayPool {
     this.eventFilters,
     this.tempRelayGener, {
     this.onNotice,
+    this.diagnosticsSink,
     this.signatureVerificationPolicy = SignatureVerificationPolicy.all,
     this.silentRepairCooldown = const Duration(seconds: 60),
     this.minSubscriptionAgeBeforeRepair = const Duration(seconds: 10),
@@ -258,6 +260,39 @@ class RelayPool {
     this.tempRelayIdleTimeout = const Duration(seconds: 120),
     this.tempRelaySweepInterval = const Duration(seconds: 60),
   });
+
+  final RelayDiagnosticsSink? diagnosticsSink;
+
+  void _diagnose(
+    RelayDiagnosticSite site,
+    RelayDiagnosticLevel level,
+    String relayUrl,
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+  }) => emitRelayDiagnostic(
+    diagnosticsSink,
+    RelayDiagnostic(
+      site: site,
+      level: level,
+      relayUrl: relayUrl,
+      message: message,
+      error: error,
+      stackTrace: stackTrace,
+    ),
+  );
+
+  String _closedReasonCategory(String reason) {
+    final normalized = reason.toLowerCase();
+    if (normalized.contains('auth')) return 'auth-required';
+    if (normalized.contains('rate') || normalized.contains('limit')) {
+      return 'rate-limited';
+    }
+    if (normalized.contains('blocked') || normalized.contains('restricted')) {
+      return 'restricted';
+    }
+    return 'other';
+  }
 
   /// How long a temp relay may sit with no inbound traffic before the sweep
   /// closes it. Injectable so tests need no wall-clock wait.
@@ -589,12 +624,24 @@ class RelayPool {
     _observeRelayStatus(relay);
 
     if (await relay.connect()) {
+      _diagnose(
+        RelayDiagnosticSite.connectionLifecycle,
+        RelayDiagnosticLevel.info,
+        relay.url,
+        'Relay connection succeeded',
+      );
       if (autoSubscribe) {
         var replayFailed = false;
         final msg =
             '🔄 autoSubscribe: re-sending ${_subscriptions.length} '
             'subscriptions to ${relay.url}';
         log(msg);
+        _diagnose(
+          RelayDiagnosticSite.subscriptionReplay,
+          RelayDiagnosticLevel.info,
+          relay.url,
+          'Re-sending ${_subscriptions.length} saved subscriptions',
+        );
         for (final subscription in _subscriptionsSnapshot()) {
           // Save the subscription to the relay so that after AUTH completes
           // the relay can re-send it. Without this, autoSubscribe sends the
@@ -609,6 +656,12 @@ class RelayPool {
           replayFailed = replayFailed || !sent;
         }
         if (replayFailed) {
+          _diagnose(
+            RelayDiagnosticSite.subscriptionReplay,
+            RelayDiagnosticLevel.warning,
+            relay.url,
+            'Saved-subscription replay failed; reconnecting once',
+          );
           relay.relayStatus.onError();
           log(
             'autoSubscribe replay failed for ${relay.url}; '
@@ -626,6 +679,12 @@ class RelayPool {
       return true;
     } else {
       log("relay connect fail! ${relay.url}");
+      _diagnose(
+        RelayDiagnosticSite.connectionLifecycle,
+        RelayDiagnosticLevel.warning,
+        relay.url,
+        'Relay connection failed',
+      );
     }
 
     relay.relayStatus.onError();
@@ -735,6 +794,13 @@ class RelayPool {
 
     try {
       var message = subscription.toJson();
+      _diagnose(
+        RelayDiagnosticSite.queryDispatch,
+        RelayDiagnosticLevel.info,
+        relay.url,
+        'Dispatching one-shot query ${subscription.id} '
+        '(filters=${subscription.filters.length})',
+      );
       if ((sendAfterAuth || relay.relayStatus.alwaysAuth) &&
           !relay.relayStatus.authed) {
         log('🔐 Auth-required query - sending to trigger AUTH challenge');
@@ -749,6 +815,12 @@ class RelayPool {
             'for replay after reconnect/auth: ${subscription.id} ${relay.url}',
           );
         }
+        _diagnose(
+          RelayDiagnosticSite.queryDispatch,
+          result ? RelayDiagnosticLevel.info : RelayDiagnosticLevel.warning,
+          relay.url,
+          'One-shot query ${subscription.id} trigger sent=$result',
+        );
         return true;
       } else {
         // Skip reconnect during query fan-out to avoid blocking
@@ -759,9 +831,23 @@ class RelayPool {
         if (result) {
           relay.saveQuery(subscription);
         }
+        _diagnose(
+          RelayDiagnosticSite.queryDispatch,
+          result ? RelayDiagnosticLevel.info : RelayDiagnosticLevel.warning,
+          relay.url,
+          'One-shot query ${subscription.id} dispatch succeeded=$result',
+        );
         return result;
       }
-    } catch (err) {
+    } catch (err, stackTrace) {
+      _diagnose(
+        RelayDiagnosticSite.queryDispatch,
+        RelayDiagnosticLevel.error,
+        relay.url,
+        'One-shot query ${subscription.id} dispatch threw',
+        error: err,
+        stackTrace: stackTrace,
+      );
       log(err.toString());
       relay.relayStatus.onError();
     }
@@ -1403,8 +1489,22 @@ class RelayPool {
   Future<void> _reconnectDroppedRelay(Relay relay) async {
     if (_closed) return;
     try {
+      _diagnose(
+        RelayDiagnosticSite.connectionLifecycle,
+        RelayDiagnosticLevel.info,
+        relay.url,
+        'Reconnecting dropped relay',
+      );
       await relay.connect();
-    } catch (e) {
+    } catch (e, stackTrace) {
+      _diagnose(
+        RelayDiagnosticSite.connectionLifecycle,
+        RelayDiagnosticLevel.warning,
+        relay.url,
+        'Dropped-relay reconnect failed',
+        error: e,
+        stackTrace: stackTrace,
+      );
       log('dropped-relay reconnect failed for ${relay.url}: $e');
     }
   }
@@ -1604,6 +1704,12 @@ class RelayPool {
     } else if (messageType == 'EOSE') {
       final subId = _stringAt(relay, json, 1, 'EOSE subscription id');
       if (subId == null) return;
+      _diagnose(
+        RelayDiagnosticSite.requestSettlement,
+        RelayDiagnosticLevel.info,
+        relay.url,
+        'Relay settled request $subId with EOSE',
+      );
       var isQuery = await relay.checkAndCompleteQuery(subId);
       if (isQuery) {
         _fireQueryCompleteIfSettled(subId, afterTerminalFrame: true);
@@ -1639,6 +1745,12 @@ class RelayPool {
         defaultValue: '',
       );
       if (message == null) return;
+      _diagnose(
+        RelayDiagnosticSite.requestSettlement,
+        success ? RelayDiagnosticLevel.info : RelayDiagnosticLevel.warning,
+        relay.url,
+        'Relay settled event $eventId with OK accepted=$success',
+      );
 
       // The relay has spoken for this event. Unless it refused for a reason
       // NIP-42 can fix, a frame retained by [_retainForAuthRetry] has served
@@ -1707,6 +1819,12 @@ class RelayPool {
         if (success) {
           relay.relayStatus.authed = true;
           log('🔐 AUTH succeeded for ${relay.url}');
+          _diagnose(
+            RelayDiagnosticSite.authentication,
+            RelayDiagnosticLevel.info,
+            relay.url,
+            'Relay authentication succeeded',
+          );
 
           // Send pending messages
           for (var message in relay.pendingAuthedMessages) {
@@ -1751,6 +1869,12 @@ class RelayPool {
         } else {
           relay.relayStatus.authed = false;
           log('🔐 AUTH failed for ${relay.url}: $message');
+          _diagnose(
+            RelayDiagnosticSite.authentication,
+            RelayDiagnosticLevel.warning,
+            relay.url,
+            'Relay authentication failed',
+          );
           _rejectAuthRequiredPublishesForRelay(relay, message);
           // The gate stayed shut, so the queries parked for the post-AUTH
           // replay will never be replayed.
@@ -1761,6 +1885,12 @@ class RelayPool {
       log('📡 NOTICE from ${relay.url}: $json');
       final message = _stringAt(relay, json, 1, 'NOTICE message');
       if (message == null) return;
+      _diagnose(
+        RelayDiagnosticSite.notice,
+        RelayDiagnosticLevel.warning,
+        relay.url,
+        'Relay sent a NOTICE frame',
+      );
 
       // notice save, TODO maybe should change code
       if (onNotice != null) {
@@ -1770,6 +1900,12 @@ class RelayPool {
       try {
         // auth needed
         log('🔐 AUTH challenge received from ${relay.url}');
+        _diagnose(
+          RelayDiagnosticSite.authentication,
+          RelayDiagnosticLevel.info,
+          relay.url,
+          'Relay requested authentication',
+        );
         final challenge = _stringAt(relay, json, 1, 'AUTH challenge');
         if (challenge == null) return;
         relay.relayStatus.alwaysAuth = true;
@@ -1812,6 +1948,14 @@ class RelayPool {
           _closeAuthGate(relay);
         }
       } catch (err, stackTrace) {
+        _diagnose(
+          RelayDiagnosticSite.authentication,
+          RelayDiagnosticLevel.error,
+          relay.url,
+          'Relay authentication handling failed',
+          error: err,
+          stackTrace: stackTrace,
+        );
         log('🔐 AUTH handling failed for ${relay.url}: $err\n$stackTrace');
         _rejectAuthRequiredPublishesForRelay(relay, '');
         _closeAuthGate(relay);
@@ -1857,6 +2001,13 @@ class RelayPool {
       if (reason == null) return;
 
       log('📡 CLOSED from ${relay.url}: $subscriptionId - $reason');
+      _diagnose(
+        RelayDiagnosticSite.requestSettlement,
+        RelayDiagnosticLevel.warning,
+        relay.url,
+        'Relay closed request $subscriptionId '
+        '(reason=${_closedReasonCategory(reason)})',
+      );
       // Check if this is a COUNT query being refused
       if (relay.hasCountQuery(subscriptionId)) {
         relay.failCountQuery(subscriptionId, reason);
@@ -2043,6 +2194,13 @@ class RelayPool {
           'readAccess=${relay.relayStatus.readAccess}, '
           'connected=${relay.relayStatus.connected})';
       log(subscribeMsg);
+      _diagnose(
+        RelayDiagnosticSite.queryDispatch,
+        RelayDiagnosticLevel.info,
+        relay.url,
+        'Dispatching request ${subscription.id} '
+        '(filters=${subscription.filters.length})',
+      );
       if ((sendAfterAuth || relay.relayStatus.alwaysAuth) &&
           !relay.relayStatus.authed) {
         log(
@@ -2053,14 +2211,34 @@ class RelayPool {
             .send(message, queueIfFailed: false, deadline: deadline)
             .timeout(perRelaySendTimeout, onTimeout: () => false);
         if (result) {
+          _diagnose(
+            RelayDiagnosticSite.queryDispatch,
+            RelayDiagnosticLevel.info,
+            relay.url,
+            'Request ${subscription.id} dispatch succeeded',
+          );
           return true;
         }
       } else {
         var result = await relay.send(message, skipReconnect: true);
         log('📤 relayDoSubscribe: ${subscription.id} send result=$result');
+        _diagnose(
+          RelayDiagnosticSite.queryDispatch,
+          result ? RelayDiagnosticLevel.info : RelayDiagnosticLevel.warning,
+          relay.url,
+          'Request ${subscription.id} dispatch succeeded=$result',
+        );
         return result;
       }
-    } catch (err) {
+    } catch (err, stackTrace) {
+      _diagnose(
+        RelayDiagnosticSite.queryDispatch,
+        RelayDiagnosticLevel.error,
+        relay.url,
+        'Request ${subscription.id} dispatch threw',
+        error: err,
+        stackTrace: stackTrace,
+      );
       log(err.toString());
       relay.relayStatus.onError();
     }
@@ -2735,6 +2913,12 @@ class RelayPool {
         '📡 $url accepted a frame but sent nothing back for the whole window '
         'the caller waited; reconnecting the stale connection',
       );
+      _diagnose(
+        RelayDiagnosticSite.connectionLifecycle,
+        RelayDiagnosticLevel.warning,
+        url,
+        'Relay sent no response during the settlement window; reconnecting',
+      );
       unawaited(
         _reconnectSilentRelay(
           relay,
@@ -2756,7 +2940,21 @@ class RelayPool {
     if (_closed) return;
     try {
       await relay.forceReconnect();
-    } catch (e) {
+      _diagnose(
+        RelayDiagnosticSite.connectionLifecycle,
+        RelayDiagnosticLevel.info,
+        relay.url,
+        'Silent-relay reconnect completed',
+      );
+    } catch (e, stackTrace) {
+      _diagnose(
+        RelayDiagnosticSite.connectionLifecycle,
+        RelayDiagnosticLevel.warning,
+        relay.url,
+        'Silent-relay reconnect failed',
+        error: e,
+        stackTrace: stackTrace,
+      );
       log('silent-relay reconnect failed for ${relay.url}: $e');
     }
   }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -282,14 +282,36 @@ class RelayPool {
     ),
   );
 
+  /// NIP-01's machine-readable `OK` / `CLOSED` prefixes, plus NIP-42's
+  /// `auth-required` and the `unsupported` prefix NIP-01 uses in its own
+  /// `CLOSED` examples.
+  static const Set<String> _closedReasonPrefixes = {
+    'auth-required',
+    'blocked',
+    'duplicate',
+    'error',
+    'invalid',
+    'mute',
+    'pow',
+    'rate-limited',
+    'restricted',
+    'unsupported',
+  };
+
+  /// Reduces a `CLOSED` reason to its NIP-01 prefix, or `other`.
+  ///
+  /// Matches the prefix rather than searching the whole reason, like
+  /// [_isExplicitAuthRequiredReason] and [_isRestrictedReason] already do.
+  /// Searching mislabels the human-readable half: `blocked: too many failed
+  /// auth attempts` is not an auth problem, and sends triage after NIP-42
+  /// when the account is blocked. Only the fixed prefixes above are ever
+  /// emitted, so relay-supplied text still cannot reach a support export.
   String _closedReasonCategory(String reason) {
-    final normalized = reason.toLowerCase();
-    if (normalized.contains('auth')) return 'auth-required';
-    if (normalized.contains('rate') || normalized.contains('limit')) {
-      return 'rate-limited';
-    }
-    if (normalized.contains('blocked') || normalized.contains('restricted')) {
-      return 'restricted';
+    final normalized = reason.trim().toLowerCase();
+    for (final prefix in _closedReasonPrefixes) {
+      if (!normalized.startsWith(prefix)) continue;
+      final rest = normalized.substring(prefix.length);
+      if (rest.isEmpty || rest.startsWith(':')) return prefix;
     }
     return 'other';
   }

--- a/mobile/packages/nostr_sdk/test/unit/relay_diagnostics_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_diagnostics_test.dart
@@ -114,6 +114,35 @@ void main() {
       },
     );
 
+    test('categorizes a CLOSED reason by its NIP-01 prefix', () async {
+      final relay = _DiagnosticRelay('wss://relay.example');
+      expect(await nostr.relayPool.add(relay), isTrue);
+
+      // The human-readable half mentions auth and rate limits; neither is
+      // what the relay actually said, and both are what a substring search
+      // would have reported.
+      await relay.deliver([
+        'CLOSED',
+        'blocked-subscription-id',
+        'blocked: too many failed auth attempts, slow your rate down',
+      ]);
+      await relay.deliver([
+        'CLOSED',
+        'unsupported-subscription-id',
+        'unsupported: filter contains unknown elements',
+      ]);
+
+      final settlements = diagnostics
+          .where((entry) => entry.site == RelayDiagnosticSite.requestSettlement)
+          .map((entry) => entry.message)
+          .toList();
+      expect(settlements, hasLength(2));
+      expect(settlements.first, contains('reason=blocked'));
+      expect(settlements.first, isNot(contains('auth-required')));
+      expect(settlements.first, isNot(contains('rate-limited')));
+      expect(settlements.last, contains('reason=unsupported'));
+    });
+
     test('a throwing diagnostics sink cannot break relay behavior', () async {
       final throwingNostr = Nostr(
         LocalNostrSigner(

--- a/mobile/packages/nostr_sdk/test/unit/relay_diagnostics_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_diagnostics_test.dart
@@ -161,4 +161,65 @@ void main() {
       );
     });
   });
+
+  group('connectionDiagnosticLevelFor', () {
+    // Every string below is copied verbatim from a `log(...)` call in
+    // web_socket_connection_manager.dart, with its interpolations resolved
+    // the way the manager resolves them — a Duration renders as
+    // `0:00:05.000000`, which is why none of the give-up messages contains
+    // the substring `timeout`.
+    test('reports how a connection gave up as a warning', () {
+      const gaveUp = [
+        'Connection timed out after 0:00:05.000000',
+        'Max reconnect attempts reached for wss://relay.example',
+        'Connect abandoned: wss://relay.example - no handshake time left',
+        'Reconnect budget cannot fit the next backoff for '
+            'wss://relay.example; stopping before attempt 3',
+        'Timed out closing orphaned channel after 0:00:02.000000',
+      ];
+
+      for (final message in gaveUp) {
+        expect(
+          RelayBase.connectionDiagnosticLevelFor(message),
+          RelayDiagnosticLevel.warning,
+          reason: 'a support export has to surface "$message"',
+        );
+      }
+    });
+
+    test('keeps already-classified failures at warning', () {
+      const failures = [
+        'Connection failed (WebSocket): WebSocketChannelException',
+        'Stream error: connection reset by peer',
+        'Health check failed: connection idle, forcing disconnect',
+        'Connection idle for 90s (timeout: 60s), forcing disconnect',
+      ];
+
+      for (final message in failures) {
+        expect(
+          RelayBase.connectionDiagnosticLevelFor(message),
+          RelayDiagnosticLevel.warning,
+          reason: 'a support export has to surface "$message"',
+        );
+      }
+    });
+
+    test('leaves ordinary lifecycle progress at info', () {
+      const progress = [
+        'Connecting to wss://relay.example',
+        'Connected to wss://relay.example',
+        'Already connected to wss://relay.example',
+        'Disconnected from wss://relay.example',
+        'Reconnecting in 4s (attempt 2/5)',
+      ];
+
+      for (final message in progress) {
+        expect(
+          RelayBase.connectionDiagnosticLevelFor(message),
+          RelayDiagnosticLevel.info,
+          reason: '"$message" is not a failure',
+        );
+      }
+    });
+  });
 }

--- a/mobile/packages/nostr_sdk/test/unit/relay_diagnostics_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_diagnostics_test.dart
@@ -1,0 +1,135 @@
+// ABOUTME: Regression tests for structured relay diagnostics emitted by RelayPool.
+// ABOUTME: Proves support-safe metadata is emitted while raw relay frames stay out.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:nostr_sdk/relay/client_connected.dart';
+
+class _DiagnosticRelay extends Relay {
+  _DiagnosticRelay(String url) : super(url, RelayStatus(url));
+
+  final List<List<dynamic>> sent = [];
+
+  @override
+  Future<bool> doConnect() async {
+    relayStatus.connected = ClientConnected.connected;
+    return true;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    relayStatus.connected = ClientConnected.disconnect;
+  }
+
+  @override
+  Future<bool> send(
+    List<dynamic> message, {
+    bool queueIfFailed = true,
+    bool skipReconnect = false,
+    DateTime? deadline,
+  }) async {
+    sent.add(message);
+    return true;
+  }
+
+  Future<void> deliver(List<dynamic> message) async {
+    final handler = onMessage;
+    expect(handler, isNotNull);
+    final dynamic result = handler!(this, message);
+    if (result is Future) await result;
+  }
+}
+
+void main() {
+  group('Relay diagnostics', () {
+    late List<RelayDiagnostic> diagnostics;
+    late Nostr nostr;
+
+    setUp(() {
+      diagnostics = [];
+      nostr = Nostr(
+        LocalNostrSigner(
+          '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+        ),
+        [],
+        (url) => _DiagnosticRelay(url),
+        diagnosticsSink: diagnostics.add,
+      );
+    });
+
+    test('emits connection, dispatch, and settlement metadata', () async {
+      final relay = _DiagnosticRelay('wss://relay.example');
+      expect(await nostr.relayPool.add(relay), isTrue);
+
+      final subscription = Subscription(
+        const [
+          {
+            'kinds': [1],
+          },
+        ],
+        (_) {},
+        id: 'full-subscription-id',
+      );
+      expect(
+        await nostr.relayPool.relayDoQuery(relay, subscription, false),
+        isTrue,
+      );
+      await relay.deliver(['EOSE', subscription.id]);
+
+      expect(
+        diagnostics.map((entry) => entry.site),
+        containsAll([
+          RelayDiagnosticSite.connectionLifecycle,
+          RelayDiagnosticSite.queryDispatch,
+          RelayDiagnosticSite.requestSettlement,
+        ]),
+      );
+      expect(
+        diagnostics.map((entry) => entry.message),
+        contains(contains('full-subscription-id')),
+      );
+    });
+
+    test(
+      'does not copy raw NOTICE or CLOSED bodies into diagnostics',
+      () async {
+        const rawSentinel = 'raw-frame-must-not-enter-support-export';
+        final relay = _DiagnosticRelay('wss://relay.example');
+        expect(await nostr.relayPool.add(relay), isTrue);
+
+        await relay.deliver(['NOTICE', rawSentinel]);
+        await relay.deliver(['CLOSED', 'full-subscription-id', rawSentinel]);
+
+        final exportedMessages = diagnostics
+            .map((entry) => entry.message)
+            .join('\n');
+        expect(exportedMessages, isNot(contains(rawSentinel)));
+        expect(
+          diagnostics.map((entry) => entry.site),
+          containsAll([
+            RelayDiagnosticSite.notice,
+            RelayDiagnosticSite.requestSettlement,
+          ]),
+        );
+      },
+    );
+
+    test('a throwing diagnostics sink cannot break relay behavior', () async {
+      final throwingNostr = Nostr(
+        LocalNostrSigner(
+          '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+        ),
+        [],
+        (url) => _DiagnosticRelay(url),
+        diagnosticsSink: (_) => throw StateError('diagnostics unavailable'),
+      );
+
+      expect(
+        await throwingNostr.relayPool.add(
+          _DiagnosticRelay('wss://relay.example'),
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/mobile/scripts/lib/nostr_id_log_truncation_detector.dart
+++ b/mobile/scripts/lib/nostr_id_log_truncation_detector.dart
@@ -148,6 +148,13 @@ const _characterViews = {'characters', 'runes', 'codeUnits', 'split'};
 /// `Log.<level>(...)` — the app-wide UnifiedLogger typedef.
 const _unifiedLogLevels = {'verbose', 'debug', 'info', 'warning', 'error'};
 
+/// Relay-diagnostics emitters. `diagnose`/`_diagnose` build a [RelayDiagnostic]
+/// whose message nostr_client forwards to `UnifiedLogger`, so their message
+/// argument reaches a support export exactly like a `Log.*` call. The string
+/// literal lives at these call sites, not at the `Log.*` that later forwards
+/// the opaque field, so the ratchet must read them here (#8930).
+const _relayDiagnosticFunctions = {'diagnose', '_diagnose'};
+
 /// package:logging levels, reached on a logger-shaped receiver.
 const _loggingPackageLevels = {
   'finest',
@@ -177,6 +184,8 @@ final _sinkTokens = <String>{
   'Log.',
   for (final r in _loggerReceivers) '$r.',
   for (final f in _bareLogFunctions) '$f(',
+  for (final f in _relayDiagnosticFunctions) '$f(',
+  'RelayDiagnostic(',
 };
 
 /// One forbidden Nostr value reaching a log sink.
@@ -632,7 +641,36 @@ class _SiteCollector extends RecursiveAstVisitor<void> {
   void visitMethodInvocation(MethodInvocation node) {
     final sink = _logSinkName(node);
     if (sink != null) _scanLogCall(node, sink);
+    // A `parseString` AST is unresolved, so an unprefixed `RelayDiagnostic(...)`
+    // is a MethodInvocation, not an InstanceCreationExpression (only const/new
+    // forms are the latter). Emit-site messages interpolate ids so they are
+    // never const — this shape is the one that reaches the export.
+    if (node.realTarget == null && node.methodName.name == 'RelayDiagnostic') {
+      _scanRelayDiagnostic(node.argumentList, node);
+    }
     super.visitMethodInvocation(node);
+  }
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    // The const/new form of the same sink; see visitMethodInvocation.
+    if (node.constructorName.type.name.lexeme == 'RelayDiagnostic') {
+      _scanRelayDiagnostic(node.argumentList, node);
+    }
+    super.visitInstanceCreationExpression(node);
+  }
+
+  /// `RelayDiagnostic(message: ...)` forwards its message to UnifiedLogger via
+  /// nostr_client, so the message is an export sink. The string literal lives
+  /// here at the constructor, not at the Log.* call that later forwards an
+  /// opaque field, so the ratchet is blind to it unless read here.
+  void _scanRelayDiagnostic(ArgumentList args, AstNode scopeNode) {
+    for (final argument in args.arguments) {
+      if (argument is NamedExpression &&
+          argument.name.label.name == 'message') {
+        _scan(argument.expression, scopeNode, 'RelayDiagnostic.message');
+      }
+    }
   }
 
   /// The sink label for [node] if it writes to a diagnostic sink, else null.
@@ -640,7 +678,11 @@ class _SiteCollector extends RecursiveAstVisitor<void> {
     final member = node.methodName.name;
     final target = node.realTarget;
     if (target == null) {
-      return _bareLogFunctions.contains(member) ? member : null;
+      if (_bareLogFunctions.contains(member) ||
+          _relayDiagnosticFunctions.contains(member)) {
+        return member;
+      }
+      return null;
     }
     final receiver = _rootIdentifierName(target);
     if (receiver == null) return null;
@@ -655,10 +697,13 @@ class _SiteCollector extends RecursiveAstVisitor<void> {
     return null;
   }
 
-  void _scanLogCall(MethodInvocation call, String sink) {
-    final locals = _shortenedLocalsVisibleAt(call);
+  void _scanLogCall(MethodInvocation call, String sink) =>
+      _scan(call.argumentList, call, sink);
+
+  void _scan(AstNode toScan, AstNode scopeNode, String sink) {
+    final locals = _shortenedLocalsVisibleAt(scopeNode);
     final finder = _ShorteningFinder(shorteners: shorteners, locals: locals);
-    call.argumentList.accept(finder);
+    toScan.accept(finder);
     for (final hit in finder.hits) {
       if (!_seen.add(hit.offset)) continue;
       sites.add(

--- a/mobile/scripts/lib/pubkey_log_encoding_detector.dart
+++ b/mobile/scripts/lib/pubkey_log_encoding_detector.dart
@@ -116,6 +116,10 @@ const _loggerReceivers = {'log', '_log', 'logger', '_logger'};
 /// Log functions callable without a receiver.
 const _bareLogFunctions = {'debugPrint', 'print', 'log'};
 
+/// Relay-diagnostics emitters whose message nostr_client forwards to the
+/// support export (#8930); their message argument is a log sink.
+const _relayDiagnosticFunctions = {'diagnose', '_diagnose'};
+
 /// Substrings that must appear in a file for it to hold a sink.
 ///
 /// DERIVED from the sink sets rather than written out, so a sink added above
@@ -126,6 +130,8 @@ final _sinkTokens = <String>{
   'developer.log',
   for (final f in _bareLogFunctions) '$f(',
   for (final r in _loggerReceivers) '$r.',
+  for (final f in _relayDiagnosticFunctions) '$f(',
+  'RelayDiagnostic(',
 };
 
 /// One pubkey reaching a log sink in a single encoding.
@@ -312,22 +318,48 @@ class _SiteCollector extends RecursiveAstVisitor<void> {
   @override
   void visitMethodInvocation(MethodInvocation node) {
     final sink = _logSinkName(node);
-    if (sink != null) {
-      final finder = _BarePubkeyFinder();
-      node.argumentList.accept(finder);
-      for (final hit in finder.hits) {
-        if (!_seen.add(hit.offset)) continue;
-        sites.add(
-          PubkeyLogSite(
-            path: path,
-            line: lineInfo.getLocation(hit.offset).lineNumber,
-            expression: hit.expression,
-            sink: sink,
-          ),
-        );
-      }
+    if (sink != null) _scan(node.argumentList, sink);
+    // Unresolved parse: an unprefixed `RelayDiagnostic(...)` is a
+    // MethodInvocation, and the diagnose/_diagnose helpers build it from a
+    // message argument that reaches the export. Both are covered above via
+    // `_logSinkName`; this catches a diagnostic built inline at a call site.
+    if (node.realTarget == null && node.methodName.name == 'RelayDiagnostic') {
+      _scanRelayDiagnostic(node.argumentList);
     }
     super.visitMethodInvocation(node);
+  }
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    if (node.constructorName.type.name.lexeme == 'RelayDiagnostic') {
+      _scanRelayDiagnostic(node.argumentList);
+    }
+    super.visitInstanceCreationExpression(node);
+  }
+
+  void _scanRelayDiagnostic(ArgumentList args) {
+    for (final argument in args.arguments) {
+      if (argument is NamedExpression &&
+          argument.name.label.name == 'message') {
+        _scan(argument.expression, 'RelayDiagnostic.message');
+      }
+    }
+  }
+
+  void _scan(AstNode toScan, String sink) {
+    final finder = _BarePubkeyFinder();
+    toScan.accept(finder);
+    for (final hit in finder.hits) {
+      if (!_seen.add(hit.offset)) continue;
+      sites.add(
+        PubkeyLogSite(
+          path: path,
+          line: lineInfo.getLocation(hit.offset).lineNumber,
+          expression: hit.expression,
+          sink: sink,
+        ),
+      );
+    }
   }
 
   /// The sink label for [node] if it writes to a diagnostic sink, else null.
@@ -335,7 +367,11 @@ class _SiteCollector extends RecursiveAstVisitor<void> {
     final member = node.methodName.name;
     final target = node.realTarget;
     if (target == null) {
-      return _bareLogFunctions.contains(member) ? member : null;
+      if (_bareLogFunctions.contains(member) ||
+          _relayDiagnosticFunctions.contains(member)) {
+        return member;
+      }
+      return null;
     }
     final receiver = _rootIdentifierName(target);
     if (receiver == null) return null;

--- a/mobile/test/services/bug_report_service_test.dart
+++ b/mobile/test/services/bug_report_service_test.dart
@@ -87,6 +87,26 @@ void main() {
       expect(data.timestamp, isA<DateTime>());
     });
 
+    test('includes captured relay diagnostics in the support export', () async {
+      final capture = LogCaptureService();
+      await capture.clearAllLogs();
+      Log.info(
+        '[wss://relay.example] Relay connection succeeded',
+        name: 'RelayDiagnostics',
+        category: LogCategory.relay,
+      );
+
+      final data = await service.collectDiagnostics(
+        userDescription: 'Relay connection problem',
+      );
+
+      final relayEntry = data.recentLogs.singleWhere(
+        (entry) => entry.name == 'RelayDiagnostics',
+      );
+      expect(relayEntry.category, LogCategory.relay);
+      expect(relayEntry.message, contains('Relay connection succeeded'));
+    });
+
     test('should collect error counts from injected tracker', () async {
       final errorTracker =
           ErrorAnalyticsTracker(sink: const NoOpAnalyticsEventSink())

--- a/mobile/test/services/bug_report_service_test.dart
+++ b/mobile/test/services/bug_report_service_test.dart
@@ -90,6 +90,9 @@ void main() {
     test('includes captured relay diagnostics in the support export', () async {
       final capture = LogCaptureService();
       await capture.clearAllLogs();
+      // The capture buffer is a process-global singleton shared by every
+      // suite in the merged VGV isolate, so this entry has to go back out.
+      addTearDown(capture.clearAllLogs);
       Log.info(
         '[wss://relay.example] Relay connection succeeded',
         name: 'RelayDiagnostics',

--- a/mobile/test/tools/nostr_id_log_truncation_detector_test.dart
+++ b/mobile/test/tools/nostr_id_log_truncation_detector_test.dart
@@ -59,6 +59,46 @@ void report(String eventId) {
         expect(sites.single.line, 2);
       });
 
+      test('a substring in a _diagnose message argument', () {
+        // The real emit path: relay sites call the diagnose/_diagnose helpers,
+        // which build the RelayDiagnostic and hand its message to nostr_client,
+        // which forwards it to UnifiedLogger and thus the support export. The
+        // literal is the helper argument, so the ratchet must read it there.
+        final sites = scan(r'''
+class RelayPool {
+  void relayDoSubscribe(String eventId) {
+    _diagnose(
+      RelayDiagnosticSite.queryDispatch,
+      RelayDiagnosticLevel.info,
+      relayUrl,
+      'found ${eventId.substring(0, 8)}...',
+    );
+  }
+}
+''');
+
+        expect(sites, hasLength(1));
+        expect(sites.single.identifier, 'eventId');
+        expect(sites.single.sink, '_diagnose');
+      });
+
+      test('a substring in a directly-built RelayDiagnostic message', () {
+        // Belt for a call site that skips the helper and builds the diagnostic
+        // inline with a literal message.
+        final sites = scan(r'''
+void report(String eventId) {
+  emitRelayDiagnostic(
+    sink,
+    RelayDiagnostic(message: 'found ${eventId.substring(0, 8)}...'),
+  );
+}
+''');
+
+        expect(sites, hasLength(1));
+        expect(sites.single.identifier, 'eventId');
+        expect(sites.single.sink, 'RelayDiagnostic.message');
+      });
+
       test('a shortened local reaching a log one statement later', () {
         // The shape three of the four #3372 sites used: compute a `preview`,
         // then log it. The truncation and the log call are different

--- a/mobile/test/tools/pubkey_log_encoding_detector_test.dart
+++ b/mobile/test/tools/pubkey_log_encoding_detector_test.dart
@@ -51,6 +51,28 @@ void report(String pubkey) {
         expect(sites.single.line, 2);
       });
 
+      test('a bare pubkey in a _diagnose message argument', () {
+        // The relay diagnose/_diagnose helpers forward their message to the
+        // support export via nostr_client, so a raw pubkey here is exported
+        // unencoded exactly as a Log.* call would be.
+        final sites = scan(r'''
+class RelayPool {
+  void relayDoSubscribe(String pubkey) {
+    _diagnose(
+      RelayDiagnosticSite.queryDispatch,
+      RelayDiagnosticLevel.info,
+      relayUrl,
+      'fetching for $pubkey',
+    );
+  }
+}
+''');
+
+        expect(sites, hasLength(1));
+        expect(sites.single.expression, 'pubkey');
+        expect(sites.single.sink, '_diagnose');
+      });
+
       test('a prefixed name, matched on its last camelCase segment', () {
         final sites = scan(r'''
 void report(String authorPubkey) {


### PR DESCRIPTION
## Problem

Support exports capture app-level logging but miss the relay-layer events needed to explain connection, replay, dispatch, and request-settlement failures. Those events currently go directly to the developer console, which is unavailable in user-submitted reports.

Closes #8930.

## Why this fix

This adds a dependency-neutral diagnostics port to `nostr_sdk` and connects it to `UnifiedLogger` from `nostr_client`, avoiding the existing `unified_logger -> models -> nostr_sdk` dependency cycle. Structured diagnostics cover connection lifecycle, saved-subscription replay, query dispatch, and request settlement.

The app adapter rate-limits repeated relay/site pairs and emits suppression summaries so reconnect loops cannot flood the bounded support-export window.

## Deliberately unchanged

- Raw relay frames, subscription JSON, NOTICE text, CLOSED reasons, and AUTH challenges remain console-only because they may contain content or excessive noise.
- Existing developer-console behavior remains the default when no diagnostics sink is supplied.
- The wider package logging architecture is left to #8933 and #8934.

## Verification

- `flutter test` in `packages/nostr_sdk` — 690 passed
- `flutter test` in `packages/nostr_client` — 365 passed
- `very_good test --coverage --min-coverage 20` in `packages/nostr_sdk` — passed
- `very_good test --coverage --min-coverage 82` in `packages/nostr_client` — passed
- `flutter test test/services/bug_report_service_test.dart` — 31 passed, 2 expected platform skips
- `flutter analyze` in both changed packages — no issues
- relay ID/pubkey and async timing guards — passed
- repository formatting and `git diff --check` — passed

Repository-wide analysis still reports the same two unrelated pre-existing `document_ignores` info diagnostics in `scripts/generate_seed_data.dart` and `scripts/generate_web_favicon.dart`.