### PR TITLE
chore(tooling): flag malformed issue titles when they are created or renamed

### DIFF
--- a/.github/scripts/lint_issue_title.py
+++ b/.github/scripts/lint_issue_title.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Lint a GitHub issue title against Divine's conventional-title policy.
+
+Background (divine-mobile#8337): the 2026-08-28 backlog triage rewrote 121
+issue titles. A grep-based check passed the same titles twice while a real
+linter later found 80 defects, because a text rule is wrong in both
+directions. This is that real linter, run as an `issues`-triggered guard that
+comments once on a non-conforming title rather than a push-triggered CI
+ratchet (issue titles are metadata, not files in the tree).
+
+Scope is the one place this diverges from #8337 as written. Rule 3 in the
+issue (2026-08-29) made a scope mandatory. Its author, Liz Sweigart,
+subsequently codified the org-wide policy in divine-context
+(`PR_REVIEW.md`, `title-conventions.json`, commit 3234369, 2026-09-02) as
+`type(scope): summary` OR `type: summary` when no scope applies. That later,
+org-canonical statement of the same author's intent wins, so a *missing*
+scope is not a defect here. It also keeps the guard from re-failing every
+Zendesk-bridged issue once divine-mobile#8335 drops the `(support)` scope
+(which produces scopeless titles) — enforcing a stricter-than-policy rule
+would recreate the "train people to ignore it" failure #8337 itself warns of.
+A scope that IS present must still not be the `support` intake channel; that
+provenance belongs on the `zendesk` label (#8335).
+
+The allowed types mirror divine-context's `title-conventions.json`
+(`pull_request_types` + `issue_only_types`). That file in divine-context is
+the source of truth; this list is a local copy kept aligned the same way the
+prose copies in AGENTS.md and PR_REVIEW.md are.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from dataclasses import dataclass
+
+# Mirror of divine-context/title-conventions.json: pull_request_types + issue_only_types.
+ALLOWED_TYPES = frozenset(
+    {
+        "feat",
+        "fix",
+        "chore",
+        "docs",
+        "refactor",
+        "test",
+        "perf",
+        "build",
+        "ci",
+        "style",
+        "revert",
+        # issue_only_types
+        "task",
+        "epic",
+    }
+)
+
+# Intake provenance belongs on the `zendesk` label, not the scope slot (#8335).
+FORBIDDEN_SCOPES = frozenset({"support"})
+
+# A summary shorter than this reads as a reporter's raw fragment ("Y"), not a
+# description. Approximate by design (#8337); the guard comments, never blocks,
+# so an occasional terse-but-valid summary costs a comment, not a merge.
+MIN_SUMMARY_LENGTH = 12
+
+# type, optional (scope), then `: summary`. Type is captured permissively so a
+# wrong-case type ("Fix") is reported as an unknown type rather than as an
+# unparseable title. A space after the colon is required by the convention.
+_TITLE_RE = re.compile(
+    r"^(?P<type>[A-Za-z][A-Za-z]*)"
+    r"(?:\((?P<scope>[^)]*)\))?"
+    r":[ \t]+(?P<summary>\S.*)$"
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    code: str
+    message: str
+
+
+def check_issue_title(title: str) -> list[Finding]:
+    """Return findings for a title; an empty list means it conforms."""
+    stripped = title.strip()
+    match = _TITLE_RE.match(stripped)
+    if match is None:
+        return [
+            Finding(
+                "unparseable",
+                "Title does not parse as `type: summary` or "
+                "`type(scope): summary`.",
+            )
+        ]
+
+    findings: list[Finding] = []
+
+    type_ = match.group("type")
+    if type_ not in ALLOWED_TYPES:
+        findings.append(
+            Finding(
+                "unknown_type",
+                f"`{type_}` is not an allowed type. Use one of: "
+                f"{', '.join(sorted(ALLOWED_TYPES))}.",
+            )
+        )
+
+    scope = match.group("scope")
+    if scope is not None:
+        # The `(...)` group is present; absence (a scopeless title) is allowed.
+        if scope.strip() == "":
+            findings.append(
+                Finding("empty_scope", "Scope parentheses are empty; drop them or name a scope.")
+            )
+        elif scope.strip().lower() in FORBIDDEN_SCOPES:
+            findings.append(
+                Finding(
+                    "support_scope",
+                    "`support` is an intake channel, not a product scope. Put "
+                    "intake provenance on the `zendesk` label and use a real "
+                    "scope, or drop the scope.",
+                )
+            )
+
+    summary = match.group("summary").strip()
+    if len(summary) <= MIN_SUMMARY_LENGTH:
+        findings.append(
+            Finding(
+                "summary_too_short",
+                f"Summary is too short (needs more than {MIN_SUMMARY_LENGTH} "
+                "characters). Describe what the issue gets someone, not the "
+                "reporter's raw words.",
+            )
+        )
+
+    return findings
+
+
+def main(argv: list[str]) -> int:
+    title = argv[1] if len(argv) > 1 else os.environ.get("ISSUE_TITLE", "")
+    findings = check_issue_title(title)
+    for finding in findings:
+        print(finding.message)
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/lint_issue_title.py
+++ b/.github/scripts/lint_issue_title.py
@@ -62,12 +62,16 @@ FORBIDDEN_SCOPES = frozenset({"support"})
 # so an occasional terse-but-valid summary costs a comment, not a merge.
 MIN_SUMMARY_LENGTH = 12
 
-# type, optional (scope), then `: summary`. Type is captured permissively so a
-# wrong-case type ("Fix") is reported as an unknown type rather than as an
-# unparseable title. A space after the colon is required by the convention.
+# type, optional (scope), an optional Conventional-Commit breaking-change `!`,
+# then `: summary`. Type is captured permissively so a wrong-case type ("Fix") is
+# reported as an unknown type rather than as an unparseable title. The `!` is
+# allowed so a valid Conventional-Commit title (`feat!:`, `feat(auth)!:`) is not
+# flagged — the org's PR check (commitlint) accepts it too. A space after the
+# colon is required by the convention.
 _TITLE_RE = re.compile(
     r"^(?P<type>[A-Za-z][A-Za-z]*)"
     r"(?:\((?P<scope>[^)]*)\))?"
+    r"!?"
     r":[ \t]+(?P<summary>\S.*)$"
 )
 

--- a/.github/scripts/lint_issue_title.py
+++ b/.github/scripts/lint_issue_title.py
@@ -8,7 +8,7 @@ directions. This is that real linter, run as an `issues`-triggered guard that
 comments once on a non-conforming title rather than a push-triggered CI
 ratchet (issue titles are metadata, not files in the tree).
 
-Scope is the one place this diverges from #8337 as written. Rule 3 in the
+Scope is one place this diverges from #8337 as written. Rule 3 in the
 issue (2026-08-29) made a scope mandatory. Its author, Liz Sweigart,
 subsequently codified the org-wide policy in divine-context
 (`PR_REVIEW.md`, `title-conventions.json`, commit 3234369, 2026-09-02) as
@@ -18,13 +18,15 @@ scope is not a defect here. It also keeps the guard from re-failing every
 Zendesk-bridged issue once divine-mobile#8335 drops the `(support)` scope
 (which produces scopeless titles) — enforcing a stricter-than-policy rule
 would recreate the "train people to ignore it" failure #8337 itself warns of.
-A scope that IS present must still not be the `support` intake channel; that
-provenance belongs on the `zendesk` label (#8335).
+The linter does not infer intake provenance from a scope name. `support` is
+also a real product area in divine-mobile, while Zendesk provenance belongs on
+the `zendesk` label (#8335).
 
 The allowed types mirror divine-context's `title-conventions.json`
 (`pull_request_types` + `issue_only_types`). That file in divine-context is
-the source of truth; this list is a local copy kept aligned the same way the
-prose copies in AGENTS.md and PR_REVIEW.md are.
+the source of truth. The workflow cannot read that private sibling repository
+with this repository's `GITHUB_TOKEN`, so this runtime list is a deliberately
+manual mirror and changes to it must be checked against the canonical manifest.
 """
 
 from __future__ import annotations
@@ -54,22 +56,12 @@ ALLOWED_TYPES = frozenset(
     }
 )
 
-# Intake provenance belongs on the `zendesk` label, not the scope slot (#8335).
-FORBIDDEN_SCOPES = frozenset({"support"})
-
-# A summary shorter than this reads as a reporter's raw fragment ("Y"), not a
-# description. Approximate by design (#8337); the guard comments, never blocks,
-# so an occasional terse-but-valid summary costs a comment, not a merge.
-MIN_SUMMARY_LENGTH = 12
-
 # type, optional (scope), an optional Conventional-Commit breaking-change `!`,
-# then `: summary`. Type is captured permissively so a wrong-case type ("Fix") is
-# reported as an unknown type rather than as an unparseable title. The `!` is
-# allowed so a valid Conventional-Commit title (`feat!:`, `feat(auth)!:`) is not
-# flagged — the org's PR check (commitlint) accepts it too. A space after the
-# colon is required by the convention.
+# then `: summary`. Type is captured permissively according to the canonical
+# type-token grammar so wrong-case and unsupported types such as `Fix`, `l10n`,
+# and `release-candidate` are reported as unknown rather than unparseable.
 _TITLE_RE = re.compile(
-    r"^(?P<type>[A-Za-z][A-Za-z]*)"
+    r"^(?P<type>[A-Za-z][A-Za-z0-9-]*)"
     r"(?:\((?P<scope>[^)]*)\))?"
     r"!?"
     r":[ \t]+(?P<summary>\S.*)$"
@@ -114,27 +106,6 @@ def check_issue_title(title: str) -> list[Finding]:
             findings.append(
                 Finding("empty_scope", "Scope parentheses are empty; drop them or name a scope.")
             )
-        elif scope.strip().lower() in FORBIDDEN_SCOPES:
-            findings.append(
-                Finding(
-                    "support_scope",
-                    "`support` is an intake channel, not a product scope. Put "
-                    "intake provenance on the `zendesk` label and use a real "
-                    "scope, or drop the scope.",
-                )
-            )
-
-    summary = match.group("summary").strip()
-    if len(summary) <= MIN_SUMMARY_LENGTH:
-        findings.append(
-            Finding(
-                "summary_too_short",
-                f"Summary is too short (needs more than {MIN_SUMMARY_LENGTH} "
-                "characters). Describe what the issue gets someone, not the "
-                "reporter's raw words.",
-            )
-        )
-
     return findings
 
 

--- a/.github/scripts/tests/test_lint_issue_title.py
+++ b/.github/scripts/tests/test_lint_issue_title.py
@@ -46,6 +46,18 @@ class ConformingTitles(unittest.TestCase):
         long_summary = "the editor drops the last second of every clip when " * 3
         self.assertEqual(codes(f"fix(editor): {long_summary}".strip()), [])
 
+    def test_breaking_change_marker_allowed(self):
+        # Conventional-Commit `!` is valid and accepted by the org's PR check.
+        self.assertEqual(codes("feat!: drop the legacy upload path for everyone"), [])
+        self.assertEqual(
+            codes("feat(auth)!: require re-login after a password reset now"), []
+        )
+        # ...but `!` does not excuse an unknown type — it's still a type error.
+        self.assertEqual(
+            codes("wibble!: change something in a way nobody can route"),
+            ["unknown_type"],
+        )
+
 
 class NonConformingTitles(unittest.TestCase):
     def test_support_scope_flagged(self):

--- a/.github/scripts/tests/test_lint_issue_title.py
+++ b/.github/scripts/tests/test_lint_issue_title.py
@@ -1,0 +1,92 @@
+"""Tests for the issue-title linter (divine-mobile#8337).
+
+The linter reconstructs the rules #8337 spells out. The one deliberate
+divergence from the issue body is scope: #8337 rule 3 made a scope mandatory
+(2026-08-29), but its author later codified the org-wide policy in
+divine-context PR_REVIEW.md / title-conventions.json (2026-09-02) as
+`type(scope): summary` OR `type: summary` when no scope applies. The later,
+org-canonical policy wins, so a missing scope is NOT a failure here. A scope
+that IS present must still not be the `support` intake channel (#8335).
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from lint_issue_title import check_issue_title  # noqa: E402
+
+
+def codes(title: str) -> list[str]:
+    return [f.code for f in check_issue_title(title)]
+
+
+class ConformingTitles(unittest.TestCase):
+    def test_type_scope_summary(self):
+        self.assertEqual(codes("fix(auth): username taken with no recovery path"), [])
+
+    def test_no_scope_passes(self):
+        # The core of the scope-optional decision: a scopeless title conforms.
+        self.assertEqual(
+            codes("feat: document how Divine counts followers and following"), []
+        )
+
+    def test_issue_only_types(self):
+        self.assertEqual(codes("task(dm): guard the unscoped DmRepository methods"), [])
+        self.assertEqual(codes("epic(l10n): launch Divine in Telugu for real"), [])
+
+    def test_proper_noun_summary_not_flagged(self):
+        # Lowercase-first-word is deliberately NOT enforced (proper nouns).
+        self.assertEqual(
+            codes("fix(verify): TikTok verification fails with non_sandbox_target"), []
+        )
+
+    def test_long_title_not_flagged_for_length(self):
+        long_summary = "the editor drops the last second of every clip when " * 3
+        self.assertEqual(codes(f"fix(editor): {long_summary}".strip()), [])
+
+
+class NonConformingTitles(unittest.TestCase):
+    def test_support_scope_flagged(self):
+        self.assertEqual(
+            codes("fix(support): the app crashes on the upload screen every time"),
+            ["support_scope"],
+        )
+
+    def test_empty_scope_flagged(self):
+        self.assertEqual(
+            codes("fix(): the app crashes on the upload screen every time"),
+            ["empty_scope"],
+        )
+
+    def test_unknown_type_flagged(self):
+        self.assertEqual(
+            codes("decision: pick the retention window for parent emails"),
+            ["unknown_type"],
+        )
+
+    def test_wrong_case_type_flagged_as_unknown(self):
+        self.assertEqual(
+            codes("Fix: the upload button does nothing on android"),
+            ["unknown_type"],
+        )
+
+    def test_unparseable_title(self):
+        self.assertEqual(
+            codes("Investigate and fix follower count instability across relays"),
+            ["unparseable"],
+        )
+
+    def test_short_summary_flagged(self):
+        self.assertEqual(codes("fix: Y"), ["summary_too_short"])
+
+    def test_support_scope_and_short_summary(self):
+        self.assertEqual(
+            sorted(codes("fix(support): Y")),
+            ["summary_too_short", "support_scope"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_lint_issue_title.py
+++ b/.github/scripts/tests/test_lint_issue_title.py
@@ -5,10 +5,13 @@ divergence from the issue body is scope: #8337 rule 3 made a scope mandatory
 (2026-08-29), but its author later codified the org-wide policy in
 divine-context PR_REVIEW.md / title-conventions.json (2026-09-02) as
 `type(scope): summary` OR `type: summary` when no scope applies. The later,
-org-canonical policy wins, so a missing scope is NOT a failure here. A scope
-that IS present must still not be the `support` intake channel (#8335).
+org-canonical policy wins, so a missing scope is NOT a failure here. `support`
+is also a real product area, while intake provenance belongs on the `zendesk`
+label (#8335).
 """
 
+import os
+import subprocess
 import sys
 import unittest
 from pathlib import Path
@@ -42,6 +45,16 @@ class ConformingTitles(unittest.TestCase):
             codes("fix(verify): TikTok verification fails with non_sandbox_target"), []
         )
 
+    def test_support_product_scope_passes(self):
+        self.assertEqual(
+            codes("epic(support): make the support and bug-report pipeline trustworthy"),
+            [],
+        )
+
+    def test_short_complete_summary_passes(self):
+        self.assertEqual(codes("feat: 機能要望"), [])
+        self.assertEqual(codes("fix: Audio Delays"), [])
+
     def test_long_title_not_flagged_for_length(self):
         long_summary = "the editor drops the last second of every clip when " * 3
         self.assertEqual(codes(f"fix(editor): {long_summary}".strip()), [])
@@ -60,10 +73,16 @@ class ConformingTitles(unittest.TestCase):
 
 
 class NonConformingTitles(unittest.TestCase):
-    def test_support_scope_flagged(self):
+    def test_digit_type_flagged_as_unknown(self):
         self.assertEqual(
-            codes("fix(support): the app crashes on the upload screen every time"),
-            ["support_scope"],
+            codes("l10n(inbox): review machine-translated strings from PR #6286"),
+            ["unknown_type"],
+        )
+
+    def test_hyphenated_type_flagged_as_unknown(self):
+        self.assertEqual(
+            codes("release-candidate: prepare the next mobile release"),
+            ["unknown_type"],
         )
 
     def test_empty_scope_flagged(self):
@@ -90,14 +109,32 @@ class NonConformingTitles(unittest.TestCase):
             ["unparseable"],
         )
 
-    def test_short_summary_flagged(self):
-        self.assertEqual(codes("fix: Y"), ["summary_too_short"])
 
-    def test_support_scope_and_short_summary(self):
-        self.assertEqual(
-            sorted(codes("fix(support): Y")),
-            ["summary_too_short", "support_scope"],
+class CommandLineInterface(unittest.TestCase):
+    def run_linter(self, title: str) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["ISSUE_TITLE"] = title
+        return subprocess.run(
+            ["python3", str(Path(__file__).resolve().parents[1] / "lint_issue_title.py")],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
         )
+
+    def test_environment_title_succeeds_silently(self):
+        result = self.run_linter("fix(auth): restore account recovery after logout")
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr, "")
+
+    def test_environment_title_prints_findings_and_fails(self):
+        result = self.run_linter("l10n(inbox): review translated strings")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("`l10n` is not an allowed type", result.stdout)
+        self.assertEqual(result.stderr, "")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/issue_title_guard.yml
+++ b/.github/workflows/issue_title_guard.yml
@@ -21,7 +21,9 @@ jobs:
   lint-title:
     name: lint-issue-title
     runs-on: ubuntu-24.04
-    if: github.actor != 'dependabot[bot]'
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      (github.event.action == 'opened' || github.event.changes.title != null)
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/issue_title_guard.yml
+++ b/.github/workflows/issue_title_guard.yml
@@ -1,0 +1,125 @@
+name: Issue Title Guard
+
+# Comments once when an issue title does not match Divine's convention
+# (`type(scope): summary`). See .github/scripts/lint_issue_title.py for the
+# rules and divine-mobile#8337 for why this is an issues-event comment rather
+# than a push-triggered CI ratchet.
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint-title:
+    name: lint-issue-title
+    runs-on: ubuntu-24.04
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Lint the issue title
+        id: lint
+        # The title is passed through env, never interpolated into the shell,
+        # so a crafted title cannot inject commands.
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          set +e
+          findings="$(python3 .github/scripts/lint_issue_title.py)"
+          code=$?
+          set -e
+          if [ "$code" -eq 0 ]; then
+            echo "conforming=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "conforming=false" >> "$GITHUB_OUTPUT"
+          fi
+          {
+            echo "findings<<FINDINGS_EOF"
+            echo "$findings"
+            echo "FINDINGS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment on a non-conforming title
+        uses: actions/github-script@v9
+        env:
+          CONFORMING: ${{ steps.lint.outputs.conforming }}
+          FINDINGS: ${{ steps.lint.outputs.findings }}
+        with:
+          script: |
+            const repo = context.repo;
+            const issueNumber = context.payload.issue.number;
+            const MARKER = '<!-- issue-title-guard-bot -->';
+
+            if (process.env.CONFORMING === 'true') {
+              await cleanup();
+              return;
+            }
+
+            const findings = (process.env.FINDINGS || '')
+              .split('\n')
+              .map(l => l.trim())
+              .filter(Boolean);
+
+            await upsertBotComment(buildComment(findings));
+
+            function buildComment(findings) {
+              const list = findings.map(f => `- ${f}`).join('\n');
+              return [
+                MARKER,
+                "### ✍️ This issue's title needs a tweak",
+                '',
+                'Divine issue titles use Conventional Commit format — ' +
+                  '`type(scope): summary`, or `type: summary` when no scope applies:',
+                '',
+                list,
+                '',
+                'Allowed types: `feat fix chore docs refactor test perf build ci ' +
+                  'style revert task epic`. The scope is optional, but when present ' +
+                  'it names a product area, not an intake channel.',
+                '',
+                'The canonical policy lives in ' +
+                  '[divine-context `PR_REVIEW.md`]' +
+                  '(https://github.com/divinevideo/divine-context/blob/main/PR_REVIEW.md) ' +
+                  '("Issue titles"). Edit the title and this comment clears itself.',
+              ].join('\n');
+            }
+
+            async function upsertBotComment(body) {
+              const comments = await github.rest.issues.listComments({
+                ...repo, issue_number: issueNumber, per_page: 100,
+              });
+              const existing = comments.data.find(
+                c => c.body && c.body.includes(MARKER)
+              );
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  ...repo, comment_id: existing.id, body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  ...repo, issue_number: issueNumber, body,
+                });
+              }
+            }
+
+            async function cleanup() {
+              const comments = await github.rest.issues.listComments({
+                ...repo, issue_number: issueNumber, per_page: 100,
+              });
+              const botComment = comments.data.find(
+                c => c.body && c.body.includes(MARKER)
+              );
+              if (botComment) {
+                await github.rest.issues.deleteComment({
+                  ...repo, comment_id: botComment.id,
+                });
+              }
+            }


### PR DESCRIPTION
Closes #8337.

## Problem

Issue titles are metadata, so the repository's push-triggered checks cannot
catch titles that drift from the `type(scope): summary` convention. The prior
grep-based audit also missed malformed titles, leaving triage inconsistent.

## Why this fix

This adds a tested Python linter and an issue-event workflow that leaves one
marker comment when a title is malformed, updates that comment when needed,
and removes it after the title is fixed. It runs when an issue opens or its
title changes; editing only the body does not produce retroactive lint noise.

The linter enforces the structural policy and allowed type list. Scope remains
optional under the canonical Divine policy. It deliberately does not infer
intake provenance from scope names because `support` is also a real product
area, and it does not impose a raw character minimum because that penalizes
short but complete summaries and CJK text.

The allowed types are a local runtime mirror of the private
`divine-context/title-conventions.json` manifest. This repository's workflow
token cannot read that sibling private repository, so changes to the list
still require comparison with the canonical manifest.

## Dependency

The Zendesk bridge fix in divine-zd-to-gh#21 merged before this pull request
was marked ready, so newly bridged issues no longer receive the intake channel
as their scope.

## Verification

- `python3 -m unittest discover -s .github/scripts/tests` (109 tests)
- `TMPDIR=/tmp .codex/scripts/test-config.sh`
- `git diff --check`
