### PR TITLE
fix(supporters): prevent purchases when verification is unavailable

### DIFF
--- a/mobile/lib/blocs/supporter/supporter_cubit.dart
+++ b/mobile/lib/blocs/supporter/supporter_cubit.dart
@@ -108,6 +108,9 @@ class SupporterCubit extends Cubit<SupporterState> {
         ),
       );
       _trackEvent('supporter_subscribe_failed');
+    } on SupporterApiException catch (error) {
+      _emitApiFailure(error);
+      _trackEvent('supporter_subscribe_failed');
     }
   }
 
@@ -146,13 +149,17 @@ class SupporterCubit extends Cubit<SupporterState> {
   }
 
   void _handleEntitlementError(Object error, StackTrace stackTrace) {
-    if (isClosed || error is! EntitlementException) return;
-    _emit(
-      state.copyWith(
-        status: SupporterStatus.error,
-        failure: SupporterFailure.fromMessage(error.message),
-      ),
-    );
+    if (isClosed) return;
+    if (error is SupporterApiException) {
+      _emitApiFailure(error);
+    } else if (error is EntitlementException) {
+      _emit(
+        state.copyWith(
+          status: SupporterStatus.error,
+          failure: SupporterFailure.fromMessage(error.message),
+        ),
+      );
+    }
   }
 
   Future<void> _refreshFromServer() async {
@@ -169,18 +176,20 @@ class SupporterCubit extends Cubit<SupporterState> {
         ),
       );
     } on SupporterApiException catch (error) {
-      if (isClosed) return;
-      final failure = switch (error.kind) {
-        SupporterApiFailureKind.ownershipConflict =>
-          SupporterFailure.ownershipConflict,
-        SupporterApiFailureKind.unavailable =>
-          SupporterFailure.verificationUnavailable,
-        _ => SupporterFailure.unknown,
-      };
-      _emit(
-        state.copyWith(status: SupporterStatus.error, failure: failure),
-      );
+      _emitApiFailure(error);
     }
+  }
+
+  void _emitApiFailure(SupporterApiException error) {
+    if (isClosed) return;
+    final failure = switch (error.kind) {
+      SupporterApiFailureKind.ownershipConflict =>
+        SupporterFailure.ownershipConflict,
+      SupporterApiFailureKind.unavailable =>
+        SupporterFailure.verificationUnavailable,
+      _ => SupporterFailure.unknown,
+    };
+    _emit(state.copyWith(status: SupporterStatus.error, failure: failure));
   }
 
   @override

--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -61,6 +61,9 @@ enum FeatureFlag {
     'Divine Supporters',
     'Optional monthly supporter subscription via in-app purchase. '
         'Nothing is gated — it keeps Divine running and recognizes supporters.',
+    // Purchases must not be exposed to ordinary users until the build has a
+    // configured verification service that can claim and acknowledge them.
+    audience: FeatureFlagAudience.internal,
   ),
   newPostNotifications(
     'New Post Notifications',

--- a/mobile/lib/router/routes/settings_routes.dart
+++ b/mobile/lib/router/routes/settings_routes.dart
@@ -11,6 +11,7 @@ import 'package:openvine/features/feature_flags/screens/feature_flag_screen.dart
 import 'package:openvine/models/authentication_source.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/invite_availability_providers.dart';
+import 'package:openvine/providers/supporter_providers.dart';
 import 'package:openvine/router/go_router_page_name.dart';
 import 'package:openvine/router/invite_availability_redirects.dart';
 import 'package:openvine/router/routes/route_extras.dart';
@@ -317,7 +318,8 @@ String? supporterRedirectIfDisabled(Ref ref) {
   final enabled = ref.read(
     isFeatureEnabledProvider(FeatureFlag.divineSupporters),
   );
-  if (enabled) return null;
+  final verificationAvailable = ref.read(supporterApiClientProvider) != null;
+  if (enabled && verificationAvailable) return null;
   return SettingsScreen.path;
 }
 

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -29,6 +29,7 @@ import 'package:openvine/providers/developer_mode_tap_provider.dart';
 import 'package:openvine/providers/device_scope.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/nip05_verification_provider.dart';
+import 'package:openvine/providers/supporter_providers.dart';
 import 'package:openvine/providers/swap_account.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/route_paths.dart';
@@ -343,6 +344,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final divineSupportersEnabled = ref.watch(
       isFeatureEnabledProvider(FeatureFlag.divineSupporters),
     );
+    final supporterVerificationAvailable =
+        ref.watch(supporterApiClientProvider) != null;
     // Watched here (not just in _VersionTile) so the Developer Options tile
     // appears immediately when dev mode is unlocked via the version tap.
     final isDeveloperMode = ref.watch(isDeveloperModeEnabledProvider);
@@ -411,7 +414,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                     onTap: () =>
                         context.push(MonetizationLinksSettingsScreen.path),
                   ),
-                if (divineSupportersEnabled)
+                if (divineSupportersEnabled && supporterVerificationAvailable)
                   DivineListTile(
                     title: context.l10n.supporterTitle,
                     icon: DivineIconName.heart,

--- a/mobile/lib/services/supporter_repository.dart
+++ b/mobile/lib/services/supporter_repository.dart
@@ -7,8 +7,10 @@ import 'dart:convert';
 
 import 'package:iap_repository/iap_repository.dart';
 import 'package:models/models.dart';
+import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
 import 'package:openvine/services/supporter_api_client.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 /// Persists and surfaces the current [SupporterEntitlement].
 ///
@@ -81,7 +83,25 @@ class SupporterRepository {
 
   /// Starts a purchase with the current full pubkey captured in the attempt.
   /// The store result is proof only; it cannot activate support.
-  Future<SupporterEntitlement> purchase(String productId) {
+  Future<SupporterEntitlement> purchase(String productId) async {
+    if (!hasServerClient) {
+      Log.warning(
+        'Supporter purchase blocked because verification is unavailable for '
+        '${pubkeyForLogs(_pubkey)}',
+        name: 'SupporterRepository',
+        category: LogCategory.system,
+      );
+      throw const SupporterApiException(
+        SupporterApiFailureKind.unavailable,
+        'Supporter verification is not configured.',
+      );
+    }
+    Log.info(
+      'Starting supporter purchase for ${pubkeyForLogs(_pubkey)} '
+      '(productId=$productId)',
+      name: 'SupporterRepository',
+      category: LogCategory.system,
+    );
     return _validator.purchase(
       productId,
       capturedPubkey: _pubkey,
@@ -235,8 +255,22 @@ class SupporterRepository {
     // switch. A device-scope durable queue will retain this case once wired.
     if (proof.capturedPubkey != _pubkey) return;
 
+    Log.info(
+      'Received supporter purchase proof for ${pubkeyForLogs(_pubkey)} '
+      '(store=${proof.store}, productId=${proof.productId})',
+      name: 'SupporterRepository',
+      category: LogCategory.system,
+    );
+
     final client = _apiClient;
     if (client == null) {
+      Log.warning(
+        'Supporter purchase proof cannot be claimed for '
+        '${pubkeyForLogs(_pubkey)}; purchase left unacknowledged for '
+        'redelivery',
+        name: 'SupporterRepository',
+        category: LogCategory.system,
+      );
       _handleValidatorError(
         const SupporterApiException(
           SupporterApiFailureKind.unavailable,
@@ -259,8 +293,22 @@ class SupporterRepository {
       );
       _handleChange(snapshot.entitlement);
       await _validator.completePurchase(proof);
+      Log.info(
+        'Claimed and acknowledged supporter purchase for '
+        '${pubkeyForLogs(_pubkey)} '
+        '(store=${proof.store}, productId=${proof.productId})',
+        name: 'SupporterRepository',
+        category: LogCategory.system,
+      );
     } on Object catch (error, stackTrace) {
       _recoveryCompleted = _isTerminalClaimFailure(error);
+      Log.warning(
+        'Supporter purchase claim failed for ${pubkeyForLogs(_pubkey)}; '
+        'purchase left unacknowledged for redelivery '
+        '(failure=${error.runtimeType})',
+        name: 'SupporterRepository',
+        category: LogCategory.system,
+      );
       if (!proof.silent) _handleValidatorError(error, stackTrace);
       // Keep the purchase unacknowledged so the store can redeliver it after
       // the Worker or signer becomes available.

--- a/mobile/test/blocs/supporter/supporter_cubit_test.dart
+++ b/mobile/test/blocs/supporter/supporter_cubit_test.dart
@@ -8,6 +8,7 @@ import 'package:iap_repository/iap_repository.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/supporter/supporter_cubit.dart';
 import 'package:openvine/blocs/supporter/supporter_state.dart';
+import 'package:openvine/services/supporter_api_client.dart';
 import 'package:openvine/services/supporter_repository.dart';
 
 class _FakeRepository extends Fake implements SupporterRepository {
@@ -25,12 +26,16 @@ class _FakeRepository extends Fake implements SupporterRepository {
   @override
   bool get hasServerClient => false;
 
+  Object? purchaseError;
+
   @override
   Stream<SupporterEntitlement> get changes => _controller.stream;
 
   @override
-  Future<SupporterEntitlement> purchase(String productId) =>
-      validator.purchase(productId);
+  Future<SupporterEntitlement> purchase(String productId) async {
+    if (purchaseError != null) throw purchaseError!;
+    return validator.purchase(productId);
+  }
 
   @override
   Future<SupporterEntitlement> restorePurchases() =>
@@ -146,6 +151,34 @@ void main() {
   });
 
   group('subscribe', () {
+    blocTest<SupporterCubit, SupporterState>(
+      'maps unavailable verification to a non-busy error',
+      build: () {
+        final repo = _FakeRepository(controller)
+          ..purchaseError = const SupporterApiException(
+            SupporterApiFailureKind.unavailable,
+            'Supporter verification is not configured.',
+          );
+        return SupporterCubit(repository: repo);
+      },
+      act: (cubit) => cubit.subscribe('divine.supporter.monthly'),
+      expect: () => [
+        isA<SupporterState>().having(
+          (s) => s.status,
+          'status',
+          SupporterStatus.purchasing,
+        ),
+        isA<SupporterState>()
+            .having((s) => s.status, 'status', SupporterStatus.error)
+            .having(
+              (s) => s.failure,
+              'failure',
+              SupporterFailure.verificationUnavailable,
+            )
+            .having((s) => s.isBusy, 'isBusy', isFalse),
+      ],
+    );
+
     blocTest<SupporterCubit, SupporterState>(
       'subscribe emits purchasing then active on success',
       build: () {
@@ -282,6 +315,32 @@ void main() {
   });
 
   group('purchase lifecycle', () {
+    test(
+      'surfaces verification failure received from the proof stream',
+      () async {
+        final repo = _FakeRepository(controller);
+        final cubit = SupporterCubit(repository: repo);
+        addTearDown(cubit.close);
+
+        cubit.start();
+        await pumpEventQueue();
+        controller.addError(
+          const SupporterApiException(
+            SupporterApiFailureKind.unavailable,
+            'Supporter verification is not configured.',
+          ),
+        );
+        await pumpEventQueue();
+
+        expect(cubit.state.status, SupporterStatus.error);
+        expect(
+          cubit.state.failure,
+          SupporterFailure.verificationUnavailable,
+        );
+        expect(cubit.state.isBusy, isFalse);
+      },
+    );
+
     test('surfaces pending and confirming purchase lifecycle', () async {
       final lifecycle = StreamController<EntitlementLifecycle>.broadcast();
       addTearDown(lifecycle.close);

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -19,6 +19,7 @@ import 'package:openvine/models/minor_account_review_status.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/protected_minor_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/supporter_providers.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/router/routes/settings_routes.dart';
 import 'package:openvine/router/universal_link_resolver.dart';
@@ -409,6 +410,21 @@ void main() {
   });
 
   group('feature-flagged settings routes', () {
+    test('supporter route redirects when verification is unavailable', () {
+      final redirectProvider = Provider<String?>(supporterRedirectIfDisabled);
+      final container = ProviderContainer(
+        overrides: [
+          featureFlagStateProvider.overrideWith(
+            (_) => const {FeatureFlag.divineSupporters: true},
+          ),
+          supporterApiClientProvider.overrideWithValue(null),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(redirectProvider), SettingsScreen.path);
+    });
+
     test('monetization settings route redirects when flag is off', () {
       final redirectProvider = Provider<String?>(
         monetizationLinksRedirectIfDisabled,

--- a/mobile/test/screens/feature_flag_screen_test.dart
+++ b/mobile/test/screens/feature_flag_screen_test.dart
@@ -96,6 +96,10 @@ void main() {
         findsNothing,
       );
       expect(find.text(FeatureFlag.feedTuning.displayName), findsNothing);
+      expect(
+        find.text(FeatureFlag.divineSupporters.displayName),
+        findsNothing,
+      );
     });
 
     testWidgets('drives the account-switching flag through its automation id', (

--- a/mobile/test/services/supporter_repository_test.dart
+++ b/mobile/test/services/supporter_repository_test.dart
@@ -25,6 +25,9 @@ class _FakeValidator implements EntitlementValidator {
   int restoreCallCount = 0;
   String? restoredPubkey;
   bool? restoredSilently;
+  int purchaseCallCount = 0;
+  int completePurchaseCallCount = 0;
+  Completer<void>? completionObserved;
   Object? restoreError;
   Completer<void>? restoreCompleter;
 
@@ -42,7 +45,10 @@ class _FakeValidator implements EntitlementValidator {
     String productId, {
     String? capturedPubkey,
     String? attemptId,
-  }) async => purchaseResult;
+  }) async {
+    purchaseCallCount++;
+    return purchaseResult;
+  }
 
   @override
   Future<SupporterEntitlement> restorePurchases({
@@ -69,7 +75,10 @@ class _FakeValidator implements EntitlementValidator {
       proofController.stream;
 
   @override
-  Future<void> completePurchase(SupporterPurchaseProof proof) async {}
+  Future<void> completePurchase(SupporterPurchaseProof proof) async {
+    completePurchaseCallCount++;
+    completionObserved?.complete();
+  }
 
   void emit(SupporterEntitlement e) => _controller.add(e);
 
@@ -119,10 +128,8 @@ void main() {
           200,
         );
       }),
-      authHeaderProvider: ({required url, required method, payload}) async => (
-        authorizationHeader: 'Nostr test-token',
-        pubkey: pubkeyA,
-      ),
+      authHeaderProvider: ({required url, required method, payload}) async =>
+          (authorizationHeader: 'Nostr test-token', pubkey: pubkeyA),
     );
   }
 
@@ -469,6 +476,58 @@ void main() {
       await repo.recoverPurchases();
 
       expect(validator.restoreCallCount, 1);
+      expect(validator.completePurchaseCallCount, 0);
+    });
+
+    test('acknowledges a purchase once after a successful claim', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final apiClient = buildApiClient(active: true);
+      final repo = SupporterRepository(
+        pubkey: pubkeyA,
+        validator: validator,
+        prefs: prefs,
+        apiClient: apiClient,
+      );
+      addTearDown(repo.dispose);
+      addTearDown(apiClient.dispose);
+      validator.completionObserved = Completer<void>();
+
+      validator.proofController.add(
+        const SupporterPurchaseProof(
+          attemptId: 'stable-attempt-1234',
+          store: 'google',
+          productId: 'divine.supporter.monthly',
+          serverVerificationData: 'opaque-proof',
+          localVerificationData: '',
+          capturedPubkey: pubkeyA,
+        ),
+      );
+      await validator.completionObserved!.future;
+
+      expect(validator.completePurchaseCallCount, 1);
+      expect(repo.isSupporter, isTrue);
+    });
+
+    test('refuses to start billing without a verification client', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final repo = SupporterRepository(
+        pubkey: pubkeyA,
+        validator: validator,
+        prefs: prefs,
+      );
+      addTearDown(repo.dispose);
+
+      await expectLater(
+        repo.purchase('divine.supporter.monthly'),
+        throwsA(
+          isA<SupporterApiException>().having(
+            (error) => error.kind,
+            'kind',
+            SupporterApiFailureKind.unavailable,
+          ),
+        ),
+      );
+      expect(validator.purchaseCallCount, 0);
     });
   });
 }

--- a/mobile/test/services/supporter_repository_test.dart
+++ b/mobile/test/services/supporter_repository_test.dart
@@ -508,6 +508,45 @@ void main() {
       expect(repo.isSupporter, isTrue);
     });
 
+    test('leaves a redelivered proof unacknowledged and surfaces unavailable '
+        'when no verification client is configured', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final repo = SupporterRepository(
+        pubkey: pubkeyA,
+        validator: validator,
+        prefs: prefs,
+      );
+      addTearDown(repo.dispose);
+
+      final errorFuture = expectLater(
+        repo.changes,
+        emitsError(
+          isA<SupporterApiException>().having(
+            (error) => error.kind,
+            'kind',
+            SupporterApiFailureKind.unavailable,
+          ),
+        ),
+      );
+
+      validator.proofController.add(
+        const SupporterPurchaseProof(
+          attemptId: 'stable-attempt-1234',
+          store: 'apple',
+          productId: 'divine.supporter.monthly',
+          serverVerificationData: 'opaque-proof',
+          localVerificationData: '',
+          capturedPubkey: pubkeyA,
+        ),
+      );
+
+      await errorFuture;
+      // The store proof must stay unacknowledged so it can be redelivered once
+      // a verification client is configured.
+      expect(validator.completePurchaseCallCount, 0);
+      expect(repo.isSupporter, isFalse);
+    });
+
     test('refuses to start billing without a verification client', () async {
       final prefs = await SharedPreferences.getInstance();
       final repo = SupporterRepository(


### PR DESCRIPTION
## Problem

Users could enable the experimental supporter flow in a build that had no configured verification service. The app would still start store billing, then discard the resulting verification error and remain on “Confirming your support…” indefinitely.

## Why this fix

This fails closed at each client boundary: the flag is internal, Settings and deep links require a configured verification client, and the repository refuses to start billing without one. If an existing purchase proof still reaches the app while verification is unavailable, the Cubit now shows the existing verification-unavailable error in a non-busy state.

The purchase remains unacknowledged when its server claim fails so the store can redeliver it after verification recovers. New diagnostics record lifecycle decisions without logging receipts, purchase tokens, verification payloads, or transaction identifiers.

## Deliberately unchanged

This does not determine the historical store-order state reported in #8935 or change the supporter service's entitlement rules. That investigation requires release configuration and store-console evidence, so this PR references rather than closes the issue.

## Verification

- 74 focused Flutter tests across supporter repository/Cubit, routing, feature flags, and localization
- targeted `flutter analyze` on all changed Dart files: no issues
- ARB consistency suite: 11 tests passed
- localization hardcoded-string scan: no findings
- pre-push analyzer and changed-test suite passed

Refs #8935
