### PR TITLE
fix(startup): let restored sessions open offline

### DIFF
--- a/mobile/lib/app/divine_app.dart
+++ b/mobile/lib/app/divine_app.dart
@@ -198,9 +198,14 @@ class _DivineAppState extends ConsumerState<DivineApp>
     final initialDeletionAttempt = ref.read(
       currentAccountDeletionAttemptProvider,
     );
+    final initialSubmittedDeletionAttempt = ref.read(
+      currentSubmittedAccountDeletionAttemptProvider,
+    );
     _authenticatedDeletionLookupSettled = authenticatedDeletionLookupSettled(
       authService.authState,
       initialDeletionAttempt,
+      submittedAttempt: initialSubmittedDeletionAttempt,
+      currentPubkeyHex: authService.currentPublicKeyHex,
     );
     _splashReleaseController = StartupSplashReleaseController(
       authStateStream: authService.authStateStream,
@@ -220,7 +225,14 @@ class _DivineAppState extends ConsumerState<DivineApp>
       currentAccountDeletionAttemptProvider,
       (_, next) {
         _authenticatedDeletionLookupSettled =
-            authenticatedDeletionLookupSettled(authService.authState, next);
+            authenticatedDeletionLookupSettled(
+              authService.authState,
+              next,
+              submittedAttempt: ref.read(
+                currentSubmittedAccountDeletionAttemptProvider,
+              ),
+              currentPubkeyHex: authService.currentPublicKeyHex,
+            );
         _splashReleaseController.reevaluate();
       },
     );

--- a/mobile/lib/providers/account_deletion_recovery_providers.dart
+++ b/mobile/lib/providers/account_deletion_recovery_providers.dart
@@ -274,13 +274,10 @@ final currentAccountDeletionAttemptProvider =
         ref.watch(currentAuthRpcCapabilityProvider);
         switch (authService.signerReadiness) {
           case SignerReadiness.pending:
-            final waitingForReadiness = Completer<AccountDeletionAttempt?>();
-            ref.onDispose(
-              () => waitingForReadiness.completeError(
-                const _SignerReadinessWaitCancelled(),
-              ),
-            );
-            return waitingForReadiness.future;
+            // A remote lookup without a durable local receipt is advisory.
+            // Let startup continue while the capability provider causes this
+            // provider to rerun when signer readiness changes.
+            return null;
           case SignerReadiness.unavailable:
             throw const AccountDeletionStatusUnavailable();
           case SignerReadiness.ready:
@@ -299,11 +296,4 @@ class AccountDeletionStatusUnavailable implements Exception {
 
   @override
   String toString() => 'AccountDeletionStatusUnavailable';
-}
-
-class _SignerReadinessWaitCancelled implements Exception {
-  const _SignerReadinessWaitCancelled();
-
-  @override
-  String toString() => '_SignerReadinessWaitCancelled';
 }

--- a/mobile/lib/providers/minor_account_review_providers.dart
+++ b/mobile/lib/providers/minor_account_review_providers.dart
@@ -64,5 +64,7 @@ final currentMinorAccountReviewStatusProvider =
       }
 
       final repository = ref.watch(minorAccountReviewRepositoryProvider);
-      return repository.fetchCurrentStatus();
-    });
+      return repository.fetchCurrentStatus().timeout(
+        const Duration(seconds: 10),
+      );
+    }, retry: (_, error) => null);

--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -27,26 +27,28 @@ bool accountDeletionRecoveryGateActive(
 /// Whether the deletion lookup is still in flight for cold-start routing.
 ///
 /// The router fails open while this is true so it never paints the recovery
-/// screen without evidence of an interrupted deletion. Separately, the native
-/// startup splash is held (via [authenticatedDeletionLookupSettled]) until this
-/// is false, so an authenticated user sees neither a false recovery screen nor
-/// a feed flash before the lookup resolves.
+/// screen without evidence of an interrupted deletion. The native startup
+/// splash uses [authenticatedDeletionLookupSettled] and only waits for this
+/// lookup when a matching durable deletion receipt exists.
 ///
 /// Any in-flight load counts as pending, including the first post-auth refetch:
 /// that re-run retains the pre-auth `AsyncData(null)`, so it is `isLoading`
 /// while `hasValue` is true. Excluding it would settle against the stale null
-/// and release the splash early (#8058: stay fail-closed until the lookup
-/// resolves).
+/// and release a receipt-backed splash early.
 bool accountDeletionRecoveryLookupPending(
   AsyncValue<AccountDeletionAttempt?>? attempt,
 ) => attempt == null || attempt.isLoading;
 
 bool authenticatedDeletionLookupSettled(
   AuthState authState,
-  AsyncValue<AccountDeletionAttempt?>? attempt,
-) =>
+  AsyncValue<AccountDeletionAttempt?>? attempt, {
+  SubmittedAccountDeletionAttempt? submittedAttempt,
+  String? currentPubkeyHex,
+}) =>
     authState == AuthState.authenticated &&
-    !accountDeletionRecoveryLookupPending(attempt);
+    (submittedAttempt == null ||
+        submittedAttempt.pubkeyHex != currentPubkeyHex ||
+        !accountDeletionRecoveryLookupPending(attempt));
 
 /// Prevents the next authenticated auth-route redirect from going home.
 ///

--- a/mobile/lib/services/api_service.dart
+++ b/mobile/lib/services/api_service.dart
@@ -27,10 +27,12 @@ class ApiService {
     required String appVersion,
     http.Client? client,
     Nip98AuthService? authService,
+    Duration requestTimeout = _defaultTimeout,
   }) : _relayManagerBaseUrl = relayManagerBaseUrl,
        _client = client ?? http.Client(),
        _authService = authService,
-       _appVersion = appVersion;
+       _appVersion = appVersion,
+       _requestTimeout = requestTimeout;
 
   /// Relay-manager worker base URL (minor-account-review endpoints live
   /// there, not on the main backend — divine-relay-manager#108). Injected
@@ -44,6 +46,7 @@ class ApiService {
   final Nip98AuthService? _authService;
 
   final String _appVersion;
+  final Duration _requestTimeout;
 
   /// Get current account restriction and minor-account review status.
   Future<Map<String, dynamic>> getMinorAccountReviewStatus() async {
@@ -57,9 +60,10 @@ class ApiService {
       final uri = Uri.parse(
         '$_relayManagerBaseUrl/v1/account/moderation-status',
       );
-      final response = await _client
-          .get(uri, headers: await _getHeaders(url: uri.toString()))
-          .timeout(_defaultTimeout);
+      final response = await _request(
+        () async =>
+            _client.get(uri, headers: await _getHeaders(url: uri.toString())),
+      );
 
       if (response.statusCode == 200) {
         return jsonDecode(response.body) as Map<String, dynamic>;
@@ -93,16 +97,16 @@ class ApiService {
       final uri = Uri.parse(
         '$_relayManagerBaseUrl/v1/minor-review-cases/$caseId/parent-contact',
       );
-      final response = await _client
-          .post(
-            uri,
-            headers: await _getHeaders(
-              url: uri.toString(),
-              method: HttpMethod.post,
-            ),
-            body: jsonEncode({'email': email}),
-          )
-          .timeout(_defaultTimeout);
+      final response = await _request(
+        () async => _client.post(
+          uri,
+          headers: await _getHeaders(
+            url: uri.toString(),
+            method: HttpMethod.post,
+          ),
+          body: jsonEncode({'email': email}),
+        ),
+      );
 
       if (response.statusCode == 200 ||
           response.statusCode == 201 ||
@@ -122,6 +126,9 @@ class ApiService {
       throw ApiException('Network error during parent contact submission: $e');
     }
   }
+
+  Future<http.Response> _request(Future<http.Response> Function() request) =>
+      request().timeout(_requestTimeout);
 
   /// Get standard headers for API requests
   Future<Map<String, String>> _getHeaders({

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -4155,44 +4155,37 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         followingKnownEmpty,
       );
 
-      // Pre-fetch following list from REST API BEFORE setting auth state.
-      // Populate redirect state before the synchronous auth-state transition.
-      if (_preFetchFollowing != null && !hasFollowingCache) {
-        Log.debug(
-          '_setupUserSession: pre-fetching following list...',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-        try {
-          await _preFetchFollowing(pubkeyHex);
-          Log.debug(
-            '_setupUserSession: following list pre-fetched',
-            name: 'AuthService',
-            category: LogCategory.auth,
-          );
-        } catch (e) {
-          Log.warning(
-            'Pre-fetch following list failed (will rely on '
-            'FollowRepository): $e',
-            name: 'AuthService',
-            category: LogCategory.auth,
-          );
-        }
-      } else if (hasFollowingCache) {
-        Log.debug(
-          '_setupUserSession: following list already cached — '
-          'skipping pre-fetch',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-      }
-
       Log.info(
         '_setupUserSession: setting auth state to authenticated',
         name: 'AuthService',
         category: LogCategory.auth,
       );
       _setAuthState(AuthState.authenticated);
+
+      if (_preFetchFollowing != null && !hasFollowingCache) {
+        unawaited(() async {
+          Log.debug(
+            '_setupUserSession: pre-fetching following list...',
+            name: 'AuthService',
+            category: LogCategory.auth,
+          );
+          try {
+            await _preFetchFollowing(pubkeyHex);
+            Log.debug(
+              '_setupUserSession: following list pre-fetched',
+              name: 'AuthService',
+              category: LogCategory.auth,
+            );
+          } catch (e) {
+            Log.warning(
+              'Pre-fetch following list failed (will rely on '
+              'FollowRepository): $e',
+              name: 'AuthService',
+              category: LogCategory.auth,
+            );
+          }
+        }());
+      }
 
       // Register this account in the known accounts list
       await _knownAccounts.upsert(pubkeyHex, source);

--- a/mobile/scripts/baseline/future_delayed_test_counts.txt
+++ b/mobile/scripts/baseline/future_delayed_test_counts.txt
@@ -73,7 +73,7 @@ test/nostr/transport/nostr_fixture_pump_test.dart	3
 test/notifications/badge_converges_after_tap_read_back_test.dart	8
 test/notifications/bloc/notification_feed_bloc_test.dart	23
 test/observability/divine_bloc_observer_test.dart	8
-test/providers/account_deletion_recovery_providers_test.dart	4
+test/providers/account_deletion_recovery_providers_test.dart	3
 test/providers/account_enforcement_providers_test.dart	2
 test/providers/auth_providers_test.dart	3
 test/providers/auth_rpc_capability_provider_test.dart	1

--- a/mobile/scripts/baseline/service_god_file_sizes.txt
+++ b/mobile/scripts/baseline/service_god_file_sizes.txt
@@ -6,7 +6,7 @@
 # This hard service baseline is authoritative over the broad advisory check for
 # service god-file ceilings.
 # Regenerate after shrinking/removing: UPDATE_BASELINE=1 bash scripts/check_service_god_file_ceiling.sh
-lib/services/auth_service.dart	4536
+lib/services/auth_service.dart	4529
 lib/services/curated_list_service.dart	1847
 lib/services/upload_manager.dart	1958
 lib/services/video_event_publisher.dart	2295

--- a/mobile/test/providers/account_deletion_recovery_providers_test.dart
+++ b/mobile/test/providers/account_deletion_recovery_providers_test.dart
@@ -98,7 +98,7 @@ void main() {
       },
     );
 
-    test('lookup stays fail-closed while signing warms up', () async {
+    test('lookup settles without a receipt while signing warms up', () async {
       final repository = _MockDeletionRepository();
       final authService = _MockAuthService();
       when(
@@ -125,11 +125,11 @@ void main() {
         fireImmediately: true,
       );
       addTearDown(subscription.close);
-      await Future<void>.delayed(Duration.zero);
+      await container.read(currentAccountDeletionAttemptProvider.future);
 
       expect(
-        container.read(currentAccountDeletionAttemptProvider).isLoading,
-        true,
+        container.read(currentAccountDeletionAttemptProvider).value,
+        isNull,
       );
       verifyNever(repository.fetchCurrent);
     });

--- a/mobile/test/router/minor_account_review_router_test.dart
+++ b/mobile/test/router/minor_account_review_router_test.dart
@@ -230,7 +230,7 @@ void main() {
             AuthState.authenticated,
             const AsyncLoading<AccountDeletionAttempt?>(),
           ),
-          isFalse,
+          isTrue,
         );
         // The post-auth refetch that retains the pre-auth null must not settle,
         // or the splash releases against the stale null and a recovery user
@@ -240,6 +240,22 @@ void main() {
           authenticatedDeletionLookupSettled(
             AuthState.authenticated,
             await _retainedNullRefetch(),
+          ),
+          isTrue,
+        );
+        expect(
+          authenticatedDeletionLookupSettled(
+            AuthState.authenticated,
+            const AsyncLoading<AccountDeletionAttempt?>(),
+            submittedAttempt: const SubmittedAccountDeletionAttempt(
+              pubkeyHex: 'user-pubkey',
+              attempt: AccountDeletionAttempt(
+                id: 'attempt-id',
+                status: AccountDeletionAttemptStatus.processing,
+              ),
+              vanishEventId: 'vanish-event-id',
+            ),
+            currentPubkeyHex: 'user-pubkey',
           ),
           isFalse,
         );

--- a/mobile/test/services/api_service_test.dart
+++ b/mobile/test/services/api_service_test.dart
@@ -1,22 +1,27 @@
 // ABOUTME: Unit tests for ApiService to verify backend communication functionality
 // ABOUTME: Tests HTTP requests, error handling, and response parsing for API endpoints
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/services/api_service.dart';
+import 'package:openvine/services/nip98_auth_service.dart';
 
 // Mock classes
 class MockHttpClient extends Mock implements http.Client {}
 
 class MockResponse extends Mock implements http.Response {}
 
+class MockNip98AuthService extends Mock implements Nip98AuthService {}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(Uri.parse('https://example.com'));
     registerFallbackValue(<String, String>{});
+    registerFallbackValue(HttpMethod.get);
   });
 
   group('ApiService', () {
@@ -51,6 +56,35 @@ void main() {
           final result = await apiService.getMinorAccountReviewStatus();
 
           expect(result['restriction'], isA<Map<String, dynamic>>());
+        },
+      );
+
+      test(
+        'bounds token creation and transport with one request deadline',
+        () async {
+          final authService = MockNip98AuthService();
+          when(() => authService.canCreateTokens).thenReturn(true);
+          when(
+            () => authService.createAuthToken(
+              url: any(named: 'url'),
+              method: any(named: 'method'),
+            ),
+          ).thenAnswer((_) => Completer<Nip98Token?>().future);
+          final service = ApiService(
+            client: mockClient,
+            authService: authService,
+            relayManagerBaseUrl: 'https://api-relay-prod.divine.video',
+            appVersion: 'test',
+            requestTimeout: const Duration(milliseconds: 1),
+          );
+
+          await expectLater(
+            service.getMinorAccountReviewStatus(),
+            throwsA(isA<ApiException>()),
+          );
+          verifyNever(
+            () => mockClient.get(any(), headers: any(named: 'headers')),
+          );
         },
       );
 

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -2313,15 +2313,20 @@ void main() {
       });
     }
 
-    test('prefetches following before auth when cache is missing', () async {
+    test('prefetches following after publishing authenticated state', () async {
       final prefetchedPubkeys = <String>[];
+      final prefetchStarted = Completer<void>();
+      final prefetchFinished = Completer<void>();
       authService = AuthService(
         backgroundActivityManager: BackgroundActivityManager(),
         userDataCleanupService: mockCleanupService,
         keyStorage: mockKeyStorage,
         flutterSecureStorage: mockSecureStorage,
         preFetchFollowing: (pubkeyHex) async {
+          expect(authService.authState, AuthState.authenticated);
           prefetchedPubkeys.add(pubkeyHex);
+          prefetchStarted.complete();
+          await prefetchFinished.future;
         },
       );
 
@@ -2338,7 +2343,9 @@ void main() {
       await _ignoringDiscoveryErrors(authService.initialize);
 
       expect(authService.authState, equals(AuthState.authenticated));
+      await prefetchStarted.future;
       expect(prefetchedPubkeys, [testKeyContainer.publicKeyHex]);
+      prefetchFinished.complete();
     });
 
     test(


### PR DESCRIPTION
## Problem
Previously signed-in users could remain behind the native splash or minor-account review loading route during an offline cold launch. Remote deletion checks, signer creation, review retries, and following prefetch all sat on the restored-session critical path.

## Fix
- Release startup against durable, matching deletion receipts only; speculative deletion lookups no longer hold the splash.
- Settle minor-review startup fetches after one bounded 10-second attempt instead of Riverpod’s default retry series.
- Apply one injectable deadline around NIP-98 signing and HTTP transport for review endpoints.
- Publish authenticated state before following-list prefetch and refresh that cache in the background.
- Preserve confirmed deletion recovery and confirmed minor-account restrictions.

This intentionally allows an account with no local deletion receipt to see cached UI briefly before a remote deletion confirmation redirects it to recovery. A first restore without a following cache may route using local defaults before the background prefetch completes.

## Verification
- Focused provider, router, API, and AuthService tests pass.
- `flutter analyze lib test` passes.
- Service god-file, production delayed-future, empty-catch, format, and pre-push checks pass.

Closes #8941