### PR TITLE
fix(logging): keep relay failures visible without duplicate console logs

### DIFF
--- a/mobile/packages/nostr_client/lib/src/relay_diagnostics_adapter.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_diagnostics_adapter.dart
@@ -20,13 +20,13 @@ class RelayDiagnosticsAdapter {
     RelayDiagnosticsClock? clock,
   }) : _clock = clock ?? DateTime.now;
 
-  /// Maximum entries emitted for one relay and site in a window.
+  /// Maximum entries emitted for one relay, site, and level in a window.
   final int maxEventsPerWindow;
 
   /// Duration of one suppression window.
   final Duration window;
 
-  /// Maximum relay/site keys retained by the limiter.
+  /// Maximum relay/site/level keys retained by the limiter.
   final int maxTrackedKeys;
   final RelayDiagnosticsClock _clock;
   final LinkedHashMap<_DiagnosticKey, _DiagnosticWindow> _windows =
@@ -35,7 +35,11 @@ class RelayDiagnosticsAdapter {
   /// Accepts one structured relay diagnostic.
   void call(RelayDiagnostic diagnostic) {
     final now = _clock();
-    final key = _DiagnosticKey(diagnostic.relayUrl, diagnostic.site);
+    final key = _DiagnosticKey(
+      diagnostic.relayUrl,
+      diagnostic.site,
+      diagnostic.level,
+    );
     var state = _windows.remove(key);
 
     final elapsed = state == null
@@ -43,38 +47,62 @@ class RelayDiagnosticsAdapter {
         : now.difference(state.startedAt);
 
     if (state == null || elapsed >= window) {
-      if (state != null && state.suppressed > 0) {
-        _write(
-          RelayDiagnostic(
-            site: diagnostic.site,
-            level: RelayDiagnosticLevel.info,
-            relayUrl: diagnostic.relayUrl,
-            message:
-                'Suppressed ${state.suppressed} repeated '
-                '${diagnostic.site.name} diagnostics in the '
-                '${elapsed.inSeconds} seconds since '
-                '${state.startedAt.toUtc().toIso8601String()}',
-          ),
-        );
-      }
+      if (state != null) _writeSuppressionSummary(key, state);
       state = _DiagnosticWindow(startedAt: now);
     }
 
     _windows[key] = state;
     while (_windows.length > maxTrackedKeys) {
-      _windows.remove(_windows.keys.first);
+      final evictedKey = _windows.keys.first;
+      final evictedState = _windows.remove(evictedKey)!;
+      _writeSuppressionSummary(evictedKey, evictedState);
     }
 
     if (state.emitted >= maxEventsPerWindow) {
       state.suppressed++;
+      if (state.suppressed == 1) {
+        _write(
+          RelayDiagnostic(
+            site: diagnostic.site,
+            level: diagnostic.level,
+            relayUrl: diagnostic.relayUrl,
+            message:
+                'Further ${diagnostic.site.name} '
+                '${diagnostic.level.name} diagnostics suppressed until '
+                '${state.startedAt.add(window).toUtc().toIso8601String()}',
+          ),
+        );
+      }
       return;
     }
     state.emitted++;
     _write(diagnostic);
   }
 
+  void _writeSuppressionSummary(
+    _DiagnosticKey key,
+    _DiagnosticWindow state,
+  ) {
+    if (state.suppressed == 0) return;
+    _write(
+      RelayDiagnostic(
+        site: key.site,
+        level: key.level,
+        relayUrl: key.relayUrl,
+        message:
+            'Suppressed ${state.suppressed} repeated ${key.site.name} '
+            '${key.level.name} diagnostics during the '
+            '${window.inSeconds}-second window starting '
+            '${state.startedAt.toUtc().toIso8601String()}',
+      ),
+    );
+  }
+
   void _write(RelayDiagnostic diagnostic) {
-    final message = '[${diagnostic.relayUrl}] ${diagnostic.message}';
+    final errorType = diagnostic.error == null
+        ? ''
+        : ' (error type: ${diagnostic.error.runtimeType})';
+    final message = '[${diagnostic.relayUrl}] ${diagnostic.message}$errorType';
     switch (diagnostic.level) {
       case RelayDiagnosticLevel.debug:
         Log.debug(
@@ -106,19 +134,21 @@ class RelayDiagnosticsAdapter {
 
 @immutable
 class _DiagnosticKey {
-  const _DiagnosticKey(this.relayUrl, this.site);
+  const _DiagnosticKey(this.relayUrl, this.site, this.level);
 
   final String relayUrl;
   final RelayDiagnosticSite site;
+  final RelayDiagnosticLevel level;
 
   @override
   bool operator ==(Object other) =>
       other is _DiagnosticKey &&
       relayUrl == other.relayUrl &&
-      site == other.site;
+      site == other.site &&
+      level == other.level;
 
   @override
-  int get hashCode => Object.hash(relayUrl, site);
+  int get hashCode => Object.hash(relayUrl, site, level);
 }
 
 class _DiagnosticWindow {

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -307,25 +307,36 @@ class RelayManager {
     final normalizedUrl = normalizeRelayUrl(url);
 
     if (normalizedUrl == null) {
-      _log('Invalid relay URL: $url');
+      _log('Invalid relay URL: $url', level: RelayDiagnosticLevel.warning);
       return false;
     }
 
     // Block known-dead relays
     if (_isBlockedRelay(normalizedUrl)) {
-      _log('Blocked dead relay: $normalizedUrl');
+      _log(
+        'Blocked dead relay: $normalizedUrl',
+        relayUrl: normalizedUrl,
+        level: RelayDiagnosticLevel.warning,
+      );
       return false;
     }
 
     // Reject relays outside the configured environment host.
     if (!isRelayAllowed(normalizedUrl)) {
-      _log('Relay not allowed in this environment: $normalizedUrl');
+      _log(
+        'Relay not allowed in this environment: $normalizedUrl',
+        relayUrl: normalizedUrl,
+        level: RelayDiagnosticLevel.warning,
+      );
       return false;
     }
 
     if (source == RelayAddSource.automatic &&
         _userRemovedRelays.contains(normalizedUrl)) {
-      _log('Skipping user-removed automatic relay: $normalizedUrl');
+      _log(
+        'Skipping user-removed automatic relay: $normalizedUrl',
+        relayUrl: normalizedUrl,
+      );
       return false;
     }
 
@@ -334,11 +345,14 @@ class RelayManager {
     }
 
     if (_configuredRelays.contains(normalizedUrl)) {
-      _log('Relay already configured: $normalizedUrl');
+      _log(
+        'Relay already configured: $normalizedUrl',
+        relayUrl: normalizedUrl,
+      );
       return false;
     }
 
-    _log('Adding relay: $normalizedUrl');
+    _log('Adding relay: $normalizedUrl', relayUrl: normalizedUrl);
 
     // Add to configured list
     _configuredRelays.add(normalizedUrl);
@@ -383,16 +397,20 @@ class RelayManager {
     final normalizedUrl = normalizeRelayUrl(url);
 
     if (normalizedUrl == null) {
-      _log('Invalid relay URL: $url');
+      _log('Invalid relay URL: $url', level: RelayDiagnosticLevel.warning);
       return false;
     }
 
     if (!_configuredRelays.contains(normalizedUrl)) {
-      _log('Relay not configured: $normalizedUrl');
+      _log(
+        'Relay not configured: $normalizedUrl',
+        relayUrl: normalizedUrl,
+        level: RelayDiagnosticLevel.warning,
+      );
       return false;
     }
 
-    _log('Removing relay: $normalizedUrl');
+    _log('Removing relay: $normalizedUrl', relayUrl: normalizedUrl);
 
     // Disconnect from the relay
     _relayPool.remove(normalizedUrl);
@@ -575,7 +593,11 @@ class RelayManager {
       if (relay is RelayBase) {
         final healthy = relay.checkHealth();
         if (!healthy) {
-          _log('Relay $url failed health check, marking as disconnected');
+          _log(
+            'Relay failed health check, marking as disconnected',
+            relayUrl: url,
+            level: RelayDiagnosticLevel.warning,
+          );
           _updateRelayStatus(url, RelayState.disconnected);
         }
       }
@@ -604,14 +626,18 @@ class RelayManager {
       final success = await _connectToRelay(url);
       if (success) {
         _updateRelayStatus(url, RelayState.connected);
-        _log('Force reconnected to $url');
+        _log('Force reconnected', relayUrl: url);
       } else {
         _updateRelayStatus(
           url,
           RelayState.error,
           errorMessage: 'Force reconnection failed',
         );
-        _log('Force reconnection failed for $url');
+        _log(
+          'Force reconnection failed',
+          relayUrl: url,
+          level: RelayDiagnosticLevel.warning,
+        );
       }
     }
 
@@ -625,7 +651,7 @@ class RelayManager {
       return false;
     }
 
-    _log('Reconnecting to relay: $normalizedUrl');
+    _log('Reconnecting to relay', relayUrl: normalizedUrl);
     _updateRelayStatus(normalizedUrl, RelayState.connecting);
     _notifyStatusChange();
 
@@ -723,10 +749,27 @@ class RelayManager {
       // subscriptions are resent to the newly connected relay so that
       // queries (e.g. follower counts) don't silently miss data.
       final success = await _relayPool.add(relay, autoSubscribe: true);
-      _log('Connect to $url: ${success ? 'success' : 'failed'}');
+      _log(
+        'Connect ${success ? 'succeeded' : 'failed'}',
+        relayUrl: url,
+        level: success
+            ? RelayDiagnosticLevel.info
+            : RelayDiagnosticLevel.warning,
+      );
       return success;
-    } on Exception catch (e) {
-      _log('Error connecting to $url: $e');
+    } on Exception catch (e, stackTrace) {
+      developer.log(
+        '[RelayManager] Error connecting to $url',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      _diagnose(
+        message: 'Relay connection threw',
+        relayUrl: url,
+        level: RelayDiagnosticLevel.error,
+        error: e,
+        stackTrace: stackTrace,
+      );
       return false;
     }
   }
@@ -882,16 +925,39 @@ class RelayManager {
     }
   }
 
-  void _log(String message) {
-    developer.log('[RelayManager] $message');
-    if (_diagnosticsSink == null) return;
+  void _log(
+    String message, {
+    String relayUrl = 'relay-manager',
+    RelayDiagnosticSite site = RelayDiagnosticSite.connectionLifecycle,
+    RelayDiagnosticLevel level = RelayDiagnosticLevel.info,
+  }) {
+    final relayContext = relayUrl == 'relay-manager' ? '' : ' [$relayUrl]';
+    developer.log('[RelayManager]$relayContext $message');
+    _diagnose(
+      message: message,
+      relayUrl: relayUrl,
+      site: site,
+      level: level,
+    );
+  }
+
+  void _diagnose({
+    required String message,
+    String relayUrl = 'relay-manager',
+    RelayDiagnosticSite site = RelayDiagnosticSite.connectionLifecycle,
+    RelayDiagnosticLevel level = RelayDiagnosticLevel.info,
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
     emitRelayDiagnostic(
       _diagnosticsSink,
       RelayDiagnostic(
-        site: RelayDiagnosticSite.connectionLifecycle,
-        level: RelayDiagnosticLevel.info,
-        relayUrl: 'relay-manager',
+        site: site,
+        level: level,
+        relayUrl: relayUrl,
         message: message,
+        error: error,
+        stackTrace: stackTrace,
       ),
     );
   }

--- a/mobile/packages/nostr_client/test/src/relay_diagnostics_adapter_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_diagnostics_adapter_test.dart
@@ -121,9 +121,21 @@ void main() {
       );
       adapter(diagnostic(message: 'first key after eviction'));
 
-      final messages = capture.getRecentLogs().map((entry) => entry.message);
+      final logs = capture.getRecentLogs().toList();
+      final messages = logs.map((entry) => entry.message);
       expect(messages, hasLength(5));
-      expect(messages.elementAt(2), contains('Suppressed 1 repeated'));
+
+      // The eviction summary must be attributed to the EVICTED key, not the
+      // incoming one that triggered the eviction.
+      final eviction = logs.elementAt(2);
+      expect(eviction.message, contains('Suppressed 1 repeated'));
+      expect(eviction.message, contains('wss://relay.example'));
+      expect(eviction.message, contains('connectionLifecycle'));
+      expect(eviction.message, contains('info'));
+      expect(eviction.message, isNot(contains('wss://other.example')));
+      expect(eviction.message, isNot(contains('queryDispatch')));
+      expect(eviction.level, LogLevel.info);
+
       expect(messages.last, contains('first key after eviction'));
     });
 

--- a/mobile/packages/nostr_client/test/src/relay_diagnostics_adapter_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_diagnostics_adapter_test.dart
@@ -24,11 +24,15 @@ void main() {
       RelayDiagnosticSite site = RelayDiagnosticSite.connectionLifecycle,
       String message = 'Relay connection succeeded',
       RelayDiagnosticLevel level = RelayDiagnosticLevel.info,
+      Object? error,
+      StackTrace? stackTrace,
     }) => RelayDiagnostic(
       site: site,
       level: level,
       relayUrl: relayUrl,
       message: message,
+      error: error,
+      stackTrace: stackTrace,
     );
 
     test('writes relay diagnostics to the support-log buffer', () {
@@ -54,14 +58,18 @@ void main() {
       adapter(diagnostic(message: 'second'));
       adapter(diagnostic(message: 'third'));
 
-      expect(capture.getRecentLogs(), hasLength(2));
+      expect(capture.getRecentLogs(), hasLength(3));
+      expect(
+        capture.getRecentLogs().last.message,
+        contains('Further connectionLifecycle info diagnostics suppressed'),
+      );
 
       now = now.add(const Duration(minutes: 1));
       adapter(diagnostic(message: 'after rollover'));
 
       final messages = capture.getRecentLogs().map((entry) => entry.message);
-      expect(messages, hasLength(4));
-      expect(messages.elementAt(2), contains('Suppressed 1 repeated'));
+      expect(messages, hasLength(5));
+      expect(messages.elementAt(3), contains('Suppressed 1 repeated'));
       expect(messages.last, contains('after rollover'));
     });
 
@@ -75,15 +83,23 @@ void main() {
       adapter(diagnostic(message: 'emitted'));
       adapter(diagnostic(message: 'suppressed'));
 
-      // The storm stops, and the next diagnostic for this key only arrives
-      // ten minutes later. Its summary is timestamped now, so it has to name
-      // when the suppressed traffic actually happened.
+      final marker = capture.getRecentLogs().elementAt(1).message;
+      expect(marker, contains('Further connectionLifecycle info diagnostics'));
+      expect(
+        marker,
+        contains(
+          windowStart.add(const Duration(minutes: 1)).toUtc().toIso8601String(),
+        ),
+      );
+
+      // The next diagnostic arrives much later, but the summary still names
+      // the fixed limiter window rather than implying a ten-minute storm.
       now = now.add(const Duration(minutes: 10));
       adapter(diagnostic(message: 'much later'));
 
-      final summary = capture.getRecentLogs().elementAt(1).message;
+      final summary = capture.getRecentLogs().elementAt(2).message;
       expect(summary, contains('Suppressed 1 repeated'));
-      expect(summary, contains('in the 600 seconds'));
+      expect(summary, contains('during the 60-second window'));
       expect(summary, contains(windowStart.toUtc().toIso8601String()));
     });
 
@@ -106,8 +122,52 @@ void main() {
       adapter(diagnostic(message: 'first key after eviction'));
 
       final messages = capture.getRecentLogs().map((entry) => entry.message);
-      expect(messages, hasLength(3));
+      expect(messages, hasLength(5));
+      expect(messages.elementAt(2), contains('Suppressed 1 repeated'));
       expect(messages.last, contains('first key after eviction'));
+    });
+
+    test('severity has an independent budget for a relay and site', () {
+      final adapter = RelayDiagnosticsAdapter(
+        maxEventsPerWindow: 1,
+        clock: () => now,
+      );
+
+      adapter(diagnostic(message: 'info emitted'));
+      adapter(diagnostic(message: 'info suppressed'));
+      adapter(
+        diagnostic(
+          level: RelayDiagnosticLevel.warning,
+          message: 'terminal warning',
+        ),
+      );
+      adapter(
+        diagnostic(
+          level: RelayDiagnosticLevel.error,
+          message: 'terminal error',
+        ),
+      );
+
+      final messages = capture.getRecentLogs().map((entry) => entry.message);
+      expect(messages, hasLength(4));
+      expect(messages, contains(contains('terminal warning')));
+      expect(messages, contains(contains('terminal error')));
+    });
+
+    test('bounds a reconnect storm to one marker per severity budget', () {
+      final adapter = RelayDiagnosticsAdapter(
+        maxEventsPerWindow: 1,
+        clock: () => now,
+      );
+
+      for (final level in RelayDiagnosticLevel.values) {
+        for (var i = 0; i < 20; i++) {
+          adapter(diagnostic(level: level, message: '${level.name} $i'));
+        }
+      }
+
+      // One original plus one suppression marker for each of four levels.
+      expect(capture.getRecentLogs(), hasLength(8));
     });
 
     test(
@@ -126,6 +186,8 @@ void main() {
             site: RelayDiagnosticSite.authentication,
             level: RelayDiagnosticLevel.error,
             message: 'authentication failed',
+            error: StateError('private failure detail'),
+            stackTrace: StackTrace.fromString('private stack frame'),
           ),
         );
 
@@ -135,6 +197,10 @@ void main() {
           LogLevel.error,
         ]);
         expect(entries.every((entry) => entry.error == null), isTrue);
+        expect(entries.every((entry) => entry.stackTrace == null), isTrue);
+        expect(entries.last.message, contains('error type: StateError'));
+        expect(entries.last.message, isNot(contains('private failure detail')));
+        expect(entries.last.message, isNot(contains('private stack frame')));
       },
     );
   });

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -5,9 +5,11 @@ import 'dart:async';
 
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_client/src/relay_diagnostics_adapter.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostr_sdk/relay/client_connected.dart';
 import 'package:test/test.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class _MockRelayPool extends Mock implements RelayPool {}
 
@@ -102,6 +104,77 @@ void main() {
   });
 
   group('RelayManager', () {
+    group('diagnostics', () {
+      test(
+        'reports a throwing connection without exporting its message',
+        () async {
+          final diagnostics = <RelayDiagnostic>[];
+          when(
+            () => mockRelayPool.add(
+              any(),
+              autoSubscribe: any(named: 'autoSubscribe'),
+            ),
+          ).thenThrow(FormatException('private relay failure detail'));
+          final diagnosticManager = RelayManager(
+            config: config,
+            relayPool: mockRelayPool,
+            diagnosticsSink: diagnostics.add,
+          );
+
+          await diagnosticManager.initialize();
+
+          final failure = diagnostics.singleWhere(
+            (entry) => entry.level == RelayDiagnosticLevel.error,
+          );
+          expect(failure.relayUrl, testDefaultRelayUrl);
+          expect(failure.message, 'Relay connection threw');
+          expect(
+            failure.message,
+            isNot(contains('private relay failure detail')),
+          );
+          expect(failure.error, isA<FormatException>());
+        },
+      );
+
+      test('pool chatter cannot suppress a per-relay failure', () async {
+        final capture = LogCaptureService();
+        await capture.clearAllLogs();
+        addTearDown(capture.clearAllLogs);
+        final adapter = RelayDiagnosticsAdapter(maxEventsPerWindow: 1);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => false);
+        final diagnosticManager = RelayManager(
+          config: config,
+          relayPool: mockRelayPool,
+          diagnosticsSink: adapter.call,
+        );
+
+        await diagnosticManager.initialize();
+
+        final entries = capture.getRecentLogs();
+        expect(
+          entries.where(
+            (entry) =>
+                entry.message.contains(testDefaultRelayUrl) &&
+                entry.message.contains('Connect failed'),
+          ),
+          hasLength(1),
+        );
+        expect(
+          entries
+              .singleWhere(
+                (entry) => entry.message.contains('Connect failed'),
+              )
+              .level,
+          LogLevel.warning,
+        );
+      });
+    });
+
     group('constructor and properties', () {
       test('defaultRelayUrl returns configured default relay', () {
         expect(manager.defaultRelayUrl, equals(testDefaultRelayUrl));

--- a/mobile/packages/nostr_sdk/lib/relay/relay.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay.dart
@@ -218,6 +218,7 @@ abstract class Relay {
       try {
         final sent = await send(subscription.toJson(), skipReconnect: true);
         if (!sent) {
+          log('Saved relay request ${subscription.id} was not sent');
           diagnose(
             RelayDiagnosticSite.subscriptionReplay,
             RelayDiagnosticLevel.warning,

--- a/mobile/packages/nostr_sdk/lib/relay/relay_diagnostics.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_diagnostics.dart
@@ -1,8 +1,6 @@
 // ABOUTME: Structured, injectable relay diagnostics for SDK consumers.
 // ABOUTME: Keeps support logging policy outside nostr_sdk's dependency graph.
 
-import 'dart:developer' as developer;
-
 /// Severity of a relay diagnostic.
 enum RelayDiagnosticLevel { debug, info, warning, error }
 
@@ -17,6 +15,10 @@ enum RelayDiagnosticSite {
 }
 
 /// A safe, structured description of relay activity.
+///
+/// [error] and [stackTrace] are available to SDK consumers that inject a sink,
+/// but support exporters must not serialize either value. The Divine support
+/// adapter exports only [error]'s runtime type as a bounded failure category.
 class RelayDiagnostic {
   const RelayDiagnostic({
     required this.site,
@@ -36,24 +38,20 @@ class RelayDiagnostic {
 }
 
 /// Receives structured relay diagnostics from nostr_sdk.
+///
+/// A null sink disables this structured channel. Console logging is owned by
+/// relay call sites so diagnostics never duplicate an existing console entry.
 typedef RelayDiagnosticsSink = void Function(RelayDiagnostic diagnostic);
 
-/// Emits [diagnostic] without allowing observability failures to affect I/O.
+/// Emits [diagnostic] to [sink] without allowing observability failures to
+/// affect relay I/O.
 void emitRelayDiagnostic(
   RelayDiagnosticsSink? sink,
   RelayDiagnostic diagnostic,
 ) {
+  if (sink == null) return;
   try {
-    if (sink != null) {
-      sink(diagnostic);
-      return;
-    }
-    developer.log(
-      diagnostic.message,
-      name: 'RelayDiagnostics',
-      error: diagnostic.error,
-      stackTrace: diagnostic.stackTrace,
-    );
+    sink(diagnostic);
   } on Object catch (_) {
     // Diagnostics are best-effort and must never change relay behavior.
   }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1739,7 +1739,14 @@ class RelayPool {
     } else if (messageType == 'EOSE') {
       final subId = _stringAt(relay, json, 1, 'EOSE subscription id');
       if (subId == null) return;
-      log('Relay ${relay.url} settled request $subId with EOSE');
+      // Debug-only: EOSE is a per-settlement frame, and logging it
+      // unconditionally cost ~6% of main-isolate CPU in on-device profiling
+      // (#5957). The assert closure never runs in profile/release; the
+      // structured diagnostic below carries the settlement to injected sinks.
+      assert(() {
+        log('Relay ${relay.url} settled request $subId with EOSE');
+        return true;
+      }());
       _diagnose(
         RelayDiagnosticSite.requestSettlement,
         RelayDiagnosticLevel.info,

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -646,6 +646,7 @@ class RelayPool {
     _observeRelayStatus(relay);
 
     if (await relay.connect()) {
+      log('Relay connection succeeded: ${relay.url}');
       _diagnose(
         RelayDiagnosticSite.connectionLifecycle,
         RelayDiagnosticLevel.info,
@@ -816,6 +817,10 @@ class RelayPool {
 
     try {
       var message = subscription.toJson();
+      log(
+        'Dispatching one-shot query ${subscription.id} to ${relay.url} '
+        '(filters=${subscription.filters.length})',
+      );
       _diagnose(
         RelayDiagnosticSite.queryDispatch,
         RelayDiagnosticLevel.info,
@@ -843,6 +848,9 @@ class RelayPool {
           relay.url,
           'One-shot query ${subscription.id} trigger sent=$result',
         );
+        if (result) {
+          log('One-shot query ${subscription.id} trigger sent to ${relay.url}');
+        }
         return true;
       } else {
         // Skip reconnect during query fan-out to avoid blocking
@@ -853,6 +861,10 @@ class RelayPool {
         if (result) {
           relay.saveQuery(subscription);
         }
+        log(
+          'One-shot query ${subscription.id} dispatch to ${relay.url} '
+          'succeeded=$result',
+        );
         _diagnose(
           RelayDiagnosticSite.queryDispatch,
           result ? RelayDiagnosticLevel.info : RelayDiagnosticLevel.warning,
@@ -1511,6 +1523,7 @@ class RelayPool {
   Future<void> _reconnectDroppedRelay(Relay relay) async {
     if (_closed) return;
     try {
+      log('Reconnecting dropped relay ${relay.url}');
       _diagnose(
         RelayDiagnosticSite.connectionLifecycle,
         RelayDiagnosticLevel.info,
@@ -1726,6 +1739,7 @@ class RelayPool {
     } else if (messageType == 'EOSE') {
       final subId = _stringAt(relay, json, 1, 'EOSE subscription id');
       if (subId == null) return;
+      log('Relay ${relay.url} settled request $subId with EOSE');
       _diagnose(
         RelayDiagnosticSite.requestSettlement,
         RelayDiagnosticLevel.info,
@@ -2233,6 +2247,7 @@ class RelayPool {
             .send(message, queueIfFailed: false, deadline: deadline)
             .timeout(perRelaySendTimeout, onTimeout: () => false);
         if (result) {
+          log('Request ${subscription.id} dispatch to ${relay.url} succeeded');
           _diagnose(
             RelayDiagnosticSite.queryDispatch,
             RelayDiagnosticLevel.info,
@@ -2962,6 +2977,7 @@ class RelayPool {
     if (_closed) return;
     try {
       await relay.forceReconnect();
+      log('Silent-relay reconnect completed for ${relay.url}');
       _diagnose(
         RelayDiagnosticSite.connectionLifecycle,
         RelayDiagnosticLevel.info,

--- a/mobile/packages/nostr_sdk/test/unit/relay_diagnostics_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_diagnostics_test.dart
@@ -76,14 +76,12 @@ void main() {
       );
       await relay.deliver(['EOSE', subscription.id]);
 
-      expect(
-        diagnostics.map((entry) => entry.site),
-        containsAll([
-          RelayDiagnosticSite.connectionLifecycle,
-          RelayDiagnosticSite.queryDispatch,
-          RelayDiagnosticSite.requestSettlement,
-        ]),
-      );
+      expect(diagnostics.map((entry) => entry.site).toList(), [
+        RelayDiagnosticSite.connectionLifecycle,
+        RelayDiagnosticSite.queryDispatch,
+        RelayDiagnosticSite.queryDispatch,
+        RelayDiagnosticSite.requestSettlement,
+      ]);
       expect(
         diagnostics.map((entry) => entry.message),
         contains(contains('full-subscription-id')),
@@ -160,6 +158,42 @@ void main() {
         isTrue,
       );
     });
+
+    test(
+      'a null sink disables structured diagnostics without affecting I/O',
+      () async {
+        final noSinkNostr = Nostr(
+          LocalNostrSigner(
+            '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+          ),
+          [],
+          (url) => _DiagnosticRelay(url),
+        );
+
+        final relay = _DiagnosticRelay('wss://relay.example');
+        expect(await noSinkNostr.relayPool.add(relay), isTrue);
+
+        final subscription = Subscription(
+          const [
+            {
+              'kinds': [1],
+            },
+          ],
+          (_) {},
+          id: 'no-sink-subscription-id',
+        );
+        expect(
+          await noSinkNostr.relayPool.relayDoQuery(relay, subscription, false),
+          isTrue,
+        );
+        await relay.deliver(['EOSE', subscription.id]);
+
+        expect(relay.sent, [
+          ['REQ', subscription.id, ...subscription.filters],
+          ['CLOSE', subscription.id],
+        ]);
+      },
+    );
   });
 
   group('connectionDiagnosticLevelFor', () {

--- a/mobile/test/services/bug_report_service_test.dart
+++ b/mobile/test/services/bug_report_service_test.dart
@@ -8,6 +8,8 @@ import 'package:analytics/analytics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' show BugReportData, LogEntry, LogLevel;
+import 'package:nostr_client/src/relay_diagnostics_adapter.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/services/bug_report_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -87,27 +89,52 @@ void main() {
       expect(data.timestamp, isA<DateTime>());
     });
 
-    test('includes captured relay diagnostics in the support export', () async {
+    test('retains a terminal relay failure after bounded chatter', () async {
       final capture = LogCaptureService();
       await capture.clearAllLogs();
       // The capture buffer is a process-global singleton shared by every
-      // suite in the merged VGV isolate, so this entry has to go back out.
+      // suite in the merged VGV isolate, so these entries have to go back out.
       addTearDown(capture.clearAllLogs);
-      Log.info(
-        '[wss://relay.example] Relay connection succeeded',
-        name: 'RelayDiagnostics',
-        category: LogCategory.relay,
+      final adapter = RelayDiagnosticsAdapter(maxEventsPerWindow: 1);
+      const relayUrl = 'wss://relay.example';
+      for (var i = 0; i < 4; i++) {
+        adapter(
+          RelayDiagnostic(
+            site: RelayDiagnosticSite.connectionLifecycle,
+            level: RelayDiagnosticLevel.info,
+            relayUrl: relayUrl,
+            message: 'Connection progress $i',
+          ),
+        );
+      }
+      adapter(
+        const RelayDiagnostic(
+          site: RelayDiagnosticSite.connectionLifecycle,
+          level: RelayDiagnosticLevel.warning,
+          relayUrl: relayUrl,
+          message: 'Relay connection failed',
+        ),
       );
 
       final data = await service.collectDiagnostics(
         userDescription: 'Relay connection problem',
       );
 
-      final relayEntry = data.recentLogs.singleWhere(
+      final relayEntries = data.recentLogs.where(
         (entry) => entry.name == 'RelayDiagnostics',
       );
-      expect(relayEntry.category, LogCategory.relay);
-      expect(relayEntry.message, contains('Relay connection succeeded'));
+      expect(
+        relayEntries.where(
+          (entry) => entry.message.contains('Relay connection failed'),
+        ),
+        hasLength(1),
+      );
+      expect(
+        relayEntries.where(
+          (entry) => entry.message.contains('diagnostics suppressed'),
+        ),
+        hasLength(1),
+      );
     });
 
     test('should collect error counts from injected tracker', () async {


### PR DESCRIPTION
## Problem

Relay support diagnostics could lose the terminal failure behind lifecycle chatter, omit any evidence that messages were suppressed, and export no safe failure classification. The structured diagnostics helper also wrote to the console when no sink was injected, duplicating SDK call-site logs.

## Why this fix

- Limits support diagnostics independently by relay, site, and severity so warning and error outcomes survive informational bursts.
- Uses real relay URLs and accurate levels for RelayManager events.
- Emits a bounded suppression marker immediately and preserves pending suppression summaries during rollover and LRU eviction.
- Exports only the exception runtime type; raw exception messages and stack traces remain out of support logs.
- Makes a null diagnostics sink disable only the structured channel, while explicit call-site logging preserves useful console coverage without duplication.

The two changes ship together because they modify the same relay diagnostics contract and RelayManager logging path.

## Deliberately unchanged

Direct RelayBase instances that do not receive the application diagnostics adapter remain outside this change. Exact final suppression counts for a storm that ends without rollover still require adapter lifecycle wiring; the immediate marker guarantees the export records that suppression occurred.

## Verification

- very_good test --coverage --min-coverage 82 (nostr_client)
- very_good test --coverage --min-coverage 20 (nostr_sdk)
- flutter test test/services/bug_report_service_test.dart
- flutter analyze lib packages test/services/bug_report_service_test.dart
- scripts/check_nostr_id_log_truncation.sh
- scripts/check_pubkey_log_encoding.sh
- pre-push analyzer and changed-file test suite

Closes #8942
Closes #8943