### PR TITLE
fix(search): show matching lists in search results

### DIFF
--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -258,9 +258,13 @@ CuratedListRepository curatedListRepository(Ref ref) {
   ref.listen(curatedListsStateProvider, (_, next) {
     next.whenData((_) {
       final service = ref.read(curatedListsStateProvider.notifier).service;
-      repository.setSubscribedLists(
-        service == null ? const [] : subscribedListsForHomeBridge(service),
-      );
+      repository
+        ..setSubscribedLists(
+          service == null ? const [] : subscribedListsForHomeBridge(service),
+        )
+        ..setOwnLists(
+          service == null ? const [] : ownListsForSearchBridge(service),
+        );
     });
   });
 
@@ -271,6 +275,12 @@ CuratedListRepository curatedListRepository(Ref ref) {
 @visibleForTesting
 List<CuratedList> subscribedListsForHomeBridge(CuratedListService service) =>
     service.subscribedLists;
+
+/// The viewer's own lists, which the search matches alongside the subscribed
+/// ones; `subscribedLists` never holds them.
+@visibleForTesting
+List<CuratedList> ownListsForSearchBridge(CuratedListService service) =>
+    service.myLists;
 
 /// Provider for HashtagRepository instance.
 ///

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -208,7 +208,7 @@ final class CuratedListRepositoryProvider
 }
 
 String _$curatedListRepositoryHash() =>
-    r'2ab27b85f298d47b068db155ec6a5bfcefeb1e33';
+    r'33126d21cc217b4b18a7c9a2743c81eac25d4933';
 
 /// Provider for HashtagRepository instance.
 ///

--- a/mobile/packages/curated_list_repository/lib/src/curated_list_repository.dart
+++ b/mobile/packages/curated_list_repository/lib/src/curated_list_repository.dart
@@ -288,7 +288,7 @@ class CuratedListRepository {
   /// 3. Local + relay matches merged (relay items without thumbnails)
   /// 4. Fully enriched (relay thumbnails resolved)
   ///
-  /// Deduplicates by list ID.
+  /// Deduplicates by author-qualified list coordinate (pubkey + d-tag).
   Stream<List<CuratedList>> searchAllLists(
     String query, {
     int maxThumbnails = 5,

--- a/mobile/packages/curated_list_repository/lib/src/curated_list_repository.dart
+++ b/mobile/packages/curated_list_repository/lib/src/curated_list_repository.dart
@@ -22,6 +22,15 @@ const _curatedListKind = 30005;
 /// Well-known d-tag for the user's default "My List".
 const defaultListId = 'my_vine_list';
 
+/// Newest kind-30005 events asked of each relay per search.
+///
+/// Every new account publishes an empty default list, and on production those
+/// placeholders are all but a percent or two of the newest events, so a
+/// 50-event window held nothing but placeholders whatever the query. 500 is
+/// the relay gateway's default discovery window; the placeholders drop out
+/// below because they carry no videos.
+const _relaySearchWindow = 500;
+
 /// {@template curated_list_repository}
 /// Repository for managing curated video list subscriptions.
 ///
@@ -48,6 +57,7 @@ class CuratedListRepository {
   final FunnelcakeApiClient _funnelcakeApiClient;
   final BlockedCuratedListFilter? _blockFilter;
   final Map<String, CuratedList> _subscribedLists = {};
+  final Map<String, CuratedList> _ownLists = {};
 
   // BehaviorSubject replays last value to late subscribers, fixing race
   // condition where BLoC subscribes AFTER initial emission.
@@ -84,6 +94,20 @@ class CuratedListRepository {
     _emitSubscribedLists();
   }
 
+  /// Replaces the lists the current user owns with [lists].
+  ///
+  /// The same transitional bridge as [setSubscribedLists]: the Page layer
+  /// pushes `CuratedListService.myLists` so [searchLists] can match the
+  /// viewer's own lists, which are not among the subscribed ones. Owned lists
+  /// take part in search only; the subscribed stream and lookups are
+  /// unaffected. Goes away with [setSubscribedLists] once the repository
+  /// loads its own data.
+  void setOwnLists(List<CuratedList> lists) {
+    _ownLists
+      ..clear()
+      ..addEntries(lists.map((list) => MapEntry(list.id, list)));
+  }
+
   // ---------------------------------------------------------------------------
   // Read-only queries
   // ---------------------------------------------------------------------------
@@ -113,28 +137,33 @@ class CuratedListRepository {
   /// Returns the user's default "My List", or `null` if not subscribed.
   CuratedList? getDefaultList() => _subscribedLists[defaultListId];
 
-  /// Searches subscribed public lists by [query] against name, description,
-  /// and tags (case-insensitive).
+  /// Searches the public lists known locally, the viewer's own and the
+  /// subscribed ones, by [query] against name, description, and tags
+  /// (case-insensitive).
   ///
   /// Returns an empty list when [query] is blank.
   List<CuratedList> searchLists(String query) {
     if (query.trim().isEmpty) return [];
 
     final lowerQuery = query.toLowerCase();
-    return _subscribedLists.values
-        .where(
-          (list) =>
-              list.isPublic &&
-              !_isBlocked(list.pubkey) &&
-              (list.name.toLowerCase().contains(lowerQuery) ||
-                  (list.description?.toLowerCase().contains(lowerQuery) ??
-                      false) ||
-                  list.tags.any(
-                    (tag) => tag.toLowerCase().contains(lowerQuery),
-                  )),
-        )
-        .toList();
+    final matches = <String, CuratedList>{};
+    for (final list in [..._ownLists.values, ..._subscribedLists.values]) {
+      if (!list.isPublic || _isBlocked(list.pubkey)) continue;
+      if (!_matchesQuery(list, lowerQuery)) continue;
+      matches.putIfAbsent(_coordinateOf(list), () => list);
+    }
+    return matches.values.toList();
   }
+
+  static bool _matchesQuery(CuratedList list, String lowerQuery) =>
+      list.name.toLowerCase().contains(lowerQuery) ||
+      (list.description?.toLowerCase().contains(lowerQuery) ?? false) ||
+      list.tags.any((tag) => tag.toLowerCase().contains(lowerQuery));
+
+  /// Author-qualified identity. Every account owns a `my_vine_list`, so the
+  /// d-tag alone conflates lists from different authors.
+  static String _coordinateOf(CuratedList list) =>
+      '${list.pubkey ?? ''}:${list.id}';
 
   /// Returns subscribed public lists that contain the given [tag].
   List<CuratedList> getListsByTag(String tag) {
@@ -207,13 +236,13 @@ class CuratedListRepository {
   /// resolving thumbnails.
   Future<List<CuratedList>> _queryListsFromRelays({
     required String query,
-    int limit = 50,
-    Set<String>? excludeIds,
+    int limit = _relaySearchWindow,
+    Set<String>? excludeCoordinates,
   }) async {
     if (query.trim().isEmpty) return [];
 
     final lowerQuery = query.toLowerCase();
-    final excluded = excludeIds ?? const {};
+    final excluded = excludeCoordinates ?? const {};
 
     final events = await _nostrClient.queryEvents([
       Filter(kinds: [_curatedListKind], limit: limit),
@@ -224,23 +253,18 @@ class CuratedListRepository {
       if (_isBlocked(event.pubkey)) continue;
       final list = CuratedListConverter.fromEvent(event);
       if (list == null) continue;
-      if (excluded.contains(list.id)) continue;
+      final coordinate = _coordinateOf(list);
+      if (excluded.contains(coordinate)) continue;
       if (!list.isPublic) continue;
       if (list.videoEventIds.isEmpty) continue;
+      if (!_matchesQuery(list, lowerQuery)) continue;
 
-      // Client-side query filter
-      final matches =
-          list.name.toLowerCase().contains(lowerQuery) ||
-          (list.description?.toLowerCase().contains(lowerQuery) ?? false) ||
-          list.tags.any((tag) => tag.toLowerCase().contains(lowerQuery));
-      if (!matches) continue;
-
-      // Dedup by d-tag, keep newest
-      final existing = seen[list.id];
+      // Dedup per author and d-tag, keep newest
+      final existing = seen[coordinate];
       if (existing != null && existing.updatedAt.isAfter(list.updatedAt)) {
         continue;
       }
-      seen[list.id] = list;
+      seen[coordinate] = list;
     }
 
     return seen.values.toList();
@@ -273,7 +297,7 @@ class CuratedListRepository {
 
     final localResults = searchLists(query);
     final merged = <String, CuratedList>{
-      for (final list in localResults) list.id: list,
+      for (final list in localResults) _coordinateOf(list): list,
     };
 
     // Yield 1: local results immediately (no thumbnails)
@@ -286,16 +310,16 @@ class CuratedListRepository {
     );
     merged
       ..clear()
-      ..addEntries(enrichedLocal.map((l) => MapEntry(l.id, l)));
+      ..addEntries(enrichedLocal.map((l) => MapEntry(_coordinateOf(l), l)));
     yield List.unmodifiable(merged.values.toList());
 
     // Yield 3: relay results merged (no thumbnails on new items)
     final relayResults = await _queryListsFromRelays(
       query: query,
-      excludeIds: merged.keys.toSet(),
+      excludeCoordinates: merged.keys.toSet(),
     );
     for (final list in relayResults) {
-      merged[list.id] = list;
+      merged[_coordinateOf(list)] = list;
     }
     yield List.unmodifiable(merged.values.toList());
 
@@ -305,7 +329,7 @@ class CuratedListRepository {
       maxThumbnails: maxThumbnails,
     );
     for (final list in enrichedRelay) {
-      merged[list.id] = list;
+      merged[_coordinateOf(list)] = list;
     }
     yield List.unmodifiable(merged.values.toList());
   }

--- a/mobile/packages/curated_list_repository/test/src/curated_list_repository_test.dart
+++ b/mobile/packages/curated_list_repository/test/src/curated_list_repository_test.dart
@@ -711,8 +711,8 @@ void main() {
           createList(id: 'shared-id', name: 'Dance Local'),
         ]);
 
-        // Relay returns a list with the same ID — but excludeIds
-        // should prevent it. Return a different one instead.
+        // Relay returns a list with the same author-qualified coordinate — but
+        // excludeCoordinates should prevent it. Return a different one instead.
         when(() => nostrClient.queryEvents(any())).thenAnswer(
           (_) async => [
             _makeEvent(

--- a/mobile/packages/curated_list_repository/test/src/curated_list_repository_test.dart
+++ b/mobile/packages/curated_list_repository/test/src/curated_list_repository_test.dart
@@ -29,14 +29,20 @@ const _blockedPubkey =
     'ffffffffffffffffffffffffffffffff'
     'ffffffffffffffffffffffffffffffff';
 
+/// Another author, for lists that share a d-tag across accounts.
+const _otherPubkey =
+    '99999999999999999999999999999999'
+    '99999999999999999999999999999999';
+
 /// Creates a kind 30005 Nostr event with the given [tags] and [content].
 Event _makeEvent({
   List<List<String>> tags = const [],
   String content = '',
   int? createdAt,
+  String pubkey = _testPubkey,
 }) {
   return Event(
-    _testPubkey,
+    pubkey,
     30005,
     tags.map(List<String>.from).toList(),
     content,
@@ -350,6 +356,35 @@ void main() {
     });
 
     group('searchLists', () {
+      test("matches the viewer's own public lists", () {
+        repository
+          ..setOwnLists([
+            createList(id: 'mine', name: 'Top Dance', pubkey: _testPubkey),
+          ])
+          ..setSubscribedLists([createList(id: 'other', name: 'Cooking')]);
+
+        final results = repository.searchLists('dance');
+
+        expect(results.map((l) => l.id), equals(['mine']));
+      });
+
+      test("excludes the viewer's own private lists", () {
+        repository.setOwnLists([
+          createList(id: 'mine', name: 'Secret Dance', isPublic: false),
+        ]);
+
+        expect(repository.searchLists('dance'), isEmpty);
+      });
+
+      test('reports a list that is both owned and subscribed once', () {
+        final list = createList(id: 'a', name: 'Dance', pubkey: _testPubkey);
+        repository
+          ..setOwnLists([list])
+          ..setSubscribedLists([list]);
+
+        expect(repository.searchLists('dance'), hasLength(1));
+      });
+
       test('returns empty for blank query', () {
         repository.setSubscribedLists([createList(id: 'a', name: 'Test')]);
 
@@ -549,6 +584,60 @@ void main() {
     group('searchAllLists', () {
       setUp(() {
         registerFallbackValue(<Filter>[]);
+      });
+
+      test('asks the relays for a window past the placeholder flood', () async {
+        // Every account publishes an empty default list, so the newest 50
+        // list events are placeholders; the search reads the same 500-event
+        // window as the discovery gallery.
+        when(() => nostrClient.queryEvents(any())).thenAnswer((_) async => []);
+
+        await repository.searchAllLists('dance').toList();
+
+        final filters =
+            verify(() => nostrClient.queryEvents(captureAny())).captured.single
+                as List<Filter>;
+        expect(filters.single.kinds, equals([30005]));
+        expect(filters.single.limit, equals(500));
+      });
+
+      test('keeps same-named lists from different authors apart', () async {
+        // Every account owns a `my_vine_list`: the viewer's must not hide
+        // other authors' lists with that d-tag, and only the viewer's own
+        // relay copy is the duplicate to drop.
+        repository.setOwnLists([
+          createList(
+            id: 'my_vine_list',
+            name: 'Dance Mine',
+            pubkey: _testPubkey,
+          ),
+        ]);
+        when(() => nostrClient.queryEvents(any())).thenAnswer(
+          (_) async => [
+            _makeEvent(
+              pubkey: _otherPubkey,
+              tags: [
+                ['d', 'my_vine_list'],
+                ['title', 'Dance Theirs'],
+                ['e', 'video-1'],
+              ],
+            ),
+            _makeEvent(
+              tags: [
+                ['d', 'my_vine_list'],
+                ['title', 'Dance Mine Stale'],
+                ['e', 'video-1'],
+              ],
+            ),
+          ],
+        );
+
+        final emissions = await repository.searchAllLists('dance').toList();
+
+        expect(
+          emissions[2].map((l) => l.name),
+          unorderedEquals(['Dance Mine', 'Dance Theirs']),
+        );
       });
 
       test('emits nothing for blank query', () async {

--- a/mobile/test/providers/curated_list_repository_bridge_test.dart
+++ b/mobile/test/providers/curated_list_repository_bridge_test.dart
@@ -1,5 +1,6 @@
 // ABOUTME: Regression tests for the curated-list repository provider bridge.
-// ABOUTME: Keeps Home feed list selection scoped to followed/subscribed lists.
+// ABOUTME: Keeps Home feed list selection scoped to subscribed lists and feeds
+// ABOUTME: the list search the viewer's own lists.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -23,6 +24,17 @@ void main() {
         subscribedListsForHomeBridge(service),
         [subscribedList],
       );
+    });
+
+    test("hands the list search the viewer's own lists", () {
+      final service = _MockCuratedListService();
+      final ownList = _curatedList(id: 'own-list');
+      final subscribedList = _curatedList(id: 'subscribed-list');
+
+      when(() => service.myLists).thenReturn([ownList]);
+      when(() => service.subscribedLists).thenReturn([subscribedList]);
+
+      expect(ownListsForSearchBridge(service), [ownList]);
     });
   });
 }


### PR DESCRIPTION
## Problem

List search rarely finds any public video lists. It asks relays for only the newest 50 list events, but that window is dominated by empty default-list placeholders. The local search pool also omits the viewer's own lists.

## Why this fix

- Read the same 500-event window used by list discovery, then discard empty lists before matching the query.
- Add the viewer's public lists to the local search pool without changing the subscribed-list stream used elsewhere.
- Identify addressable lists by author and d-tag so different accounts' default lists do not collapse into one result.

This extracts the already-tested fix from draft PR #8540 so the search correction can ship independently.

## Deliberately unchanged

- People-list search remains behind the product decision in #8939.
- Server-side NIP-51 search remains tracked by divinevideo/divine-funnelcake#1228; this PR keeps client-side filtering as the current fallback.

## CI isolation repair discovered during this work

The first CI run exposed an existing order dependency in `crosspost_job_client_auth_test.dart`: its second group used Mocktail's `Uri` matcher before the first group's fallback registration when groups were randomized. The repair was initially made on this branch, but it reached `main` through #8885 before this PR merged, so it is not part of this PR's final diff. The completed repair is tracked by #8948.

## Verification

- `flutter test test/src/curated_list_repository_test.dart` in `packages/curated_list_repository`
- `flutter test test/providers/curated_list_repository_bridge_test.dart`
- `flutter test test/providers/crosspost_job_client_auth_test.dart --test-randomize-ordering-seed=random`
- Repository pre-push checks: analyzer, generated-file verification, and all inferred affected tests
- `dart format --output=none --set-exit-if-changed` on all changed Dart files

Closes #8940
