### PR TITLE
fix(follow): keep login prefetch from undoing newer follow changes

### DIFF
--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:follow_repository/follow_repository.dart';
@@ -153,13 +152,13 @@ AuthService authService(Ref ref) {
       return true;
     },
     preFetchFollowing: (pubkeyHex) async {
-      // Pre-fetch following list from funnelcake REST API during login
-      // setup. This populates SharedPreferences BEFORE auth state is
-      // set, so the router redirect has accurate cache data and sends
-      // user to /home not /explore.
+      // Pre-fetch following from the Funnelcake REST API after authentication
+      // is published. This may seed SharedPreferences for a later startup, but
+      // must not replace a record another authenticated writer creates while
+      // the request is pending.
       final environmentConfig = ref.read(currentEnvironmentProvider);
-      // Instrumented and closed here: this one-shot client blocks the login
-      // redirect, so its latency is worth reporting, and nothing reuses it.
+      // Instrumented and closed here: this one-shot client runs during login,
+      // so its latency is worth reporting, and nothing reuses it.
       final httpClient = ref.read(instrumentedHttpClientFactoryProvider)();
       final client = FunnelcakeApiClient(
         baseUrl: environmentConfig.apiBaseUrl,
@@ -203,7 +202,10 @@ AuthService authService(Ref ref) {
 /// beside a non-zero count is the index contradicting itself — it has not
 /// caught up with the account's published follows — so nothing is recorded and
 /// the next login asks again rather than treating the gap as an answer.
-@visibleForTesting
+///
+/// A non-empty response only seeds an absent cache. Authentication is already
+/// published while this request runs, so any record now present was written by
+/// a newer authenticated operation and must remain unchanged.
 Future<void> persistFollowingPrefetchForAuthRedirect({
   required SharedPreferences prefs,
   required String pubkeyHex,
@@ -220,10 +222,18 @@ Future<void> persistFollowingPrefetchForAuthRedirect({
     return;
   }
   if (pubkeys.isNotEmpty) {
-    await prefs.setString(
-      FollowingCacheRecord.storageKey(pubkeyHex),
-      FollowingCacheRecord(pubkeys: pubkeys).encode(),
+    final seeded = await seedFollowingCacheIfAbsent(
+      prefs: prefs,
+      pubkeyHex: pubkeyHex,
+      pubkeys: pubkeys,
     );
+    if (!seeded) {
+      Log.debug(
+        'Keeping following cache written while auth prefetch was pending',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
+    }
   }
   await markFollowingPrefetchComplete(prefs, pubkeyHex);
 }

--- a/mobile/packages/follow_repository/lib/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/follow_repository.dart
@@ -13,4 +13,5 @@ export 'src/follow_sort_order.dart';
 export 'src/follower_stats.dart';
 export 'src/followers_snapshot.dart';
 export 'src/following_cache_record.dart';
+export 'src/following_cache_seed.dart';
 export 'src/following_snapshot.dart';

--- a/mobile/packages/follow_repository/lib/src/following_cache_seed.dart
+++ b/mobile/packages/follow_repository/lib/src/following_cache_seed.dart
@@ -1,0 +1,33 @@
+// ABOUTME: Seeds the following cache from timestamp-free bootstrap sources.
+// ABOUTME: Prevents stale snapshots from displacing records written later.
+
+import 'package:follow_repository/src/following_cache_record.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Seeds the following cache from a source that carries no `created_at`.
+///
+/// Mirrors the repository's NIP-01 ordering for a timestamp-free source:
+/// it may seed an absent record but never displaces one. The auth-time REST
+/// prefetch is concurrent with the repository's own writes, and the prefetch
+/// only starts when the record is absent, so any record present here was
+/// written while the request was pending.
+///
+/// Empty lists are represented by the auth prefetch completion marker rather
+/// than a cache record, because an empty timestamp-free snapshot is not an
+/// authoritative contact list.
+///
+/// Returns whether the record was written.
+Future<bool> seedFollowingCacheIfAbsent({
+  required SharedPreferences prefs,
+  required String pubkeyHex,
+  required List<String> pubkeys,
+}) async {
+  if (pubkeys.isEmpty) return false;
+
+  final key = FollowingCacheRecord.storageKey(pubkeyHex);
+  if (prefs.containsKey(key)) return false;
+
+  // SharedPreferences updates its local cache when setString is invoked. Keep
+  // this call adjacent to containsKey so same-isolate writers cannot interleave.
+  return prefs.setString(key, FollowingCacheRecord(pubkeys: pubkeys).encode());
+}

--- a/mobile/packages/follow_repository/test/src/following_cache_seed_test.dart
+++ b/mobile/packages/follow_repository/test/src/following_cache_seed_test.dart
@@ -1,0 +1,123 @@
+// ABOUTME: Tests seed-only persistence for timestamp-free following snapshots.
+// ABOUTME: Protects newer cache records and account-specific cache keys.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('seedFollowingCacheIfAbsent', () {
+    test('seeds an absent cache', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+
+      final written = await seedFollowingCacheIfAbsent(
+        prefs: prefs,
+        pubkeyHex:
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        pubkeys: const [
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        ],
+      );
+
+      final encoded = prefs.getString(
+        FollowingCacheRecord.storageKey(
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        ),
+      );
+      expect(written, isTrue);
+      expect(FollowingCacheRecord.decode(encoded!).pubkeys, const [
+        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      ]);
+    });
+
+    test('preserves an existing record and its provenance', () async {
+      const account =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      final existing = FollowingCacheRecord(
+        pubkeys: const [
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        ],
+        createdAt: 1234,
+        eventId:
+            'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+      );
+      SharedPreferences.setMockInitialValues({
+        FollowingCacheRecord.storageKey(account): existing.encode(),
+      });
+      final prefs = await SharedPreferences.getInstance();
+
+      final written = await seedFollowingCacheIfAbsent(
+        prefs: prefs,
+        pubkeyHex: account,
+        pubkeys: const [
+          'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+        ],
+      );
+
+      final persisted = FollowingCacheRecord.decode(
+        prefs.getString(FollowingCacheRecord.storageKey(account))!,
+      );
+      expect(written, isFalse);
+      expect(persisted.pubkeys, existing.pubkeys);
+      expect(persisted.createdAt, 1234);
+      expect(persisted.eventId, existing.eventId);
+    });
+
+    test('does not create a record for an empty snapshot', () async {
+      const account =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+
+      final written = await seedFollowingCacheIfAbsent(
+        prefs: prefs,
+        pubkeyHex: account,
+        pubkeys: const [],
+      );
+
+      expect(written, isFalse);
+      expect(
+        prefs.getString(FollowingCacheRecord.storageKey(account)),
+        isNull,
+      );
+    });
+
+    test('does not let another account record block seeding', () async {
+      const firstAccount =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const secondAccount =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      SharedPreferences.setMockInitialValues({
+        FollowingCacheRecord.storageKey(firstAccount): FollowingCacheRecord(
+          pubkeys: const [
+            'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+          ],
+        ).encode(),
+      });
+      final prefs = await SharedPreferences.getInstance();
+
+      final written = await seedFollowingCacheIfAbsent(
+        prefs: prefs,
+        pubkeyHex: secondAccount,
+        pubkeys: const [
+          'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+        ],
+      );
+
+      expect(written, isTrue);
+      expect(
+        prefs.containsKey(FollowingCacheRecord.storageKey(firstAccount)),
+        isTrue,
+      );
+      expect(
+        FollowingCacheRecord.decode(
+          prefs.getString(FollowingCacheRecord.storageKey(secondAccount))!,
+        ).pubkeys,
+        const [
+          'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+        ],
+      );
+    });
+  });
+}

--- a/mobile/test/providers/auth_providers_test.dart
+++ b/mobile/test/providers/auth_providers_test.dart
@@ -20,6 +20,17 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
 
+const _accountPubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _firstFollow =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _secondFollow =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+const _removedFollow =
+    'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+const _contactListEventId =
+    'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+
 class _FakeExtension extends NostrExtension {
   @override
   Future<String> getPublicKey() async =>
@@ -107,6 +118,87 @@ void main() {
       );
       expect(hasFollowingPrefetchMarker(prefs, 'account-pubkey'), isFalse);
     });
+
+    test('preserves a follow written while the prefetch is pending', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final response = Completer<List<String>>();
+      final persistence = () async {
+        final pubkeys = await response.future;
+        await persistFollowingPrefetchForAuthRedirect(
+          prefs: prefs,
+          pubkeyHex: _accountPubkey,
+          pubkeys: pubkeys,
+        );
+      }();
+
+      final newerRecord = FollowingCacheRecord(
+        pubkeys: const [_firstFollow, _secondFollow],
+        createdAt: 1234,
+        eventId: _contactListEventId,
+      );
+      await prefs.setString(
+        FollowingCacheRecord.storageKey(_accountPubkey),
+        newerRecord.encode(),
+      );
+      final beforeRelease = FollowingCacheRecord.decode(
+        prefs.getString(FollowingCacheRecord.storageKey(_accountPubkey))!,
+      );
+      expect(beforeRelease.pubkeys, hasLength(2));
+
+      response.complete(const [_firstFollow]);
+      await persistence;
+
+      final persisted = FollowingCacheRecord.decode(
+        prefs.getString(FollowingCacheRecord.storageKey(_accountPubkey))!,
+      );
+      expect(persisted.pubkeys, const [_firstFollow, _secondFollow]);
+      expect(persisted.createdAt, 1234);
+      expect(persisted.eventId, _contactListEventId);
+      expect(hasFollowingPrefetchMarker(prefs, _accountPubkey), isTrue);
+    });
+
+    test(
+      'preserves an unfollow written while the prefetch is pending',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final response = Completer<List<String>>();
+        final persistence = () async {
+          final pubkeys = await response.future;
+          await persistFollowingPrefetchForAuthRedirect(
+            prefs: prefs,
+            pubkeyHex: _accountPubkey,
+            pubkeys: pubkeys,
+          );
+        }();
+
+        final newerRecord = FollowingCacheRecord(
+          pubkeys: const [_firstFollow],
+          createdAt: 1234,
+          eventId: _contactListEventId,
+        );
+        await prefs.setString(
+          FollowingCacheRecord.storageKey(_accountPubkey),
+          newerRecord.encode(),
+        );
+        final beforeRelease = FollowingCacheRecord.decode(
+          prefs.getString(FollowingCacheRecord.storageKey(_accountPubkey))!,
+        );
+        expect(beforeRelease.pubkeys, const [_firstFollow]);
+
+        response.complete(const [_firstFollow, _removedFollow]);
+        await persistence;
+
+        final persisted = FollowingCacheRecord.decode(
+          prefs.getString(FollowingCacheRecord.storageKey(_accountPubkey))!,
+        );
+        expect(persisted.pubkeys, const [_firstFollow]);
+        expect(persisted.createdAt, 1234);
+        expect(persisted.eventId, _contactListEventId);
+        expect(hasFollowingPrefetchMarker(prefs, _accountPubkey), isTrue);
+      },
+    );
   });
 
   group('flutterSecureStorageProvider', () {


### PR DESCRIPTION
## Problem

A following-list request started during login can finish after the authenticated app has already saved a newer follow or unfollow. The older REST snapshot then replaced that newer cache record, so a later cold start could restore stale following data and lose the contact-list timestamp and event provenance.

## Why this fix

The auth-time REST response has no Nostr `created_at`, so it now uses a package-owned seed operation that only writes when the per-account cache is still absent. Because this prefetch only starts when the cache and completion marker are absent, any record present when the response arrives was written while the request was pending and must win. Empty snapshots remain represented by the completion marker instead of an authoritative empty cache record.

## Deliberately unchanged

- Authentication still becomes available before the REST prefetch completes.
- Contradictory empty pages with a nonzero reported total still remain unmarked so a later login retries.
- FollowRepository still refreshes from authoritative relay kind-3 events.

## Verification

- `flutter test test/providers/auth_providers_test.dart test/services/auth_service_multi_account_test.dart test/router/empty_contacts_redirect_test.dart` (124 tests)
- `flutter test --coverage` in `mobile/packages/follow_repository` (332 tests; new helper 5/5 lines covered)
- `dart analyze lib test`
- Future-delayed, empty-catch, test-grouping, unchanged-assertion, Nostr-ID logging, and pubkey-log encoding guards
- Red/green race proof: both new delayed-prefetch tests fail with the old unconditional write and pass with this change

Closes #8952