### PR TITLE
fix(editor): stop timeline thumbnails from competing with the editor preview

### DIFF
--- a/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
+++ b/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
@@ -16,6 +16,7 @@ typedef StripThumbnailStreamFactory =
       required Duration duration,
       required Size outputSize,
       required int thumbsPerSecond,
+      Duration startOffset,
       List<Duration>? priorityTimestamps,
     });
 
@@ -40,6 +41,10 @@ class ClipThumbnailManager {
   // split renders the trimmed segment to a new file) and restart
   // thumbnail generation against the new file.
   final Map<String, String> _videoPaths = {};
+  // Source range each clip's frames were generated for. A clip only ever
+  // renders its trimmed window, so that is all we extract; this records what
+  // was asked for so a later trim that reaches outside it can re-extract.
+  final Map<String, _StripWindow> _windows = {};
   // IDs whose notifier has been pre-populated from another clip's
   // thumbnails (a trim-based split borrows the source clip's frames so the
   // new halves show correct content immediately). Cleared on the next
@@ -58,6 +63,12 @@ class ClipThumbnailManager {
   // eviction.
   final Map<String, _RetiredStrip> _retired = {};
   static const _maxRetiredStrips = 8;
+
+  // Slack extracted on each side of the visible window so ordinary trim-handle
+  // nudges do not cancel and restart extraction. One second is ~600 px of drag
+  // at maximum zoom and ~52 px at 1x, and costs 13 frames per side — cheap
+  // next to the 500-frame cap a full-source request hits.
+  static const _windowPadding = Duration(seconds: 1);
 
   /// When true, newly started subscriptions begin paused and existing ones are
   /// held. See [pauseAll].
@@ -89,6 +100,7 @@ class ClipThumbnailManager {
     for (final id in staleIds) {
       _subscriptions.remove(id)?.cancel();
       final videoPath = _videoPaths.remove(id);
+      final window = _windows.remove(id);
       final wasSeeded = _seeded.remove(id);
       final wasComplete = _complete.remove(id);
       final notifier = _notifiers.remove(id);
@@ -100,7 +112,7 @@ class ClipThumbnailManager {
       // here — restoring them later would misalign timestamps. The
       // unreferenced check keeps the borrowed files alive through the
       // source's retired entry.
-      if (frames.isEmpty || videoPath == null || wasSeeded) {
+      if (frames.isEmpty || videoPath == null || window == null || wasSeeded) {
         _deleteUnreferencedFiles(frames);
         continue;
       }
@@ -108,6 +120,7 @@ class ClipThumbnailManager {
         id,
         _RetiredStrip(
           videoPath: videoPath,
+          window: window,
           frames: frames,
           complete: wasComplete,
         ),
@@ -123,6 +136,9 @@ class ClipThumbnailManager {
       final newPath = clip.video?.file?.path;
       final hasSubscription = _subscriptions.containsKey(clip.id);
       final isSeeded = _seeded.contains(clip.id);
+      // Everything the strip can currently show. Frames outside it are
+      // clipped away by the tile, so they are not worth extracting.
+      final visibleWindow = _visibleWindow(clip);
 
       // Instant restore for a returning clip id (undo/redo): reuse the
       // retired strip instead of flashing posters and re-extracting.
@@ -132,7 +148,8 @@ class ClipThumbnailManager {
           if (newPath != null && newPath == retired.videoPath) {
             notifier.value = retired.frames;
             _videoPaths[clip.id] = newPath;
-            if (retired.complete) {
+            _windows[clip.id] = retired.window;
+            if (retired.complete && retired.window.covers(visibleWindow)) {
               _complete.add(clip.id);
               continue;
             }
@@ -148,6 +165,11 @@ class ClipThumbnailManager {
       }
 
       final currentPath = _videoPaths[clip.id];
+      // False once a trim reaches outside the range the frames on hand were
+      // generated for — the newly exposed footage has no frames at all.
+      final currentWindow = _windows[clip.id];
+      final windowCovered =
+          currentWindow != null && currentWindow.covers(visibleWindow);
 
       if (!hasSubscription) {
         if (isSeeded) {
@@ -161,8 +183,10 @@ class ClipThumbnailManager {
           _seeded.remove(clip.id);
         } else if (_complete.contains(clip.id)) {
           // Restored from the retired cache at full density — only a
-          // source-file change warrants re-extraction.
-          if (newPath == null || newPath == currentPath) continue;
+          // source-file change or a widened window warrants re-extraction.
+          if ((newPath == null || newPath == currentPath) && windowCovered) {
+            continue;
+          }
           _complete.remove(clip.id);
         }
         _loadThumbnails(
@@ -170,9 +194,11 @@ class ClipThumbnailManager {
           devicePixelRatio,
           priorityTimestamps: priorityTimestamps[clip.id],
         );
-      } else if (newPath != null && newPath != currentPath) {
+      } else if ((newPath != null && newPath != currentPath) ||
+          !windowCovered) {
         // Source file of an already-subscribed clip changed (e.g. it was
-        // re-rendered to a trimmed file). Restart against the new file
+        // re-rendered to a trimmed file), or the trim window grew past what
+        // the current request covers. Restart against the new file / window
         // but keep the current frames on screen — clearing them here
         // would flash black until the first fresh batch arrives. The old
         // frames are merged out progressively as fresh batches cover
@@ -248,7 +274,9 @@ class ClipThumbnailManager {
     final videoPath = clip.video?.file?.path;
     if (videoPath == null) return;
 
+    final window = _generationWindow(clip);
     _videoPaths[clip.id] = videoPath;
+    _windows[clip.id] = window;
     _complete.remove(clip.id);
 
     final outputSize = Size(
@@ -283,7 +311,8 @@ class ClipThumbnailManager {
         _generateStripThumbnails(
           videoPath: videoPath,
           clipId: clip.id,
-          duration: clip.duration,
+          duration: window.end - window.start,
+          startOffset: window.start,
           outputSize: outputSize,
           thumbsPerSecond: thumbsPerSecond,
           priorityTimestamps: priorityTimestamps,
@@ -343,6 +372,31 @@ class ClipThumbnailManager {
     // subscription paused too so it doesn't start extracting off-screen.
     if (_paused) subscription.pause();
     _subscriptions[clip.id] = subscription;
+  }
+
+  /// The source range [clip]'s strip can currently display — its trim
+  /// window, clamped into the file.
+  static _StripWindow _visibleWindow(DivineVideoClip clip) {
+    final duration = clip.duration.isNegative ? Duration.zero : clip.duration;
+    var start = clip.trimStart;
+    if (start < Duration.zero) start = Duration.zero;
+    if (start > duration) start = duration;
+    var end = duration - clip.trimEnd;
+    if (end > duration) end = duration;
+    if (end < start) end = start;
+    return _StripWindow(start: start, end: end);
+  }
+
+  /// The source range to extract for [clip] — its visible window plus
+  /// [_windowPadding] of trim slack on each side, clamped into the file.
+  static _StripWindow _generationWindow(DivineVideoClip clip) {
+    final duration = clip.duration.isNegative ? Duration.zero : clip.duration;
+    final visible = _visibleWindow(clip);
+    var start = visible.start - _windowPadding;
+    if (start < Duration.zero) start = Duration.zero;
+    var end = visible.end + _windowPadding;
+    if (end > duration) end = duration;
+    return _StripWindow(start: start, end: end);
   }
 
   /// Merges carried-over frames into a fresh accumulated batch.
@@ -480,6 +534,7 @@ class ClipThumbnailManager {
     _subscriptions.clear();
     _notifiers.clear();
     _videoPaths.clear();
+    _windows.clear();
     _seeded.clear();
     _complete.clear();
     _retired.clear();
@@ -491,12 +546,18 @@ class ClipThumbnailManager {
 class _RetiredStrip {
   const _RetiredStrip({
     required this.videoPath,
+    required this.window,
     required this.frames,
     required this.complete,
   });
 
   /// Source video path the frames were extracted from (or borrowed for).
   final String videoPath;
+
+  /// Source range the frames were generated for. A clip that returns with a
+  /// wider trim than it left with needs a fresh subscription even when
+  /// [complete] is set.
+  final _StripWindow window;
 
   final List<StripThumbnail> frames;
 
@@ -511,4 +572,15 @@ class DurationRange {
 
   final Duration start;
   final Duration end;
+}
+
+/// A source-time range of a clip's file, in `[start, end]`.
+class _StripWindow {
+  const _StripWindow({required this.start, required this.end});
+
+  final Duration start;
+  final Duration end;
+
+  /// Whether this range contains all of [other].
+  bool covers(_StripWindow other) => start <= other.start && end >= other.end;
 }

--- a/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
+++ b/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
@@ -64,15 +64,26 @@ class ClipThumbnailManager {
   final Map<String, _RetiredStrip> _retired = {};
   static const _maxRetiredStrips = 8;
 
-  // Slack extracted on each side of the visible window so ordinary trim-handle
-  // nudges do not cancel and restart extraction. One second is ~600 px of drag
-  // at maximum zoom and ~52 px at 1x, and costs 13 frames per side — cheap
-  // next to the 500-frame cap a full-source request hits.
+  // Slack extracted on each side of the visible window so a small trim change
+  // shows real frames immediately instead of waiting for a fresh extraction.
+  // A moving drag holds restarts ([sync]'s trimmingClipId), so this only has
+  // to cover nudges, programmatic edits, and the first moments of a drag:
+  // one second is ~600 px of drag at maximum zoom but only ~52 px at the
+  // default zoom, which is why the slack alone cannot carry a gesture. Costs
+  // 13 frames per side.
   static const _windowPadding = Duration(seconds: 1);
 
+  /// Set while another route covers the editor. See [pauseAll].
+  bool _routePaused = false;
+
+  /// Set while the editor's preview player is still loading. See
+  /// [holdForPlayerStartup].
+  bool _startupHeld = false;
+
   /// When true, newly started subscriptions begin paused and existing ones are
-  /// held. See [pauseAll].
-  bool _paused = false;
+  /// held. The two reasons are independent — releasing one while the other
+  /// still holds must not restart extraction.
+  bool get _paused => _routePaused || _startupHeld;
 
   /// Returns the thumbnail notifier for the given [clipId].
   ValueNotifier<List<StripThumbnail>> operator [](String clipId) =>
@@ -85,10 +96,15 @@ class ClipThumbnailManager {
   /// that the currently visible slots need. New clips whose ID is
   /// in this map will generate those frames first before filling
   /// the full-density set.
+  ///
+  /// [trimmingClipId] is the clip whose trim handle is moving right now, if
+  /// any. Its window is left alone for as long as the caller keeps passing it
+  /// — the caller drops it once the gesture settles or ends.
   void sync({
     required List<DivineVideoClip> clips,
     required double devicePixelRatio,
     Map<String, List<Duration>> priorityTimestamps = const {},
+    String? trimmingClipId,
   }) {
     final currentIds = clips.map((c) => c.id).toSet();
 
@@ -170,6 +186,12 @@ class ClipThumbnailManager {
       final currentWindow = _windows[clip.id];
       final windowCovered =
           currentWindow != null && currentWindow.covers(visibleWindow);
+      // A trim drag commits every step of the gesture, and at the default
+      // zoom one pixel of drag is ~1/52 s of source — a normal handle drag
+      // walks the window past the padding several times over. Restarting on
+      // each step would cancel and re-request extraction throughout the
+      // gesture, so the restart waits for the handle to settle.
+      final windowSatisfied = windowCovered || clip.id == trimmingClipId;
 
       if (!hasSubscription) {
         if (isSeeded) {
@@ -184,7 +206,7 @@ class ClipThumbnailManager {
         } else if (_complete.contains(clip.id)) {
           // Restored from the retired cache at full density — only a
           // source-file change or a widened window warrants re-extraction.
-          if ((newPath == null || newPath == currentPath) && windowCovered) {
+          if ((newPath == null || newPath == currentPath) && windowSatisfied) {
             continue;
           }
           _complete.remove(clip.id);
@@ -195,7 +217,7 @@ class ClipThumbnailManager {
           priorityTimestamps: priorityTimestamps[clip.id],
         );
       } else if ((newPath != null && newPath != currentPath) ||
-          !windowCovered) {
+          !windowSatisfied) {
         // Source file of an already-subscribed clip changed (e.g. it was
         // re-rendered to a trimmed file), or the trim window grew past what
         // the current request covers. Restart against the new file / window
@@ -457,17 +479,43 @@ class ClipThumbnailManager {
   /// contending for hardware decoders and CPU. Lossless: the batch stream
   /// generators suspend at the next batch boundary and continue on [resumeAll].
   void pauseAll() {
-    _paused = true;
-    for (final sub in _subscriptions.values) {
-      if (!sub.isPaused) sub.pause();
-    }
+    _routePaused = true;
+    _applyPause();
   }
 
   /// Resumes thumbnail extraction paused by [pauseAll].
   void resumeAll() {
-    _paused = false;
+    _routePaused = false;
+    _applyPause();
+  }
+
+  /// Holds extraction while the editor's preview player is still loading its
+  /// clips.
+  ///
+  /// Both run native video decoding, and the strip's request starts on the
+  /// same frame the canvas initialises its player — on a device with a small
+  /// decoder budget the strip can starve the preview, which then stays on its
+  /// static poster with no error and no retry. Released by
+  /// [releasePlayerStartupHold] once the player reports ready.
+  void holdForPlayerStartup() {
+    _startupHeld = true;
+    _applyPause();
+  }
+
+  /// Releases the hold taken by [holdForPlayerStartup].
+  void releasePlayerStartupHold() {
+    _startupHeld = false;
+    _applyPause();
+  }
+
+  void _applyPause() {
+    final paused = _paused;
     for (final sub in _subscriptions.values) {
-      if (sub.isPaused) sub.resume();
+      if (paused && !sub.isPaused) {
+        sub.pause();
+      } else if (!paused && sub.isPaused) {
+        sub.resume();
+      }
     }
   }
 

--- a/mobile/lib/services/video_thumbnail_service.dart
+++ b/mobile/lib/services/video_thumbnail_service.dart
@@ -544,6 +544,17 @@ class VideoThumbnailService {
   /// Generates thumbnails for a timeline strip, yielded in batches so the
   /// UI can update progressively.
   ///
+  /// Covers the source range `[startOffset, startOffset + duration]` — the
+  /// window a caller actually shows, not necessarily the whole file. A
+  /// timeline clip only ever renders its trimmed window, so sizing the
+  /// request off the untrimmed source duration extracts frames nothing can
+  /// display: a 60 s import trimmed to 6 s asked for the 500-frame cap
+  /// instead of ~80.
+  ///
+  /// Emitted [StripThumbnail.timestamp]s stay absolute positions in the file,
+  /// so a caller that later widens its window can merge frames from two
+  /// requests without rebasing them.
+  ///
   /// [thumbsPerSecond] controls how many frames are extracted per second of
   /// video. Pass `ceil(maxPixelsPerSecond / thumbnailWidth)` to ensure every
   /// visual slot has a distinct frame at maximum zoom.
@@ -567,6 +578,7 @@ class VideoThumbnailService {
     int thumbsPerSecond = 1,
     int quality = _thumbnailQuality,
     int batchSize = 6,
+    Duration startOffset = Duration.zero,
     List<Duration>? priorityTimestamps,
   }) async* {
     if (duration <= Duration.zero) return;
@@ -579,6 +591,7 @@ class VideoThumbnailService {
       thumbsPerSecond: thumbsPerSecond,
       quality: quality,
       batchSize: batchSize,
+      startOffset: startOffset,
       priorityTimestamps: priorityTimestamps,
     );
   }
@@ -606,6 +619,7 @@ class VideoThumbnailService {
     required int thumbsPerSecond,
     required int quality,
     required int batchSize,
+    required Duration startOffset,
     List<Duration>? priorityTimestamps,
   }) async* {
     final durationMs = duration.inMilliseconds;
@@ -616,6 +630,7 @@ class VideoThumbnailService {
     final densityTimestamps = _buildProgressiveStripTimestamps(
       durationMs: durationMs,
       count: count,
+      startMs: startOffset.inMilliseconds,
     );
 
     // Priority timestamps go first (the exact frames the visible slots
@@ -691,14 +706,18 @@ class VideoThumbnailService {
     }
   }
 
-  /// Builds a center-first timestamp sequence (midpoint refinement).
+  /// Builds a center-first timestamp sequence (midpoint refinement) covering
+  /// `[startMs, startMs + durationMs]`.
   ///
   /// Example progression for ~10s: 5.0s, 2.5s, 7.5s, 1.25s, 3.75s...
   /// This improves perceived loading because early batches cover the full
-  /// timeline instead of only the beginning.
+  /// requested window instead of only the beginning. The refinement runs in
+  /// window-local time and every result is shifted by [startMs], so the
+  /// returned timestamps are absolute positions in the source file.
   static List<Duration> _buildProgressiveStripTimestamps({
     required int durationMs,
     required int count,
+    int startMs = 0,
   }) {
     final timestamps = <Duration>[];
     final seenMs = <int>{};
@@ -717,7 +736,7 @@ class VideoThumbnailService {
       final midMs = ((start + end) / 2).round().clamp(minMs, maxMs);
 
       if (seenMs.add(midMs)) {
-        timestamps.add(Duration(milliseconds: midMs));
+        timestamps.add(Duration(milliseconds: startMs + midMs));
       }
 
       if (width > 1) {
@@ -732,7 +751,7 @@ class VideoThumbnailService {
       for (var i = 0; i < count && timestamps.length < count; i++) {
         final fraction = (i + 0.5) / count;
         final ms = (durationMs * fraction).round().clamp(minMs, maxMs);
-        timestamps.add(Duration(milliseconds: ms));
+        timestamps.add(Duration(milliseconds: startMs + ms));
       }
     }
 

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -167,6 +167,30 @@ class _VideoEditorTimelineClipStripState
   bool _isExitingVolumeMode = false;
   Timer? _volumeExitTimer;
 
+  /// True between a trim handle's drag start and its release. The manager
+  /// leaves the dragged clip's extraction window alone for that span instead
+  /// of restarting on every committed step of the gesture.
+  bool _isTrimDragging = false;
+  Timer? _trimCatchUpTimer;
+
+  /// How long the trim window has to sit still mid-drag before it is requested
+  /// anyway. Without this the newly exposed footage would stay on posters for
+  /// the whole gesture, which is worse than the thrash the hold prevents: the
+  /// user drags a handle out precisely to see what is there. Re-armed on every
+  /// committed step, so a continuous drag never fires it and a pause always
+  /// does.
+  static const _trimCatchUpDelay = Duration(milliseconds: 250);
+
+  /// True until the editor's preview player reports ready, or
+  /// [_playerGateTimeout] elapses. Thumbnail extraction is held meanwhile.
+  bool _awaitingPlayer = true;
+  Timer? _playerGateTimer;
+
+  /// Upper bound on the startup hold. A composition that fails to load
+  /// publishes `isPlayerReady: false` and never corrects itself, so without
+  /// this the strip would stay on posters for the whole session.
+  static const _playerGateTimeout = Duration(seconds: 5);
+
   @override
   void initState() {
     super.initState();
@@ -189,6 +213,7 @@ class _VideoEditorTimelineClipStripState
     if (route is PageRoute) {
       routeObserver.subscribe(this, route);
     }
+    _updatePlayerGate();
     _maybeSeedSplit();
     _syncThumbnails();
   }
@@ -214,13 +239,52 @@ class _VideoEditorTimelineClipStripState
     routeObserver.unsubscribe(this);
     _stopAutoScroll();
     _volumeExitTimer?.cancel();
+    _playerGateTimer?.cancel();
+    _trimCatchUpTimer?.cancel();
     _reorderAnimController.dispose();
     _thumbnails.dispose();
     _waveforms.dispose();
     super.dispose();
   }
 
-  void _syncThumbnails() {
+  /// Holds thumbnail extraction until the editor's preview player has loaded.
+  ///
+  /// Both decode video, and the strip's first request starts on the same frame
+  /// the canvas initialises its player. Once released the gate never re-arms:
+  /// `isPlayerReady` also drops on every later reload (trim, reorder, speed),
+  /// and suspending the strip for those would be a different, unwanted change.
+  void _updatePlayerGate() {
+    if (!_awaitingPlayer) return;
+    final bloc = context.read<VideoEditorMainBloc?>();
+    if (bloc == null || bloc.state.isPlayerReady) {
+      _releasePlayerGate();
+      return;
+    }
+    _thumbnails.holdForPlayerStartup();
+    _playerGateTimer ??= Timer(_playerGateTimeout, _releasePlayerGate);
+  }
+
+  void _releasePlayerGate() {
+    if (!_awaitingPlayer) return;
+    _awaitingPlayer = false;
+    _playerGateTimer?.cancel();
+    _playerGateTimer = null;
+    _thumbnails.releasePlayerStartupHold();
+  }
+
+  void _handleTrimDragChanged(bool isDragging) {
+    _isTrimDragging = isDragging;
+    widget.onTrimDragChanged?.call(isDragging);
+    if (isDragging) return;
+    // Request the window the drag opened up, once. Not left to the parent
+    // rebuild: widget.onTrimDragChanged is nullable, so one is not guaranteed.
+    _trimCatchUpTimer?.cancel();
+    _syncThumbnails();
+  }
+
+  /// [ignoreTrimHold] requests the dragged clip's current window even though
+  /// the gesture is still running — see [_trimCatchUpDelay].
+  void _syncThumbnails({bool ignoreTrimHold = false}) {
     final clips = widget.clips;
     final pps = widget.pixelsPerSecond;
     if (!identical(_prevSlotClips, clips) || _prevSlotPps != pps) {
@@ -228,12 +292,21 @@ class _VideoEditorTimelineClipStripState
       _prevSlotPps = pps;
       _cachedSlotTimestamps = _computeSlotTimestamps();
     }
+    final holdTrimOn = _isTrimDragging && !ignoreTrimHold
+        ? widget.trimmingClipId
+        : null;
     _thumbnails.sync(
       clips: clips,
       devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
       priorityTimestamps: _cachedSlotTimestamps,
+      trimmingClipId: holdTrimOn,
     );
     _waveforms.sync(clips: clips);
+    if (holdTrimOn == null) return;
+    _trimCatchUpTimer?.cancel();
+    _trimCatchUpTimer = Timer(_trimCatchUpDelay, () {
+      if (mounted) _syncThumbnails(ignoreTrimHold: true);
+    });
   }
 
   /// Seeds the new clips' thumbnail notifiers from the source clip's
@@ -662,16 +735,24 @@ class _VideoEditorTimelineClipStripState
         : TimelineConstants.thumbnailStripHeight;
     final volumeAnimating = isVolumeEditMode || _isExitingVolumeMode;
 
-    return BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
-      listenWhen: (prev, curr) =>
-          prev.isVolumeEditMode && !curr.isVolumeEditMode,
-      listener: (_, _) {
-        _volumeExitTimer?.cancel();
-        setState(() => _isExitingVolumeMode = true);
-        _volumeExitTimer = Timer(animDuration, () {
-          if (mounted) setState(() => _isExitingVolumeMode = false);
-        });
-      },
+    return MultiBlocListener(
+      listeners: [
+        BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
+          listenWhen: (prev, curr) => !prev.isPlayerReady && curr.isPlayerReady,
+          listener: (_, _) => _releasePlayerGate(),
+        ),
+        BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
+          listenWhen: (prev, curr) =>
+              prev.isVolumeEditMode && !curr.isVolumeEditMode,
+          listener: (_, _) {
+            _volumeExitTimer?.cancel();
+            setState(() => _isExitingVolumeMode = true);
+            _volumeExitTimer = Timer(animDuration, () {
+              if (mounted) setState(() => _isExitingVolumeMode = false);
+            });
+          },
+        ),
+      ],
       child: Semantics(
         label: context.l10n.videoEditorTimelineLongPressToDragHint,
         button: true,
@@ -739,7 +820,7 @@ class _VideoEditorTimelineClipStripState
                   trimExpand: trimExpand,
                   pixelsPerSecond: widget.pixelsPerSecond,
                   onTrimChanged: widget.onTrimChanged,
-                  onTrimDragChanged: widget.onTrimDragChanged,
+                  onTrimDragChanged: _handleTrimDragChanged,
                   onClipTapped: widget.onClipTapped,
                   reorderSize: _reorderSize,
                   isVolumeEditMode: isVolumeEditMode,

--- a/mobile/test/services/subtitle_timeline_thumbnail_service_test.dart
+++ b/mobile/test/services/subtitle_timeline_thumbnail_service_test.dart
@@ -36,6 +36,7 @@ void main() {
               required Duration duration,
               required Size outputSize,
               required int thumbsPerSecond,
+              Duration startOffset = Duration.zero,
               List<Duration>? priorityTimestamps,
             }) {
               requestedPaths.add(videoPath);
@@ -76,6 +77,7 @@ void main() {
               required Duration duration,
               required Size outputSize,
               required int thumbsPerSecond,
+              Duration startOffset = Duration.zero,
               List<Duration>? priorityTimestamps,
             }) => fail('extraction must not start for an HLS manifest'),
       );
@@ -103,6 +105,7 @@ void main() {
               required Duration duration,
               required Size outputSize,
               required int thumbsPerSecond,
+              Duration startOffset = Duration.zero,
               List<Duration>? priorityTimestamps,
             }) => fail('extraction must not start without a file'),
       );
@@ -131,6 +134,7 @@ void main() {
               required Duration duration,
               required Size outputSize,
               required int thumbsPerSecond,
+              Duration startOffset = Duration.zero,
               List<Duration>? priorityTimestamps,
             }) => fail('extraction must not start without a file'),
       );
@@ -158,6 +162,7 @@ void main() {
               required Duration duration,
               required Size outputSize,
               required int thumbsPerSecond,
+              Duration startOffset = Duration.zero,
               List<Duration>? priorityTimestamps,
             }) async* {
               yield [

--- a/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
+++ b/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
@@ -1208,6 +1208,35 @@ void main() {
         await pumpEventQueue();
         expect(fakeStreamManager['a'].value, hasLength(1));
       });
+
+      test('the route pause and the startup hold are independent', () async {
+        syncFileClip();
+        streamController.add(firstBatch);
+        await pumpEventQueue();
+        expect(fakeStreamManager['a'].value, hasLength(1));
+
+        // Two independent hold reasons; the second must not re-pause.
+        fakeStreamManager.pauseAll();
+        fakeStreamManager.holdForPlayerStartup();
+        await pumpEventQueue();
+        expect(pauses, equals(1));
+
+        streamController.add(secondBatch);
+        await pumpEventQueue();
+        expect(fakeStreamManager['a'].value, hasLength(1));
+
+        // Releasing one reason while the other still holds must not resume.
+        fakeStreamManager.releasePlayerStartupHold();
+        await pumpEventQueue();
+        expect(resumes, equals(0));
+        expect(fakeStreamManager['a'].value, hasLength(1));
+
+        // Only when the last reason clears does delivery resume, losslessly.
+        fakeStreamManager.resumeAll();
+        await pumpEventQueue();
+        expect(resumes, equals(1));
+        expect(fakeStreamManager['a'].value, hasLength(2));
+      });
     });
 
     group('dispose', () {

--- a/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
+++ b/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
@@ -289,6 +289,7 @@ void main() {
                   required Duration duration,
                   required Size outputSize,
                   required int thumbsPerSecond,
+                  Duration startOffset = Duration.zero,
                   List<Duration>? priorityTimestamps,
                 }) {
                   final controller = StreamController<List<StripThumbnail>>();
@@ -406,6 +407,7 @@ void main() {
                 required Duration duration,
                 required Size outputSize,
                 required int thumbsPerSecond,
+                Duration startOffset = Duration.zero,
                 List<Duration>? priorityTimestamps,
               }) {
                 final controller = StreamController<List<StripThumbnail>>();
@@ -899,6 +901,7 @@ void main() {
                 required Duration duration,
                 required Size outputSize,
                 required int thumbsPerSecond,
+                Duration startOffset = Duration.zero,
                 List<Duration>? priorityTimestamps,
               }) {
                 final controller = StreamController<List<StripThumbnail>>();
@@ -969,6 +972,50 @@ void main() {
           // Subsequent syncs must not re-subscribe either.
           fakeStreamManager.sync(clips: [clipA, clipB], devicePixelRatio: 1);
           expect(controllers, hasLength(2));
+        },
+      );
+
+      test(
+        're-extracts a restored complete strip when the clip returns with a '
+        'wider trim than its frames were generated for',
+        () async {
+          final frame = writeFrame('widened_frame');
+          final trimmed = _createFileClip(
+            id: 'a',
+            videoPath: '${tempDir.path}/a.mp4',
+            seconds: 60,
+            trimStart: const Duration(seconds: 20),
+            trimEnd: const Duration(milliseconds: 33700),
+          );
+
+          fakeStreamManager.sync(clips: [trimmed], devicePixelRatio: 1);
+          controllers.single.add([
+            StripThumbnail(
+              path: frame.path,
+              timestamp: const Duration(seconds: 22),
+            ),
+          ]);
+          await pumpEventQueue();
+          await controllers.single.close();
+          await pumpEventQueue();
+
+          // 'a' leaves the timeline and returns with the trim dragged wide
+          // open. Its retired frames only cover the old window, so being
+          // "complete" is not enough to skip re-extraction.
+          fakeStreamManager.sync(clips: [], devicePixelRatio: 1);
+          fakeStreamManager.sync(
+            clips: [
+              _createFileClip(
+                id: 'a',
+                videoPath: '${tempDir.path}/a.mp4',
+                seconds: 60,
+              ),
+            ],
+            devicePixelRatio: 1,
+          );
+
+          expect(controllers, hasLength(2));
+          expect(fakeStreamManager['a'].value.single.path, equals(frame.path));
         },
       );
 
@@ -1097,6 +1144,7 @@ void main() {
                 required Duration duration,
                 required Size outputSize,
                 required int thumbsPerSecond,
+                Duration startOffset = Duration.zero,
                 List<Duration>? priorityTimestamps,
               }) => streamController.stream,
         );
@@ -1225,6 +1273,185 @@ void main() {
         },
       );
     });
+
+    // =========================================================
+    // Trim window sizing
+    // =========================================================
+
+    group('trim window', () {
+      late List<_StripRequest> requests;
+      late List<StreamController<List<StripThumbnail>>> controllers;
+      late ClipThumbnailManager windowManager;
+      late Directory tempDir;
+
+      setUp(() {
+        requests = [];
+        controllers = [];
+        windowManager = ClipThumbnailManager(
+          stripThumbnailStreamFactory:
+              ({
+                required String videoPath,
+                required String clipId,
+                required Duration duration,
+                required Size outputSize,
+                required int thumbsPerSecond,
+                Duration startOffset = Duration.zero,
+                List<Duration>? priorityTimestamps,
+              }) {
+                requests.add(
+                  _StripRequest(startOffset: startOffset, duration: duration),
+                );
+                final controller = StreamController<List<StripThumbnail>>();
+                controllers.add(controller);
+                return controller.stream;
+              },
+        );
+        tempDir = Directory.systemTemp.createTempSync(
+          'clip_thumbnail_window_test_',
+        );
+      });
+
+      tearDown(() {
+        windowManager.dispose();
+        for (final controller in controllers) {
+          unawaited(controller.close());
+        }
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      });
+
+      /// A 60 s library import seeded with a trim down to the 6.3 s
+      /// recording budget: visible source range `[20 s, 26.3 s]`.
+      DivineVideoClip importClip({
+        Duration trimStart = const Duration(seconds: 20),
+        Duration trimEnd = const Duration(milliseconds: 33700),
+      }) => _createFileClip(
+        id: 'import',
+        videoPath: '${tempDir.path}/import.mp4',
+        seconds: 60,
+        trimStart: trimStart,
+        trimEnd: trimEnd,
+      );
+
+      test('asks only for the trimmed window plus a second of slack', () {
+        final clip = importClip();
+
+        windowManager.sync(clips: [clip], devicePixelRatio: 1);
+
+        // Not the untrimmed 60 s source: at 13 thumbs/s that hit the
+        // generator's 500-frame cap for footage the strip cannot show.
+        expect(requests, hasLength(1));
+        expect(
+          requests.single.startOffset,
+          equals(const Duration(seconds: 19)),
+        );
+        expect(
+          requests.single.end,
+          equals(const Duration(milliseconds: 27300)),
+        );
+        expect(requests.single.duration, lessThan(clip.duration));
+      });
+
+      test('covers the whole source when the clip is untrimmed', () {
+        final clip = _createFileClip(
+          id: 'import',
+          videoPath: '${tempDir.path}/import.mp4',
+          seconds: 6,
+        );
+
+        windowManager.sync(clips: [clip], devicePixelRatio: 1);
+
+        expect(requests.single.startOffset, equals(Duration.zero));
+        expect(requests.single.duration, equals(clip.duration));
+      });
+
+      test('does not restart while the trim stays inside the slack', () {
+        windowManager.sync(clips: [importClip()], devicePixelRatio: 1);
+
+        // Half a second of handle drag outwards on each side — still inside
+        // the padded window, so the in-flight extraction is left alone.
+        windowManager.sync(
+          clips: [
+            importClip(
+              trimStart: const Duration(milliseconds: 19500),
+              trimEnd: const Duration(milliseconds: 33200),
+            ),
+          ],
+          devicePixelRatio: 1,
+        );
+
+        expect(requests, hasLength(1));
+      });
+
+      test('restarts against the widened window when the trim reaches past '
+          'the generated range', () {
+        windowManager.sync(clips: [importClip()], devicePixelRatio: 1);
+
+        windowManager.sync(
+          clips: [importClip(trimStart: const Duration(seconds: 10))],
+          devicePixelRatio: 1,
+        );
+
+        expect(requests, hasLength(2));
+        expect(requests.last.startOffset, equals(const Duration(seconds: 9)));
+        expect(requests.last.end, equals(const Duration(milliseconds: 27300)));
+      });
+
+      test('restarts when the trim window moves to a different part of the '
+          'source', () {
+        windowManager.sync(clips: [importClip()], devicePixelRatio: 1);
+
+        // Same 6.3 s length, shifted 20 s later in the source.
+        windowManager.sync(
+          clips: [
+            importClip(
+              trimStart: const Duration(seconds: 40),
+              trimEnd: const Duration(milliseconds: 13700),
+            ),
+          ],
+          devicePixelRatio: 1,
+        );
+
+        expect(requests, hasLength(2));
+        expect(requests.last.startOffset, equals(const Duration(seconds: 39)));
+        expect(
+          requests.last.end,
+          equals(const Duration(milliseconds: 47300)),
+        );
+      });
+
+      test(
+        'keeps the frames it already has while the wider window loads',
+        () async {
+          final frame = File('${tempDir.path}/loaded.jpg')
+            ..writeAsStringSync('loaded');
+          windowManager.sync(clips: [importClip()], devicePixelRatio: 1);
+          controllers.single.add([
+            StripThumbnail(
+              path: frame.path,
+              timestamp: const Duration(seconds: 22),
+            ),
+          ]);
+          await pumpEventQueue();
+          expect(windowManager['import'].value, hasLength(1));
+
+          windowManager.sync(
+            clips: [importClip(trimStart: const Duration(seconds: 10))],
+            devicePixelRatio: 1,
+          );
+
+          // The restart must not blank the strip — the already-extracted
+          // frame stays on screen until fresh batches cover its slot.
+          expect(requests, hasLength(2));
+          expect(
+            windowManager['import'].value.single.path,
+            equals(frame.path),
+          );
+          expect(frame.existsSync(), isTrue);
+        },
+      );
+    });
   });
 
   // =========================================================
@@ -1271,6 +1498,8 @@ DivineVideoClip _createFileClip({
   required String id,
   required String videoPath,
   int seconds = 3,
+  Duration trimStart = Duration.zero,
+  Duration trimEnd = Duration.zero,
 }) {
   return DivineVideoClip(
     id: id,
@@ -1279,5 +1508,18 @@ DivineVideoClip _createFileClip({
     recordedAt: DateTime(2025),
     originalAspectRatio: 9 / 16,
     targetAspectRatio: .vertical,
+    trimStart: trimStart,
+    trimEnd: trimEnd,
   );
+}
+
+/// One [StripThumbnailStreamFactory] invocation, so tests can assert what
+/// range the manager actually asked the extractor for.
+class _StripRequest {
+  const _StripRequest({required this.startOffset, required this.duration});
+
+  final Duration startOffset;
+  final Duration duration;
+
+  Duration get end => startOffset + duration;
 }

--- a/mobile/test/services/video_thumbnail_service_test.dart
+++ b/mobile/test/services/video_thumbnail_service_test.dart
@@ -349,6 +349,59 @@ void main() {
           }
         },
       );
+
+      test(
+        'extracts only inside the requested window, timestamped in absolute '
+        'source time',
+        () async {
+          VideoThumbnailService.resetStripBatchQueueForTesting();
+
+          final fakeJpegBytes = Uint8List.fromList(
+            List<int>.generate(16, (i) => i),
+          );
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(channel, (call) async {
+                if (call.method == 'getThumbnails') {
+                  return List<Uint8List>.generate(6, (_) => fakeJpegBytes);
+                }
+                return null;
+              });
+
+          // A 3 s window starting 20 s into the file: 3 s at 2 thumbs/s is
+          // exactly one batch of 6.
+          final batches = <List<StripThumbnail>>[];
+          final done = Completer<void>();
+          VideoThumbnailService.generateStripThumbnails(
+            videoPath: testVideoPath,
+            clipId: 'clip-windowed',
+            duration: const Duration(seconds: 3),
+            startOffset: const Duration(seconds: 20),
+            outputSize: const Size(48, 64),
+            thumbsPerSecond: 2,
+          ).listen(batches.add, onDone: done.complete);
+          await done.future;
+
+          expect(batches, hasLength(1));
+          final thumbnails = batches.single;
+          expect(thumbnails, hasLength(6));
+          for (final thumbnail in thumbnails) {
+            expect(
+              thumbnail.timestamp.inMilliseconds,
+              inInclusiveRange(20000, 23000),
+            );
+          }
+          // Center-first refinement still spreads across the window rather
+          // than clustering at one edge.
+          expect(
+            thumbnails.first.timestamp,
+            isNot(equals(thumbnails.last.timestamp)),
+          );
+
+          for (final thumbnail in thumbnails) {
+            File(thumbnail.path).deleteSync();
+          }
+        },
+      );
     });
   });
 

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
@@ -346,6 +346,7 @@ void main() {
                   required Duration duration,
                   required Size outputSize,
                   required int thumbsPerSecond,
+                  Duration startOffset = Duration.zero,
                   List<Duration>? priorityTimestamps,
                 }) => const Stream.empty(),
           );
@@ -449,6 +450,7 @@ void main() {
                   required Duration duration,
                   required Size outputSize,
                   required int thumbsPerSecond,
+                  Duration startOffset = Duration.zero,
                   List<Duration>? priorityTimestamps,
                 }) => const Stream.empty(),
           );
@@ -1025,6 +1027,7 @@ void main() {
                 required Duration duration,
                 required Size outputSize,
                 required int thumbsPerSecond,
+                Duration startOffset = Duration.zero,
                 List<Duration>? priorityTimestamps,
               }) => const Stream<List<StripThumbnail>>.empty(),
         );


### PR DESCRIPTION
## Description

Opening the editor starts two things on the same frame: the canvas initialises its preview player, and the timeline strip starts extracting thumbnails through a process-global serial queue. Both decode video. On a device with a small decoder budget the strip can starve the preview, which then stays on its static poster with no error and no retry — the shape reported in #7571.

Two independent levers, one commit each.

### 1. Extract only the window the strip can show

A timeline clip renders slots for the **full** source duration and clips the trimmed region out with a `ClipRect`, so every frame outside the trim was extracted and then discarded.

Swapping `clip.duration` for the trimmed duration alone would have moved the window rather than shrinking it. The emitted timestamps have to stay absolute file positions, or the strip cannot merge frames from an earlier and a later request when the user widens the trim.

So the request is sized off the visible window instead:

- `VideoThumbnailService.generateStripThumbnails` takes a `startOffset` (default `Duration.zero`, so every existing caller is unchanged) and covers `[startOffset, startOffset + duration]`. The midpoint refinement runs in window-local time and shifts each result by `startMs`, so emitted timestamps stay absolute.
- `ClipThumbnailManager` tracks a window per clip, requests the trim padded by 1 s per side, and restarts the subscription only when a trim reaches outside the range on hand — the same code path as a source-file swap, so frames already on screen stay as gap-fillers.
- A **moving** trim drag holds that restart (`sync`'s new `trimmingClipId`); it fires 250 ms after the handle settles, and again on release. The drag commits every step of the gesture, and at the default zoom one pixel of drag is ~1/52 s of source, so 1 s of padding is ~52 px — nowhere near enough to carry a gesture on its own, which is why the hold exists at all. Holding until *release* was the first shape and it was wrong: dragging a handle outwards is exactly when the user wants to see the footage it exposes, and on `main` that footage is already extracted, so a release-only restart would have been a visible regression. The debounce keeps both properties — nothing restarts while the handle is moving, and frames arrive within 250 ms of it stopping.

### 2. Hold extraction until the preview player is ready

`ClipThumbnailManager` grows a second, independent hold reason beside the existing route-level `pauseAll` (used when a route covers the editor). Releasing one while the other still holds must not restart extraction, hence two flags rather than one.

The strip arms the hold in `didChangeDependencies` and releases it on `VideoEditorMainState.isPlayerReady` going true — a signal the canvas already publishes and the strip's bloc already carries, so this needs no new plumbing.

Two deliberate asymmetries:

- **The gate never re-arms.** `isPlayerReady` also drops on every later reload (trim, reorder, speed change). Suspending the strip for those is a different change and not wanted here.
- **It times out after 5 s.** A composition that fails to load publishes `isPlayerReady: false` and never corrects itself; without the bound the strip would sit on posters for the whole session.

## Why lever 2 is the one that fixes the reported case

The issue's reasoning assumes a long library import reaches the editor already trimmed to the 6.3 s budget, via #7574's `seedImportTrimForEditorBudget`. **That code does not exist on `main`.** No import path writes `trimStart`/`trimEnd`: `video_clip_import_service.dart:154` constructs the clip with neither, and `clip_manager_provider.dart:404` / `:424` append it verbatim. Only the recorder shortens a clip, and it does so by re-encoding the file rather than by trimming.

So a 60 s import lands untrimmed, its visible window is the whole file, and lever 1 alone asks for exactly what it asked for before. Lever 1 pays off once the clip *is* trimmed — the user drags a handle, a split half is created, a rendered file lands — and lever 2 is what keeps the untrimmed import off the decoders while the preview loads.

## Out of Scope

- **Density.** The strip fixes extraction at `ceil(maxPixelsPerSecond / thumbnailWidth)` = 13 frames per second of source regardless of zoom, which is what makes an untrimmed 60 s clip hit the 500-frame cap once the gate opens. Sizing density off the current zoom means re-extracting on zoom-in, which is the thrash lever 1 just removed. Separate change, separate device verification.
- **Seeding an import trim.** Whether a long import should enter the editor pre-trimmed is a product decision, not a thumbnail one.
- Whether #7571 is fully explained by decoder contention still needs ruling in or out on a device.

## Verification

- `dart format --output=none --set-exit-if-changed` on the changed files — clean.
- `flutter analyze lib test integration_test` — no issues.
- `flutter test test/services/video_editor/clip_thumbnail_manager_test.dart test/services/video_thumbnail_service_test.dart test/services/subtitle_timeline_thumbnail_service_test.dart test/widgets/video_editor/ test/screens/video_metadata/` — **988 passed**, including the existing route pause/resume test, which the two-flag split leaves untouched.
- Ratchets checked: uncancellable timer wait, future-delayed production, post-close emit, empty catch, service god-file, l10n delegates, placeholder tests, ungrouped tests — all pass.
- Lever 1's tests are mutation-checked: reverting the window to the full source reds five of them, zeroing the padding reds the anti-thrash test, dropping the end-of-file clamp reds the untrimmed test, and dropping the `startMs` shift reds the service test.

**Related Issue:** Closes #7582

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
