### PR TITLE
fix(media-cache): reclaim old cache files that no cleanup path could ever delete

### DIFF
--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -21,7 +21,9 @@ import 'package:unified_logger/unified_logger.dart';
 /// [_hasLegacyUrlTailName] or [_webHelperCacheFilePattern], so
 /// externally-managed files that share the cache directory — e.g. the alias
 /// manifest or caller-owned sidecar files — are never removed.
-final RegExp _managedCacheFilePattern = RegExp(r'_\d+_\d+\.[A-Za-z0-9]+$');
+final RegExp _managedCacheFilePattern = RegExp(
+  r'_\d{13,19}_\d+\.[A-Za-z0-9]+$',
+);
 
 /// Splits the `_<microseconds>_<seq>.<tail>` suffix this package writes,
 /// capturing `<tail>` so [_hasLegacyUrlTailName] can judge it.

--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -17,11 +17,22 @@ import 'package:unified_logger/unified_logger.dart';
 
 /// Filenames written by [MediaCacheManager] end with
 /// `_<microseconds>_<seq><ext>` (see `_relativePathFor`). Reclamation only
-/// deletes *untracked* files matching this shape or
-/// [_webHelperCacheFilePattern], so externally-managed files that share the
-/// cache directory — e.g. the alias manifest or caller-owned sidecar files —
-/// are never removed.
+/// deletes *untracked* files matching this shape,
+/// [_hasLegacyUrlTailName] or [_webHelperCacheFilePattern], so
+/// externally-managed files that share the cache directory — e.g. the alias
+/// manifest or caller-owned sidecar files — are never removed.
 final RegExp _managedCacheFilePattern = RegExp(r'_\d+_\d+\.[A-Za-z0-9]+$');
+
+/// Splits the `_<microseconds>_<seq>.<tail>` suffix this package writes,
+/// capturing `<tail>` so [_hasLegacyUrlTailName] can judge it.
+///
+/// The timestamp run is pinned to the width of a microsecond epoch (13–19
+/// digits; every write has carried 16 since 2001) rather than `\d+`, so an
+/// externally-owned name that happens to carry a short `_<digits>_<digits>.`
+/// infix — `report_2024_01.csv.gz` — is never a reclamation candidate.
+final RegExp _timestampedCacheFilePattern = RegExp(
+  r'_\d{13,19}_\d+\.([^/\\]*)$',
+);
 
 /// Filenames written by `flutter_cache_manager`'s WebHelper — the path behind
 /// the inherited [CacheManager.downloadFile] / [CacheManager.getSingleFile] —
@@ -55,8 +66,32 @@ const int _keyDigestLength = 16;
 /// segments whose "extension" is an arbitrarily long tail (`.png?v=2`), which
 /// neither describes a container nor matches [_managedCacheFilePattern].
 /// Anything outside this shape falls back to
-/// [MediaCacheConfig.defaultExtension].
+/// [MediaCacheConfig.defaultExtension]. Files already written under the
+/// pre-cap behaviour are reclaimed via [_hasLegacyUrlTailName].
 final RegExp _usableExtensionPattern = RegExp(r'^\.[A-Za-z0-9]{1,10}$');
+
+/// Whether [name] is a file this package wrote before `_extensionFor` gained
+/// [_usableExtensionPattern] — the same `_<microseconds>_<seq>.` infix, but a
+/// tail carried over verbatim from a percent-decoded URL segment rather than
+/// a container extension: `…_1723600000000000_4.png?v=2`, `…_4.jpg (1)`, or
+/// the bare `…_4.` a segment ending in a dot produced.
+///
+/// Reclamation has to recognise these or their bytes are stranded for the
+/// life of the install. Such a file stops being tracked the moment a
+/// re-download writes today's clean name, and it never matched
+/// [_managedCacheFilePattern], whose extension class is `[A-Za-z0-9]+`
+/// anchored at end-of-string. Untracked *and* unmatched means neither
+/// reclamation nor byte eviction could see it, so it sat on top of the
+/// configured budget until `clearCache()`.
+///
+/// The tail is judged with [_usableExtensionPattern] itself rather than a
+/// hand-written negation of it, so the two cannot drift apart: this accepts
+/// exactly the tails today's `_extensionFor` would refuse to write.
+bool _hasLegacyUrlTailName(String name) {
+  final tail = _timestampedCacheFilePattern.firstMatch(name)?.group(1);
+  if (tail == null) return false;
+  return !_usableExtensionPattern.hasMatch('.$tail');
+}
 
 /// Untracked files younger than this are never reclaimed. Covers the window
 /// where a download settled after the sweep's snapshots were taken (its store
@@ -1139,7 +1174,8 @@ class MediaCacheManager extends CacheManager {
   ///
   /// 1. **Reclamation** — deletes top-level files in the cache directory that
   ///    neither the cache store nor the sync manifest still tracks and match
-  ///    [_managedCacheFilePattern] or [_webHelperCacheFilePattern].
+  ///    [_managedCacheFilePattern], [_hasLegacyUrlTailName] or
+  ///    [_webHelperCacheFilePattern].
   ///    `flutter_cache_manager` drops database rows on eviction without
   ///    reliably deleting the underlying file for this on-disk layout, so
   ///    evicted and superseded downloads pile up as untracked orphans; this
@@ -1289,6 +1325,7 @@ class MediaCacheManager extends CacheManager {
       if (manifestNames.contains(name)) continue;
       if (_inFlightRelativePaths.contains(name)) continue;
       if (!_managedCacheFilePattern.hasMatch(name) &&
+          !_hasLegacyUrlTailName(name) &&
           !_webHelperCacheFilePattern.hasMatch(name)) {
         continue;
       }

--- a/mobile/packages/media_cache/test/src/enforce_cache_limits_test.dart
+++ b/mobile/packages/media_cache/test/src/enforce_cache_limits_test.dart
@@ -79,8 +79,8 @@ void main() {
     test('reclaims untracked managed-pattern files, keeps everything '
         'else', () async {
       final (manager, dir) = build();
-      final tracked = writeFile(dir, 'vid_key_100_1.mp4', 10);
-      final orphan = writeFile(dir, 'vid_key_200_2.mp4', 10);
+      final tracked = writeFile(dir, 'vid_key_1723600000000000_1.mp4', 10);
+      final orphan = writeFile(dir, 'vid_key_1723600000000001_2.mp4', 10);
       final seedVideo = writeFile(dir, 'a1b2c3d4e5f6', 10);
       final seedThumb = writeFile(dir, 'thumbnail_a1b2c3.jpg', 10);
       final aliases = writeFile(dir, 'aliases.json', 10);
@@ -88,7 +88,7 @@ void main() {
       final nestedManagedName = writeFile(nested, 'nested_300_3.mp4', 10);
 
       when(repo.getAllObjects).thenAnswer(
-        (_) async => [obj('vid_key_100_1.mp4', id: 1)],
+        (_) async => [obj('vid_key_1723600000000000_1.mp4', id: 1)],
       );
 
       await manager.enforceCacheLimits();
@@ -148,9 +148,9 @@ void main() {
       final aliasesTmp = writeFile(dir, 'aliases.json.tmp', 10);
       final seedThumb = writeFile(dir, 'thumbnail_${'a1b2c3d4' * 8}.jpg', 10);
       final seedMarker = writeFile(dir, '.seed_media_loaded', 10);
-      // Two digit runs and a multi-part tail, but four digits cannot be a
+      // Two digit runs and a simple extension, but four digits cannot be a
       // microsecond epoch, so this is not one of our writes.
-      final shortInfix = writeFile(dir, 'report_2024_01.csv.gz', 10);
+      final shortInfix = writeFile(dir, 'report_2024_01.csv', 10);
 
       when(repo.getAllObjects).thenAnswer((_) async => []);
 
@@ -358,7 +358,7 @@ void main() {
     test('does nothing when the repository fails to open', () async {
       when(repo.open).thenAnswer((_) async => false);
       final (manager, dir) = build();
-      final orphan = writeFile(dir, 'x_1_1.mp4', 10);
+      final orphan = writeFile(dir, 'x_1723600000000000_1.mp4', 10);
 
       await manager.enforceCacheLimits();
 
@@ -370,7 +370,7 @@ void main() {
         'open', () async {
       when(repo.open).thenAnswer((_) async => false);
       final (manager, dir) = build();
-      final orphan = writeFile(dir, 'x_1_1.mp4', 10);
+      final orphan = writeFile(dir, 'x_1723600000000000_1.mp4', 10);
 
       await manager.enforceCacheLimits();
       expect(orphan.existsSync(), isTrue, reason: 'first pass could not run');
@@ -403,7 +403,7 @@ void main() {
           await manager.close();
         } on Object catch (_) {}
       }, (_, _) {});
-      final orphan = writeFile(dir, 'x_1_1.mp4', 10);
+      final orphan = writeFile(dir, 'x_1723600000000000_1.mp4', 10);
 
       await manager.enforceCacheLimits();
 
@@ -415,7 +415,7 @@ void main() {
       final gate = Completer<List<CacheObject>>();
       when(repo.getAllObjects).thenAnswer((_) => gate.future);
       final (manager, dir) = build();
-      final orphan = writeFile(dir, 'x_1_1.mp4', 10);
+      final orphan = writeFile(dir, 'x_1723600000000000_1.mp4', 10);
 
       final first = manager.enforceCacheLimits();
       // Second call sees _sweepInProgress and returns immediately.
@@ -432,12 +432,12 @@ void main() {
     test('skips a second pass within the throttle window', () async {
       when(repo.getAllObjects).thenAnswer((_) async => []);
       final (manager, dir) = build();
-      final firstOrphan = writeFile(dir, 'a_1_1.mp4', 10);
+      final firstOrphan = writeFile(dir, 'a_1723600000000000_1.mp4', 10);
 
       await manager.enforceCacheLimits();
       expect(firstOrphan.existsSync(), isFalse, reason: 'first pass ran');
 
-      final secondOrphan = writeFile(dir, 'b_2_2.mp4', 10);
+      final secondOrphan = writeFile(dir, 'b_1723600000000001_2.mp4', 10);
       await manager.enforceCacheLimits();
 
       expect(
@@ -451,12 +451,12 @@ void main() {
     test('force bypasses the throttle window', () async {
       when(repo.getAllObjects).thenAnswer((_) async => []);
       final (manager, dir) = build();
-      final firstOrphan = writeFile(dir, 'a_1_1.mp4', 10);
+      final firstOrphan = writeFile(dir, 'a_1723600000000000_1.mp4', 10);
 
       await manager.enforceCacheLimits();
       expect(firstOrphan.existsSync(), isFalse);
 
-      final secondOrphan = writeFile(dir, 'b_2_2.mp4', 10);
+      final secondOrphan = writeFile(dir, 'b_1723600000000001_2.mp4', 10);
       await manager.enforceCacheLimits(force: true);
 
       expect(

--- a/mobile/packages/media_cache/test/src/enforce_cache_limits_test.dart
+++ b/mobile/packages/media_cache/test/src/enforce_cache_limits_test.dart
@@ -106,6 +106,105 @@ void main() {
       );
     });
 
+    // Before `_extensionFor` gained its usable-extension guard (#7364), the
+    // extension was `path.extension` of a percent-decoded URL segment,
+    // verbatim. An image proxied through
+    // `…/https%3A%2F%2Fbucket%2Fx.png%3Fv%3D2` therefore cached as
+    // `…_<micros>_<seq>.png?v=2`. Writes have carried a 16-digit microsecond
+    // epoch since 2001.
+    const legacyMicros = '1723600000000000';
+
+    test('reclaims untracked orphans whose extension came from a pre-cap '
+        'URL tail', () async {
+      final (manager, dir) = build();
+      final query = writeFile(dir, 'img_key_${legacyMicros}_4.png?v=2', 10);
+      final spaced = writeFile(dir, 'img_key_${legacyMicros}_5.jpg (1)', 10);
+      final bareDot = writeFile(dir, 'img_key_${legacyMicros}_6.', 10);
+
+      when(repo.getAllObjects).thenAnswer((_) async => []);
+
+      await manager.enforceCacheLimits();
+
+      expect(
+        query.existsSync(),
+        isFalse,
+        reason: 'a query string after the dot no longer strands the file',
+      );
+      expect(
+        spaced.existsSync(),
+        isFalse,
+        reason: 'any non-extension tail is reclaimable, not just query ones',
+      );
+      expect(
+        bareDot.existsSync(),
+        isFalse,
+        reason: 'a segment ending in a dot wrote an empty extension',
+      );
+    });
+
+    test('keeps externally-owned files that resemble a pre-cap name', () async {
+      final (manager, dir) = build();
+      final aliases = writeFile(dir, 'aliases.json', 10);
+      final aliasesTmp = writeFile(dir, 'aliases.json.tmp', 10);
+      final seedThumb = writeFile(dir, 'thumbnail_${'a1b2c3d4' * 8}.jpg', 10);
+      final seedMarker = writeFile(dir, '.seed_media_loaded', 10);
+      // Two digit runs and a multi-part tail, but four digits cannot be a
+      // microsecond epoch, so this is not one of our writes.
+      final shortInfix = writeFile(dir, 'report_2024_01.csv.gz', 10);
+
+      when(repo.getAllObjects).thenAnswer((_) async => []);
+
+      await manager.enforceCacheLimits();
+
+      expect(aliases.existsSync(), isTrue, reason: 'alias manifest kept');
+      expect(aliasesTmp.existsSync(), isTrue, reason: 'alias temp file kept');
+      expect(seedThumb.existsSync(), isTrue, reason: 'seed thumbnail kept');
+      expect(
+        seedMarker.existsSync(),
+        isTrue,
+        reason: 'SeedMediaCleanupService retries off this marker',
+      );
+      expect(
+        shortInfix.existsSync(),
+        isTrue,
+        reason: 'a short digit infix is not a microsecond timestamp',
+      );
+    });
+
+    test('keeps a tracked pre-cap file, which is still a live entry', () async {
+      final (manager, dir) = build();
+      const name = 'img_key_${legacyMicros}_4.png?v=2';
+      final tracked = writeFile(dir, name, 10);
+
+      when(repo.getAllObjects).thenAnswer((_) async => [obj(name, id: 1)]);
+
+      await manager.enforceCacheLimits();
+
+      expect(
+        tracked.existsSync(),
+        isTrue,
+        reason: 'the store still serves this file; reclamation is for orphans',
+      );
+    });
+
+    test('evicts a tracked pre-cap file to converge on the byte '
+        'budget', () async {
+      final (manager, dir) = build(maxCacheSizeBytes: 50);
+      const name = 'img_key_${legacyMicros}_4.png?v=2';
+      final tracked = writeFile(dir, name, 60);
+
+      when(repo.getAllObjects).thenAnswer(
+        (_) async => [obj(name, id: 1, touched: DateTime(2020))],
+      );
+
+      await manager.enforceCacheLimits();
+
+      expect(tracked.existsSync(), isFalse);
+      final captured =
+          verify(() => repo.deleteAll(captureAny())).captured.single as List;
+      expect(captured, equals(<int>[1]));
+    });
+
     test('releases the repository lease after each sweep', () async {
       when(repo.getAllObjects).thenAnswer((_) async => []);
       final (manager, _) = build();


### PR DESCRIPTION
## Description

Image-cache files whose name carried a URL query string — `…_<micros>_<seq>.png?v=2`, plus `…_<seq>.jpg (1)` and the bare `…_<seq>.` a URL segment ending in a dot produced — can never be deleted. Two conditions have to hold for a file to be reclaimable, and these fail both: they stop being tracked as soon as a re-download writes today's clean name, and they never matched `_managedCacheFilePattern`, whose extension class is `[A-Za-z0-9]+` anchored at end-of-string. Untracked *and* unmatched means neither `_reclaimOrphanedFiles` nor `_evictToByteBudget` can see them, so their bytes sit on top of the 256 MB image budget for the life of the install and only `clearCache()` frees them.

Half of the issue is already fixed: #7364 introduced `_usableExtensionPattern` and gates both the URL-derived extension and the configured `defaultExtension` through it, so no new query-bearing name can be minted. This change covers the other half — the residue already on users' disks.

**No migration is needed, and that is deliberate.** `enforceCacheLimits()` is called unconditionally at every launch for both the image and video caches, and `_reclaimOrphanedFiles` is a full top-level directory walk on every pass. These files survived that walk only because of the pattern, so teaching the pattern the legacy shape reclaims them on the next launch. A marker-gated one-time sweep would duplicate a walk that already happens, and no install carries a marker to gate it on.

Two design points worth review:

- **The tail is judged with `_usableExtensionPattern` itself, negated,** rather than a hand-written inverse. The first draft used a bespoke negated character class; it can silently drift from the writer's rule and it missed the bare-dot shape. The predicate now accepts exactly the tails today's `_extensionFor` would refuse to write.
- **The timestamp run is pinned to microsecond-epoch width (13–19 digits)** instead of `\d+`, so an externally-owned name that happens to carry a short `_<digits>_<digits>.` infix — `report_2024_01.csv.gz` — is never a reclamation candidate.

A still-tracked legacy file is deliberately not reclaimed (it is a live entry), but `_evictToByteBudget` already handles it through its `CacheObject` row, so the budget converges either way. There is a test for that.

**Related Issue:** Closes #7366

## Out of Scope

- **The size of the residue is still unmeasured.** This makes it reclaimable; it does not tell us how much there was. A number needs a device probe of `openvine_image_cache` before and after a launch.

## Verification

- `dart format --output=none --set-exit-if-changed` on both changed files — clean.
- `flutter analyze` in `mobile/packages/media_cache` — **No issues found**.
- `flutter analyze lib test` from `mobile/` — 25 info-level lints, all pre-existing and all outside this diff, which is confined to `packages/media_cache/`.
- `flutter test --coverage` in `mobile/packages/media_cache` — **253 passed, 0 failed; 98.44 % (882/896)** against the package's `min_coverage: 98`. Every new line is covered; the four uncovered lines are pre-existing.
- Ratchets checked: ungrouped tests, placeholder tests, unpinned-unchanged assertions, skip ceiling — no `media_cache` hits.
- Mutation-checked: deleting the single guard line turns the reclamation test red.

Four tests were added: reclaiming untracked `.png?v=2` / `.jpg (1)` / bare-dot orphans; keeping `aliases.json`, `aliases.json.tmp`, a 64-hex seed thumbnail, the `.seed_media_loaded` marker and `report_2024_01.csv.gz`; keeping a *tracked* legacy file; and byte eviction removing a tracked legacy file.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
