### PR TITLE
fix(audio): free the disk space a deleted My Sounds import leaves behind

### DIFF
--- a/mobile/lib/providers/saved_sounds_provider.dart
+++ b/mobile/lib/providers/saved_sounds_provider.dart
@@ -3,8 +3,10 @@
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/documents_path_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/local_audio_cleanup_service.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
 
 final savedSoundsServiceProvider = Provider<SavedSoundsService>((ref) {
@@ -12,11 +14,24 @@ final savedSoundsServiceProvider = Provider<SavedSoundsService>((ref) {
   // list built from it) always targets the current account's bucket.
   ref.watch(currentAuthStateProvider);
   final pubkeyHex = ref.watch(authServiceProvider).currentPublicKeyHex;
+  final preferences = ref.watch(sharedPreferencesProvider);
   return SavedSoundsService(
-    ref.watch(sharedPreferencesProvider),
+    preferences,
     pubkeyHex: pubkeyHex,
     // Draft-local audio is stored relative to the documents directory; iOS
     // rewrites that path on every app update, so it is rebased on load.
     documentsPath: ref.watch(documentsPathProvider),
+    // Removing a saved sound reclaims the audio file it owned. Resolved on
+    // demand rather than watched: the database is only needed when a removal
+    // actually happens, and watching it would make every reader of this
+    // provider — including the app-shell sounds scope — depend on it.
+    audioReclaimer: (audioFilePath) {
+      final database = ref.read(databaseProvider);
+      return LocalAudioCleanupService(
+        draftsDao: database.draftsDao,
+        clipsDao: database.clipsDao,
+        preferences: preferences,
+      ).reclaimUnreferencedAudio(audioFilePath);
+    },
   );
 });

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -12,7 +12,7 @@ import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/observability/crash_reporter.dart';
 import 'package:openvine/services/file_cleanup_service.dart';
-import 'package:openvine/services/saved_sounds_service.dart';
+import 'package:openvine/services/local_audio_cleanup_service.dart';
 import 'package:openvine/utils/path_resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:shared_preferences/shared_preferences.dart';
@@ -28,9 +28,16 @@ class DraftStorageService {
   }) : _crashReporter = crashReporter ?? const SilentCrashReporter(),
        _draftsDao = draftsDao,
        _clipsDao = clipsDao,
-       _preferences = preferences;
+       _localAudioCleanup = LocalAudioCleanupService(
+         draftsDao: draftsDao,
+         clipsDao: clipsDao,
+         preferences: preferences,
+       );
 
   final DraftsDao _draftsDao;
+
+  /// Shared sweep over every store that can name a draft-local audio file.
+  final LocalAudioCleanupService _localAudioCleanup;
 
   final CrashReporter _crashReporter;
 
@@ -38,12 +45,6 @@ class DraftStorageService {
   CrashReporter get crashReporterForTesting => _crashReporter;
 
   final ClipsDao _clipsDao;
-
-  /// Where saved sounds live, consulted before deleting a draft's audio files.
-  ///
-  /// Nullable so tests that never delete a draft need not wire it; a null
-  /// instance simply cannot see My Sounds references.
-  final SharedPreferences? _preferences;
 
   /// Hex pubkey of the current account. When set, new drafts are tagged
   /// with this owner and queries filter by it (plus legacy NULL rows).
@@ -670,9 +671,7 @@ class DraftStorageService {
   /// The same local audio file can be shared by a draft and its publish copy —
   /// `copyWith` carries [DivineVideoDraft.editorStateHistory] and
   /// [DivineVideoDraft.selectedSound] — so this guard keeps shared audio until
-  /// the last referencing draft is deleted. Scans the draft `data` blobs
-  /// directly (audio paths live there, not in an indexed column) and never
-  /// throws: a corrupt blob is logged and skipped.
+  /// the last referencing draft is deleted.
   ///
   /// My Sounds is scanned too. Audio imported from the Library is written
   /// under whichever draft was open at the time, so deleting that draft would
@@ -681,42 +680,13 @@ class DraftStorageService {
   ///
   /// Callers run this *after* deleting the draft they are cleaning up, so
   /// every row it sees is a survivor and there is nothing to exclude.
-  Future<Set<String>> _referencedLocalAudioFilenames() async {
-    final rows = await _draftsDao.getAllDrafts();
-    final documentsPath = await getDocumentsPath();
-    final filenames = <String>{..._savedSoundAudioFilenames()};
-
-    for (final row in rows) {
-      final DivineVideoDraft draft;
-      try {
-        draft = DivineVideoDraft.fromJson(
-          json.decode(row.data) as Map<String, dynamic>,
-          documentsPath,
-        );
-      } catch (e) {
-        Log.error(
-          '🧹 Skipping draft ${row.id} during audio reference scan: $e',
-          name: 'DraftStorageService',
-          category: LogCategory.video,
-        );
-        continue;
-      }
-      for (final path in draft.localAudioFilePaths) {
-        filenames.add(p.basename(path));
-      }
-    }
-
-    return filenames;
-  }
-
-  /// Basenames of draft-local audio files a saved sound points at, or empty
-  /// when this instance was built without access to storage.
-  Set<String> _savedSoundAudioFilenames() {
-    final preferences = _preferences;
-    return preferences == null
-        ? const {}
-        : SavedSoundsService.referencedLocalAudioFilenames(preferences);
-  }
+  ///
+  /// The sweep's completeness flag is deliberately ignored here: an unreadable
+  /// store only ever costs this caller references it would have *kept*, so the
+  /// worst case is the pre-#7977 behaviour for one file. Saved-sound removal
+  /// deletes on the same set and must not ignore it.
+  Future<Set<String>> _referencedLocalAudioFilenames() async =>
+      (await _localAudioCleanup.referencedAudioFilenames()).filenames;
 
   /// Basenames of clip ghost-frame files referenced by any surviving clip,
   /// across all accounts — library clips, whose `draftId` is NULL, included.
@@ -817,7 +787,9 @@ class DraftStorageService {
       allAudioPaths,
       draftsDao: _draftsDao,
       clipsDao: _clipsDao,
-      referencedAudioFilenames: _savedSoundAudioFilenames(),
+      referencedAudioFilenames: _localAudioCleanup
+          .savedSoundReferences()
+          .filenames,
     );
   }
 }

--- a/mobile/lib/services/local_audio_cleanup_service.dart
+++ b/mobile/lib/services/local_audio_cleanup_service.dart
@@ -1,0 +1,168 @@
+// ABOUTME: Sweeps every store that can reference a draft-local audio file
+// ABOUTME: so an orphaned one can be reclaimed without deleting audio in use
+
+import 'dart:convert';
+
+import 'package:db_client/db_client.dart';
+import 'package:openvine/extensions/draft_local_audio_extensions.dart';
+import 'package:openvine/models/divine_video_draft.dart';
+import 'package:openvine/services/file_cleanup_service.dart';
+import 'package:openvine/services/saved_sounds_service.dart';
+import 'package:openvine/utils/draft_audio_path_resolver.dart';
+import 'package:openvine/utils/path_resolver.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Basenames of draft-local audio still referenced on this device, plus
+/// whether the sweep that produced them could read every store it found.
+///
+/// [isComplete] is the difference between "no reference exists" and "no
+/// reference was *found*". A corrupt draft blob, an undecodable My Sounds
+/// bucket, or a payload written by a newer build all leave a reference the
+/// sweep cannot see, and a caller that deletes on the strength of the set
+/// would then reclaim a file the user is still using. Callers that only widen
+/// what they keep (draft deletion) may ignore it; callers that delete on the
+/// absence of a reference must refuse when it is false.
+typedef LocalAudioReferences = ({Set<String> filenames, bool isComplete});
+
+/// Reference sweep over every store that can name a draft-local audio file.
+///
+/// Draft-local audio — imported tracks under `draft_audio_imports/`, committed
+/// voice-over takes, and audio extracted from a draft's own clips — is
+/// persisted inside the draft `data` blob and inside the My Sounds buckets,
+/// neither of which is an indexed file column. So the indexed clip/draft
+/// reference check that [FileCleanupService] applies to video and thumbnail
+/// files cannot see any of it, and every caller that deletes such a file has
+/// to be handed the basenames a scan of those blobs found.
+///
+/// One implementation, two directions: draft deletion asks which files a
+/// *surviving* draft or saved sound still needs, and saved-sound removal asks
+/// whether anything at all still needs the file the removed entry owned. A
+/// second copy of this scan drifting from the first is exactly how a file the
+/// user still plays gets deleted, so both go through here.
+class LocalAudioCleanupService {
+  LocalAudioCleanupService({
+    required DraftsDao draftsDao,
+    required ClipsDao clipsDao,
+    SharedPreferences? preferences,
+  }) : _draftsDao = draftsDao,
+       _clipsDao = clipsDao,
+       _preferences = preferences;
+
+  final DraftsDao _draftsDao;
+  final ClipsDao _clipsDao;
+
+  /// Where My Sounds lives. Nullable so callers that never delete audio need
+  /// not wire it; an instance without it cannot prove a file is unreferenced
+  /// and therefore never reclaims one.
+  final SharedPreferences? _preferences;
+
+  static const _logName = 'LocalAudioCleanupService';
+
+  /// Basenames of draft-local audio a saved sound points at, across every
+  /// account bucket on this device.
+  ///
+  /// All accounts, not just the signed-in one: audio cleanup runs device-wide
+  /// and a saved sound outlives the account switch that hides it.
+  LocalAudioReferences savedSoundReferences() {
+    final preferences = _preferences;
+    return preferences == null
+        ? (filenames: const <String>{}, isComplete: false)
+        : SavedSoundsService.localAudioReferences(preferences);
+  }
+
+  /// Basenames of draft-local audio referenced by any draft still in the
+  /// database or any saved sound, across all accounts.
+  ///
+  /// Scans the draft `data` blobs directly — audio paths live there, not in an
+  /// indexed column — and never throws: a blob that will not parse is logged,
+  /// skipped, and reported through [LocalAudioReferences.isComplete].
+  ///
+  /// Callers run this *after* removing the draft or saved sound they are
+  /// cleaning up, so everything it sees is a survivor and there is nothing to
+  /// exclude.
+  Future<LocalAudioReferences> referencedAudioFilenames() async {
+    final savedSounds = savedSoundReferences();
+    final rows = await _draftsDao.getAllDrafts();
+    final documentsPath = await getDocumentsPath();
+
+    final filenames = <String>{...savedSounds.filenames};
+    var isComplete = savedSounds.isComplete;
+
+    for (final row in rows) {
+      final DivineVideoDraft draft;
+      try {
+        draft = DivineVideoDraft.fromJson(
+          json.decode(row.data) as Map<String, dynamic>,
+          documentsPath,
+        );
+      } catch (e) {
+        isComplete = false;
+        Log.error(
+          '🧹 Skipping draft ${row.id} during audio reference scan: $e',
+          name: _logName,
+          category: LogCategory.video,
+        );
+        continue;
+      }
+      for (final path in draft.localAudioFilePaths) {
+        filenames.add(p.basename(path));
+      }
+    }
+
+    return (filenames: filenames, isComplete: isComplete);
+  }
+
+  /// Deletes [audioFilePath] once nothing on this device references it.
+  ///
+  /// Called after a My Sounds entry is removed. Audio imported from the
+  /// Library is written under whichever draft was open at the time, so the
+  /// file the entry pointed at can equally be a draft's own track, a track a
+  /// second saved sound shares, or nobody's — only the sweep can tell them
+  /// apart. #8011 taught the draft side to keep a file My Sounds still names;
+  /// without this the same file simply became a permanent orphan when the
+  /// saved sound went instead.
+  ///
+  /// Refuses to delete whenever the sweep is incomplete: an unreadable store
+  /// means the reference set is a lower bound, and a leaked file costs disk
+  /// while a wrongly reclaimed one costs the user audio they still play. Also
+  /// refuses any path outside this app's own audio storage — a stored
+  /// `localFilePath` that never went through an importer is not ours to
+  /// reclaim, whatever it points at.
+  ///
+  /// Throws:
+  ///
+  /// * Exceptions from the draft query or the filesystem existence check are
+  ///   propagated. Deletion failures are logged by [FileCleanupService] and
+  ///   otherwise ignored.
+  Future<void> reclaimUnreferencedAudio(String? audioFilePath) async {
+    if (audioFilePath == null || audioFilePath.isEmpty) return;
+
+    if (!isDraftLocalAudioPath(audioFilePath)) {
+      Log.warning(
+        '🔒 Not draft-local audio storage, keeping file: $audioFilePath',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      return;
+    }
+
+    final references = await referencedAudioFilenames();
+    if (!references.isComplete) {
+      Log.warning(
+        '🔒 Audio reference scan incomplete, keeping file: $audioFilePath',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      return;
+    }
+
+    await FileCleanupService.deleteDraftAudioFiles(
+      [audioFilePath],
+      draftsDao: _draftsDao,
+      clipsDao: _clipsDao,
+      referencedAudioFilenames: references.filenames,
+    );
+  }
+}

--- a/mobile/lib/services/saved_sounds_service.dart
+++ b/mobile/lib/services/saved_sounds_service.dart
@@ -10,16 +10,28 @@ import 'package:openvine/models/saved_sound.dart';
 import 'package:openvine/utils/draft_audio_path_resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 enum SavedSoundSaveResult { saved, alreadySaved }
+
+/// Reclaims the draft-local audio file at [audioFilePath] once nothing else
+/// on the device references it.
+///
+/// A port rather than a direct dependency: proving a file is unreferenced
+/// needs the draft and clip tables, and this service owns nothing but
+/// `SharedPreferences`. `LocalAudioCleanupService.reclaimUnreferencedAudio`
+/// is the production implementation, wired in `savedSoundsServiceProvider`.
+typedef LocalAudioReclaimer = Future<void> Function(String audioFilePath);
 
 class SavedSoundsService {
   SavedSoundsService(
     this._preferences, {
     String? pubkeyHex,
     String documentsPath = '',
+    LocalAudioReclaimer? audioReclaimer,
   }) : _pubkeyHex = pubkeyHex,
-       _documentsPath = documentsPath;
+       _documentsPath = documentsPath,
+       _audioReclaimer = audioReclaimer;
 
   /// Prefix for the per-account storage keys.
   static const _keyPrefix = 'saved_reusable_sounds';
@@ -51,6 +63,11 @@ class SavedSoundsService {
   /// Application documents directory that draft-local audio paths are stored
   /// relative to. Empty on web, and in tests that never persist a local file.
   final String _documentsPath;
+
+  /// Reclaims a removed sound's audio file, or `null` when this instance
+  /// cannot reach the stores that would prove the file unreferenced — in
+  /// which case removal leaves the file in place, as it did before #8025.
+  final LocalAudioReclaimer? _audioReclaimer;
 
   /// SharedPreferences key for a specific account's saved sounds.
   ///
@@ -143,11 +160,46 @@ class SavedSoundsService {
     return SavedSoundSaveResult.saved;
   }
 
+  /// Removes [soundId] from this account's library and reclaims the audio file
+  /// it owned when nothing else still references it.
+  ///
+  /// The reclaim runs *after* the write, so the entry being removed cannot
+  /// count as a reference to its own file, and the surviving buckets that
+  /// [localAudioReferences] scans are the real survivors.
   Future<void> removeSound(String soundId) async {
-    final sounds = loadSavedSounds()
-        .where((savedSound) => savedSound.id != soundId)
+    final sounds = loadSavedSounds();
+    final removed = sounds
+        .where((savedSound) => savedSound.id == soundId)
         .toList();
-    await _writeSavedSounds(sounds);
+    await _writeSavedSounds(
+      sounds.where((savedSound) => savedSound.id != soundId).toList(),
+    );
+    for (final sound in removed) {
+      await _reclaimAudio(sound.audio.localFilePath);
+    }
+  }
+
+  /// Hands [audioFilePath] to the reclaimer, absorbing any failure.
+  ///
+  /// The library write has already succeeded by the time this runs, so a
+  /// failed reclaim must not fail [removeSound]: the caller reads a throw as
+  /// "the entry is still saved" and would leave a deleted sound on screen.
+  /// Nothing retries — the file is simply left where it is.
+  Future<void> _reclaimAudio(String? audioFilePath) async {
+    final reclaimer = _audioReclaimer;
+    if (reclaimer == null || audioFilePath == null || audioFilePath.isEmpty) {
+      return;
+    }
+    try {
+      await reclaimer(audioFilePath);
+    } catch (error) {
+      Log.warning(
+        '⚠️ Failed to reclaim audio for a removed saved sound: '
+        '$audioFilePath - $error',
+        name: 'SavedSoundsService',
+        category: LogCategory.video,
+      );
+    }
   }
 
   Future<void> replaceSavedSound(SavedSound sound) async {
@@ -221,50 +273,78 @@ class SavedSoundsService {
   /// All accounts, not just the signed-in one — draft cleanup already scans
   /// drafts device-wide, and a saved sound outlives the account switch that
   /// hides it. Never throws: an undecodable bucket contributes nothing.
+  ///
+  /// Callers that *delete* on the absence of a reference want
+  /// [localAudioReferences] instead, which additionally reports whether every
+  /// bucket was readable.
   static Set<String> referencedLocalAudioFilenames(
+    SharedPreferences preferences,
+  ) => localAudioReferences(preferences).filenames;
+
+  /// [referencedLocalAudioFilenames] plus whether the scan could read every
+  /// bucket and entry it found.
+  ///
+  /// `isComplete` is false when a bucket does not decode, is not one of the
+  /// two recognized shapes (a payload from a newer build reaches this), or
+  /// holds an entry that will not parse as an `AudioEvent`. The reference such
+  /// an entry might have carried is unknown, so the filename set is a lower
+  /// bound rather than the whole truth — see `LocalAudioReferences`.
+  static ({Set<String> filenames, bool isComplete}) localAudioReferences(
     SharedPreferences preferences,
   ) {
     final filenames = <String>{};
+    var isComplete = true;
     for (final key in preferences.getKeys()) {
       if (!key.startsWith(_keyPrefix)) continue;
       final raw = preferences.getString(key);
       if (raw == null || raw.isEmpty) continue;
-      for (final audioJson in _storedAudioJson(raw)) {
+      final bucket = _storedAudioJson(raw);
+      if (!bucket.isComplete) isComplete = false;
+      for (final audioJson in bucket.entries) {
         try {
           final path = AudioEvent.fromJson(audioJson).localFilePath;
           if (path != null && path.isNotEmpty) {
             filenames.add(p.basename(path));
           }
         } catch (_) {
-          continue;
+          isComplete = false;
         }
       }
     }
-    return filenames;
+    return (filenames: filenames, isComplete: isComplete);
   }
 
   /// The `AudioEvent` json of every entry in a stored bucket [raw], in either
-  /// the legacy list shape or the versioned `{schemaVersion, sounds}` shape.
-  static Iterable<Map<String, dynamic>> _storedAudioJson(String raw) sync* {
+  /// the legacy list shape or the versioned `{schemaVersion, sounds}` shape,
+  /// and whether the whole bucket was readable in one of those two shapes.
+  static ({List<Map<String, dynamic>> entries, bool isComplete})
+  _storedAudioJson(String raw) {
     final Object? decoded;
     try {
       decoded = jsonDecode(raw);
     } catch (_) {
-      return;
+      return (entries: const [], isComplete: false);
     }
-    final List<dynamic> entries;
+    final List<dynamic> rawEntries;
     if (decoded is List) {
-      entries = decoded;
+      rawEntries = decoded;
     } else if (decoded is Map && decoded['sounds'] is List) {
-      entries = decoded['sounds'] as List<dynamic>;
+      rawEntries = decoded['sounds'] as List<dynamic>;
     } else {
-      return;
+      return (entries: const [], isComplete: false);
     }
-    for (final entry in entries.whereType<Map>()) {
+    final entries = <Map<String, dynamic>>[];
+    var isComplete = true;
+    for (final entry in rawEntries) {
+      if (entry is! Map) {
+        isComplete = false;
+        continue;
+      }
       // Legacy entries are the AudioEvent itself; versioned ones nest it.
       final audio = entry['audio'];
-      yield Map<String, dynamic>.from(audio is Map ? audio : entry);
+      entries.add(Map<String, dynamic>.from(audio is Map ? audio : entry));
     }
+    return (entries: entries, isComplete: isComplete);
   }
 
   static bool _isNewerSchema(Map<String, dynamic> decoded) {

--- a/mobile/lib/utils/draft_audio_path_resolver.dart
+++ b/mobile/lib/utils/draft_audio_path_resolver.dart
@@ -49,7 +49,15 @@ String toPortableAudioPath(String path) => _belowAudioRoot(path) ?? path;
 /// writes below one of those roots, so a stored `localFilePath` pointing
 /// anywhere else did not come from this app's own audio storage and must not
 /// be deleted on its behalf.
-bool isDraftLocalAudioPath(String path) => _belowAudioRoot(path) != null;
+///
+/// A `..` segment below the root is rejected: the root name matches, but the
+/// path escapes upward out of app audio storage, and reclaim deletes the raw
+/// path. Nothing writes such a path today, so this only keeps the delete
+/// bound honest if one ever reaches the stored `localFilePath`.
+bool isDraftLocalAudioPath(String path) {
+  final relative = _belowAudioRoot(path);
+  return relative != null && !p.split(relative).contains('..');
+}
 
 /// Absolute path for a persisted audio [path], rooted at [documentsPath].
 ///

--- a/mobile/lib/utils/draft_audio_path_resolver.dart
+++ b/mobile/lib/utils/draft_audio_path_resolver.dart
@@ -41,6 +41,16 @@ const Set<String> _draftLocalMarkers = {
 /// returned unchanged.
 String toPortableAudioPath(String path) => _belowAudioRoot(path) ?? path;
 
+/// Whether [path] names a file inside one of the three directories this app
+/// writes draft-local audio into.
+///
+/// Bounds what an audio-reclaim path is allowed to delete. Every producer —
+/// `LocalAudioImportService`, the voice-over cubit, clip audio extraction —
+/// writes below one of those roots, so a stored `localFilePath` pointing
+/// anywhere else did not come from this app's own audio storage and must not
+/// be deleted on its behalf.
+bool isDraftLocalAudioPath(String path) => _belowAudioRoot(path) != null;
+
 /// Absolute path for a persisted audio [path], rooted at [documentsPath].
 ///
 /// Accepts the portable form as well as an absolute path from a previous

--- a/mobile/test/providers/saved_sounds_provider_test.dart
+++ b/mobile/test/providers/saved_sounds_provider_test.dart
@@ -2,17 +2,22 @@
 // ABOUTME: Pins the account bucket and the documents path the service reads.
 
 import 'dart:async';
+import 'dart:io';
 
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/documents_path_provider.dart';
 import 'package:openvine/providers/saved_sounds_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
+import 'package:path/path.dart' as p;
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
@@ -77,6 +82,66 @@ void main() {
         afterUpdate.loadSounds().single.url,
         '$newContainer/$relativePath',
       );
+    });
+
+    group('audio reclamation', () {
+      late Directory documents;
+      late AppDatabase database;
+
+      setUp(() {
+        TestWidgetsFlutterBinding.ensureInitialized();
+        documents = Directory.systemTemp.createTempSync('saved_sounds_wiring');
+        database = AppDatabase.test(NativeDatabase.memory());
+      });
+
+      tearDown(() async {
+        await database.close();
+        if (documents.existsSync()) documents.deleteSync(recursive: true);
+      });
+
+      SavedSoundsService createService() {
+        final container = ProviderContainer(
+          overrides: [
+            authServiceProvider.overrideWithValue(authService),
+            sharedPreferencesProvider.overrideWithValue(preferences),
+            documentsPathProvider.overrideWithValue(documents.path),
+            databaseProvider.overrideWithValue(database),
+          ],
+        );
+        addTearDown(container.dispose);
+        return container.read(savedSoundsServiceProvider);
+      }
+
+      File writeImportedAudio() {
+        final file = File(p.join(documents.path, relativePath));
+        file.parent.createSync(recursive: true);
+        file.writeAsBytesSync(const [0, 1, 2, 3]);
+        return file;
+      }
+
+      test('removing an imported sound reclaims its audio file', () async {
+        final audio = writeImportedAudio();
+        final service = createService();
+        await service.saveSound(
+          AudioEvent.fromLocalImport(
+            id: 'local_import_1',
+            filePath: audio.path,
+            createdAt: 1700000000,
+            title: 'Imported sound',
+            mimeType: 'audio/mp4',
+          ),
+        );
+
+        await service.removeSound('local_import_1');
+
+        expect(
+          audio.existsSync(),
+          isFalse,
+          reason:
+              'the provider must wire a reclaimer, or the file leaks for '
+              'the life of the install (#8025)',
+        );
+      });
     });
   });
 }

--- a/mobile/test/services/local_audio_cleanup_service_test.dart
+++ b/mobile/test/services/local_audio_cleanup_service_test.dart
@@ -1,0 +1,368 @@
+// ABOUTME: Tests the reference sweep that guards draft-local audio deletion.
+// ABOUTME: Pins what counts as a reference and when reclaiming must refuse.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' show AspectRatio, AudioEvent;
+import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/divine_video_draft.dart';
+import 'package:openvine/services/draft_storage_service.dart';
+import 'package:openvine/services/local_audio_cleanup_service.dart';
+import 'package:openvine/services/saved_sounds_service.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../mocks/mock_path_provider_platform.dart';
+
+void main() {
+  group(LocalAudioCleanupService, () {
+    late Directory documents;
+    late AppDatabase database;
+    late SharedPreferences preferences;
+    late DraftStorageService drafts;
+    late PathProviderPlatform originalPathProviderInstance;
+
+    setUp(() async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+      documents = Directory.systemTemp.createTempSync('local_audio_cleanup');
+      originalPathProviderInstance = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = MockPathProviderPlatform()
+        ..setApplicationDocumentsPath(documents.path);
+
+      database = AppDatabase.test(NativeDatabase.memory());
+      SavedSoundsService.resetLegacyMigrationClaimForTesting();
+      SharedPreferences.setMockInitialValues({});
+      preferences = await SharedPreferences.getInstance();
+      drafts = DraftStorageService(
+        draftsDao: database.draftsDao,
+        clipsDao: database.clipsDao,
+      );
+    });
+
+    tearDown(() async {
+      PathProviderPlatform.instance = originalPathProviderInstance;
+      await database.close();
+      if (documents.existsSync()) documents.deleteSync(recursive: true);
+    });
+
+    LocalAudioCleanupService createService({bool withPreferences = true}) =>
+        LocalAudioCleanupService(
+          draftsDao: database.draftsDao,
+          clipsDao: database.clipsDao,
+          preferences: withPreferences ? preferences : null,
+        );
+
+    File writeAudio(String relativePath) {
+      final file = File(p.join(documents.path, relativePath));
+      file.parent.createSync(recursive: true);
+      file.writeAsBytesSync(const [0, 1, 2, 3]);
+      return file;
+    }
+
+    AudioEvent localTrack({required String id, required String filePath}) =>
+        AudioEvent.fromLocalImport(
+          id: id,
+          filePath: filePath,
+          createdAt: 1700000000,
+          title: 'Local audio',
+          mimeType: 'audio/mp4',
+        );
+
+    Future<void> saveDraftWithAudio({
+      required String id,
+      required String audioPath,
+      required String audioId,
+    }) => drafts.saveDraft(
+      DivineVideoDraft.create(
+        id: id,
+        clips: [
+          DivineVideoClip(
+            id: 'clip_$id',
+            video: EditorVideo.file('/path/to/video.mp4'),
+            duration: const Duration(seconds: 6),
+            recordedAt: DateTime(2025),
+            targetAspectRatio: AspectRatio.square,
+            originalAspectRatio: 9 / 16,
+          ),
+        ],
+        title: 'Audio draft',
+        description: '',
+        hashtags: const {},
+        selectedApproach: 'video',
+        editorStateHistory: {
+          'position': 0,
+          'history': [
+            {
+              'meta': {
+                VideoEditorConstants.audioStateHistoryKey: [
+                  localTrack(id: audioId, filePath: audioPath).toJson(),
+                ],
+              },
+            },
+          ],
+        },
+      ),
+    );
+
+    Future<void> saveSound({required String id, required String filePath}) =>
+        SavedSoundsService(
+          preferences,
+          documentsPath: documents.path,
+        ).saveSound(localTrack(id: id, filePath: filePath));
+
+    /// Inserts a draft row whose `data` blob cannot be decoded, so the sweep
+    /// cannot tell whether it referenced the file under test.
+    Future<void> writeCorruptDraftRow() => database.draftsDao.upsertDraft(
+      id: 'draft_corrupt',
+      title: 'Corrupt',
+      description: '',
+      publishStatus: 'draft',
+      createdAt: DateTime(2025),
+      lastModified: DateTime(2025),
+      renderedFilePath: null,
+      renderedThumbnailPath: null,
+      data: 'not json',
+    );
+
+    /// Replaces the current account's stored bucket with [raw], simulating a
+    /// payload this build cannot decode.
+    Future<void> writeRawSoundBucket(String raw) => preferences.setString(
+      SavedSoundsService.accountStorageKey(''),
+      raw,
+    );
+
+    group('savedSoundReferences', () {
+      test('collects basenames from every account bucket', () async {
+        await preferences.setString(
+          SavedSoundsService.accountStorageKey('aa'),
+          jsonEncode({
+            'schemaVersion': 1,
+            'sounds': [
+              {
+                'audio': localTrack(
+                  id: 'local_import_other_account',
+                  filePath: p.join(
+                    documents.path,
+                    'draft_audio_imports',
+                    'd1',
+                    'other.m4a',
+                  ),
+                ).toJson(),
+              },
+            ],
+          }),
+        );
+
+        final references = createService().savedSoundReferences();
+
+        expect(references.filenames, equals({'other.m4a'}));
+        expect(references.isComplete, isTrue);
+      });
+
+      test('reports incomplete without preferences', () {
+        final references = createService(
+          withPreferences: false,
+        ).savedSoundReferences();
+
+        expect(references.filenames, isEmpty);
+        expect(
+          references.isComplete,
+          isFalse,
+          reason:
+              'an instance that cannot read My Sounds has not proven '
+              'anything about it',
+        );
+      });
+    });
+
+    group('referencedAudioFilenames', () {
+      test('unions surviving drafts with every saved sound', () async {
+        await saveDraftWithAudio(
+          id: 'draft_a',
+          audioPath: p.join(
+            documents.path,
+            'draft_audio_imports',
+            'draft_a',
+            'from_draft.m4a',
+          ),
+          audioId: 'local_import_draft',
+        );
+        await saveSound(
+          id: 'local_import_saved',
+          filePath: p.join(
+            documents.path,
+            'draft_audio_imports',
+            'draft_a',
+            'from_sound.m4a',
+          ),
+        );
+
+        final references = await createService().referencedAudioFilenames();
+
+        expect(
+          references.filenames,
+          equals({'from_draft.m4a', 'from_sound.m4a'}),
+        );
+        expect(references.isComplete, isTrue);
+      });
+
+      test('reports incomplete when a draft blob will not parse', () async {
+        await saveDraftWithAudio(
+          id: 'draft_ok',
+          audioPath: p.join(
+            documents.path,
+            'draft_audio_imports',
+            'draft_ok',
+            'readable.m4a',
+          ),
+          audioId: 'local_import_ok',
+        );
+        await writeCorruptDraftRow();
+
+        final references = await createService().referencedAudioFilenames();
+
+        expect(
+          references.filenames,
+          contains('readable.m4a'),
+          reason:
+              'a corrupt sibling must not cost the readable draft its '
+              'reference',
+        );
+        expect(references.isComplete, isFalse);
+      });
+
+      test(
+        'reports incomplete when a saved-sound bucket will not decode',
+        () async {
+          await writeRawSoundBucket('{ not json');
+
+          final references = await createService().referencedAudioFilenames();
+
+          expect(references.filenames, isEmpty);
+          expect(references.isComplete, isFalse);
+        },
+      );
+    });
+
+    group('reclaimUnreferencedAudio', () {
+      test('deletes a file nothing references', () async {
+        final audio = writeAudio(
+          p.join('draft_audio_imports', 'draft_gone', 'orphan.m4a'),
+        );
+
+        await createService().reclaimUnreferencedAudio(audio.path);
+
+        expect(audio.existsSync(), isFalse);
+      });
+
+      test('keeps a file a surviving draft still references', () async {
+        final audio = writeAudio(
+          p.join('draft_audio_imports', 'draft_live', 'shared.m4a'),
+        );
+        await saveDraftWithAudio(
+          id: 'draft_live',
+          audioPath: audio.path,
+          audioId: 'local_import_shared',
+        );
+
+        await createService().reclaimUnreferencedAudio(audio.path);
+
+        expect(
+          audio.existsSync(),
+          isTrue,
+          reason: 'a draft still renders and plays this track',
+        );
+      });
+
+      test('keeps a file another saved sound still references', () async {
+        final audio = writeAudio(
+          p.join('draft_audio_imports', 'draft_autosave', 'twice_saved.m4a'),
+        );
+        await saveSound(id: 'local_import_survivor', filePath: audio.path);
+
+        await createService().reclaimUnreferencedAudio(audio.path);
+
+        expect(
+          audio.existsSync(),
+          isTrue,
+          reason: 'a second My Sounds entry still points at this file',
+        );
+      });
+
+      test('keeps a file when a draft blob could not be read', () async {
+        final audio = writeAudio(
+          p.join('draft_audio_imports', 'draft_gone', 'unprovable.m4a'),
+        );
+        await writeCorruptDraftRow();
+
+        await createService().reclaimUnreferencedAudio(audio.path);
+
+        expect(
+          audio.existsSync(),
+          isTrue,
+          reason:
+              'an unreadable draft may hold the last reference, so the '
+              'sweep cannot prove the file is an orphan',
+        );
+      });
+
+      test(
+        'keeps a file when a saved-sound bucket could not be read',
+        () async {
+          final audio = writeAudio(
+            p.join('draft_audio_imports', 'draft_gone', 'foreign.m4a'),
+          );
+          await writeRawSoundBucket('{ not json');
+
+          await createService().reclaimUnreferencedAudio(audio.path);
+
+          expect(audio.existsSync(), isTrue);
+        },
+      );
+
+      test('keeps a file when built without access to My Sounds', () async {
+        final audio = writeAudio(
+          p.join('draft_audio_imports', 'draft_gone', 'unchecked.m4a'),
+        );
+
+        await createService(
+          withPreferences: false,
+        ).reclaimUnreferencedAudio(audio.path);
+
+        expect(audio.existsSync(), isTrue);
+      });
+
+      test("keeps a file outside this app's audio storage", () async {
+        final audio = writeAudio(p.join('picker_cache', 'user_original.m4a'));
+
+        await createService().reclaimUnreferencedAudio(audio.path);
+
+        expect(
+          audio.existsSync(),
+          isTrue,
+          reason:
+              'a path that never went through an importer is not ours to '
+              'reclaim, whatever nothing references it',
+        );
+      });
+
+      test('ignores a null path', () async {
+        await createService().reclaimUnreferencedAudio(null);
+
+        expect(
+          documents.listSync(),
+          isEmpty,
+          reason: 'nothing to reclaim must not create or remove anything',
+        );
+      });
+    });
+  });
+}

--- a/mobile/test/services/saved_sounds_service_test.dart
+++ b/mobile/test/services/saved_sounds_service_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -703,6 +704,242 @@ void main() {
           SavedSoundsService.referencedLocalAudioFilenames(sharedPreferences),
           isEmpty,
         );
+      });
+    });
+
+    group('localAudioReferences', () {
+      test('reports a readable library as complete', () async {
+        await SavedSoundsService(
+          sharedPreferences,
+          documentsPath: '/documents',
+        ).saveSound(
+          _importedSound(
+            id: 'local_import_readable',
+            filePath: '/documents/draft_audio_imports/d1/readable.m4a',
+          ),
+        );
+
+        final references = SavedSoundsService.localAudioReferences(
+          sharedPreferences,
+        );
+
+        expect(references.filenames, {'readable.m4a'});
+        expect(references.isComplete, isTrue);
+      });
+
+      test('reports a bucket that will not decode as incomplete', () async {
+        await sharedPreferences.setString(
+          'saved_reusable_sounds_anon',
+          'not json',
+        );
+
+        final references = SavedSoundsService.localAudioReferences(
+          sharedPreferences,
+        );
+
+        expect(references.filenames, isEmpty);
+        expect(
+          references.isComplete,
+          isFalse,
+          reason: 'the bucket may name a file, so the set is a lower bound',
+        );
+      });
+
+      test('reports a payload from a newer build as incomplete', () async {
+        await sharedPreferences.setString(
+          'saved_reusable_sounds_anon',
+          jsonEncode({'schemaVersion': 99, 'entries': <dynamic>[]}),
+        );
+
+        final references = SavedSoundsService.localAudioReferences(
+          sharedPreferences,
+        );
+
+        expect(references.isComplete, isFalse);
+      });
+
+      test('reports an entry that will not parse as incomplete', () async {
+        await SavedSoundsService(
+          sharedPreferences,
+          documentsPath: '/documents',
+        ).saveSound(
+          _importedSound(
+            id: 'local_import_good',
+            filePath: '/documents/draft_audio_imports/d1/good.m4a',
+          ),
+        );
+        final stored =
+            jsonDecode(
+                  sharedPreferences.getString('saved_reusable_sounds_anon')!,
+                )
+                as Map<String, dynamic>;
+        (stored['sounds'] as List<dynamic>).add({'audio': 'not a map'});
+        await sharedPreferences.setString(
+          'saved_reusable_sounds_anon',
+          jsonEncode(stored),
+        );
+
+        final references = SavedSoundsService.localAudioReferences(
+          sharedPreferences,
+        );
+
+        expect(
+          references.filenames,
+          {'good.m4a'},
+          reason: 'one bad entry must not cost the readable ones',
+        );
+        expect(references.isComplete, isFalse);
+      });
+    });
+
+    group('removeSound', () {
+      const filePath = '/documents/draft_audio_imports/d1/imported.m4a';
+
+      SavedSoundsService createService({
+        LocalAudioReclaimer? audioReclaimer,
+      }) => SavedSoundsService(
+        sharedPreferences,
+        documentsPath: '/documents',
+        audioReclaimer: audioReclaimer,
+      );
+
+      test("hands the removed entry's audio file to the reclaimer", () async {
+        final reclaimed = <String>[];
+        final service = createService(
+          audioReclaimer: (path) async => reclaimed.add(path),
+        );
+        await service.saveSound(
+          _importedSound(id: 'local_import_1', filePath: filePath),
+        );
+
+        await service.removeSound('local_import_1');
+
+        expect(reclaimed, [filePath]);
+      });
+
+      test('reclaims only after the shrunken library is persisted', () async {
+        late List<AudioEvent> soundsDuringReclaim;
+        final service = createService(
+          audioReclaimer: (_) async {
+            soundsDuringReclaim = SavedSoundsService(
+              sharedPreferences,
+              documentsPath: '/documents',
+            ).loadSounds();
+          },
+        );
+        await service.saveSound(
+          _importedSound(id: 'local_import_1', filePath: filePath),
+        );
+
+        await service.removeSound('local_import_1');
+
+        expect(
+          soundsDuringReclaim,
+          isEmpty,
+          reason: 'the entry must not count as a reference to its own file',
+        );
+      });
+
+      test('does not reclaim a published sound', () async {
+        final reclaimed = <String>[];
+        final service = createService(
+          audioReclaimer: (path) async => reclaimed.add(path),
+        );
+        await service.saveSound(_sound(id: 'published'));
+
+        await service.removeSound('published');
+
+        expect(
+          reclaimed,
+          isEmpty,
+          reason: 'a remote url is not a file this device may delete',
+        );
+      });
+
+      test('does not reclaim when the id matches nothing', () async {
+        final reclaimed = <String>[];
+        final service = createService(
+          audioReclaimer: (path) async => reclaimed.add(path),
+        );
+        await service.saveSound(
+          _importedSound(id: 'local_import_1', filePath: filePath),
+        );
+
+        await service.removeSound('local_import_absent');
+
+        expect(reclaimed, isEmpty);
+      });
+
+      test('keeps the file when the library write fails', () async {
+        final reclaimed = <String>[];
+        final failing = _MockSharedPreferences();
+        when(failing.getKeys).thenReturn({'saved_reusable_sounds_anon'});
+        when(() => failing.containsKey(any())).thenReturn(true);
+        when(
+          () => failing.getString('saved_reusable_sounds_anon'),
+        ).thenReturn(
+          jsonEncode({
+            'schemaVersion': 1,
+            'sounds': [
+              {
+                'audio': _importedSound(
+                  id: 'local_import_1',
+                  filePath: filePath,
+                ).toJson(),
+              },
+            ],
+          }),
+        );
+        when(
+          () => failing.setString(any(), any()),
+        ).thenAnswer((_) async => false);
+        final service = SavedSoundsService(
+          failing,
+          documentsPath: '/documents',
+          audioReclaimer: (path) async => reclaimed.add(path),
+        );
+
+        await expectLater(
+          service.removeSound('local_import_1'),
+          throwsA(isA<StateError>()),
+        );
+
+        expect(
+          reclaimed,
+          isEmpty,
+          reason: 'the entry still points at the file, so it must survive',
+        );
+      });
+
+      test('still removes the entry when the reclaimer throws', () async {
+        final service = createService(
+          audioReclaimer: (_) async => throw const FileSystemException('boom'),
+        );
+        await service.saveSound(
+          _importedSound(id: 'local_import_1', filePath: filePath),
+        );
+
+        await service.removeSound('local_import_1');
+
+        expect(
+          SavedSoundsService(
+            sharedPreferences,
+            documentsPath: '/documents',
+          ).loadSounds(),
+          isEmpty,
+          reason: 'a throw here would be read as "the delete did not happen"',
+        );
+      });
+
+      test('removes the entry when no reclaimer is wired', () async {
+        final service = createService();
+        await service.saveSound(
+          _importedSound(id: 'local_import_1', filePath: filePath),
+        );
+
+        await service.removeSound('local_import_1');
+
+        expect(service.loadSounds(), isEmpty);
       });
     });
   });

--- a/mobile/test/utils/draft_audio_path_resolver_test.dart
+++ b/mobile/test/utils/draft_audio_path_resolver_test.dart
@@ -263,5 +263,16 @@ void main() {
     test('rejects the audio root directory itself', () {
       expect(isDraftLocalAudioPath('$_newDocs/draft_audio_imports'), isFalse);
     });
+
+    test('rejects a path that escapes the root with ..', () {
+      expect(
+        isDraftLocalAudioPath('$_newDocs/draft_audio_imports/../../etc/x'),
+        isFalse,
+      );
+      expect(
+        isDraftLocalAudioPath('$_newDocs/voice_over_recordings/../secret.key'),
+        isFalse,
+      );
+    });
   });
 }

--- a/mobile/test/utils/draft_audio_path_resolver_test.dart
+++ b/mobile/test/utils/draft_audio_path_resolver_test.dart
@@ -236,4 +236,32 @@ void main() {
       expect(identical(toPortableAudioPaths(json), json), isTrue);
     });
   });
+
+  group('isDraftLocalAudioPath', () {
+    test('accepts a file under each audio root', () {
+      expect(
+        isDraftLocalAudioPath('$_newDocs/draft_audio_imports/d1/song.m4a'),
+        isTrue,
+      );
+      expect(
+        isDraftLocalAudioPath('$_newDocs/voice_over_recordings/take_1.m4a'),
+        isTrue,
+      );
+      expect(
+        isDraftLocalAudioPath('$_newDocs/extracted_clip_audio/clip_1.m4a'),
+        isTrue,
+      );
+      expect(isDraftLocalAudioPath('draft_audio_imports/d1/song.m4a'), isTrue);
+    });
+
+    test('rejects a path outside the audio roots', () {
+      expect(isDraftLocalAudioPath('$_newDocs/picker_cache/song.m4a'), isFalse);
+      expect(isDraftLocalAudioPath('$_newDocs/song.m4a'), isFalse);
+      expect(isDraftLocalAudioPath(''), isFalse);
+    });
+
+    test('rejects the audio root directory itself', () {
+      expect(isDraftLocalAudioPath('$_newDocs/draft_audio_imports'), isFalse);
+    });
+  });
 }


### PR DESCRIPTION
## Description

Deleting a locally imported My Sounds entry never reclaimed its audio file under `Documents/draft_audio_imports/`. `SavedSoundsService.removeSound` had no file-cleanup dependency and the app has no draft-audio sweeper, so the file survived for the life of the install and the leak repeated for every imported sound removed this way. #8011 began preserving files My Sounds still references and deliberately left the final-reference cleanup out of scope.

`removeSound` now captures the removed entry's resolved `localFilePath`, writes the shrunken library **first**, then hands the path to an injected `LocalAudioReclaimer` port. The ordering is load-bearing and mirrors `deleteDraft` / `clearAllDrafts`: the entry being removed must not count as a reference to its own file.

### How "no remaining reference" is established

Exactly **two persistent stores** can name a `draft_audio_imports/` file. Clips, pending uploads, sync cursors, `custom_sounds` and every Hive box were checked and carry no audio path:

1. **Every `drafts.data` blob, all accounts** — `DraftsDao.getAllDrafts()` (null owner ⇒ device-wide) → `DivineVideoDraft.fromJson` → `DraftLocalAudioPaths.localAudioFilePaths`, covering all three carriers: `selectedSound`, the undo/redo history, and the completed-editor snapshot.
2. **Every `saved_reusable_sounds*` bucket, all accounts plus the legacy key** — `SavedSoundsService.localAudioReferences`.

Comparison is by **basename**, because stored paths are a mixture of portable and stale-absolute iOS container forms.

That sweep already existed inside `DraftStorageService` for the opposite direction. Rather than copy it, it is extracted into `LocalAudioCleanupService` and both directions now share it — two copies of this check drifting apart is precisely how a file a user still plays gets deleted.

### Three refusals keep it conservative

Deletion is skipped unless it can be *proven* safe:

- The sweep reports `isComplete: false` when a draft blob will not parse, a My Sounds bucket will not decode, a payload came from a newer build, or an entry will not parse as an `AudioEvent`. An unreadable store makes the reference set a lower bound, so the file is kept. Draft deletion deliberately ignores this flag — there, an unreadable store only costs references it would have *kept*.
- An instance built without `SharedPreferences` cannot see My Sounds, so it never reclaims.
- `isDraftLocalAudioPath` bounds deletion to the three directories this app writes audio into. A stored `localFilePath` that never went through an importer is not ours to delete.

Failures are absorbed in `removeSound`: the library write already succeeded, and the bloc reads a throw as "the delete did not happen".

**Related Issue:** Closes #8025

## Out of Scope

- `saved_sounds_bloc.dart`, `saved_sounds_state.dart` and the sounds UI are deliberately untouched — PR #8912 (#8023) modifies those. There is zero file overlap between the two PRs.
- **Two adjacent leaks found and left alone:** `UserDataCleanupService` wipes an account's saved-sounds bucket on destructive account deletion without reclaiming any audio; and `VoiceOverCubit._deleteFile` deletes take files unconditionally without consulting My Sounds (uncommitted takes under `voice_over_recordings/`, so lower risk). Both are worth their own issues.
- Storage ownership and migration (#8024) remain out of scope.

## Verification

- `dart format` on all nine changed files, in place — 0 changed on the final pass.
- `flutter analyze lib test` — 25 issues, **none** in any touched file; all pre-existing elsewhere.
- Scoped tests: **305 passed, 0 failed** across the 13 affected suites (cleanup service, saved sounds service + provider + bloc + scope, draft storage, file cleanup, local store, sounds tab, draft audio extensions/resolver, user data cleanup), plus 757 more across every other suite referencing the changed classes — all green.
- **Mutation-checked all seven load-bearing behaviours**; each turns the suite red on its own: removing the reclaim call, reclaiming before the write, dropping the `isComplete` guard, dropping the saved-sound union, dropping the draft blob scan, dropping the storage-root guard, and making the path predicate constant.
- 36 `check_*.sh` ratchets run, all pass — including `check_untested_services_floor`, since the new service ships with its same-named test and needs no baseline change.

One thing a reviewer should know: `check_async_safety_ceiling.sh` fails in this local environment, and not from this diff — it reports ~19 files *below* their frozen ceiling and ~14 baselined keys no longer emitted, all outside this diff, with HEAD identical to `origin/main`. That looks like local-toolchain drift against the CI-generated baseline, so it was deliberately not regenerated from here. The one genuine regression this change did cause (`saved_sounds_service_test.dart` 9 → 11) is fixed by awaiting the two added `setString` calls; the ratchet reports no growth now.


## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
