### PR TITLE
fix(logging): catch formatted imports that bypass support logging

### DIFF
--- a/mobile/scripts/check_raw_logging.sh
+++ b/mobile/scripts/check_raw_logging.sh
@@ -40,6 +40,7 @@ ALLOW_NO_BASE_VAR="RAW_LOGGING_ALLOW_NO_BASE"
 RATCHET_LABEL="raw_logging"
 
 CODE_ONLY_FILTER="$SCRIPT_DIR/lib/dart_code_only.awk"
+IMPORT_DIRECTIVE_FILTER="$SCRIPT_DIR/lib/dart_import_directives.awk"
 # Match dart:developer in either the primary URI or a conditional URI, while
 # stopping at the directive terminator so a later comment cannot invent one.
 DEVELOPER_IMPORT_RE="^[[:space:]]*import[[:space:]]+[^;]*['\"]dart:developer['\"]"
@@ -63,6 +64,16 @@ if [[ ! -f "$CODE_ONLY_FILTER" ]]; then
   echo "FAIL [raw_logging]: Dart code-only filter is unavailable: $CODE_ONLY_FILTER" >&2
   exit 1
 fi
+
+if [[ ! -f "$IMPORT_DIRECTIVE_FILTER" ]]; then
+  echo "FAIL [raw_logging]: Dart import scanner is unavailable: $IMPORT_DIRECTIVE_FILTER" >&2
+  exit 1
+fi
+
+has_developer_import() {
+  awk -f "$IMPORT_DIRECTIVE_FILTER" "$1" 2>/dev/null \
+    | grep -E "$DEVELOPER_IMPORT_RE" >/dev/null
+}
 
 code_call_violations() {
   local pattern="$1" matches
@@ -101,7 +112,7 @@ APP_DEVELOPER_IMPORTS="$(
   find "$LIB_DIR" "${GENERATED_EXCLUDES[@]}" \
     -name "*.dart" -print0 2>/dev/null \
   | while IFS= read -r -d '' file; do
-      if grep -qE "$DEVELOPER_IMPORT_RE" "$file"; then
+      if has_developer_import "$file"; then
         printf '%s\n' "${file#"$PATH_PREFIX"/}"
       fi
     done | LC_ALL=C sort -u || true
@@ -117,7 +128,7 @@ emit_current() {
     -path "*/lib/*" -not -path "*/unified_logger/*" \
     -name "*.dart" -print0 2>/dev/null \
   | while IFS= read -r -d '' file; do
-      if grep -qE "$DEVELOPER_IMPORT_RE" "$file"; then
+      if has_developer_import "$file"; then
         printf '%s\n' "${file#"$PATH_PREFIX"/}"
       fi
     done | LC_ALL=C sort -u || true

--- a/mobile/scripts/lib/dart_import_directives.awk
+++ b/mobile/scripts/lib/dart_import_directives.awk
@@ -1,0 +1,85 @@
+# Emit complete Dart import directives on one line each.
+#
+# Line and nested block comments are removed while string literals are kept,
+# allowing callers to inspect every URI in a conditional import. Semicolons
+# inside strings or comments do not terminate the directive.
+# Bash 3.2 / POSIX awk compatible.
+
+BEGIN {
+  block_depth = 0
+  in_string = 0
+  quote = ""
+  directive = ""
+}
+
+function finish_statement() {
+  if (directive ~ /^[[:space:]]*import[[:space:]]+/) {
+    gsub(/[[:space:]]+/, " ", directive)
+    print directive
+  }
+  directive = ""
+}
+
+{
+  line = $0
+  i = 1
+  length_of_line = length(line)
+
+  while (i <= length_of_line) {
+    character = substr(line, i, 1)
+    pair = substr(line, i, 2)
+
+    if (block_depth > 0) {
+      if (pair == "*/") {
+        block_depth--
+        i += 2
+      } else if (pair == "/*") {
+        block_depth++
+        i += 2
+      } else {
+        i++
+      }
+      continue
+    }
+
+    if (in_string) {
+      directive = directive character
+      if (character == "\\") {
+        if (i < length_of_line) {
+          directive = directive substr(line, i + 1, 1)
+          i += 2
+        } else {
+          i++
+        }
+      } else if (character == quote) {
+        in_string = 0
+        quote = ""
+        i++
+      } else {
+        i++
+      }
+      continue
+    }
+
+    if (pair == "//") break
+    if (pair == "/*") {
+      block_depth++
+      directive = directive " "
+      i += 2
+      continue
+    }
+    if (character == "'" || character == "\"") {
+      in_string = 1
+      quote = character
+      directive = directive character
+      i++
+      continue
+    }
+
+    directive = directive character
+    if (character == ";") finish_statement()
+    i++
+  }
+
+  directive = directive " "
+}

--- a/mobile/test/tools/raw_logging_test.dart
+++ b/mobile/test/tools/raw_logging_test.dart
@@ -88,6 +88,32 @@ void main() {
       });
     }
 
+    test('fails NEW for a formatted multiline conditional import', () {
+      writeMobileFile(
+        'packages/example/lib/logging.dart',
+        "import 'package:example/very_long_developer_logging_stub.dart'\n"
+            "    if (dart.library.io) 'dart:developer'\n"
+            '    as developer;\n',
+      );
+
+      final result = runGuard();
+
+      expect(result.exitCode, 1);
+      expect(result.stdout, contains('NEW entr(y/ies)'));
+      expect(result.stdout, contains('packages/example/lib/logging.dart'));
+    });
+
+    test('comments cannot invent a multiline conditional import', () {
+      writeMobileFile(
+        'packages/example/lib/logging.dart',
+        "/* import 'package:example/logging_stub.dart'\n"
+            "    if (dart.library.io) 'dart:developer'; */\n"
+            'void log() {}\n',
+      );
+
+      expect(runGuard().exitCode, 0);
+    });
+
     test('a baselined package import passes', () {
       writeMobileFile(
         'packages/example/lib/logging.dart',

--- a/mobile/test/tools/raw_logging_test.dart
+++ b/mobile/test/tools/raw_logging_test.dart
@@ -114,6 +114,23 @@ void main() {
       expect(runGuard().exitCode, 0);
     });
 
+    test(
+      'a block comment around an import line does not invent a violation',
+      () {
+        // A per-line check matched the `import` line inside the block comment.
+        // The directive scanner strips the comment, so this must stay clean.
+        writeMobileFile(
+          'packages/example/lib/logging.dart',
+          '/*\n'
+              "import 'dart:developer';\n"
+              '*/\n'
+              'void log() {}\n',
+        );
+
+        expect(runGuard().exitCode, 0);
+      },
+    );
+
     test('a baselined package import passes', () {
       writeMobileFile(
         'packages/example/lib/logging.dart',


### PR DESCRIPTION
Closes #8969

## Problem

The package logging guard added in #8951 checked each physical source line independently. When `dart format` wrapped a conditional import, the `dart:developer` URI moved off the line containing `import`, so a new package could bypass the shrink-only baseline and write logs that never reach support exports.

Rabble identified and reproduced this gap in his post-merge review of #8951. This follow-up implements that feedback.

## Why this fix

The guard now scans complete Dart import directives before applying the existing `dart:developer` rule. The scanner preserves import URI strings, joins formatted multiline directives, removes line and nested block comments, and only terminates a directive at a real semicolon. The baseline and its shrink-only policy are unchanged.

Regression coverage proves both sides of the boundary: a formatter-shaped multiline conditional import fails as a new entry, while the same text inside a block comment does not invent a violation.

## Out of scope

This does not migrate any of the existing package `dart:developer` imports. That work remains tracked in #8967 and #8934.

## Verification

- `flutter test test/tools/raw_logging_test.dart --no-pub` — 18 passed
- `flutter analyze test/tools/raw_logging_test.dart --no-pub` — no issues
- `bash scripts/check_raw_logging.sh`
- `shellcheck -x scripts/check_raw_logging.sh`
- `TMPDIR=/private/tmp ../.codex/scripts/test-config.sh`
- pre-push analyzer and changed-file tests

Follow-up to #8951.
