### PR TITLE
fix(ios): stop release archives from silently dropping privacy manifests

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -605,6 +605,11 @@ definitions:
           --dart-define-from-file=build/shorebird/dart_defines.json \
           --public-key-path=build/shorebird/patch_public_key.pem \
           --export-options-plist=/Users/builder/export_options.plist
+
+        # Prove CocoaPods and Xcode copied each manifest into the exact
+        # Shorebird archive before later steps can promote its artifacts.
+        bash scripts/check_privacy_manifest_coverage.sh \
+          --archive build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app
     - &patch_ios
       name: Patch iOS (Shorebird)
       script: |

--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -144,6 +144,9 @@ Archive mode derives its expected resource-bundle names from those same
 podspec declarations, so adding a first-party plugin manifest automatically
 adds a corresponding product check. Codemagic runs archive mode against the
 `.app` inside the Shorebird-produced release archive.
+Because Shorebird records the release before this check runs, a failure requires
+deleting that failed Shorebird release or advancing the store build number before
+retrying; the release preflight deliberately rejects reuse of the recorded version.
 
 Behaviour is pinned by
 `mobile/test/tools/privacy_manifest_coverage_detector_test.dart`.

--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -33,6 +33,7 @@ macOS is not listed, which is why `mobile/macos` carries no obligation here.
 |---|---|---|
 | App (`Runner`) | `mobile/ios/Runner/PrivacyInfo.xcprivacy` | `Copy Bundle Resources` in `Runner.xcodeproj` |
 | `divine_camera` | `mobile/packages/divine_camera/ios/Resources/PrivacyInfo.xcprivacy` | `s.resource_bundles` in its podspec |
+| `divine_device_attestation` | `mobile/packages/divine_device_attestation/ios/Resources/PrivacyInfo.xcprivacy` | `s.resource_bundles` in its podspec |
 | `divine_quick_actions` | `mobile/packages/divine_quick_actions/ios/Resources/PrivacyInfo.xcprivacy` | `s.resource_bundles` |
 | `LibProofMode` (vendored) | `mobile/ios/LocalPods/LibProofMode/Resources/PrivacyInfo.xcprivacy` | `s.resource_bundles` |
 
@@ -49,7 +50,8 @@ when refreshing it until each change is present upstream:
 - `Classes/MediaItem.swift` imports `UniformTypeIdentifiers` and qualifies the
   movie and audio types as `UTType.movie` and `UTType.audio` for current Xcode.
 - `Resources/PrivacyInfo.xcprivacy` declares the required file-timestamp API,
-  and `LibProofMode.podspec` bundles that manifest.
+  and `LibProofMode.podspec` bundles that manifest. The upstream contribution
+  remains tracked in #8851.
 
 The Podfile selects LibProofMode's existing `PrivacyProtected` subspec. Divine
 sets `showDeviceIds: false`, so compiling out `AdSupport` and
@@ -61,6 +63,7 @@ declaration described below.
 | Bundle | Category | Reason | Justification |
 |---|---|---|---|
 | `divine_camera` | `SystemBootTime` | `35F9.1` | `VolumeKeyHandler.swift` reads `ProcessInfo.systemUptime` at two sites purely to measure elapsed time for Bluetooth-trigger cooldown and debounce. Nothing derived from it leaves the device — the file has no method channel or event sink. |
+| `divine_device_attestation` | `UserDefaults` | `CA92.1` | App Attest key handles are cached in `UserDefaults.standard`, the app's own defaults domain, and are accessible only to this app. |
 | `LibProofMode` | `FileTimestamp` | `C617.1` | `MediaItem.withData` reads `URLResourceKey.contentModificationDateKey` / `.creationDateKey`. Every path Divine feeds to `MediaItem(mediaUrl:)` is a file the app wrote in its own container (editor render output or a recorded clip). |
 | App (`Runner`) | *(none)* | — | The Runner target's own Release code calls no required-reason API. Its single `UserDefaults` call is inside `#if DEBUG`. |
 | `divine_quick_actions` | *(none)* | — | No required-reason API detected. |
@@ -137,6 +140,10 @@ bash scripts/check_privacy_manifest_coverage.sh --archive build/ios/iphoneos/Run
 It also fails on an invalid reason code for a category, an unknown category
 string, and a manifest that exists but is not bundled by the selected podspec
 or subspec — a manifest nothing ships is a manifest Apple never reads.
+Archive mode derives its expected resource-bundle names from those same
+podspec declarations, so adding a first-party plugin manifest automatically
+adds a corresponding product check. Codemagic runs archive mode against the
+`.app` inside the Shorebird-produced release archive.
 
 Behaviour is pinned by
 `mobile/test/tools/privacy_manifest_coverage_detector_test.dart`.
@@ -199,12 +206,10 @@ document still matches the catalogue.
    bash scripts/check_privacy_manifest_coverage.sh --archive build/ios/iphoneos/Runner.app
    ```
 
-## Known follow-ups
+## Status and follow-ups
 
-- `divine_device_attestation` (PR #8779, not yet merged) caches App Attest key
-  handles in `UserDefaults` and ships no manifest. When that PR lands, add
-  `NSPrivacyAccessedAPICategoryUserDefaults` / `CA92.1` plus a
-  `s.resource_bundles` entry to its podspec. The guard will fail until then,
-  which is the intended behaviour.
-- `NSPrivacyCollectedDataTypes` for the app target needs a product/legal pass
-  against the App Store Connect privacy label.
+- `divine_device_attestation` was resolved in #8779. Its owning package now
+  ships the `UserDefaults` / `CA92.1` declaration described above.
+- App-target `NSPrivacyCollectedDataTypes` reconciliation with the aggregate
+  privacy report and App Store Connect label is tracked in #8850.
+- Upstreaming Divine's LibProofMode manifest is tracked in #8851.

--- a/mobile/scripts/lib/privacy_manifest_coverage.py
+++ b/mobile/scripts/lib/privacy_manifest_coverage.py
@@ -578,6 +578,9 @@ def check_archive(app: str, mobile: str) -> int:
 
     failures = []
     expected = expected_archive_manifests(mobile)
+    if not expected:
+        print(f"❌ no first-party privacy manifest discovered under {mobile}")
+        return 1
     for label, rel in expected.items():
         if rel in found:
             print(f"  ✅ {label}: {rel}")

--- a/mobile/scripts/lib/privacy_manifest_coverage.py
+++ b/mobile/scripts/lib/privacy_manifest_coverage.py
@@ -434,20 +434,18 @@ def podspec_manifest_bundle(spec: str, selected_subspec: str | None) -> str | No
         variable = r"\w+"
         scope = uncommented
 
-    bundles = re.search(
+    for bundles in re.finditer(
         rf"\b{variable}\.resource_bundles\s*=\s*\{{(?P<body>[^}}]*)\}}",
         scope,
         re.S,
-    )
-    if not bundles:
-        return None
-    for bundle_name, resources in re.findall(
-        r"['\"]([^'\"]+)['\"]\s*=>\s*(\[[^]]*\]|['\"][^'\"]*['\"])",
-        bundles.group("body"),
-        re.S,
     ):
-        if "PrivacyInfo.xcprivacy" in resources:
-            return bundle_name
+        for bundle_name, resources in re.findall(
+            r"['\"]([^'\"]+)['\"]\s*=>\s*(\[[^]]*\]|['\"][^'\"]*['\"])",
+            bundles.group("body"),
+            re.S,
+        ):
+            if "PrivacyInfo.xcprivacy" in resources:
+                return bundle_name
     return None
 
 
@@ -579,15 +577,14 @@ def check_archive(app: str, mobile: str) -> int:
     print(f"ℹ️  {len(found)} privacy manifest(s) in {os.path.basename(app)}")
 
     failures = []
-    for label, rel in expected_archive_manifests(mobile).items():
+    expected = expected_archive_manifests(mobile)
+    for label, rel in expected.items():
         if rel in found:
             print(f"  ✅ {label}: {rel}")
         else:
             failures.append(f"{label}: expected {rel} in the built app, not found")
 
-    for rel in sorted(found):
-        if not rel.startswith(("divine_", "LibProofMode_")) and rel != "PrivacyInfo.xcprivacy":
-            continue
+    for rel in sorted(found & set(expected.values())):
         try:
             with open(os.path.join(app, rel), "rb") as handle:
                 plistlib.load(handle)

--- a/mobile/scripts/lib/privacy_manifest_coverage.py
+++ b/mobile/scripts/lib/privacy_manifest_coverage.py
@@ -414,8 +414,8 @@ def xcode_manifest_is_runner_resource(project: str) -> bool:
     return False
 
 
-def podspec_bundles_manifest(spec: str, selected_subspec: str | None) -> bool:
-    """Return whether the selected pod specification bundles the manifest."""
+def podspec_manifest_bundle(spec: str, selected_subspec: str | None) -> str | None:
+    """Return the selected pod specification's privacy resource-bundle name."""
     uncommented = "\n".join(
         line for line in spec.splitlines() if not line.lstrip().startswith("#")
     )
@@ -427,23 +427,57 @@ def podspec_bundles_manifest(spec: str, selected_subspec: str | None) -> bool:
             re.M | re.S,
         )
         if not subspec:
-            return False
-        variable = re.escape(subspec.group("var"))
-        return bool(
-            re.search(
-                rf"\b{variable}\.resource_bundles\s*=\s*"
-                r"\{[^}]*PrivacyInfo\.xcprivacy[^}]*\}",
-                subspec.group("body"),
-                re.S,
-            )
-        )
-    return bool(
-        re.search(
-            r"\b\w+\.resource_bundles\s*=\s*\{[^}]*PrivacyInfo\.xcprivacy[^}]*\}",
-            uncommented,
-            re.S,
-        )
+            return None
+        variable = subspec.group("var")
+        scope = subspec.group("body")
+    else:
+        variable = r"\w+"
+        scope = uncommented
+
+    bundles = re.search(
+        rf"\b{variable}\.resource_bundles\s*=\s*\{{(?P<body>[^}}]*)\}}",
+        scope,
+        re.S,
     )
+    if not bundles:
+        return None
+    for bundle_name, resources in re.findall(
+        r"['\"]([^'\"]+)['\"]\s*=>\s*(\[[^]]*\]|['\"][^'\"]*['\"])",
+        bundles.group("body"),
+        re.S,
+    ):
+        if "PrivacyInfo.xcprivacy" in resources:
+            return bundle_name
+    return None
+
+
+def podspec_bundles_manifest(spec: str, selected_subspec: str | None) -> bool:
+    """Return whether the selected pod specification bundles the manifest."""
+    return podspec_manifest_bundle(spec, selected_subspec) is not None
+
+
+def expected_archive_manifests(mobile: str) -> dict[str, str]:
+    """Derive archive expectations from manifests wired into source targets."""
+    expected: dict[str, str] = {}
+    for unit in discover(mobile):
+        if not os.path.exists(unit.manifest):
+            continue
+        if unit.xcodeproj:
+            expected[unit.name] = os.path.basename(unit.manifest)
+            continue
+        if not unit.podspec:
+            continue
+        try:
+            with open(unit.podspec, "r", encoding="utf-8") as handle:
+                spec = handle.read()
+        except OSError:
+            continue
+        bundle = podspec_manifest_bundle(spec, unit.selected_subspec)
+        if bundle:
+            expected[unit.name] = os.path.join(
+                f"{bundle}.bundle", "PrivacyInfo.xcprivacy"
+            )
+    return expected
 
 
 def check_sources(mobile: str) -> int:
@@ -544,14 +578,8 @@ def check_archive(app: str, mobile: str) -> int:
                 found.add(os.path.relpath(os.path.join(dirpath, filename), app))
     print(f"ℹ️  {len(found)} privacy manifest(s) in {os.path.basename(app)}")
 
-    expected = {
-        "app manifest": "PrivacyInfo.xcprivacy",
-        "divine_camera": "divine_camera_privacy.bundle/PrivacyInfo.xcprivacy",
-        "divine_quick_actions": "divine_quick_actions_privacy.bundle/PrivacyInfo.xcprivacy",
-        "LibProofMode": "LibProofMode_privacy.bundle/PrivacyInfo.xcprivacy",
-    }
     failures = []
-    for label, rel in expected.items():
+    for label, rel in expected_archive_manifests(mobile).items():
         if rel in found:
             print(f"  ✅ {label}: {rel}")
         else:

--- a/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
+++ b/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
@@ -515,6 +515,24 @@ ABC123 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo
       );
     });
 
+    test('archive mode rejects an empty expectation set', () {
+      final root = Directory.systemTemp.createTempSync('privacy_archive_test');
+      addTearDown(() => root.deleteSync(recursive: true));
+      Directory('${root.path}/ios/Runner').createSync(recursive: true);
+      final app = Directory('${root.path}/Runner.app')..createSync();
+      File(
+        '${app.path}/PrivacyInfo.xcprivacy',
+      ).writeAsStringSync('not a plist');
+
+      final result = run(root: root, args: ['--archive', app.path]);
+
+      expect(result.exitCode, equals(1));
+      expect(
+        result.output,
+        contains('no first-party privacy manifest discovered'),
+      );
+    });
+
     test('archive mode uses the selected subspec privacy bundle name', () {
       final root = makeTree(
         swift: '',

--- a/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
+++ b/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
@@ -524,5 +524,36 @@ ABC123 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo
         contains('selected_privacy.bundle/PrivacyInfo.xcprivacy'),
       );
     });
+
+    // Every other archive-mode test asserts a failure, so a change that made
+    // the found/expected comparison never match would leave all of them green
+    // while breaking the release workflow. This pins the accepting direction.
+    test('archive mode accepts an app carrying every derived bundle', () {
+      final plist = manifestFor(
+        'NSPrivacyAccessedAPICategorySystemBootTime',
+        '35F9.1',
+      );
+      final root = makeTree(
+        swift: '',
+        manifest: plist,
+        podspec:
+            "s.resource_bundles = {'sample_privacy' => "
+            "['Resources/PrivacyInfo.xcprivacy']}",
+      );
+      final app = Directory('${root.path}/Runner.app')..createSync();
+      final bundled = File(
+        '${app.path}/sample_privacy.bundle/PrivacyInfo.xcprivacy',
+      );
+      bundled.parent.createSync(recursive: true);
+      bundled.writeAsStringSync(plist);
+
+      final result = run(root: root, args: ['--archive', app.path]);
+
+      expect(result.exitCode, equals(0), reason: result.output);
+      expect(
+        result.output,
+        contains('sample_privacy.bundle/PrivacyInfo.xcprivacy'),
+      );
+    });
   });
 }

--- a/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
+++ b/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
@@ -469,6 +469,24 @@ ABC123 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo
 
         expect(result.exitCode, equals(0), reason: result.output);
       });
+
+      test('accepts a privacy bundle after another resource assignment', () {
+        final root = makeTree(
+          swift: 'let t = ProcessInfo.processInfo.systemUptime\n',
+          manifest: manifestFor(
+            'NSPrivacyAccessedAPICategorySystemBootTime',
+            '35F9.1',
+          ),
+          podspec:
+              "s.resource_bundles = {'sample_assets' => ['Assets/*']}\n"
+              "s.resource_bundles = {'sample_privacy' => "
+              "['Resources/PrivacyInfo.xcprivacy']}",
+        );
+
+        final result = run(root: root);
+
+        expect(result.exitCode, equals(0), reason: result.output);
+      });
     });
 
     test('archive mode requires every discovered privacy bundle', () {
@@ -523,6 +541,30 @@ ABC123 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo
         result.output,
         contains('selected_privacy.bundle/PrivacyInfo.xcprivacy'),
       );
+    });
+
+    test('archive mode validates a derived bundle with any name', () {
+      final root = makeTree(
+        swift: '',
+        manifest: manifestFor(
+          'NSPrivacyAccessedAPICategorySystemBootTime',
+          '35F9.1',
+        ),
+        podspec:
+            "s.resource_bundles = {'custom_privacy' => "
+            "['Resources/PrivacyInfo.xcprivacy']}",
+      );
+      final app = Directory('${root.path}/Runner.app')..createSync();
+      final bundled = File(
+        '${app.path}/custom_privacy.bundle/PrivacyInfo.xcprivacy',
+      );
+      bundled.parent.createSync(recursive: true);
+      bundled.writeAsStringSync('not a plist');
+
+      final result = run(root: root, args: ['--archive', app.path]);
+
+      expect(result.exitCode, equals(1));
+      expect(result.output, contains('bundled manifest is unreadable'));
     });
 
     // Every other archive-mode test asserts a failure, so a change that made

--- a/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
+++ b/mobile/test/tools/privacy_manifest_coverage_detector_test.dart
@@ -471,28 +471,58 @@ ABC123 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo
       });
     });
 
-    test('archive mode requires the quick-actions privacy bundle', () {
-      final root = Directory.systemTemp.createTempSync('privacy_archive_test');
-      addTearDown(() => root.deleteSync(recursive: true));
-      final app = Directory('${root.path}/Runner.app')..createSync();
-      final plist = manifestFor(
-        'NSPrivacyAccessedAPICategorySystemBootTime',
-        '35F9.1',
+    test('archive mode requires every discovered privacy bundle', () {
+      final root = makeTree(
+        swift: '',
+        manifest: manifestFor(
+          'NSPrivacyAccessedAPICategorySystemBootTime',
+          '35F9.1',
+        ),
+        podspec:
+            "s.resource_bundles = {'sample_privacy' => "
+            "['Resources/PrivacyInfo.xcprivacy']}",
       );
-      for (final path in [
-        'PrivacyInfo.xcprivacy',
-        'divine_camera_privacy.bundle/PrivacyInfo.xcprivacy',
-        'LibProofMode_privacy.bundle/PrivacyInfo.xcprivacy',
-      ]) {
-        final file = File('${app.path}/$path');
-        file.parent.createSync(recursive: true);
-        file.writeAsStringSync(plist);
-      }
+      final app = Directory('${root.path}/Runner.app')..createSync();
+      File('${app.path}/PrivacyInfo.xcprivacy').writeAsStringSync(
+        manifestFor('NSPrivacyAccessedAPICategorySystemBootTime', '35F9.1'),
+      );
 
       final result = run(root: root, args: ['--archive', app.path]);
 
       expect(result.exitCode, equals(1));
-      expect(result.output, contains('divine_quick_actions'));
+      expect(result.output, contains('package:sample'));
+      expect(
+        result.output,
+        contains('sample_privacy.bundle/PrivacyInfo.xcprivacy'),
+      );
+    });
+
+    test('archive mode uses the selected subspec privacy bundle name', () {
+      final root = makeTree(
+        swift: '',
+        manifest: manifestFor(
+          'NSPrivacyAccessedAPICategorySystemBootTime',
+          '35F9.1',
+        ),
+        selectedSubspec: 'PrivacyProtected',
+        podspec:
+            "s.subspec 'PrivacyProtected' do |ss|\n"
+            "  ss.resource_bundles = {'selected_privacy' => "
+            "['Resources/PrivacyInfo.xcprivacy']}\n"
+            'end\n',
+      );
+      final app = Directory('${root.path}/Runner.app')..createSync();
+      File('${app.path}/PrivacyInfo.xcprivacy').writeAsStringSync(
+        manifestFor('NSPrivacyAccessedAPICategorySystemBootTime', '35F9.1'),
+      );
+
+      final result = run(root: root, args: ['--archive', app.path]);
+
+      expect(result.exitCode, equals(1));
+      expect(
+        result.output,
+        contains('selected_privacy.bundle/PrivacyInfo.xcprivacy'),
+      );
     });
   });
 }


### PR DESCRIPTION
## Problem

The privacy-manifest source guard knew that device attestation declared `UserDefaults`, but archive verification still used a separate hardcoded list written before that package landed. A release archive could therefore omit `divine_device_attestation_privacy.bundle` while the verifier reported success. The store pipeline also never ran archive verification against the Shorebird-built product.

## Why this fix

Archive expectations now come from the same discovered manifests and CocoaPods `resource_bundles` declarations used by source validation, including a selected subspec such as LibProofMode. Adding a first-party plugin manifest therefore adds its archive expectation and readability check automatically instead of requiring a second manual list update.

The iOS Codemagic release checks the `.app` inside the exact Shorebird-produced archive immediately after the release build. This makes missing or unreadable bundles fail the release workflow instead of relying on a one-time local inspection.

The privacy-manifest inventory now records the device-attestation `UserDefaults` / `CA92.1` declaration and points the remaining collected-data and upstream work to #8850 and #8851.

## Deliberately unchanged

This does not decide `NSPrivacyCollectedDataTypes`, change any required-reason declaration, or claim that manifest presence replaces Xcode aggregate privacy-report review. #8850 remains the gate for reviewing the Shorebird-enabled release candidate and reconciling App Store Connect disclosures.

Release automation change: the iOS store workflow now fails when an expected first-party privacy manifest is absent or unreadable in the archive. `shorebird release ios` creates the internal release before this check runs; later artifact and App Store publishing steps remain blocked on failure. Delete that failed Shorebird release or advance the store build number before retrying, because the release preflight deliberately rejects reuse of the recorded version.

## Verification

- 33 focused privacy-manifest detector tests
- mutation verification for all three archive-detector regressions
- `flutter analyze lib test integration_test`
- `bash scripts/check_privacy_manifest_coverage.sh`
- `flutter build ios --release --no-codesign` with Flutter 3.47.2 / Dart 3.13.2
- archive inspection found 63 manifests and verified all five expected first-party paths, including `divine_device_attestation_privacy.bundle/PrivacyInfo.xcprivacy`
- Codemagic variable-group guard
- required-reason catalogue render check
- Codex repository configuration checks
- pre-push changed-file analysis and tests

Part of #8803
