### PR TITLE
fix(e2e): stop leaving a real private key on the test device clipboard

### DIFF
--- a/mobile/e2e/maestro/tests/backupYourKey.yaml
+++ b/mobile/e2e/maestro/tests/backupYourKey.yaml
@@ -1,4 +1,16 @@
 appId: co.openvine.app.staging
+# Step 3 puts the signed-in account's private key on the device clipboard.
+# The copy is the behaviour under test; the key left behind is not. #8777
+# removed the deletion flow that used to consume it, so without this a run
+# ends with a live account's nsec readable by every app on the device.
+#
+# Declared as a hook rather than a trailing command because Maestro runs
+# onFlowComplete from a `finally` — for a direct run and for a subflow reached
+# through `runFlow:` alike. A trailing command runs only when the flow reaches
+# it, and the confirmation assert sitting between the copy and the clear is
+# exactly the step that fails while the key is already on the clipboard.
+onFlowComplete:
+  - setClipboard: "divine-e2e-clipboard-cleared"
 ---
 # Verify that a signed-in user can reach key management and back up their
 # private key to the clipboard.
@@ -6,7 +18,8 @@ appId: co.openvine.app.staging
 # 1. Open Settings, then Nostr Settings
 # 2. Open Key Management and verify the Nostr Keys screen
 # 3. Copy the private key and verify the confirmation
-# 4. Overwrite the copy so the key does not outlive the run
+#
+# The clipboard is overwritten by the onFlowComplete hook above, pass or fail.
 
 # 1. Settings -> Nostr Settings
 - runFlow: ../utils/openSettings.yaml
@@ -32,10 +45,3 @@ appId: co.openvine.app.staging
 - tapOn:
     id: "copy_nsec_button"
 - runFlow: ../asserts/assertPrivKeyCopied.yaml
-
-# 4. Overwrite the key the step above put on the device clipboard.
-#
-# The copy is the behaviour under test; the key left behind is not. #8777
-# removed the deletion flow that used to consume it, so without this a run
-# ends with a live account's nsec readable by every app on the device.
-- setClipboard: "divine-e2e-clipboard-cleared"

--- a/mobile/e2e/maestro/tests/backupYourKey.yaml
+++ b/mobile/e2e/maestro/tests/backupYourKey.yaml
@@ -1,16 +1,35 @@
 appId: co.openvine.app.staging
 # Step 3 puts the signed-in account's private key on the device clipboard.
 # The copy is the behaviour under test; the key left behind is not. #8777
-# removed the deletion flow that used to consume it, so without this a run
-# ends with a live account's nsec readable by every app on the device.
+# removed the deletion flow that used to consume it, so without step 4 and
+# this hook a run ends with a live account's nsec readable by every app on
+# the device.
 #
-# Declared as a hook rather than a trailing command because Maestro runs
-# onFlowComplete from a `finally` — for a direct run and for a subflow reached
-# through `runFlow:` alike. A trailing command runs only when the flow reaches
-# it, and the confirmation assert sitting between the copy and the clear is
-# exactly the step that fails while the key is already on the clipboard.
+# Both overwrite it by tapping the app's own public key copy, which writes the
+# device clipboard. Maestro's `setClipboard` cannot: it only sets Maestro's
+# copied text for `pasteText` and never reaches the device. That button sits
+# above the fold once the flow has scrolled down to the private key copy, so
+# both scroll back up to it first.
+#
+# The hook covers failures: Maestro runs onFlowComplete from a `finally`, for
+# a direct run and for a subflow reached through `runFlow:` alike. It acts
+# only while the private key copy is on screen — before that nothing was
+# copied — and its steps are optional because a subflow's hook has no catch
+# of its own: a step failing there would replace the flow's real failure.
 onFlowComplete:
-  - setClipboard: "divine-e2e-clipboard-cleared"
+  - runFlow:
+      when:
+        visible:
+          id: "copy_nsec_button"
+      commands:
+        - scrollUntilVisible:
+            element:
+              id: "copy_npub_button"
+            direction: UP
+            optional: true
+        - tapOn:
+            id: "copy_npub_button"
+            optional: true
 ---
 # Verify that a signed-in user can reach key management and back up their
 # private key to the clipboard.
@@ -18,8 +37,7 @@ onFlowComplete:
 # 1. Open Settings, then Nostr Settings
 # 2. Open Key Management and verify the Nostr Keys screen
 # 3. Copy the private key and verify the confirmation
-#
-# The clipboard is overwritten by the onFlowComplete hook above, pass or fail.
+# 4. Overwrite the clipboard with the public key
 
 # 1. Settings -> Nostr Settings
 - runFlow: ../utils/openSettings.yaml
@@ -45,3 +63,12 @@ onFlowComplete:
 - tapOn:
     id: "copy_nsec_button"
 - runFlow: ../asserts/assertPrivKeyCopied.yaml
+
+# 4. Not optional, so a passing run proves the overwrite happened. The hook
+# above repeats it for runs that fail between the copy and here.
+- scrollUntilVisible:
+    element:
+      id: "copy_npub_button"
+    direction: UP
+- tapOn:
+    id: "copy_npub_button"

--- a/mobile/e2e/maestro/tests/backupYourKey.yaml
+++ b/mobile/e2e/maestro/tests/backupYourKey.yaml
@@ -6,6 +6,7 @@ appId: co.openvine.app.staging
 # 1. Open Settings, then Nostr Settings
 # 2. Open Key Management and verify the Nostr Keys screen
 # 3. Copy the private key and verify the confirmation
+# 4. Overwrite the copy so the key does not outlive the run
 
 # 1. Settings -> Nostr Settings
 - runFlow: ../utils/openSettings.yaml
@@ -31,3 +32,10 @@ appId: co.openvine.app.staging
 - tapOn:
     id: "copy_nsec_button"
 - runFlow: ../asserts/assertPrivKeyCopied.yaml
+
+# 4. Overwrite the key the step above put on the device clipboard.
+#
+# The copy is the behaviour under test; the key left behind is not. #8777
+# removed the deletion flow that used to consume it, so without this a run
+# ends with a live account's nsec readable by every app on the device.
+- setClipboard: "divine-e2e-clipboard-cleared"

--- a/mobile/lib/constants/semantic_ids.dart
+++ b/mobile/lib/constants/semantic_ids.dart
@@ -123,6 +123,10 @@ abstract class SemanticIds {
   /// Key backup action. Copy changes should not strand the recovery journey.
   static const String keyManagementCopyNsecButton = 'copy_nsec_button';
 
+  /// Public key copy. The key backup journey taps it to overwrite the private
+  /// key it copied: Maestro cannot write the device clipboard itself.
+  static const String keyManagementCopyNpubButton = 'copy_npub_button';
+
   /// Account portability. The row leaves the app for the hosted Divine Exit
   /// flow, so an E2E flow can only assert the handoff by addressing the row.
   static const String settingsMoveAccountRow = 'move_account_tile';

--- a/mobile/lib/screens/key_management_screen.dart
+++ b/mobile/lib/screens/key_management_screen.dart
@@ -409,6 +409,7 @@ class _NpubDisplayBlock extends ConsumerWidget {
             foregroundColor: context.vineColors.onSurface,
             showShadow: false,
             tooltip: l10n.keyManagementCopyPublicKeyTooltip,
+            semanticIdentifier: SemanticIds.keyManagementCopyNpubButton,
             onPressed: () => _copyNpub(context, npub),
           ),
         ],

--- a/mobile/test/screens/key_management_screen_test.dart
+++ b/mobile/test/screens/key_management_screen_test.dart
@@ -151,6 +151,31 @@ void main() {
       expect(find.text(l10n.keyManagementPublicKeyCopied), findsOneWidget);
     });
 
+    testWidgets('copies npub from the control the key backup journey taps', (
+      tester,
+    ) async {
+      // backupYourKey.yaml overwrites the private key it copied by tapping
+      // this id, so the id has to stay on a control that writes the npub.
+      String? clipboardPayload;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardPayload = (call.arguments as Map)['text'] as String?;
+          }
+          return null;
+        },
+      );
+
+      await pumpSubject(tester);
+      await tester.tap(
+        find.bySemanticsIdentifier(SemanticIds.keyManagementCopyNpubButton),
+      );
+      await tester.pumpAndSettle();
+
+      expect(clipboardPayload, equals(testNpub));
+    });
+
     testWidgets(
       'shows private key copy action when Keycast account has a local nsec',
       (tester) async {

--- a/mobile/test/tools/maestro_clipboard_hygiene_test.dart
+++ b/mobile/test/tools/maestro_clipboard_hygiene_test.dart
@@ -87,6 +87,24 @@ void main() {
       );
     });
 
+    test('a flow still taps the control the guard watches', () {
+      // The guard below skips every flow that does not tap the button, so
+      // renaming the control turns it green while the copy still happens —
+      // #8777's shape exactly. Pin that the detector has something to check.
+      expect(
+        flows.where(
+          (flow) => _tapsId(_documentsOf(flow).commands, _copyPrivateKeyId),
+        ),
+        isNotEmpty,
+        reason:
+            'no flow under $_maestroDir taps $_copyPrivateKeyId, so the '
+            'clipboard guard checks nothing. If the control was renamed, '
+            'point $_copyPrivateKeyId at the new '
+            '`SemanticIds.keyManagementCopyNsecButton`; if the copy journey '
+            'was deleted, delete this guard with it (#8828).',
+      );
+    });
+
     test('a flow that copies the private key clears it on completion', () {
       for (final flow in flows) {
         final (:header, :commands) = _documentsOf(flow);

--- a/mobile/test/tools/maestro_clipboard_hygiene_test.dart
+++ b/mobile/test/tools/maestro_clipboard_hygiene_test.dart
@@ -1,9 +1,10 @@
-// ABOUTME: Pins that a Maestro flow copying the private key also clears it.
+// ABOUTME: Pins that a Maestro flow copying the private key also overwrites it.
 // ABOUTME: The copy is the journey under test; the key left behind is not.
 
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:yaml/yaml.dart';
 
 /// The control whose tap puts the signed-in account's `nsec` on the device
@@ -11,12 +12,16 @@ import 'package:yaml/yaml.dart';
 ///
 /// Asserting the button is *visible* is harmless and several flows do it;
 /// only a tap moves key material, so this guard keys on the tap.
-const _copyPrivateKeyId = 'copy_nsec_button';
+const String _copyPrivateKeyId = SemanticIds.keyManagementCopyNsecButton;
 
-/// Maestro's command for overwriting the clipboard with a literal.
+/// The public key copy on the same screen: the control a flow taps to
+/// overwrite the device clipboard.
 ///
-/// Present in the pinned CLI (`MAESTRO_VERSION` in `codemagic.yaml`).
-const _setClipboard = 'setClipboard';
+/// Maestro cannot do that itself. Its `setClipboard` only sets Maestro's own
+/// copied text, which `pasteText` reads back, and never reaches the device
+/// (`Orchestra.setClipboardCommand` in the `MAESTRO_VERSION` codemagic.yaml
+/// pins).
+const String _copyPublicKeyId = SemanticIds.keyManagementCopyNpubButton;
 
 /// The flow-config key whose commands Maestro runs from a `finally`.
 ///
@@ -24,7 +29,7 @@ const _setClipboard = 'setClipboard';
 /// between the copy and the end of the flow leaves the key on the clipboard —
 /// which is the state #8828 is about. The hook runs pass or fail, for a direct
 /// run and for a subflow reached through `runFlow:` alike, so the guard
-/// requires the clear there rather than anywhere in the command list.
+/// requires the overwrite there rather than anywhere in the command list.
 const _onFlowComplete = 'onFlowComplete';
 
 const _maestroDir = 'e2e/maestro';
@@ -58,14 +63,9 @@ bool _tapsId(Object? node, String id) {
   return node.values.any((child) => _tapsId(child, id));
 }
 
-bool _isSetClipboard(Object? command) =>
-    command is YamlMap && command.containsKey(_setClipboard);
-
-/// Whether [header] overwrites the clipboard from its `onFlowComplete` hook.
-bool _clearsClipboardOnComplete(YamlMap? header) {
-  final hook = header?[_onFlowComplete];
-  return hook is YamlList && hook.any(_isSetClipboard);
-}
+/// Whether [header]'s `onFlowComplete` hook overwrites the device clipboard.
+bool _overwritesClipboardOnComplete(YamlMap? header) =>
+    _tapsId(header?[_onFlowComplete], _copyPublicKeyId);
 
 void main() {
   group('Maestro clipboard hygiene', () {
@@ -88,9 +88,10 @@ void main() {
     });
 
     test('a flow still taps the control the guard watches', () {
-      // The guard below skips every flow that does not tap the button, so
-      // renaming the control turns it green while the copy still happens —
-      // #8777's shape exactly. Pin that the detector has something to check.
+      // The guard below skips every flow that does not tap the button, so a
+      // flow that stops reaching it by id turns the guard green while the
+      // copy still happens — #8777's shape exactly. Pin that the detector has
+      // something to check.
       expect(
         flows.where(
           (flow) => _tapsId(_documentsOf(flow).commands, _copyPrivateKeyId),
@@ -98,28 +99,29 @@ void main() {
         isNotEmpty,
         reason:
             'no flow under $_maestroDir taps $_copyPrivateKeyId, so the '
-            'clipboard guard checks nothing. If the control was renamed, '
-            'point $_copyPrivateKeyId at the new '
-            '`SemanticIds.keyManagementCopyNsecButton`; if the copy journey '
-            'was deleted, delete this guard with it (#8828).',
+            'clipboard guard checks nothing. If the copy journey reaches the '
+            'button another way, target it by '
+            '`SemanticIds.keyManagementCopyNsecButton`; if the journey was '
+            'deleted, delete this guard with it (#8828).',
       );
     });
 
-    test('a flow that copies the private key clears it on completion', () {
+    test('a flow that copies the private key overwrites it on completion', () {
       for (final flow in flows) {
         final (:header, :commands) = _documentsOf(flow);
         if (!_tapsId(commands, _copyPrivateKeyId)) continue;
 
         expect(
-          _clearsClipboardOnComplete(header),
+          _overwritesClipboardOnComplete(header),
           isTrue,
           reason:
               '${flow.path} taps $_copyPrivateKeyId, which copies a live '
               "account's private key to the device clipboard. The flow must "
-              'overwrite it from an `$_onFlowComplete` hook, which Maestro '
-              'runs pass or fail — a trailing `$_setClipboard` is skipped by '
-              'any failure after the copy and leaves the key on a shared '
-              'device (#8828).',
+              'tap $_copyPublicKeyId from an `$_onFlowComplete` hook, which '
+              'Maestro runs pass or fail, so the app overwrites the key. '
+              "Maestro's own `setClipboard` never reaches the device, and a "
+              'trailing command is skipped by any failure after the copy '
+              '(#8828).',
         );
       }
     });
@@ -150,24 +152,53 @@ void main() {
         expect(_tapsId(commands, _copyPrivateKeyId), isFalse);
       });
 
-      test('rejects a header whose hook does not clear the clipboard', () {
-        final withHook = loadYaml('''
+      test('accepts only a hook that taps the public key copy', () {
+        final tapsPublicKeyCopy = loadYaml('''
 appId: co.openvine.app.staging
 $_onFlowComplete:
-  - $_setClipboard: "cleared"
+  - runFlow:
+      when:
+        visible:
+          id: "$_copyPrivateKeyId"
+      commands:
+        - scrollUntilVisible:
+            element:
+              id: "$_copyPublicKeyId"
+            direction: UP
+            optional: true
+        - tapOn:
+            id: "$_copyPublicKeyId"
+            optional: true
+''') as YamlMap;
+        final scrollsWithoutTapping = loadYaml('''
+appId: co.openvine.app.staging
+$_onFlowComplete:
+  - scrollUntilVisible:
+      element:
+        id: "$_copyPublicKeyId"
+      direction: UP
+''') as YamlMap;
+        final setsMaestroClipboard = loadYaml('''
+appId: co.openvine.app.staging
+$_onFlowComplete:
+  - setClipboard: "cleared"
+''') as YamlMap;
+        final tapsPrivateKeyCopy = loadYaml('''
+appId: co.openvine.app.staging
+$_onFlowComplete:
+  - tapOn:
+      id: "$_copyPrivateKeyId"
 ''') as YamlMap;
         final withoutHook =
             loadYaml('appId: co.openvine.app.staging') as YamlMap;
-        final emptyHook = loadYaml('''
-appId: co.openvine.app.staging
-$_onFlowComplete:
-  - back
-''') as YamlMap;
 
-        expect(_clearsClipboardOnComplete(withHook), isTrue);
-        expect(_clearsClipboardOnComplete(withoutHook), isFalse);
-        expect(_clearsClipboardOnComplete(emptyHook), isFalse);
-        expect(_clearsClipboardOnComplete(null), isFalse);
+        expect(_overwritesClipboardOnComplete(tapsPublicKeyCopy), isTrue);
+        expect(_overwritesClipboardOnComplete(scrollsWithoutTapping), isFalse);
+        // Sets Maestro's copied text only; the device keeps the key.
+        expect(_overwritesClipboardOnComplete(setsMaestroClipboard), isFalse);
+        expect(_overwritesClipboardOnComplete(tapsPrivateKeyCopy), isFalse);
+        expect(_overwritesClipboardOnComplete(withoutHook), isFalse);
+        expect(_overwritesClipboardOnComplete(null), isFalse);
       });
     });
   });

--- a/mobile/test/tools/maestro_clipboard_hygiene_test.dart
+++ b/mobile/test/tools/maestro_clipboard_hygiene_test.dart
@@ -18,32 +18,54 @@ const _copyPrivateKeyId = 'copy_nsec_button';
 /// Present in the pinned CLI (`MAESTRO_VERSION` in `codemagic.yaml`).
 const _setClipboard = 'setClipboard';
 
+/// The flow-config key whose commands Maestro runs from a `finally`.
+///
+/// A trailing command runs only when the flow reaches it, so a failure
+/// between the copy and the end of the flow leaves the key on the clipboard —
+/// which is the state #8828 is about. The hook runs pass or fail, for a direct
+/// run and for a subflow reached through `runFlow:` alike, so the guard
+/// requires the clear there rather than anywhere in the command list.
+const _onFlowComplete = 'onFlowComplete';
+
 const _maestroDir = 'e2e/maestro';
 
-/// Every command in a flow, in order.
+/// A Maestro flow's optional config header and its command list.
 ///
-/// A Maestro flow is two YAML documents — an `appId`/`tags` header, then the
-/// command list — so the commands are the last document rather than the
-/// first.
-List<Object?> _commandsOf(File flow) {
+/// A flow is two YAML documents — an `appId`/`onFlowComplete` header, then the
+/// commands — so the commands are the last document rather than the first. A
+/// file with a single document declares no header.
+({YamlMap? header, List<Object?> commands}) _documentsOf(File flow) {
   final documents = loadYamlDocuments(flow.readAsStringSync());
-  if (documents.isEmpty) return const [];
+  if (documents.isEmpty) return (header: null, commands: const []);
+  final header = documents.length > 1 ? documents.first.contents.value : null;
   final commands = documents.last.contents.value;
-  return commands is YamlList ? commands.toList() : const [];
+  return (
+    header: header is YamlMap ? header : null,
+    commands: commands is YamlList ? commands.toList() : const [],
+  );
 }
 
-/// Whether [command] is a `tapOn` naming [id].
+/// Whether [node] or anything nested under it taps [id].
 ///
-/// Maestro accepts both the nested (`tapOn:` then `id:`) and inline forms, so
-/// this reads the argument as a map rather than matching source text.
-bool _tapsId(Object? command, String id) {
-  if (command is! YamlMap) return false;
-  final argument = command['tapOn'];
-  return argument is YamlMap && argument['id'] == id;
+/// The walk is recursive because `tapOn` can sit under `repeat:`, `retry:` or
+/// an inline `runFlow:`, and reads the argument as a map rather than matching
+/// source text because Maestro accepts both the nested and inline forms.
+bool _tapsId(Object? node, String id) {
+  if (node is List) return node.any((child) => _tapsId(child, id));
+  if (node is! YamlMap) return false;
+  final argument = node['tapOn'];
+  if (argument is YamlMap && argument['id'] == id) return true;
+  return node.values.any((child) => _tapsId(child, id));
 }
 
 bool _isSetClipboard(Object? command) =>
     command is YamlMap && command.containsKey(_setClipboard);
+
+/// Whether [header] overwrites the clipboard from its `onFlowComplete` hook.
+bool _clearsClipboardOnComplete(YamlMap? header) {
+  final hook = header?[_onFlowComplete];
+  return hook is YamlList && hook.any(_isSetClipboard);
+}
 
 void main() {
   group('Maestro clipboard hygiene', () {
@@ -65,25 +87,70 @@ void main() {
       );
     });
 
-    test('a flow that copies the private key clears the clipboard after', () {
+    test('a flow that copies the private key clears it on completion', () {
       for (final flow in flows) {
-        final commands = _commandsOf(flow);
-        final tapIndex = commands.indexWhere(
-          (command) => _tapsId(command, _copyPrivateKeyId),
-        );
-        if (tapIndex < 0) continue;
+        final (:header, :commands) = _documentsOf(flow);
+        if (!_tapsId(commands, _copyPrivateKeyId)) continue;
 
-        final clearIndex = commands.indexWhere(_isSetClipboard);
         expect(
-          clearIndex,
-          greaterThan(tapIndex),
+          _clearsClipboardOnComplete(header),
+          isTrue,
           reason:
               '${flow.path} taps $_copyPrivateKeyId, which copies a live '
               "account's private key to the device clipboard. The flow must "
-              'overwrite it with `$_setClipboard` before it ends, or the key '
-              'outlives the run on a shared device (#8828).',
+              'overwrite it from an `$_onFlowComplete` hook, which Maestro '
+              'runs pass or fail — a trailing `$_setClipboard` is skipped by '
+              'any failure after the copy and leaves the key on a shared '
+              'device (#8828).',
         );
       }
+    });
+
+    group('detector', () {
+      test('finds a tap nested inside another command', () {
+        final commands = loadYaml('''
+- retry:
+    maxRetries: 2
+    commands:
+      - tapOn:
+          id: "$_copyPrivateKeyId"
+''');
+
+        expect(_tapsId(commands, _copyPrivateKeyId), isTrue);
+      });
+
+      test('does not treat a visibility assertion as a tap', () {
+        final commands = loadYaml('''
+- assertVisible:
+    id: "$_copyPrivateKeyId"
+- extendedWaitUntil:
+    visible:
+      id: "$_copyPrivateKeyId"
+    timeout: 30000
+''');
+
+        expect(_tapsId(commands, _copyPrivateKeyId), isFalse);
+      });
+
+      test('rejects a header whose hook does not clear the clipboard', () {
+        final withHook = loadYaml('''
+appId: co.openvine.app.staging
+$_onFlowComplete:
+  - $_setClipboard: "cleared"
+''') as YamlMap;
+        final withoutHook =
+            loadYaml('appId: co.openvine.app.staging') as YamlMap;
+        final emptyHook = loadYaml('''
+appId: co.openvine.app.staging
+$_onFlowComplete:
+  - back
+''') as YamlMap;
+
+        expect(_clearsClipboardOnComplete(withHook), isTrue);
+        expect(_clearsClipboardOnComplete(withoutHook), isFalse);
+        expect(_clearsClipboardOnComplete(emptyHook), isFalse);
+        expect(_clearsClipboardOnComplete(null), isFalse);
+      });
     });
   });
 }

--- a/mobile/test/tools/maestro_clipboard_hygiene_test.dart
+++ b/mobile/test/tools/maestro_clipboard_hygiene_test.dart
@@ -1,0 +1,89 @@
+// ABOUTME: Pins that a Maestro flow copying the private key also clears it.
+// ABOUTME: The copy is the journey under test; the key left behind is not.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yaml/yaml.dart';
+
+/// The control whose tap puts the signed-in account's `nsec` on the device
+/// clipboard.
+///
+/// Asserting the button is *visible* is harmless and several flows do it;
+/// only a tap moves key material, so this guard keys on the tap.
+const _copyPrivateKeyId = 'copy_nsec_button';
+
+/// Maestro's command for overwriting the clipboard with a literal.
+///
+/// Present in the pinned CLI (`MAESTRO_VERSION` in `codemagic.yaml`).
+const _setClipboard = 'setClipboard';
+
+const _maestroDir = 'e2e/maestro';
+
+/// Every command in a flow, in order.
+///
+/// A Maestro flow is two YAML documents — an `appId`/`tags` header, then the
+/// command list — so the commands are the last document rather than the
+/// first.
+List<Object?> _commandsOf(File flow) {
+  final documents = loadYamlDocuments(flow.readAsStringSync());
+  if (documents.isEmpty) return const [];
+  final commands = documents.last.contents.value;
+  return commands is YamlList ? commands.toList() : const [];
+}
+
+/// Whether [command] is a `tapOn` naming [id].
+///
+/// Maestro accepts both the nested (`tapOn:` then `id:`) and inline forms, so
+/// this reads the argument as a map rather than matching source text.
+bool _tapsId(Object? command, String id) {
+  if (command is! YamlMap) return false;
+  final argument = command['tapOn'];
+  return argument is YamlMap && argument['id'] == id;
+}
+
+bool _isSetClipboard(Object? command) =>
+    command is YamlMap && command.containsKey(_setClipboard);
+
+void main() {
+  group('Maestro clipboard hygiene', () {
+    final flows =
+        Directory(_maestroDir)
+            .listSync(recursive: true)
+            .whereType<File>()
+            .where((file) => file.path.endsWith('.yaml'))
+            .toList()
+          ..sort((a, b) => a.path.compareTo(b.path));
+
+    test('the suite is present and readable', () {
+      // A guard over an empty set passes for the wrong reason; #8777 is
+      // exactly the kind of change that can move these files.
+      expect(flows, isNotEmpty, reason: 'no flows found under $_maestroDir');
+      expect(
+        flows.map((file) => file.path),
+        contains(contains('backupYourKey.yaml')),
+      );
+    });
+
+    test('a flow that copies the private key clears the clipboard after', () {
+      for (final flow in flows) {
+        final commands = _commandsOf(flow);
+        final tapIndex = commands.indexWhere(
+          (command) => _tapsId(command, _copyPrivateKeyId),
+        );
+        if (tapIndex < 0) continue;
+
+        final clearIndex = commands.indexWhere(_isSetClipboard);
+        expect(
+          clearIndex,
+          greaterThan(tapIndex),
+          reason:
+              '${flow.path} taps $_copyPrivateKeyId, which copies a live '
+              "account's private key to the device clipboard. The flow must "
+              'overwrite it with `$_setClipboard` before it ends, or the key '
+              'outlives the run on a shared device (#8828).',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Description

The backup-your-key regression journey taps the button that copies the signed-in account's private key to the device clipboard. That is the point of the journey and it is right to test it. What went missing is anything that consumes or destroys the copy.

The run used to read the key straight back and hand it to a deletion flow that removed that identity minutes later, so the key that leaked belonged to an account destroyed within the same run. #8777 deleted the read-back and the deletion flow and kept the copy — `grep -rn PRIV_KEY_TO_DELETE mobile/e2e/` returns nothing on `main`.

So a full-regression run now ends with a **live account's nsec sitting on a shared staging device**, readable by every app on it and on iOS by any Handoff-paired Mac. Three more flows run after this one, so it stays there for the rest of the run and past the end of it.

The exposure is small and the account is a throwaway. The property is the bad one: a private key outliving the run that created it, on a shared device, with no owner.

**Related Issue:** Closes #8828

## Why this fix

The journey keeps its coverage: it still taps the real button and asserts the real confirmation. Then it taps the same screen's **copy public key** button, which replaces the nsec on the device clipboard with the account's npub.

It has to go through the app. Maestro's `setClipboard`, which the first version of this PR used, never touches the device. It only sets Maestro's own copied-text variable, the one `pasteText` reads: `Orchestra.setClipboardCommand` says "Internal variable setting - no UI effect", unchanged from the pinned 2.8.0 through `main`, and no Maestro driver has a clipboard API at all. On a simulator the device clipboard kept its value through `setClipboard` in the flow body and in the hook.

The button sits above the fold once the journey has scrolled down to the private key copy, and Flutter leaves off-screen controls out of the accessibility tree Maestro reads, so each overwrite scrolls back up to it first. It runs in two places:

- **In `onFlowComplete`** (@hm21's change, kept). Maestro runs the hook from a `finally`, for a direct run and for a subflow reached through `runFlow:`, so a failure between the copy and the end of the flow still overwrites the key. It acts only while the private key copy is on screen, since nothing was copied before the flow got there, and its steps are `optional`: a subflow's hook has no catch of its own, so a failing step there would replace the flow's real failure.
- **As a step after the confirmation**, not optional, so a passing run proves the overwrite happened.

The public key button gets a stable id, `SemanticIds.keyManagementCopyNpubButton`, so the flow does not bind to translated copy. It is a test anchor only: never announced, no visual or behaviour change.

The guard test pins the property rather than the line: any flow that taps the private key copy must tap the public key copy from its `onFlowComplete` hook. It reads both ids from `SemanticIds`, so renaming either control moves the guard with it, and it rejects a `setClipboard`-only hook explicitly.

## What this deliberately leaves alone

- **The account is still left on staging relays.** Restoring the deletion journey is #8827.
- **The app does not expire a copied nsec.** A real user's copy also stays on the clipboard indefinitely; changing that is a product decision, not part of this fix.
- **An app crash after the copy, or a run cancelled by a timeout or Ctrl-C,** leaves the key: nothing inside the flow runs then, and Maestro skips hooks on cancellation.
- **No new tier registry entry.** The flow is reached through `suites/fullRegression.yaml`, which is registered; the registry covers entry points.

## Verification

End to end on a throwaway iOS simulator with a throwaway account (`loginFreshInstall`, no credentials), reached through `runFlow:` the way `fullRegression` reaches it. The device clipboard was set to a sentinel before each run and read with `xcrun simctl pbpaste` after:

| Flow | Run | Device clipboard afterwards |
|---|---|---|
| Previously approved head (`setClipboard` hook) | passes | **private key** — #8828 reproduces with the old fix in place |
| This PR | passes | public key |
| This PR, failing right after the copy (confirmation forced to fail, so only the hook can act) | fails on the forced assert | public key |
| This PR, failing before the key screen | fails on its own step, hook skipped | untouched — nothing was copied |

- Both tests mutation-checked, each mutation restored afterwards. The guard goes red for: the old `setClipboard` hook, no hook, a hook that re-copies the private key, a hook that scrolls but never taps, and a rename of either id in `SemanticIds`. The widget test goes red when the button loses its id.
- `flutter analyze lib test integration_test` — clean
- `maestro_clipboard_hygiene_test.dart`, `key_management_screen_test.dart`, `maestro_pr_smoke_contract_test.dart`, `maestro_copy_drift_detector_test.dart` — 74 green
- `maestro check-syntax` on the flow — OK
- Every `scripts/check_*.sh` on disk plus `e2e/maestro/scripts/check_refs.sh` (66): 62 green, including `check_maestro_copy_drift.sh` and `check_refs.sh`. The four red ones are not from this diff:
  - `check_skip_ceiling.sh` and `check_async_safety_ceiling.sh` compare against a newer `main`, where #8950 and #8985 shrank their baselines after this branch was cut. This branch touches neither baseline nor the files they name, and CI checks the merge, where `main`'s baselines win.
  - `check_coordinator_route_serving.sh` probes live servers: staging and production pass, and the POC host returns 404.
  - `check_ios_extension_signing_contract.sh` needs `IOS_EXTENSION_BUNDLE_IDS`, which only CI provides.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test
