### PR TITLE
fix(supporters): recover paid purchases and confirm access before success

### DIFF
--- a/mobile/docs/SUPPORTER_RELEASE_CHECKLIST.md
+++ b/mobile/docs/SUPPORTER_RELEASE_CHECKLIST.md
@@ -1,0 +1,89 @@
+# Supporter release and purchase recovery
+
+The store is the source of payment evidence. The supporter service verifies store
+proofs and owns account entitlement. Firebase events measure the client funnel;
+an analytics revenue number or subscription-renewal event is not a paid-account
+ledger, and renewal events are not a count of distinct supporters.
+
+## Before enabling purchases
+
+- Record the exact public iOS and Android version/build, source commit, and any
+  applicable Shorebird patch. Confirm each artifact contains the verification
+  configuration guard and purchase recovery code. A fix merged to main is not
+  evidence that a public binary contains it. Builds made without Shorebird need
+  a new store release.
+- Verify `SUPPORTERS_API_BASE_URL` in the built artifact and authenticate `/v1/me`
+  using the account's signer. The purchase path checks this before opening the
+  store, but `/health` and `/v1/me` do not prove store-verifier credentials work.
+- Verify each offered product is approved and available in its store. The native
+  product list currently offers the monthly plan; do not advertise additional
+  plans before the app can deliver them.
+- Deploy and verify the supporter service's transient-claim retry and current
+  snapshot replay behavior before enabling the mobile recovery changes.
+- Keep sandbox/TestFlight/test purchases separate from paid production reporting.
+  Verify receipt environment on the server; do not infer it from a release build
+  or the configured Apple endpoint alone. The verifier can fall back to sandbox.
+- Confirm store notifications, scheduled reconciliation, and expired/grace
+  handling update the canonical account after the app is closed.
+
+## Device acceptance matrix
+
+Run these with store-backed builds on both supported purchase platforms. Unit
+and widget tests cover the failure modes but do not replace these checks.
+
+| Scenario | Required result |
+| --- | --- |
+| New subscription | Store confirmation, verified account entitlement, active supporter badge, then store acknowledgment |
+| Missing verifier URL or failed authenticated preflight | Billing does not start; actionable failure appears |
+| Verification temporarily unavailable after payment | No false success; transaction remains recoverable; identical proof succeeds after recovery |
+| Kill app after payment or before acknowledgment | Same account recovers and acknowledges without charging again |
+| Account switch during or after purchase | Purchase remains bound to its initiating account; another account cannot claim it |
+| Canceled purchase or store refuses to start | No entitlement; no leftover pending account lock |
+| Existing subscription on a fresh installation | Explicit Restore claims the purchase with the intended account; a rejected wrong-account restore does not block the rightful owner |
+| Automatic restore with no known local owner | Does not silently assign a legacy purchase to the current account |
+| Renewal, billing grace, expiry, refund/revocation | UI follows current canonical state; replaying an old claim cannot restore an obsolete entitlement |
+| Active supporter presses subscribe | Server preflight returns existing entitlement without opening billing |
+| Analytics unavailable or consent declined | Purchase and restoration still work |
+
+Verify both Settings entry visibility and the supporter screen in the actual
+release artifact. Existing purchasers need a reachable Restore path and clear
+account-selection guidance. Do not enable purchase access more broadly than the
+restore and entitlement display paths have been tested.
+
+## Reconciliation and monitoring
+
+Use credentialed store sales/financial reports and verified transaction state to
+reconcile the same period, platform, product, environment, and currency. Keep the
+following counts separate: unique paying store subscriptions, verified
+transactions, distinct entitled Divine accounts, and renewal events. Investigate
+production purchases without an account claim and active entitlements without
+production payment evidence. Keep receipts, tokens, and identity-linked reports
+out of public issues and PRs.
+
+The screen sends `supporter_subscribe_tapped`,
+`supporter_subscribe_succeeded`, and `supporter_subscribe_failed` through the
+configured analytics sink. Success means canonical entitlement became active
+during that screen's purchase flow; it is not a financial revenue event and may
+include an already-active account. `supporter_restore_completed` means the store
+restore call returned, not that every proof has been verified. Use server
+entitlement and claim outcomes to measure recovery and renewals across app
+restarts or screen closure.
+
+During a limited rollout, inspect claim failure status, pending processing age,
+verified environment, acknowledgment recovery, webhook/reconciliation failures,
+and the store-to-entitlement discrepancy. Stop expanding purchase access when a
+paid transaction cannot be restored or recognized. Preserve restoration and
+entitlement access while resolving the failure.
+
+## Product scope and rollout decision
+
+The current mobile supporter screen provides subscription status and a thank-you
+badge. A public profile halo, discovery directory, recognition preferences, and
+other advertised benefits need their own delivery and acceptance evidence; a
+server preference field alone does not deliver the benefit in the app. Align
+public copy with what the release actually provides before accepting payments.
+
+Open rollout only after the store report reconciliation, device matrix, shipped
+artifact provenance, and advertised-benefit checks are recorded. Keep the
+feature flag gated until those checks pass and the release owner approves the
+rollout. This checklist does not itself change production configuration.

--- a/mobile/docs/SUPPORTER_RELEASE_CHECKLIST.md
+++ b/mobile/docs/SUPPORTER_RELEASE_CHECKLIST.md
@@ -19,7 +19,7 @@ ledger, and renewal events are not a count of distinct supporters.
   product list currently offers the monthly plan; do not advertise additional
   plans before the app can deliver them.
 - Deploy and verify the supporter service's transient-claim retry and current
-  snapshot replay behavior before enabling the mobile recovery changes.
+  snapshot replay behavior and the existing-owner restore endpoint before enabling the mobile recovery changes.
 - Keep sandbox/TestFlight/test purchases separate from paid production reporting.
   Verify receipt environment on the server; do not infer it from a release build
   or the configured Apple endpoint alone. The verifier can fall back to sandbox.
@@ -40,7 +40,7 @@ and widget tests cover the failure modes but do not replace these checks.
 | Account switch during or after purchase | Purchase remains bound to its initiating account; another account cannot claim it |
 | Canceled purchase or store refuses to start | No entitlement; no leftover pending account lock |
 | Existing subscription on a fresh installation | Explicit Restore claims the purchase with the intended account; a rejected wrong-account restore does not block the rightful owner |
-| Automatic restore with no known local owner | Does not silently assign a legacy purchase to the current account |
+| Automatic restore with no known local owner | Server verifies existing subscription ownership; never creates a new account binding |
 | Renewal, billing grace, expiry, refund/revocation | UI follows current canonical state; replaying an old claim cannot restore an obsolete entitlement |
 | Active supporter presses subscribe | Server preflight returns existing entitlement without opening billing |
 | Analytics unavailable or consent declined | Purchase and restoration still work |
@@ -49,10 +49,13 @@ Verify both Settings entry visibility and the supporter screen in the actual
 release artifact. Existing purchasers need a reachable Restore path and clear
 account-selection guidance. Do not enable purchase access more broadly than the
 restore and entitlement display paths have been tested. A renewal can have a new
-store transaction identifier without a saved local owner. Such proofs currently
-require explicit Restore; this change does not establish unattended renewal
-acknowledgment. Test that case before rollout, including a stale canonical account
-and termination before StoreKit finishes the transaction.
+store transaction identifier without a saved local owner. Background recovery
+uses `/v1/purchases/restore`, which verifies the canonical subscription owner
+before updating entitlement or acknowledging the transaction. An unbound legacy
+purchase still needs explicit Restore. Older servers without this endpoint fail
+closed; the app never falls back to first-time binding during background recovery.
+Test new renewal IDs, stale canonical state, and process termination before
+StoreKit finishes the transaction.
 
 ## Reconciliation and monitoring
 

--- a/mobile/docs/SUPPORTER_RELEASE_CHECKLIST.md
+++ b/mobile/docs/SUPPORTER_RELEASE_CHECKLIST.md
@@ -48,7 +48,11 @@ and widget tests cover the failure modes but do not replace these checks.
 Verify both Settings entry visibility and the supporter screen in the actual
 release artifact. Existing purchasers need a reachable Restore path and clear
 account-selection guidance. Do not enable purchase access more broadly than the
-restore and entitlement display paths have been tested.
+restore and entitlement display paths have been tested. A renewal can have a new
+store transaction identifier without a saved local owner. Such proofs currently
+require explicit Restore; this change does not establish unattended renewal
+acknowledgment. Test that case before rollout, including a stale canonical account
+and termination before StoreKit finishes the transaction.
 
 ## Reconciliation and monitoring
 

--- a/mobile/lib/blocs/supporter/supporter_cubit.dart
+++ b/mobile/lib/blocs/supporter/supporter_cubit.dart
@@ -9,8 +9,9 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/supporter/supporter_state.dart';
 import 'package:openvine/services/supporter_api_client.dart';
 import 'package:openvine/services/supporter_repository.dart';
+import 'package:unified_logger/unified_logger.dart';
 
-typedef SupporterAnalyticsSink = void Function(String event);
+typedef SupporterAnalyticsSink = FutureOr<void> Function(String event);
 
 class SupporterCubit extends Cubit<SupporterState> {
   /// Creates a [SupporterCubit].
@@ -37,8 +38,11 @@ class SupporterCubit extends Cubit<SupporterState> {
   void start() {
     _entitlementSub ??= _repository.changes.listen(
       (entitlement) {
+        if (entitlement.isSupporter) _finishPurchaseAnalytics(succeeded: true);
         _emit(
           state.copyWith(
+            awaitingPurchaseConfirmation:
+                !entitlement.isSupporter && state.awaitingPurchaseConfirmation,
             entitlement: entitlement,
             status: entitlement.isSupporter
                 ? SupporterStatus.active
@@ -69,7 +73,14 @@ class SupporterCubit extends Cubit<SupporterState> {
     try {
       final tiers = await _repository.validator.fetchProducts();
       if (isClosed) return;
-      _emit(state.copyWith(tiers: tiers, status: SupporterStatus.idle));
+      _emit(
+        state.copyWith(
+          tiers: tiers,
+          status: state.status == SupporterStatus.loading
+              ? SupporterStatus.idle
+              : state.status,
+        ),
+      );
     } on EntitlementException catch (e) {
       _emit(
         state.copyWith(
@@ -84,14 +95,24 @@ class SupporterCubit extends Cubit<SupporterState> {
   Future<void> subscribe(String productId) async {
     if (state.isBusy) return;
     _emit(
-      state.copyWith(status: SupporterStatus.purchasing, clearFailure: true),
+      state.copyWith(
+        status: SupporterStatus.purchasing,
+        clearFailure: true,
+        awaitingPurchaseConfirmation: true,
+      ),
     );
-    _trackEvent('supporter_subscribe_tapped');
+    _recordEvent('supporter_subscribe_tapped');
     try {
       final entitlement = await _repository.purchase(productId);
       if (isClosed) return;
+      if (entitlement.isSupporter) _finishPurchaseAnalytics(succeeded: true);
+      // Canonical updates may arrive before the store future completes.
+      if (!entitlement.isSupporter && !state.awaitingPurchaseConfirmation) {
+        return;
+      }
       _emit(
         state.copyWith(
+          awaitingPurchaseConfirmation: !entitlement.isSupporter,
           entitlement: entitlement,
           status: entitlement.isSupporter
               ? SupporterStatus.active
@@ -99,18 +120,18 @@ class SupporterCubit extends Cubit<SupporterState> {
           clearFailure: true,
         ),
       );
-      _trackEvent('supporter_subscribe_succeeded');
     } on EntitlementException catch (e) {
+      _finishPurchaseAnalytics(succeeded: false);
       _emit(
         state.copyWith(
+          awaitingPurchaseConfirmation: false,
           status: SupporterStatus.idle,
           failure: SupporterFailure.fromMessage(e.message),
         ),
       );
-      _trackEvent('supporter_subscribe_failed');
     } on SupporterApiException catch (error) {
+      _finishPurchaseAnalytics(succeeded: false);
       _emitApiFailure(error);
-      _trackEvent('supporter_subscribe_failed');
     }
   }
 
@@ -120,14 +141,14 @@ class SupporterCubit extends Cubit<SupporterState> {
     _emit(
       state.copyWith(status: SupporterStatus.restoring, clearFailure: true),
     );
-    _trackEvent('supporter_restore_tapped');
+    _recordEvent('supporter_restore_tapped');
     try {
       await _repository.restorePurchases();
       // The restored entitlement arrives on the repository stream; reset to idle
       // and let the stream listener surface the active status.
       if (isClosed) return;
       _emit(state.copyWith(status: SupporterStatus.idle));
-      _trackEvent('supporter_restore_completed');
+      _recordEvent('supporter_restore_completed');
     } on EntitlementException catch (e) {
       _emit(
         state.copyWith(
@@ -135,7 +156,30 @@ class SupporterCubit extends Cubit<SupporterState> {
           failure: SupporterFailure.fromMessage(e.message),
         ),
       );
-      _trackEvent('supporter_restore_failed');
+      _recordEvent('supporter_restore_failed');
+    }
+  }
+
+  void _finishPurchaseAnalytics({required bool succeeded}) {
+    if (!state.awaitingPurchaseConfirmation) return;
+    _recordEvent(
+      succeeded
+          ? 'supporter_subscribe_succeeded'
+          : 'supporter_subscribe_failed',
+    );
+  }
+
+  void _recordEvent(String event) => unawaited(_sendEvent(event));
+
+  Future<void> _sendEvent(String event) async {
+    try {
+      await _trackEvent(event);
+    } on Object {
+      Log.warning(
+        'Supporter analytics delivery failed (event=$event)',
+        name: 'SupporterCubit',
+        category: LogCategory.system,
+      );
     }
   }
 
@@ -150,11 +194,13 @@ class SupporterCubit extends Cubit<SupporterState> {
 
   void _handleEntitlementError(Object error, StackTrace stackTrace) {
     if (isClosed) return;
+    _finishPurchaseAnalytics(succeeded: false);
     if (error is SupporterApiException) {
       _emitApiFailure(error);
     } else if (error is EntitlementException) {
       _emit(
         state.copyWith(
+          awaitingPurchaseConfirmation: false,
           status: SupporterStatus.error,
           failure: SupporterFailure.fromMessage(error.message),
         ),
@@ -189,7 +235,13 @@ class SupporterCubit extends Cubit<SupporterState> {
         SupporterFailure.verificationUnavailable,
       _ => SupporterFailure.unknown,
     };
-    _emit(state.copyWith(status: SupporterStatus.error, failure: failure));
+    _emit(
+      state.copyWith(
+        awaitingPurchaseConfirmation: false,
+        status: SupporterStatus.error,
+        failure: failure,
+      ),
+    );
   }
 
   @override

--- a/mobile/lib/blocs/supporter/supporter_state.dart
+++ b/mobile/lib/blocs/supporter/supporter_state.dart
@@ -44,6 +44,7 @@ class SupporterState extends Equatable {
     this.entitlement = SupporterEntitlement.inactive,
     this.status = SupporterStatus.idle,
     this.failure,
+    this.awaitingPurchaseConfirmation = false,
   });
 
   /// Purchasable supporter tiers loaded from the store.
@@ -54,6 +55,9 @@ class SupporterState extends Equatable {
 
   final SupporterStatus status;
   final SupporterFailure? failure;
+
+  /// Whether a user-initiated purchase still awaits canonical verification.
+  final bool awaitingPurchaseConfirmation;
 
   bool get isSupporter => entitlement.isSupporter;
   bool get isBusy =>
@@ -70,8 +74,11 @@ class SupporterState extends Equatable {
     SupporterStatus? status,
     SupporterFailure? failure,
     bool clearFailure = false,
+    bool? awaitingPurchaseConfirmation,
   }) {
     return SupporterState(
+      awaitingPurchaseConfirmation:
+          awaitingPurchaseConfirmation ?? this.awaitingPurchaseConfirmation,
       tiers: tiers ?? this.tiers,
       entitlement: entitlement ?? this.entitlement,
       status: status ?? this.status,
@@ -80,5 +87,11 @@ class SupporterState extends Equatable {
   }
 
   @override
-  List<Object?> get props => [tiers, entitlement, status, failure];
+  List<Object?> get props => [
+    tiers,
+    entitlement,
+    status,
+    failure,
+    awaitingPurchaseConfirmation,
+  ];
 }

--- a/mobile/lib/providers/supporter_providers.dart
+++ b/mobile/lib/providers/supporter_providers.dart
@@ -92,10 +92,10 @@ SupporterRepository supporterRepository(Ref ref) {
 /// foreground.
 ///
 /// This deliberately does not depend on the Supporter screen or the feature
-/// flag: anyone whose store purchase succeeded before the Worker was wired
-/// must be able to claim it as soon as an authenticated build with the Worker
-/// URL opens. The repository first checks canonical state, coalesces overlapping
-/// calls, and retries failures on a later foreground edge.
+/// flag. Purchases with a known local or canonical account owner can recover
+/// without opening Settings. Unbound legacy purchases require explicit Restore
+/// to choose their account. The repository coalesces overlapping calls and
+/// retries temporary failures on a later foreground edge.
 final supporterRecoveryProvider = Provider<Future<void>?>((ref) {
   final authService = ref.watch(authServiceProvider);
   final authState = ref.watch(currentAuthStateProvider);

--- a/mobile/lib/screens/settings/supporter_screen.dart
+++ b/mobile/lib/screens/settings/supporter_screen.dart
@@ -9,6 +9,7 @@ import 'package:openvine/blocs/supporter/supporter_cubit.dart';
 import 'package:openvine/blocs/supporter/supporter_state.dart';
 import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/supporter_providers.dart';
 import 'package:openvine/screens/settings/settings_screen.dart';
 
@@ -22,8 +23,15 @@ class SupporterScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final repository = ref.watch(supporterRepositoryProvider);
+    final analytics = ref.watch(analyticsEventSinkProvider);
     return BlocProvider(
-      create: (_) => SupporterCubit(repository: repository),
+      create: (_) => SupporterCubit(
+        repository: repository,
+        trackEvent: (event) => analytics.logEvent(
+          name: event,
+          parameters: const {},
+        ),
+      ),
       child: const SupporterScreenView(),
     );
   }

--- a/mobile/lib/services/supporter_api_client.dart
+++ b/mobile/lib/services/supporter_api_client.dart
@@ -224,14 +224,17 @@ class SupporterApiClient {
   }
 
   /// Claims a store purchase for the pubkey represented by the NIP-98 signer.
+  /// [existingOwnerOnly] verifies an already-bound subscription without
+  /// creating new ownership, for background recovery and renewals.
   Future<SupporterAccountSnapshot> claimPurchase(
     SupporterPurchaseClaim claim, {
     required String expectedPubkey,
+    bool existingOwnerOnly = false,
   }) async {
     final body = jsonEncode(claim.toJson());
     final response = await _send(
       HttpMethod.post,
-      '/v1/purchases/claim',
+      existingOwnerOnly ? '/v1/purchases/restore' : '/v1/purchases/claim',
       body: body,
       expectedPubkey: expectedPubkey,
     );

--- a/mobile/lib/services/supporter_api_client.dart
+++ b/mobile/lib/services/supporter_api_client.dart
@@ -89,9 +89,14 @@ class SupporterAccountSnapshot {
   /// Parses the normalized `/v1/me` response.
   factory SupporterAccountSnapshot.fromJson(Map<String, dynamic> json) {
     final entitlementJson = json['entitlement'];
-    final entitlement = entitlementJson is Map<String, dynamic>
+    var entitlement = entitlementJson is Map<String, dynamic>
         ? SupporterEntitlement.fromJson(entitlementJson)
         : SupporterEntitlement.inactive;
+    final status = SupporterServerStatus.fromValue(json['status']);
+    final graceThrough = _parseDate(json['graceThroughAt']);
+    if (status == SupporterServerStatus.grace && graceThrough != null) {
+      entitlement = entitlement.copyWith(expirationDate: graceThrough);
+    }
     final recognition = json['recognition'];
     final recognitionJson = recognition is Map<String, dynamic>
         ? recognition
@@ -100,9 +105,9 @@ class SupporterAccountSnapshot {
 
     return SupporterAccountSnapshot(
       entitlement: entitlement,
-      status: SupporterServerStatus.fromValue(json['status']),
+      status: status,
       paidThrough: _parseDate(json['paidThroughAt']),
-      graceThrough: _parseDate(json['graceThroughAt']),
+      graceThrough: graceThrough,
       haloVisible: recognitionJson['haloVisible'] as bool? ?? false,
       discoveryVisible: recognitionJson['discoveryVisible'] as bool? ?? false,
       foundingHistoryVisible:

--- a/mobile/lib/services/supporter_repository.dart
+++ b/mobile/lib/services/supporter_repository.dart
@@ -283,8 +283,15 @@ class SupporterRepository {
   Future<void> _confirmPurchase(SupporterPurchaseProof proof) async {
     final proofOwnerKey = '$_proofOwnerPrefix${proof.attemptId}';
     final pendingKey = '$_pendingOwnerPrefix${proof.productId}';
+    final proofOwner = _prefs.getString(proofOwnerKey);
+    final pendingOwner = _prefs.getString(pendingKey);
+    // The pending marker is product-scoped, so it is a single slot shared by
+    // every account on the device. It may only authorize this account's own
+    // foreground purchase, never a background or foreign-captured redelivery,
+    // or account B's pending marker would first-time-claim account A's
+    // redelivered receipt under B.
     final owner =
-        _prefs.getString(proofOwnerKey) ?? _prefs.getString(pendingKey);
+        proofOwner ?? (proof.capturedPubkey == _pubkey ? pendingOwner : null);
     final background = proof.silent || proof.capturedPubkey == null;
     final existingOwnerOnly = owner == null && background;
     if (owner != null

--- a/mobile/lib/services/supporter_repository.dart
+++ b/mobile/lib/services/supporter_repository.dart
@@ -56,6 +56,8 @@ class SupporterRepository {
   final SharedPreferences _prefs;
 
   static const String _cacheKeyPrefix = 'divine_supporter_entitlement:';
+  static const _pendingOwnerPrefix = 'divine_supporter_pending_owner:';
+  static const _proofOwnerPrefix = 'divine_supporter_proof_owner:';
   final String _cacheKey;
 
   late SupporterEntitlement _current;
@@ -63,6 +65,7 @@ class SupporterRepository {
   StreamSubscription<SupporterPurchaseProof>? _proofSubscription;
   Future<void>? _recoveryInFlight;
   bool _recoveryCompleted = false;
+  int _claimFailureRevision = 0;
   final StreamController<SupporterEntitlement> _controller =
       StreamController<SupporterEntitlement>.broadcast();
 
@@ -96,17 +99,45 @@ class SupporterRepository {
         'Supporter verification is not configured.',
       );
     }
+    final snapshot = await refreshFromServer();
+    if (snapshot.entitlement.isSupporter) return snapshot.entitlement;
+
+    final pendingKey = '$_pendingOwnerPrefix$productId';
+    final pendingOwner = _prefs.getString(pendingKey);
+    if (pendingOwner != null && pendingOwner != _pubkey) {
+      throw const SupporterApiException(
+        SupporterApiFailureKind.ownershipConflict,
+        'An unfinished store purchase belongs to another Divine account.',
+      );
+    }
+    await _rememberOwner(pendingKey);
+
     Log.info(
       'Starting supporter purchase for ${pubkeyForLogs(_pubkey)} '
       '(productId=$productId)',
       name: 'SupporterRepository',
       category: LogCategory.system,
     );
-    return _validator.purchase(
-      productId,
-      capturedPubkey: _pubkey,
-      attemptId: 'supporter-${DateTime.now().microsecondsSinceEpoch}',
-    );
+    try {
+      return await _validator.purchase(
+        productId,
+        capturedPubkey: _pubkey,
+        attemptId: 'supporter-${DateTime.now().microsecondsSinceEpoch}',
+      );
+    } on StoreUnavailableException {
+      if (pendingOwner == null && _prefs.getString(pendingKey) == _pubkey) {
+        await _prefs.remove(pendingKey);
+      }
+      rethrow;
+    } on PurchaseFailedException catch (error) {
+      if ((error.responseCode == 'cancelled' ||
+              error.responseCode == 'not_started') &&
+          pendingOwner == null &&
+          _prefs.getString(pendingKey) == _pubkey) {
+        await _prefs.remove(pendingKey);
+      }
+      rethrow;
+    }
   }
 
   /// Restores purchases for this exact signed-in account.
@@ -142,18 +173,17 @@ class SupporterRepository {
 
   Future<void> _recoverPurchases() async {
     try {
-      final snapshot = await refreshFromServer();
-      if (snapshot.entitlement.isSupporter) {
-        _recoveryCompleted = true;
-        return;
-      }
+      await refreshFromServer();
+      // Even active accounts may have a transaction still awaiting store
+      // acknowledgment after the app closed during a successful claim.
+      final failureRevision = _claimFailureRevision;
       await _validator.restorePurchases(
         capturedPubkey: _pubkey,
         attemptId:
             'supporter-recovery-${DateTime.now().microsecondsSinceEpoch}',
         silent: true,
       );
-      _recoveryCompleted = true;
+      if (failureRevision == _claimFailureRevision) _recoveryCompleted = true;
     } on Object {
       // Background repair stays silent. A later foreground edge retries.
     }
@@ -251,9 +281,30 @@ class SupporterRepository {
   }
 
   Future<void> _confirmPurchase(SupporterPurchaseProof proof) async {
-    // Never send a store result under a different account after an account
-    // switch. A device-scope durable queue will retain this case once wired.
-    if (proof.capturedPubkey != _pubkey) return;
+    final proofOwnerKey = '$_proofOwnerPrefix${proof.attemptId}';
+    final pendingKey = '$_pendingOwnerPrefix${proof.productId}';
+    final owner =
+        _prefs.getString(proofOwnerKey) ?? _prefs.getString(pendingKey);
+    if (owner != null ? owner != _pubkey : proof.capturedPubkey != _pubkey) {
+      if (!proof.silent && proof.capturedPubkey == _pubkey) {
+        _handleValidatorError(
+          const SupporterApiException(
+            SupporterApiFailureKind.ownershipConflict,
+            'This store purchase belongs to another Divine account.',
+          ),
+          StackTrace.current,
+        );
+      }
+      return;
+    }
+    if (owner == null && proof.silent) {
+      Log.info(
+        'Unbound supporter purchase requires an explicit restore.',
+        name: 'SupporterRepository',
+        category: LogCategory.system,
+      );
+      return;
+    }
 
     Log.info(
       'Received supporter purchase proof for ${pubkeyForLogs(_pubkey)} '
@@ -282,6 +333,8 @@ class SupporterRepository {
     }
 
     try {
+      // Legacy restores acquire local ownership only after server acceptance.
+      if (owner != null) await _rememberOwner(proofOwnerKey);
       final snapshot = await client.claimPurchase(
         SupporterPurchaseClaim(
           store: proof.store,
@@ -291,8 +344,12 @@ class SupporterRepository {
         ),
         expectedPubkey: _pubkey,
       );
+      await _rememberOwner(proofOwnerKey);
       _handleChange(snapshot.entitlement);
       await _validator.completePurchase(proof);
+      if (_prefs.getString(pendingKey) == _pubkey) {
+        await _prefs.remove(pendingKey);
+      }
       Log.info(
         'Claimed and acknowledged supporter purchase for '
         '${pubkeyForLogs(_pubkey)} '
@@ -301,6 +358,7 @@ class SupporterRepository {
         category: LogCategory.system,
       );
     } on Object catch (error, stackTrace) {
+      _claimFailureRevision++;
       _recoveryCompleted = _isTerminalClaimFailure(error);
       Log.warning(
         'Supporter purchase claim failed for ${pubkeyForLogs(_pubkey)}; '
@@ -312,6 +370,17 @@ class SupporterRepository {
       if (!proof.silent) _handleValidatorError(error, stackTrace);
       // Keep the purchase unacknowledged so the store can redeliver it after
       // the Worker or signer becomes available.
+    }
+  }
+
+  Future<void> _rememberOwner(String key) async {
+    // Persist only the public account identifier and opaque proof digest,
+    // never store receipts or purchase tokens.
+    if (!await _prefs.setString(key, _pubkey)) {
+      throw const SupporterApiException(
+        SupporterApiFailureKind.unavailable,
+        'Could not save the purchase account. Try again later.',
+      );
     }
   }
 

--- a/mobile/lib/services/supporter_repository.dart
+++ b/mobile/lib/services/supporter_repository.dart
@@ -291,7 +291,10 @@ class SupporterRepository {
     // or account B's pending marker would first-time-claim account A's
     // redelivered receipt under B.
     final owner =
-        proofOwner ?? (proof.capturedPubkey == _pubkey ? pendingOwner : null);
+        proofOwner ??
+        (!proof.silent && proof.capturedPubkey == _pubkey
+            ? pendingOwner
+            : null);
     final background = proof.silent || proof.capturedPubkey == null;
     final existingOwnerOnly = owner == null && background;
     if (owner != null

--- a/mobile/lib/services/supporter_repository.dart
+++ b/mobile/lib/services/supporter_repository.dart
@@ -285,7 +285,11 @@ class SupporterRepository {
     final pendingKey = '$_pendingOwnerPrefix${proof.productId}';
     final owner =
         _prefs.getString(proofOwnerKey) ?? _prefs.getString(pendingKey);
-    if (owner != null ? owner != _pubkey : proof.capturedPubkey != _pubkey) {
+    final background = proof.silent || proof.capturedPubkey == null;
+    final existingOwnerOnly = owner == null && background;
+    if (owner != null
+        ? owner != _pubkey
+        : !existingOwnerOnly && proof.capturedPubkey != _pubkey) {
       if (!proof.silent && proof.capturedPubkey == _pubkey) {
         _handleValidatorError(
           const SupporterApiException(
@@ -295,14 +299,6 @@ class SupporterRepository {
           StackTrace.current,
         );
       }
-      return;
-    }
-    if (owner == null && proof.silent) {
-      Log.info(
-        'Unbound supporter purchase requires an explicit restore.',
-        name: 'SupporterRepository',
-        category: LogCategory.system,
-      );
       return;
     }
 
@@ -343,6 +339,7 @@ class SupporterRepository {
           proof: proof.toJson(),
         ),
         expectedPubkey: _pubkey,
+        existingOwnerOnly: existingOwnerOnly,
       );
       await _rememberOwner(proofOwnerKey);
       _handleChange(snapshot.entitlement);
@@ -367,7 +364,7 @@ class SupporterRepository {
         name: 'SupporterRepository',
         category: LogCategory.system,
       );
-      if (!proof.silent) _handleValidatorError(error, stackTrace);
+      if (!background) _handleValidatorError(error, stackTrace);
       // Keep the purchase unacknowledged so the store can redeliver it after
       // the Worker or signer becomes available.
     }

--- a/mobile/packages/iap_repository/lib/src/in_app_purchase_validator.dart
+++ b/mobile/packages/iap_repository/lib/src/in_app_purchase_validator.dart
@@ -117,7 +117,7 @@ class InAppPurchaseValidator implements EntitlementValidator {
         }
       case PurchaseStatus.canceled:
         const exception = PurchaseFailedException(
-          null,
+          'cancelled',
           'Purchase was cancelled.',
         );
         pending?.completer?.completeError(exception);
@@ -207,7 +207,7 @@ class InAppPurchaseValidator implements EntitlementValidator {
     if (!initiated) {
       _pendingPurchases.remove(productId);
       throw const PurchaseFailedException(
-        null,
+        'not_started',
         'Store did not start the purchase.',
       );
     }

--- a/mobile/packages/iap_repository/lib/src/in_app_purchase_validator.dart
+++ b/mobile/packages/iap_repository/lib/src/in_app_purchase_validator.dart
@@ -267,7 +267,13 @@ class InAppPurchaseValidator implements EntitlementValidator {
   @override
   Future<void> completePurchase(SupporterPurchaseProof proof) async {
     final purchase = _unacknowledgedPurchases[proof.attemptId];
-    if (purchase == null || !purchase.pendingCompletePurchase) return;
+    if (purchase == null) return;
+    // StoreKit 2 sets pendingCompletePurchase=false for restored transactions,
+    // including those redelivered after a crash before finishTransaction.
+    final restoredApplePurchase =
+        defaultTargetPlatform == TargetPlatform.iOS &&
+        purchase.status == PurchaseStatus.restored;
+    if (!purchase.pendingCompletePurchase && !restoredApplePurchase) return;
     await _store.completePurchase(purchase);
     _unacknowledgedPurchases.remove(proof.attemptId);
   }

--- a/mobile/packages/iap_repository/lib/src/in_app_purchase_validator.dart
+++ b/mobile/packages/iap_repository/lib/src/in_app_purchase_validator.dart
@@ -97,7 +97,7 @@ class InAppPurchaseValidator implements EntitlementValidator {
     switch (purchase.status) {
       case PurchaseStatus.purchased:
       case PurchaseStatus.restored:
-        if (context?.silent != true) {
+        if (context != null && !context.silent) {
           _lifecycleController.add(EntitlementLifecycle.confirming);
         }
         final proof = _proofFromPurchase(purchase, context);
@@ -127,7 +127,7 @@ class InAppPurchaseValidator implements EntitlementValidator {
         if (pending != null) {
           _pendingPurchases[purchase.productID] = pending;
         }
-        if (context?.silent != true) {
+        if (context != null && !context.silent) {
           _lifecycleController.add(EntitlementLifecycle.pending);
         }
     }

--- a/mobile/packages/iap_repository/test/in_app_purchase_validator_test.dart
+++ b/mobile/packages/iap_repository/test/in_app_purchase_validator_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:iap_repository/iap_repository.dart';
 import 'package:in_app_purchase/in_app_purchase.dart';
@@ -432,6 +433,38 @@ void main() {
           expect(firstAttemptId, (await secondProof).attemptId);
         },
       );
+
+      for (final platform in [TargetPlatform.iOS, TargetPlatform.android]) {
+        test(
+          'completes verified restored transactions appropriately on $platform',
+          () async {
+            debugDefaultTargetPlatformOverride = platform;
+            addTearDown(() => debugDefaultTargetPlatformOverride = null);
+            final purchase = _purchase(
+              'divine.supporter.monthly',
+              status: PurchaseStatus.restored,
+              purchaseID: '12345',
+            );
+            when(
+              () => store.completePurchase(purchase),
+            ).thenAnswer((_) async {});
+            validator.startListening();
+            final proofFuture = validator.purchaseProofChanges.first;
+            streamController.add([purchase]);
+            final proof = await proofFuture;
+            verifyNever(() => store.completePurchase(purchase));
+
+            await validator.completePurchase(proof);
+            await validator.completePurchase(proof);
+
+            if (platform == TargetPlatform.iOS) {
+              verify(() => store.completePurchase(purchase)).called(1);
+            } else {
+              verifyNever(() => store.completePurchase(purchase));
+            }
+          },
+        );
+      }
 
       test(
         'silent restore does not emit interactive lifecycle state',

--- a/mobile/packages/iap_repository/test/in_app_purchase_validator_test.dart
+++ b/mobile/packages/iap_repository/test/in_app_purchase_validator_test.dart
@@ -142,7 +142,13 @@ void main() {
           ).thenAnswer((_) => const Stream<List<PurchaseDetails>>.empty());
           await expectLater(
             validator.purchase('divine.supporter.monthly'),
-            throwsA(isA<PurchaseFailedException>()),
+            throwsA(
+              isA<PurchaseFailedException>().having(
+                (error) => error.responseCode,
+                'responseCode',
+                'not_started',
+              ),
+            ),
           );
         },
       );
@@ -256,7 +262,16 @@ void main() {
             status: PurchaseStatus.canceled,
           ),
         ]);
-        await expectLater(future, throwsA(isA<PurchaseFailedException>()));
+        await expectLater(
+          future,
+          throwsA(
+            isA<PurchaseFailedException>().having(
+              (error) => error.responseCode,
+              'responseCode',
+              'cancelled',
+            ),
+          ),
+        );
       });
 
       test(

--- a/mobile/packages/iap_repository/test/in_app_purchase_validator_test.dart
+++ b/mobile/packages/iap_repository/test/in_app_purchase_validator_test.dart
@@ -319,7 +319,7 @@ void main() {
       });
 
       test(
-        'passive renewal delivers proof without entering interactive purchase state',
+        'passive renewal delivers proof without interactive progress',
         () async {
           final lifecycle = <EntitlementLifecycle>[];
           validator.lifecycleChanges.listen(lifecycle.add);

--- a/mobile/packages/iap_repository/test/in_app_purchase_validator_test.dart
+++ b/mobile/packages/iap_repository/test/in_app_purchase_validator_test.dart
@@ -318,6 +318,23 @@ void main() {
         expect(emitted, isEmpty);
       });
 
+      test(
+        'passive renewal delivers proof without entering interactive purchase state',
+        () async {
+          final lifecycle = <EntitlementLifecycle>[];
+          validator.lifecycleChanges.listen(lifecycle.add);
+          validator.startListening();
+          final proofFuture = validator.purchaseProofChanges.first;
+          streamController.add([
+            _purchase('divine.supporter.monthly', purchaseID: 'renewal-123'),
+          ]);
+          final proof = await proofFuture;
+          expect(proof.transactionId, 'renewal-123');
+          expect(proof.capturedPubkey, isNull);
+          expect(lifecycle, isEmpty);
+        },
+      );
+
       test('emits pending and confirming lifecycle states', () async {
         final emitted = <EntitlementLifecycle>[];
         validator.lifecycleChanges.listen(emitted.add);

--- a/mobile/test/blocs/supporter/supporter_cubit_test.dart
+++ b/mobile/test/blocs/supporter/supporter_cubit_test.dart
@@ -27,6 +27,7 @@ class _FakeRepository extends Fake implements SupporterRepository {
   bool get hasServerClient => false;
 
   Object? purchaseError;
+  Completer<SupporterEntitlement>? purchaseCompleter;
 
   @override
   Stream<SupporterEntitlement> get changes => _controller.stream;
@@ -34,7 +35,7 @@ class _FakeRepository extends Fake implements SupporterRepository {
   @override
   Future<SupporterEntitlement> purchase(String productId) async {
     if (purchaseError != null) throw purchaseError!;
-    return validator.purchase(productId);
+    return purchaseCompleter?.future ?? validator.purchase(productId);
   }
 
   @override
@@ -315,6 +316,103 @@ void main() {
   });
 
   group('purchase lifecycle', () {
+    test('late store completion does not overwrite verified status', () async {
+      final events = <String>[];
+      final repo = _FakeRepository(controller)
+        ..purchaseCompleter = Completer<SupporterEntitlement>();
+      final cubit = SupporterCubit(repository: repo, trackEvent: events.add);
+      addTearDown(cubit.close);
+      cubit.start();
+      await pumpEventQueue();
+      final purchase = cubit.subscribe('divine.supporter.monthly');
+      controller.add(
+        const SupporterEntitlement(
+          productId: 'divine.supporter.monthly',
+          source: EntitlementSource.server,
+        ),
+      );
+      await pumpEventQueue();
+      repo.purchaseCompleter!.complete(SupporterEntitlement.inactive);
+      await purchase;
+
+      expect(cubit.state.isSupporter, isTrue);
+      expect(cubit.state.status, SupporterStatus.active);
+      expect(
+        events.where((event) => event == 'supporter_subscribe_succeeded'),
+        hasLength(1),
+      );
+    });
+
+    test('records success only after canonical activation', () async {
+      final events = <String>[];
+      final repo = _FakeRepository(controller);
+      final cubit = SupporterCubit(repository: repo, trackEvent: events.add);
+      addTearDown(cubit.close);
+      cubit.start();
+      await pumpEventQueue();
+
+      await cubit.subscribe('divine.supporter.monthly');
+
+      expect(cubit.state.status, SupporterStatus.confirming);
+      expect(events, ['supporter_subscribe_tapped']);
+
+      controller.add(
+        const SupporterEntitlement(
+          productId: 'divine.supporter.monthly',
+          source: EntitlementSource.server,
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(cubit.state.isSupporter, isTrue);
+      expect(events, [
+        'supporter_subscribe_tapped',
+        'supporter_subscribe_succeeded',
+      ]);
+    });
+
+    test('records failed verification instead of purchase success', () async {
+      final events = <String>[];
+      final cubit = SupporterCubit(
+        repository: _FakeRepository(controller),
+        trackEvent: events.add,
+      );
+      addTearDown(cubit.close);
+      cubit.start();
+      await pumpEventQueue();
+      await cubit.subscribe('divine.supporter.monthly');
+      controller.addError(
+        const SupporterApiException(
+          SupporterApiFailureKind.unavailable,
+          'Verification unavailable.',
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(cubit.state.isBusy, isFalse);
+      expect(events, [
+        'supporter_subscribe_tapped',
+        'supporter_subscribe_failed',
+      ]);
+    });
+
+    test('analytics failures cannot prevent a purchase', () async {
+      final repo = _FakeRepository(controller);
+      repo.validator.purchaseResult = const SupporterEntitlement(
+        productId: 'divine.supporter.monthly',
+        source: EntitlementSource.server,
+      );
+      final cubit = SupporterCubit(
+        repository: repo,
+        trackEvent: (_) => throw StateError('Analytics unavailable'),
+      );
+      addTearDown(cubit.close);
+
+      await cubit.subscribe('divine.supporter.monthly');
+
+      expect(cubit.state.isSupporter, isTrue);
+    });
+
     test(
       'surfaces verification failure received from the proof stream',
       () async {

--- a/mobile/test/services/supporter_api_client_test.dart
+++ b/mobile/test/services/supporter_api_client_test.dart
@@ -123,53 +123,64 @@ void main() {
       },
     );
 
-    test(
-      'claim sends idempotency key and opaque proof without changing it',
-      () async {
-        late String requestBody;
-        when(
-          () => httpClient.post(
-            any(),
-            headers: any(named: 'headers'),
-            body: any(named: 'body'),
-          ),
-        ).thenAnswer((invocation) async {
-          requestBody = invocation.namedArguments[#body] as String;
-          return http.Response(
-            jsonEncode({
-              'status': 'active',
-              'entitlement': {
-                'productId': 'divine.supporter.monthly',
-                'source': 'server',
-                'isActive': true,
-              },
-              'recognition': {},
-            }),
-            200,
+    for (final existingOwnerOnly in [false, true]) {
+      test(
+        'signs the exact proof and endpoint (existingOwnerOnly=$existingOwnerOnly)',
+        () async {
+          late String requestBody;
+          late Uri requestUri;
+          when(
+            () => httpClient.post(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer((invocation) async {
+            requestUri = invocation.positionalArguments.first as Uri;
+            requestBody = invocation.namedArguments[#body] as String;
+            return http.Response(
+              jsonEncode({
+                'status': 'active',
+                'entitlement': {
+                  'productId': 'divine.supporter.monthly',
+                  'source': 'server',
+                  'isActive': true,
+                },
+                'recognition': {},
+              }),
+              200,
+            );
+          });
+
+          final proof = {'signed_payload': 'opaque-proof-material'};
+          await buildClient().claimPurchase(
+            SupporterPurchaseClaim(
+              store: 'apple',
+              productId: 'divine.supporter.monthly',
+              idempotencyKey: 'attempt-1234567890',
+              proof: proof,
+            ),
+            existingOwnerOnly: existingOwnerOnly,
+            expectedPubkey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           );
-        });
 
-        final proof = {'signed_payload': 'opaque-proof-material'};
-        await buildClient().claimPurchase(
-          SupporterPurchaseClaim(
-            store: 'apple',
-            productId: 'divine.supporter.monthly',
-            idempotencyKey: 'attempt-1234567890',
-            proof: proof,
-          ),
-          expectedPubkey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        );
-
-        expect(jsonDecode(requestBody), {
-          'store': 'apple',
-          'product_id': 'divine.supporter.monthly',
-          'idempotency_key': 'attempt-1234567890',
-          'proof': proof,
-        });
-        expect(authCalls.single.method, HttpMethod.post);
-        expect(authCalls.single.payload, requestBody);
-      },
-    );
+          expect(jsonDecode(requestBody), {
+            'store': 'apple',
+            'product_id': 'divine.supporter.monthly',
+            'idempotency_key': 'attempt-1234567890',
+            'proof': proof,
+          });
+          final endpoint = existingOwnerOnly ? 'restore' : 'claim';
+          expect(
+            requestUri.toString(),
+            'https://supporters.test/v1/purchases/$endpoint',
+          );
+          expect(authCalls.single.url, requestUri.toString());
+          expect(authCalls.single.method, HttpMethod.post);
+          expect(authCalls.single.payload, requestBody);
+        },
+      );
+    }
 
     test('rejects a claim signed by a different account', () async {
       final client = SupporterApiClient(

--- a/mobile/test/services/supporter_api_client_test.dart
+++ b/mobile/test/services/supporter_api_client_test.dart
@@ -40,6 +40,43 @@ void main() {
   tearDown(() => httpClient.close());
 
   group('SupporterApiClient methods', () {
+    test('does not extend expired billing grace', () {
+      final past = DateTime.now().toUtc().subtract(const Duration(days: 1));
+      final snapshot = SupporterAccountSnapshot.fromJson({
+        'status': 'grace',
+        'entitlement': {
+          'isActive': true,
+          'expirationDate': past
+              .subtract(const Duration(days: 3))
+              .toIso8601String(),
+        },
+        'graceThroughAt': past.toIso8601String(),
+      });
+      expect(snapshot.entitlement.isSupporter, isFalse);
+    });
+
+    test('preserves supporter status until billing grace ends', () {
+      final paidThrough = DateTime.now().toUtc().subtract(
+        const Duration(days: 1),
+      );
+      final graceThrough = DateTime.now().toUtc().add(const Duration(days: 3));
+      final snapshot = SupporterAccountSnapshot.fromJson({
+        'status': 'grace',
+        'entitlement': {
+          'productId': 'divine.supporter.monthly',
+          'source': 'app_store',
+          'isActive': true,
+          'expirationDate': paidThrough.toIso8601String(),
+        },
+        'paidThroughAt': paidThrough.toIso8601String(),
+        'graceThroughAt': graceThrough.toIso8601String(),
+      });
+
+      expect(snapshot.entitlement.isSupporter, isTrue);
+      expect(snapshot.entitlement.expirationDate, graceThrough);
+      expect(snapshot.paidThrough, paidThrough);
+    });
+
     test(
       'fetchMe signs the exact Worker URL and maps canonical state',
       () async {

--- a/mobile/test/services/supporter_repository_test.dart
+++ b/mobile/test/services/supporter_repository_test.dart
@@ -815,7 +815,7 @@ void main() {
     });
 
     test(
-      'preserves purchase ownership across account switch and restart',
+      'routes a foreign purchase through owned restore after account switch',
       () async {
         final prefs = await SharedPreferences.getInstance();
         final apiClientA = buildApiClient();
@@ -828,12 +828,17 @@ void main() {
         );
         await original.purchase('divine.supporter.monthly');
         original.dispose();
-        var claims = 0;
+        final paths = <String>[];
         final apiClientB = SupporterApiClient(
           baseUri: Uri.parse('https://supporters.test'),
-          httpClient: MockClient((_) async {
-            claims++;
-            return http.Response('{}', 200);
+          httpClient: MockClient((request) async {
+            paths.add(request.url.path);
+            return http.Response(
+              jsonEncode({
+                'error': {'code': 'ownership_conflict'},
+              }),
+              409,
+            );
           }),
           authHeaderProvider:
               ({required url, required method, payload}) async =>
@@ -860,7 +865,7 @@ void main() {
         );
         await pumpEventQueue();
 
-        expect(claims, 0);
+        expect(paths, ['/v1/purchases/restore']);
         expect(switched.isSupporter, isFalse);
         expect(validator.completePurchaseCallCount, 0);
       },
@@ -1077,8 +1082,10 @@ void main() {
 
         // B starts a purchase, setting the product-scoped pending marker to B.
         await repoB.purchase('divine.supporter.monthly');
-        // Account A's paid-but-unclaimed transaction redelivers unsolicited:
-        // no proof-owner marker, no captured pubkey, silent.
+        // Account A's paid-but-unclaimed transaction redelivers during B's
+        // automatic recovery. The restore context captures B even though the
+        // receipt may belong to another store account, so silent recovery must
+        // never treat that captured pubkey as first-time claim authority.
         validator.proofController.add(
           const SupporterPurchaseProof(
             attemptId: 'account-a-unfinished',
@@ -1086,6 +1093,7 @@ void main() {
             productId: 'divine.supporter.monthly',
             serverVerificationData: 'account-a-receipt',
             localVerificationData: '',
+            capturedPubkey: pubkeyB,
             silent: true,
           ),
         );

--- a/mobile/test/services/supporter_repository_test.dart
+++ b/mobile/test/services/supporter_repository_test.dart
@@ -1097,5 +1097,44 @@ void main() {
         expect(repoB.isSupporter, isFalse);
       },
     );
+
+    test('preflight rejects a purchase when another account holds the pending '
+        'marker', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final clientA = buildApiClient();
+      final clientB = buildApiClient(pubkey: pubkeyB);
+      addTearDown(clientA.dispose);
+      addTearDown(clientB.dispose);
+      // Account A leaves a pending marker by starting (not finishing) a buy.
+      final repoA = SupporterRepository(
+        pubkey: pubkeyA,
+        validator: validator,
+        prefs: prefs,
+        apiClient: clientA,
+      );
+      await repoA.purchase('divine.supporter.monthly');
+      repoA.dispose();
+      final purchasesBefore = validator.purchaseCallCount;
+
+      final repoB = SupporterRepository(
+        pubkey: pubkeyB,
+        validator: validator,
+        prefs: prefs,
+        apiClient: clientB,
+      );
+      addTearDown(repoB.dispose);
+      await expectLater(
+        repoB.purchase('divine.supporter.monthly'),
+        throwsA(
+          isA<SupporterApiException>().having(
+            (error) => error.kind,
+            'kind',
+            SupporterApiFailureKind.ownershipConflict,
+          ),
+        ),
+      );
+      // B never reached the store: preflight refused before billing started.
+      expect(validator.purchaseCallCount, purchasesBefore);
+    });
   });
 }

--- a/mobile/test/services/supporter_repository_test.dart
+++ b/mobile/test/services/supporter_repository_test.dart
@@ -28,7 +28,10 @@ class _FakeValidator implements EntitlementValidator {
   int purchaseCallCount = 0;
   int completePurchaseCallCount = 0;
   Completer<void>? completionObserved;
+  void Function()? onRestore;
+  Object? completionError;
   Object? restoreError;
+  Object? purchaseError;
   Completer<void>? restoreCompleter;
 
   @override
@@ -47,6 +50,7 @@ class _FakeValidator implements EntitlementValidator {
     String? attemptId,
   }) async {
     purchaseCallCount++;
+    if (purchaseError != null) throw purchaseError!;
     return purchaseResult;
   }
 
@@ -60,6 +64,7 @@ class _FakeValidator implements EntitlementValidator {
     restoredPubkey = capturedPubkey;
     restoredSilently = silent;
     if (restoreError != null) throw restoreError!;
+    onRestore?.call();
     await restoreCompleter?.future;
     return purchaseResult;
   }
@@ -77,6 +82,7 @@ class _FakeValidator implements EntitlementValidator {
   @override
   Future<void> completePurchase(SupporterPurchaseProof proof) async {
     completePurchaseCallCount++;
+    if (completionError != null) throw completionError!;
     completionObserved?.complete();
   }
 
@@ -99,6 +105,7 @@ void main() {
 
   SupporterApiClient buildApiClient({
     bool active = false,
+    String pubkey = pubkeyA,
     int? claimStatus,
     String? claimErrorCode,
     Completer<void>? claimObserved,
@@ -129,7 +136,7 @@ void main() {
         );
       }),
       authHeaderProvider: ({required url, required method, payload}) async =>
-          (authorizationHeader: 'Nostr test-token', pubkey: pubkeyA),
+          (authorizationHeader: 'Nostr test-token', pubkey: pubkey),
     );
   }
 
@@ -151,6 +158,177 @@ void main() {
     tearDown(() {
       controller.close();
     });
+
+    for (final error in <Object>[
+      const StoreUnavailableException(),
+      const PurchaseFailedException('not_started', 'Store did not start.'),
+      const PurchaseFailedException('cancelled', 'Canceled.'),
+    ]) {
+      test('releases pending ownership after $error', () async {
+        final prefs = await SharedPreferences.getInstance();
+        final clientA = buildApiClient();
+        final clientB = buildApiClient(pubkey: pubkeyB);
+        addTearDown(clientA.dispose);
+        addTearDown(clientB.dispose);
+        final repoA = SupporterRepository(
+          pubkey: pubkeyA,
+          validator: validator,
+          prefs: prefs,
+          apiClient: clientA,
+        );
+        validator.purchaseError = error;
+        await expectLater(
+          repoA.purchase('divine.supporter.monthly'),
+          throwsA(same(error)),
+        );
+        repoA.dispose();
+        validator.purchaseError = null;
+        final repoB = SupporterRepository(
+          pubkey: pubkeyB,
+          validator: validator,
+          prefs: prefs,
+          apiClient: clientB,
+        );
+        addTearDown(repoB.dispose);
+        await repoB.purchase('divine.supporter.monthly');
+        expect(validator.purchaseCallCount, 2);
+      });
+    }
+
+    test('rejected legacy restore does not block the rightful owner', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final clientB = buildApiClient(
+        pubkey: pubkeyB,
+        claimStatus: 409,
+        claimErrorCode: 'ownership_conflict',
+      );
+      final repoB = SupporterRepository(
+        pubkey: pubkeyB,
+        validator: validator,
+        prefs: prefs,
+        apiClient: clientB,
+      );
+      addTearDown(clientB.dispose);
+      final errors = <Object>[];
+      repoB.changes.listen((_) {}, onError: errors.add);
+      validator.proofController.add(
+        const SupporterPurchaseProof(
+          attemptId: 'legacy-proof',
+          store: 'apple',
+          productId: 'divine.supporter.monthly',
+          serverVerificationData: 'opaque-proof',
+          localVerificationData: '',
+          capturedPubkey: pubkeyB,
+        ),
+      );
+      await pumpEventQueue();
+      expect(errors, hasLength(1));
+      repoB.dispose();
+      final clientA = buildApiClient(active: true);
+      addTearDown(clientA.dispose);
+      final repoA = SupporterRepository(
+        pubkey: pubkeyA,
+        validator: validator,
+        prefs: prefs,
+        apiClient: clientA,
+      );
+      addTearDown(repoA.dispose);
+      repoA.changes.listen((_) {}, onError: errors.add);
+      validator.proofController.add(
+        const SupporterPurchaseProof(
+          attemptId: 'legacy-proof',
+          store: 'apple',
+          productId: 'divine.supporter.monthly',
+          serverVerificationData: 'opaque-proof',
+          localVerificationData: '',
+          capturedPubkey: pubkeyA,
+        ),
+      );
+      await pumpEventQueue();
+      expect(repoA.isSupporter, isTrue);
+      expect(validator.completePurchaseCallCount, 1);
+      expect(errors, hasLength(1));
+    });
+
+    test(
+      'failed retry preserves ownership of an earlier unfinished purchase',
+      () async {
+        final prefs = await SharedPreferences.getInstance();
+        const pendingKey =
+            'divine_supporter_pending_owner:divine.supporter.monthly';
+        await prefs.setString(pendingKey, pubkeyA);
+        final client = buildApiClient();
+        addTearDown(client.dispose);
+        final repo = SupporterRepository(
+          pubkey: pubkeyA,
+          validator: validator,
+          prefs: prefs,
+          apiClient: client,
+        );
+        addTearDown(repo.dispose);
+        validator.purchaseError = const StoreUnavailableException();
+        await expectLater(
+          repo.purchase('divine.supporter.monthly'),
+          throwsA(isA<StoreUnavailableException>()),
+        );
+        expect(prefs.getString(pendingKey), pubkeyA);
+      },
+    );
+
+    test(
+      'legacy restore stays unbound through transient and ownership failures',
+      () async {
+        final prefs = await SharedPreferences.getInstance();
+        var status = 503;
+        final client = SupporterApiClient(
+          baseUri: Uri.parse('https://supporters.test'),
+          httpClient: MockClient(
+            (request) async => http.Response(
+              jsonEncode({
+                'error': {
+                  'code': status == 409
+                      ? 'ownership_conflict'
+                      : 'verification_unavailable',
+                },
+              }),
+              status,
+            ),
+          ),
+          authHeaderProvider:
+              ({required url, required method, payload}) async =>
+                  (authorizationHeader: 'Nostr test-token', pubkey: pubkeyB),
+        );
+        addTearDown(client.dispose);
+        final repo = SupporterRepository(
+          pubkey: pubkeyB,
+          validator: validator,
+          prefs: prefs,
+          apiClient: client,
+        );
+        addTearDown(repo.dispose);
+        final errors = <Object>[];
+        repo.changes.listen((_) {}, onError: errors.add);
+        const proof = SupporterPurchaseProof(
+          attemptId: 'legacy-retry-proof',
+          store: 'apple',
+          productId: 'divine.supporter.monthly',
+          serverVerificationData: 'opaque-proof',
+          localVerificationData: '',
+          capturedPubkey: pubkeyB,
+        );
+        validator.proofController.add(proof);
+        await pumpEventQueue();
+        expect(errors, hasLength(1));
+        status = 409;
+        validator.proofController.add(proof);
+        await pumpEventQueue();
+        expect(errors, hasLength(2));
+        expect(
+          prefs.getString('divine_supporter_proof_owner:legacy-retry-proof'),
+          isNull,
+        );
+      },
+    );
 
     test('loads inactive when no cache present', () async {
       final prefs = await SharedPreferences.getInstance();
@@ -380,24 +558,27 @@ void main() {
       },
     );
 
-    test('skips store restore when canonical entitlement is active', () async {
-      final prefs = await SharedPreferences.getInstance();
-      final apiClient = buildApiClient(active: true);
-      final repo = SupporterRepository(
-        pubkey: pubkeyA,
-        validator: validator,
-        prefs: prefs,
-        apiClient: apiClient,
-      );
-      addTearDown(repo.dispose);
-      addTearDown(apiClient.dispose);
+    test(
+      'restores once to acknowledge purchases even when already active',
+      () async {
+        final prefs = await SharedPreferences.getInstance();
+        final apiClient = buildApiClient(active: true);
+        final repo = SupporterRepository(
+          pubkey: pubkeyA,
+          validator: validator,
+          prefs: prefs,
+          apiClient: apiClient,
+        );
+        addTearDown(repo.dispose);
+        addTearDown(apiClient.dispose);
 
-      await repo.recoverPurchases();
-      await repo.recoverPurchases();
+        await repo.recoverPurchases();
+        await repo.recoverPurchases();
 
-      expect(repo.isSupporter, isTrue);
-      expect(validator.restoreCallCount, 0);
-    });
+        expect(repo.isSupporter, isTrue);
+        expect(validator.restoreCallCount, 1);
+      },
+    );
 
     test('does not repeat a successful recovery in the same process', () async {
       final prefs = await SharedPreferences.getInstance();
@@ -444,6 +625,10 @@ void main() {
 
     test('does not retry a purchase owned by another account', () async {
       final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'divine_supporter_proof_owner:stable-attempt-1234',
+        pubkeyA,
+      );
       final claimObserved = Completer<void>();
       final apiClient = buildApiClient(
         claimStatus: 409,
@@ -476,6 +661,88 @@ void main() {
       await repo.recoverPurchases();
 
       expect(validator.restoreCallCount, 1);
+      expect(validator.completePurchaseCallCount, 0);
+    });
+
+    test('retries store acknowledgement after canonical activation', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'divine_supporter_proof_owner:stable-attempt-1234',
+        pubkeyA,
+      );
+      final apiClient = buildApiClient(active: true);
+      final repo = SupporterRepository(
+        pubkey: pubkeyA,
+        validator: validator,
+        prefs: prefs,
+        apiClient: apiClient,
+      );
+      addTearDown(repo.dispose);
+      addTearDown(apiClient.dispose);
+      validator.completionError = StateError('Store disconnected');
+      const proof = SupporterPurchaseProof(
+        attemptId: 'stable-attempt-1234',
+        store: 'google',
+        productId: 'divine.supporter.monthly',
+        serverVerificationData: 'opaque-proof',
+        localVerificationData: '',
+        capturedPubkey: pubkeyA,
+        silent: true,
+      );
+      validator.proofController.add(proof);
+      await pumpEventQueue();
+      expect(repo.isSupporter, isTrue);
+      expect(validator.completePurchaseCallCount, 1);
+      validator.completionError = null;
+      validator.completionObserved = Completer<void>();
+      validator.onRestore = () => validator.proofController.add(proof);
+
+      await repo.recoverPurchases();
+      await validator.completionObserved!.future;
+
+      expect(validator.completePurchaseCallCount, 2);
+    });
+
+    test('failed claim during restore remains retryable', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'divine_supporter_proof_owner:stable-attempt-1234',
+        pubkeyA,
+      );
+      final claimObserved = Completer<void>();
+      final apiClient = buildApiClient(
+        claimStatus: 503,
+        claimObserved: claimObserved,
+      );
+      final repo = SupporterRepository(
+        pubkey: pubkeyA,
+        validator: validator,
+        prefs: prefs,
+        apiClient: apiClient,
+      );
+      addTearDown(repo.dispose);
+      addTearDown(apiClient.dispose);
+      validator.restoreCompleter = Completer<void>();
+      final recovery = repo.recoverPurchases();
+      await pumpEventQueue();
+      validator.proofController.add(
+        const SupporterPurchaseProof(
+          attemptId: 'stable-attempt-1234',
+          store: 'apple',
+          productId: 'divine.supporter.monthly',
+          serverVerificationData: 'opaque-proof',
+          localVerificationData: '',
+          capturedPubkey: pubkeyA,
+          silent: true,
+        ),
+      );
+      await claimObserved.future;
+      await pumpEventQueue();
+      validator.restoreCompleter!.complete();
+      await recovery;
+      await repo.recoverPurchases();
+
+      expect(validator.restoreCallCount, 2);
       expect(validator.completePurchaseCallCount, 0);
     });
 
@@ -545,6 +812,136 @@ void main() {
       // a verification client is configured.
       expect(validator.completePurchaseCallCount, 0);
       expect(repo.isSupporter, isFalse);
+    });
+
+    test(
+      'preserves purchase ownership across account switch and restart',
+      () async {
+        final prefs = await SharedPreferences.getInstance();
+        final apiClientA = buildApiClient();
+        addTearDown(apiClientA.dispose);
+        final original = SupporterRepository(
+          pubkey: pubkeyA,
+          validator: validator,
+          prefs: prefs,
+          apiClient: apiClientA,
+        );
+        await original.purchase('divine.supporter.monthly');
+        original.dispose();
+        var claims = 0;
+        final apiClientB = SupporterApiClient(
+          baseUri: Uri.parse('https://supporters.test'),
+          httpClient: MockClient((_) async {
+            claims++;
+            return http.Response('{}', 200);
+          }),
+          authHeaderProvider:
+              ({required url, required method, payload}) async =>
+                  (authorizationHeader: 'Nostr test-token', pubkey: pubkeyB),
+        );
+        addTearDown(apiClientB.dispose);
+        final switched = SupporterRepository(
+          pubkey: pubkeyB,
+          validator: validator,
+          prefs: prefs,
+          apiClient: apiClientB,
+        );
+        addTearDown(switched.dispose);
+        validator.proofController.add(
+          const SupporterPurchaseProof(
+            attemptId: 'stable-attempt-1234',
+            store: 'apple',
+            productId: 'divine.supporter.monthly',
+            serverVerificationData: 'opaque-proof',
+            localVerificationData: '',
+            capturedPubkey: pubkeyB,
+            silent: true,
+          ),
+        );
+        await pumpEventQueue();
+
+        expect(claims, 0);
+        expect(switched.isSupporter, isFalse);
+        expect(validator.completePurchaseCallCount, 0);
+      },
+    );
+
+    test('does not silently assign an unbound legacy purchase', () async {
+      final prefs = await SharedPreferences.getInstance();
+      var claims = 0;
+      final apiClient = SupporterApiClient(
+        baseUri: Uri.parse('https://supporters.test'),
+        httpClient: MockClient((_) async {
+          claims++;
+          return http.Response('{}', 200);
+        }),
+        authHeaderProvider: ({required url, required method, payload}) async =>
+            (authorizationHeader: 'Nostr test-token', pubkey: pubkeyA),
+      );
+      addTearDown(apiClient.dispose);
+      final repo = SupporterRepository(
+        pubkey: pubkeyA,
+        validator: validator,
+        prefs: prefs,
+        apiClient: apiClient,
+      );
+      addTearDown(repo.dispose);
+      validator.proofController.add(
+        const SupporterPurchaseProof(
+          attemptId: 'unbound-legacy-attempt',
+          store: 'apple',
+          productId: 'divine.supporter.monthly',
+          serverVerificationData: 'opaque-proof',
+          localVerificationData: '',
+          capturedPubkey: pubkeyA,
+          silent: true,
+        ),
+      );
+      await pumpEventQueue();
+      expect(claims, 0);
+      expect(validator.completePurchaseCallCount, 0);
+    });
+
+    test('checks authenticated server state before starting billing', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final apiClient = SupporterApiClient(
+        baseUri: Uri.parse('https://supporters.test'),
+        httpClient: MockClient((_) async => http.Response('', 503)),
+        authHeaderProvider: ({required url, required method, payload}) async =>
+            (authorizationHeader: 'Nostr test-token', pubkey: pubkeyA),
+      );
+      addTearDown(apiClient.dispose);
+      final repo = SupporterRepository(
+        pubkey: pubkeyA,
+        validator: validator,
+        prefs: prefs,
+        apiClient: apiClient,
+      );
+      addTearDown(repo.dispose);
+
+      await expectLater(
+        repo.purchase('divine.supporter.monthly'),
+        throwsA(isA<SupporterApiException>()),
+      );
+      expect(validator.purchaseCallCount, 0);
+    });
+
+    test('does not charge an already active supporter again', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final apiClient = buildApiClient(active: true);
+      addTearDown(apiClient.dispose);
+      final repo = SupporterRepository(
+        pubkey: pubkeyA,
+        validator: validator,
+        prefs: prefs,
+        apiClient: apiClient,
+      );
+      addTearDown(repo.dispose);
+
+      final entitlement = await repo.purchase('divine.supporter.monthly');
+
+      expect(entitlement.isSupporter, isTrue);
+      expect(validator.purchaseCallCount, 0);
     });
 
     test('refuses to start billing without a verification client', () async {

--- a/mobile/test/services/supporter_repository_test.dart
+++ b/mobile/test/services/supporter_repository_test.dart
@@ -866,41 +866,115 @@ void main() {
       },
     );
 
-    test('does not silently assign an unbound legacy purchase', () async {
-      final prefs = await SharedPreferences.getInstance();
-      var claims = 0;
-      final apiClient = SupporterApiClient(
-        baseUri: Uri.parse('https://supporters.test'),
-        httpClient: MockClient((_) async {
-          claims++;
-          return http.Response('{}', 200);
-        }),
-        authHeaderProvider: ({required url, required method, payload}) async =>
-            (authorizationHeader: 'Nostr test-token', pubkey: pubkeyA),
+    for (final status in [404, 503]) {
+      test(
+        'unbound automatic restore uses only the owned endpoint ($status)',
+        () async {
+          final prefs = await SharedPreferences.getInstance();
+          final paths = <String>[];
+          final apiClient = SupporterApiClient(
+            baseUri: Uri.parse('https://supporters.test'),
+            httpClient: MockClient((request) async {
+              paths.add(request.url.path);
+              return http.Response('{}', status);
+            }),
+            authHeaderProvider:
+                ({required url, required method, payload}) async =>
+                    (authorizationHeader: 'Nostr test-token', pubkey: pubkeyA),
+          );
+          addTearDown(apiClient.dispose);
+          final repo = SupporterRepository(
+            pubkey: pubkeyA,
+            validator: validator,
+            prefs: prefs,
+            apiClient: apiClient,
+          );
+          addTearDown(repo.dispose);
+          final errors = <Object>[];
+          repo.changes.listen((_) {}, onError: errors.add);
+          validator.proofController.add(
+            const SupporterPurchaseProof(
+              attemptId: 'unbound-legacy-attempt',
+              store: 'apple',
+              productId: 'divine.supporter.monthly',
+              serverVerificationData: 'opaque-proof',
+              localVerificationData: '',
+              capturedPubkey: pubkeyA,
+              silent: true,
+            ),
+          );
+          await pumpEventQueue();
+          expect(paths, ['/v1/purchases/restore']);
+          expect(validator.completePurchaseCallCount, 0);
+          expect(errors, isEmpty);
+          expect(
+            prefs.getString(
+              'divine_supporter_proof_owner:unbound-legacy-attempt',
+            ),
+            isNull,
+          );
+        },
       );
-      addTearDown(apiClient.dispose);
-      final repo = SupporterRepository(
-        pubkey: pubkeyA,
-        validator: validator,
-        prefs: prefs,
-        apiClient: apiClient,
+    }
+
+    for (final passive in [false, true]) {
+      test(
+        'recovers a server-owned renewal with a new transaction ID (passive=$passive)',
+        () async {
+          final prefs = await SharedPreferences.getInstance();
+          final paths = <String>[];
+          final apiClient = SupporterApiClient(
+            baseUri: Uri.parse('https://supporters.test'),
+            httpClient: MockClient((request) async {
+              paths.add(request.url.path);
+              return http.Response(
+                jsonEncode({
+                  'status': 'active',
+                  'entitlement': {
+                    'productId': 'divine.supporter.monthly',
+                    'source': 'server',
+                    'isActive': true,
+                  },
+                }),
+                200,
+              );
+            }),
+            authHeaderProvider:
+                ({required url, required method, payload}) async =>
+                    (authorizationHeader: 'Nostr test-token', pubkey: pubkeyA),
+          );
+          addTearDown(apiClient.dispose);
+          final repo = SupporterRepository(
+            pubkey: pubkeyA,
+            validator: validator,
+            prefs: prefs,
+            apiClient: apiClient,
+          );
+          addTearDown(repo.dispose);
+          validator.proofController.add(
+            SupporterPurchaseProof(
+              attemptId: 'new-renewal-transaction',
+              store: 'apple',
+              productId: 'divine.supporter.monthly',
+              serverVerificationData: 'opaque-proof',
+              localVerificationData: '',
+              capturedPubkey: passive ? null : pubkeyA,
+              silent: !passive,
+            ),
+          );
+          await pumpEventQueue();
+          expect(paths, ['/v1/purchases/restore']);
+          expect(repo.isSupporter, isTrue);
+          expect(validator.completePurchaseCallCount, 1);
+          expect(
+            prefs.getString(
+              'divine_supporter_proof_owner:new-renewal-transaction',
+            ),
+            pubkeyA,
+          );
+        },
       );
-      addTearDown(repo.dispose);
-      validator.proofController.add(
-        const SupporterPurchaseProof(
-          attemptId: 'unbound-legacy-attempt',
-          store: 'apple',
-          productId: 'divine.supporter.monthly',
-          serverVerificationData: 'opaque-proof',
-          localVerificationData: '',
-          capturedPubkey: pubkeyA,
-          silent: true,
-        ),
-      );
-      await pumpEventQueue();
-      expect(claims, 0);
-      expect(validator.completePurchaseCallCount, 0);
-    });
+    }
 
     test('checks authenticated server state before starting billing', () async {
       final prefs = await SharedPreferences.getInstance();

--- a/mobile/test/services/supporter_repository_test.dart
+++ b/mobile/test/services/supporter_repository_test.dart
@@ -1039,5 +1039,63 @@ void main() {
       );
       expect(validator.purchaseCallCount, 0);
     });
+
+    test(
+      'does not claim another account unfinished redelivery under the pending '
+      'account',
+      () async {
+        final prefs = await SharedPreferences.getInstance();
+        final posts = <String>[];
+        final clientB = SupporterApiClient(
+          baseUri: Uri.parse('https://supporters.test'),
+          httpClient: MockClient((request) async {
+            if (request.method == 'POST') posts.add(request.url.path);
+            return http.Response(
+              jsonEncode({
+                'status': 'inactive',
+                'entitlement': {
+                  'source': 'server',
+                  'isActive': false,
+                },
+                'recognition': <String, dynamic>{},
+              }),
+              200,
+            );
+          }),
+          authHeaderProvider:
+              ({required url, required method, payload}) async =>
+                  (authorizationHeader: 'Nostr test-token', pubkey: pubkeyB),
+        );
+        addTearDown(clientB.dispose);
+        final repoB = SupporterRepository(
+          pubkey: pubkeyB,
+          validator: validator,
+          prefs: prefs,
+          apiClient: clientB,
+        );
+        addTearDown(repoB.dispose);
+
+        // B starts a purchase, setting the product-scoped pending marker to B.
+        await repoB.purchase('divine.supporter.monthly');
+        // Account A's paid-but-unclaimed transaction redelivers unsolicited:
+        // no proof-owner marker, no captured pubkey, silent.
+        validator.proofController.add(
+          const SupporterPurchaseProof(
+            attemptId: 'account-a-unfinished',
+            store: 'apple',
+            productId: 'divine.supporter.monthly',
+            serverVerificationData: 'account-a-receipt',
+            localVerificationData: '',
+            silent: true,
+          ),
+        );
+        await pumpEventQueue();
+
+        // The redelivery must not first-time-claim A's receipt under B. It may
+        // only reach the restore endpoint, which the server fails closed.
+        expect(posts, isNot(contains('/v1/purchases/claim')));
+        expect(repoB.isSupporter, isFalse);
+      },
+    );
   });
 }


### PR DESCRIPTION
Closes #8935

## Description

A store purchase could finish while the app still had no verified supporter entitlement. The screen could then report purchase success too early, and recovery could miss an acknowledgment or stop retrying after a temporary verification failure.

This change checks authenticated account state before opening billing, saves the initiating account before a purchase starts, and retries unfinished claims and acknowledgments. Explicit restores of older purchases acquire local ownership only after the server accepts them. Background transactions without a saved local owner use the new server endpoint that can only restore an already-owned subscription; older servers fail closed without falling back to first-time binding. Definite purchase cancellations and failures to start release only the new attempt's ownership marker. Existing supporters retain access during verified billing grace. Verified Apple restores explicitly finish the transaction even when StoreKit 2 reports it as not pending completion.

The supporter screen now sends its funnel events through the analytics provider. Purchase success is recorded after canonical activation; analytics failures cannot interrupt payment or restoration. An already-active account returns from preflight without starting billing. The release checklist documents device acceptance, payment reconciliation, artifact provenance, and advertised-benefit gates.

**Related Issue:** Closes #8935. Backend recovery fix: https://github.com/divinevideo/divine-supporters/pull/9.

## Out of Scope

Production rollout, store product approval, new app releases, store financial reconciliation, and new supporter benefits. The feature flag remains gated. Deploy the backend recovery fix before enabling the updated mobile recovery flow.

## Verification

- Flutter 3.47.2: full `flutter analyze lib test integration_test` passed after rebase.
- 74 focused app/widget/localization tests passed after rebase; all 45 IAP package tests passed. The pre-push hook also passed its affected tests.
- Regression coverage includes temporary verification failure, acknowledgment retry, account switching/restart, wrong-account legacy restore, cancellation, failed initiation, grace expiry, and delayed purchase completion.
- Changed-screen localization scan and `git diff --check` passed. No visual layout or user-facing copy changes.
- Physical-device store purchases, renewal acknowledgment, and restorations have not been exercised in this change; they are explicit rollout gates in `mobile/docs/SUPPORTER_RELEASE_CHECKLIST.md`.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation


