### PR TITLE
fix(router): stop a stale saved route from crashing the app on launch

### DIFF
--- a/mobile/lib/router/restoration_safe_router_config.dart
+++ b/mobile/lib/router/restoration_safe_router_config.dart
@@ -1,0 +1,131 @@
+// ABOUTME: Router config that survives saved route state go_router cannot decode
+// ABOUTME: Guards the launch-loop crash in RouteMatchListCodec (#7869)
+
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/observability/crash_reporter.dart';
+import 'package:openvine/providers/crash_reporting_provider.dart';
+import 'package:openvine/router/app_router.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// The [RouterConfig] `MaterialApp.router` is given.
+///
+/// Held by a provider rather than built in `build` so the parser keeps its
+/// identity across a locale or appearance change. `Router.didUpdateWidget`
+/// invalidates its in-flight route transaction whenever the parser instance
+/// changes, which would drop a navigation that is still resolving.
+final routerConfigProvider = Provider<RouterConfig<RouteMatchList>>(
+  (ref) => restorationSafeRouterConfig(
+    ref.watch(goRouterProvider),
+    crashReporter: ref.watch(crashReportingServiceProvider),
+  ),
+);
+
+/// Wraps [router] so a saved route state it cannot decode is dropped rather
+/// than thrown out of the launch path.
+///
+/// The saved state is an optimization — it restores the imperative push stack
+/// on top of the location. The location itself travels in the URI and is
+/// enough to land the user on the right screen, so falling back to it costs a
+/// pushed route and keeps the app usable.
+RouterConfig<RouteMatchList> restorationSafeRouterConfig(
+  GoRouter router, {
+  CrashReporter crashReporter = const SilentCrashReporter(),
+}) {
+  return RouterConfig<RouteMatchList>(
+    routeInformationProvider: router.routeInformationProvider,
+    routeInformationParser: RestorationSafeRouteInformationParser(
+      router.routeInformationParser,
+      crashReporter: crashReporter,
+    ),
+    routerDelegate: router.routerDelegate,
+    backButtonDispatcher: router.backButtonDispatcher,
+  );
+}
+
+/// A [RouteInformationParser] that degrades a failed saved-state decode to a
+/// plain navigation to the same URI.
+///
+/// go_router builds the match list for an unresolvable location as
+/// `const <RouteMatch>[]` (`configuration.dart`, `parser.dart`). Restoring a
+/// state whose root location no longer resolves therefore copies that
+/// `List<RouteMatch>` in `RouteMatchList._createNewMatchUntilIncompatible` and
+/// appends the shell branch its imperative match resolved to, which throws
+/// `type 'ShellRouteMatch' is not a subtype of type 'RouteMatch' of 'value'`.
+///
+/// The throw lands in `Router.restoreState`, before the app is interactive,
+/// and the same state is replayed on every cold start — so an affected install
+/// loops rather than recovering. Still present in go_router 18.0.1, the latest
+/// release at the time of writing, so a version bump does not remove it.
+@visibleForTesting
+class RestorationSafeRouteInformationParser
+    extends RouteInformationParser<RouteMatchList> {
+  /// Creates a parser that guards [_delegate]'s saved-state decode.
+  RestorationSafeRouteInformationParser(
+    this._delegate, {
+    CrashReporter crashReporter = const SilentCrashReporter(),
+  }) : _crashReporter = crashReporter;
+
+  final RouteInformationParser<RouteMatchList> _delegate;
+  final CrashReporter _crashReporter;
+
+  @override
+  Future<RouteMatchList> parseRouteInformationWithDependencies(
+    RouteInformation routeInformation,
+    BuildContext context,
+  ) {
+    if (!_carriesEncodedMatchList(routeInformation)) {
+      return _delegate.parseRouteInformationWithDependencies(
+        routeInformation,
+        context,
+      );
+    }
+    try {
+      return _delegate.parseRouteInformationWithDependencies(
+        routeInformation,
+        context,
+      );
+    } catch (error, stackTrace) {
+      Log.error(
+        'Dropping undecodable saved route state for ${routeInformation.uri}',
+        name: 'RestorationSafeRouter',
+        category: LogCategory.ui,
+        error: error,
+        stackTrace: stackTrace,
+      );
+      unawaited(
+        _crashReporter.recordError(
+          error,
+          stackTrace,
+          reason: 'RestorationSafeRouter.parseRouteInformation',
+        ),
+      );
+      return _delegate.parseRouteInformationWithDependencies(
+        RouteInformation(uri: routeInformation.uri),
+        context,
+      );
+    }
+  }
+
+  @override
+  Future<RouteMatchList> parseRouteInformation(
+    RouteInformation routeInformation,
+  ) => _delegate.parseRouteInformation(routeInformation);
+
+  @override
+  RouteInformation? restoreRouteInformation(RouteMatchList configuration) =>
+      _delegate.restoreRouteInformation(configuration);
+
+  /// Whether go_router will decode [routeInformation]'s state as a stored
+  /// match list, which is the only branch that can throw here.
+  ///
+  /// A null state is a synthesized navigation and a [RouteInformationState] is
+  /// one of our own `go` / `push` calls; neither reaches the codec.
+  static bool _carriesEncodedMatchList(RouteInformation routeInformation) {
+    final state = routeInformation.state;
+    return state != null && state is! RouteInformationState;
+  }
+}

--- a/mobile/lib/router/router.dart
+++ b/mobile/lib/router/router.dart
@@ -3,6 +3,7 @@ export 'app_shell.dart';
 export 'auth_entry_redirect.dart';
 export 'navigator_keys.dart';
 export 'providers/providers.dart';
+export 'restoration_safe_router_config.dart';
 export 'route_error_screen.dart';
 export 'routes/routes.dart';
 export 'widgets/widgets.dart';

--- a/mobile/lib/startup/divine_material_app.dart
+++ b/mobile/lib/startup/divine_material_app.dart
@@ -42,7 +42,10 @@ class DivineMaterialApp extends ConsumerWidget {
         theme: VineTheme.lightTheme,
         darkTheme: VineTheme.theme,
         themeMode: themeMode,
-        routerConfig: ref.read(goRouterProvider),
+        // A saved route state go_router cannot decode must not take the
+        // launch path down with it — the same state replays on every cold
+        // start, so the crash loops instead of recovering (#7869).
+        routerConfig: ref.read(routerConfigProvider),
         locale: locale,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,

--- a/mobile/test/router/restoration_safe_router_config_test.dart
+++ b/mobile/test/router/restoration_safe_router_config_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Pins the saved-route-state guard against the go_router codec bug
 // ABOUTME: Regression coverage for the #7869 launch-loop crash
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -76,7 +78,9 @@ Future<RouteInformation> _savedStateFromRetiredLocation(
   await tester.pumpAndSettle();
   previousBuild.go('/retired');
   await tester.pumpAndSettle();
-  previousBuild.push('/home/detail');
+  // Fire-and-forget: the future completes when the pushed route pops, and
+  // this one never does.
+  unawaited(previousBuild.push('/home/detail'));
   await tester.pumpAndSettle();
   final saved = previousBuild.routeInformationParser.restoreRouteInformation(
     previousBuild.routerDelegate.currentConfiguration,
@@ -144,15 +148,17 @@ void main() {
         await tester.pumpAndSettle();
         final context = tester.element(find.byType(Navigator).first);
 
-        // Pins the defect the guard exists for. The decode runs before the
-        // parser's first await, so the throw is synchronous. When a future
-        // go_router release fixes `_createNewMatchUntilIncompatible`, this
-        // fails and the guard can go.
-        expect(
-          () => router.routeInformationParser
-              .parseRouteInformationWithDependencies(saved, context),
-          throwsA(isA<TypeError>()),
-        );
+        // Pins the defect the guard exists for. When a future go_router
+        // release fixes `_createNewMatchUntilIncompatible`, this fails and
+        // tells us the guard can go.
+        Object? thrown;
+        try {
+          await router.routeInformationParser
+              .parseRouteInformationWithDependencies(saved, context);
+        } catch (error) {
+          thrown = error;
+        }
+        expect(thrown, isA<TypeError>());
       });
 
       testWidgets('leaves an ordinary navigation untouched', (tester) async {

--- a/mobile/test/router/restoration_safe_router_config_test.dart
+++ b/mobile/test/router/restoration_safe_router_config_test.dart
@@ -1,0 +1,209 @@
+// ABOUTME: Pins the saved-route-state guard against the go_router codec bug
+// ABOUTME: Regression coverage for the #7869 launch-loop crash
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/observability/crash_reporter.dart';
+import 'package:openvine/router/restoration_safe_router_config.dart';
+
+class _RecordingCrashReporter implements CrashReporter {
+  final List<({Object error, String? reason})> recorded = [];
+
+  @override
+  void log(String message) {}
+
+  @override
+  Future<void> setCustomKey(String key, Object value) async {}
+
+  @override
+  Future<void> recordError(
+    Object error,
+    StackTrace? stack, {
+    String? reason,
+  }) async {
+    recorded.add((error: error, reason: reason));
+  }
+}
+
+/// A shell-based router in the shape of the app's own: bottom-nav branches
+/// wrapped in a `StatefulShellRoute`, with a detail route the user can push.
+GoRouter _buildRouter({required bool withRetiredRoute}) {
+  return GoRouter(
+    initialLocation: '/home',
+    routes: <RouteBase>[
+      if (withRetiredRoute)
+        GoRoute(path: '/retired', builder: (_, _) => const Text('retired')),
+      StatefulShellRoute.indexedStack(
+        builder: (context, state, shell) => shell,
+        branches: <StatefulShellBranch>[
+          StatefulShellBranch(
+            routes: <RouteBase>[
+              GoRoute(
+                path: '/home',
+                builder: (_, _) => const Text('home'),
+                routes: <RouteBase>[
+                  GoRoute(
+                    path: 'detail',
+                    builder: (_, _) => const Text('detail'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
+}
+
+/// Produces the saved route state an install would replay on cold start: a
+/// root location that the *next* build no longer serves, with an imperative
+/// push on top of it that still resolves through the shell.
+Future<RouteInformation> _savedStateFromRetiredLocation(
+  WidgetTester tester,
+) async {
+  final previousBuild = _buildRouter(withRetiredRoute: true);
+  addTearDown(previousBuild.dispose);
+  await tester.pumpWidget(
+    MaterialApp.router(
+      routerConfig: previousBuild,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+    ),
+  );
+  await tester.pumpAndSettle();
+  previousBuild.go('/retired');
+  await tester.pumpAndSettle();
+  previousBuild.push('/home/detail');
+  await tester.pumpAndSettle();
+  final saved = previousBuild.routeInformationParser.restoreRouteInformation(
+    previousBuild.routerDelegate.currentConfiguration,
+  );
+  expect(saved, isNotNull, reason: 'go_router must encode a state to restore');
+  expect(saved!.state, isNot(isA<RouteInformationState<Object?>>()));
+  return saved;
+}
+
+void main() {
+  group(RestorationSafeRouteInformationParser, () {
+    group('parseRouteInformationWithDependencies', () {
+      testWidgets('recovers when the saved root location no longer resolves', (
+        tester,
+      ) async {
+        final saved = await _savedStateFromRetiredLocation(tester);
+
+        final router = _buildRouter(withRetiredRoute: false);
+        addTearDown(router.dispose);
+        final reporter = _RecordingCrashReporter();
+        await tester.pumpWidget(
+          MaterialApp.router(
+            routerConfig: restorationSafeRouterConfig(
+              router,
+              crashReporter: reporter,
+            ),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
+        );
+        await tester.pumpAndSettle();
+        final context = tester.element(find.byType(Navigator).first);
+
+        final parser = RestorationSafeRouteInformationParser(
+          router.routeInformationParser,
+          crashReporter: reporter,
+        );
+        final matches = await parser.parseRouteInformationWithDependencies(
+          saved,
+          context,
+        );
+
+        expect(matches.uri.path, '/retired');
+        expect(reporter.recorded, hasLength(1));
+        expect(
+          reporter.recorded.single.reason,
+          'RestorationSafeRouter.parseRouteInformation',
+        );
+      });
+
+      testWidgets('the unguarded parser throws on that same state', (
+        tester,
+      ) async {
+        final saved = await _savedStateFromRetiredLocation(tester);
+
+        final router = _buildRouter(withRetiredRoute: false);
+        addTearDown(router.dispose);
+        await tester.pumpWidget(
+          MaterialApp.router(
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
+        );
+        await tester.pumpAndSettle();
+        final context = tester.element(find.byType(Navigator).first);
+
+        // Pins the defect the guard exists for. The decode runs before the
+        // parser's first await, so the throw is synchronous. When a future
+        // go_router release fixes `_createNewMatchUntilIncompatible`, this
+        // fails and the guard can go.
+        expect(
+          () => router.routeInformationParser
+              .parseRouteInformationWithDependencies(saved, context),
+          throwsA(isA<TypeError>()),
+        );
+      });
+
+      testWidgets('leaves an ordinary navigation untouched', (tester) async {
+        final router = _buildRouter(withRetiredRoute: false);
+        addTearDown(router.dispose);
+        final reporter = _RecordingCrashReporter();
+        await tester.pumpWidget(
+          MaterialApp.router(
+            routerConfig: restorationSafeRouterConfig(
+              router,
+              crashReporter: reporter,
+            ),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        router.go('/home/detail');
+        await tester.pumpAndSettle();
+
+        expect(find.text('detail'), findsOneWidget);
+        expect(reporter.recorded, isEmpty);
+      });
+    });
+
+    group('restoreRouteInformation', () {
+      testWidgets('delegates encoding unchanged', (tester) async {
+        final router = _buildRouter(withRetiredRoute: false);
+        addTearDown(router.dispose);
+        await tester.pumpWidget(
+          MaterialApp.router(
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final configuration = router.routerDelegate.currentConfiguration;
+        final parser = RestorationSafeRouteInformationParser(
+          router.routeInformationParser,
+        );
+
+        expect(
+          parser.restoreRouteInformation(configuration)?.uri,
+          router.routeInformationParser
+              .restoreRouteInformation(configuration)
+              ?.uri,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## The problem

An install crashed on launch, before the first frame, with

```
type 'ShellRouteMatch' is not a subtype of type 'RouteMatch' of 'value'
  at RouteMatchList._createNewMatchUntilIncompatible (go_router/src/match.dart:657)
  at RouteMatchList.push (go_router/src/match.dart:625)
  at _RouteMatchListDecoder.convert (go_router/src/match.dart:1057)
  at GoRouteInformationParser.parseRouteInformationWithDependencies
  at _RouterState.restoreState
```

The bad part is not the crash, it is that the app cannot get out of it. The state that produced the crash is the state the app saved, and it is replayed on every cold start — so an affected install crashes again, and again, until it is reinstalled.

## What causes it

go_router represents "this location matches no route" as a match list whose `matches` is `const <RouteMatch>[]` (`configuration.dart:198`, `parser.dart:662`). Every other match list is a `List<RouteMatchBase>`, which is the type that can also hold a `ShellRouteMatch`.

Restoring saved route state hits both at once. The decoder rebuilds the saved location, then replays each imperative `push` on top of it. If the saved root location no longer resolves in the running build — a route that was removed, renamed, or is behind a gate that is now closed — the base is the error list, and `_createNewMatchUntilIncompatible` copies it with `toList()`, preserving its `RouteMatch` element type. The push it then appends resolved through the bottom-nav `StatefulShellRoute`, so it is a `ShellRouteMatch`, and `List.add` throws.

This is a go_router defect, and it is **still present in 18.0.1**, the latest release — I checked the source rather than the changelog. So a version bump is not the fix, and the repo is on 16.3.0 regardless.

## The fix

`RestorationSafeRouteInformationParser` wraps go_router's parser and guards the one branch that can throw: the decode of a saved state. If it fails, the state is dropped and the same URI is navigated to normally.

That is a real degradation, and a small one. The saved state carries two things: the location, which also travels in `RouteInformation.uri`, and the imperative push stack on top of it. Dropping it costs the pushed route — the user lands on the saved screen instead of the screen they had pushed on top of it — and keeps the app launchable. The failure is logged and recorded as a non-fatal, so we can see whether it happens to anyone else.

The wrapped config is held by `routerConfigProvider` rather than built in `build`. `DivineMaterialApp` rebuilds on every locale and appearance change, and `Router.didUpdateWidget` invalidates its in-flight route transaction whenever the parser instance changes — building a new one per rebuild would drop a navigation that is still resolving.

## What this deliberately does not do

**It does not explain how the affected install got a restoration bucket.** Route restoration needs one, and `MaterialApp.router` is constructed with no `restorationScopeId` — which `git log -S` says has never been set in this repo. I could not close that gap, and I am not going to assert a mechanism I have not proven. It does not change the fix: both call sites in `Router.restoreState` funnel through `parseRouteInformationWithDependencies`, which is where the guard sits, so the guard holds either way.

**It does not fix go_router.** `const <RouteMatch>[]` should be `const <RouteMatchBase>[]` in both places. That belongs upstream in `flutter/packages`; this PR is the local guard so we stop shipping the crash while that happens.

## Verification

- New `test/router/restoration_safe_router_config_test.dart`. One test drives the real go_router codec into the exact reported failure — the stack it produces matches the Crashlytics one line for line — and pins that the unguarded parser throws, so the day a go_router release fixes this, that test fails and tells us the guard can go.
- `flutter analyze lib test integration_test` clean.
- `flutter test test/router test/startup` — 774 passing.
- Device-verified by @hm21 on a physical Samsung Galaxy (SM-S942B), Android 16: cold start, every tab and back, profile → settings → back, profile → library → back, a feed video opened and dismissed, the Android back gesture, scroll position held across a tab switch, the camera route opened over the shell and left again, and a kill-and-relaunch from the app switcher. No navigation regressions.

  Worth knowing for whoever reviews this: the relaunch comes back on the feed, not on the route that was open. That is the same evidence as the `restorationScopeId` gap above, from the other side — this build does not restore routes at all, so the device pass proves the guard is inert on the healthy path rather than proving it catches the crash. The unit test is what covers the failure.

  Unrelated and pre-existing: the Inbox tab currently renders an empty 114dp app bar above its own header. That is on `main` — #8956 added a second consumer to a single-subscription stream in `routerLocationStreamProvider`, which silently kills `pageContextProvider` and leaves the shell without a route context. It reproduces identically with this PR's one changed line reverted, so it is not from here.

Closes #7869
