### PR TITLE
fix(proof): verify a signed video before it overwrites the recording

### DIFF
--- a/mobile/docs/AI_TRAINING_POLICY.md
+++ b/mobile/docs/AI_TRAINING_POLICY.md
@@ -69,7 +69,7 @@ the signature.
 The assertion is built unconditionally by
 `C2paIdentityManifestService.buildCreatedVideoManifest`
 (`mobile/lib/services/c2pa_identity_manifest_service.dart`) and embedded
-during signing by `C2paSigningService.signVideo`
+during signing by `C2paSigningService.signVideoInPlace`
 (`mobile/lib/services/c2pa_signing_service.dart`).
 
 It also appears in the `referenced_assertions` list of the Nostr

--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -30,9 +30,10 @@ abstract class C2paEditActions {
 enum C2paSigningFailureReason {
   inputMissing,
 
-  /// Signing produced no usable output: either nothing was written, or the
-  /// file it wrote was empty. Both are reported here because neither can
-  /// replace the recording.
+  /// Signing produced no usable output: nothing was written, the file it
+  /// wrote was empty, or that file carries no readable active C2PA manifest.
+  /// All three are reported here because none of them may replace the
+  /// recording.
   outputMissing,
   tls,
   network,
@@ -53,6 +54,7 @@ class C2paSigningResult {
     required this.success,
     this.error,
     this.failureReason,
+    this.manifest,
   });
 
   /// Path to the signed video file
@@ -66,6 +68,13 @@ class C2paSigningResult {
 
   /// Machine-readable reason when signing failed.
   final C2paSigningFailureReason? failureReason;
+
+  /// The manifest read back out of the signed file, when signing succeeded.
+  ///
+  /// [C2paSigningService.signVideoInPlace] has to read this before it may
+  /// replace the input, so it hands the result to the caller rather than
+  /// making them read the same manifest off the same file a second time.
+  final ManifestStoreInfo? manifest;
 }
 
 /// Service for signing videos with C2PA content credentials.
@@ -117,17 +126,31 @@ class C2paSigningService {
   /// callers gate the "sign or skip" prompt on this (#6058).
   static bool get isSigningConfigured => !_signingDisabled;
 
-  /// Signs a video file with C2PA content credentials.
+  /// Signs the video at [videoPath] and **replaces it with the signed bytes**.
   ///
-  /// [videoPath] - Path to the video file to sign
+  /// The replacement is the point of this method, not a side effect. ProofMode
+  /// hashes the credentialed media, and the editor, exporter and uploader all
+  /// read the same path afterwards, so the signed file has to become the
+  /// canonical one. The name says so because the caller is handing over
+  /// ownership of the file: on success the bytes at [videoPath] are different
+  /// bytes, and the recording as captured no longer exists anywhere.
+  ///
+  /// Nothing replaces the input until the signed output has been read back and
+  /// found to carry an active C2PA manifest that does not fail validation. An
+  /// output that does not is deleted, and [videoPath] is left byte-for-byte
+  /// untouched — a file that merely exists and is non-empty is not evidence
+  /// that signing worked, and the input is the only copy.
+  ///
+  /// That successful read is returned as [C2paSigningResult.manifest] so the
+  /// caller does not read the same manifest off the same file again.
   ///
   /// The CAWG `training-mining` assertion (opt-out of AI training and data
   /// mining) is embedded unconditionally as a matter of Divine policy.
   /// See `mobile/docs/AI_TRAINING_POLICY.md`.
   ///
-  /// Returns the path to the signed video file, or the original path if
-  /// signing fails (signing is best-effort, not blocking).
-  Future<C2paSigningResult> signVideo({
+  /// Signing is best-effort and never throws: on failure the result carries
+  /// the original path, `success: false`, and a [C2paSigningFailureReason].
+  Future<C2paSigningResult> signVideoInPlace({
     required String videoPath,
     NostrCreatorBindingAssertion? creatorBindingAssertion,
     Map<String, dynamic>? cawgIdentityAssertion,
@@ -242,6 +265,26 @@ class C2paSigningService {
         );
       }
 
+      // The rename is irreversible and the input is the only copy, so prove
+      // the output is actually credentialed before trusting it with that.
+      // A non-empty file can still be a re-encode the signer never stamped.
+      final manifest = await readManifest(signedPath);
+      final rejection = _describeUnusableManifest(manifest);
+      if (rejection != null) {
+        _deleteSignedOutput(signedPath);
+        Log.warning(
+          'Refusing to replace "$videoPath": $rejection',
+          name: 'C2paSigningService',
+          category: LogCategory.video,
+        );
+        return C2paSigningResult(
+          signedFilePath: videoPath,
+          success: false,
+          error: 'Signed file $rejection',
+          failureReason: C2paSigningFailureReason.outputMissing,
+        );
+      }
+
       final sFileNew = signedFile.renameSync(inputFile.path);
       Log.debug(
         'Signed file renamed: ${sFileNew.path}',
@@ -256,7 +299,11 @@ class C2paSigningService {
         category: LogCategory.video,
       );
 
-      return C2paSigningResult(signedFilePath: sFileNew.path, success: true);
+      return C2paSigningResult(
+        signedFilePath: sFileNew.path,
+        success: true,
+        manifest: manifest,
+      );
     } catch (e, stackTrace) {
       final failureReason = classifyFailureReason(e);
       Log.error(
@@ -414,6 +461,27 @@ class C2paSigningService {
         error: e.toString(),
       );
     }
+  }
+
+  /// Why [manifest] does not establish that signing worked, or null when it
+  /// does.
+  ///
+  /// `ValidationStatus.unknown` passes deliberately. The library reports it
+  /// whenever the native read returned no `validation_status` key at all,
+  /// which is what an ordinary clean read looks like — only `invalid` is
+  /// positive evidence that the output is broken
+  /// (`ManifestStoreInfo._determineValidationStatus`). Rejecting `unknown`
+  /// would throw away correctly signed recordings.
+  static String? _describeUnusableManifest(ManifestStoreInfo? manifest) {
+    if (manifest == null) return 'carries no readable C2PA manifest';
+    if (manifest.activeManifest == null) {
+      return 'carries no active C2PA manifest';
+    }
+    if (manifest.validationStatus == ValidationStatus.invalid) {
+      return 'carries a C2PA manifest that failed validation '
+          '(${manifest.validationErrors.length} error(s))';
+    }
+    return null;
   }
 
   /// Removes the signed-file the native call may still write after a timeout.

--- a/mobile/lib/services/native_proofmode_service.dart
+++ b/mobile/lib/services/native_proofmode_service.dart
@@ -167,7 +167,9 @@ class NativeProofModeService {
         name: 'VideoRecorderProofService',
         category: LogCategory.video,
       );
-      final c2paResult = await c2paSigningService.signVideo(
+      // Replaces videoFile's bytes in place — deliberately, so the ProofMode
+      // hash below covers the credentialed media.
+      final c2paResult = await c2paSigningService.signVideoInPlace(
         videoPath: videoFile.path,
         creatorBindingAssertion: creatorBindingAssertion,
         cawgIdentityAssertion: cawgIdentityAssertion,
@@ -188,19 +190,10 @@ class NativeProofModeService {
         );
       }
 
-      final ManifestStoreInfo? manifestInfo;
-      if (c2paResult.success) {
-        manifestInfo = await c2paSigningService.readManifest(
-          c2paResult.signedFilePath,
-        );
-      } else {
-        manifestInfo = null;
-        Log.info(
-          'Skipping C2PA manifest read after failed signing (${c2paResult.failureReason?.name ?? 'unknown'})',
-          name: 'VideoRecorderProofService',
-          category: LogCategory.video,
-        );
-      }
+      // Signing already read this back off the signed file to decide whether
+      // it was safe to replace the recording, so reuse it rather than reading
+      // the same manifest off the same path again.
+      final ManifestStoreInfo? manifestInfo = c2paResult.manifest;
       if (manifestInfo?.validationStatus != null) {
         Log.debug('C2PA Active Manifest ID: ${manifestInfo?.activeManifest}');
       }

--- a/mobile/test/services/c2pa_signing_service_test.dart
+++ b/mobile/test/services/c2pa_signing_service_test.dart
@@ -187,7 +187,7 @@ void main() {
       );
     });
 
-    group('signVideo', () {
+    group('signVideoInPlace', () {
       test(
         'deletes the partial output when the native call throws (#7739)',
         () async {

--- a/mobile/test/services/c2pa_signing_service_test.dart
+++ b/mobile/test/services/c2pa_signing_service_test.dart
@@ -123,7 +123,9 @@ void main() {
           ),
         );
 
-        final result = await failingService.signVideo(videoPath: video.path);
+        final result = await failingService.signVideoInPlace(
+          videoPath: video.path,
+        );
 
         expect(result.success, isFalse);
         expect(result.signedFilePath, video.path);
@@ -140,7 +142,9 @@ void main() {
             signingTimeout: const Duration(milliseconds: 10),
           );
 
-          final result = await hangingService.signVideo(videoPath: video.path);
+          final result = await hangingService.signVideoInPlace(
+            videoPath: video.path,
+          );
 
           expect(result.success, isFalse);
           expect(
@@ -162,7 +166,9 @@ void main() {
             signingTimeout: const Duration(milliseconds: 10),
           );
 
-          final result = await slowService.signVideo(videoPath: video.path);
+          final result = await slowService.signVideoInPlace(
+            videoPath: video.path,
+          );
           expect(result.success, isFalse);
           expect(result.failureReason, C2paSigningFailureReason.network);
 
@@ -196,7 +202,9 @@ void main() {
             ),
           );
 
-          final result = await failingService.signVideo(videoPath: video.path);
+          final result = await failingService.signVideoInPlace(
+            videoPath: video.path,
+          );
 
           expect(result.success, isFalse);
           expect(
@@ -223,7 +231,7 @@ void main() {
             c2pa: _WritingC2pa(const []),
           );
 
-          final result = await emptyOutputService.signVideo(
+          final result = await emptyOutputService.signVideoInPlace(
             videoPath: video.path,
           );
 
@@ -244,11 +252,10 @@ void main() {
         'replaces the original in place and leaves nothing else behind',
         () async {
           final video = writeFile('video.mp4', const [0, 1, 2, 3]);
-          final service = C2paSigningService(
-            c2pa: _WritingC2pa(const [7, 8, 9, 10, 11]),
-          );
+          final c2pa = _WritingC2pa(const [7, 8, 9, 10, 11]);
+          final service = C2paSigningService(c2pa: c2pa);
 
-          final result = await service.signVideo(videoPath: video.path);
+          final result = await service.signVideoInPlace(videoPath: video.path);
 
           expect(result.success, isTrue);
           expect(result.error, isNull);
@@ -262,6 +269,125 @@ void main() {
             ),
             equals(['video.mp4']),
           );
+          // Handed to the caller so ProofMode does not read the same manifest
+          // off the same file a second time (#8799).
+          expect(result.manifest?.activeManifest, 'urn:c2pa:signed');
+          expect(c2pa.readManifestCallCount, 1);
+        },
+      );
+
+      test(
+        'keeps the recording when the output carries no manifest (#8799)',
+        () async {
+          final video = writeFile('video.mp4', const [0, 1, 2, 3]);
+          final service = C2paSigningService(
+            c2pa: _WritingC2pa(const [7, 8, 9], manifest: null),
+          );
+
+          final result = await service.signVideoInPlace(videoPath: video.path);
+
+          expect(result.success, isFalse);
+          expect(result.failureReason, C2paSigningFailureReason.outputMissing);
+          expect(result.signedFilePath, video.path);
+          expect(result.manifest, isNull);
+          expect(
+            video.readAsBytesSync(),
+            equals([0, 1, 2, 3]),
+            reason:
+                'a non-empty output that was never stamped must not replace '
+                'the only copy of the recording',
+          );
+          expect(signedLeftovers(), isEmpty);
+        },
+      );
+
+      test(
+        'keeps the recording when the manifest has no active claim (#8799)',
+        () async {
+          final video = writeFile('video.mp4', const [0, 1, 2, 3]);
+          final service = C2paSigningService(
+            c2pa: _WritingC2pa(
+              const [7, 8, 9],
+              manifest: const ManifestStoreInfo(),
+            ),
+          );
+
+          final result = await service.signVideoInPlace(videoPath: video.path);
+
+          expect(result.success, isFalse);
+          expect(result.failureReason, C2paSigningFailureReason.outputMissing);
+          expect(video.readAsBytesSync(), equals([0, 1, 2, 3]));
+          expect(signedLeftovers(), isEmpty);
+        },
+      );
+
+      test(
+        'keeps the recording when the manifest fails validation (#8799)',
+        () async {
+          final video = writeFile('video.mp4', const [0, 1, 2, 3]);
+          final service = C2paSigningService(
+            c2pa: _WritingC2pa(
+              const [7, 8, 9],
+              manifest: const ManifestStoreInfo(
+                activeManifest: 'urn:c2pa:broken',
+                validationErrors: [
+                  ValidationError(
+                    code: 'signingCredential.untrusted',
+                    message: 'untrusted signer',
+                  ),
+                ],
+                validationStatus: ValidationStatus.invalid,
+              ),
+            ),
+          );
+
+          final result = await service.signVideoInPlace(videoPath: video.path);
+
+          expect(result.success, isFalse);
+          expect(result.failureReason, C2paSigningFailureReason.outputMissing);
+          expect(video.readAsBytesSync(), equals([0, 1, 2, 3]));
+          expect(signedLeftovers(), isEmpty);
+        },
+      );
+
+      test(
+        'keeps the recording when the output cannot be read at all (#8799)',
+        () async {
+          final video = writeFile('video.mp4', const [0, 1, 2, 3]);
+          final service = C2paSigningService(
+            c2pa: _UnreadableManifestC2pa(const [7, 8, 9]),
+          );
+
+          final result = await service.signVideoInPlace(videoPath: video.path);
+
+          expect(result.success, isFalse);
+          expect(result.failureReason, C2paSigningFailureReason.outputMissing);
+          expect(video.readAsBytesSync(), equals([0, 1, 2, 3]));
+          expect(signedLeftovers(), isEmpty);
+        },
+      );
+
+      test(
+        'accepts an unknown validation status, which is a clean read (#8799)',
+        () async {
+          // `unknown` is what the library reports when the native read
+          // returned no `validation_status` key — the ordinary success shape.
+          // Only `invalid` is positive evidence the output is broken, so
+          // rejecting `unknown` would discard correctly signed recordings.
+          final video = writeFile('video.mp4', const [0, 1, 2, 3]);
+          final service = C2paSigningService(
+            c2pa: _WritingC2pa(
+              const [7, 8, 9],
+              manifest: const ManifestStoreInfo(
+                activeManifest: 'urn:c2pa:signed',
+              ),
+            ),
+          );
+
+          final result = await service.signVideoInPlace(videoPath: video.path);
+
+          expect(result.success, isTrue);
+          expect(video.readAsBytesSync(), equals([7, 8, 9]));
         },
       );
     });
@@ -480,8 +606,48 @@ class _WriteThenThrowC2pa extends C2pa {
   }
 }
 
+/// Simulates a signing call that writes [bytes] and, on read-back, reports
+/// [manifest].
+///
+/// The manifest matters as much as the bytes: signing reads its own output
+/// back before it is allowed to replace the recording, so a fake that reports
+/// nothing is a fake whose output must be rejected (#8799).
 class _WritingC2pa extends C2pa {
-  _WritingC2pa(this.bytes);
+  _WritingC2pa(
+    this.bytes, {
+    this.manifest = const ManifestStoreInfo(
+      activeManifest: 'urn:c2pa:signed',
+      validationStatus: ValidationStatus.valid,
+    ),
+  });
+
+  final List<int> bytes;
+  final ManifestStoreInfo? manifest;
+  int readManifestCallCount = 0;
+
+  @override
+  Future<void> signFile({
+    required String sourcePath,
+    required String destPath,
+    required String manifestJson,
+    required C2paSigner signer,
+  }) async {
+    File(destPath).writeAsBytesSync(bytes);
+  }
+
+  @override
+  Future<ManifestStoreInfo?> readManifestFromFile(
+    String path, {
+    ReaderOptions options = const ReaderOptions(),
+  }) async {
+    readManifestCallCount += 1;
+    return manifest;
+  }
+}
+
+/// Simulates an output the native reader cannot parse at all.
+class _UnreadableManifestC2pa extends C2pa {
+  _UnreadableManifestC2pa(this.bytes);
 
   final List<int> bytes;
 
@@ -493,5 +659,13 @@ class _WritingC2pa extends C2pa {
     required C2paSigner signer,
   }) async {
     File(destPath).writeAsBytesSync(bytes);
+  }
+
+  @override
+  Future<ManifestStoreInfo?> readManifestFromFile(
+    String path, {
+    ReaderOptions options = const ReaderOptions(),
+  }) async {
+    throw const FormatException('not a C2PA container');
   }
 }

--- a/mobile/test/services/native_proofmode_service_test.dart
+++ b/mobile/test/services/native_proofmode_service_test.dart
@@ -161,9 +161,7 @@ void main() {
       expect(proofData!.videoHash, generatedProofHash);
       expect(c2paService.readManifestCallCount, 0);
       expect(
-        _latestLogContaining(
-          'Skipping C2PA manifest read after failed signing (tls)',
-        ),
+        _latestLogContaining('C2PA signing failed (tls; continuing without)'),
         isNotNull,
       );
     });
@@ -261,7 +259,10 @@ void main() {
       expect(proofData, isNotNull);
       expect(proofData!.c2paManifestId, 'urn:c2pa:generated');
       expect(c2paService.signVideoCallCount, 1);
-      expect(c2paService.readManifestCallCount, 1);
+      // Signing already read the manifest back to decide it was safe to
+      // replace the recording, so proofFile reuses that read rather than
+      // performing a second one over the same file (#8799).
+      expect(c2paService.readManifestCallCount, 0);
     });
   });
 
@@ -361,7 +362,7 @@ class _FailingC2paSigningService extends C2paSigningService {
   int readManifestCallCount = 0;
 
   @override
-  Future<C2paSigningResult> signVideo({
+  Future<C2paSigningResult> signVideoInPlace({
     required String videoPath,
     NostrCreatorBindingAssertion? creatorBindingAssertion,
     Map<String, dynamic>? cawgIdentityAssertion,
@@ -387,7 +388,7 @@ class _ExistingProofC2paSigningService extends C2paSigningService {
   int signVideoCallCount = 0;
 
   @override
-  Future<C2paSigningResult> signVideo({
+  Future<C2paSigningResult> signVideoInPlace({
     required String videoPath,
     NostrCreatorBindingAssertion? creatorBindingAssertion,
     Map<String, dynamic>? cawgIdentityAssertion,
@@ -412,14 +413,18 @@ class _SuccessfulC2paSigningService extends C2paSigningService {
   int signVideoCallCount = 0;
 
   @override
-  Future<C2paSigningResult> signVideo({
+  Future<C2paSigningResult> signVideoInPlace({
     required String videoPath,
     NostrCreatorBindingAssertion? creatorBindingAssertion,
     Map<String, dynamic>? cawgIdentityAssertion,
     bool enableAdvancedCawgEmbedding = false,
   }) async {
     signVideoCallCount += 1;
-    return C2paSigningResult(signedFilePath: this.videoPath, success: true);
+    return C2paSigningResult(
+      signedFilePath: this.videoPath,
+      success: true,
+      manifest: const ManifestStoreInfo(activeManifest: 'urn:c2pa:generated'),
+    );
   }
 
   @override

--- a/mobile/test/services/native_proofmode_service_test.dart
+++ b/mobile/test/services/native_proofmode_service_test.dart
@@ -210,7 +210,7 @@ void main() {
       expect(proofData, isNotNull);
       expect(proofData!.c2paManifestId, 'urn:c2pa:existing');
       expect(c2paService.readManifestCallCount, 1);
-      expect(c2paService.signVideoCallCount, 0);
+      expect(c2paService.signVideoInPlaceCallCount, 0);
     });
 
     test('preserves the active manifest ID after generating a proof', () async {
@@ -258,7 +258,7 @@ void main() {
 
       expect(proofData, isNotNull);
       expect(proofData!.c2paManifestId, 'urn:c2pa:generated');
-      expect(c2paService.signVideoCallCount, 1);
+      expect(c2paService.signVideoInPlaceCallCount, 1);
       // Signing already read the manifest back to decide it was safe to
       // replace the recording, so proofFile reuses that read rather than
       // performing a second one over the same file (#8799).
@@ -385,7 +385,7 @@ class _FailingC2paSigningService extends C2paSigningService {
 
 class _ExistingProofC2paSigningService extends C2paSigningService {
   int readManifestCallCount = 0;
-  int signVideoCallCount = 0;
+  int signVideoInPlaceCallCount = 0;
 
   @override
   Future<C2paSigningResult> signVideoInPlace({
@@ -394,7 +394,7 @@ class _ExistingProofC2paSigningService extends C2paSigningService {
     Map<String, dynamic>? cawgIdentityAssertion,
     bool enableAdvancedCawgEmbedding = false,
   }) async {
-    signVideoCallCount += 1;
+    signVideoInPlaceCallCount += 1;
     throw StateError('Existing proof must not be signed again');
   }
 
@@ -410,7 +410,7 @@ class _SuccessfulC2paSigningService extends C2paSigningService {
 
   final String videoPath;
   int readManifestCallCount = 0;
-  int signVideoCallCount = 0;
+  int signVideoInPlaceCallCount = 0;
 
   @override
   Future<C2paSigningResult> signVideoInPlace({
@@ -419,7 +419,7 @@ class _SuccessfulC2paSigningService extends C2paSigningService {
     Map<String, dynamic>? cawgIdentityAssertion,
     bool enableAdvancedCawgEmbedding = false,
   }) async {
-    signVideoCallCount += 1;
+    signVideoInPlaceCallCount += 1;
     return C2paSigningResult(
       signedFilePath: this.videoPath,
       success: true,


### PR DESCRIPTION
## The problem

C2PA signing writes a signed copy of a recording and then replaces the recording with it. That replacement is correct and intended: ProofMode hashes the credentialed media, and the editor, exporter and uploader all read the same path afterwards, so the signed file has to become the canonical one.

Two things were wrong with how it got there.

**The output was not checked for what makes it worth keeping.** The guards before the rename verified that the file existed and was longer than zero bytes. Neither establishes that the signer stamped anything. A native call that wrote a re-encode without a manifest, or wrote one that fails validation, would pass both and overwrite the recording — and there is no other copy. #7739 added the non-empty guard for exactly this reason; this closes the rest of it.

**The destruction was not visible at the call site.** `signVideo(videoPath: ...)` reads like "sign this and tell me where the signed file is". It was in fact "hand me this file, it will not exist afterwards". Any new caller would have opted into that without knowing.

This runs on the ordinary capture path, not just editor backfill: `ClipManagerNotifier.addClip` → `_generateClipProof` → `NativeProofModeService.proofFile` → sign, then hash the signed bytes.

## What changed

**The output is verified before it is trusted.** After signing, the temporary file is read back and has to carry an active C2PA manifest that does not fail validation. If it does not, the temporary file is deleted, the recording is left byte-for-byte untouched, and the result reports `outputMissing`.

**`ValidationStatus.unknown` passes, deliberately.** This is the part worth a second look. The obvious reading is "only accept `valid`", and it is wrong here: `ManifestStoreInfo._determineValidationStatus` returns `unknown` whenever the native read produced no `validation_status` key at all, which is what an ordinary clean read looks like. Only `invalid` is positive evidence that the output is broken. Rejecting `unknown` would throw away correctly signed recordings and silently strip credentials from real captures. There is a test that pins this so nobody "tightens" it later.

**`signVideo` is now `signVideoInPlace`.** The name states the ownership transfer, and the rename is a compile error for any caller that had opted into it by accident. The compiler found the six existing call sites for me, which is the point.

**The manifest travels back on the result.** Signing now has to read it anyway, so `C2paSigningResult.manifest` carries it and `NativeProofModeService` no longer reads the same manifest off the same file a second time.

## What this deliberately does not do

- **No unsigned backup of the recording.** The credentialed file is meant to be the canonical ProofMode artifact; keeping the pre-signing bytes around would undermine that and double the disk cost of every capture.
- **In-place signing stays on the capture, render and publish paths.** This hardens the contract, it does not reverse it.
- **No non-replacing mode.** The issue lists one as optional ("if retained as part of the API"). There is no caller for it today, and an unused second signing path is speculative surface — `resignDerived` already covers signing into a file the caller owns.
- **Clip-level proof combination is untouched** — that is #8798.

## Verification

- Five new tests in `test/services/c2pa_signing_service_test.dart`, one per rejection shape (no manifest, no active claim, failed validation, unreadable output) plus the `unknown`-is-fine case. Each asserts the recording still holds its original bytes and that no `c2pa_signed_*.mp4` was left behind.
- `native_proofmode_service_test.dart` now asserts the manifest is read **zero** times after successful signing, which is the redundant read this removes.
- `flutter analyze lib test integration_test` clean; 31 tests passing across the C2PA and ProofMode suites.
- **The success path is not device-testable outside a release build**, and that is worth stating plainly rather than leaving as a gap. `PROOFMODE_SIGNING_SERVER_TOKEN` is a dart-define supplied by `build_android.sh` / `build_ios.sh`; a plain `flutter run` passes none, the signer returns `Signature: internal error (COSE signature invalid)`, and the run classifies as `signingCredential` and continues without credentials. So a local device pass cannot exercise the manifest read this PR adds, and neither can a reviewer without release credentials.

- What a device run *does* cover is the safety property, and that was verified on a physical Samsung Galaxy (SM-S942B), Android 16: a recorded clip whose signing failed was left byte-identical (3,012,785 bytes before the attempt, same file and size after), with no orphaned `c2pa_signed_*.mp4` in the documents directory, and the video still published. That is the guarantee the guard exists to keep — a signing pass that does not produce something worth keeping must not touch the recording.

- The rejection branches themselves (no manifest, no active claim, failed validation, unreadable output) are covered by the five unit tests above, each asserting the recording still holds its original bytes.

Closes #8799
