### PR TITLE
fix(audio): stop storing imported tracks inside the open draft

### DIFF
--- a/mobile/lib/extensions/draft_local_audio_extensions.dart
+++ b/mobile/lib/extensions/draft_local_audio_extensions.dart
@@ -6,10 +6,10 @@ import 'package:openvine/models/divine_video_draft.dart';
 extension DraftLocalAudioPaths on DivineVideoDraft {
   /// Absolute file paths of draft-local audio referenced by this draft.
   ///
-  /// Covers imported audio created by `LocalAudioImportService` (stored under
-  /// `draft_audio_imports/<draftId>`), committed voice-over recordings, and
-  /// audio extracted from the draft's own clips — all persisted as draft-local
-  /// [AudioEvent]s. Sweeps every history entry's audio metadata in
+  /// Covers library-owned audio created by `LocalAudioImportService`, committed
+  /// voice-over recordings, and audio extracted from the draft's own clips —
+  /// all persisted as local [AudioEvent]s. Sweeps every history entry's audio
+  /// metadata in
   /// [DivineVideoDraft.editorStateHistory], the completed-editor snapshot in
   /// [DivineVideoDraft.editorEditingParameters], plus the legacy
   /// [DivineVideoDraft.selectedSound], collecting [AudioEvent.localFilePath]

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -710,10 +710,10 @@ class DraftStorageService {
   /// [DivineVideoDraft.selectedSound] — so this guard keeps shared audio until
   /// the last referencing draft is deleted.
   ///
-  /// My Sounds is scanned too. Audio imported from the Library is written
-  /// under whichever draft was open at the time, so deleting that draft would
-  /// otherwise reclaim a file a saved sound still points at — and unlike a
-  /// stale path, a deleted file cannot be healed on load (#7977).
+  /// My Sounds is scanned too. Imported audio lives in library storage, but a
+  /// draft can still reference the same file as a saved sound, so deleting the
+  /// draft must not reclaim it. Unlike a stale path, a deleted file cannot be
+  /// healed on load (#7977).
   ///
   /// Callers run this *after* deleting the draft they are cleaning up, so
   /// every row it sees is a survivor and there is nothing to exclude.

--- a/mobile/lib/services/local_audio_cleanup_service.dart
+++ b/mobile/lib/services/local_audio_cleanup_service.dart
@@ -28,8 +28,8 @@ typedef LocalAudioReferences = ({Set<String> filenames, bool isComplete});
 
 /// Reference sweep over every store that can name a draft-local audio file.
 ///
-/// Draft-local audio — imported tracks under `draft_audio_imports/`, committed
-/// voice-over takes, and audio extracted from a draft's own clips — is
+/// Local audio — library-owned imports, committed voice-over takes, and audio
+/// extracted from a draft's own clips — is
 /// persisted inside the draft `data` blob and inside the My Sounds buckets,
 /// neither of which is an indexed file column. So the indexed clip/draft
 /// reference check that [FileCleanupService] applies to video and thumbnail
@@ -116,13 +116,12 @@ class LocalAudioCleanupService {
 
   /// Deletes [audioFilePath] once nothing on this device references it.
   ///
-  /// Called after a My Sounds entry is removed. Audio imported from the
-  /// Library is written under whichever draft was open at the time, so the
-  /// file the entry pointed at can equally be a draft's own track, a track a
-  /// second saved sound shares, or nobody's — only the sweep can tell them
-  /// apart. #8011 taught the draft side to keep a file My Sounds still names;
-  /// without this the same file simply became a permanent orphan when the
-  /// saved sound went instead.
+  /// Called after a My Sounds entry is removed. The file it pointed at can
+  /// equally be a track a draft still uses, a track a second saved sound
+  /// shares, or nobody's — only the sweep can tell them apart. #8011 taught
+  /// the draft side to keep a file My Sounds still names; without this the
+  /// same file simply became a permanent orphan when the saved sound went
+  /// instead.
   ///
   /// Refuses to delete whenever the sweep is incomplete: an unreadable store
   /// means the reference set is a lower bound, and a leaked file costs disk

--- a/mobile/lib/services/local_audio_import_service.dart
+++ b/mobile/lib/services/local_audio_import_service.dart
@@ -32,9 +32,13 @@ class LocalAudioImportService {
   final AudioImportDurationResolver _durationResolver;
   final AudioImportClock _clock;
 
+  /// Copies [sourcePath] into library-owned audio storage.
+  ///
+  /// The destination is [libraryAudioImportsDirName], not the open draft: an
+  /// imported track can be saved to My Sounds and outlive any draft, so no
+  /// draft owns it (#8024).
   Future<AudioEvent> importAudioFile({
     required String sourcePath,
-    required String draftId,
     required String displayName,
   }) async {
     final source = File(sourcePath);
@@ -55,10 +59,9 @@ class LocalAudioImportService {
       '${now.millisecondsSinceEpoch}_${p.basename(displayName)}',
     );
     final root = await _storageRootProvider();
-    final draftDir = Directory(p.join(root.path, _safeFileName(draftId)));
-    await draftDir.create(recursive: true);
+    await root.create(recursive: true);
 
-    final copied = await source.copy(p.join(draftDir.path, fileName));
+    final copied = await source.copy(p.join(root.path, fileName));
     final duration = await _durationResolver(copied);
 
     return AudioEvent.fromLocalImport(
@@ -73,7 +76,7 @@ class LocalAudioImportService {
 
   static Future<Directory> _defaultStorageRoot() async {
     final docs = await getApplicationDocumentsDirectory();
-    return Directory(p.join(docs.path, draftAudioImportsDirName));
+    return Directory(p.join(docs.path, libraryAudioImportsDirName));
   }
 
   static Future<Duration?> _defaultDurationResolver(File file) async {

--- a/mobile/lib/services/saved_sounds_service.dart
+++ b/mobile/lib/services/saved_sounds_service.dart
@@ -264,11 +264,10 @@ class SavedSoundsService {
   /// Basenames of draft-local audio files a saved sound points at, across
   /// *every* account bucket on this device.
   ///
-  /// Audio imported from the Library still lands under the draft that was open
-  /// at the time (`draft_audio_imports/<draftId>/`), so a file a My Sounds
-  /// entry depends on can be owned by a draft the user later deletes. Draft
-  /// cleanup consults this and keeps such a file: a dangling path heals on the
-  /// next load, a deleted file does not (#7977).
+  /// Imported audio lives in library storage, but a draft can still reference
+  /// the same file as a My Sounds entry. Draft cleanup consults this and keeps
+  /// such a file: a dangling path can heal on load, while a deleted file cannot
+  /// (#7977).
   ///
   /// All accounts, not just the signed-in one — draft cleanup already scans
   /// drafts device-wide, and a saved sound outlives the account switch that

--- a/mobile/lib/startup/startup_phases.dart
+++ b/mobile/lib/startup/startup_phases.dart
@@ -24,6 +24,7 @@ import 'package:openvine/services/seed_media_cleanup_service.dart';
 import 'package:openvine/services/startup_performance_service.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
 import 'package:openvine/startup/timed_startup_task.dart';
+import 'package:openvine/utils/library_audio_migration.dart';
 import 'package:openvine/utils/open_vine_image_cache.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:path_provider/path_provider.dart';
@@ -43,6 +44,17 @@ Future<void> initializeCoreServices(ProviderContainer container) async {
   await migrateLegacyNostrKeys(container.read(secureKeyStorageProvider));
   Log.info(
     '[INIT] ✅ Legacy key migration checked',
+    name: 'Main',
+    category: LogCategory.system,
+  );
+
+  // Relocate imported audio that older builds stored under whichever draft
+  // was open at the time. A track saved to My Sounds outlives that draft, so
+  // no draft owns it (#8024). Best-effort and idempotent; a file it cannot
+  // move still resolves at its old path.
+  await migrateDraftOwnedAudioImports();
+  Log.info(
+    '[INIT] ✅ Imported-audio storage checked',
     name: 'Main',
     category: LogCategory.system,
   );

--- a/mobile/lib/startup/startup_phases.dart
+++ b/mobile/lib/startup/startup_phases.dart
@@ -50,8 +50,8 @@ Future<void> initializeCoreServices(ProviderContainer container) async {
 
   // Relocate imported audio that older builds stored under whichever draft
   // was open at the time. A track saved to My Sounds outlives that draft, so
-  // no draft owns it (#8024). Best-effort and idempotent; a file it cannot
-  // move still resolves at its old path.
+  // no draft owns it (#8024). Best-effort and idempotent; transient failures
+  // are retried on the next launch.
   await migrateDraftOwnedAudioImports();
   Log.info(
     '[INIT] ✅ Imported-audio storage checked',

--- a/mobile/lib/utils/draft_audio_path_resolver.dart
+++ b/mobile/lib/utils/draft_audio_path_resolver.dart
@@ -13,9 +13,8 @@ import 'package:path/path.dart' as p;
 /// [libraryAudioImportsDirName] and existing trees are moved there by
 /// `migrateDraftOwnedAudioImports`.
 ///
-/// The name stays a known audio root so a path persisted before the move
-/// still resolves, and so audio reclaim still recognizes anything the move
-/// could not relocate.
+/// The name stays a known audio root so paths persisted before the move can be
+/// recognized and rebased onto library storage.
 const String draftAudioImportsDirName = 'draft_audio_imports';
 
 /// Documents-relative directory holding audio files the user imported.
@@ -54,13 +53,13 @@ const Set<String> _draftLocalMarkers = {
 /// iOS rewrites the app container path on every app update, so an absolute
 /// audio path baked into a saved draft dangles from then on: the video still
 /// plays — clip paths are persisted as basenames and rejoined on load — while
-/// every sound goes silent. Imported audio lives in per-draft subdirectories,
-/// so unlike a clip it keeps the whole subpath below the documents directory
-/// instead of just the basename. Paths outside a known audio directory are
+/// every sound goes silent. Audio paths keep their whole subpath below the
+/// documents directory rather than only the basename because some audio roots
+/// contain nested directories. Paths outside a known audio directory are
 /// returned unchanged.
 String toPortableAudioPath(String path) => _belowAudioRoot(path) ?? path;
 
-/// Whether [path] names a file inside one of the three directories this app
+/// Whether [path] names a file inside one of the four directories this app
 /// writes draft-local audio into.
 ///
 /// Bounds what an audio-reclaim path is allowed to delete. Every producer —

--- a/mobile/lib/utils/draft_audio_path_resolver.dart
+++ b/mobile/lib/utils/draft_audio_path_resolver.dart
@@ -4,8 +4,26 @@
 import 'package:models/models.dart' show AudioEvent;
 import 'package:path/path.dart' as p;
 
-/// Documents-relative directory holding audio files imported into a draft.
+/// Documents-relative directory that *used* to hold imported audio files.
+///
+/// Imports landed under `draft_audio_imports/<draftId>/` — the draft that
+/// happened to be open when the user picked the file. A track saved to My
+/// Sounds is a library entry that outlives that draft, so the draft was never
+/// its owner; only the directory said otherwise. New imports go to
+/// [libraryAudioImportsDirName] and existing trees are moved there by
+/// `migrateDraftOwnedAudioImports`.
+///
+/// The name stays a known audio root so a path persisted before the move
+/// still resolves, and so audio reclaim still recognizes anything the move
+/// could not relocate.
 const String draftAudioImportsDirName = 'draft_audio_imports';
+
+/// Documents-relative directory holding audio files the user imported.
+///
+/// Owned by the sound library rather than by any draft: its lifetime is the
+/// user's, and nothing about deleting a draft implies deleting a track the
+/// user imported while that draft happened to be open (#8024).
+const String libraryAudioImportsDirName = 'library_audio_imports';
 
 /// Documents-relative directory holding committed voice-over recordings.
 const String voiceOverRecordingsDirName = 'voice_over_recordings';
@@ -20,6 +38,7 @@ const String extractedClipAudioDirName = 'extracted_clip_audio';
 
 const Set<String> _audioRootDirNames = {
   draftAudioImportsDirName,
+  libraryAudioImportsDirName,
   voiceOverRecordingsDirName,
   extractedClipAudioDirName,
 };
@@ -63,10 +82,24 @@ bool isDraftLocalAudioPath(String path) {
 ///
 /// Accepts the portable form as well as an absolute path from a previous
 /// container, so drafts written before the portable form existed heal the
-/// first time they are loaded.
+/// first time they are loaded. A path still naming the retired
+/// [draftAudioImportsDirName] root is rebased onto
+/// [libraryAudioImportsDirName], which is where
+/// `migrateDraftOwnedAudioImports` put the file — the tail below the root is
+/// preserved exactly, so basenames (which is what audio reclaim matches on)
+/// do not change.
 String resolveAudioPath(String path, String documentsPath) {
   final relative = _belowAudioRoot(path);
-  return relative == null ? path : p.join(documentsPath, relative);
+  if (relative == null) return path;
+  return p.join(documentsPath, _relocateRetiredImportRoot(relative));
+}
+
+/// [relative] with a leading [draftAudioImportsDirName] segment replaced by
+/// [libraryAudioImportsDirName].
+String _relocateRetiredImportRoot(String relative) {
+  final segments = p.split(relative);
+  if (segments.first != draftAudioImportsDirName) return relative;
+  return p.joinAll([libraryAudioImportsDirName, ...segments.skip(1)]);
 }
 
 /// [json] with every draft-local audio path rewritten to its portable form.

--- a/mobile/lib/utils/library_audio_migration.dart
+++ b/mobile/lib/utils/library_audio_migration.dart
@@ -3,6 +3,7 @@
 
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:openvine/utils/draft_audio_path_resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -17,12 +18,10 @@ import 'package:unified_logger/unified_logger.dart';
 /// place.
 ///
 /// **The tail below the root is preserved exactly**, per-draft subdirectory
-/// included. That is not tidiness left undone. Audio reclaim decides what to
-/// delete by matching *basenames* against the references it finds in drafts
-/// and My Sounds (`LocalAudioCleanupService`), so a rename would make a file
-/// the user still plays look unreferenced. Preserving the tail also makes
-/// [resolveAudioPath]'s rewrite of persisted paths a pure segment swap, which
-/// is what keeps a stored path and its file pointing at the same place.
+/// included. That is not tidiness left undone: it makes [resolveAudioPath]'s
+/// rewrite of persisted paths a pure segment swap, which keeps a stored path
+/// and its file pointing at the same place. It also prevents imports from
+/// different drafts that share a basename from colliding during migration.
 ///
 /// Directories are merged rather than skipped, for the same reason: a stored
 /// path resolves to the library root whether or not this ran, so a source left
@@ -42,6 +41,8 @@ import 'package:unified_logger/unified_logger.dart';
 Future<void> migrateDraftOwnedAudioImports({
   Directory? documentsDirectory,
 }) async {
+  if (kIsWeb) return;
+
   try {
     final documents =
         documentsDirectory ?? await getApplicationDocumentsDirectory();
@@ -63,8 +64,8 @@ Future<void> migrateDraftOwnedAudioImports({
     }
     await _deleteIfEmpty(source);
   } catch (e, stackTrace) {
-    // Best-effort: a failed migration leaves every file readable at its old
-    // path, so it must never take the launch down with it.
+    // Best-effort: a failed migration is retried next launch and must never
+    // take startup down with it.
     Log.error(
       'Imported-audio migration failed: $e',
       name: 'LibraryAudioMigration',

--- a/mobile/lib/utils/library_audio_migration.dart
+++ b/mobile/lib/utils/library_audio_migration.dart
@@ -1,0 +1,124 @@
+// ABOUTME: Moves imported audio out of draft-owned storage into the library
+// ABOUTME: One-shot, idempotent, basename-preserving migration for #8024
+
+import 'dart:io';
+
+import 'package:openvine/utils/draft_audio_path_resolver.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Moves everything under `draft_audio_imports/` to `library_audio_imports/`.
+///
+/// Imports used to land under the draft that was open when the user picked the
+/// file, so a track they later saved to My Sounds was stored inside something
+/// with a shorter life than the track. New imports go straight to the library
+/// root; this relocates the files already on disk so both shapes end up in one
+/// place.
+///
+/// **The tail below the root is preserved exactly**, per-draft subdirectory
+/// included. That is not tidiness left undone. Audio reclaim decides what to
+/// delete by matching *basenames* against the references it finds in drafts
+/// and My Sounds (`LocalAudioCleanupService`), so a rename would make a file
+/// the user still plays look unreferenced. Preserving the tail also makes
+/// [resolveAudioPath]'s rewrite of persisted paths a pure segment swap, which
+/// is what keeps a stored path and its file pointing at the same place.
+///
+/// Directories are merged rather than skipped, for the same reason: a stored
+/// path resolves to the library root whether or not this ran, so a source left
+/// behind under a name the destination already uses would be a path that
+/// resolves to somebody else's file. Merging removes that case except for two
+/// files with the same basename, which cannot happen for two imports — the
+/// name carries the import's millisecond timestamp.
+///
+/// Idempotent and best-effort: with nothing to move it does nothing, nothing
+/// is ever overwritten or deleted, and [draftAudioImportsDirName] stays a
+/// known audio root so anything left behind still resolves.
+Future<void> migrateDraftOwnedAudioImports({
+  Directory? documentsDirectory,
+}) async {
+  try {
+    final documents =
+        documentsDirectory ?? await getApplicationDocumentsDirectory();
+    final source = Directory(p.join(documents.path, draftAudioImportsDirName));
+    if (!source.existsSync()) return;
+
+    final target = Directory(
+      p.join(documents.path, libraryAudioImportsDirName),
+    );
+    final outcome = await _mergeInto(source, target);
+
+    if (outcome.moved > 0 || outcome.blocked > 0) {
+      Log.info(
+        'Moved ${outcome.moved} imported-audio file(s) into library storage'
+        '${outcome.blocked == 0 ? '' : ', ${outcome.blocked} left in place'}',
+        name: 'LibraryAudioMigration',
+        category: LogCategory.system,
+      );
+    }
+    await _deleteIfEmpty(source);
+  } catch (e, stackTrace) {
+    // Best-effort: a failed migration leaves every file readable at its old
+    // path, so it must never take the launch down with it.
+    Log.error(
+      'Imported-audio migration failed: $e',
+      name: 'LibraryAudioMigration',
+      category: LogCategory.system,
+      error: e,
+      stackTrace: stackTrace,
+    );
+  }
+}
+
+/// Moves every file under [source] to the same relative place under [target].
+Future<({int moved, int blocked})> _mergeInto(
+  Directory source,
+  Directory target,
+) async {
+  var moved = 0;
+  var blocked = 0;
+  await target.create(recursive: true);
+
+  for (final entity in source.listSync()) {
+    final destination = p.join(target.path, p.basename(entity.path));
+    if (entity is Directory) {
+      final nested = await _mergeInto(entity, Directory(destination));
+      moved += nested.moved;
+      blocked += nested.blocked;
+      await _deleteIfEmpty(entity);
+      continue;
+    }
+    if (FileSystemEntity.typeSync(destination) !=
+        FileSystemEntityType.notFound) {
+      // Two files with the same basename. Overwriting would lose one and the
+      // stored paths cannot distinguish them either, so leave the source.
+      blocked += 1;
+      Log.warning(
+        'Left imported audio "${p.basename(entity.path)}" in draft storage: '
+        'library storage already holds that name',
+        name: 'LibraryAudioMigration',
+        category: LogCategory.system,
+      );
+      continue;
+    }
+    try {
+      await entity.rename(destination);
+      moved += 1;
+    } catch (e) {
+      blocked += 1;
+      Log.warning(
+        'Could not move imported audio "${p.basename(entity.path)}" into '
+        'library storage: $e',
+        name: 'LibraryAudioMigration',
+        category: LogCategory.system,
+      );
+    }
+  }
+  return (moved: moved, blocked: blocked);
+}
+
+Future<void> _deleteIfEmpty(Directory directory) async {
+  if (!directory.existsSync()) return;
+  if (directory.listSync().isNotEmpty) return;
+  await directory.delete();
+}

--- a/mobile/lib/utils/library_audio_migration.dart
+++ b/mobile/lib/utils/library_audio_migration.dart
@@ -31,9 +31,14 @@ import 'package:unified_logger/unified_logger.dart';
 /// files with the same basename, which cannot happen for two imports — the
 /// name carries the import's millisecond timestamp.
 ///
-/// Idempotent and best-effort: with nothing to move it does nothing, nothing
-/// is ever overwritten or deleted, and [draftAudioImportsDirName] stays a
-/// known audio root so anything left behind still resolves.
+/// Idempotent and best-effort: with nothing to move it does nothing and
+/// nothing is ever overwritten or deleted. It runs on every launch, so a file
+/// a transient I/O error stranded is picked up next time. A file it can never
+/// move — the same-basename standoff — keeps its bytes but stops being
+/// reachable through a persisted path, since [resolveAudioPath] rebases those
+/// onto the library root either way. That is a leak of one file, not a loss
+/// of one; the alternative is overwriting whichever copy the user still
+/// plays.
 Future<void> migrateDraftOwnedAudioImports({
   Directory? documentsDirectory,
 }) async {

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
@@ -14,7 +14,6 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/reduced_motion_tab_controller_mixin.dart';
 import 'package:openvine/providers/sound_library_service_provider.dart';
 import 'package:openvine/providers/sounds_providers.dart';
-import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/screens/video_editor/video_audio_editor_timing_screen.dart';
 import 'package:openvine/services/local_audio_import_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
@@ -316,7 +315,6 @@ class _AudioSelectionBottomSheetState
           await (widget.localAudioImportService ?? LocalAudioImportService())
               .importAudioFile(
                 sourcePath: filePath,
-                draftId: ref.read(videoEditorProvider.notifier).draftId,
                 displayName: file.name,
               );
 

--- a/mobile/test/models/divine_video_draft_audio_path_test.dart
+++ b/mobile/test/models/divine_video_draft_audio_path_test.dart
@@ -113,21 +113,25 @@ void main() {
       );
     });
 
+    // The import root moved out of draft-owned storage (#8024): a path
+    // persisted under the retired root resolves to library storage, where
+    // `migrateDraftOwnedAudioImports` put the file. The portable form is
+    // left as stored and heals on the next save.
     test('rebases draft-local audio onto the current container on load', () {
       final restored = DivineVideoDraft.fromJson(_draft().toJson(), _newDocs);
 
       expect(_historyAudioUrls(restored), [
-        '$_newDocs/draft_audio_imports/draft_1/song.m4a',
+        '$_newDocs/library_audio_imports/draft_1/song.m4a',
         '$_newDocs/voice_over_recordings/take_1.m4a',
         '$_newDocs/extracted_clip_audio/extracted_audio_1.wav',
       ]);
       expect(
         _parametersAudioUrl(restored),
-        '$_newDocs/draft_audio_imports/draft_1/song.m4a',
+        '$_newDocs/library_audio_imports/draft_1/song.m4a',
       );
       expect(
         restored.selectedSound?.localFilePath,
-        '$_newDocs/draft_audio_imports/draft_1/song.m4a',
+        '$_newDocs/library_audio_imports/draft_1/song.m4a',
       );
     });
 
@@ -151,7 +155,7 @@ void main() {
       final restored = DivineVideoDraft.fromJson(legacyJson, _newDocs);
 
       expect(_historyAudioUrls(restored), [
-        '$_newDocs/draft_audio_imports/draft_1/song.m4a',
+        '$_newDocs/library_audio_imports/draft_1/song.m4a',
       ]);
     });
 
@@ -181,7 +185,7 @@ void main() {
       final restored = DivineVideoDraft.fromJson(_draft().toJson(), _newDocs);
 
       expect(restored.localAudioFilePaths, {
-        '$_newDocs/draft_audio_imports/draft_1/song.m4a',
+        '$_newDocs/library_audio_imports/draft_1/song.m4a',
         '$_newDocs/voice_over_recordings/take_1.m4a',
         '$_newDocs/extracted_clip_audio/extracted_audio_1.wav',
       });

--- a/mobile/test/providers/saved_sounds_provider_test.dart
+++ b/mobile/test/providers/saved_sounds_provider_test.dart
@@ -28,7 +28,7 @@ void main() {
         'a1b2c3d4e5f6789012345678901234567890abcdef1234567890123456789012';
     const oldContainer = '/var/mobile/Containers/Data/Application/OLD';
     const newContainer = '/var/mobile/Containers/Data/Application/NEW';
-    const relativePath = 'draft_audio_imports/draft_autosave/imported.m4a';
+    const relativePath = 'library_audio_imports/imported.m4a';
 
     late SharedPreferences preferences;
     late _MockAuthService authService;

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -2120,7 +2120,7 @@ void main() {
 
       test('deletes imported audio when the draft is deleted', () async {
         final audio = writeAudio(
-          p.join('draft_audio_imports', 'draft_audio', 'imported.m4a'),
+          p.join('library_audio_imports', 'draft_audio', 'imported.m4a'),
         );
         final draft = draftWithAudio(
           id: 'draft_audio',
@@ -2246,7 +2246,7 @@ void main() {
       test('still deletes the target audio when a sibling draft has a corrupt '
           'data blob', () async {
         final audio = writeAudio(
-          p.join('draft_audio_imports', 'draft_target', 'imported.m4a'),
+          p.join('library_audio_imports', 'draft_target', 'imported.m4a'),
         );
         final draft = draftWithAudio(
           id: 'draft_target',
@@ -2280,12 +2280,12 @@ void main() {
       });
 
       test('keeps audio a saved sound still points at', () async {
-        // Importing audio from the Library still writes it under whichever
-        // draft was open (`draft_audio_imports/<draftId>/`), so deleting that
-        // draft would otherwise reclaim a file My Sounds depends on. Unlike a
-        // stale path, a deleted file cannot be healed on load (#7977).
+        // Imported audio lives in library storage, but a draft can still be
+        // the only thing whose timeline references it, so deleting that draft
+        // would otherwise reclaim a file My Sounds depends on. Unlike a stale
+        // path, a deleted file cannot be healed on load (#7977).
         final audio = writeAudio(
-          p.join('draft_audio_imports', 'draft_autosave', 'imported.m4a'),
+          p.join('library_audio_imports', 'draft_autosave', 'imported.m4a'),
         );
         SavedSoundsService.resetLegacyMigrationClaimForTesting();
         SharedPreferences.setMockInitialValues({});
@@ -2325,7 +2325,7 @@ void main() {
 
       test('deletes audio no saved sound points at', () async {
         final audio = writeAudio(
-          p.join('draft_audio_imports', 'draft_unsaved', 'imported.m4a'),
+          p.join('library_audio_imports', 'draft_unsaved', 'imported.m4a'),
         );
         SavedSoundsService.resetLegacyMigrationClaimForTesting();
         SharedPreferences.setMockInitialValues({});
@@ -2354,7 +2354,7 @@ void main() {
         'keeps audio a saved sound points at when all drafts are cleared',
         () async {
           final audio = writeAudio(
-            p.join('draft_audio_imports', 'draft_cleared', 'imported.m4a'),
+            p.join('library_audio_imports', 'draft_cleared', 'imported.m4a'),
           );
           SavedSoundsService.resetLegacyMigrationClaimForTesting();
           SharedPreferences.setMockInitialValues({});
@@ -2396,7 +2396,7 @@ void main() {
 
       test('deletes audio files when all drafts are cleared', () async {
         final audio = writeAudio(
-          p.join('draft_audio_imports', 'draft_clear', 'imported.m4a'),
+          p.join('library_audio_imports', 'draft_clear', 'imported.m4a'),
         );
         final draft = draftWithAudio(
           id: 'draft_clear',

--- a/mobile/test/services/local_audio_import_service_test.dart
+++ b/mobile/test/services/local_audio_import_service_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/local_audio_import_service.dart';
+import 'package:path/path.dart' as p;
 
 void main() {
   group(LocalAudioImportService, () {
@@ -22,7 +23,7 @@ void main() {
     });
 
     test(
-      'copies picked audio into draft storage and returns local AudioEvent',
+      'copies picked audio into library storage and returns local AudioEvent',
       () async {
         final source = File('${sourceDir.path}/My Sound.MP3');
         await source.writeAsBytes([1, 2, 3, 4]);
@@ -34,7 +35,6 @@ void main() {
 
         final event = await service.importAudioFile(
           sourcePath: source.path,
-          draftId: 'draft_123',
           displayName: 'My Sound.MP3',
         );
 
@@ -43,7 +43,12 @@ void main() {
         expect(event.mimeType, equals('audio/mpeg'));
         expect(event.duration, equals(2.5));
         expect(event.localFilePath, isNot(equals(source.path)));
-        expect(event.localFilePath, contains('/draft_123/'));
+        // No draft segment: an imported track can be saved to My Sounds and
+        // outlive whichever draft was open when it was picked (#8024).
+        expect(
+          p.dirname(event.localFilePath!),
+          equals(storageDir.path),
+        );
         expect(
           await File(event.localFilePath!).readAsBytes(),
           equals([1, 2, 3, 4]),
@@ -61,7 +66,6 @@ void main() {
       await expectLater(
         service.importAudioFile(
           sourcePath: source.path,
-          draftId: 'draft_123',
           displayName: 'notes.txt',
         ),
         throwsA(isA<LocalAudioImportException>()),
@@ -78,7 +82,6 @@ void main() {
       await expectLater(
         service.importAudioFile(
           sourcePath: '${sourceDir.path}/missing.mp3',
-          draftId: 'draft_123',
           displayName: 'missing.mp3',
         ),
         throwsA(isA<LocalAudioImportException>()),

--- a/mobile/test/services/saved_sounds_service_test.dart
+++ b/mobile/test/services/saved_sounds_service_test.dart
@@ -479,7 +479,7 @@ void main() {
       // The container UUID iOS rewrites on every app update.
       const oldContainer = '/var/mobile/Containers/Data/Application/OLD';
       const newContainer = '/var/mobile/Containers/Data/Application/NEW';
-      const relativePath = 'draft_audio_imports/draft_autosave/imported.m4a';
+      const relativePath = 'library_audio_imports/imported.m4a';
 
       test(
         'persists an imported sound relative to the documents directory',
@@ -552,6 +552,31 @@ void main() {
         );
 
         expect(service.loadSounds().single.url, '$newContainer/$relativePath');
+      });
+
+      test('rebases a path stored under the retired draft-import root', () {
+        // Written before imports moved out of draft-owned storage; the file
+        // was relocated by `migrateDraftOwnedAudioImports` (#8024).
+        sharedPreferences.setString(
+          'saved_reusable_sounds_anon',
+          jsonEncode([
+            _importedSound(
+              id: 'local_import_1',
+              filePath:
+                  '$oldContainer/draft_audio_imports/draft_autosave/old.m4a',
+            ).toJson(),
+          ]),
+        );
+
+        final service = SavedSoundsService(
+          sharedPreferences,
+          documentsPath: newContainer,
+        );
+
+        expect(
+          service.loadSounds().single.url,
+          '$newContainer/library_audio_imports/draft_autosave/old.m4a',
+        );
       });
 
       test('leaves a published sound url alone', () async {
@@ -788,7 +813,7 @@ void main() {
     });
 
     group('removeSound', () {
-      const filePath = '/documents/draft_audio_imports/d1/imported.m4a';
+      const filePath = '/documents/library_audio_imports/imported.m4a';
 
       SavedSoundsService createService({
         LocalAudioReclaimer? audioReclaimer,

--- a/mobile/test/services/saved_sounds_service_test.dart
+++ b/mobile/test/services/saved_sounds_service_test.dart
@@ -554,30 +554,33 @@ void main() {
         expect(service.loadSounds().single.url, '$newContainer/$relativePath');
       });
 
-      test('rebases a path stored under the retired draft-import root', () {
-        // Written before imports moved out of draft-owned storage; the file
-        // was relocated by `migrateDraftOwnedAudioImports` (#8024).
-        sharedPreferences.setString(
-          'saved_reusable_sounds_anon',
-          jsonEncode([
-            _importedSound(
-              id: 'local_import_1',
-              filePath:
-                  '$oldContainer/draft_audio_imports/draft_autosave/old.m4a',
-            ).toJson(),
-          ]),
-        );
+      test(
+        'rebases a path stored under the retired draft-import root',
+        () async {
+          // Written before imports moved out of draft-owned storage; the file
+          // was relocated by `migrateDraftOwnedAudioImports` (#8024).
+          await sharedPreferences.setString(
+            'saved_reusable_sounds_anon',
+            jsonEncode([
+              _importedSound(
+                id: 'local_import_1',
+                filePath:
+                    '$oldContainer/draft_audio_imports/draft_autosave/old.m4a',
+              ).toJson(),
+            ]),
+          );
 
-        final service = SavedSoundsService(
-          sharedPreferences,
-          documentsPath: newContainer,
-        );
+          final service = SavedSoundsService(
+            sharedPreferences,
+            documentsPath: newContainer,
+          );
 
-        expect(
-          service.loadSounds().single.url,
-          '$newContainer/library_audio_imports/draft_autosave/old.m4a',
-        );
-      });
+          expect(
+            service.loadSounds().single.url,
+            '$newContainer/library_audio_imports/draft_autosave/old.m4a',
+          );
+        },
+      );
 
       test('leaves a published sound url alone', () async {
         // A remote url that happens to carry an audio-root segment: without

--- a/mobile/test/utils/draft_audio_path_resolver_test.dart
+++ b/mobile/test/utils/draft_audio_path_resolver_test.dart
@@ -63,8 +63,35 @@ void main() {
   group('resolveAudioPath', () {
     test('roots a portable path at the current documents directory', () {
       expect(
+        resolveAudioPath('library_audio_imports/song.m4a', _newDocs),
+        '$_newDocs/library_audio_imports/song.m4a',
+      );
+    });
+
+    test('rebases a retired draft-import path onto library storage', () {
+      // `migrateDraftOwnedAudioImports` moved the file; a path persisted
+      // before that still names the old root, and the tail below it — the
+      // basename audio reclaim matches on — is preserved (#8024).
+      expect(
         resolveAudioPath('draft_audio_imports/draft_1/song.m4a', _newDocs),
-        '$_newDocs/draft_audio_imports/draft_1/song.m4a',
+        '$_newDocs/library_audio_imports/draft_1/song.m4a',
+      );
+    });
+
+    test('rebases an absolute pre-move path onto library storage', () {
+      expect(
+        resolveAudioPath(
+          '$_oldDocs/draft_audio_imports/d1/song.m4a',
+          _newDocs,
+        ),
+        '$_newDocs/library_audio_imports/d1/song.m4a',
+      );
+    });
+
+    test('leaves the other audio roots where they are', () {
+      expect(
+        resolveAudioPath('extracted_clip_audio/clip.m4a', _newDocs),
+        '$_newDocs/extracted_clip_audio/clip.m4a',
       );
     });
 
@@ -121,7 +148,7 @@ void main() {
       expect(
         (resolvedAudio['audio'] as List).map((e) => (e as Map)['url']),
         [
-          '$_newDocs/draft_audio_imports/d1/song.m4a',
+          '$_newDocs/library_audio_imports/d1/song.m4a',
           '$_newDocs/voice_over_recordings/take.m4a',
         ],
       );
@@ -139,7 +166,7 @@ void main() {
         _newDocs,
       );
       final audio = ((resolved['meta'] as Map)['audio'] as List).first as Map;
-      expect(audio['url'], '$_newDocs/draft_audio_imports/d1/song.m4a');
+      expect(audio['url'], '$_newDocs/library_audio_imports/d1/song.m4a');
     });
 
     test('rewrites a bare audio event map', () {

--- a/mobile/test/utils/library_audio_migration_test.dart
+++ b/mobile/test/utils/library_audio_migration_test.dart
@@ -123,8 +123,9 @@ void main() {
       'leaves a file alone rather than overwrite a same-named one',
       () async {
         seedDraftImport('draft_1', 'a.m4a', const [1]);
-        Directory(p.join(newRoot().path, 'draft_1'))
-            .createSync(recursive: true);
+        Directory(
+          p.join(newRoot().path, 'draft_1'),
+        ).createSync(recursive: true);
         File(
           p.join(newRoot().path, 'draft_1', 'a.m4a'),
         ).writeAsBytesSync(const [7]);
@@ -141,7 +142,7 @@ void main() {
           equals([1]),
           reason:
               'and it must not delete what it could not move — the old root '
-              'stays a known audio root, so the file is still reclaimable',
+              'retains the blocked source rather than losing its bytes',
         );
       },
     );

--- a/mobile/test/utils/library_audio_migration_test.dart
+++ b/mobile/test/utils/library_audio_migration_test.dart
@@ -1,0 +1,169 @@
+// ABOUTME: Pins the move of imported audio out of draft-owned storage
+// ABOUTME: Regression coverage for #8024, including its no-op cases
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/draft_audio_path_resolver.dart';
+import 'package:openvine/utils/library_audio_migration.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('migrateDraftOwnedAudioImports', () {
+    late Directory documents;
+
+    setUp(() {
+      documents = Directory.systemTemp.createTempSync('library_audio_');
+    });
+
+    tearDown(() {
+      if (documents.existsSync()) documents.deleteSync(recursive: true);
+    });
+
+    Directory oldRoot() =>
+        Directory(p.join(documents.path, draftAudioImportsDirName));
+    Directory newRoot() =>
+        Directory(p.join(documents.path, libraryAudioImportsDirName));
+
+    File seedDraftImport(String draftId, String fileName, List<int> bytes) {
+      final dir = Directory(p.join(oldRoot().path, draftId))
+        ..createSync(recursive: true);
+      return File(p.join(dir.path, fileName))..writeAsBytesSync(bytes);
+    }
+
+    test('moves a draft-owned import into library storage', () async {
+      seedDraftImport('draft_1', '1700000000000_song.m4a', const [1, 2, 3]);
+
+      await migrateDraftOwnedAudioImports(documentsDirectory: documents);
+
+      final moved = File(
+        p.join(newRoot().path, 'draft_1', '1700000000000_song.m4a'),
+      );
+      expect(moved.existsSync(), isTrue);
+      expect(moved.readAsBytesSync(), equals([1, 2, 3]));
+      expect(oldRoot().existsSync(), isFalse);
+    });
+
+    test(
+      'keeps the basename, which is what audio reclaim matches on',
+      () async {
+        seedDraftImport('draft_1', '1700000000000_song.m4a', const [1]);
+
+        await migrateDraftOwnedAudioImports(documentsDirectory: documents);
+
+        final names = newRoot()
+            .listSync(recursive: true)
+            .whereType<File>()
+            .map((file) => p.basename(file.path));
+        expect(names, equals(['1700000000000_song.m4a']));
+      },
+    );
+
+    test('moves every draft tree, not just the first', () async {
+      seedDraftImport('draft_1', 'a.m4a', const [1]);
+      seedDraftImport('draft_2', 'b.m4a', const [2]);
+
+      await migrateDraftOwnedAudioImports(documentsDirectory: documents);
+
+      expect(
+        File(p.join(newRoot().path, 'draft_1', 'a.m4a')).existsSync(),
+        isTrue,
+      );
+      expect(
+        File(p.join(newRoot().path, 'draft_2', 'b.m4a')).existsSync(),
+        isTrue,
+      );
+    });
+
+    test('merges into a library root a newer import already created', () async {
+      seedDraftImport('draft_1', 'a.m4a', const [1]);
+      final root = newRoot()..createSync(recursive: true);
+      File(p.join(root.path, '1700000000001_new.m4a')).writeAsBytesSync(
+        const [9],
+      );
+
+      await migrateDraftOwnedAudioImports(documentsDirectory: documents);
+
+      expect(
+        File(p.join(root.path, 'draft_1', 'a.m4a')).existsSync(),
+        isTrue,
+      );
+      expect(
+        File(p.join(root.path, '1700000000001_new.m4a')).existsSync(),
+        isTrue,
+        reason: 'a file already in library storage must survive the move',
+      );
+    });
+
+    test('merges into a draft directory the destination already has', () async {
+      seedDraftImport('draft_1', 'a.m4a', const [1]);
+      seedDraftImport('draft_1', 'b.m4a', const [2]);
+      Directory(p.join(newRoot().path, 'draft_1')).createSync(recursive: true);
+      File(
+        p.join(newRoot().path, 'draft_1', 'c.m4a'),
+      ).writeAsBytesSync(const [3]);
+
+      await migrateDraftOwnedAudioImports(documentsDirectory: documents);
+
+      // A directory whose name is taken must be merged, not skipped: a
+      // persisted path resolves to library storage either way, so a source
+      // left behind would be a path pointing at somebody else's file.
+      final merged =
+          Directory(p.join(newRoot().path, 'draft_1'))
+              .listSync()
+              .whereType<File>()
+              .map((file) => p.basename(file.path))
+              .toList()
+            ..sort();
+      expect(merged, equals(['a.m4a', 'b.m4a', 'c.m4a']));
+      expect(oldRoot().existsSync(), isFalse);
+    });
+
+    test(
+      'leaves a file alone rather than overwrite a same-named one',
+      () async {
+        seedDraftImport('draft_1', 'a.m4a', const [1]);
+        Directory(p.join(newRoot().path, 'draft_1'))
+            .createSync(recursive: true);
+        File(
+          p.join(newRoot().path, 'draft_1', 'a.m4a'),
+        ).writeAsBytesSync(const [7]);
+
+        await migrateDraftOwnedAudioImports(documentsDirectory: documents);
+
+        expect(
+          File(p.join(newRoot().path, 'draft_1', 'a.m4a')).readAsBytesSync(),
+          equals([7]),
+          reason: 'the migration must never overwrite what is already there',
+        );
+        expect(
+          File(p.join(oldRoot().path, 'draft_1', 'a.m4a')).readAsBytesSync(),
+          equals([1]),
+          reason:
+              'and it must not delete what it could not move — the old root '
+              'stays a known audio root, so the file is still reclaimable',
+        );
+      },
+    );
+
+    test('is a no-op when nothing was ever imported', () async {
+      await migrateDraftOwnedAudioImports(documentsDirectory: documents);
+
+      expect(oldRoot().existsSync(), isFalse);
+      expect(newRoot().existsSync(), isFalse);
+    });
+
+    test('running twice changes nothing the second time', () async {
+      seedDraftImport('draft_1', 'a.m4a', const [1]);
+
+      await migrateDraftOwnedAudioImports(documentsDirectory: documents);
+      await migrateDraftOwnedAudioImports(documentsDirectory: documents);
+
+      expect(
+        File(p.join(newRoot().path, 'draft_1', 'a.m4a')).readAsBytesSync(),
+        equals([1]),
+      );
+      expect(oldRoot().existsSync(), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## The problem

A track the user imports can be saved to My Sounds. At that point it is theirs, and it outlives whatever they were editing. It was nevertheless written to `draft_audio_imports/<draftId>/` — the draft that happened to be open when they picked the file — so a library entry lived inside a container with a shorter life than itself.

Nothing is losing audio today: #8011 added a reference guard, so draft cleanup already keeps a file a My Sounds entry points at. But the guard exists to compensate for storage that is in the wrong place, and every future path that touches draft storage has to remember it.

## What changed

**New imports go to `library_audio_imports/`, flat.** No draft segment, and `importAudioFile` no longer takes a `draftId` — the parameter only ever named the currently-open draft, and the call site no longer has to reach into `videoEditorProvider` for it.

**A one-shot startup migration moves what is already on disk**, next to the existing `migrateLegacyNostrKeys` step. It is idempotent, best-effort, and never overwrites or deletes. Web skips the filesystem migration because it has no application documents directory.

**A persisted path pointing at the old root resolves to the new one.** `resolveAudioPath` already rebases stored audio paths — that is how drafts survive iOS rewriting the container UUID — so the relocation rides the same mechanism, and the next save writes the new form back.

## Two decisions worth checking

**The migration keeps the per-draft subdirectory.** `library_audio_imports/draft_7/song.m4a` looks like leftover mess, but preserving the tail makes the persisted-path rewrite a pure segment swap so a stored path and its file cannot drift apart. It also rules out two drafts' files colliding on one name during migration. Audio reclaim continues matching basenames, which remain unchanged.

**Directories are merged, not skipped.** The first version skipped a source whose destination name was taken. That is a trap: a persisted path resolves to library storage whether or not the move happened, so a source left behind is a path resolving to *somebody else's* file — and the thing at the end of that path is a delete. Merging removes the case except for two files with the same basename, which needs two imports with the same millisecond timestamp *and* the same filename. In that one case the source is left alone and logged — it keeps its bytes but stops being reachable through a persisted path, since a stored path resolves to library storage whether or not the move happened. That is a leak of one file rather than a loss of one, and the alternative is overwriting whichever copy the user still plays. The migration runs every launch, so anything stranded by a transient I/O error is picked up next time.

## Verification

- New `test/utils/library_audio_migration_test.dart` — 8 tests: the move, basename preservation, several draft trees, merging into an existing library root, merging into an existing draft directory, the same-basename standoff, the empty no-op, and running twice.
- `draft_audio_path_resolver_test.dart` gains the relocation cases, including an absolute pre-move path; `saved_sounds_service_test.dart` gains a round-trip from the retired root.
- `flutter analyze lib test integration_test` clean; 1648 tests passing across `test/utils`, the audio-cleanup, saved-sounds, import, startup and video-editor suites.
- Device-verified on a physical Samsung Galaxy (SM-S942B), Android 16: the app starts, the sound library and existing drafts keep their audio, an import lands in library storage, survives a kill-and-relaunch, and publishes.
- Release web build completes with the filesystem migration skipped.

- The migration's own move was verified separately, because a device that never imported audio under the old layout has nothing for it to do — the startup step ran and correctly no-opped. So the old layout was seeded by hand (`draft_audio_imports/draft_probe/1700000000000_probe.m4a`) and the app restarted: the file came back at `library_audio_imports/draft_probe/1700000000000_probe.m4a`, same bytes, subdirectory and basename intact, with the old root removed. The probe file was deleted afterwards.

Closes #8024
