### PR TITLE
fix(dm): re-publish the DM inbox list if the relay never ends up serving it

### DIFF
--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -803,10 +803,10 @@ DmRepository dmRepository(Ref ref) {
       // `since: (newestWireSyncedAt ?? newestSyncedAt) - 2d` and isolate
       // decrypt so cold start stays cheap regardless of lifetime DM count.
       unawaited(repository.startListening());
-      // Self-advertise the user's NIP-17 kind-10050 DM inbox relay list once
-      // per (device, pubkey) when absent, so compliant senders deliver where
-      // divine reads. Flag-on-OK, so it no-ops + retries until the relay
-      // accepts the kind — never blocks login. See #4974.
+      // Self-advertise the user's NIP-17 kind-10050 DM inbox relay list when
+      // absent, so compliant senders deliver where divine reads. Recorded only
+      // once a relay read returns it, so it retries until one does — never
+      // blocks login. See #4974, #8433.
       unawaited(repository.ensureDmRelayListPublished());
     }
   }

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -805,8 +805,8 @@ DmRepository dmRepository(Ref ref) {
       unawaited(repository.startListening());
       // Self-advertise the user's NIP-17 kind-10050 DM inbox relay list when
       // absent, so compliant senders deliver where divine reads. Recorded only
-      // once a relay read returns it, so it retries until one does — never
-      // blocks login. See #4974, #8433.
+      // once the advertised relay serves it, so it retries until that relay
+      // does — never blocks login. See #4974, #8433.
       unawaited(repository.ensureDmRelayListPublished());
     }
   }

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -4264,13 +4264,17 @@ class DmRepository {
   /// relay that answers — which is right for a caller that falls back to the
   /// default pool but not for one about to replace what it read. Sharing it
   /// was what made the guard above unreachable (#8212). The extra query is
-  /// bounded: this method returns early once `dmRelayListPublished` is set, so
-  /// it runs at most once per (device, pubkey), and it is never awaited by
-  /// login. Idempotent per (device, pubkey) via
-  /// `DmSyncState.dmRelayListPublished`, with the flag set ONLY once
-  /// [_dmInboxRelayUrl] itself confirms `OK`. A rejection there, or a
-  /// slow/failed signer, leaves the flag unset and the next login retries —
-  /// the publish never blocks login and self-heals.
+  /// bounded: this method returns early once `dmRelayListPublished` is set,
+  /// and it is never awaited by login.
+  ///
+  /// `DmSyncState.dmRelayListPublished` is set only when that read returns the
+  /// list — never on a publish's `OK`. [_dmInboxRelayUrl] answers `OK` once
+  /// the event is queued, commits it minutes later, and can lose it in
+  /// between (#8433), so an `OK` proves the relay took the event, not that
+  /// anyone can read it. The session after a publish reads it back: `found`
+  /// records the flag, `absent` publishes again. A rejection, or a slow/failed
+  /// signer, records nothing and the next login retries — the publish never
+  /// blocks login and self-heals.
   ///
   /// No-op when uninitialized, when no signer / sync state is wired, or when
   /// no valid advertised relay URL is configured.
@@ -4351,10 +4355,10 @@ class DmRepository {
         targetRelays: <String>[relayUrl, ...discoveryTargets],
       );
       if (_disposed || _resetGeneration != gen) return;
-      // Success is the advertised relay's own `OK`, not "something accepted".
-      // A discovery relay accepting while divine's relay refused would mark
-      // the list published and stop retrying, leaving the one relay divine
-      // reads from without it.
+      // The advertised relay's own `OK` decides which line is logged, never
+      // what is recorded: that relay queues the event and commits it minutes
+      // later, and can lose it in between (#8433). Nothing is recorded here
+      // either way; the next session's read finds the list or publishes again.
       if (!outcome.acceptedBy.contains(relayUrl)) {
         Log.warning(
           'kind-10050 publish: $relayUrl did not accept '
@@ -4375,13 +4379,13 @@ class DmRepository {
         );
       }
 
-      await syncState.markDmRelayListPublished(pubkey);
       // The event id is the anchor: a relay serves only the newest revision of
       // a replaceable kind for a coordinate query, so an id is the one handle
       // that still reaches an earlier one. Logged whole.
       Log.info(
         'Published kind-10050 DM inbox relay list for ${pubkeyForLogs(pubkey)} '
-        '-> $relayUrl (event ${signed.id})',
+        '-> $relayUrl (event ${signed.id}); recorded once a relay read '
+        'returns it',
         category: LogCategory.system,
       );
     } on Object catch (e, stackTrace) {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1249,8 +1249,8 @@ class DmRepository {
       // falls back to the default pool on `absent` and `failed` alike, and
       // `startListening` awaits it before opening the subscription. Making it
       // strict would put a full timeout in front of DM delivery on every login
-      // and every reconnect to protect a write that happens at most once per
-      // device. The publish path reads authoritatively on its own instead.
+      // and every reconnect to protect the inbox-list publish, which reads
+      // authoritatively on its own instead.
       // See #8212.
       requireAuthoritative: false,
       source: _DmRelayListSource.selfAuthored,
@@ -4356,10 +4356,7 @@ class DmRepository {
         targetRelays: <String>[relayUrl, ...discoveryTargets],
       );
       if (_disposed || _resetGeneration != gen) return;
-      // The advertised relay's own `OK` decides which line is logged, never
-      // what is recorded: that relay queues the event and commits it minutes
-      // later, and can lose it in between (#8433). Nothing is recorded here
-      // either way; the next session's read finds the list or publishes again.
+      // The advertised relay's `OK` only decides which line is logged (#8433).
       if (!outcome.acceptedBy.contains(relayUrl)) {
         Log.warning(
           'kind-10050 publish: $relayUrl did not accept '

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -40,6 +40,7 @@ import 'package:nostr_sdk/nip19/pubkeys_equal.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_batch_unwrap.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
 import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay_type.dart';
 import 'package:nostr_sdk/signer/isolate_decrypt_signer.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
 import 'package:nostr_sdk/utils/relay_url_policy.dart';
@@ -4079,14 +4080,13 @@ class DmRepository {
       // five-second budget. Both must settle before an empty answer means
       // `absent`; if either is incomplete the send stays pending and retries.
       //
-      // Own-inbox reads deliberately keep the existing single pool-only leg.
-      // The fast read is in front of the receiving subscription, while the
-      // authoritative read protects publication (#8212); widening receipt is
-      // a separate asynchronous concern and must not add a cold connection to
-      // either synchronous path. The publish alone passes [advertisedRelay]:
-      // a user can remove that relay from the pool, and a read that never
-      // asks where the list was written can neither confirm it nor see a
-      // list held only there (#8433).
+      // The live memo read and the drain's strict read keep a single
+      // pool-only leg: the memo is in front of the receiving subscription, and
+      // widening receipt is a separate asynchronous concern (#8212). Only the
+      // publish passes [advertisedRelay], and that leg asks it alone: a user
+      // can remove the relay from the pool, and a read that never asks where
+      // the list was written can neither confirm it nor see a list held only
+      // there (#8433).
       final queryFutures = [
         _nostrClient.queryEventsDetailed(
           filter,
@@ -4111,6 +4111,7 @@ class DmRepository {
             filter,
             useCache: false,
             tempRelays: [advertisedRelay],
+            relayTypes: const [RelayType.temp],
             requireAllRelaysSettled: true,
             timeout: _ownDmInboxAuthoritativeTimeout,
           ),

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -300,6 +300,15 @@ enum _OwnDmInboxState {
   failed,
 }
 
+/// An own-inbox read's outcome. `advertisedMissing` is the newest list found,
+/// set only for a `found` read that asked the advertised relay without that
+/// relay returning it (#8433).
+typedef _OwnDmInboxRead = ({
+  _OwnDmInboxState state,
+  List<String>? relays,
+  Event? advertisedMissing,
+});
+
 /// Why a recipient's NIP-17 DM inbox lookup returned what it did.
 ///
 /// The relay list alone cannot answer this: [DmInboxResolution.absent] and
@@ -645,7 +654,7 @@ class DmRepository {
   /// reconnects don't re-query; a `failed` (transient relay error) outcome is
   /// NOT cached — the memo is cleared once it resolves so the next caller
   /// re-queries, and RC3 never overwrites a real list on a transient failure.
-  Future<({_OwnDmInboxState state, List<String>? relays})>? _ownInboxFuture;
+  Future<_OwnDmInboxRead>? _ownInboxFuture;
 
   /// Debounced cross-device DM read-state marker publish (#4977). Reading a
   /// conversation advances its read cursor and schedules this; a burst of
@@ -1238,8 +1247,7 @@ class DmRepository {
   /// — the memo clears itself once it resolves `failed` so the next caller
   /// re-queries instead of degrading the whole session to the default pool.
   /// [_resetState] clears the memo on account switch.
-  Future<({_OwnDmInboxState state, List<String>? relays})>
-  _resolveOwnDmInbox() {
+  Future<_OwnDmInboxRead> _resolveOwnDmInbox() {
     final cached = _ownInboxFuture;
     if (cached != null) return cached;
     final future = _queryOwnDmInbox(
@@ -4053,7 +4061,7 @@ class DmRepository {
   /// Resolving a COUNTERPARTY's inbox passes `false`: it runs on every send,
   /// degrades to the default pool on either outcome, and overwrites nothing,
   /// so it keeps the cache and the first answer it gets.
-  Future<({_OwnDmInboxState state, List<String>? relays})> _queryOwnDmInbox(
+  Future<_OwnDmInboxRead> _queryOwnDmInbox(
     String pubkey, {
     required bool requireAuthoritative,
     // Defaults to the strict reading so a call site added later fails closed.
@@ -4120,6 +4128,10 @@ class DmRepository {
         inboxResolutionBudget,
       );
       final events = [for (final result in results) ...result.events];
+      // The advertised leg, when asked, is queued last.
+      final advertisedEvents = advertisedRelay == null
+          ? null
+          : results.last.events;
       // Computed here but applied ONLY at the two exits below where nothing
       // matching came back. A read that DID return the list stays `found` even
       // when some relay never settled: the list is in hand, and RC3's job is
@@ -4178,7 +4190,7 @@ class DmRepository {
 
       if (events.isEmpty) {
         logInconclusiveRead();
-        return (state: absentOrFailed, relays: null);
+        return (state: absentOrFailed, relays: null, advertisedMissing: null);
       }
       final matchingEvents = [
         for (final event in events)
@@ -4192,7 +4204,7 @@ class DmRepository {
           category: LogCategory.system,
         );
         logInconclusiveRead();
-        return (state: absentOrFailed, relays: null);
+        return (state: absentOrFailed, relays: null, advertisedMissing: null);
       }
       // Newest wins for a replaceable event served from multiple relays.
       matchingEvents.sort((a, b) => b.createdAt.compareTo(a.createdAt));
@@ -4214,9 +4226,24 @@ class DmRepository {
         pubkey,
         source,
       );
-      return relays.isEmpty
-          ? (state: _OwnDmInboxState.absent, relays: null)
-          : (state: _OwnDmInboxState.found, relays: relays);
+      if (relays.isEmpty) {
+        return (
+          state: _OwnDmInboxState.absent,
+          relays: null,
+          advertisedMissing: null,
+        );
+      }
+      final advertisedServesList =
+          advertisedEvents == null ||
+          advertisedEvents.any(
+            (event) =>
+                event.kind == EventKind.dmRelaysList && event.pubkey == pubkey,
+          );
+      return (
+        state: _OwnDmInboxState.found,
+        relays: relays,
+        advertisedMissing: advertisedServesList ? null : matchingEvents.first,
+      );
     } on TimeoutException {
       // Deliberately `failed`, never `absent`. NIP-17 says an absent kind-10050
       // means the user "is not ready to receive messages"; a read we abandoned
@@ -4228,13 +4255,21 @@ class DmRepository {
         '${inboxResolutionBudget.inMilliseconds}ms; treating as unread',
         category: LogCategory.system,
       );
-      return (state: _OwnDmInboxState.failed, relays: null);
+      return (
+        state: _OwnDmInboxState.failed,
+        relays: null,
+        advertisedMissing: null,
+      );
     } on Object catch (e) {
       Log.warning(
         'Failed to resolve DM inbox relays for ${pubkeyForLogs(pubkey)}: $e',
         category: LogCategory.system,
       );
-      return (state: _OwnDmInboxState.failed, relays: null);
+      return (
+        state: _OwnDmInboxState.failed,
+        relays: null,
+        advertisedMissing: null,
+      );
     }
   }
 
@@ -4268,14 +4303,16 @@ class DmRepository {
   /// bounded: this method returns early once `dmRelayListPublished` is set,
   /// and it is never awaited by login.
   ///
-  /// `DmSyncState.dmRelayListPublished` is set only when that read returns the
-  /// list — never on a publish's `OK`. [_dmInboxRelayUrl] answers `OK` once
-  /// the event is queued, commits it minutes later, and can lose it in
-  /// between (#8433), so an `OK` proves the relay took the event, not that
-  /// anyone can read it. The session after a publish reads it back: `found`
-  /// records the flag, `absent` publishes again. A rejection, or a slow/failed
-  /// signer, records nothing and the next login retries — the publish never
-  /// blocks login and self-heals.
+  /// `DmSyncState.dmRelayListPublished` is set only when [_dmInboxRelayUrl]
+  /// itself returns the list — never on a publish's `OK`, and never on another
+  /// relay's copy. That relay answers `OK` once the event is queued, commits
+  /// it minutes later, and can lose it in between (#8433), so an `OK` proves
+  /// the relay took the event, not that anyone can read it. The session after
+  /// a publish reads it back: the advertised relay's copy records the flag, a
+  /// list only other relays serve is sent there unchanged, and `absent`
+  /// publishes again. A rejection, or a slow/failed signer, records nothing
+  /// and the next login retries — the publish never blocks login and
+  /// self-heals.
   ///
   /// No-op when uninitialized, when no signer / sync state is wired, or when
   /// no valid advertised relay URL is configured.
@@ -4295,7 +4332,8 @@ class DmRepository {
 
       // Its own authoritative read, NOT the shared session memo: this is the
       // one caller that replaces what it read. See #8212. It also asks the
-      // relay it publishes to, which the pool may not contain (#8433).
+      // relay it publishes to on its own: only that relay's copy is recorded,
+      // and the pool may not contain it (#8433).
       final resolution = await _queryOwnDmInbox(
         pubkey,
         requireAuthoritative: true,
@@ -4304,6 +4342,13 @@ class DmRepository {
       );
       if (_disposed || _resetGeneration != gen) return;
       if (resolution.state == _OwnDmInboxState.found) {
+        final missing = resolution.advertisedMissing;
+        if (missing != null) {
+          // Only other relays serve it: send that same signed list to the
+          // advertised relay, and record it once that relay serves it.
+          await _resendDmRelayList(missing, relayUrl);
+          return;
+        }
         // Already advertising an inbox — never overwrite a richer list.
         // Record the flag so we stop re-checking every login.
         await syncState.markDmRelayListPublished(pubkey);
@@ -4382,8 +4427,7 @@ class DmRepository {
       // that still reaches an earlier one. Logged whole.
       Log.info(
         'Published kind-10050 DM inbox relay list for ${pubkeyForLogs(pubkey)} '
-        '-> $relayUrl (event ${signed.id}); recorded once a relay read '
-        'returns it',
+        '-> $relayUrl (event ${signed.id}); recorded once $relayUrl serves it',
         category: LogCategory.system,
       );
     } on Object catch (e, stackTrace) {
@@ -4394,6 +4438,32 @@ class DmRepository {
         stackTrace: stackTrace,
       );
     }
+  }
+
+  /// Sends [list], the user's own signed kind-10050 found only on other
+  /// relays, to [relayUrl] unchanged — nothing is re-signed or published over.
+  /// Nothing is recorded either: the next session records it once [relayUrl]
+  /// returns it (#8433).
+  Future<void> _resendDmRelayList(Event list, String relayUrl) async {
+    final outcome = await _nostrClient.publishEventAwaitOk(
+      list,
+      targetRelays: [relayUrl],
+    );
+    if (!outcome.acceptedBy.contains(relayUrl)) {
+      Log.warning(
+        'kind-10050 re-send to $relayUrl did not land '
+        '(${outcome.rejectedBy[relayUrl] ?? 'no response'}) — will retry next '
+        'login',
+        category: LogCategory.system,
+      );
+      return;
+    }
+    Log.info(
+      'Re-sent kind-10050 DM inbox relay list for '
+      '${pubkeyForLogs(list.pubkey)} -> $relayUrl (event ${list.id}), which '
+      'did not serve it; recorded once it does',
+      category: LogCategory.system,
+    );
   }
 
   /// Upserts a conversation for a LIVE outgoing send and marks it read in

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -4059,6 +4059,9 @@ class DmRepository {
     // Every path here except the signed-in user's own inbox is resolving
     // somebody else's list.
     _DmRelayListSource source = _DmRelayListSource.remote,
+    // Read as its own leg when given. Only the publish passes it — see the
+    // leg comment below.
+    String? advertisedRelay,
   }) async {
     try {
       final filter = [
@@ -4080,7 +4083,10 @@ class DmRepository {
       // The fast read is in front of the receiving subscription, while the
       // authoritative read protects publication (#8212); widening receipt is
       // a separate asynchronous concern and must not add a cold connection to
-      // either synchronous path.
+      // either synchronous path. The publish alone passes [advertisedRelay]:
+      // a user can remove that relay from the pool, and a read that never
+      // asks where the list was written can neither confirm it nor see a
+      // list held only there (#8433).
       final queryFutures = [
         _nostrClient.queryEventsDetailed(
           filter,
@@ -4099,6 +4105,14 @@ class DmRepository {
             tempRelays: _dmInboxLookupRelays,
             requireAllRelaysSettled: true,
             timeout: _dmInboxDiscoveryQueryTimeout,
+          ),
+        if (advertisedRelay != null)
+          _nostrClient.queryEventsDetailed(
+            filter,
+            useCache: false,
+            tempRelays: [advertisedRelay],
+            requireAllRelaysSettled: true,
+            timeout: _ownDmInboxAuthoritativeTimeout,
           ),
       ];
       final results = await Future.wait(queryFutures).timeout(
@@ -4275,11 +4289,13 @@ class DmRepository {
       if (syncState.dmRelayListPublished(pubkey)) return;
 
       // Its own authoritative read, NOT the shared session memo: this is the
-      // one caller that replaces what it read. See #8212.
+      // one caller that replaces what it read. See #8212. It also asks the
+      // relay it publishes to, which the pool may not contain (#8433).
       final resolution = await _queryOwnDmInbox(
         pubkey,
         requireAuthoritative: true,
         source: _DmRelayListSource.selfAuthored,
+        advertisedRelay: relayUrl,
       );
       if (_disposed || _resetGeneration != gen) return;
       if (resolution.state == _OwnDmInboxState.found) {

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -398,16 +398,16 @@ class DmSyncState {
   /// Whether a NIP-17 kind-10050 DM inbox relay list has been published for
   /// [pubkey] from this device.
   ///
-  /// Gates #4974's publish-on-login. Set only when a relay read returns the
-  /// list (see [markDmRelayListPublished]) — a relay's `OK` is not enough,
-  /// because it acknowledges before storing (#8433). A reinstall wipes
-  /// SharedPreferences and a fresh install should re-advertise, so this
-  /// correctly reads `false` again then.
+  /// Gates #4974's publish-on-login. Set only when the advertised DM relay
+  /// itself returns the list (see [markDmRelayListPublished]) — neither a
+  /// relay's `OK`, which acknowledges before storing, nor another relay's copy
+  /// is enough (#8433). A reinstall wipes SharedPreferences and a fresh
+  /// install should re-advertise, so this correctly reads `false` again then.
   bool dmRelayListPublished(String pubkey) =>
       _prefs.getBool('$_dmRelayListPublishedPrefix$pubkey') ?? false;
 
-  /// Records that a relay read returned a kind-10050 DM inbox relay list for
-  /// [pubkey]. See [dmRelayListPublished].
+  /// Records that the advertised DM relay returned a kind-10050 DM inbox relay
+  /// list for [pubkey]. See [dmRelayListPublished].
   Future<void> markDmRelayListPublished(String pubkey) async {
     await _prefs.setBool('$_dmRelayListPublishedPrefix$pubkey', true);
   }

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -398,16 +398,16 @@ class DmSyncState {
   /// Whether a NIP-17 kind-10050 DM inbox relay list has been published for
   /// [pubkey] from this device.
   ///
-  /// Gates #4974's publish-on-login so it runs at most once per
-  /// (device, pubkey). Set only on a confirmed relay `OK` (see
-  /// [markDmRelayListPublished]); a reinstall wipes SharedPreferences and a
-  /// fresh install should re-advertise, so this correctly reads `false`
-  /// again then.
+  /// Gates #4974's publish-on-login. Set only when a relay read returns the
+  /// list (see [markDmRelayListPublished]) — a relay's `OK` is not enough,
+  /// because it acknowledges before storing (#8433). A reinstall wipes
+  /// SharedPreferences and a fresh install should re-advertise, so this
+  /// correctly reads `false` again then.
   bool dmRelayListPublished(String pubkey) =>
       _prefs.getBool('$_dmRelayListPublishedPrefix$pubkey') ?? false;
 
-  /// Records that a kind-10050 DM inbox relay list has been published for
-  /// [pubkey] (or that one already exists). See [dmRelayListPublished].
+  /// Records that a relay read returned a kind-10050 DM inbox relay list for
+  /// [pubkey]. See [dmRelayListPublished].
   Future<void> markDmRelayListPublished(String pubkey) async {
     await _prefs.setBool('$_dmRelayListPublishedPrefix$pubkey', true);
   }

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -6295,6 +6295,41 @@ void main() {
         );
 
         test(
+          'a list only other relays serve is re-sent to the advertised relay '
+          'and not recorded (#8433)',
+          () async {
+            final list = existingInbox(const ['wss://relay.divine.video']);
+            stubOwnInboxByLeg(
+              pool: answeredList([list]),
+              advertised: answeredList(const <Event>[]),
+            );
+            Event? sent;
+            List<String>? sentTo;
+            when(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            ).thenAnswer((invocation) async {
+              sent = invocation.positionalArguments.first as Event;
+              sentTo =
+                  invocation.namedArguments[#targetRelays] as List<String>?;
+              return outcome(accepted: true);
+            });
+
+            final syncState = _FakeDmSyncState();
+            final repository = createRepository(syncState: syncState);
+            await repository.ensureDmRelayListPublished();
+
+            // The same signed event, to that relay alone: nothing re-signed,
+            // nothing published over the user's list.
+            expect(sent?.id, list.id);
+            expect(sentTo, ['wss://relay.divine.video']);
+            expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
+          },
+        );
+
+        test(
           'reads a recipient kind-10050 conclusively before reporting absent',
           () async {
             stubOwnInbox(answeredList(const <Event>[]));

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -6050,9 +6050,10 @@ void main() {
           expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
 
           // Next login: the failure was not memoized, so it re-queries,
-          // resolves absent, and publishes.
+          // resolves absent, and publishes. Each read asks the pool and the
+          // advertised relay.
           await repository.ensureDmRelayListPublished();
-          expect(queries, 2);
+          expect(queries, 4);
           verify(
             () => mockNostrClient.publishEventAwaitOk(
               any(),
@@ -6117,8 +6118,9 @@ void main() {
           await repository.startListening();
           await repository.ensureDmRelayListPublished();
 
-          // The live read stays cheap; exactly one read is authoritative.
-          expect(settlementByRead, [false, true]);
+          // The live read stays cheap; only the publish's own read — the pool
+          // leg and the advertised-relay leg — is authoritative.
+          expect(settlementByRead, [false, true, true]);
 
           await repository.stopListening();
           await controller.close();
@@ -6148,6 +6150,29 @@ void main() {
               targetRelays: any(named: 'targetRelays'),
             ),
           ).thenAnswer((_) async => outcome(accepted: true));
+        }
+
+        /// Answers the pool read and the advertised-relay read separately;
+        /// only the latter names a temp relay.
+        void stubOwnInboxByLeg({
+          required ({List<Event> events, bool timedOut, bool noRelays}) pool,
+          required ({List<Event> events, bool timedOut, bool noRelays})
+          advertised,
+        }) {
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (invocation) async => invocation.namedArguments[#tempRelays] == null
+                ? pool
+                : advertised,
+          );
         }
 
         test(
@@ -6291,6 +6316,91 @@ void main() {
         );
 
         test(
+          'reads the own kind-10050 from the relay it publishes to as well as '
+          'from the pool (#8433)',
+          () async {
+            stubOwnInbox(answeredList(const <Event>[]));
+            stubAcceptedPublish();
+
+            final repository = createRepository(syncState: _FakeDmSyncState());
+            await repository.ensureDmRelayListPublished();
+
+            final captured = verify(
+              () => mockNostrClient.queryEventsDetailed(
+                any(),
+                subscriptionId: any(named: 'subscriptionId'),
+                useCache: any(named: 'useCache'),
+                tempRelays: captureAny(named: 'tempRelays'),
+                requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+                timeout: any(named: 'timeout'),
+              ),
+            ).captured;
+            // A user can remove the advertised relay from their pool; a read
+            // that never asks it cannot see the list it holds.
+            expect(
+              captured,
+              unorderedEquals(<Object?>[
+                null,
+                ['wss://relay.divine.video'],
+              ]),
+            );
+          },
+        );
+
+        test(
+          'a list only the advertised relay serves is found — never '
+          'published over (#8433)',
+          () async {
+            stubOwnInboxByLeg(
+              pool: answeredList(const <Event>[]),
+              advertised: answeredList([
+                existingInbox(const ['wss://relay.divine.video']),
+              ]),
+            );
+            stubAcceptedPublish();
+
+            final syncState = _FakeDmSyncState();
+            final repository = createRepository(syncState: syncState);
+            await repository.ensureDmRelayListPublished();
+
+            verifyNever(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            );
+            expect(
+              syncState.dmRelayListPublishedPubkeys,
+              contains(_validPubkeyA),
+            );
+          },
+        );
+
+        test(
+          'an advertised-relay read that did not settle is not evidence of '
+          'absence (#8433)',
+          () async {
+            stubOwnInboxByLeg(
+              pool: answeredList(const <Event>[]),
+              advertised: unansweredList(timedOut: true),
+            );
+            stubAcceptedPublish();
+
+            final syncState = _FakeDmSyncState();
+            final repository = createRepository(syncState: syncState);
+            await repository.ensureDmRelayListPublished();
+
+            verifyNever(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            );
+            expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
+          },
+        );
+
+        test(
           'reads a recipient kind-10050 conclusively before reporting absent',
           () async {
             stubOwnInbox(answeredList(const <Event>[]));
@@ -6359,7 +6469,8 @@ void main() {
             await repository.ensureDmRelayListPublished();
             await repository.ensureDmRelayListPublished();
 
-            expect(queries, 2);
+            // Two legs per read: the pool and the advertised relay.
+            expect(queries, 4);
             verify(
               () => mockNostrClient.publishEventAwaitOk(
                 any(),

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -5650,7 +5650,7 @@ void main() {
 
       test(
         'publishes a kind-10050 advertising the injected stable relay when '
-        'absent and records the flag on a confirmed OK',
+        'absent, and leaves recording it to a later read (#8433)',
         () async {
           // setUp default queryEventsDetailed -> [] : no existing kind-10050.
           when(
@@ -5676,10 +5676,9 @@ void main() {
             ['relay', 'wss://relay.divine.video'],
           ]);
           expect(captured[1], ['wss://relay.divine.video']);
-          expect(
-            syncState.dmRelayListPublishedPubkeys,
-            contains(_validPubkeyA),
-          );
+          // The relay's OK means it queued the event, not that anyone can
+          // read it yet, so nothing is recorded until a read returns it.
+          expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
         },
       );
 
@@ -5746,39 +5745,57 @@ void main() {
               dmFallback2,
               discovery,
             ]);
-            expect(
-              syncState.dmRelayListPublishedPubkeys,
-              contains(_validPubkeyA),
-            );
           },
         );
 
         test(
-          'a discovery relay refusing the kind is best-effort — the list is '
-          'still published',
+          'a discovery relay refusing the kind is best-effort — the next '
+          'login records the list the advertised relay serves',
           () async {
+            Event? published;
             when(
               () => mockNostrClient.publishEventAwaitOk(
                 any(),
                 targetRelays: any(named: 'targetRelays'),
               ),
-            ).thenAnswer(
-              (_) async => partialOutcome(
+            ).thenAnswer((invocation) async {
+              published = invocation.positionalArguments.first as Event;
+              return partialOutcome(
                 targets: const [divine, discovery],
                 acceptedBy: const [divine],
+              );
+            });
+            when(
+              () => mockNostrClient.queryEventsDetailed(
+                any(),
+                subscriptionId: any(named: 'subscriptionId'),
+                useCache: any(named: 'useCache'),
+                tempRelays: any(named: 'tempRelays'),
+                requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+                timeout: any(named: 'timeout'),
               ),
-            );
+            ).thenAnswer((_) async {
+              final event = published;
+              return answeredList(event == null ? const <Event>[] : [event]);
+            });
 
             final syncState = _FakeDmSyncState();
-            final repository = createRepository(
+            DmRepository login() => createRepository(
               syncState: syncState,
               dmInboxDiscoveryRelays: const [discovery],
             );
-            await repository.ensureDmRelayListPublished();
+            await login().ensureDmRelayListPublished();
+            await login().ensureDmRelayListPublished();
 
             // Discovery is a bonus, not a precondition: a third-party relay
             // changing its kind policy must never put every account into a
             // republish loop on each login.
+            verify(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            ).called(1);
             expect(
               syncState.dmRelayListPublishedPubkeys,
               contains(_validPubkeyA),
@@ -6060,10 +6077,6 @@ void main() {
               targetRelays: any(named: 'targetRelays'),
             ),
           ).called(1);
-          expect(
-            syncState.dmRelayListPublishedPubkeys,
-            contains(_validPubkeyA),
-          );
         },
       );
 
@@ -6234,10 +6247,6 @@ void main() {
                 targetRelays: any(named: 'targetRelays'),
               ),
             ).called(1);
-            expect(
-              syncState.dmRelayListPublishedPubkeys,
-              contains(_validPubkeyA),
-            );
           },
         );
 
@@ -6477,10 +6486,100 @@ void main() {
                 targetRelays: any(named: 'targetRelays'),
               ),
             ).called(1);
+          },
+        );
+      });
+
+      group('records the list only once a relay read returns it (#8433)', () {
+        test(
+          'a later session whose read returns the published list records it '
+          'without publishing again',
+          () async {
+            Event? published;
+            when(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            ).thenAnswer((invocation) async {
+              published = invocation.positionalArguments.first as Event;
+              return outcome(accepted: true);
+            });
+            when(
+              () => mockNostrClient.queryEventsDetailed(
+                any(),
+                subscriptionId: any(named: 'subscriptionId'),
+                useCache: any(named: 'useCache'),
+                tempRelays: any(named: 'tempRelays'),
+                requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+                timeout: any(named: 'timeout'),
+              ),
+            ).thenAnswer((_) async {
+              final event = published;
+              return answeredList(event == null ? const <Event>[] : [event]);
+            });
+
+            final syncState = _FakeDmSyncState();
+            await createRepository(
+              syncState: syncState,
+            ).ensureDmRelayListPublished();
+            expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
+
+            // Next login: the relay now serves what it acknowledged.
+            await createRepository(
+              syncState: syncState,
+            ).ensureDmRelayListPublished();
+
+            verify(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            ).called(1);
             expect(
               syncState.dmRelayListPublishedPubkeys,
               contains(_validPubkeyA),
             );
+          },
+        );
+
+        test(
+          'a later session whose read still finds nothing publishes again — '
+          'an acknowledged list the relay never served is retried',
+          () async {
+            when(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            ).thenAnswer((_) async => outcome(accepted: true));
+            // Every read answers, and none returns the list.
+            when(
+              () => mockNostrClient.queryEventsDetailed(
+                any(),
+                subscriptionId: any(named: 'subscriptionId'),
+                useCache: any(named: 'useCache'),
+                tempRelays: any(named: 'tempRelays'),
+                requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+                timeout: any(named: 'timeout'),
+              ),
+            ).thenAnswer((_) async => answeredList(const <Event>[]));
+
+            final syncState = _FakeDmSyncState();
+            await createRepository(
+              syncState: syncState,
+            ).ensureDmRelayListPublished();
+            await createRepository(
+              syncState: syncState,
+            ).ensureDmRelayListPublished();
+
+            verify(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            ).called(2);
+            expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
           },
         );
       });

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -20,6 +20,7 @@ import 'package:nostr_sdk/nip44/nip44_v2.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_batch_unwrap.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
 import 'package:nostr_sdk/relay/publish_outcome.dart';
+import 'package:nostr_sdk/relay/relay_type.dart';
 import 'package:nostr_sdk/signer/isolate_decrypt_signer.dart';
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
@@ -732,6 +733,7 @@ void main() {
           subscriptionId: any(named: 'subscriptionId'),
           useCache: any(named: 'useCache'),
           tempRelays: any(named: 'tempRelays'),
+          relayTypes: any(named: 'relayTypes'),
           requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           timeout: any(named: 'timeout'),
         ),
@@ -977,6 +979,7 @@ void main() {
         subscriptionId: any(named: 'subscriptionId'),
         useCache: any(named: 'useCache'),
         tempRelays: any(named: 'tempRelays'),
+        relayTypes: any(named: 'relayTypes'),
         requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
         timeout: any(named: 'timeout'),
       ),
@@ -5901,6 +5904,7 @@ void main() {
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
               tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
               requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
               timeout: any(named: 'timeout'),
             ),
@@ -5991,6 +5995,7 @@ void main() {
             subscriptionId: any(named: 'subscriptionId'),
             useCache: any(named: 'useCache'),
             tempRelays: any(named: 'tempRelays'),
+            relayTypes: any(named: 'relayTypes'),
             requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             timeout: any(named: 'timeout'),
           ),
@@ -6014,6 +6019,7 @@ void main() {
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
               tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
               requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
               timeout: any(named: 'timeout'),
             ),
@@ -6044,6 +6050,7 @@ void main() {
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
               tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
               requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
               timeout: any(named: 'timeout'),
             ),
@@ -6105,6 +6112,7 @@ void main() {
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
               tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
               requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
               timeout: any(named: 'timeout'),
             ),
@@ -6150,6 +6158,7 @@ void main() {
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
               tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
               requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
               timeout: any(named: 'timeout'),
             ),
@@ -6165,8 +6174,8 @@ void main() {
           ).thenAnswer((_) async => outcome(accepted: true));
         }
 
-        /// Answers the pool read and the advertised-relay read separately;
-        /// only the latter names a temp relay.
+        /// Answers the pool read and the advertised-relay read separately. The
+        /// advertised leg must ask that relay alone, not re-ask the pool.
         void stubOwnInboxByLeg({
           required ({List<Event> events, bool timedOut, bool noRelays}) pool,
           required ({List<Event> events, bool timedOut, bool noRelays})
@@ -6178,14 +6187,26 @@ void main() {
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
               tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
               requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
               timeout: any(named: 'timeout'),
             ),
-          ).thenAnswer(
-            (invocation) async => invocation.namedArguments[#tempRelays] == null
-                ? pool
-                : advertised,
-          );
+          ).thenAnswer((invocation) async {
+            final tempRelays =
+                invocation.namedArguments[#tempRelays] as List<String>?;
+            if (tempRelays == null) return pool;
+            final relayTypes =
+                invocation.namedArguments[#relayTypes] as List<int>;
+            final asksOnlyTheAdvertisedRelay =
+                tempRelays.length == 1 &&
+                tempRelays.single == 'wss://relay.divine.video' &&
+                relayTypes.length == 1 &&
+                relayTypes.single == RelayType.temp;
+            if (!asksOnlyTheAdvertisedRelay) {
+              throw StateError('unexpected own-inbox read: $tempRelays');
+            }
+            return advertised;
+          });
         }
 
         test(
@@ -6298,6 +6319,7 @@ void main() {
                 subscriptionId: any(named: 'subscriptionId'),
                 useCache: captureAny(named: 'useCache'),
                 tempRelays: any(named: 'tempRelays'),
+                relayTypes: any(named: 'relayTypes'),
                 requireAllRelaysSettled: captureAny(
                   named: 'requireAllRelaysSettled',
                 ),
@@ -6321,38 +6343,6 @@ void main() {
               );
             }
             expect(sawOwnInboxRead, isTrue);
-          },
-        );
-
-        test(
-          'reads the own kind-10050 from the relay it publishes to as well as '
-          'from the pool (#8433)',
-          () async {
-            stubOwnInbox(answeredList(const <Event>[]));
-            stubAcceptedPublish();
-
-            final repository = createRepository(syncState: _FakeDmSyncState());
-            await repository.ensureDmRelayListPublished();
-
-            final captured = verify(
-              () => mockNostrClient.queryEventsDetailed(
-                any(),
-                subscriptionId: any(named: 'subscriptionId'),
-                useCache: any(named: 'useCache'),
-                tempRelays: captureAny(named: 'tempRelays'),
-                requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
-                timeout: any(named: 'timeout'),
-              ),
-            ).captured;
-            // A user can remove the advertised relay from their pool; a read
-            // that never asks it cannot see the list it holds.
-            expect(
-              captured,
-              unorderedEquals(<Object?>[
-                null,
-                ['wss://relay.divine.video'],
-              ]),
-            );
           },
         );
 
@@ -6460,6 +6450,7 @@ void main() {
                 subscriptionId: any(named: 'subscriptionId'),
                 useCache: any(named: 'useCache'),
                 tempRelays: any(named: 'tempRelays'),
+                relayTypes: any(named: 'relayTypes'),
                 requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
                 timeout: any(named: 'timeout'),
               ),
@@ -6511,6 +6502,7 @@ void main() {
                 subscriptionId: any(named: 'subscriptionId'),
                 useCache: any(named: 'useCache'),
                 tempRelays: any(named: 'tempRelays'),
+                relayTypes: any(named: 'relayTypes'),
                 requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
                 timeout: any(named: 'timeout'),
               ),
@@ -6560,6 +6552,7 @@ void main() {
                 subscriptionId: any(named: 'subscriptionId'),
                 useCache: any(named: 'useCache'),
                 tempRelays: any(named: 'tempRelays'),
+                relayTypes: any(named: 'relayTypes'),
                 requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
                 timeout: any(named: 'timeout'),
               ),

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -5752,91 +5752,6 @@ void main() {
         );
 
         test(
-          'a discovery relay refusing the kind is best-effort — the next '
-          'login records the list the advertised relay serves',
-          () async {
-            Event? published;
-            when(
-              () => mockNostrClient.publishEventAwaitOk(
-                any(),
-                targetRelays: any(named: 'targetRelays'),
-              ),
-            ).thenAnswer((invocation) async {
-              published = invocation.positionalArguments.first as Event;
-              return partialOutcome(
-                targets: const [divine, discovery],
-                acceptedBy: const [divine],
-              );
-            });
-            when(
-              () => mockNostrClient.queryEventsDetailed(
-                any(),
-                subscriptionId: any(named: 'subscriptionId'),
-                useCache: any(named: 'useCache'),
-                tempRelays: any(named: 'tempRelays'),
-                requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
-                timeout: any(named: 'timeout'),
-              ),
-            ).thenAnswer((_) async {
-              final event = published;
-              return answeredList(event == null ? const <Event>[] : [event]);
-            });
-
-            final syncState = _FakeDmSyncState();
-            DmRepository login() => createRepository(
-              syncState: syncState,
-              dmInboxDiscoveryRelays: const [discovery],
-            );
-            await login().ensureDmRelayListPublished();
-            await login().ensureDmRelayListPublished();
-
-            // Discovery is a bonus, not a precondition: a third-party relay
-            // changing its kind policy must never put every account into a
-            // republish loop on each login.
-            verify(
-              () => mockNostrClient.publishEventAwaitOk(
-                any(),
-                targetRelays: any(named: 'targetRelays'),
-              ),
-            ).called(1);
-            expect(
-              syncState.dmRelayListPublishedPubkeys,
-              contains(_validPubkeyA),
-            );
-          },
-        );
-
-        test(
-          'a discovery relay accepting does NOT stand in for the advertised '
-          'relay refusing — retries next login',
-          () async {
-            when(
-              () => mockNostrClient.publishEventAwaitOk(
-                any(),
-                targetRelays: any(named: 'targetRelays'),
-              ),
-            ).thenAnswer(
-              (_) async => partialOutcome(
-                targets: const [divine, discovery],
-                acceptedBy: const [discovery],
-              ),
-            );
-
-            final syncState = _FakeDmSyncState();
-            final repository = createRepository(
-              syncState: syncState,
-              dmInboxDiscoveryRelays: const [discovery],
-            );
-            await repository.ensureDmRelayListPublished();
-
-            // "Something accepted" is the wrong bar. The advertised relay is
-            // the one divine drains, so a list that never reached it leaves
-            // the account undeliverable while the flag says it is done.
-            expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
-          },
-        );
-
-        test(
           'drops a discovery relay whose URL is not a usable relay',
           () async {
             when(
@@ -5869,30 +5784,6 @@ void main() {
           },
         );
       });
-
-      test(
-        'does NOT record the flag when no relay accepts — retries next login',
-        () async {
-          when(
-            () => mockNostrClient.publishEventAwaitOk(
-              any(),
-              targetRelays: any(named: 'targetRelays'),
-            ),
-          ).thenAnswer((_) async => outcome(accepted: false));
-
-          final syncState = _FakeDmSyncState();
-          final repository = createRepository(syncState: syncState);
-          await repository.ensureDmRelayListPublished();
-
-          verify(
-            () => mockNostrClient.publishEventAwaitOk(
-              any(),
-              targetRelays: any(named: 'targetRelays'),
-            ),
-          ).called(1);
-          expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
-        },
-      );
 
       test(
         'skips publishing and records the flag when the user already '
@@ -6054,7 +5945,11 @@ void main() {
               requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
               timeout: any(named: 'timeout'),
             ),
-          ).thenAnswer((_) async {
+          ).thenAnswer((invocation) async {
+            // Count the pool leg only; the advertised relay has nothing.
+            if (invocation.namedArguments[#tempRelays] != null) {
+              return answeredList(const <Event>[]);
+            }
             queries++;
             if (queries == 1) throw Exception('relay down');
             return answeredList(const <Event>[]); // absent on the retry
@@ -6074,10 +5969,9 @@ void main() {
           expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
 
           // Next login: the failure was not memoized, so it re-queries,
-          // resolves absent, and publishes. Each read asks the pool and the
-          // advertised relay.
+          // resolves absent, and publishes.
           await repository.ensureDmRelayListPublished();
-          expect(queries, 4);
+          expect(queries, 2);
           verify(
             () => mockNostrClient.publishEventAwaitOk(
               any(),
@@ -6120,7 +6014,9 @@ void main() {
             final filter =
                 (inv.positionalArguments.first as List<nostr_filter.Filter>)
                     .single;
-            if (filter.kinds?.contains(EventKind.dmRelaysList) ?? false) {
+            final isPoolLeg = inv.namedArguments[#tempRelays] == null;
+            if (isPoolLeg &&
+                (filter.kinds?.contains(EventKind.dmRelaysList) ?? false)) {
               settlementByRead.add(
                 inv.namedArguments[#requireAllRelaysSettled] as bool?,
               );
@@ -6139,9 +6035,8 @@ void main() {
           await repository.startListening();
           await repository.ensureDmRelayListPublished();
 
-          // The live read stays cheap; only the publish's own read — the pool
-          // leg and the advertised-relay leg — is authoritative.
-          expect(settlementByRead, [false, true, true]);
+          // The live read stays cheap; exactly one pool read is authoritative.
+          expect(settlementByRead, [false, true]);
 
           await repository.stopListening();
           await controller.close();
@@ -6454,7 +6349,11 @@ void main() {
                 requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
                 timeout: any(named: 'timeout'),
               ),
-            ).thenAnswer((_) async {
+            ).thenAnswer((invocation) async {
+              // Count the pool leg only; the advertised relay has nothing.
+              if (invocation.namedArguments[#tempRelays] != null) {
+                return answeredList(const <Event>[]);
+              }
               queries++;
               // A read nothing answered — not an exception. This is the shape
               // #8212 actually fails in; the throwing variant is a separate
@@ -6469,8 +6368,7 @@ void main() {
             await repository.ensureDmRelayListPublished();
             await repository.ensureDmRelayListPublished();
 
-            // Two legs per read: the pool and the advertised relay.
-            expect(queries, 4);
+            expect(queries, 2);
             verify(
               () => mockNostrClient.publishEventAwaitOk(
                 any(),
@@ -6573,6 +6471,78 @@ void main() {
               ),
             ).called(2);
             expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
+          },
+        );
+
+        test(
+          'a list read back after sign-out is not recorded for the departed '
+          'session',
+          () async {
+            final read =
+                Completer<
+                  ({List<Event> events, bool timedOut, bool noRelays})
+                >();
+            when(
+              () => mockNostrClient.queryEventsDetailed(
+                any(),
+                subscriptionId: any(named: 'subscriptionId'),
+                useCache: any(named: 'useCache'),
+                tempRelays: any(named: 'tempRelays'),
+                relayTypes: any(named: 'relayTypes'),
+                requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+                timeout: any(named: 'timeout'),
+              ),
+            ).thenAnswer((_) => read.future);
+
+            final syncState = _FakeDmSyncState();
+            final repository = createRepository(syncState: syncState);
+            final pending = repository.ensureDmRelayListPublished();
+            await repository.stopListening();
+            read.complete(
+              answeredList([
+                existingInbox(const ['wss://relay.divine.video']),
+              ]),
+            );
+            await pending;
+
+            expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
+          },
+        );
+
+        test(
+          'an empty read back after sign-out does not sign for the departed '
+          'session',
+          () async {
+            final read =
+                Completer<
+                  ({List<Event> events, bool timedOut, bool noRelays})
+                >();
+            when(
+              () => mockNostrClient.queryEventsDetailed(
+                any(),
+                subscriptionId: any(named: 'subscriptionId'),
+                useCache: any(named: 'useCache'),
+                tempRelays: any(named: 'tempRelays'),
+                relayTypes: any(named: 'relayTypes'),
+                requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+                timeout: any(named: 'timeout'),
+              ),
+            ).thenAnswer((_) => read.future);
+            final signer = _MockNostrSigner();
+            when(() => signer.signEvent(any())).thenAnswer((_) async => null);
+
+            final repository = createRepository(
+              signer: signer,
+              syncState: _FakeDmSyncState(),
+            );
+            final pending = repository.ensureDmRelayListPublished();
+            await repository.stopListening();
+            read.complete(answeredList(const <Event>[]));
+            await pending;
+
+            // Signing is the first effect of an empty answer; a remote signer
+            // would prompt for a session that has already signed out.
+            verifyNever(() => signer.signEvent(any()));
           },
         );
       });


### PR DESCRIPTION
## Description

**The problem.** A Divine account publishes a NIP-17 DM inbox list (kind 10050) so other Nostr apps know where to deliver its private messages. The app recorded that list as published — once per device, never checked again — as soon as relay.divine.video answered `OK`. That `OK` means the relay accepted the event, not that anyone can read it yet: the relay makes events readable after its next batch write, up to about three minutes later, and an event it has acknowledged can still be lost before that write (for example if the relay restarts). If that happened, the device had already recorded the list as published and never looked again, so the account kept advertising no DM inbox to apps that look for it there.

#8433 was filed as the relay "acknowledging a kind-10050 it then does not serve". The investigation found that report was the normal write delay — its reads came 17–25 s after the publish, and the same event was served later — but the assumption the app made about that `OK` was real. This PR fixes the assumption.

**The fix.**

- The "published" flag now means "relay.divine.video returned the list". A publish records nothing; the next session reads the list back and records it once relay.divine.video serves it, or publishes again if no relay has it.
- That read asks relay.divine.video on its own, as well as the user's relay pool. Users can remove that relay from their pool; without this, their read would come back empty on every login and republish each time, and the existing publish-when-absent check could overwrite a list held only on that relay.
- A copy on another relay no longer counts. If nos.lol or relay.primal.net serve the list but relay.divine.video does not, the app sends that same signed event to relay.divine.video — nothing is re-signed or overwritten — and records it once that relay serves it. Apps that read a user's lists from the user's own relays (NIP-65) look for it on relay.divine.video.

**Why this shape.** It reuses the existing authoritative read (#8212) and its found / absent / failed rules: no timers, no new stored state, and no dependency on how long the relay takes to write. It is correct whether a missing list means "not written yet" or "lost".

**Related Issue:** Closes #8433 · part of #8295

## Out of Scope

- The relay's delay between accepting and serving an event — a relay-side question, tracked in divinevideo/divine-funnelcake#716.
- Discovery relays (nos.lol, primal, purplepag.es) stay best-effort and are not retried.
- The live DM subscription and the history drain keep reading the relay pool only.
- A relay.divine.video copy older than another relay's still counts; only a missing copy is re-sent.
- No migration of the existing flag: recording it on an `OK` never shipped in a release, so only internal builds can hold a flag set that way.
- No in-session guard against a second publish: the DM repository is rebuilt on every session change, so an in-memory guard would not hold. The rare cost is one duplicate list (same relays, newer timestamp) when a rebuild lands inside the relay's write window and no other relay holds a copy either.
- Cost: on the launch after a publish, one extra read of the user's own list (3 s budget, not awaited by login). That read asks relay.divine.video once more on its own, over the pool's connection when there is one. A re-send is one event to one relay.

## Verification

- `dm_repository_test.dart`: 500 tests pass (496 on `main`). New tests: an `OK` records nothing; a later session records the list relay.divine.video serves without publishing again; a later session republishes a list no relay served; a list only relay.divine.video holds is found and never overwritten; an unsettled read of relay.divine.video is not treated as absence; a list only other relays serve is sent to relay.divine.video unchanged and not recorded; a read that returns after sign-out neither records nor signs anything for the signed-out account. The relay.divine.video read is checked to ask only that relay. Removed: three tests that could no longer fail.
- Mutation-checked: restoring record-on-`OK`, dropping the relay.divine.video read, letting that read ask the whole pool, removing the sign-out guard, and recording another relay's copy instead of re-sending it each fail at least one test.
- `dm_repository` package: 951 tests pass, line coverage 94.95% (gate 93%).
- `dart format` and `dart analyze` clean. The shared-setup-stub, unpinned-unchanged-assertion, placeholder, ungrouped-test, pubkey-log-encoding, Nostr-id-truncation and empty-catch checks pass.
- The design rests on a read-only measurement of production: 45 events broadcast live by relay.divine.video, each polled by id every 5 s, all became readable — median 121 s, longest 202 s — and only 24% were readable within 25 s.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
