### PR TITLE
fix(counts): report an unanswered count as unknown instead of downloading thousands of events

### DIFF
--- a/mobile/docs/brainstorm/2026-09-10-issue8710-count-fallback-brainstorm.md
+++ b/mobile/docs/brainstorm/2026-09-10-issue8710-count-fallback-brainstorm.md
@@ -1,0 +1,233 @@
+# Brainstorm: A failed count must not turn into a 5,000-event download (#8710)
+
+Date: 2026-09-10
+
+Evidence base: `tasks/findings_8710.md` (local). All six load-bearing hypotheses there hold at 1.0,
+backed by code at both ends, two executed scratch reproductions, and a live observation in #8992.
+
+## Problem Statement
+
+`NostrClient.countEvents` can fail to get a NIP-45 COUNT answer from any relay. When that happens it re-sends the caller's
+limitless filter as a REQ. It then downloads up to 5,000 full events, writes them into the local event
+database, and returns their number as an exact count. "No answer" is not rare. It covers:
+
+- every COUNT sent into a relay pool that dropped its idle socket and has not been redialled (COUNT is the only read path that never redials);
+- every 5-second timeout;
+- every CLOSED from a struggling backend.
+
+The repositories then cache that number for the session. The sound detail screen always shows it, and so do feed
+items that have no REST seed, both as fact.
+
+## Constraints
+
+- **Layering and failure contract.** The flow is UI → BLoC → Repository → Client. Choosing a fallback between sources
+  belongs in the repository (`.claude/rules/architecture.md`). The client throws a typed exception and never
+  returns a value that also means "it failed". A repository rethrows a typed exception or returns a
+  documented sentinel. BLoC state carries status and values, never errors (`.claude/rules/error_handling.md`).
+- **"A zero is not data"** (`tasks/lessons.md`, #7486 / PR #8405). An unknown count must not render as a
+  number, or be treated as one.
+- **Coverage gates.** `reposts_repository` and `sounds_repository` are at 100%. `nostr_client` 82,
+  `comments_repository` 80, `likes_repository` 62, `nostr_sdk` 20.
+- **#8992** (idle sockets dropped and never redialled) is a separate open issue. This fix must not depend
+  on it, and it must not blank counts during idle windows (findings H6).
+- **Relay contract.** funnelcake ignores `limit` on COUNT (F25), clamps a limitless REQ at 5,000 (F8), and
+  CLOSEs a COUNT on a storage error (F26). NIP-45 says nothing about `limit` on COUNT.
+- **Logging.** Any new diagnostic follows the Nostr-identifier logging rules: full ids, and `pubkeyForLogs` for pubkeys.
+- One focused PR against `main`. No stacking, and no deferred TODOs.
+
+## Prior Art
+
+- **#660** (2025-12-16) introduced COUNT, and the client-side fallback "if the relay doesn't support NIP-45".
+  It mapped timeouts to "not supported" from day one (F28).
+- **`queryEventsDetailed`** already has what COUNT lacks: a redial-first step (#5202, #8550), one deadline for
+  the whole call (#7091), and a "no relay took the request" signal (`noRelaysParticipated`).
+- **#8936 / #8947** added the relay diagnostics port and the rate-limited support-export adapter. That is the
+  channel for making COUNT failures visible.
+- **REST stats.** `FunnelcakeApiClient.getVideoStats` / `getBulkVideoStats` and `VideosRepository.getVideoStats`
+  supply the feed seeds (`liveRepostCountSeed`, `liveCommentCountSeed`).
+- **Audio-reuse design** (`mobile/docs/plans/2025-01-01-audio-reuse-design.md`). The sound usage count uses NIP-45.
+  When the relay is unavailable it asks for a "non-fatal error and retry", not a guess, and it caches
+  usage counts with a short TTL.
+- **`VideoActionButton(count:, labelWhenZero:)`** already renders zero as the action's label, so an unknown count
+  on the feed buttons is visually neutral today.
+- **Adjacent issues:** #6238 (`queryEvents` partial results look complete), #8992 (idle drop), #6742
+  (bound `fetchEventReposters`).
+
+## Approaches Explored
+
+### Approach A: Bound and label the fallback (the issue's suggested direction)
+
+**Description:** Keep the COUNT→REQ fallback inside `countEvents`, but give each filter a bound: a copy with
+`limit: N`, since `Filter.limit` is mutable and `Filter.fromJson` exists. Mark the result
+`approximate: true` when the bound is hit, or when the query leg timed out or reached no relay. Forward
+the caller's `timeout` to the fallback.
+
+**Layers affected:** Client.
+
+**Pros:**
+- The smallest diff: one method and its tests.
+- The worst case drops from 5,000 events to N.
+- No public API change. It is the direction the issue proposes.
+
+**Cons:**
+- It still sends a REQ on every failed COUNT, and failures are routine (idle windows: H3, F29). The waste
+  continues at N events per count.
+- It still returns a number. Nothing reads `approximate` except one debug log, so the repositories still cache,
+  and the screens still show, a capped or cache-only floor as exact. That is the defect class of #7486.
+- It leaves the idle trigger (H3) and the queued-COUNT replay (E3) alone, and adds no observability.
+
+**Risks / Unknowns:** It looks finished while the user-visible wrongness remains. Making `approximate`
+mean anything needs "5,000+" rendering on every surface, which means per-surface UI plus l10n in 22
+locales. That is Approach A's hidden second half.
+
+**Complexity:** Low as scoped. Medium if `approximate` is made visible.
+
+### Approach B: Make COUNT a first-class read, where "no answer" means unknown
+
+**Description:**
+1. **Client.** `countEvents` gets the redial-first step queries have. One deadline covers the call, and it runs
+   `retryDisconnectedRelays()` first when no relay is connected. A count issued after an idle drop is then
+   answered by NIP-45 instead of failing. This removes H3's frequency without waiting on #8992.
+2. **Client.** Remove the REQ fallback. When no relay answers, throw a typed failure (the client-layer contract)
+   instead of returning a guess.
+3. **SDK.** `RelayPool.count()` sends with `queueIfFailed: false`, so a failed COUNT is never replayed later with
+   no one waiting (E3). It reports COUNT timeouts and unsent COUNTs through the existing relay diagnostics
+   channel, so the frequency shows up in support exports (N9, N15).
+4. **Repositories** (reposts, comments, likes, sounds). Translate the typed failure into a documented "unknown"
+   result, and never cache it, so the next view asks again.
+5. **BLoC.** Accept an unknown count per field and keep the seed. Today one failing count in `Future.wait`
+   discards all three. A null sentinel adds no new exceptions to that path.
+6. **UI.** Sound detail hides its usage line when the count is unknown, instead of saying "no videos". The feed
+   buttons need no change: an unknown already renders as the label, as it does today.
+
+**Layers affected:** Client (`nostr_client`, `nostr_sdk`), Repository ×4, BLoC ×1, UI ×1 screen plus its provider.
+
+**Pros:**
+- The expensive query is gone entirely.
+- Counts in idle windows become *more* available than today: a real NIP-45 answer after a dial, not a guess.
+- No wrong number is ever cached or shown.
+- It follows the per-layer failure contract (error_handling.md), keeps source choice in the repository
+  (architecture.md), and follows lesson #7486.
+- COUNT failures become observable.
+
+**Cons:**
+- A wider PR: two SDK packages, four repositories (two of them at 100% coverage), a bloc, a provider, and a screen.
+- Repository count APIs go from `Future<int>` to a nullable result, which ripples through tests.
+- A user whose relay set has no NIP-45 relay loses relay counts. The feed still shows REST seeds, but sound
+  detail shows no count. That is a deliberate behaviour change, and the PR must call it out.
+- A COUNT sent into an idle pool now waits for a dial. That is the same trade queries made in #5202 and #8550.
+
+**Risks / Unknowns:**
+- RelayManager's snapshot of connected relays can lag an idle drop by up to 5 s (F19), so a pre-flight redial
+  can miss. Mitigation: have the SDK tell "no relay took the COUNT" apart from "relays took it and none
+  answered", as queries do, and redial once for the former.
+- The #6022 like-floor arithmetic has to handle a nullable fetch.
+
+**Complexity:** Medium.
+
+### Approach C: Stop asking the relay, using seed-aware fetches and REST stats
+
+**Description:** `VideoInteractionsBloc` fetches only the counts it has no seed for. Today it fires three COUNTs
+per feed item and throws them away when a seed exists (N7). For a seedless video it gets reactions,
+comments and reposts from one REST call (`VideosRepository.getVideoStats`, funnelcake
+`/api/videos/{id}/stats`), with relay COUNT kept only as the repository's last resort. Sound usage has no
+REST endpoint, so it stays on relay COUNT.
+
+**Layers affected:** BLoC, Repository (a new composition point for REST and relay counts). The client is unchanged.
+
+**Pros:**
+- It removes most COUNT traffic in the healthy case, not only the failure case.
+- It fits #4747's REST-first data-source direction and the intent of #3607.
+
+**Cons:**
+- It does not fix `countEvents`. Sounds, non-addressable likes, and every REST-failure path still reach the
+  unsafe fallback, so it needs A or B anyway.
+- It changes which source a count comes from. REST and relay semantics already diverge (#5751, #6021),
+  which invites count/list divergence regressions.
+- Repository-to-repository dependencies are forbidden (architecture.md), so it needs a new composition point.
+
+**Risks / Unknowns:** Scope creep well beyond #8710. A REST outage lands back on relay COUNT.
+
+**Complexity:** High.
+
+### Approach D: Classify relays by capability, and fall back only where one lacks NIP-45
+
+**Description:** In `RelayPool.count()`, check each relay's NIP-11 `supported_nips` (`Relay.info`, which is
+fetched on connect but never read today: N22). A relay that advertises no NIP-45 gets a bounded,
+approximate REQ-based count. A NIP-45 relay that fails yields "unknown". Unknown capability is treated as NIP-45.
+
+**Layers affected:** Client (`nostr_sdk`), on top of B's client and repository changes.
+
+**Pros:**
+- It serves the one population #660's fallback was built for: users whose relay set lacks NIP-45 (F34, N14).
+- It does so without charging everyone else a REQ on a transient failure.
+- It is the first real use of NIP-11 in the codebase.
+
+**Cons:**
+- The signal is best-effort. It is null until a fetch that nothing awaits has landed, null on any HTTP
+  error (with no retry), and reset on every redial (F42–F44), so the classification flaps.
+- It adds SDK complexity for a population nobody can size today (no telemetry: F32).
+- It still requires B.
+
+**Risks / Unknowns:** Relays that advertise NIP-45 but disable it, and the other way round.
+
+**Complexity:** Medium–High.
+
+## Recommendation
+
+**Approach B.** It is the only option that removes every confirmed cause:
+
+- **Cost (H1):** no REQ fallback.
+- **Conflation (H2):** the typed failure means "unknown", nothing more.
+- **Frequency (H3, H6):** COUNT redials the way queries do.
+- **Wrong numbers (H4, H5):** an unknown is never cached or shown as a number.
+- **Orphan replay (E3):** COUNT is no longer queued.
+- **Observability (N9, N15):** COUNT failures reach support exports.
+
+It also follows the repo's own contracts rather than working around them: the per-layer failure
+contract, "fallback belongs in the repository", and lesson #7486.
+
+A is the cheapest diff, but it keeps the routine REQ and ships a floor that nothing labels, which is
+the defect class the team already paid for once. C is valuable but is a data-source initiative (#4747)
+that leaves `countEvents` unfixed. Its "don't fetch counts you already have a seed for" part (N7) should
+be its own issue. D is YAGNI until someone shows that custom-relay users need relay counts. It can be
+layered onto B later without rework, because B's typed failure is exactly the hook D would use.
+
+**Decision to confirm (product-shaped, OQ6 and OQ8).** B chooses "unavailable" over "capped floor", and sound
+detail hides its usage line when the count is unknown. Both follow the #7486 precedent. The remaining
+product call is whether any surface should show a placeholder such as "—" instead of hiding it. The plan
+assumes hide.
+
+## Open Questions for /plan
+
+- [ ] **Typed failure at the client boundary.** Propagate the SDK's `CountNotSupportedException`, which is misnamed
+      because it also fires on timeouts and failed sends? Or introduce a `nostr_client` exception whose
+      name says what happened? Prefer the shape that stops the H2 conflation from coming back.
+- [ ] **Repository "unknown" shape.** `Future<int?>` with a documented null, or a small result type? The BLoC needs
+      each count to fail independently either way.
+- [ ] **Redial trigger.** Only the pre-flight `connectedRelays.isEmpty` check (as queries do), or also one
+      redial-and-retry when `RelayPool.count()` reports that no relay took the COUNT? The second needs a
+      "sent to nobody" signal from the SDK.
+- [ ] **Timeout budget.** One deadline covering the redial and the COUNT. Which default? Today 5 s covers the COUNT alone.
+- [ ] **Diagnostics.** Which `RelayDiagnosticSite` and level? Should the client also log once when a count is unknown?
+- [ ] **Sound detail.** The unknown rendering (hide or placeholder) and its widget test. Hiding has no l10n impact.
+- [ ] **Old tests.** Tests that pin the old behaviour must change deliberately: `nostr_client_test.dart:5352-5386`,
+      plus any repository test that asserts a client-side count. `CountSource.clientSide` becomes dead code.
+
+## Prerequisites
+
+- [ ] Product/UX: confirm that an unknown count hides the sound-detail usage line (the plan's default).
+- Nothing else blocks: no protocol change, new package, or backend change. funnelcake already supports
+  NIP-45 and ignores `limit` on COUNT.
+
+## Not in scope (tracked elsewhere)
+
+- #8992: idle sockets dropped and never redialled. B makes COUNT self-sufficient; it does not keep sockets alive.
+- #6742: bound `fetchEventReposters`.
+- #6238: signal partial results from `queryEvents`.
+- N7: blocs fetch counts they already have seeds for. A candidate for its own issue.
+
+## Next Step
+
+`/plan https://github.com/divinevideo/divine-mobile/issues/8710` on Approach B, with `tasks/findings_8710.md`
+as the evidence base.

--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -238,7 +238,7 @@ class VideoInteractionsBloc
       // non-addressable getLikeCount is a raw, unfiltered tally that must not
       // raise the count. originalLikes (archival) is kept out of the floor so
       // it can't mask newly resolved Nostr likes.
-      final likeCount = _addressableId != null
+      final likeCount = _addressableId != null && fetchedLikeCount != null
           ? math.max(
               preFetchLikeCount ?? 0,
               (_archivedLikeCount ?? 0) + fetchedLikeCount,

--- a/mobile/lib/providers/sounds_providers.dart
+++ b/mobile/lib/providers/sounds_providers.dart
@@ -125,16 +125,16 @@ Future<List<AudioEvent>> soundsByCreator(Ref ref, String pubkey) async {
 
 /// Family provider for video usage count of a specific sound.
 ///
-/// Returns the number of Kind 34236 video events that reference the audio event.
-/// Uses NIP-45 COUNT if supported by relay, otherwise falls back to client-side count.
+/// Returns the number of Kind 34236 video events that reference the audio
+/// event, or `null` when the count is unknown because no relay answered.
 ///
 /// Usage:
 /// ```dart
 /// final countAsync = ref.watch(soundUsageCountProvider('audio-event-id'));
-/// final count = countAsync.valueOrNull ?? 0;
+/// final count = countAsync.value; // null while loading or when unknown
 /// ```
 @riverpod
-Future<int> soundUsageCount(Ref ref, String audioEventId) async {
+Future<int?> soundUsageCount(Ref ref, String audioEventId) async {
   if (audioEventId.isEmpty) return 0;
 
   final repository = ref.watch(soundsRepositoryProvider);

--- a/mobile/lib/providers/sounds_providers.g.dart
+++ b/mobile/lib/providers/sounds_providers.g.dart
@@ -476,13 +476,13 @@ final class SoundsByCreatorFamily extends $Family
 
 /// Family provider for video usage count of a specific sound.
 ///
-/// Returns the number of Kind 34236 video events that reference the audio event.
-/// Uses NIP-45 COUNT if supported by relay, otherwise falls back to client-side count.
+/// Returns the number of Kind 34236 video events that reference the audio
+/// event, or `null` when the count is unknown because no relay answered.
 ///
 /// Usage:
 /// ```dart
 /// final countAsync = ref.watch(soundUsageCountProvider('audio-event-id'));
-/// final count = countAsync.valueOrNull ?? 0;
+/// final count = countAsync.value; // null while loading or when unknown
 /// ```
 
 @ProviderFor(soundUsageCount)
@@ -490,27 +490,27 @@ final soundUsageCountProvider = SoundUsageCountFamily._();
 
 /// Family provider for video usage count of a specific sound.
 ///
-/// Returns the number of Kind 34236 video events that reference the audio event.
-/// Uses NIP-45 COUNT if supported by relay, otherwise falls back to client-side count.
+/// Returns the number of Kind 34236 video events that reference the audio
+/// event, or `null` when the count is unknown because no relay answered.
 ///
 /// Usage:
 /// ```dart
 /// final countAsync = ref.watch(soundUsageCountProvider('audio-event-id'));
-/// final count = countAsync.valueOrNull ?? 0;
+/// final count = countAsync.value; // null while loading or when unknown
 /// ```
 
 final class SoundUsageCountProvider
-    extends $FunctionalProvider<AsyncValue<int>, int, FutureOr<int>>
-    with $FutureModifier<int>, $FutureProvider<int> {
+    extends $FunctionalProvider<AsyncValue<int?>, int?, FutureOr<int?>>
+    with $FutureModifier<int?>, $FutureProvider<int?> {
   /// Family provider for video usage count of a specific sound.
   ///
-  /// Returns the number of Kind 34236 video events that reference the audio event.
-  /// Uses NIP-45 COUNT if supported by relay, otherwise falls back to client-side count.
+  /// Returns the number of Kind 34236 video events that reference the audio
+  /// event, or `null` when the count is unknown because no relay answered.
   ///
   /// Usage:
   /// ```dart
   /// final countAsync = ref.watch(soundUsageCountProvider('audio-event-id'));
-  /// final count = countAsync.valueOrNull ?? 0;
+  /// final count = countAsync.value; // null while loading or when unknown
   /// ```
   SoundUsageCountProvider._({
     required SoundUsageCountFamily super.from,
@@ -535,11 +535,11 @@ final class SoundUsageCountProvider
 
   @$internal
   @override
-  $FutureProviderElement<int> $createElement($ProviderPointer pointer) =>
+  $FutureProviderElement<int?> $createElement($ProviderPointer pointer) =>
       $FutureProviderElement(pointer);
 
   @override
-  FutureOr<int> create(Ref ref) {
+  FutureOr<int?> create(Ref ref) {
     final argument = this.argument as String;
     return soundUsageCount(ref, argument);
   }
@@ -555,21 +555,21 @@ final class SoundUsageCountProvider
   }
 }
 
-String _$soundUsageCountHash() => r'0006d93e606657fae006e7309d2f8cb8e1c0140d';
+String _$soundUsageCountHash() => r'1e8f4436c83dfe5b149c6a5c92ff53de304d639a';
 
 /// Family provider for video usage count of a specific sound.
 ///
-/// Returns the number of Kind 34236 video events that reference the audio event.
-/// Uses NIP-45 COUNT if supported by relay, otherwise falls back to client-side count.
+/// Returns the number of Kind 34236 video events that reference the audio
+/// event, or `null` when the count is unknown because no relay answered.
 ///
 /// Usage:
 /// ```dart
 /// final countAsync = ref.watch(soundUsageCountProvider('audio-event-id'));
-/// final count = countAsync.valueOrNull ?? 0;
+/// final count = countAsync.value; // null while loading or when unknown
 /// ```
 
 final class SoundUsageCountFamily extends $Family
-    with $FunctionalFamilyOverride<FutureOr<int>, String> {
+    with $FunctionalFamilyOverride<FutureOr<int?>, String> {
   SoundUsageCountFamily._()
     : super(
         retry: null,
@@ -581,13 +581,13 @@ final class SoundUsageCountFamily extends $Family
 
   /// Family provider for video usage count of a specific sound.
   ///
-  /// Returns the number of Kind 34236 video events that reference the audio event.
-  /// Uses NIP-45 COUNT if supported by relay, otherwise falls back to client-side count.
+  /// Returns the number of Kind 34236 video events that reference the audio
+  /// event, or `null` when the count is unknown because no relay answered.
   ///
   /// Usage:
   /// ```dart
   /// final countAsync = ref.watch(soundUsageCountProvider('audio-event-id'));
-  /// final count = countAsync.valueOrNull ?? 0;
+  /// final count = countAsync.value; // null while loading or when unknown
   /// ```
 
   SoundUsageCountProvider call(String audioEventId) =>

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -385,7 +385,7 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
                 SliverToBoxAdapter(
                   child: _SoundHeader(
                     sound: widget.sound,
-                    usageCount: usageCountAsync.value ?? 0,
+                    usageCount: usageCountAsync.value,
                     isPlaying: _isPlayingPreview,
                     isLoadingPreview: _isLoadingPreview,
                     onPreviewTap: _togglePreview,
@@ -462,7 +462,9 @@ class _SoundHeader extends ConsumerStatefulWidget {
   });
 
   final AudioEvent sound;
-  final int usageCount;
+
+  /// How many videos reuse this sound, or `null` while unknown.
+  final int? usageCount;
   final bool isPlaying;
   final bool isLoadingPreview;
   final VoidCallback onPreviewTap;
@@ -530,10 +532,13 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
     return '$minutes:${remainingSeconds.padLeft(2, '0')}';
   }
 
-  String _videoCountText(AppLocalizations l10n) {
-    if (widget.usageCount == 0) return l10n.soundNoVideoCount;
-    if (widget.usageCount == 1) return l10n.soundOneVideo;
-    return l10n.soundVideoCount(widget.usageCount);
+  String? _videoCountText(AppLocalizations l10n) {
+    return switch (widget.usageCount) {
+      null => null,
+      0 => l10n.soundNoVideoCount,
+      1 => l10n.soundOneVideo,
+      final count => l10n.soundVideoCount(count),
+    };
   }
 
   @override
@@ -598,12 +603,14 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
                       maxLines: 2,
                       overflow: TextOverflow.ellipsis,
                     ),
-                    Text(
-                      _metadataText(context.l10n),
-                      style: VineTheme.bodyMediumFont(
-                        color: context.vineColors.secondaryText,
+                    if (_metadataText(context.l10n) case final metadata
+                        when metadata.isNotEmpty)
+                      Text(
+                        metadata,
+                        style: VineTheme.bodyMediumFont(
+                          color: context.vineColors.secondaryText,
+                        ),
                       ),
-                    ),
                     if (profileCreditPubkey != null &&
                         profileCreditName != null)
                       _ProfileAttributionInfo(
@@ -701,7 +708,7 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
     final duration = _formattedDuration;
     return [
       if (duration.isNotEmpty) duration,
-      _videoCountText(l10n),
+      ?_videoCountText(l10n),
     ].join(' · ');
   }
 

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_stats_row.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_stats_row.dart
@@ -219,11 +219,9 @@ class _StatColumn extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final displayValue = isLoading
+    final displayValue = isLoading || count == null
         ? '—'
-        : count != null
-        ? StringUtils.formatCompactNumber(count!)
-        : '0';
+        : StringUtils.formatCompactNumber(count!);
 
     return Column(
       children: [

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -425,10 +425,7 @@ class CommentsRepository {
     }
   }
 
-  /// Gets the comment count for an event.
-  ///
-  /// Uses NIP-45 COUNT requests if supported by relays,
-  /// otherwise falls back to querying and counting.
+  /// Gets the comment count for an event from NIP-45 COUNT requests.
   ///
   /// Parameters:
   /// - [rootEventId]: The ID of the event to count comments for
@@ -439,10 +436,15 @@ class CommentsRepository {
   ///   the count. Defaults to `false` so flag-off callers do not inflate the
   ///   comment badge with reply-only videos.
   ///
-  /// Returns the number of comments on the event.
+  /// Returns the number of comments on the event, or `null` when the count is
+  /// unknown because a relay did not answer. When both the E and A counts are
+  /// needed and only one answers, the result is `null` too: the answer is the
+  /// larger of the two, and one side alone is only a floor. Nothing is cached
+  /// for an unknown count, so the next call asks again.
   ///
-  /// Throws [CountCommentsFailedException] if counting fails.
-  Future<int> getCommentsCount(
+  /// Throws [CountCommentsFailedException] if counting fails for any other
+  /// reason.
+  Future<int?> getCommentsCount(
     String rootEventId, {
     String? rootAddressableId,
     bool includeVideoReplies = false,
@@ -494,6 +496,8 @@ class CommentsRepository {
         rootAddressableId: rootAddressableId,
       );
       return count;
+    } on CountUnavailableException {
+      return null;
     } on Exception catch (e) {
       throw CountCommentsFailedException('Failed to count comments: $e');
     }

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -2132,6 +2132,52 @@ void main() {
         );
       });
 
+      test('returns null and caches nothing when no relay answered', () async {
+        when(() => mockNostrClient.countEvents(any())).thenThrow(
+          const CountUnavailableException('No relay responded to COUNT'),
+        );
+
+        final first = await repository.getCommentsCount(testRootEventId);
+        final second = await repository.getCommentsCount(testRootEventId);
+
+        expect(first, isNull);
+        expect(second, isNull);
+        verify(() => mockNostrClient.countEvents(any())).called(2);
+      });
+
+      test(
+        'returns null rather than a floor when only one of the E and A '
+        'counts is answered',
+        () async {
+          const testAddressableId =
+              '34236:$testRootAuthorPubkey'
+              ':video-dtag';
+
+          var callCount = 0;
+          when(() => mockNostrClient.countEvents(any())).thenAnswer((_) async {
+            callCount++;
+            // The E count answers and the A count does not.
+            if (callCount.isOdd) return const CountResult(count: 5);
+            throw const CountUnavailableException(
+              'No relay responded to COUNT',
+            );
+          });
+
+          final first = await repository.getCommentsCount(
+            testRootEventId,
+            rootAddressableId: testAddressableId,
+          );
+          final second = await repository.getCommentsCount(
+            testRootEventId,
+            rootAddressableId: testAddressableId,
+          );
+
+          expect(first, isNull);
+          expect(second, isNull);
+          verify(() => mockNostrClient.countEvents(any())).called(4);
+        },
+      );
+
       test('returns cached count on second call without relay query', () async {
         when(() => mockNostrClient.countEvents(any())).thenAnswer(
           (_) async => const CountResult(count: 42),

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -1457,8 +1457,12 @@ class LikesRepository {
   /// moderation, so it can legitimately be wider or narrower than this count
   /// (#6021). The two denominators are reconciled in divine-funnelcake#626.
   ///
+  /// Returns `null` when the COUNT for a non-addressable event gets no
+  /// answer from any relay. Nothing is cached then, so the next call asks
+  /// again.
+  ///
   /// Note: This counts all likes, not just the current user's.
-  Future<int> getLikeCount(String eventId, {String? addressableId}) async {
+  Future<int?> getLikeCount(String eventId, {String? addressableId}) async {
     final cached = _readCachedLikeCount(eventId, addressableId: addressableId);
     if (cached != null) return cached;
 
@@ -1477,8 +1481,12 @@ class LikesRepository {
     } else {
       // Query relays for the count of Kind 7 reactions on this event.
       final filterByE = Filter(kinds: const [EventKind.reaction], e: [eventId]);
-      final result = await _nostrClient.countEvents([filterByE]);
-      count = result.count;
+      try {
+        final result = await _nostrClient.countEvents([filterByE]);
+        count = result.count;
+      } on CountUnavailableException {
+        return null;
+      }
     }
 
     _writeCachedLikeCount(eventId, count, addressableId: addressableId);

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -2657,6 +2657,17 @@ void main() {
     });
 
     group('getLikeCount', () {
+      test('returns null and caches nothing when no relay answered', () async {
+        when(() => mockNostrClient.countEvents(any())).thenThrow(
+          const CountUnavailableException('No relay responded to COUNT'),
+        );
+
+        repository = createRepository();
+        expect(await repository.getLikeCount(testEventId), isNull);
+        expect(await repository.getLikeCount(testEventId), isNull);
+        verify(() => mockNostrClient.countEvents(any())).called(2);
+      });
+
       test('queries relay for like count by event ID', () async {
         when(
           () => mockNostrClient.countEvents(any()),

--- a/mobile/packages/nostr_client/lib/src/models/count_result.dart
+++ b/mobile/packages/nostr_client/lib/src/models/count_result.dart
@@ -13,9 +13,6 @@ enum CountSource {
 
   /// Count came from WebSocket relay (NIP-45)
   websocket,
-
-  /// Count was computed client-side by fetching events
-  clientSide,
 }
 
 /// Result of a COUNT query (NIP-45)
@@ -60,4 +57,20 @@ class CountResult extends Equatable {
 
   @override
   List<Object?> get props => [count, approximate, source];
+}
+
+/// Thrown by `NostrClient.countEvents` when no relay produced a NIP-45 COUNT
+/// answer: every relay was unreachable, too slow, refused the COUNT with
+/// CLOSED, or does not implement it.
+///
+/// The count is unknown. Callers must not substitute a number for it.
+class CountUnavailableException implements Exception {
+  /// Creates an exception carrying the relay layer's [reason].
+  const CountUnavailableException(this.reason);
+
+  /// Why no count came back, as reported by the relay layer.
+  final String reason;
+
+  @override
+  String toString() => 'CountUnavailableException: $reason';
 }

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -1145,12 +1145,17 @@ class NostrClient {
     return result.events;
   }
 
-  /// Counts events matching the given filters using NIP-45.
+  /// Counts events matching the given filters using NIP-45 COUNT.
   ///
   /// This is more efficient than [queryEvents] when you only need the count,
-  /// not the actual events. Uses NIP-45 COUNT requests to relays.
+  /// not the actual events.
   ///
-  /// Falls back to client-side counting if relay doesn't support NIP-45.
+  /// [timeout] bounds the whole call. When no relay took the COUNT, because
+  /// the pool went idle or every relay dropped, the relays are redialled once
+  /// and the COUNT is asked again within what is left of it.
+  ///
+  /// Throws [CountUnavailableException] when no relay answered. The count is
+  /// then unknown, and no number is substituted for it.
   ///
   /// Example - Count followers:
   /// ```dart
@@ -1174,32 +1179,46 @@ class NostrClient {
     List<int> relayTypes = RelayType.all,
     Duration timeout = const Duration(seconds: 5),
   }) async {
+    final deadline = DateTime.now().add(timeout);
+    Duration remainingTimeout() {
+      final remaining = deadline.difference(DateTime.now());
+      return remaining.isNegative ? Duration.zero : remaining;
+    }
+
     final effectiveTempRelays = _allowedRelays(tempRelays);
     final filtersJson = filters.map((f) => f.toJson()).toList();
+    Future<CountResponse> askRelays(Duration budget) => _nostr.countEvents(
+      filtersJson,
+      id: subscriptionId,
+      tempRelays: effectiveTempRelays,
+      relayTypes: relayTypes,
+      timeout: budget,
+    );
 
     try {
-      // Try NIP-45 COUNT first
-      final response = await _nostr.countEvents(
-        filtersJson,
-        id: subscriptionId,
-        tempRelays: effectiveTempRelays,
-        relayTypes: relayTypes,
-        timeout: timeout,
-      );
+      CountResponse response;
+      try {
+        response = await askRelays(timeout);
+      } on CountNotSentException catch (e) {
+        // No relay took the COUNT, so the pool is idle or down. Redial once,
+        // as queries do, and ask again within what is left of the budget.
+        try {
+          await retryDisconnectedRelays().timeout(remainingTimeout());
+        } on TimeoutException {
+          // The redial outlived the budget; nothing is left to ask with.
+        }
+        if (remainingTimeout() == Duration.zero) {
+          throw CountUnavailableException(e.reason);
+        }
+        response = await askRelays(remainingTimeout());
+      }
 
       return CountResult(
         count: _normalizeRelayCount(response.count),
         approximate: response.approximate,
       );
-    } on CountNotSupportedException {
-      // Fall back to fetching events and counting client-side
-      final events = await queryEvents(
-        filters,
-        tempRelays: effectiveTempRelays,
-        relayTypes: relayTypes,
-      );
-
-      return CountResult(count: events.length, source: CountSource.clientSide);
+    } on CountNotSupportedException catch (e) {
+      throw CountUnavailableException(e.reason);
     }
   }
 

--- a/mobile/packages/nostr_client/test/src/models/count_result_test.dart
+++ b/mobile/packages/nostr_client/test/src/models/count_result_test.dart
@@ -18,12 +18,12 @@ void main() {
       const result = CountResult(
         count: 100,
         approximate: true,
-        source: CountSource.clientSide,
+        source: CountSource.cache,
       );
 
       expect(result.count, equals(100));
       expect(result.approximate, isTrue);
-      expect(result.source, equals(CountSource.clientSide));
+      expect(result.source, equals(CountSource.cache));
     });
 
     test('copyWith creates new instance with updated values', () {
@@ -58,22 +58,12 @@ void main() {
     test('equality works correctly', () {
       const result1 = CountResult(count: 42);
       const result2 = CountResult(count: 42);
-      const result3 = CountResult(count: 42, source: CountSource.clientSide);
+      const result3 = CountResult(count: 42, source: CountSource.gateway);
       const result4 = CountResult(count: 100);
 
       expect(result1, equals(result2));
       expect(result1, isNot(equals(result3)));
       expect(result1, isNot(equals(result4)));
-    });
-  });
-
-  group('CountSource', () {
-    test('has all expected values', () {
-      expect(CountSource.values, hasLength(4));
-      expect(CountSource.values, contains(CountSource.cache));
-      expect(CountSource.values, contains(CountSource.gateway));
-      expect(CountSource.values, contains(CountSource.websocket));
-      expect(CountSource.values, contains(CountSource.clientSide));
     });
   });
 }

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -5349,16 +5349,11 @@ void main() {
         expect(result.source, equals(CountSource.websocket));
       });
 
-      test('falls back to queryEvents when COUNT not supported', () async {
+      test('throws $CountUnavailableException when no relay answers, '
+          'without fetching events', () async {
         final filters = [
           Filter(kinds: [EventKind.textNote]),
         ];
-        final events = [
-          _createTestEvent(),
-          _createTestEvent(),
-          _createTestEvent(),
-        ];
-
         when(
           () => mockNostr.countEvents(
             any(),
@@ -5367,7 +5362,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             timeout: any(named: 'timeout'),
           ),
-        ).thenThrow(CountNotSupportedException('Not supported'));
+        ).thenThrow(CountNotSupportedException('No relay responded to COUNT'));
         when(
           () => mockNostr.queryEvents(
             any(),
@@ -5376,14 +5371,154 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
           ),
-        ).thenAnswer((_) async => events);
+        ).thenAnswer((_) async => [_createTestEvent(), _createTestEvent()]);
 
-        final result = await client.countEvents(filters);
-
-        expect(result.count, equals(3));
-        expect(result.approximate, isFalse);
-        expect(result.source, equals(CountSource.clientSide));
+        await expectLater(
+          client.countEvents(filters),
+          throwsA(isA<CountUnavailableException>()),
+        );
+        verifyNever(
+          () => mockNostr.queryEvents(
+            any(),
+            id: any(named: 'id'),
+            tempRelays: any(named: 'tempRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            sendAfterAuth: any(named: 'sendAfterAuth'),
+          ),
+        );
       });
+
+      test(
+        'redials once and asks again when no relay took the COUNT',
+        () async {
+          final calls = <String>[];
+          var attempts = 0;
+          when(
+            () => mockNostr.countEvents(
+              any(),
+              id: any(named: 'id'),
+              tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async {
+            calls.add('COUNT');
+            attempts++;
+            if (attempts == 1) {
+              throw CountNotSentException('No relay accepted COUNT');
+            }
+            return const CountResponse(count: 7);
+          });
+          when(mockRelayManager.retryDisconnectedRelays).thenAnswer((_) async {
+            calls.add('redial');
+          });
+
+          final result = await client.countEvents([
+            Filter(kinds: [EventKind.textNote]),
+          ]);
+
+          expect(calls, equals(['COUNT', 'redial', 'COUNT']));
+          expect(result.count, equals(7));
+        },
+      );
+
+      test('gives up after one redial when no relay takes the COUNT either '
+          'time', () async {
+        when(
+          () => mockNostr.countEvents(
+            any(),
+            id: any(named: 'id'),
+            tempRelays: any(named: 'tempRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenThrow(CountNotSentException('No relay accepted COUNT'));
+        when(mockRelayManager.retryDisconnectedRelays).thenAnswer((_) async {});
+
+        await expectLater(
+          client.countEvents([
+            Filter(kinds: [EventKind.textNote]),
+          ]),
+          throwsA(isA<CountUnavailableException>()),
+        );
+        verify(mockRelayManager.retryDisconnectedRelays).called(1);
+        verify(
+          () => mockNostr.countEvents(
+            any(),
+            id: any(named: 'id'),
+            tempRelays: any(named: 'tempRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).called(2);
+      });
+
+      test(
+        'does not redial when a relay took the COUNT but none answered',
+        () async {
+          when(
+            () => mockNostr.countEvents(
+              any(),
+              id: any(named: 'id'),
+              tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenThrow(
+            CountNotSupportedException('No relay responded to COUNT'),
+          );
+
+          await expectLater(
+            client.countEvents([
+              Filter(kinds: [EventKind.textNote]),
+            ]),
+            throwsA(isA<CountUnavailableException>()),
+          );
+          verifyNever(mockRelayManager.retryDisconnectedRelays);
+        },
+      );
+
+      test(
+        'does not ask again once the redial has spent the whole timeout',
+        () async {
+          final redial = Completer<void>();
+          addTearDown(() {
+            if (!redial.isCompleted) redial.complete();
+          });
+          when(
+            () => mockNostr.countEvents(
+              any(),
+              id: any(named: 'id'),
+              tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenThrow(CountNotSentException('No relay accepted COUNT'));
+          when(
+            mockRelayManager.retryDisconnectedRelays,
+          ).thenAnswer((_) => redial.future);
+
+          await expectLater(
+            client.countEvents(
+              [
+                Filter(kinds: [EventKind.textNote]),
+              ],
+              timeout: const Duration(milliseconds: 200),
+            ),
+            throwsA(isA<CountUnavailableException>()),
+          );
+          verify(
+            () => mockNostr.countEvents(
+              any(),
+              id: any(named: 'id'),
+              tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).called(1);
+        },
+        timeout: const Timeout(Duration(seconds: 3)),
+      );
 
       test('passes subscriptionId parameter', () async {
         final filters = [

--- a/mobile/packages/nostr_sdk/lib/count_response.dart
+++ b/mobile/packages/nostr_sdk/lib/count_response.dart
@@ -26,7 +26,12 @@ class CountResponse {
   int get hashCode => Object.hash(count, approximate);
 }
 
-/// Exception thrown when a relay doesn't support COUNT queries (NIP-45)
+/// Thrown when no relay produced a NIP-45 COUNT answer.
+///
+/// Despite the name, a relay without NIP-45 is only one cause: a relay that
+/// refused the COUNT (CLOSED), did not answer before the deadline, or could
+/// not be reached at all ends here too. [CountNotSentException] narrows it to
+/// the last case.
 class CountNotSupportedException implements Exception {
   final String reason;
 
@@ -34,4 +39,16 @@ class CountNotSupportedException implements Exception {
 
   @override
   String toString() => 'CountNotSupportedException: $reason';
+}
+
+/// Thrown when no relay accepted the COUNT frame, because every eligible
+/// relay was disconnected or could not be written before the deadline.
+///
+/// Unlike a COUNT a relay accepted and did not answer, this one can be cured
+/// by reconnecting and asking again.
+class CountNotSentException extends CountNotSupportedException {
+  CountNotSentException(super.reason);
+
+  @override
+  String toString() => 'CountNotSentException: $reason';
 }

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -428,7 +428,9 @@ class Nostr {
   /// Unlike [queryEvents], this returns a single count rather than
   /// a list of events. Useful for follower counts, reaction counts, etc.
   ///
-  /// Throws [CountNotSupportedException] if no relay supports NIP-45.
+  /// Throws [CountNotSentException] when no relay accepted the COUNT, and
+  /// [CountNotSupportedException] when relays accepted it but none answered.
+  /// See [RelayPool.count].
   Future<CountResponse> countEvents(
     List<Map<String, dynamic>> filters, {
     String? id,

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -3303,17 +3303,25 @@ class RelayPool {
     return completer.future;
   }
 
-  /// Sends a COUNT query (NIP-45) to relays and returns the count.
+  /// Sends a COUNT query (NIP-45) to relays and returns the largest count.
   ///
   /// Unlike [query], this returns a count rather than events.
-  /// Throws [CountNotSupportedException] if no relay supports NIP-45.
+  ///
+  /// [timeout] bounds the whole request, the send included, so a relay that
+  /// is still connecting cannot hold it past the deadline. A COUNT that could
+  /// not be written is dropped, not queued: replayed on the next connection,
+  /// its answer would reach nobody.
+  ///
+  /// Throws [CountNotSentException] when no relay accepted the COUNT, and
+  /// [CountNotSupportedException] when relays accepted it but none answered
+  /// in time, whether by timing out or refusing with CLOSED.
   ///
   /// Parameters:
   /// - [filters]: The filters to count events for (same format as REQ)
   /// - [id]: Optional subscription ID
   /// - [tempRelays]: Optional list of temporary relays to query
   /// - [relayTypes]: Types of relays to query (default: all)
-  /// - [timeout]: How long to wait for a response (default: 5 seconds)
+  /// - [timeout]: How long the whole request may take (default: 5 seconds)
   Future<CountResponse> count(
     List<Map<String, dynamic>> filters, {
     String? id,
@@ -3323,6 +3331,12 @@ class RelayPool {
   }) async {
     if (filters.isEmpty) {
       throw ArgumentError('No filters given', 'filters');
+    }
+
+    final deadline = DateTime.now().add(timeout);
+    Duration remaining() {
+      final left = deadline.difference(DateTime.now());
+      return left.isNegative ? Duration.zero : left;
     }
 
     tempRelays = handleAddrList(tempRelays);
@@ -3369,9 +3383,10 @@ class RelayPool {
         .toList();
 
     if (eligibleRelays.isEmpty) {
-      throw CountNotSupportedException('No relay responded to COUNT');
+      throw CountNotSentException('No relay can take COUNT');
     }
 
+    var acceptedByAny = false;
     final futures = <Future<CountResponse?>>[];
     for (var i = 0; i < eligibleRelays.length; i++) {
       final relay = eligibleRelays[i];
@@ -3381,28 +3396,55 @@ class RelayPool {
 
       futures.add(() async {
         try {
-          final sent = await relay.send(relayMessage, skipReconnect: true);
-          if (!sent) return null;
+          final sent = await relay.send(
+            relayMessage,
+            queueIfFailed: false,
+            skipReconnect: true,
+            deadline: deadline,
+          );
+          if (!sent) {
+            log('📊 COUNT not sent to ${relay.url}');
+            _diagnose(
+              RelayDiagnosticSite.queryDispatch,
+              RelayDiagnosticLevel.info,
+              relay.url,
+              'COUNT $relaySubId not sent',
+            );
+            return null;
+          }
+          acceptedByAny = true;
 
           // Only register after successful send to avoid orphaned completers
           final responseFuture = relay.registerCountQuery(relaySubId);
           log('📊 COUNT request sent to ${relay.url}');
-          return await responseFuture.timeout(
-            timeout,
-            onTimeout: () {
-              // Clean up the completer on timeout
-              if (relay.hasCountQuery(relaySubId)) {
-                relay.failCountQuery(relaySubId, 'Timeout');
-              }
-              throw CountNotSupportedException('Timeout');
-            },
+          return await responseFuture.timeout(remaining());
+        } on TimeoutException {
+          log('📊 COUNT timed out on ${relay.url}');
+          relay.failCountQuery(relaySubId, 'Timeout');
+          _diagnose(
+            RelayDiagnosticSite.requestSettlement,
+            RelayDiagnosticLevel.warning,
+            relay.url,
+            'Relay did not answer COUNT $relaySubId within '
+            '${timeout.inMilliseconds} ms',
           );
+          return null;
+        } on CountNotSupportedException catch (e) {
+          // A CLOSED refusal, which the CLOSED handler has already reported.
+          log('📊 COUNT refused by ${relay.url}: $e');
+          return null;
         } catch (e) {
           log('📊 COUNT failed on ${relay.url}: $e');
           // Clean up if the completer is still pending
           if (relay.hasCountQuery(relaySubId)) {
             relay.failCountQuery(relaySubId, e.toString());
           }
+          _diagnose(
+            RelayDiagnosticSite.requestSettlement,
+            RelayDiagnosticLevel.warning,
+            relay.url,
+            'COUNT $relaySubId failed (${e.runtimeType})',
+          );
           return null;
         }
       }());
@@ -3415,6 +3457,9 @@ class RelayPool {
     );
 
     if (best == null) {
+      if (!acceptedByAny) {
+        throw CountNotSentException('No relay accepted COUNT');
+      }
       throw CountNotSupportedException('No relay responded to COUNT');
     }
 

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -3395,6 +3395,10 @@ class RelayPool {
       final relayMessage = ['COUNT', relaySubId, ...filters];
 
       futures.add(() async {
+        // What is left of the budget once the send is done, so the timeout
+        // diagnostic reports the wait the relay actually had rather than the
+        // whole request budget.
+        var answerBudget = timeout;
         try {
           final sent = await relay.send(
             relayMessage,
@@ -3417,7 +3421,8 @@ class RelayPool {
           // Only register after successful send to avoid orphaned completers
           final responseFuture = relay.registerCountQuery(relaySubId);
           log('📊 COUNT request sent to ${relay.url}');
-          return await responseFuture.timeout(remaining());
+          answerBudget = remaining();
+          return await responseFuture.timeout(answerBudget);
         } on TimeoutException {
           log('📊 COUNT timed out on ${relay.url}');
           relay.failCountQuery(relaySubId, 'Timeout');
@@ -3426,7 +3431,7 @@ class RelayPool {
             RelayDiagnosticLevel.warning,
             relay.url,
             'Relay did not answer COUNT $relaySubId within '
-            '${timeout.inMilliseconds} ms',
+            '${answerBudget.inMilliseconds} ms',
           );
           return null;
         } on CountNotSupportedException catch (e) {

--- a/mobile/packages/nostr_sdk/test/support/fake_web_socket.dart
+++ b/mobile/packages/nostr_sdk/test/support/fake_web_socket.dart
@@ -73,6 +73,11 @@ class FakeWebSocketChannel implements WebSocketChannel {
 
   void simulateMessage(dynamic message) => _streamController.add(message);
 
+  /// Ends the stream as a relay dropping the socket would. The connection
+  /// manager handles this through the same `_handleDisconnect()` its idle
+  /// heartbeat uses, so it also stands in for an idle drop.
+  Future<void> closeFromRemote() => _streamController.close();
+
   List<dynamic> get sentMessages => _sink.messages;
 
   /// Whether the sink was closed — i.e. whether the socket this channel

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_count_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_count_test.dart
@@ -1,10 +1,183 @@
 // ABOUTME: Unit tests for NIP-45 COUNT functionality in RelayPool.
 // ABOUTME: Tests the count method and countEvents on Nostr class.
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:nostr_sdk/relay/client_connected.dart';
+
+import '../support/fake_web_socket.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('RelayPool.count delivery', () {
+    const relayUrl = 'wss://relay.test';
+    const countId = 'count-8710';
+    const filterSentinel = 'filter-sentinel-must-not-reach-diagnostics';
+    final filters = [
+      {
+        'kinds': [16],
+        '#a': [
+          '34236:82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2'
+              ':$filterSentinel',
+        ],
+      },
+    ];
+
+    late List<RelayDiagnostic> diagnostics;
+    late FakeWebSocketChannelFactory factory;
+    late Nostr nostr;
+    late RelayBase relay;
+
+    setUp(() async {
+      diagnostics = [];
+      factory = FakeWebSocketChannelFactory();
+      nostr = Nostr(
+        LocalNostrSigner(
+          '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+        ),
+        [],
+        (url) => RelayBase(url, RelayStatus(url), channelFactory: factory),
+        diagnosticsSink: diagnostics.add,
+      );
+      relay = RelayBase(
+        relayUrl,
+        RelayStatus(relayUrl),
+        channelFactory: factory,
+      );
+      expect(await nostr.relayPool.add(relay), isTrue);
+    });
+
+    tearDown(() => nostr.close());
+
+    Future<void> dropSocket() async {
+      await factory.lastChannel!.closeFromRemote();
+      await pumpEventQueue();
+      expect(relay.relayStatus.connected, ClientConnected.disconnect);
+    }
+
+    Iterable<String> countFramesOn(FakeWebSocketChannel channel) => channel
+        .sentMessages
+        .cast<String>()
+        .where((frame) => frame.startsWith('["COUNT"'));
+
+    Iterable<(RelayDiagnosticSite, RelayDiagnosticLevel)> countDiagnostics() =>
+        diagnostics
+            .where((entry) => entry.message.contains(countId))
+            .map((entry) => (entry.site, entry.level));
+
+    test('does not replay a COUNT the dropped socket could not take once the '
+        'socket is back', () async {
+      await dropSocket();
+      await expectLater(
+        nostr.relayPool.count(filters, id: countId),
+        throwsA(isA<CountNotSupportedException>()),
+      );
+
+      expect(await relay.connect(), isTrue);
+      await pumpEventQueue();
+
+      expect(factory.createdChannels, hasLength(2));
+      expect(countFramesOn(factory.lastChannel!), isEmpty);
+    });
+
+    test('reports a COUNT no relay could take as not sent', () async {
+      await dropSocket();
+
+      await expectLater(
+        nostr.relayPool.count(filters, id: countId),
+        throwsA(isA<CountNotSentException>()),
+      );
+    });
+
+    test('reports a COUNT a relay took but never answered as unanswered, '
+        'not as not sent', () async {
+      await expectLater(
+        nostr.relayPool.count(
+          filters,
+          id: countId,
+          timeout: const Duration(milliseconds: 50),
+        ),
+        throwsA(
+          allOf(
+            isA<CountNotSupportedException>(),
+            isNot(isA<CountNotSentException>()),
+          ),
+        ),
+      );
+
+      expect(countFramesOn(factory.lastChannel!), hasLength(1));
+    });
+
+    test('does not let a relay that is still connecting hold the COUNT past '
+        'its timeout', () async {
+      await dropSocket();
+      final handshake = Completer<void>();
+      addTearDown(() {
+        if (!handshake.isCompleted) handshake.complete();
+      });
+      factory.readyFutureFactory = () => handshake.future;
+      unawaited(relay.connect());
+      await pumpEventQueue();
+
+      await expectLater(
+        nostr.relayPool.count(
+          filters,
+          id: countId,
+          timeout: const Duration(milliseconds: 100),
+        ),
+        throwsA(isA<CountNotSentException>()),
+      );
+    }, timeout: const Timeout(Duration(seconds: 3)));
+
+    test('records a COUNT no relay could take as a dispatch diagnostic, '
+        'without the filter', () async {
+      await dropSocket();
+      await expectLater(
+        nostr.relayPool.count(filters, id: countId),
+        throwsA(isA<CountNotSupportedException>()),
+      );
+
+      expect(
+        countDiagnostics(),
+        contains((
+          RelayDiagnosticSite.queryDispatch,
+          RelayDiagnosticLevel.info,
+        )),
+      );
+      expect(
+        diagnostics.map((entry) => entry.message).join('\n'),
+        isNot(contains(filterSentinel)),
+      );
+    });
+
+    test('records a COUNT a relay never answered as a settlement warning, '
+        'without the filter', () async {
+      await expectLater(
+        nostr.relayPool.count(
+          filters,
+          id: countId,
+          timeout: const Duration(milliseconds: 50),
+        ),
+        throwsA(isA<CountNotSupportedException>()),
+      );
+
+      expect(
+        countDiagnostics(),
+        contains((
+          RelayDiagnosticSite.requestSettlement,
+          RelayDiagnosticLevel.warning,
+        )),
+      );
+      expect(
+        diagnostics.map((entry) => entry.message).join('\n'),
+        isNot(contains(filterSentinel)),
+      );
+    });
+  });
+
   group('RelayPool count Tests', () {
     late Nostr nostr;
     late LocalNostrSigner signer;

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -240,8 +240,11 @@ class RepostsRepository {
   /// Returns a locally-cached count if available (set by recent toggle
   /// operations), otherwise queries relays via NIP-45 COUNT.
   ///
+  /// Returns `null` when no relay answered. Nothing is cached then, so the
+  /// next call asks again.
+  ///
   /// Note: This counts all reposts from all users, not just the current user's.
-  Future<int> getRepostCount(String addressableId) async {
+  Future<int?> getRepostCount(String addressableId) async {
     // Use local cache if available (set by recent toggle operations or a
     // previous relay fetch). This prevents redundant relay queries when
     // scrolling back to an already-viewed video.
@@ -255,9 +258,7 @@ class RepostsRepository {
       a: [addressableId],
     );
 
-    final result = await _nostrClient.countEvents([filter]);
-    _cacheRepostCount(addressableId, result.count);
-    return result.count;
+    return _countAndCache(addressableId, filter);
   }
 
   /// Get the repost count for a video by its event ID.
@@ -267,8 +268,11 @@ class RepostsRepository {
   ///
   /// Use this method for non-addressable videos (videos without a d-tag).
   ///
+  /// Returns `null` when no relay answered. Nothing is cached then, so the
+  /// next call asks again.
+  ///
   /// Note: This counts all reposts from all users, not just the current user's.
-  Future<int> getRepostCountByEventId(String eventId) async {
+  Future<int?> getRepostCountByEventId(String eventId) async {
     if (_localCountCache.containsKey(eventId)) {
       return _localCountCache[eventId]!;
     }
@@ -280,8 +284,17 @@ class RepostsRepository {
       e: [eventId],
     );
 
-    final result = await _nostrClient.countEvents([filter]);
-    _cacheRepostCount(eventId, result.count);
+    return _countAndCache(eventId, filter);
+  }
+
+  Future<int?> _countAndCache(String cacheKey, Filter filter) async {
+    final CountResult result;
+    try {
+      result = await _nostrClient.countEvents([filter]);
+    } on CountUnavailableException {
+      return null;
+    }
+    _cacheRepostCount(cacheKey, result.count);
     return result.count;
   }
 

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -1350,6 +1350,18 @@ void main() {
     });
 
     group('getRepostCount', () {
+      test('returns null and caches nothing when no relay answered', () async {
+        when(() => mockNostrClient.countEvents(any())).thenThrow(
+          const CountUnavailableException('No relay responded to COUNT'),
+        );
+
+        final repository = RepostsRepository(nostrClient: mockNostrClient);
+
+        expect(await repository.getRepostCount(testAddressableId), isNull);
+        expect(await repository.getRepostCount(testAddressableId), isNull);
+        verify(() => mockNostrClient.countEvents(any())).called(2);
+      });
+
       test('queries relays for repost count', () async {
         when(
           () => mockNostrClient.countEvents(any()),
@@ -1541,6 +1553,18 @@ void main() {
         final count = await repository.getRepostCountByEventId(testEventId);
 
         expect(count, equals(0));
+      });
+
+      test('returns null and caches nothing when no relay answered', () async {
+        when(() => mockNostrClient.countEvents(any())).thenThrow(
+          const CountUnavailableException('No relay responded to COUNT'),
+        );
+
+        final repository = RepostsRepository(nostrClient: mockNostrClient);
+
+        expect(await repository.getRepostCountByEventId(testEventId), isNull);
+        expect(await repository.getRepostCountByEventId(testEventId), isNull);
+        verify(() => mockNostrClient.countEvents(any())).called(2);
       });
     });
 

--- a/mobile/packages/sounds_repository/lib/src/sounds_repository.dart
+++ b/mobile/packages/sounds_repository/lib/src/sounds_repository.dart
@@ -313,14 +313,15 @@ class SoundsRepository {
     return _cache[eventId];
   }
 
-  /// Fetch the count of videos using a specific sound.
-  ///
-  /// Uses NIP-45 COUNT if the relay supports it, otherwise falls back to
-  /// fetching events and counting client-side.
+  /// Fetch the count of videos using a specific sound, via NIP-45 COUNT.
   ///
   /// The count is based on Kind 34236 video events that reference the
   /// audio event ID in their tags.
-  Future<int> fetchVideosUsingSoundCount(String audioEventId) async {
+  ///
+  /// Returns `null` when the count is unknown, because no relay answered or
+  /// the query failed. An empty [audioEventId] cannot be referenced by any
+  /// video, so it returns 0.
+  Future<int?> fetchVideosUsingSoundCount(String audioEventId) async {
     if (audioEventId.isEmpty) {
       Log.debug(
         'Empty audioEventId provided to fetchVideosUsingSoundCount',
@@ -353,13 +354,20 @@ class SoundsRepository {
       );
 
       return result.count;
+    } on CountUnavailableException catch (e) {
+      Log.debug(
+        'Video count for audio $audioEventId unavailable: ${e.reason}',
+        name: 'SoundsRepository',
+        category: LogCategory.api,
+      );
+      return null;
     } on Exception catch (e) {
       Log.error(
         'Error fetching video count for audio: $e',
         name: 'SoundsRepository',
         category: LogCategory.api,
       );
-      return 0;
+      return null;
     }
   }
 

--- a/mobile/packages/sounds_repository/test/src/sounds_repository_test.dart
+++ b/mobile/packages/sounds_repository/test/src/sounds_repository_test.dart
@@ -443,7 +443,25 @@ void main() {
         expect(filters.first.e, contains(testEventId1));
       });
 
-      test('returns 0 on error', () async {
+      test('returns null when no relay answered the count', () async {
+        when(
+          () => mockNostrClient.countEvents(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            tempRelays: any(named: 'tempRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenThrow(
+          const CountUnavailableException('No relay responded to COUNT'),
+        );
+
+        final count = await repository.fetchVideosUsingSoundCount(testEventId1);
+
+        expect(count, isNull);
+      });
+
+      test('returns null rather than zero on error', () async {
         when(
           () => mockNostrClient.countEvents(
             any(),
@@ -456,7 +474,7 @@ void main() {
 
         final count = await repository.fetchVideosUsingSoundCount(testEventId1);
 
-        expect(count, 0);
+        expect(count, isNull);
       });
     });
 

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -153,6 +153,77 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        'leaves an unknown addressable like count unknown instead of zero',
+        setUp: () {
+          when(
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+              addressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockRepostsRepository.isReposted(testAddressableId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockLikesRepository.getLikeCount(
+              testEventId,
+              addressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockCommentsRepository.getCommentsCount(
+              testEventId,
+              rootAddressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => 7);
+          when(
+            () => mockRepostsRepository.getRepostCount(testAddressableId),
+          ).thenAnswer((_) async => 32);
+        },
+        build: () => createBloc(addressableId: testAddressableId),
+        act: (bloc) => bloc.add(const VideoInteractionsFetchRequested()),
+        expect: () => [
+          const VideoInteractionsState(status: VideoInteractionsStatus.loading),
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            commentCount: 7,
+            repostCount: 32,
+          ),
+        ],
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        'applies the like and repost counts when the comment count is unknown',
+        setUp: () {
+          when(
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+            ),
+          ).thenAnswer((_) async => true);
+          when(
+            () => mockLikesRepository.getLikeCount(testEventId),
+          ).thenAnswer((_) async => 42);
+          when(
+            () => mockCommentsRepository.getCommentsCount(testEventId),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockRepostsRepository.getRepostCountByEventId(testEventId),
+          ).thenAnswer((_) async => 5);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const VideoInteractionsFetchRequested()),
+        expect: () => [
+          const VideoInteractionsState(status: VideoInteractionsStatus.loading),
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            isLiked: true,
+            likeCount: 42,
+            repostCount: 5,
+          ),
+        ],
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
         // #6022: the like floor is addressable + likes-ONLY. The clean
         // addressable relay resolve raises the like count above the seed, but
         // comment and repost counts are NOT floored — their higher relay

--- a/mobile/test/providers/sounds_providers_test.dart
+++ b/mobile/test/providers/sounds_providers_test.dart
@@ -469,6 +469,27 @@ void main() {
         expect(count, equals(42));
       });
 
+      test('returns null when the repository cannot tell', () async {
+        when(
+          () => mockRepository.fetchVideosUsingSoundCount('audio-123'),
+        ).thenAnswer((_) async => null);
+        when(() => mockRepository.initialize()).thenAnswer((_) async {});
+        when(() => mockRepository.dispose()).thenAnswer((_) async {});
+
+        final container = ProviderContainer(
+          overrides: [
+            soundsRepositoryProvider.overrideWithValue(mockRepository),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final count = await container.read(
+          soundUsageCountProvider('audio-123').future,
+        );
+
+        expect(count, isNull);
+      });
+
       test('returns 0 for empty audioEventId', () async {
         when(() => mockRepository.initialize()).thenAnswer((_) async {});
         when(() => mockRepository.dispose()).thenAnswer((_) async {});

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -184,6 +184,91 @@ void main() {
       when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
     });
 
+    group('Usage count', () {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      Future<void> pumpWithUsageCount(
+        WidgetTester tester,
+        AudioEvent sound,
+        Future<int?> usageCount,
+      ) async {
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(sound: sound),
+            overrides: [
+              soundUsageCountProvider(
+                sound.id,
+              ).overrideWith((ref) => usageCount),
+              videosUsingSoundProvider(
+                sound.id,
+              ).overrideWith((ref) => Future.value(<String>[])),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+      }
+
+      testWidgets('shows how many videos reuse the sound', (tester) async {
+        final sound = createTestAudioEvent(id: 'sound1');
+
+        await pumpWithUsageCount(tester, sound, Future.value(3));
+
+        expect(
+          find.textContaining(l10n.soundVideoCount(3)),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('says there are no videos only for a real zero', (
+        tester,
+      ) async {
+        final sound = createTestAudioEvent(id: 'sound1');
+
+        await pumpWithUsageCount(tester, sound, Future.value(0));
+
+        expect(
+          find.text('6.0s · ${l10n.soundNoVideoCount}'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('leaves the count out while it is unknown', (tester) async {
+        final sound = createTestAudioEvent(id: 'sound1');
+
+        await pumpWithUsageCount(tester, sound, Future<int?>.value());
+
+        expect(find.text('6.0s'), findsOneWidget);
+        expect(find.textContaining('6.0s ·'), findsNothing);
+        expect(find.textContaining('null'), findsNothing);
+      });
+
+      testWidgets('leaves the count out while it is still loading', (
+        tester,
+      ) async {
+        final sound = createTestAudioEvent(id: 'sound1');
+
+        await pumpWithUsageCount(tester, sound, Completer<int?>().future);
+
+        expect(find.text('6.0s'), findsOneWidget);
+        expect(find.textContaining('6.0s ·'), findsNothing);
+      });
+
+      testWidgets(
+        'drops the metadata line when neither the duration nor the count is '
+        'known',
+        (tester) async {
+          final sound = createTestAudioEvent(id: 'sound1', duration: 0);
+
+          await pumpWithUsageCount(tester, sound, Future<int?>.value());
+
+          expect(find.text(sound.title!), findsOneWidget);
+          expect(find.text(''), findsNothing);
+        },
+      );
+    });
+
     group('Widget Structure', () {
       testWidgets('renders with correct title in AppBar', (tester) async {
         final testSound = createTestAudioEvent(id: 'sound1');

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_stats_row_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_stats_row_test.dart
@@ -121,6 +121,23 @@ void main() {
       expect(find.text('2.1M'), findsOneWidget);
     });
 
+    testWidgets('shows unknown interaction counts without fabricating zero', (
+      tester,
+    ) async {
+      whenListen(
+        bloc,
+        const Stream<VideoInteractionsState>.empty(),
+        initialState: const VideoInteractionsState(
+          status: VideoInteractionsStatus.success,
+        ),
+      );
+
+      await _pump(tester, video: _video(), bloc: bloc);
+
+      expect(find.text('—'), findsNWidgets(3));
+      expect(find.text('0'), findsOneWidget);
+    });
+
     testWidgets('shows the Vine and diVine breakdown for a classic Vine', (
       tester,
     ) async {


### PR DESCRIPTION
## Description

**The problem.** When the app asked relays how many reposts, comments or sound reuses something has (a NIP-45 COUNT) and got no answer, it quietly downloaded the matching events instead. It fetched up to the relay's 5,000-event cap, stored them in the local database, and showed their number as if it were exact.

"No answer" is much more common than a relay without COUNT support:

- After about two minutes of quiet the app drops its relay connection, and nothing reconnects it (#8992). COUNT was the only read that never reconnected, so the first counts after every quiet spell failed at once and fell back to the download.
- A timeout, or a relay refusing the COUNT (the relay does this on storage errors), did the same. Backend trouble therefore produced the heaviest query in the app.
- The number shown could be capped at 5,000, or built from as few as 100 locally cached rows when the download timed out, and it was cached for the session. Sound detail always showed it. Feed items showed it whenever they had no count from the REST feed.

**The fix, layer by layer:**

- **Relay pool.** A COUNT now has one deadline that covers the send. It is never queued for replay on a later connection, where its answer would reach nobody. A failure now says whether no relay took the COUNT, or relays took it and did not answer. COUNT failures now reach support exports through the relay diagnostics port.
- **Client.** `countEvents` no longer falls back to downloading events. When no relay took the COUNT, it reconnects once and asks again within the same timeout, as queries already do, so a quiet spell does not blank counts. If there is still no answer, it throws `CountUnavailableException`.
- **Repositories** (reposts, comments, likes, sounds). An unknown count is `null`, and it is never cached, so the next view asks again. A comment count where only one of its two halves answered is also unknown, because one half alone is only a floor.
- **App.** The interactions bloc keeps a seeded count when the fetch comes back unknown. Sound detail leaves the count out of its header while it is unknown or loading, instead of saying "no videos".

**Why this approach.** The issue suggested bounding the download and marking the result approximate. Nothing reads the `approximate` flag, though, so a capped number would still be cached and shown as exact, and the download would still run after every quiet spell. Reporting "unknown" removes the download entirely. It also follows the repo's own rules: the client throws a typed failure, the repository decides what to do with it, and "a zero is not data" (the lesson from #7486). The four options considered are written up in `mobile/docs/brainstorm/2026-09-10-issue8710-count-fallback-brainstorm.md`.

**Behaviour changes to know about:**

- A user whose relay list contains no relay that supports NIP-45 no longer gets relay counts. Feeds still show counts from the REST feed, and sound detail shows none. The default relay and the local Docker stack both support NIP-45.
- The sound usage count no longer turns an error into "no videos".
- A COUNT sent while the relay pool is idle now waits for a reconnect, within the same 5-second budget.

**Related Issue:** Closes #8710

Related: #8992 (idle relay connections are dropped and not redialled) and #8995 (feed items ask relays for counts they already have).

## Out of Scope

- Keeping idle relay connections alive, or redialling them for live subscriptions (#8992). This PR only makes COUNT reconnect for itself.
- Feed items fetching counts they already have from the REST feed (#8995).
- Bounding `fetchEventReposters` (#6742) and flagging partial `queryEvents` results (#6238).

## Verification

- **Test-first.** Each new test was run and seen failing before its fix. The SDK and client tests reproduce the three failure paths: the dropped-socket replay, the idle-pool redial order, and the fallback download. As a mutation check, restoring the old `?? 0` in sound detail makes the unknown-count and loading tests fail.
- **Package suites, all passing:**
  - `nostr_sdk`: 701
  - `nostr_client`: 373
  - `reposts_repository`: 148
  - `likes_repository`: 285
  - `comments_repository`: 150
  - `sounds_repository`: 72

  `very_good test --coverage` meets each package's floor; reposts and sounds are at 100%.
- **App.** `video_interactions_bloc_test`, `sounds_providers_test` and `sound_detail_screen_test` pass. `flutter analyze lib test integration_test` is clean. The regenerated `sounds_providers.g.dart` is committed; it is a type change only.
- **CI-only ratchets, run locally, all passing:**
  - `future_delayed`
  - `shared_setup_stubs`
  - `unpinned_unchanged_assertions`
  - `placeholder_tests`
  - `nostr_id_log_truncation`
  - `pubkey_log_encoding`
  - `empty_catch`
  - `post_close_emit`
  - `raw_logging`
  - `ungrouped_tests`
  - `skip_ceiling`
  - `l10n_delegates`
  - `uncancellable_timer_wait`
  - `raw_textstyle`
  - `raw_colors`
- **Removed code.** `CountSource.clientSide` had no producer left, so it is gone. Its enum-shape test went with it, because that test could only fail on a deliberate redesign.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
