### PR TITLE
fix(input): stop iOS autocorrect rewriting typed relay and web addresses

### DIFF
--- a/mobile/lib/screens/profile_setup/widgets/image_url_sheet.dart
+++ b/mobile/lib/screens/profile_setup/widgets/image_url_sheet.dart
@@ -78,6 +78,7 @@ class _ImageUrlFormState extends State<_ImageUrlForm> {
             primaryWhenFilled: true,
             textCapitalization: .none,
             keyboardType: TextInputType.url,
+            autocorrect: false,
             textInputAction: TextInputAction.done,
             autofocus: true,
             onSubmitted: (_) => _save(),

--- a/mobile/lib/screens/profile_setup/widgets/website_field.dart
+++ b/mobile/lib/screens/profile_setup/widgets/website_field.dart
@@ -23,6 +23,7 @@ class WebsiteField extends StatelessWidget {
       primaryWhenFilled: true,
       textCapitalization: .none,
       keyboardType: TextInputType.url,
+      autocorrect: false,
       // Last field in the form, so done dismisses the keyboard rather than
       // moving on. Flutter does that for `done` without an onSubmitted.
       textInputAction: TextInputAction.done,

--- a/mobile/lib/screens/relay_settings_screen.dart
+++ b/mobile/lib/screens/relay_settings_screen.dart
@@ -649,6 +649,7 @@ class _AddRelaySheetState extends State<_AddRelaySheet> {
             labelText: 'wss://relay.example.com',
             keyboardType: TextInputType.url,
             textCapitalization: TextCapitalization.none,
+            autocorrect: false,
             autofocus: true,
             filled: true,
             textInputAction: .done,

--- a/mobile/lib/screens/verify/verify_connect_screen.dart
+++ b/mobile/lib/screens/verify/verify_connect_screen.dart
@@ -261,6 +261,7 @@ class _ConnectForm extends StatelessWidget {
           textInputAction: .send,
           keyboardType: TextInputType.url,
           textCapitalization: TextCapitalization.none,
+          autocorrect: false,
           onChanged: context.read<VerifyConnectCubit>().proofChanged,
           onSubmitted: (_) => state.isBusy || !state.canSubmitProof
               ? null

--- a/mobile/test/screens/profile_setup/website_field_test.dart
+++ b/mobile/test/screens/profile_setup/website_field_test.dart
@@ -49,5 +49,14 @@ void main() {
         TextInputType.url,
       );
     });
+
+    testWidgets('does not autocorrect a typed web address', (tester) async {
+      await pump(tester);
+
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).autocorrect,
+        isFalse,
+      );
+    });
   });
 }

--- a/mobile/test/screens/profile_setup/widgets/image_url_sheet_test.dart
+++ b/mobile/test/screens/profile_setup/widgets/image_url_sheet_test.dart
@@ -1,0 +1,40 @@
+// ABOUTME: Widget tests for the profile-setup image URL sheet.
+// ABOUTME: Pins the URL field's input traits so a typed link is not mangled.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/screens/profile_setup/widgets/image_url_sheet.dart';
+
+void main() {
+  group('showImageUrlSheet', () {
+    Future<void> openSheet(WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TextButton(
+                onPressed: () => showImageUrlSheet(context),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('does not autocorrect a typed image address', (tester) async {
+      await openSheet(tester);
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.autocorrect, isFalse);
+      expect(field.keyboardType, TextInputType.url);
+    });
+  });
+}

--- a/mobile/test/screens/relay_settings_screen_layout_test.dart
+++ b/mobile/test/screens/relay_settings_screen_layout_test.dart
@@ -373,6 +373,22 @@ void main() {
       ).called(1);
     });
 
+    testWidgets('does not autocorrect a typed relay address (#8993)', (
+      tester,
+    ) async {
+      await pumpScreen(tester, nostrService: _MockNostrService());
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await tester.tap(find.text(l10n.relaySettingsAddCustomRelay));
+      await tester.pumpAndSettle();
+
+      // iOS autocorrect rewrote `ws://` to `we://` as soon as `:` was typed,
+      // and the address was then rejected as invalid.
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.autocorrect, isFalse);
+      expect(field.keyboardType, TextInputType.url);
+    });
+
     testWidgets('warns when added relay is saved but not connected', (
       tester,
     ) async {

--- a/mobile/test/screens/verify/verify_connect_screen_test.dart
+++ b/mobile/test/screens/verify/verify_connect_screen_test.dart
@@ -104,6 +104,14 @@ void main() {
       expect(find.byType(TextField), findsNWidgets(2));
     });
 
+    testWidgets('does not autocorrect a typed proof link', (tester) async {
+      await pump(tester);
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.autocorrect, isFalse);
+      expect(field.keyboardType, TextInputType.url);
+    });
+
     testWidgets('keeps the typed proof when the account field appears', (
       tester,
     ) async {


### PR DESCRIPTION
## Description

On iOS, typing a relay address into Settings → Nostr Settings → Relays → Add Relay can get autocorrected mid-word: `ws://localhost:47778` becomes `we://localhost:47778` the moment `:` is typed, and the app then rejects it as an invalid address. The field asks for a URL keyboard, but it never turns autocorrect off, so iOS treats `ws` as a misspelled word.

Three other fields that take a web address had the same gap: the website field and the image link sheet in profile setup, and the proof-post link field used when linking another platform's account. Nobody has reported those, but a link typed there can be rewritten the same way.

`autocorrect: false` is the switch for exactly this. Flutter passes it to iOS as `UITextAutocorrectionTypeNo`; left unset, iOS uses its default, which is on. The repo's text-field rule already asks for it on URL fields, and the other three URL fields in the app (Blossom server, monetization link, audio credit source) already set it. After this change all seven do. On Android the flag stops Flutter asking the keyboard to auto-correct, which a URL field wants there too.

Two commits, so each can be reverted on its own: the Add Relay field (#8993), then the other three fields. Each comes with a test.

**Related Issue:** Closes #8993

## Out of Scope

- `enableSuggestions`, which the issue suggests considering. Flutter documents it as Android-only: on iOS, suggestions follow autocorrect, so turning autocorrect off already covers them. `DivineTextField` does not expose it, so adding it would mean a new `divine_ui` parameter with no effect on iOS.

## Verification

- Each new test fails on `main` (`Expected: false, Actual: <null>`, autocorrect unset) and passes with the fix:
  - `does not autocorrect a typed relay address (#8993)` in `relay_settings_screen_layout_test.dart`
  - `does not autocorrect a typed web address` in `website_field_test.dart`
  - `does not autocorrect a typed image address` in `image_url_sheet_test.dart` (new file)
  - `does not autocorrect a typed proof link` in `verify_connect_screen_test.dart`
- All 27 tests in those four files pass.
- `flutter analyze lib test integration_test` is clean.
- 64 of the 66 local guard scripts pass. The other two need CI: one probes live servers, the other needs a CI-only environment variable.
- Not re-checked on a device or simulator. The tests prove each field now tells iOS to turn autocorrect off; they cannot show what the keyboard does with it. The issue's reproduction used an iOS 26.5 simulator. To check by hand, note that the Relays row only appears with the `advancedRelaySettings` feature flag on.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
