### PR TITLE
fix(router): prevent startup from breaking navigation state

### DIFF
--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Derived provider that parses router location into structured context
 // ABOUTME: Single source of truth for "what page are we on?" with route types and parsing
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
 import 'package:openvine/router/providers/router_location_provider.dart';
@@ -904,19 +906,31 @@ String buildRoute(RouteContext context) {
 ///   error: (e, s) => ErrorWidget(e),
 /// );
 /// ```
-final pageContextProvider = StreamProvider<RouteContext>((ref) async* {
-  // Get the raw location stream (overridable in tests)
-  final locations = ref.watch(routerLocationStreamProvider);
+final pageContextProvider = StreamProvider<RouteContext>((ref) {
+  // Derived from routerLocationProvider rather than from the raw location
+  // stream, because that stream is single-subscription and this is not its
+  // only consumer: supportRouteTrailProvider takes the same locations, and
+  // AppRootSideEffects activates it during the first frame — long before the
+  // shell route builds and anything reads this provider. Subscribing to the
+  // raw stream here as well threw `Stream has already been listened to` at
+  // whichever came second, which is this one, and left it in a permanent
+  // error state that read as a null route context app-wide. Going through the
+  // StreamProvider lets Riverpod multiplex the one subscription instead.
+  final contexts = StreamController<RouteContext>();
 
-  // Emit a context immediately if the stream is a single-value Stream.value(...)
-  // (In tests we often use Stream.value('/profile/npub...'))
-  await for (final loc in locations) {
-    final ctx = parseRoute(loc);
+  ref.listen(routerLocationProvider, (_, next) {
+    final location = next.asData?.value;
+    if (location == null || contexts.isClosed) return;
+    final ctx = parseRoute(location);
     Log.info(
       'CTX derive: type=${ctx.type} npub=${pubkeyForLogs(ctx.npub)} index=${ctx.videoIndex}',
       name: 'Route',
       category: LogCategory.system,
     );
-    yield ctx;
-  }
+    contexts.add(ctx);
+  }, fireImmediately: true);
+
+  ref.onDispose(contexts.close);
+
+  return contexts.stream;
 });

--- a/mobile/lib/router/providers/router_location_provider.dart
+++ b/mobile/lib/router/providers/router_location_provider.dart
@@ -8,6 +8,12 @@ import 'package:openvine/router/app_router.dart';
 
 /// Provider that exposes the raw router location stream
 ///
+/// Single-subscription: the stream accepts exactly one listener, and that
+/// listener is [routerLocationProvider]. Consume the locations through that
+/// provider — Riverpod multiplexes it — rather than subscribing here a second
+/// time, which throws `Stream has already been listened to` and strands the
+/// losing consumer in a permanent error state.
+///
 /// For testing, access this directly: `container.read(routerLocationStreamProvider)`
 final routerLocationStreamProvider = Provider<Stream<String>>((ref) {
   final router = ref.read(goRouterProvider);

--- a/mobile/test/router/providers/page_context_provider_test.dart
+++ b/mobile/test/router/providers/page_context_provider_test.dart
@@ -1,9 +1,15 @@
 // ABOUTME: Tests the route predicate that decides whether the user is
-// ABOUTME: standing on their own profile.
+// ABOUTME: standing on their own profile, and that the page context survives
+// ABOUTME: alongside the other consumer of the router location.
 
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:nostr_sdk/nip19/nip19_tlv.dart';
-import 'package:openvine/router/providers/page_context_provider.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/router/app_router.dart';
+import 'package:openvine/router/providers/providers.dart';
 import 'package:openvine/router/route_paths.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 
@@ -223,6 +229,77 @@ void main() {
           null,
         ),
         isFalse,
+      );
+    });
+  });
+
+  group('pageContextProvider', () {
+    late GoRouter router;
+    late ProviderContainer container;
+
+    setUp(() {
+      router = GoRouter(
+        initialLocation: '/home/0',
+        routes: [
+          GoRoute(
+            path: '/home/:index',
+            builder: (_, _) => const SizedBox.shrink(),
+          ),
+          GoRoute(path: '/explore', builder: (_, _) => const SizedBox.shrink()),
+        ],
+      );
+      container = ProviderContainer(
+        overrides: [goRouterProvider.overrideWithValue(router)],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+      router.dispose();
+    });
+
+    test(
+      'resolves alongside the other consumer of the router location',
+      () async {
+        // The order production uses: AppRootSideEffects activates the support
+        // trail during the first frame, and nothing reads the page context
+        // until the shell route builds. Both once shared one
+        // single-subscription stream, so the second one to subscribe was left
+        // in a permanent `Stream has already been listened to` error state —
+        // read app-wide as a null route context.
+        container.listen(routerLocationProvider, (_, _) {});
+        await pumpEventQueue();
+
+        container.listen(pageContextProvider, (_, _) {});
+        await pumpEventQueue();
+
+        expect(container.read(routerLocationProvider).value, '/home/0');
+        expect(container.read(pageContextProvider).value?.type, RouteType.home);
+      },
+    );
+
+    testWidgets('follows navigations for every consumer', (tester) async {
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: router,
+          ),
+        ),
+      );
+      container.listen(routerLocationProvider, (_, _) {});
+      container.listen(pageContextProvider, (_, _) {});
+      await tester.pumpAndSettle();
+
+      router.go('/explore');
+      await tester.pumpAndSettle();
+
+      expect(container.read(routerLocationProvider).value, '/explore');
+      expect(
+        container.read(pageContextProvider).value?.type,
+        RouteType.explore,
       );
     });
   });


### PR DESCRIPTION
Closes #9011

## Description

| Before | After |
| ------- | ----- |
|     <img width="946" height="2049" alt="image" src="https://github.com/user-attachments/assets/2b31a76a-d639-4b3e-a636-6ddd2c684252" />     |        <img width="946" height="2049" alt="image" src="https://github.com/user-attachments/assets/ed77e6ab-8c5e-4ca5-bc5d-5044d0719e09" /> |

`routerLocationStreamProvider` hands out a **single-subscription** stream. Until recently `pageContextProvider` was its only consumer. #8956 added `supportRouteTrailProvider`, which takes the same locations through `routerLocationProvider`, and activated it from `AppRootSideEffects` — during the first frame, long before the shell route exists and anything reads the page context.

So the two race, and `pageContextProvider` loses: it gets `Bad state: Stream has already been listened to` and stays in a permanent `AsyncError`. `asData` is null forever, and every root-level reader sees a null route context — the shell app bar and its title, `tabHistoryProvider`, `lastTabPositionProvider`, back navigation, `activeVideoProvider` playback gating and the readiness gates. Branch screens kept working because `branchPage` overrides the provider per tab, which is why this surfaced as assorted chrome and navigation glitches rather than as a dead provider.

The fix derives `pageContextProvider` from `routerLocationProvider` instead of from the raw stream. That leaves the raw stream with exactly one listener and lets Riverpod's `StreamProvider` multiplex it, so a third consumer is covered by construction instead of by whoever happens to build first. A doc note on the primitive records the contract.

Fixing the primitive itself was the first attempt — making it fan out per listener. It works in production but hangs three existing tests in `test/router/router_location_provider_test.dart` inside `tester.pumpWidget`, so the one-listener contract is the version that ships.

**Related Issue:** 

## Out of Scope

The `CircularDependencyError` on `analyticsServiceProvider` via `ViewEventRetryService.sweep` that the device log shows at startup. It predates this branch and is unrelated to the router.

## Verification

- `flutter analyze lib test integration_test` — clean
- Two new regression tests in `page_context_provider_test.dart`; both fail without the fix with exactly the production symptom (`Expected RouteType.home, Actual: <null>`)
- `flutter test test/router test/providers test/startup test/screens/explore test/services/back_button_handler_test.dart` — 1721 passed, including the three tests that the discarded first attempt hung
- Verified on a real Samsung Galaxy (SM-S942B): the route context now resolves across `welcome → videoRecorder → home → inbox → profile`, where before it never left `null`

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore