### PR TITLE
fix(feed): show cached videos when switching feeds

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -120,6 +120,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   final FeedModePreferenceStore _modePreferences;
   StreamSubscription<List<String>>? _followingSubscription;
   StreamSubscription<List<CuratedList>>? _curatedListsSubscription;
+  int _sourceSelectionSequence = 0;
 
   /// Tracks when the last successful load completed, used by
   /// [_onAutoRefreshRequested] to skip refreshes when data is fresh.
@@ -353,24 +354,48 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       reason: FeedLoadReason.sourceSwitch,
     );
 
+    final selectionSequence = ++_sourceSelectionSequence;
+    final cachedVideos = await _readCachedFeed(source, skipCache: false);
+    if (selectionSequence != _sourceSelectionSequence || emit.isDone) {
+      if (feedLoad != null) _feedTracker?.abandonFeedLoad(feedLoad);
+      return;
+    }
+
     await _modePreferences.persist(source);
+    if (selectionSequence != _sourceSelectionSequence || emit.isDone) {
+      if (feedLoad != null) _feedTracker?.abandonFeedLoad(feedLoad);
+      return;
+    }
 
-    emit(
-      state.copyWith(
-        status: VideoFeedStatus.loading,
-        source: source,
-        videos: [],
-        hasMore: true,
-        isLoadingMore: false,
-        clearError: true,
-        videoListSources: const {},
-        listOnlyVideoIds: const {},
-        clearPaginationCursor: true,
-        currentIndex: 0,
-      ),
+    final selectedState = state.copyWith(
+      status: VideoFeedStatus.loading,
+      source: source,
+      videos: [],
+      hasMore: true,
+      isLoadingMore: false,
+      clearError: true,
+      videoListSources: const {},
+      listOnlyVideoIds: const {},
+      clearPaginationCursor: true,
+      currentIndex: 0,
     );
+    final servedCache = _emitCachedFeed(
+      source,
+      cachedVideos,
+      emit,
+      baseState: selectedState,
+      requireCurrentSource: false,
+      feedLoad: feedLoad,
+    );
+    if (!servedCache) emit(selectedState);
 
-    await _loadVideos(source, emit, feedLoad: feedLoad, revalidate: true);
+    await _loadVideos(
+      source,
+      emit,
+      feedLoad: feedLoad,
+      revalidate: true,
+      prefetchedCachedVideos: cachedVideos,
+    );
   }
 
   bool _listsEqual(List<String> a, List<String> b) {
@@ -748,14 +773,12 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     FeedLoadHandle? feedLoad,
     bool skipCache = false,
     bool revalidate = false,
+    List<VideoEvent>? prefetchedCachedVideos,
   }) async {
     try {
-      final servedCache = await _maybeServeCachedFeed(
-        source,
-        emit,
-        skipCache,
-        feedLoad,
-      );
+      final servedCache =
+          prefetchedCachedVideos?.isNotEmpty ??
+          await _maybeServeCachedFeed(source, emit, skipCache, feedLoad);
       if (!_canEmitForSource(source, emit)) return;
 
       // `revalidate` serves the cached window *and* forces a fresh fetch.
@@ -893,17 +916,37 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     bool skipCache,
     FeedLoadHandle? feedLoad,
   ) async {
+    final cachedValid = await _readCachedFeed(source, skipCache: skipCache);
+    return _emitCachedFeed(source, cachedValid, emit, feedLoad: feedLoad);
+  }
+
+  Future<List<VideoEvent>> _readCachedFeed(
+    VideoFeedSource source, {
+    required bool skipCache,
+  }) async {
     if (skipCache || !_serveCachedHomeFeed || !_usesHomeFeedCache(source)) {
-      return false;
+      return const [];
     }
 
     final mode = source.mode.name;
-    final cachedValid = await _resumeManager.readServeableWindow(
+    return _resumeManager.readServeableWindow(
       pubkey: _userPubkey,
       mode: mode,
     );
-    if (cachedValid.isEmpty) return false;
-    if (!_canEmitForSource(source, emit)) return false;
+  }
+
+  bool _emitCachedFeed(
+    VideoFeedSource source,
+    List<VideoEvent> cachedValid,
+    Emitter<VideoFeedBlocState> emit, {
+    VideoFeedBlocState? baseState,
+    bool requireCurrentSource = true,
+    FeedLoadHandle? feedLoad,
+  }) {
+    if (cachedValid.isEmpty || emit.isDone) return false;
+    if (requireCurrentSource && state.source != source) return false;
+
+    final mode = source.mode.name;
 
     // The cached window already starts at the resume position (already-watched
     // videos were dropped on write), so it is served at index 0.
@@ -911,7 +954,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       _feedTracker?.markFirstVideosReceived(feedLoad, cachedValid.length);
     }
     emit(
-      state.copyWith(
+      (baseState ?? state).copyWith(
         status: VideoFeedStatus.success,
         videos: cachedValid,
         currentIndex: 0,

--- a/mobile/test/blocs/video_feed/video_feed_bloc_revalidate_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_revalidate_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests that a cold start revalidates instead of trusting the cache
 // ABOUTME: Pins the #7719 fix: serve cached content, then fetch fresh
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:curated_list_repository/curated_list_repository.dart';
 import 'package:feed_tuning_repository/feed_tuning_repository.dart';
@@ -8,6 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/video_feed/home_feed_cache.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -21,6 +24,8 @@ class _MockCuratedListRepository extends Mock
     implements CuratedListRepository {}
 
 class _MockFeedTuningRepository extends Mock implements FeedTuningRepository {}
+
+class _MockHomeFeedCache extends Mock implements HomeFeedCache {}
 
 VideoEvent _video(String id) => VideoEvent(
   id: id,
@@ -38,6 +43,8 @@ void main() {
       late _MockFollowRepository followRepository;
       late _MockCuratedListRepository curatedListRepository;
       late _MockFeedTuningRepository feedTuningRepository;
+      late _MockHomeFeedCache homeFeedCache;
+      late Completer<HomeFeedResult> freshResult;
 
       setUp(() async {
         SharedPreferences.setMockInitialValues({});
@@ -45,6 +52,8 @@ void main() {
         followRepository = _MockFollowRepository();
         curatedListRepository = _MockCuratedListRepository();
         feedTuningRepository = _MockFeedTuningRepository();
+        homeFeedCache = _MockHomeFeedCache();
+        freshResult = Completer<HomeFeedResult>();
 
         when(() => followRepository.followingPubkeys).thenReturn([]);
         when(
@@ -62,6 +71,29 @@ void main() {
             revalidate: any(named: 'revalidate'),
           ),
         ).thenAnswer((_) async => HomeFeedResult(videos: [_video('fresh')]));
+        when(() => videosRepository.applyContentPreferences(any())).thenAnswer(
+          (invocation) =>
+              invocation.positionalArguments.single as List<VideoEvent>,
+        );
+        when(
+          () => homeFeedCache.readVideos(
+            pubkey: any(named: 'pubkey'),
+            mode: any(named: 'mode'),
+          ),
+        ).thenAnswer((_) async => null);
+        when(
+          () => homeFeedCache.writeVideos(
+            pubkey: any(named: 'pubkey'),
+            mode: any(named: 'mode'),
+            videos: any(named: 'videos'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => homeFeedCache.clearVideos(
+            pubkey: any(named: 'pubkey'),
+            mode: any(named: 'mode'),
+          ),
+        ).thenAnswer((_) async {});
         when(
           () => videosRepository.getClassicVideos(
             limit: any(named: 'limit'),
@@ -84,6 +116,7 @@ void main() {
         followRepository: followRepository,
         curatedListRepository: curatedListRepository,
         feedTuningRepository: feedTuningRepository,
+        homeFeedCache: homeFeedCache,
       );
 
       // The regression this pins (#7719): `_onStarted` used to call
@@ -154,6 +187,76 @@ void main() {
             ),
           ).captured;
           expect(captured, [isFalse]);
+        },
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'switches directly to cached content before revalidation completes',
+        setUp: () {
+          when(
+            () => homeFeedCache.readVideos(pubkey: null, mode: 'latest'),
+          ).thenAnswer((_) async => [_video('cached')]);
+          when(
+            () => videosRepository.getNewVideos(
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+              revalidate: any(named: 'revalidate'),
+            ),
+          ).thenAnswer((_) => freshResult.future);
+          addTearDown(() {
+            if (!freshResult.isCompleted) {
+              freshResult.complete(const HomeFeedResult(videos: []));
+            }
+          });
+        },
+        build: buildBloc,
+        seed: () => VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          mode: FeedMode.classic,
+          videos: [_video('previous-source')],
+        ),
+        act: (bloc) async {
+          bloc.add(const VideoFeedModeChanged(FeedMode.latest));
+          await bloc.stream.firstWhere(
+            (state) => state.videos.singleOrNull?.id == 'cached',
+          );
+          freshResult.complete(HomeFeedResult(videos: [_video('fresh')]));
+        },
+        expect: () => [
+          isA<VideoFeedBlocState>()
+              .having((state) => state.mode, 'mode', FeedMode.latest)
+              .having(
+                (state) => state.status,
+                'status',
+                VideoFeedStatus.success,
+              )
+              .having(
+                (state) => state.videos.map((video) => video.id),
+                'cached videos',
+                ['cached'],
+              ),
+          isA<VideoFeedBlocState>()
+              .having((state) => state.mode, 'mode', FeedMode.latest)
+              .having(
+                (state) => state.status,
+                'status',
+                VideoFeedStatus.success,
+              )
+              .having(
+                (state) => state.videos.map((video) => video.id),
+                'fresh videos spliced after cache',
+                ['cached', 'fresh'],
+              ),
+        ],
+        verify: (_) {
+          verify(
+            () => videosRepository.getNewVideos(
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              revalidate: true,
+            ),
+          ).called(1);
         },
       );
 


### PR DESCRIPTION
## Problem

Switching feed modes clears the current list before the selected mode’s persisted feed window is read. On higher-latency connections, that exposes a blank screen even when usable source-specific videos are already cached.

## Why this fix

The bloc now reads the selected source’s persisted window before publishing the source change. When cached videos exist, it publishes the new source and its own cached videos atomically, then preserves the existing background revalidation so the feed does not remain stale. Rapid selections are sequenced so a slower earlier cache read cannot overwrite the latest selection.

## Deliberately unchanged

First visits without a usable cache retain the existing loading state. Network revalidation remains enabled to preserve the stale-feed fix from #7719. Startup latency, relay diagnostics, and regional infrastructure are separate concerns.

Refs #8979

## Verification

- `flutter test --no-pub test/blocs/video_feed` (126 tests)
- `flutter analyze --no-pub` (no new findings; three existing repository-level lint notices)
- Regression test proves cached content is emitted while the fresh response is still gated and verifies `revalidate: true`.