### PR TITLE
fix(feed): stop empty-feed diagnostics from querying relays

### DIFF
--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -6251,19 +6251,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     SubscriptionType subscriptionType,
   ) => _applyLikeCountToVideo(videoId, likeCount, subscriptionType);
 
-  List<Filter> _buildDiagnosticProbeFilters(List<Filter> filters) {
-    return filters.map((filter) {
-      final diagnosticFilter = Filter.fromJson(filter.toJson());
-      final existingLimit = diagnosticFilter.limit;
-      diagnosticFilter.limit = existingLimit == null || existingLimit > 100
-          ? 100
-          : existingLimit;
-      return diagnosticFilter;
-    }).toList();
-  }
-
   /// Run automatic diagnostics when feed fails to load events
-  /// This logs relay status, connection info, and tests direct queries to help debug
+  /// This logs relay status, connection info, and subscription filters.
   Future<void> _runAutoDiagnostics(
     SubscriptionType subscriptionType,
     List<Filter> filters,
@@ -6360,91 +6349,14 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         }
       }
 
-      // 3. Test direct query with the same filters to see if matching events
-      // exist in the database. queryEvents only consults the local cache for
-      // single-filter queries, so probe each filter separately — otherwise
-      // repost-enabled (multi-filter) feeds skip the cache entirely and the
-      // "subscription broken" branch below can never fire.
-      final diagnosticFilters = _buildDiagnosticProbeFilters(filters);
-      Log.warning(
-        '🔍 Testing direct database query with subscription filters (bypassing subscription)...',
+      Log.info(
+        'Empty-feed diagnostics use subscription and connection state only; '
+        'no follow-up relay query issued.',
         name: 'VideoEventService',
         category: LogCategory.video,
       );
 
-      final directQueryEvents = <Event>[];
-      for (final diagnosticFilter in diagnosticFilters) {
-        directQueryEvents.addAll(
-          await _nostrService.queryEvents([diagnosticFilter]),
-        );
-      }
-
-      Log.warning(
-        '✅ Filtered direct query returned ${directQueryEvents.length} matching events',
-        name: 'VideoEventService',
-        category: LogCategory.video,
-      );
-
-      if (directQueryEvents.isEmpty) {
-        Log.info(
-          '✅ DIAGNOSTIC: No cached events match the empty $subscriptionType subscription filters.',
-          name: 'VideoEventService',
-          category: LogCategory.video,
-        );
-        Log.info(
-          '   Expected when the requested authors or filters have no matching cached videos.',
-          name: 'VideoEventService',
-          category: LogCategory.video,
-        );
-      } else {
-        Log.warning(
-          '✅ DIAGNOSTIC: Database HAS ${directQueryEvents.length} events matching the subscription filters, but subscription returned 0.',
-          name: 'VideoEventService',
-          category: LogCategory.video,
-        );
-        Log.error(
-          '❌ This means subscription filtering is too restrictive OR subscription stream is broken.',
-          name: 'VideoEventService',
-          category: LogCategory.video,
-        );
-
-        // Log sample events to help compare with subscription filters
-        Log.warning(
-          '📄 Sample matching events in database:',
-          name: 'VideoEventService',
-          category: LogCategory.video,
-        );
-        for (var i = 0; i < directQueryEvents.length && i < 3; i++) {
-          final event = directQueryEvents[i];
-          Log.warning(
-            '   Event $i:',
-            name: 'VideoEventService',
-            category: LogCategory.video,
-          );
-          Log.warning(
-            '      - id: ${event.id}',
-            name: 'VideoEventService',
-            category: LogCategory.video,
-          );
-          Log.warning(
-            '      - kind: ${event.kind}',
-            name: 'VideoEventService',
-            category: LogCategory.video,
-          );
-          Log.warning(
-            '      - pubkey: ${pubkeyForLogs(event.pubkey)}',
-            name: 'VideoEventService',
-            category: LogCategory.video,
-          );
-          Log.warning(
-            '      - createdAt: ${DateTime.fromMillisecondsSinceEpoch(event.createdAt * 1000)}',
-            name: 'VideoEventService',
-            category: LogCategory.video,
-          );
-        }
-      }
-
-      // 4. Get relay stats for additional diagnostics
+      // 3. Get local relay stats for additional diagnostics
       final relayStats = await _nostrService.getRelayStats();
       if (relayStats != null) {
         Log.warning(

--- a/mobile/test/services/video_event_service_eose_empty_test.dart
+++ b/mobile/test/services/video_event_service_eose_empty_test.dart
@@ -9,7 +9,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
-import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/observability/crash_reporter.dart';
 import 'package:openvine/services/subscription_manager.dart';
 import 'package:openvine/services/video_event_service.dart';
@@ -190,7 +189,7 @@ void main() {
     });
 
     test(
-      'runs empty-feed diagnostic query with profile author filters',
+      'does not issue relay queries while diagnosing an empty profile feed',
       () async {
         void Function()? capturedOnEose;
         final controller = StreamController<Event>();
@@ -214,61 +213,12 @@ void main() {
         capturedOnEose!();
         await pumpEventQueue();
 
-        final capturedCalls = verify(
-          () => mockNostrService.queryEvents(captureAny()),
-        ).captured.cast<List<Filter>>();
-
-        expect(
-          capturedCalls,
-          hasLength(3),
-          reason:
-              'Each subscription filter is probed separately so the local '
-              'cache is consulted (queryEvents only reads cache for '
-              'single-filter queries).',
-        );
-        expect(
-          capturedCalls.every((filters) => filters.length == 1),
-          isTrue,
-          reason: 'Probe must query one filter at a time to hit the cache',
-        );
-
-        final probeFilters = capturedCalls
-            .map((filters) => filters.single)
-            .toList();
-
-        expect(
-          probeFilters.every(
-            (filter) => filter.authors != null && filter.authors!.isNotEmpty,
-          ),
-          isTrue,
-          reason: 'Diagnostic probe must not fall back to a global video query',
-        );
-        expect(
-          probeFilters.map((filter) => filter.authors).toList(),
-          everyElement(equals([_profileAuthor])),
-        );
-        final videoFilter = probeFilters.singleWhere(
-          (filter) =>
-              filter.kinds != null &&
-              filter.kinds!.length ==
-                  NIP71VideoKinds.getAllVideoKinds().length &&
-              filter.kinds!.every(NIP71VideoKinds.getAllVideoKinds().contains),
-        );
-        final repostFilter = probeFilters.singleWhere(
-          (filter) => filter.kinds != null && filter.kinds!.singleOrNull == 16,
-        );
-        final deletionFilter = probeFilters.singleWhere(
-          (filter) => filter.kinds != null && filter.kinds!.singleOrNull == 5,
-        );
-
-        expect(videoFilter.limit, 100);
-        expect(repostFilter.limit, 50);
-        expect(deletionFilter.limit, 100);
+        verifyNever(() => mockNostrService.queryEvents(any()));
       },
     );
 
     test(
-      'logs expected empty profile state without subscription error',
+      'logs that empty-feed diagnostics do not issue a follow-up query',
       () async {
         void Function()? capturedOnEose;
         final controller = StreamController<Event>();
@@ -291,74 +241,11 @@ void main() {
         await pumpEventQueue();
 
         final logs = LogCaptureService().getRecentLogs();
-        expect(
-          logs.where(
-            (entry) =>
-                entry.level == LogLevel.error &&
-                entry.message.contains(
-                  'subscription filtering is too restrictive OR subscription stream is broken',
-                ),
-          ),
-          isEmpty,
-        );
         expect(
           logs.where(
             (entry) =>
                 entry.level == LogLevel.info &&
-                entry.message.contains(
-                  'No cached events match the empty SubscriptionType.profile subscription filters',
-                ),
-          ),
-          isNotEmpty,
-        );
-      },
-    );
-
-    test(
-      'keeps subscription error when filtered diagnostic query has events',
-      () async {
-        void Function()? capturedOnEose;
-        final controller = StreamController<Event>();
-        addTearDown(controller.close);
-
-        when(
-          () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
-        ).thenAnswer((invocation) {
-          capturedOnEose =
-              invocation.namedArguments[#onEose] as void Function()?;
-          return controller.stream;
-        });
-        when(() => mockNostrService.queryEvents(any())).thenAnswer(
-          (_) async => [
-            Event(
-              _profileAuthor,
-              NIP71VideoKinds.addressableShortVideo,
-              const [
-                ['d', 'diagnostic-video'],
-                ['url', 'https://example.com/video.mp4'],
-              ],
-              '',
-              createdAt: 1000,
-            )..id = 'diagnostic-video-event',
-          ],
-        );
-
-        await videoEventService.subscribeToVideoFeed(
-          subscriptionType: SubscriptionType.profile,
-          authors: const [_profileAuthor],
-        );
-
-        capturedOnEose!();
-        await pumpEventQueue();
-
-        final logs = LogCaptureService().getRecentLogs();
-        expect(
-          logs.where(
-            (entry) =>
-                entry.level == LogLevel.error &&
-                entry.message.contains(
-                  'subscription filtering is too restrictive OR subscription stream is broken',
-                ),
+                entry.message.contains('no follow-up relay query issued'),
           ),
           isNotEmpty,
         );


### PR DESCRIPTION
## Problem

An expected empty video subscription launches a diagnostic `queryEvents` call for every subscription filter. Those calls combine cache and WebSocket results, so production diagnostics can add relay traffic and network timeout exposure while claiming to perform a direct database query.

## Why this fix

The diagnostic now reports the subscription filters, connection state, and local relay statistics without issuing any follow-up relay request. This preserves useful empty-feed observability and removes conclusions that could not distinguish cached results from new WebSocket results.

## Deliberately unchanged

Empty EOSE still clears loading state, updates pagination, notifies listeners, and reports the empty-feed event to Crashlytics. This does not change feed fetching or relay infrastructure.

Closes #9015

Related to #8979.

## Verification

- `flutter test --no-pub test/services/video_event_service_eose_empty_test.dart` (5 tests)
- `bash scripts/check_service_god_file_ceiling.sh`
- Changed-file analysis: no issues
- Full analysis: only three existing repository-level lint notices
- Regression test failed on three relay queries before the fix and now verifies zero.