### PR TITLE
fix(nostr): keep live follow, like, repost and comment updates working on relays that enforce the subscription-id limit

### DIFF
--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -744,7 +744,10 @@ class CommentsRepository {
           ),
       ];
 
-      _watchSubscriptionId = 'comments_watch_$rootEventId';
+      _watchSubscriptionId = scopedSubscriptionId(
+        'comments_watch',
+        rootEventId,
+      );
 
       final eventStream = _nostrClient.subscribe(
         filters,

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -2537,6 +2537,47 @@ void main() {
         await controller.close();
       });
 
+      test(
+        'opens the subscription under an id within the NIP-01 cap',
+        () async {
+          final controller = StreamController<Event>.broadcast();
+
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          repository.watchComments(
+            rootEventId: testRootEventId,
+            rootEventKind: _testRootEventKind,
+          );
+
+          final id =
+              verify(
+                    () => mockNostrClient.subscribe(
+                      any(),
+                      subscriptionId: captureAny(named: 'subscriptionId'),
+                    ),
+                  ).captured.single
+                  as String;
+          expect(
+            id.length,
+            lessThanOrEqualTo(nip01MaxSubscriptionIdLength),
+            reason:
+                '"$id" is ${id.length} characters; relays enforcing '
+                'NIP-01 refuse the REQ',
+          );
+          expect(
+            id,
+            equals(scopedSubscriptionId('comments_watch', testRootEventId)),
+          );
+
+          await controller.close();
+        },
+      );
+
       test('allows watchComments without since and forwards onEose', () async {
         final controller = StreamController<Event>.broadcast();
         void Function()? capturedOnEose;
@@ -2740,11 +2781,15 @@ void main() {
 
         await repository.stopWatchingComments();
 
-        verify(
-          () => mockNostrClient.unsubscribe(
-            'comments_watch_$testRootEventId',
-          ),
-        ).called(1);
+        final subscribedId =
+            verify(
+                  () => mockNostrClient.subscribe(
+                    any(),
+                    subscriptionId: captureAny(named: 'subscriptionId'),
+                  ),
+                ).captured.single
+                as String;
+        verify(() => mockNostrClient.unsubscribe(subscribedId)).called(1);
 
         await controller.close();
       });

--- a/mobile/packages/dm_repository/lib/src/dm_subscription_ids.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_subscription_ids.dart
@@ -1,36 +1,16 @@
 // ABOUTME: Builds DM relay subscription ids that stay inside NIP-01's
 // ABOUTME: 64-character cap while remaining distinct per account and page.
 
-import 'dart:convert';
-
-import 'package:crypto/crypto.dart';
-
-/// NIP-01: "`<subscription_id>` is an arbitrary, non-empty string of max
-/// length 64 chars."
-///
-/// A relay that enforces this refuses the `REQ` outright, and the only trace
-/// is one `invalid subscription id length` line — DM receive then degrades
-/// silently on that relay.
-const int nip01MaxSubscriptionIdLength = 64;
-
-/// A short, stable, per-account tag for a subscription id.
-///
-/// A full 64-character hex pubkey behind any prefix already exceeds the cap on
-/// its own, so the account component is hashed rather than shortened. That is
-/// also the reason to hash instead of taking a prefix of the pubkey: a
-/// shortened public identifier looks correlatable and is not, whereas a digest
-/// is honestly opaque and never mistaken for the key itself.
-String _accountTag(String pubkey) =>
-    sha256.convert(utf8.encode(pubkey)).toString().substring(0, 16);
+import 'package:nostr_sdk/nostr_sdk.dart';
 
 /// Subscription id for the live gift-wrap inbox of [pubkey].
 String dmInboxSubscriptionId(String pubkey) =>
-    'dm_inbox_${_accountTag(pubkey)}';
+    scopedSubscriptionId('dm_inbox', pubkey);
 
 /// Subscription id for page [page] of the NIP-17 history drain of [pubkey].
 String dmHistoryDrainSubscriptionId(String pubkey, int page) =>
-    'dm_drain_${_accountTag(pubkey)}_$page';
+    '${scopedSubscriptionId('dm_drain', pubkey)}_$page';
 
 /// Subscription id for page [page] of the NIP-04 history drain of [pubkey].
 String dmNip04DrainSubscriptionId(String pubkey, int page) =>
-    'dm_drain_nip04_${_accountTag(pubkey)}_$page';
+    '${scopedSubscriptionId('dm_drain_nip04', pubkey)}_$page';

--- a/mobile/packages/dm_repository/test/src/dm_subscription_ids_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_subscription_ids_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:dm_repository/src/dm_subscription_ids.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart' show nip01MaxSubscriptionIdLength;
 
 const _pubkey =
     '1111111111111111111111111111111111111111111111111111111111111111';

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -2711,7 +2711,10 @@ class FollowRepository {
     );
 
     // Use a deterministic subscription ID so we can unsubscribe later
-    _contactListSubscriptionId = 'follow_repo_contact_list_$currentUserPubkey';
+    _contactListSubscriptionId = scopedSubscriptionId(
+      'follow_repo_contact_list',
+      currentUserPubkey,
+    );
 
     final eventStream = _nostrClient.subscribe([
       Filter(

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -2784,6 +2784,50 @@ void main() {
         await realTimeStreamController.close();
       });
 
+      test(
+        'keeps the contact list subscription id within the NIP-01 cap from '
+        'subscribe to dispose',
+        () async {
+          final subscriptionIds = <String>[];
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              sendAfterAuth: any(named: 'sendAfterAuth'),
+              onEose: any(named: 'onEose'),
+            ),
+          ).thenAnswer((invocation) {
+            final id = invocation.namedArguments[#subscriptionId] as String?;
+            if (id != null) {
+              subscriptionIds.add(id);
+            }
+            return realTimeStreamController.stream;
+          });
+
+          await repository.initialize();
+          await repository.dispose();
+
+          for (final id in subscriptionIds) {
+            expect(
+              id.length,
+              lessThanOrEqualTo(nip01MaxSubscriptionIdLength),
+              reason:
+                  '"$id" is ${id.length} characters; relays enforcing '
+                  'NIP-01 refuse the REQ',
+            );
+          }
+          final contactListId = scopedSubscriptionId(
+            'follow_repo_contact_list',
+            testCurrentUserPubkey,
+          );
+          expect(subscriptionIds, contains(contactListId));
+          verify(() => mockNostrClient.unsubscribe(contactListId)).called(1);
+        },
+      );
+
       test('updates following list when newer Kind 3 event arrives', () async {
         await repository.initialize();
 

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -2704,7 +2704,10 @@ class LikesRepository {
   /// updates the local cache.
   void _subscribeToReactions(String currentUserPubkey) {
     // Use a deterministic subscription ID so we can unsubscribe later
-    _reactionSubscriptionId = 'likes_repo_reactions_$currentUserPubkey';
+    _reactionSubscriptionId = scopedSubscriptionId(
+      'likes_repo_reactions',
+      currentUserPubkey,
+    );
 
     final eventStream = _nostrClient.subscribe([
       Filter(

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -4694,6 +4694,47 @@ void main() {
         },
       );
 
+      test(
+        'keeps the reactions subscription id within the NIP-01 cap from '
+        'subscribe to dispose',
+        () async {
+          // A full-length hex key: the short fixture above would hide an id
+          // that runs past the cap.
+          const hexPubkey =
+              'c3d4e5f6789012345678901234567890'
+              'abcdef1234567890123456789012ab12';
+          when(() => mockNostrClient.publicKey).thenReturn(hexPubkey);
+          when(
+            () => mockNostrClient.resolvePublicKey(),
+          ).thenAnswer((_) async => hexPubkey);
+
+          repository = createRepository();
+          await repository.initialize();
+          repository.dispose();
+
+          final id =
+              verify(
+                    () => mockNostrClient.subscribe(
+                      any(),
+                      subscriptionId: captureAny(named: 'subscriptionId'),
+                    ),
+                  ).captured.single
+                  as String;
+          expect(
+            id.length,
+            lessThanOrEqualTo(nip01MaxSubscriptionIdLength),
+            reason:
+                '"$id" is ${id.length} characters; relays enforcing '
+                'NIP-01 refuse the REQ',
+          );
+          expect(
+            id,
+            equals(scopedSubscriptionId('likes_repo_reactions', hexPubkey)),
+          );
+          verify(() => mockNostrClient.unsubscribe(id)).called(1);
+        },
+      );
+
       test('is idempotent', () async {
         when(
           () => mockNostrClient.resolvePublicKey(),

--- a/mobile/packages/nostr_sdk/lib/subscription.dart
+++ b/mobile/packages/nostr_sdk/lib/subscription.dart
@@ -1,6 +1,41 @@
+import 'dart:convert';
+
 import 'event.dart';
 import 'filter.dart';
+import 'utils/hash_util.dart';
 import 'utils/string_util.dart';
+
+/// NIP-01: "`<subscription_id>` is an arbitrary, non-empty string of max
+/// length 64 chars."
+///
+/// A relay that enforces this refuses the `REQ` outright (strfry answers with
+/// `CLOSED` or `NOTICE`), so a subscription with a longer id silently gets
+/// nothing from that relay.
+const int nip01MaxSubscriptionIdLength = 64;
+
+/// Hex characters of the scope digest kept by [scopedSubscriptionId].
+const int _scopeTagLength = 16;
+
+/// Builds a stable subscription id for [prefix] that stays distinct per
+/// [scope], such as one live subscription per account (a pubkey) or per
+/// thread (a root event id).
+///
+/// A 64-character hex pubkey or event id behind any prefix already exceeds
+/// [nip01MaxSubscriptionIdLength], so [scope] is hashed rather than
+/// shortened: a shortened public identifier looks correlatable and is not,
+/// whereas a digest is honestly opaque and never mistaken for the key itself.
+String scopedSubscriptionId(String prefix, String scope) {
+  final tag = HashUtil.sha256Bytes(
+    utf8.encode(scope),
+  ).substring(0, _scopeTagLength);
+  final id = '${prefix}_$tag';
+  assert(
+    id.length <= nip01MaxSubscriptionIdLength,
+    'Subscription id "$id" is ${id.length} characters; prefix "$prefix" '
+    'leaves no room under the $nip01MaxSubscriptionIdLength-character cap',
+  );
+  return id;
+}
 
 /// Representation of a Nostr event subscription.
 class Subscription {
@@ -28,13 +63,25 @@ class Subscription {
   /// Subscription ID
   String get id => _id;
 
+  /// Creates a subscription for [filters].
+  ///
+  /// An explicit [id] must be 1 to [nip01MaxSubscriptionIdLength] characters
+  /// long; build one with [scopedSubscriptionId]. Without it, a random
+  /// 16-character id is generated.
   Subscription(
     this.filters,
     this.onEvent, {
     String? id,
     this.onEose,
     this.onClosed,
-  }) : _id = id ?? StringUtil.rndNameStr(16),
+  }) : assert(
+         id == null ||
+             (id.isNotEmpty && id.length <= nip01MaxSubscriptionIdLength),
+         'Subscription id "$id" is ${id.length} characters; NIP-01 allows '
+         '1 to $nip01MaxSubscriptionIdLength, and a relay enforcing that '
+         'refuses the REQ',
+       ),
+       _id = id ?? StringUtil.rndNameStr(16),
        _parsedFilters = [for (final filter in filters) Filter.fromJson(filter)];
 
   /// Whether [event] satisfies at least one filter in this subscription.

--- a/mobile/packages/nostr_sdk/test/unit/subscription_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/subscription_test.dart
@@ -92,6 +92,8 @@ void main() {
         'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
     test('brings every production prefix inside the NIP-01 cap', () {
+      // Each repository's own id test runs only when its package changes, so
+      // this list guards a builder change that would push one past the cap.
       const prefixes = [
         'comments_watch',
         'dm_drain',
@@ -103,11 +105,6 @@ void main() {
       ];
 
       for (final prefix in prefixes) {
-        expect(
-          '${prefix}_$scope'.length,
-          greaterThan(nip01MaxSubscriptionIdLength),
-          reason: 'a full hex id behind "$prefix" is what relays refused',
-        );
         expect(
           scopedSubscriptionId(prefix, scope).length,
           lessThanOrEqualTo(nip01MaxSubscriptionIdLength),

--- a/mobile/packages/nostr_sdk/test/unit/subscription_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/subscription_test.dart
@@ -1,6 +1,6 @@
-// ABOUTME: Tests that Subscription parses its filters once, at construction.
-// ABOUTME: matchesEvent gates every inbound frame, so an unparseable filter
-// ABOUTME: must fail loudly at subscribe time rather than per event.
+// ABOUTME: Tests Subscription construction: filters parse once, so a bad
+// ABOUTME: filter fails at subscribe time, and ids stay inside NIP-01's
+// ABOUTME: 64-character cap, since a relay enforcing it refuses the REQ.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
@@ -48,6 +48,95 @@ void main() {
       ], (_) {});
 
       expect(subscription.matchesEvent(event), isFalse);
+    });
+
+    group('id', () {
+      Subscription subscriptionWithId(String? id) => Subscription(
+        [
+          Filter(kinds: const [1]).toJson(),
+        ],
+        (_) {},
+        id: id,
+      );
+
+      test('accepts an id at the NIP-01 cap', () {
+        final id = 'a' * nip01MaxSubscriptionIdLength;
+
+        expect(subscriptionWithId(id).id, equals(id));
+      });
+
+      test('rejects an id longer than NIP-01 allows', () {
+        expect(
+          () => subscriptionWithId('a' * (nip01MaxSubscriptionIdLength + 1)),
+          throwsA(isA<AssertionError>()),
+        );
+      });
+
+      test('rejects an empty id', () {
+        expect(() => subscriptionWithId(''), throwsA(isA<AssertionError>()));
+      });
+
+      test('generates an id inside the cap when none is given', () {
+        expect(
+          subscriptionWithId(null).id.length,
+          inInclusiveRange(1, nip01MaxSubscriptionIdLength),
+        );
+      });
+    });
+  });
+
+  group('scopedSubscriptionId', () {
+    const scope =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const otherScope =
+        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+    test('brings every production prefix inside the NIP-01 cap', () {
+      const prefixes = [
+        'comments_watch',
+        'dm_drain',
+        'dm_drain_nip04',
+        'dm_inbox',
+        'follow_repo_contact_list',
+        'likes_repo_reactions',
+        'reposts_repo_reposts',
+      ];
+
+      for (final prefix in prefixes) {
+        expect(
+          '${prefix}_$scope'.length,
+          greaterThan(nip01MaxSubscriptionIdLength),
+          reason: 'a full hex id behind "$prefix" is what relays refused',
+        );
+        expect(
+          scopedSubscriptionId(prefix, scope).length,
+          lessThanOrEqualTo(nip01MaxSubscriptionIdLength),
+          reason: prefix,
+        );
+      }
+    });
+
+    test('refuses a prefix that leaves no room under the cap', () {
+      expect(
+        () => scopedSubscriptionId('p' * nip01MaxSubscriptionIdLength, scope),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('returns a different id for a different scope', () {
+      expect(
+        scopedSubscriptionId('comments_watch', scope),
+        isNot(equals(scopedSubscriptionId('comments_watch', otherScope))),
+      );
+    });
+
+    test('keeps the tag the DM subscription ids already use', () {
+      // The first 16 hex characters of sha256(scope), as the DM helper
+      // computed them before delegating here, so DM ids do not change.
+      expect(
+        scopedSubscriptionId('dm_inbox', scope),
+        equals('dm_inbox_ffe054fe7ae0cb6d'),
+      );
     });
   });
 }

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -1057,7 +1057,10 @@ class RepostsRepository {
   /// updates the local cache.
   void _subscribeToReposts(String currentUserPubkey) {
     // Use a deterministic subscription ID so we can unsubscribe later
-    _repostSubscriptionId = 'reposts_repo_reposts_$currentUserPubkey';
+    _repostSubscriptionId = scopedSubscriptionId(
+      'reposts_repo_reposts',
+      currentUserPubkey,
+    );
 
     final eventStream = _nostrClient.subscribe([
       Filter(

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -2592,6 +2592,44 @@ void main() {
           expect(captured.single.authors, equals([testPubkey]));
         },
       );
+
+      test(
+        'keeps the reposts subscription id within the NIP-01 cap from '
+        'subscribe to dispose',
+        () async {
+          when(
+            () => mockNostrClient.unsubscribe(any()),
+          ).thenAnswer((_) async {});
+
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+          );
+          await repository.initialize();
+          repository.dispose();
+
+          final id =
+              verify(
+                    () => mockNostrClient.subscribe(
+                      any(),
+                      subscriptionId: captureAny(named: 'subscriptionId'),
+                    ),
+                  ).captured.single
+                  as String;
+          expect(
+            id.length,
+            lessThanOrEqualTo(nip01MaxSubscriptionIdLength),
+            reason:
+                '"$id" is ${id.length} characters; relays enforcing '
+                'NIP-01 refuse the REQ',
+          );
+          expect(
+            id,
+            equals(scopedSubscriptionId('reposts_repo_reposts', testPubkey)),
+          );
+          verify(() => mockNostrClient.unsubscribe(id)).called(1);
+        },
+      );
     });
 
     group('real-time sync', () {


### PR DESCRIPTION
## Description

**Problem.** NIP-01 allows a subscription id of at most 64 characters. Four live subscriptions built theirs as `<prefix>_<64-character hex>` — a pubkey or an event id — which came to 79–89 characters:

| Live subscription | Old id | Length |
|---|---|---|
| Your follow list | `follow_repo_contact_list_<pubkey>` | 89 |
| Your likes | `likes_repo_reactions_<pubkey>` | 85 |
| Your reposts | `reposts_repo_reposts_<pubkey>` | 84 |
| A video's comments | `comments_watch_<event id>` | 79 |

Relays that enforce the limit refuse such a request: strfry 1.1 and later (nos.lol and relay.damus.io among them) with `CLOSED "ERROR: bad req: invalid subscription id length"`, and strfry 1.0 (relay.primal.net) with `NOTICE "ERROR: bad req: subscription id too long"`. nos.lol and relay.primal.net are in every production account's relay pool, so every account hit this:

- Most of the time silently: the Divine relay accepts the long id, so updates kept arriving from it alone.
- When the refusal landed while the pool was reconnecting (about two seconds into every cold start, and on resume), no other relay held the subscription at that moment and the app ended it for the rest of the session: no more real-time follow, like, repost or comment updates until a restart. An instrumented iOS simulator cold start showed the likes subscription torn down about three seconds after launch.
- On a comments sheet, relay.primal.net's `NOTICE` cannot be matched to a request, so primal stays counted as serving the subscription and its end-of-stored-events callback never fires — the signal the comments sheet waits for before it counts new comments.

**Fix.** `nostr_sdk` gains `scopedSubscriptionId(prefix, scope)`, next to `Subscription`, which returns `<prefix>_<first 16 hex characters of sha256(scope)>`. The four subscriptions now send ids of 41, 37, 37 and 31 characters. The DM subscription ids, which #8426 already moved to this scheme, now call the same builder and do not change.

Hashing rather than shortening is deliberate: a shortened public id looks correlatable and is not (the repo's rule against truncating Nostr ids), while a digest is honestly opaque, stable for one account or thread (so unsubscribe still finds it), and different across them.

`Subscription` also asserts, in debug builds, that an explicit id is 1 to 64 characters, so a new over-long id fails in tests and on the first debug run instead of silently on strict relays. Ids the client generates when none is given are well under the limit and unaffected.

**Related Issue:** Closes #8430

## Out of Scope

The investigation found four adjacent problems. Each has its own issue and is untouched here; this PR only stops these four ids from triggering them.

- #9006 — any refusal (`rate-limited`, `auth-required`, `restricted`) that arrives while no other relay holds a live subscription still ends it for the session.
- #9007 — a relay that refuses with `NOTICE` stays counted as serving the subscription, which can hold back its end-of-stored-events callback.
- #8990 — the connectivity reconnect two seconds into every launch, which opens the window above.
- #9009 — NIP-45 `COUNT` sent to relays without it can make every count wait five seconds.

## Verification

- Tests written first. The new `nostr_sdk` tests (the builder and the 64-character assert) and one test per repository failed on `main` for the right reason — the captured ids were 89, 85, 84 and 79 characters — then passed.
- Package suites: `nostr_sdk`, `nostr_client`, `dm_repository`, `follow_repository` (100 % line coverage), `likes_repository`, `reposts_repository` (100 % line coverage), `comments_repository`. `flutter analyze` on the six packages and on `lib test integration_test`; `check_nostr_id_log_truncation.sh` and `check_pubkey_log_encoding.sh`.
- Live relays (a scratch probe driving the real `NostrClient` and `RelayPool`, not committed): with the new ids, relay.divine.video, nos.lol, relay.damus.io, relay.primal.net and relay.nos.social each accept all four subscriptions and settle them; the comments subscription reaches its end-of-stored-events callback with relay.primal.net in the pool; a pool of only strict relays, and a resume with the Divine relay down, both keep the subscription alive.
- iOS simulator, debug build against production relays with a signed-in account: two cold starts, each with the startup reconnect race present, subscribed the three account ids at 41, 37 and 37 characters, and nos.lol, relay.divine.video and relay.primal.net all settled them with no refusal. The same runs before the fix logged 14–32 `subscription id too long` NOTICEs and 12–22 `invalid subscription id length` CLOSEDs each, and relay.primal.net settled none of the four subscriptions. After each resume, every relay was sent all three again (plus the open comments subscription on the second). A comments sheet's 31-character subscription was settled by all three relays, primal included. Neither run logged an assertion or exception.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
