### PR TITLE
fix(proof): stop throwing away genuine C2PA signatures after signing

### DIFF
--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -466,20 +466,26 @@ class C2paSigningService {
   /// Why [manifest] does not establish that signing worked, or null when it
   /// does.
   ///
-  /// `ValidationStatus.unknown` passes deliberately. The library reports it
-  /// whenever the native read returned no `validation_status` key at all,
-  /// which is what an ordinary clean read looks like — only `invalid` is
-  /// positive evidence that the output is broken
-  /// (`ManifestStoreInfo._determineValidationStatus`). Rejecting `unknown`
-  /// would throw away correctly signed recordings.
+  /// Judged on the failure codes, not on [ManifestStoreInfo.validationStatus]:
+  /// the plugin reports `invalid` for any code at all, and this app loads no
+  /// C2PA trust anchors, so every ProofSign-signed file reads back with
+  /// `signingCredential.untrusted`. c2pa-rs still counts a manifest whose only
+  /// failure is that code as valid (C2PA 2.3, "valid manifest"); any other
+  /// code, such as `assertion.bmffHash.mismatch`, means the output is broken.
   static String? _describeUnusableManifest(ManifestStoreInfo? manifest) {
     if (manifest == null) return 'carries no readable C2PA manifest';
     if (manifest.activeManifest == null) {
       return 'carries no active C2PA manifest';
     }
-    if (manifest.validationStatus == ValidationStatus.invalid) {
+    final failures = manifest.validationErrors
+        .map((error) => error.code)
+        .where(
+          (code) =>
+              code != ValidationStatusCode.signingCredentialUntrusted.code,
+        );
+    if (failures.isNotEmpty) {
       return 'carries a C2PA manifest that failed validation '
-          '(${manifest.validationErrors.length} error(s))';
+          '(${failures.join(', ')})';
     }
     return null;
   }

--- a/mobile/test/services/c2pa_signing_service_test.dart
+++ b/mobile/test/services/c2pa_signing_service_test.dart
@@ -324,6 +324,9 @@ void main() {
       test(
         'keeps the recording when the manifest fails validation (#8799)',
         () async {
+          // How a signed file reads back once its media bytes change: the
+          // untrusted-credential finding every ProofSign file carries, plus a
+          // hash mismatch, which is the actual evidence of breakage.
           final video = writeFile('video.mp4', const [0, 1, 2, 3]);
           final service = C2paSigningService(
             c2pa: _WritingC2pa(
@@ -333,7 +336,11 @@ void main() {
                 validationErrors: [
                   ValidationError(
                     code: 'signingCredential.untrusted',
-                    message: 'untrusted signer',
+                    message: 'signing certificate untrusted',
+                  ),
+                  ValidationError(
+                    code: 'assertion.bmffHash.mismatch',
+                    message: 'asset hash error',
                   ),
                 ],
                 validationStatus: ValidationStatus.invalid,
@@ -345,7 +352,40 @@ void main() {
 
           expect(result.success, isFalse);
           expect(result.failureReason, C2paSigningFailureReason.outputMissing);
+          expect(result.error, contains('assertion.bmffHash.mismatch'));
           expect(video.readAsBytesSync(), equals([0, 1, 2, 3]));
+          expect(signedLeftovers(), isEmpty);
+        },
+      );
+
+      test(
+        'accepts a genuine ProofSign signature, whose only finding is an '
+        'untrusted signing credential (#8799)',
+        () async {
+          // What the native reader returns for a real Divine-signed capture.
+          // The app loads no C2PA trust anchors, so this is the normal
+          // success shape, and the plugin still flags it `invalid`.
+          final genuine = ManifestStoreInfo.fromMap(const <String, dynamic>{
+            'active_manifest': 'urn:c2pa:signed',
+            'validation_status': <dynamic>[
+              <String, dynamic>{
+                'code': 'signingCredential.untrusted',
+                'url': 'self#jumbf=/c2pa/urn:c2pa:signed/c2pa.signature',
+                'explanation': 'signing certificate untrusted',
+              },
+            ],
+          });
+          expect(genuine.validationStatus, ValidationStatus.invalid);
+          final video = writeFile('video.mp4', const [0, 1, 2, 3]);
+          final service = C2paSigningService(
+            c2pa: _WritingC2pa(const [7, 8, 9], manifest: genuine),
+          );
+
+          final result = await service.signVideoInPlace(videoPath: video.path);
+
+          expect(result.success, isTrue);
+          expect(result.manifest?.activeManifest, 'urn:c2pa:signed');
+          expect(video.readAsBytesSync(), equals([7, 8, 9]));
           expect(signedLeftovers(), isEmpty);
         },
       );
@@ -370,10 +410,8 @@ void main() {
       test(
         'accepts an unknown validation status, which is a clean read (#8799)',
         () async {
-          // `unknown` is what the library reports when the native read
-          // returned no `validation_status` key — the ordinary success shape.
-          // Only `invalid` is positive evidence the output is broken, so
-          // rejecting `unknown` would discard correctly signed recordings.
+          // `unknown` is what the plugin reports when the native read returned
+          // no `validation_status` key at all, e.g. with trust checks off.
           final video = writeFile('video.mp4', const [0, 1, 2, 3]);
           final service = C2paSigningService(
             c2pa: _WritingC2pa(


### PR DESCRIPTION
## The problem

Since #8987, every successful C2PA signing is rejected and deleted. The clip is kept unsigned, so it goes out without its content credential. The editor then asks to post without the human-made check, and the published event loses its `c2pa_manifest_id`.

#8987 reads the signed file back before it replaces the recording, and refuses anything whose `ManifestStoreInfo.validationStatus` is `invalid`. The plugin reports `invalid` for any validation finding at all. The app loads no C2PA trust anchors and c2pa-rs checks trust by default, so a correctly signed file always comes back with exactly one finding: `signingCredential.untrusted`.

## Why this fix

c2pa-rs itself does not treat that code as making a manifest invalid: its C2PA 2.3 "valid manifest" rule accepts a manifest whose only failure is an untrusted signing credential. The check now looks at the failure codes and rejects on anything other than `signingCredential.untrusted`. A real break, such as media bytes changed after signing (`assertion.bmffHash.mismatch`), is still rejected.

## What it leaves alone

- The #8987 contract: replace in place only after a read-back, delete a rejected output, never touch the recording on rejection.
- Trust configuration. The app still loads no trust anchors; whether it should trust the ProofSign root is a separate question.
- The plugin's `ValidationStatus` mapping, which lives upstream in c2pa_flutter.

## Verification

- Two recent public uploads from production, one signed by the iOS signer and one by the Android signer, read with c2pa-rs 0.76.1 (the core the app bundles): `Valid`, with only `signingCredential.untrusted`. With trust checks off, the finding disappears. The same file with one media byte flipped reads `Invalid` and adds `assertion.bmffHash.mismatch`.
- On an iPhone (iOS 26.6.1), a throwaway probe fed those signed bytes through the real `signVideoInPlace` and the real native reader. Before: both genuine files rejected and the clip left unsigned. After: both accepted, the clip holds the signed bytes, the tampered one is still rejected, and nothing is left behind.
- Tests: the "fails validation" test now uses a real break (hash mismatch), and a new test runs the exact read-back of a genuine file through the plugin's own parser and expects it to be accepted. Putting the old check back fails the new test; dropping the check fails the mismatch test.
- `flutter analyze` is clean; the C2PA and ProofMode suites pass.

Refs #8799
