### PR TITLE
test(router): prove the crash guard holds when the app rebuilds its router

### DIFF
--- a/mobile/lib/router/restoration_safe_router_config.dart
+++ b/mobile/lib/router/restoration_safe_router_config.dart
@@ -58,8 +58,11 @@ RouterConfig<RouteMatchList> restorationSafeRouterConfig(
 ///
 /// go_router decodes that state whenever a [Router] is mounted again over a
 /// router that already reported a location, and on every `refresh()`; on web,
-/// browser history hands it back too. Thrown from `Router.restoreState`, it
-/// leaves the app with no routes. Still present in go_router 18.0.1
+/// browser history hands it back too. Only the remount throws from
+/// `Router.restoreState` — the other two come through the route-information
+/// listener — so which frame carries it depends on the trigger. Either way
+/// the app is left with no routes. Still present in go_router 18.0.1, the
+/// latest release at the time of writing and ahead of the 16.x this app pins
 /// (flutter/flutter#153258), so a version bump does not remove it.
 @visibleForTesting
 class RestorationSafeRouteInformationParser

--- a/mobile/lib/router/restoration_safe_router_config.dart
+++ b/mobile/lib/router/restoration_safe_router_config.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Router config that survives saved route state go_router cannot decode
-// ABOUTME: Guards the launch-loop crash in RouteMatchListCodec (#7869)
+// ABOUTME: Router config that survives route state go_router cannot decode
+// ABOUTME: Guards the RouteMatchListCodec crash behind #7869
 
 import 'dart:async';
 
@@ -24,13 +24,13 @@ final routerConfigProvider = Provider<RouterConfig<RouteMatchList>>(
   ),
 );
 
-/// Wraps [router] so a saved route state it cannot decode is dropped rather
-/// than thrown out of the launch path.
+/// Wraps [router] so a route state it cannot decode is dropped rather than
+/// thrown out of the widget tree.
 ///
-/// The saved state is an optimization — it restores the imperative push stack
-/// on top of the location. The location itself travels in the URI and is
-/// enough to land the user on the right screen, so falling back to it costs a
-/// pushed route and keeps the app usable.
+/// The state only adds the imperative push stack on top of the location in
+/// the URI, so the fallback navigates to that location. In the known failure
+/// (#7869) that location no longer matches a route either, so the user lands
+/// on the not-found page instead of losing the app.
 RouterConfig<RouteMatchList> restorationSafeRouterConfig(
   GoRouter router, {
   CrashReporter crashReporter = const SilentCrashReporter(),
@@ -56,10 +56,11 @@ RouterConfig<RouteMatchList> restorationSafeRouterConfig(
 /// appends the shell branch its imperative match resolved to, which throws
 /// `type 'ShellRouteMatch' is not a subtype of type 'RouteMatch' of 'value'`.
 ///
-/// The throw lands in `Router.restoreState`, before the app is interactive,
-/// and the same state is replayed on every cold start — so an affected install
-/// loops rather than recovering. Still present in go_router 18.0.1, the latest
-/// release at the time of writing, so a version bump does not remove it.
+/// go_router decodes that state whenever a [Router] is mounted again over a
+/// router that already reported a location, and on every `refresh()`; on web,
+/// browser history hands it back too. Thrown from `Router.restoreState`, it
+/// leaves the app with no routes. Still present in go_router 18.0.1
+/// (flutter/flutter#153258), so a version bump does not remove it.
 @visibleForTesting
 class RestorationSafeRouteInformationParser
     extends RouteInformationParser<RouteMatchList> {

--- a/mobile/lib/startup/divine_material_app.dart
+++ b/mobile/lib/startup/divine_material_app.dart
@@ -42,9 +42,9 @@ class DivineMaterialApp extends ConsumerWidget {
         theme: VineTheme.lightTheme,
         darkTheme: VineTheme.theme,
         themeMode: themeMode,
-        // A saved route state go_router cannot decode must not take the
-        // launch path down with it — the same state replays on every cold
-        // start, so the crash loops instead of recovering (#7869).
+        // go_router can fail to decode the route state it reported itself when
+        // this router is mounted again or refreshed; unguarded, that leaves
+        // the app with no routes (#7869).
         routerConfig: ref.read(routerConfigProvider),
         locale: locale,
         localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/mobile/test/router/restoration_safe_router_config_test.dart
+++ b/mobile/test/router/restoration_safe_router_config_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Pins the saved-route-state guard against the go_router codec bug
-// ABOUTME: Regression coverage for the #7869 launch-loop crash
+// ABOUTME: Pins the route-state guard against the go_router codec bug
+// ABOUTME: Regression coverage for the #7869 crash
 
 import 'dart:async';
 
@@ -60,9 +60,9 @@ GoRouter _buildRouter({required bool withRetiredRoute}) {
   );
 }
 
-/// Produces the saved route state an install would replay on cold start: a
-/// root location that the *next* build no longer serves, with an imperative
-/// push on top of it that still resolves through the shell.
+/// Produces a route state whose root location the router under test no
+/// longer serves, with an imperative push on top of it that still resolves
+/// through the shell.
 Future<RouteInformation> _savedStateFromRetiredLocation(
   WidgetTester tester,
 ) async {

--- a/mobile/test/router/restoration_safe_router_config_test.dart
+++ b/mobile/test/router/restoration_safe_router_config_test.dart
@@ -185,6 +185,39 @@ void main() {
       });
     });
 
+    group('restorationSafeRouterConfig', () {
+      testWidgets('keeps a router mounted again alive when its state no longer '
+          'decodes', (tester) async {
+        final saved = await _savedStateFromRetiredLocation(tester);
+
+        final router = _buildRouter(withRetiredRoute: false);
+        addTearDown(router.dispose);
+        final reporter = _RecordingCrashReporter();
+        final config = restorationSafeRouterConfig(
+          router,
+          crashReporter: reporter,
+        );
+        Widget app(Key key) => MaterialApp.router(
+          key: key,
+          routerConfig: config,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        );
+        await tester.pumpWidget(app(const ValueKey(1)));
+        await tester.pumpAndSettle();
+
+        // The router reports every location it lands on, so its provider
+        // holds an encoded state. A Router mounted again over the same
+        // GoRouter decodes it from Router.restoreState — the #7869 stack.
+        router.routeInformationProvider.routerReportsNewRouteInformation(saved);
+        await tester.pumpWidget(app(const ValueKey(2)));
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(reporter.recorded, hasLength(1));
+      });
+    });
+
     group('restoreRouteInformation', () {
       testWidgets('delegates encoding unchanged', (tester) async {
         final router = _buildRouter(withRetiredRoute: false);

--- a/mobile/test/startup/divine_material_app_test.dart
+++ b/mobile/test/startup/divine_material_app_test.dart
@@ -1,10 +1,131 @@
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/locale/locale_cubit.dart';
+import 'package:openvine/features/appearance/bloc/appearance_cubit.dart';
+import 'package:openvine/features/appearance/models/appearance_mode.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/models/auth_state.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/crash_reporting_provider.dart';
+import 'package:openvine/router/router.dart';
+import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/startup/divine_material_app.dart';
 
+class _MockLocaleCubit extends MockCubit<LocaleState> implements LocaleCubit {}
+
+class _MockAppearanceCubit extends MockCubit<AppearanceMode>
+    implements AppearanceCubit {}
+
+class _RecordingCrashReportingService extends Fake
+    implements CrashReportingService {
+  final List<String?> reasons = [];
+
+  @override
+  Future<void> recordError(
+    dynamic exception,
+    StackTrace? stack, {
+    String? reason,
+  }) async {
+    reasons.add(reason);
+  }
+}
+
+GoRouter _shellRouter({required bool withRetiredRoute}) => GoRouter(
+  initialLocation: '/home',
+  routes: <RouteBase>[
+    if (withRetiredRoute)
+      GoRoute(path: '/retired', builder: (_, _) => const Text('retired')),
+    StatefulShellRoute.indexedStack(
+      builder: (context, state, shell) => shell,
+      branches: <StatefulShellBranch>[
+        StatefulShellBranch(
+          routes: <RouteBase>[
+            GoRoute(path: '/home', builder: (_, _) => const Text('home')),
+          ],
+        ),
+      ],
+    ),
+  ],
+);
+
+/// A route state the running router cannot decode: its root location is gone
+/// and the page pushed on top resolves through the shell (#7869).
+Future<RouteInformation> _undecodableState(WidgetTester tester) async {
+  final previous = _shellRouter(withRetiredRoute: true);
+  addTearDown(previous.dispose);
+  await tester.pumpWidget(
+    MaterialApp.router(
+      routerConfig: previous,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+    ),
+  );
+  await tester.pumpAndSettle();
+  previous.go('/retired');
+  await tester.pumpAndSettle();
+  // The pushed route never pops, so its future never completes.
+  unawaited(previous.push('/home'));
+  await tester.pumpAndSettle();
+  final state = previous.routeInformationParser.restoreRouteInformation(
+    previous.routerDelegate.currentConfiguration,
+  );
+  await tester.pumpWidget(const SizedBox());
+  return state!;
+}
+
 void main() {
+  group(DivineMaterialApp, () {
+    testWidgets('survives a remount whose router state no longer decodes', (
+      tester,
+    ) async {
+      final stale = await _undecodableState(tester);
+      final router = _shellRouter(withRetiredRoute: false);
+      addTearDown(router.dispose);
+      final crashReporting = _RecordingCrashReportingService();
+      final localeCubit = _MockLocaleCubit();
+      when(() => localeCubit.state).thenReturn(const LocaleState());
+      final appearanceCubit = _MockAppearanceCubit();
+      when(() => appearanceCubit.state).thenReturn(AppearanceMode.dark);
+
+      Widget app(Key key) => ProviderScope(
+        overrides: [
+          goRouterProvider.overrideWithValue(router),
+          crashReportingServiceProvider.overrideWithValue(crashReporting),
+          currentAuthStateProvider.overrideWithValue(AuthState.unauthenticated),
+        ],
+        child: MultiBlocProvider(
+          providers: [
+            BlocProvider<LocaleCubit>.value(value: localeCubit),
+            BlocProvider<AppearanceCubit>.value(value: appearanceCubit),
+          ],
+          child: DivineMaterialApp(key: key),
+        ),
+      );
+
+      await tester.pumpWidget(app(const ValueKey(1)));
+      await tester.pumpAndSettle();
+      // A re-keyed ancestor mounts the Router again over the same GoRouter,
+      // which then decodes the state it last reported.
+      router.routeInformationProvider.routerReportsNewRouteInformation(stale);
+      await tester.pumpWidget(app(const ValueKey(2)));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(crashReporting.reasons, [
+        'RestorationSafeRouter.parseRouteInformation',
+      ]);
+    });
+  });
+
   group('PlatformBrightnessStatusBar', () {
     testWidgets('updates the overlay style when platform brightness changes', (
       tester,


### PR DESCRIPTION
## The problem

#8986 guards go_router's route-state decode so a stale route can't take the app down (#7869). Its tests call the guarded parser directly. Nothing checks that the app itself uses it: pointing `DivineMaterialApp` back at `goRouterProvider` keeps every router and startup test green. The comments also say the crash replays on every cold start. It doesn't.

## What actually happens

Nothing is saved across launches, and a fresh router never decodes on its first parse. The crash comes from the Router being mounted again in the same session over a GoRouter that already reported a location. Sign-in and sign-out re-key `SavedSoundsScope` above `MaterialApp.router`, which remounts the app, and every `refresh()` runs the same decode. On main, on the simulator against the local stack, the app ends on "Oops, something went wrong" with the Crashlytics stack frame for frame. A force-quit recovers.

## This PR

- A test that mounts the Router again over a router holding an undecodable state, through `restorationSafeRouterConfig`.
- The same through `DivineMaterialApp`, so the wiring can't silently go.
- Comments corrected to match, with a link to flutter/flutter#153258 (still in go_router 18.0.1).

## Deliberately unchanged

Where the user lands. In this failure the fallback goes to the not-found page, because the root is exactly what stopped matching. Falling back to the live stack instead is an open question on #8986.

## Verification

- Each new test fails with the #7869 TypeError when the guard is bypassed or unwired, and passes otherwise.
- `flutter analyze` clean; test/router and test/startup green; ratchets green.
- Also checked on a physical iPhone (debug build, staging): same stale state plus a refresh, the guard fired, no crash, the app moved from Explore to the not-found page, and Go home recovered.

Refs #7869

