### PR TITLE
perf(feed): measure visible and fresh load phases

### DIFF
--- a/mobile/docs/FEED_INTERACTIVE_LATENCY.md
+++ b/mobile/docs/FEED_INTERACTIVE_LATENCY.md
@@ -1,0 +1,64 @@
+# Feed interactive-latency telemetry
+
+Status: Current
+
+The `feed_load_*` Firebase Analytics events measure the user-visible home-feed
+load owned by `VideoFeedBloc`. They complement the relay-subscription Firebase
+Performance traces documented in [FEED_LOAD_TRACES.md](FEED_LOAD_TRACES.md).
+
+## Event contract
+
+Every accepted load emits `feed_load_started` with:
+
+- `feed_type`: the stable feed-source tag;
+- `load_reason`: `appStart`, `sourceSwitch`, `refresh`, or `pagination`.
+
+The first nonempty list that can be rendered emits
+`feed_first_content_visible`. It records `time_to_first_visible_ms`, video
+count, and `served_from_cache`. A cache milestone does not finish the session.
+
+The repository result emits `feed_fresh_result_complete`, even when it is
+empty. It records `fresh_result_time_ms`, the earlier visible-content duration
+when one exists, cache usage, and these bounded counters:
+
+- `recommendation_page_count` for recommendation top-up pages;
+- `following_page_count` for REST or relay following-feed pages.
+
+These events contain no account, content, IP, locale, country, or precise
+location identifiers. Regional analysis must use Firebase Analytics' derived
+country/region dimensions and group them into `North America`, `Europe`,
+`APAC`, and `Other/unknown` in the reporting query. Do not add client-derived
+location fields to this event contract.
+
+`feed_load_complete` remains emitted for dashboard compatibility. Its duration
+now ends at the fresh result; new analysis should use the phase-specific event.
+
+## Initial service target
+
+For each feed type, initiation reason, cache state, platform, and coarse region:
+
+- p75 time to first visible content: under 1 second;
+- p95 time to first visible content: under 2.5 seconds;
+- p75 fresh-result completion: under 3 seconds.
+
+Evaluate a region only after at least 100 completed loads over a rolling
+14-day window. Revisit these thresholds after the first complete window rather
+than tuning them from individual reports.
+
+## Deadline placement
+
+Use the phase data before adding deadlines:
+
+- High first-visible time with no cache points to cache lookup or the first
+  upstream request. Bound the end-to-end BLoC load and return the best partial
+  result available.
+- Normal first-visible time but high fresh completion, correlated with page
+  counts, points to repository page walks. Stop starting another page when the
+  remaining load budget is exhausted; do not try to interrupt an in-flight
+  HTTP or relay request with an elapsed-time check between awaits.
+- High latency without elevated page counts points to transport or origin
+  latency. A client page cap will not address it.
+
+Cancellation belongs at the BLoC operation boundary when a load is superseded
+by a source switch. Partial-result deadlines belong in the repository only
+after the first page has produced usable content.

--- a/mobile/docs/FEED_LOAD_TRACES.md
+++ b/mobile/docs/FEED_LOAD_TRACES.md
@@ -10,6 +10,9 @@ takes to reach its first terminal milestone. They cover the cache lookup and
 the relay subscription as one operation. They do not measure only relay
 latency, and they do not necessarily measure time until a video is visible.
 
+For end-to-end cache, first-visible, and fresh-result phases, use
+[FEED_INTERACTIVE_LATENCY.md](FEED_INTERACTIVE_LATENCY.md).
+
 Use this reference when interpreting these traces in Firebase Performance.
 The implementation lives in
 [`VideoEventService`](../lib/services/video_event_service.dart), while

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -348,6 +348,11 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       return;
     }
 
+    _feedTracker?.startFeedLoad(
+      source.mode.name,
+      reason: FeedLoadReason.sourceSwitch,
+    );
+
     await _modePreferences.persist(source);
 
     emit(
@@ -397,6 +402,10 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     }
 
     final source = state.source;
+    _feedTracker?.startFeedLoad(
+      source.mode.name,
+      reason: FeedLoadReason.pagination,
+    );
     emit(state.copyWith(isLoadingMore: true));
 
     try {
@@ -470,6 +479,20 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         ),
       );
 
+      if (updatedVideos.isNotEmpty) {
+        _feedTracker?.markFirstVisibleContent(
+          source.mode.name,
+          updatedVideos.length,
+          servedFromCache: false,
+        );
+      }
+      _feedTracker?.markFreshResultCompleted(
+        source.mode.name,
+        updatedVideos.length,
+        recommendationPageCount: result.recommendationPageCount,
+        followingPageCount: result.followingPageCount,
+      );
+
       _scheduleNostrEnrichment(source: source, videos: updatedVideos);
 
       // Batch-fetch profiles for new creators only.
@@ -495,6 +518,10 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     VideoFeedRefreshRequested event,
     Emitter<VideoFeedBlocState> emit,
   ) async {
+    _feedTracker?.startFeedLoad(
+      state.source.mode.name,
+      reason: FeedLoadReason.refresh,
+    );
     emit(
       state.copyWith(
         status: VideoFeedStatus.loading,
@@ -553,6 +580,11 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       ),
     );
 
+    _feedTracker?.startFeedLoad(
+      state.source.mode.name,
+      reason: FeedLoadReason.refresh,
+    );
+
     await _loadVideos(
       state.source,
       emit,
@@ -594,6 +626,10 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     }
 
     // Silent refresh — keep current videos visible, replace when done.
+    _feedTracker?.startFeedLoad(
+      state.source.mode.name,
+      reason: FeedLoadReason.refresh,
+    );
     await _loadVideos(state.source, emit, skipCache: true);
   }
 
@@ -645,6 +681,11 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         clearPaginationCursor: true,
         currentIndex: 0,
       ),
+    );
+
+    _feedTracker?.startFeedLoad(
+      nextSource.mode.name,
+      reason: FeedLoadReason.refresh,
     );
 
     await _loadVideos(nextSource, emit, skipCache: true);
@@ -743,7 +784,6 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         source.mode.name,
         displayedVideos.length,
       );
-
       emit(
         state.copyWith(
           status: VideoFeedStatus.success,
@@ -765,9 +805,22 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         ),
       );
 
+      if (!servedCache && displayedVideos.isNotEmpty) {
+        _feedTracker?.markFirstVisibleContent(
+          source.mode.name,
+          displayedVideos.length,
+          servedFromCache: false,
+        );
+      }
+
       _scheduleNostrEnrichment(source: source, videos: displayedVideos);
 
-      _feedTracker?.markFeedDisplayed(source.mode.name, displayedVideos.length);
+      _feedTracker?.markFreshResultCompleted(
+        source.mode.name,
+        displayedVideos.length,
+        recommendationPageCount: result.recommendationPageCount,
+        followingPageCount: result.followingPageCount,
+      );
 
       // Batch-fetch creator profiles to warm the Drift cache.
       await _fetchCreatorProfiles(validVideos, source, emit);
@@ -846,8 +899,11 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         clearError: true,
       ),
     );
-    _feedTracker?.markFeedDisplayed(mode, cachedValid.length);
-
+    _feedTracker?.markFirstVisibleContent(
+      mode,
+      cachedValid.length,
+      servedFromCache: true,
+    );
     // Advance the resume point immediately so a quick reopen (before the fresh
     // fetch lands and the load-time write runs) still opens on the next video
     // rather than this one again.

--- a/mobile/packages/analytics/lib/src/feed_performance_tracker.dart
+++ b/mobile/packages/analytics/lib/src/feed_performance_tracker.dart
@@ -21,6 +21,9 @@ import 'package:unified_logger/unified_logger.dart';
 /// load times (e.g. 27+ hours).
 const _maxSessionAge = Duration(seconds: 60);
 
+/// Why a user-visible feed load began.
+enum FeedLoadReason { appStart, sourceSwitch, refresh, pagination }
+
 /// Service for tracking feed performance and user engagement
 ///
 /// Feed-load sessions are keyed by feed type and shared across consumers — one
@@ -56,19 +59,119 @@ class FeedPerformanceTracker {
   }
 
   /// Start tracking feed load
-  void startFeedLoad(String feedType, {Map<String, dynamic>? params}) {
+  void startFeedLoad(
+    String feedType, {
+    FeedLoadReason reason = FeedLoadReason.appStart,
+    Map<String, dynamic>? params,
+  }) {
+    final session = _startSession(
+      feedType,
+      {'load_reason': reason.name, ...?params},
+    );
+
+    _analytics.logEvent(
+      name: 'feed_load_started',
+      parameters: {'feed_type': feedType, ...session.params},
+    );
+  }
+
+  _FeedLoadSession _startSession(
+    String feedType,
+    Map<String, dynamic> params,
+  ) {
     final session = _FeedLoadSession(
       feedType: feedType,
       startTime: DateTime.now(),
-      params: params ?? {},
+      params: params,
     );
-
     _activeSessions[feedType] = session;
-
     UnifiedLogger.info(
       '📺 Feed load started: $feedType',
       name: 'FeedPerformance',
     );
+    return session;
+  }
+
+  /// Records the first content a person can actually see.
+  ///
+  /// This does not close the session: a cache-first load remains active until
+  /// [markFreshResultCompleted] records the later network result.
+  void markFirstVisibleContent(
+    String feedType,
+    int count, {
+    required bool servedFromCache,
+  }) {
+    final session = _activeSessions[feedType];
+    if (session == null || session.firstVisibleTime != null) return;
+    if (_isStale(session)) {
+      _discardStaleSession(feedType);
+      return;
+    }
+
+    session
+      ..firstVisibleTime = DateTime.now()
+      ..servedFromCache = servedFromCache;
+    final elapsed = session.firstVisibleTime!
+        .difference(session.startTime)
+        .inMilliseconds;
+    _analytics.logEvent(
+      name: 'feed_first_content_visible',
+      parameters: {
+        'feed_type': feedType,
+        'time_to_first_visible_ms': elapsed,
+        'video_count': count,
+        'served_from_cache': servedFromCache ? 1 : 0,
+        ...session.params,
+      },
+    );
+  }
+
+  /// Records the fresh repository result and closes the user-visible load.
+  void markFreshResultCompleted(
+    String feedType,
+    int totalCount, {
+    int recommendationPageCount = 0,
+    int followingPageCount = 0,
+  }) {
+    final session = _activeSessions[feedType];
+    if (session == null) return;
+    if (_isStale(session)) {
+      _discardStaleSession(feedType);
+      return;
+    }
+
+    final now = DateTime.now();
+    final freshResultTimeMs = now.difference(session.startTime).inMilliseconds;
+    final firstVisibleTimeMs = session.firstVisibleTime
+        ?.difference(session.startTime)
+        .inMilliseconds;
+    final parameters = <String, Object>{
+      'feed_type': feedType,
+      'fresh_result_time_ms': freshResultTimeMs,
+      'total_videos': totalCount,
+      'served_from_cache': session.servedFromCache ? 1 : 0,
+      'recommendation_page_count': recommendationPageCount,
+      'following_page_count': followingPageCount,
+      ...session.params,
+    };
+    if (firstVisibleTimeMs != null) {
+      parameters['time_to_first_visible_ms'] = firstVisibleTimeMs;
+    }
+    _analytics.logEvent(
+      name: 'feed_fresh_result_complete',
+      parameters: parameters,
+    );
+    _analytics.logEvent(
+      name: 'feed_load_complete',
+      parameters: {
+        'feed_type': feedType,
+        'total_load_time_ms': freshResultTimeMs,
+        'total_videos': totalCount,
+        'first_batch_count': session.firstBatchCount ?? 0,
+        ...session.params,
+      },
+    );
+    _activeSessions.remove(feedType);
   }
 
   /// Mark when first videos arrive from Nostr
@@ -274,7 +377,7 @@ class FeedPerformanceTracker {
   /// when [markVideoSwipeComplete] is called.
   void startVideoSwipeTracking(String videoId) {
     final feedType = 'video_swipe_$videoId';
-    startFeedLoad(feedType);
+    _startSession(feedType, const {});
   }
 
   /// Mark a video swipe as complete (video is now playing).
@@ -364,4 +467,6 @@ class _FeedLoadSession {
   DateTime? displayedTime;
   int? firstBatchCount;
   int? totalVideosDisplayed;
+  DateTime? firstVisibleTime;
+  bool servedFromCache = false;
 }

--- a/mobile/packages/analytics/test/feed_performance_tracker_test.dart
+++ b/mobile/packages/analytics/test/feed_performance_tracker_test.dart
@@ -35,6 +35,73 @@ class _RecordingAnalyticsEventSink implements AnalyticsEventSink {
 
 void main() {
   group(FeedPerformanceTracker, () {
+    group('feed load phases', () {
+      late _RecordingAnalyticsEventSink sink;
+      late FeedPerformanceTracker tracker;
+
+      setUp(() {
+        sink = _RecordingAnalyticsEventSink();
+        tracker = FeedPerformanceTracker(sink: sink);
+      });
+
+      test('records initiation reason and keeps cache-first session open', () {
+        tracker
+          ..startFeedLoad('forYou', reason: FeedLoadReason.sourceSwitch)
+          ..markFirstVisibleContent('forYou', 5, servedFromCache: true);
+
+        expect(tracker.activeSessionCount, 1);
+        expect(sink.events.first.name, 'feed_load_started');
+        expect(sink.events.first.parameters, {
+          'feed_type': 'forYou',
+          'load_reason': 'sourceSwitch',
+        });
+        expect(sink.events[1].parameters, containsPair('served_from_cache', 1));
+      });
+
+      test('records fresh completion separately with traversal counts', () {
+        tracker
+          ..startFeedLoad('forYou')
+          ..markFirstVisibleContent('forYou', 4, servedFromCache: false)
+          ..markFreshResultCompleted(
+            'forYou',
+            12,
+            recommendationPageCount: 3,
+          );
+
+        expect(tracker.activeSessionCount, 0);
+        final completion = sink.events.firstWhere(
+          (event) => event.name == 'feed_fresh_result_complete',
+        );
+        expect(
+          completion.parameters,
+          containsPair('recommendation_page_count', 3),
+        );
+        expect(completion.parameters, containsPair('following_page_count', 0));
+        expect(
+          completion.parameters,
+          containsPair('time_to_first_visible_ms', isA<int>()),
+        );
+        expect(
+          completion.parameters,
+          containsPair('fresh_result_time_ms', isA<int>()),
+        );
+      });
+
+      test('only records the first visible-content milestone', () {
+        tracker
+          ..startFeedLoad('following')
+          ..markFirstVisibleContent('following', 3, servedFromCache: true)
+          ..markFirstVisibleContent('following', 8, servedFromCache: false);
+
+        expect(
+          sink.events.where(
+            (event) => event.name == 'feed_first_content_visible',
+          ),
+          hasLength(1),
+        );
+      });
+    });
+
     group('video swipe tracking', () {
       const videoId =
           'abc123def456abc123def456abc123def456abc123def456abc123def456abcd';

--- a/mobile/packages/videos_repository/lib/src/home_feed_result.dart
+++ b/mobile/packages/videos_repository/lib/src/home_feed_result.dart
@@ -27,6 +27,8 @@ class HomeFeedResult extends Equatable {
     this.nextCursor,
     this.paginationCursor,
     this.hasMore,
+    this.recommendationPageCount = 0,
+    this.followingPageCount = 0,
   });
 
   /// All videos (following + list), sorted by createdAt descending.
@@ -59,6 +61,12 @@ class HomeFeedResult extends Equatable {
   /// Whether the upstream feed has more data to fetch.
   final bool? hasMore;
 
+  /// Recommendation pages fetched to produce this result.
+  final int recommendationPageCount;
+
+  /// Following-feed pages fetched across REST or relay fallback.
+  final int followingPageCount;
+
   @override
   List<Object?> get props => [
     videos,
@@ -68,5 +76,7 @@ class HomeFeedResult extends Equatable {
     nextCursor,
     paginationCursor,
     hasMore,
+    recommendationPageCount,
+    followingPageCount,
   ];
 }

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -34,6 +34,13 @@ const int _videoKind = EventKind.videoVertical;
 /// Default number of videos to fetch per page.
 const int _defaultLimit = 25;
 
+class _FollowingFetchResult {
+  const _FollowingFetchResult({required this.videos, this.pageCount = 0});
+
+  final List<VideoEvent> videos;
+  final int pageCount;
+}
+
 /// Author-feed REST page size used for the `hasMore` fallback heuristic when
 /// the v2 envelope omits the flag. Mirrors `AppConstants.paginationBatchSize`
 /// (50) in the app layer — kept here as a package-local const so the
@@ -284,7 +291,7 @@ class VideosRepository {
     }
 
     // 1. Fetch following videos (Funnelcake API → Nostr relay waterfall)
-    final videos = await _fetchFollowingVideos(
+    final following = await _fetchFollowingVideos(
       authors: authors,
       userPubkey: userPubkey,
       limit: limit,
@@ -293,14 +300,17 @@ class VideosRepository {
 
     // 2. If no list refs, return following-only result (with seen demotion)
     if (videoRefs.isEmpty) {
-      final ordered = await _orderBySeenFreshness(videos);
-      final result = HomeFeedResult(videos: ordered);
+      final ordered = await _orderBySeenFreshness(following.videos);
+      final result = HomeFeedResult(
+        videos: ordered,
+        followingPageCount: following.pageCount,
+      );
       return result;
     }
 
     // 3. Merge list videos with following videos
     final merged = await _mergeListVideos(
-      followingVideos: videos,
+      followingVideos: following.videos,
       videoRefs: videoRefs,
     );
     final orderedVideos = await _orderBySeenFreshness(merged.videos);
@@ -308,12 +318,13 @@ class VideosRepository {
       videos: orderedVideos,
       videoListSources: merged.videoListSources,
       listOnlyVideoIds: merged.listOnlyVideoIds,
+      followingPageCount: following.pageCount,
     );
     return result;
   }
 
   /// Fetches videos from followed users via Funnelcake API or Nostr relays.
-  Future<List<VideoEvent>> _fetchFollowingVideos({
+  Future<_FollowingFetchResult> _fetchFollowingVideos({
     required List<String> authors,
     String? userPubkey,
     int limit = _defaultLimit,
@@ -345,7 +356,7 @@ class VideosRepository {
     );
   }
 
-  Future<List<VideoEvent>> _fetchVisibleHomeVideosFromStatsApi({
+  Future<_FollowingFetchResult> _fetchVisibleHomeVideosFromStatsApi({
     required String userPubkey,
     required int limit,
     int? until,
@@ -353,11 +364,13 @@ class VideosRepository {
     var cursor = until;
     final visible = <VideoEvent>[];
     final seenVideoKeys = <String>{};
+    var pageCount = 0;
 
     // Intentionally walk until we have enough visible videos or the upstream
     // feed is exhausted. A hard page cap caused premature EOF on reply-dense
     // feeds by hiding visible videos behind reply-only raw pages.
     while (visible.length < limit) {
+      pageCount++;
       final response = await _funnelcakeApiClient!.getHomeFeed(
         pubkey: userPubkey,
         limit: limit,
@@ -379,23 +392,28 @@ class VideosRepository {
       cursor = nextCursor;
     }
 
-    return visible.take(limit).toList();
+    return _FollowingFetchResult(
+      videos: visible.take(limit).toList(),
+      pageCount: pageCount,
+    );
   }
 
-  Future<List<VideoEvent>> _fetchVisibleHomeVideosFromRelays({
+  Future<_FollowingFetchResult> _fetchVisibleHomeVideosFromRelays({
     required List<String> authors,
     required int limit,
     int? until,
   }) async {
     // Nostr fallback — skip when authors list is empty (fast-path startup
     // before follow list is ready).
-    if (authors.isEmpty) return <VideoEvent>[];
+    if (authors.isEmpty) return const _FollowingFetchResult(videos: []);
 
     var cursor = until;
     final visible = <VideoEvent>[];
     final seenVideoKeys = <String>{};
+    var pageCount = 0;
 
     while (visible.length < limit) {
+      pageCount++;
       final filter = Filter(
         kinds: [_videoKind],
         authors: authors,
@@ -419,7 +437,10 @@ class VideosRepository {
       cursor = nextCursor;
     }
 
-    return visible.take(limit).toList();
+    return _FollowingFetchResult(
+      videos: visible.take(limit).toList(),
+      pageCount: pageCount,
+    );
   }
 
   Future<List<VideoEvent>> _hydrateVideosWithBulkStats(
@@ -3067,6 +3088,7 @@ class VideosRepository {
     var nextCursor = currentResponse.nextCursor;
     var hasMore = currentResponse.hasMore;
     var fetchedCursor = recommendationCursor;
+    var pageCount = 1;
 
     while (true) {
       _appendUniqueVideos(
@@ -3093,6 +3115,7 @@ class VideosRepository {
         preferredLanguages: preferredLanguages,
         viewerCountry: viewerCountry,
       );
+      pageCount++;
       nextCursor = currentResponse.nextCursor;
       hasMore = currentResponse.hasMore;
     }
@@ -3104,6 +3127,7 @@ class VideosRepository {
       ),
       paginationCursor: nextCursor,
       hasMore: hasMore,
+      recommendationPageCount: pageCount,
     );
   }
 

--- a/mobile/packages/videos_repository/test/src/home_feed_result_test.dart
+++ b/mobile/packages/videos_repository/test/src/home_feed_result_test.dart
@@ -21,6 +21,8 @@ void main() {
       expect(result.videoListSources, isEmpty);
       expect(result.listOnlyVideoIds, isEmpty);
       expect(result.consumedItemCount, isNull);
+      expect(result.recommendationPageCount, 0);
+      expect(result.followingPageCount, 0);
     });
 
     test('can be instantiated with all fields', () {
@@ -34,6 +36,8 @@ void main() {
         nextCursor: 1234,
         paginationCursor: 'o:2',
         hasMore: true,
+        recommendationPageCount: 2,
+        followingPageCount: 3,
       );
 
       expect(result.videos, hasLength(1));
@@ -43,6 +47,8 @@ void main() {
       expect(result.nextCursor, 1234);
       expect(result.paginationCursor, 'o:2');
       expect(result.hasMore, isTrue);
+      expect(result.recommendationPageCount, 2);
+      expect(result.followingPageCount, 3);
     });
 
     test('empty constructor defaults', () {
@@ -151,6 +157,20 @@ void main() {
       expect(result1, isNot(equals(result2)));
     });
 
+    test('inequality when traversal counts differ', () {
+      final video = createVideo(id: 'v1');
+      final result1 = HomeFeedResult(
+        videos: [video],
+        recommendationPageCount: 1,
+      );
+      final result2 = HomeFeedResult(
+        videos: [video],
+        followingPageCount: 1,
+      );
+
+      expect(result1, isNot(equals(result2)));
+    });
+
     test('props includes all fields', () {
       final video = createVideo(id: 'v1');
       const sources = {
@@ -166,9 +186,11 @@ void main() {
         nextCursor: 1234,
         paginationCursor: 'o:2',
         hasMore: true,
+        recommendationPageCount: 2,
+        followingPageCount: 3,
       );
 
-      expect(result.props, hasLength(7));
+      expect(result.props, hasLength(9));
       expect(result.props[0], equals([video]));
       expect(result.props[1], equals(sources));
       expect(result.props[2], equals(listOnly));
@@ -176,6 +198,8 @@ void main() {
       expect(result.props[4], 1234);
       expect(result.props[5], 'o:2');
       expect(result.props[6], isTrue);
+      expect(result.props[7], 2);
+      expect(result.props[8], 3);
     });
   });
 }

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -2518,6 +2518,7 @@ void main() {
             );
 
             expect(result.videos.map((video) => video.id), ['feed-video']);
+            expect(result.followingPageCount, 2);
             verify(
               () => mockFunnelcakeClient.getHomeFeed(
                 pubkey: any(named: 'pubkey'),
@@ -2821,6 +2822,7 @@ void main() {
           );
 
           expect(result.videos.map((video) => video.id), ['feed-video']);
+          expect(result.followingPageCount, 2);
           verify(() => mockNostrClient.queryEvents(any())).called(2);
         },
       );
@@ -11619,6 +11621,7 @@ void main() {
           ]);
           expect(result.paginationCursor, equals('page-3'));
           expect(result.hasMore, isTrue);
+          expect(result.recommendationPageCount, 2);
           expect(requestedCursors, [null, 'page-2']);
         },
       );

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -3652,7 +3652,7 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'calls markFirstVideosReceived and markFeedDisplayed on success',
+        'records first-visible and fresh-result milestones on success',
         setUp: () {
           final videos = createTestVideos(3);
           when(() => mockFollowRepository.followingPubkeys).thenReturn(['a']);
@@ -3664,7 +3664,12 @@ void main() {
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
-          ).thenAnswer((_) async => HomeFeedResult(videos: videos));
+          ).thenAnswer(
+            (_) async => HomeFeedResult(
+              videos: videos,
+              followingPageCount: 2,
+            ),
+          );
         },
         build: createBlocWithTracker,
         act: (bloc) =>
@@ -3673,7 +3678,20 @@ void main() {
           verify(
             () => mockTracker.markFirstVideosReceived('following', 3),
           ).called(1);
-          verify(() => mockTracker.markFeedDisplayed('following', 3)).called(1);
+          verify(
+            () => mockTracker.markFirstVisibleContent(
+              'following',
+              3,
+              servedFromCache: false,
+            ),
+          ).called(1);
+          verify(
+            () => mockTracker.markFreshResultCompleted(
+              'following',
+              3,
+              followingPageCount: 2,
+            ),
+          ).called(1);
         },
       );
 
@@ -3703,7 +3721,9 @@ void main() {
             ),
           ).called(1);
           verifyNever(() => mockTracker.markFirstVideosReceived(any(), any()));
-          verifyNever(() => mockTracker.markFeedDisplayed(any(), any()));
+          verifyNever(
+            () => mockTracker.markFreshResultCompleted(any(), any()),
+          );
         },
       );
 
@@ -3727,7 +3747,9 @@ void main() {
           verify(
             () => mockTracker.markFirstVideosReceived('latest', 3),
           ).called(1);
-          verify(() => mockTracker.markFeedDisplayed('latest', 3)).called(1);
+          verify(
+            () => mockTracker.markFreshResultCompleted('latest', 3),
+          ).called(1);
         },
       );
     });


### PR DESCRIPTION
## Problem

Feed telemetry currently records one completion time, so we cannot distinguish the moment a person first sees usable content from the later completion of network refresh work. It also lacks the load trigger and page-walk depth needed to explain latency differences.

## Why this fix

This instruments app start, source switches, refreshes, and pagination as distinct load reasons. It records first-visible and fresh-result milestones separately, including whether cached content was served and privacy-safe recommendation/following page counts. Region analysis uses Firebase Analytics derived geography; the app does not collect or publish a location or account identifier.

The event contract and initial interactive latency targets are documented so dashboards and any future deadline enforcement share the same definitions.

## Deliberately unchanged

This PR measures the current load paths. It does not add request deadlines, change paging behavior, or alter feed caching and source-switch behavior.

## Verification

- analytics package: 80 tests passed with coverage
- videos_repository package: 504 tests passed with coverage
- video feed/cache tests: 125 tests passed
- focused analyzer passes for analytics, videos_repository, and app changes
- full Flutter analyze completed without errors
- pre-push checks passed

Closes #9017