### PR TITLE
fix(relays): stop reconnecting and double-dialling relays at startup and sign-in

### DIFF
--- a/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
+++ b/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
@@ -171,11 +171,18 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
 
   Future<RetryConnectionOutcome> retryConnection() async {
     try {
-      await _nostrClient.forceReconnectAll();
+      final outcome = await _nostrClient.forceReconnectAll();
       final connectedCount = _nostrClient.connectedRelayCount;
       if (connectedCount > 0) {
         await _videoEventService.resetAndResubscribeAll();
         return RetryConnectionOutcome.connected(connectedCount);
+      }
+      // Nothing connected YET is only a failure once the cycle has actually
+      // finished. A caller that joined shortly before the shared deadline gets
+      // here with dials still open, and calling that a failure contradicts the
+      // reconnect that is still running.
+      if (outcome == ForceReconnectOutcome.stillDialling) {
+        return const RetryConnectionOutcome.stillConnecting();
       }
       return const RetryConnectionOutcome.notConnected();
     } catch (e, stackTrace) {

--- a/mobile/lib/blocs/relay_settings/relay_settings_state.dart
+++ b/mobile/lib/blocs/relay_settings/relay_settings_state.dart
@@ -113,6 +113,8 @@ class RetryConnectionOutcome extends Equatable {
     : this._(kind: RetryConnectionOutcomeKind.connected, connectedCount: count);
   const RetryConnectionOutcome.notConnected()
     : this._(kind: RetryConnectionOutcomeKind.notConnected);
+  const RetryConnectionOutcome.stillConnecting()
+    : this._(kind: RetryConnectionOutcomeKind.stillConnecting);
   const RetryConnectionOutcome.failed()
     : this._(kind: RetryConnectionOutcomeKind.failed);
 
@@ -123,4 +125,18 @@ class RetryConnectionOutcome extends Equatable {
   List<Object?> get props => [kind, connectedCount];
 }
 
-enum RetryConnectionOutcomeKind { connected, notConnected, failed }
+enum RetryConnectionOutcomeKind {
+  /// The reconnect finished and at least one relay is connected.
+  connected,
+
+  /// The reconnect finished and nothing connected.
+  notConnected,
+
+  /// The reconnect had not finished when we stopped waiting, so nothing is
+  /// known yet. Distinct from [notConnected]: reporting a failure here tells
+  /// the user the retry failed while it is still succeeding.
+  stillConnecting,
+
+  /// The reconnect threw.
+  failed,
+}

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -945,6 +945,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "ከቅብብሎሽ ጋር መገናኘት አልተሳካም። እባክዎ የአውታረ መረብ ግንኙነትዎን ያረጋግጡ።",
+    "relaySettingsStillConnecting": "አሁንም ከቅብብሎሽ ጋር በመገናኘት ላይ ነው። እባክዎ ትንሽ ይጠብቁ።",
     "relaySettingsSavedLocallyPublishPending": "በዚህ መሣሪያ ላይ ተቀምጧል። ማተም እንደገና ሲሰራ ወደ መለያዎ እናስመሳስለዋለን።",
     "relaySettingsAddRelayTitle": "ቅብብል ጨምር",
     "relaySettingsAddRelayPrompt": "ማከል የምትፈልገውን የሪሌይ WebSocket URL አስገባ:",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -797,6 +797,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "فشل الاتصال بالمحولات. يرجى التحقق من اتصال الشبكة.",
+    "relaySettingsStillConnecting": "لا يزال الاتصال بالمحولات جارياً. يرجى الانتظار لحظة.",
     "relaySettingsSavedLocallyPublishPending": "تم الحفظ على هذا الجهاز. سنزامنه مع حسابك عندما يعمل النشر مرة أخرى.",
     "relaySettingsAddRelayTitle": "إضافة محول",
     "relaySettingsAddRelayPrompt": "أدخل رابط WebSocket للمحول الذي تريد إضافته:",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -884,6 +884,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Не успяхме да се свържем с релетата. Провери мрежовата си връзка.",
+    "relaySettingsStillConnecting": "Все още се свързваме с релетата. Изчакай малко.",
     "relaySettingsSavedLocallyPublishPending": "Запазено е на това устройство. Ще го синхронизираме с акаунта ти, когато публикуването заработи отново.",
     "relaySettingsAddRelayTitle": "Добави реле",
     "relaySettingsAddRelayPrompt": "Въведи WebSocket URL на релето, което искаш да добавиш:",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -800,6 +800,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Verbindung zu Relays fehlgeschlagen. Bitte prüf deine Netzwerkverbindung.",
+    "relaySettingsStillConnecting": "Verbindung zu Relays wird noch aufgebaut. Einen Moment noch.",
     "relaySettingsSavedLocallyPublishPending": "Auf diesem Gerät gespeichert. Wir synchronisieren es mit deinem Konto, sobald das Veröffentlichen wieder funktioniert.",
     "relaySettingsAddRelayTitle": "Relay hinzufügen",
     "relaySettingsAddRelayPrompt": "Gib die WebSocket-URL des Relays ein, das du hinzufügen willst:",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1548,6 +1548,8 @@
     }
   },
   "relaySettingsFailedToConnectCheck": "Failed to connect to relays. Please check your network connection.",
+  "relaySettingsStillConnecting": "Still connecting. This is taking a moment - your relays will show up here when they land.",
+  "@relaySettingsStillConnecting": {"description": "Shown when a relay reconnect has not finished within its budget, so whether it succeeded is not yet known. Deliberately not an error: the reconnect is still running."},
   "relaySettingsSavedLocallyPublishPending": "Saved on this device. We'll sync it to your account when publishing works again.",
   "relaySettingsAddRelayTitle": "Add Relay",
   "relaySettingsAddRelayPrompt": "Enter the WebSocket URL of the relay you want to add:",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1548,8 +1548,10 @@
     }
   },
   "relaySettingsFailedToConnectCheck": "Failed to connect to relays. Please check your network connection.",
-  "relaySettingsStillConnecting": "Still connecting. This is taking a moment - your relays will show up here when they land.",
-  "@relaySettingsStillConnecting": {"description": "Shown when a relay reconnect has not finished within its budget, so whether it succeeded is not yet known. Deliberately not an error: the reconnect is still running."},
+  "relaySettingsStillConnecting": "Still connecting to relays. Give it a moment.",
+  "@relaySettingsStillConnecting": {
+    "description": "Shown after the user taps Retry on the Relays screen when the reconnect wait ends before any relay has connected, while connections are still being made. Not an error: the connections keep going in the background."
+  },
   "relaySettingsSavedLocallyPublishPending": "Saved on this device. We'll sync it to your account when publishing works again.",
   "relaySettingsAddRelayTitle": "Add Relay",
   "relaySettingsAddRelayPrompt": "Enter the WebSocket URL of the relay you want to add:",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -800,6 +800,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "No se pudo conectar a los relays. Revisá tu conexión de red.",
+    "relaySettingsStillConnecting": "Todavía nos estamos conectando a los relays. Dale un momento.",
     "relaySettingsSavedLocallyPublishPending": "Guardado en este dispositivo. Lo sincronizaremos con tu cuenta cuando la publicación vuelva a funcionar.",
     "relaySettingsAddRelayTitle": "Agregar relay",
     "relaySettingsAddRelayPrompt": "Ingresá la URL WebSocket del relay que querés agregar:",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -608,6 +608,7 @@
     "relaySettingsForcingReconnection": "Pinipilit ang muling pagkonekta sa relay...",
     "relaySettingsConnectedToRelays": "Nakakonekta sa {count} relay!",
     "relaySettingsFailedToConnectCheck": "Hindi nakakonekta sa mga relay. Pakitsek ang iyong network connection.",
+    "relaySettingsStillConnecting": "Kumokonekta pa rin sa mga relay. Sandali lang.",
     "relaySettingsSavedLocallyPublishPending": "Naka-save sa device na ito. Isi-sync namin ito sa account mo kapag gumana ulit ang publishing.",
     "relaySettingsAddRelayTitle": "Magdagdag ng Relay",
     "relaySettingsAddRelayPrompt": "Ilagay ang WebSocket URL ng relay na gusto mong idagdag:",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -800,6 +800,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Échec de la connexion aux relays. Vérifie ta connexion réseau.",
+    "relaySettingsStillConnecting": "Connexion aux relays toujours en cours. Patiente un instant.",
     "relaySettingsSavedLocallyPublishPending": "Enregistré sur cet appareil. On le synchronisera avec ton compte quand la publication refonctionnera.",
     "relaySettingsAddRelayTitle": "Ajouter un relay",
     "relaySettingsAddRelayPrompt": "Entre l'URL WebSocket du relay que tu veux ajouter :",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -797,6 +797,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Gagal terhubung ke relay. Silakan cek koneksi jaringanmu.",
+    "relaySettingsStillConnecting": "Masih menghubungkan ke relay. Tunggu sebentar.",
     "relaySettingsSavedLocallyPublishPending": "Tersimpan di perangkat ini. Kami akan menyinkronkannya ke akunmu saat penerbitan berfungsi lagi.",
     "relaySettingsAddRelayTitle": "Tambah Relay",
     "relaySettingsAddRelayPrompt": "Masukkan URL WebSocket relay yang ingin kamu tambahkan:",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -800,6 +800,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Impossibile connettersi ai relay. Controlla la connessione di rete.",
+    "relaySettingsStillConnecting": "Connessione ai relay ancora in corso. Aspetta un attimo.",
     "relaySettingsSavedLocallyPublishPending": "Salvato su questo dispositivo. Lo sincronizzeremo con il tuo account quando la pubblicazione tornerà a funzionare.",
     "relaySettingsAddRelayTitle": "Aggiungi relay",
     "relaySettingsAddRelayPrompt": "Inserisci l'URL WebSocket del relay che vuoi aggiungere:",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -797,6 +797,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "リレーに接続できなかった。ネット接続を確認してみて。",
+    "relaySettingsStillConnecting": "リレーにまだ接続中です。少しお待ちください。",
     "relaySettingsSavedLocallyPublishPending": "この端末に保存しました。公開がまた動くようになったらアカウントに同期します。",
     "relaySettingsAddRelayTitle": "リレーを追加",
     "relaySettingsAddRelayPrompt": "追加したいリレーの WebSocket URL を入力してね:",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -545,6 +545,7 @@
     "relaySettingsForcingReconnection": "릴레이 재연결 중...",
     "relaySettingsConnectedToRelays": "릴레이 {count}개에 연결됐어요!",
     "relaySettingsFailedToConnectCheck": "릴레이 연결에 실패했어요. 네트워크 연결을 확인해주세요.",
+    "relaySettingsStillConnecting": "아직 릴레이에 연결하고 있어요. 잠시만 기다려 주세요.",
     "relaySettingsSavedLocallyPublishPending": "이 기기에 저장됐어요. 게시가 다시 작동하면 계정에 동기화할게요.",
     "relaySettingsAddRelayTitle": "릴레이 추가",
     "relaySettingsAddRelayPrompt": "추가할 릴레이의 WebSocket URL을 입력해주세요:",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -1177,6 +1177,7 @@
     }
   },
   "relaySettingsFailedToConnectCheck": "Gagal bersambung ke relay. Sila semak sambungan rangkaian anda.",
+  "relaySettingsStillConnecting": "Masih menyambung ke relay. Sila tunggu sebentar.",
   "relaySettingsSavedLocallyPublishPending": "Disimpan pada peranti ini. Kami akan menyegerakkannya ke akaun anda apabila penerbitan berfungsi semula.",
   "relaySettingsAddRelayTitle": "Tambah Relay",
   "relaySettingsAddRelayPrompt": "Masukkan URL WebSocket relay yang mahu anda tambah:",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -800,6 +800,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Verbinden met relays mislukt. Check je netwerkverbinding.",
+    "relaySettingsStillConnecting": "Verbinden met relays is nog bezig. Geef het even de tijd.",
     "relaySettingsSavedLocallyPublishPending": "Op dit apparaat opgeslagen. We synchroniseren het met je account zodra publiceren weer werkt.",
     "relaySettingsAddRelayTitle": "Relay toevoegen",
     "relaySettingsAddRelayPrompt": "Voer de WebSocket-URL in van de relay die je wilt toevoegen:",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -800,6 +800,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Nie udało się połączyć z przekaźnikami. Sprawdź połączenie z siecią.",
+    "relaySettingsStillConnecting": "Wciąż łączymy się z przekaźnikami. Daj nam chwilę.",
     "relaySettingsSavedLocallyPublishPending": "Zapisano na tym urządzeniu. Zsynchronizujemy to z Twoim kontem, gdy publikowanie znów zadziała.",
     "relaySettingsAddRelayTitle": "Dodaj przekaźnik",
     "relaySettingsAddRelayPrompt": "Wprowadź URL WebSocket przekaźnika, który chcesz dodać:",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -800,6 +800,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Falha ao conectar aos relays. Verifique sua conexão de rede.",
+    "relaySettingsStillConnecting": "Ainda conectando aos relays. Aguarde um momento.",
     "relaySettingsSavedLocallyPublishPending": "Salvo neste dispositivo. Vamos sincronizar com sua conta quando a publicação voltar a funcionar.",
     "relaySettingsAddRelayTitle": "Adicionar relay",
     "relaySettingsAddRelayPrompt": "Digite a URL WebSocket do relay que você quer adicionar:",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -800,6 +800,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "N-am putut conecta la relay-uri. Verifică-ți conexiunea la rețea.",
+    "relaySettingsStillConnecting": "Încă ne conectăm la relay-uri. Mai așteaptă puțin.",
     "relaySettingsSavedLocallyPublishPending": "Salvat pe acest dispozitiv. Îl vom sincroniza cu contul tău când publicarea funcționează din nou.",
     "relaySettingsAddRelayTitle": "Adaugă relay",
     "relaySettingsAddRelayPrompt": "Introdu URL-ul WebSocket al relay-ului pe care vrei să-l adaugi:",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -800,6 +800,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Kunde inte ansluta till reler. Kolla din nätverksanslutning.",
+    "relaySettingsStillConnecting": "Ansluter fortfarande till reler. Vänta en liten stund.",
     "relaySettingsSavedLocallyPublishPending": "Sparat på den här enheten. Vi synkar det till ditt konto när publicering fungerar igen.",
     "relaySettingsAddRelayTitle": "Lägg till rel",
     "relaySettingsAddRelayPrompt": "Ange WebSocket-URL:en för relen du vill lägga till:",

--- a/mobile/lib/l10n/app_te.arb
+++ b/mobile/lib/l10n/app_te.arb
@@ -1521,6 +1521,7 @@
     }
   },
   "relaySettingsFailedToConnectCheck": "రిలేలకు కనెక్ట్ చేయడంలో విఫలమైంది. దయచేసి మీ నెట్‌వర్క్ కనెక్షన్‌ని తనిఖీ చేయండి.",
+  "relaySettingsStillConnecting": "ఇంకా రిలేలకు కనెక్ట్ అవుతోంది. దయచేసి కొంచెం సేపు వేచి ఉండండి.",
   "relaySettingsSavedLocallyPublishPending": "ఈ పరికరంలో సేవ్ చేయబడింది. రచనలను మళ్లీ ప్రచురించేటప్పుడు మేము దానిని మీ ఖాతాకు సమకాలీకరిస్తాము.",
   "relaySettingsAddRelayTitle": "రిలేని జోడించండి",
   "relaySettingsAddRelayPrompt": "మీరు జోడించాలనుకుంటున్న రిలే యొక్క WebSocket URLని నమోదు చేయండి:",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -797,6 +797,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Rölelere bağlanılamadı. Lütfen ağ bağlantını kontrol et.",
+    "relaySettingsStillConnecting": "Rölelere hâlâ bağlanılıyor. Biraz bekle.",
     "relaySettingsSavedLocallyPublishPending": "Bu cihazda kaydedildi. Yayınlama tekrar çalıştığında hesabınla eşitleyeceğiz.",
     "relaySettingsAddRelayTitle": "Röle Ekle",
     "relaySettingsAddRelayPrompt": "Eklemek istediğin rölenin WebSocket URL'sini gir:",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -1177,6 +1177,7 @@
     }
   },
   "relaySettingsFailedToConnectCheck": "ریلے سے منسلک نہیں ہو سکا۔ براہ کرم اپنا نیٹ ورک کنکشن چیک کریں۔",
+  "relaySettingsStillConnecting": "ریلے سے ابھی بھی منسلک ہو رہا ہے۔ براہ کرم تھوڑا انتظار کریں۔",
   "relaySettingsSavedLocallyPublishPending": "اس ڈیوائس پر محفوظ ہو گیا۔ اشاعت دوبارہ کام کرنے لگے تو ہم اسے آپ کے اکاؤنٹ سے ہم آہنگ کر دیں گے۔",
   "relaySettingsAddRelayTitle": "ریلے شامل کریں",
   "relaySettingsAddRelayPrompt": "جس ریلے کو شامل کرنا چاہتے ہیں اس کا WebSocket URL درج کریں:",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -1177,6 +1177,7 @@
     }
   },
   "relaySettingsFailedToConnectCheck": "Không kết nối được với relay. Vui lòng kiểm tra kết nối mạng của bạn.",
+  "relaySettingsStillConnecting": "Vẫn đang kết nối với relay. Vui lòng chờ một chút.",
   "relaySettingsSavedLocallyPublishPending": "Đã lưu trên thiết bị này. Chúng tôi sẽ đồng bộ với tài khoản của bạn khi việc đăng lại hoạt động.",
   "relaySettingsAddRelayTitle": "Thêm relay",
   "relaySettingsAddRelayPrompt": "Nhập URL WebSocket của relay bạn muốn thêm:",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -1177,6 +1177,7 @@
     }
   },
   "relaySettingsFailedToConnectCheck": "连接中继失败。请检查网络连接。",
+  "relaySettingsStillConnecting": "仍在连接中继。请稍候。",
   "relaySettingsSavedLocallyPublishPending": "已保存在此设备上。发布恢复正常后，我们会将它同步到你的账号。",
   "relaySettingsAddRelayTitle": "添加中继",
   "relaySettingsAddRelayPrompt": "输入要添加的中继 WebSocket URL：",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -3969,6 +3969,12 @@ abstract class AppLocalizations {
   /// **'Failed to connect to relays. Please check your network connection.'**
   String get relaySettingsFailedToConnectCheck;
 
+  /// Shown when a relay reconnect has not finished within its budget, so whether it succeeded is not yet known. Deliberately not an error: the reconnect is still running.
+  ///
+  /// In en, this message translates to:
+  /// **'Still connecting. This is taking a moment - your relays will show up here when they land.'**
+  String get relaySettingsStillConnecting;
+
   /// No description provided for @relaySettingsSavedLocallyPublishPending.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -3969,10 +3969,10 @@ abstract class AppLocalizations {
   /// **'Failed to connect to relays. Please check your network connection.'**
   String get relaySettingsFailedToConnectCheck;
 
-  /// Shown when a relay reconnect has not finished within its budget, so whether it succeeded is not yet known. Deliberately not an error: the reconnect is still running.
+  /// Shown after the user taps Retry on the Relays screen when the reconnect wait ends before any relay has connected, while connections are still being made. Not an error: the connections keep going in the background.
   ///
   /// In en, this message translates to:
-  /// **'Still connecting. This is taking a moment - your relays will show up here when they land.'**
+  /// **'Still connecting to relays. Give it a moment.'**
   String get relaySettingsStillConnecting;
 
   /// No description provided for @relaySettingsSavedLocallyPublishPending.

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -2263,7 +2263,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'አሁንም ከቅብብሎሽ ጋር በመገናኘት ላይ ነው። እባክዎ ትንሽ ይጠብቁ።';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -2262,6 +2262,10 @@ class AppLocalizationsAm extends AppLocalizations {
       'ከቅብብሎሽ ጋር መገናኘት አልተሳካም። እባክዎ የአውታረ መረብ ግንኙነትዎን ያረጋግጡ።';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'በዚህ መሣሪያ ላይ ተቀምጧል። ማተም እንደገና ሲሰራ ወደ መለያዎ እናስመሳስለዋለን።';
 

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -2294,6 +2294,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'فشل الاتصال بالمحولات. يرجى التحقق من اتصال الشبكة.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'تم الحفظ على هذا الجهاز. سنزامنه مع حسابك عندما يعمل النشر مرة أخرى.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -2295,7 +2295,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'لا يزال الاتصال بالمحولات جارياً. يرجى الانتظار لحظة.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2355,7 +2355,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'Все още се свързваме с релетата. Изчакай малко.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2354,6 +2354,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Не успяхме да се свържем с релетата. Провери мрежовата си връзка.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'Запазено е на това устройство. Ще го синхронизираме с акаунта ти, когато публикуването заработи отново.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2343,7 +2343,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'Verbindung zu Relays wird noch aufgebaut. Einen Moment noch.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2342,6 +2342,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Verbindung zu Relays fehlgeschlagen. Bitte prüf deine Netzwerkverbindung.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'Auf diesem Gerät gespeichert. Wir synchronisieren es mit deinem Konto, sobald das Veröffentlichen wieder funktioniert.';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2324,6 +2324,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Failed to connect to relays. Please check your network connection.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'Saved on this device. We\'ll sync it to your account when publishing works again.';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2325,7 +2325,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'Still connecting to relays. Give it a moment.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2340,6 +2340,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se pudo conectar a los relays. Revisá tu conexión de red.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'Guardado en este dispositivo. Lo sincronizaremos con tu cuenta cuando la publicación vuelva a funcionar.';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2341,7 +2341,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'Todavía nos estamos conectando a los relays. Dale un momento.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2320,6 +2320,10 @@ class AppLocalizationsFil extends AppLocalizations {
       'Hindi nakakonekta sa mga relay. Pakitsek ang iyong network connection.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'Naka-save sa device na ito. Isi-sync namin ito sa account mo kapag gumana ulit ang publishing.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2321,7 +2321,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'Kumokonekta pa rin sa mga relay. Sandali lang.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2353,6 +2353,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Échec de la connexion aux relays. Vérifie ta connexion réseau.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'Enregistré sur cet appareil. On le synchronisera avec ton compte quand la publication refonctionnera.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2354,7 +2354,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'Connexion aux relays toujours en cours. Patiente un instant.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -2243,6 +2243,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Gagal terhubung ke relay. Silakan cek koneksi jaringanmu.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'Tersimpan di perangkat ini. Kami akan menyinkronkannya ke akunmu saat penerbitan berfungsi lagi.';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -2244,7 +2244,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'Masih menghubungkan ke relay. Tunggu sebentar.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2347,6 +2347,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Impossibile connettersi ai relay. Controlla la connessione di rete.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'Salvato su questo dispositivo. Lo sincronizzeremo con il tuo account quando la pubblicazione tornerà a funzionare.';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2348,7 +2348,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'Connessione ai relay ancora in corso. Aspetta un attimo.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2147,6 +2147,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get relaySettingsFailedToConnectCheck => 'リレーに接続できなかった。ネット接続を確認してみて。';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'この端末に保存しました。公開がまた動くようになったらアカウントに同期します。';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2147,8 +2147,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get relaySettingsFailedToConnectCheck => 'リレーに接続できなかった。ネット接続を確認してみて。';
 
   @override
-  String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+  String get relaySettingsStillConnecting => 'リレーにまだ接続中です。少しお待ちください。';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2157,8 +2157,7 @@ class AppLocalizationsKo extends AppLocalizations {
       '릴레이 연결에 실패했어요. 네트워크 연결을 확인해주세요.';
 
   @override
-  String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+  String get relaySettingsStillConnecting => '아직 릴레이에 연결하고 있어요. 잠시만 기다려 주세요.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2157,6 +2157,10 @@ class AppLocalizationsKo extends AppLocalizations {
       '릴레이 연결에 실패했어요. 네트워크 연결을 확인해주세요.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       '이 기기에 저장됐어요. 게시가 다시 작동하면 계정에 동기화할게요.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -2298,7 +2298,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'Masih menyambung ke relay. Sila tunggu sebentar.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -2297,6 +2297,10 @@ class AppLocalizationsMs extends AppLocalizations {
       'Gagal bersambung ke relay. Sila semak sambungan rangkaian anda.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'Disimpan pada peranti ini. Kami akan menyegerakkannya ke akaun anda apabila penerbitan berfungsi semula.';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2324,6 +2324,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Verbinden met relays mislukt. Check je netwerkverbinding.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'Op dit apparaat opgeslagen. We synchroniseren het met je account zodra publiceren weer werkt.';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2325,7 +2325,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'Verbinden met relays is nog bezig. Geef het even de tijd.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2365,6 +2365,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Nie udało się połączyć z przekaźnikami. Sprawdź połączenie z siecią.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'Zapisano na tym urządzeniu. Zsynchronizujemy to z Twoim kontem, gdy publikowanie znów zadziała.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2366,7 +2366,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'Wciąż łączymy się z przekaźnikami. Daj nam chwilę.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2334,7 +2334,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'Ainda conectando aos relays. Aguarde um momento.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2333,6 +2333,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Falha ao conectar aos relays. Verifique sua conexão de rede.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'Salvo neste dispositivo. Vamos sincronizar com sua conta quando a publicação voltar a funcionar.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2372,6 +2372,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'N-am putut conecta la relay-uri. Verifică-ți conexiunea la rețea.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'Salvat pe acest dispozitiv. Îl vom sincroniza cu contul tău când publicarea funcționează din nou.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2373,7 +2373,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'Încă ne conectăm la relay-uri. Mai așteaptă puțin.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -2308,6 +2308,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Kunde inte ansluta till reler. Kolla din nätverksanslutning.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'Sparat på den här enheten. Vi synkar det till ditt konto när publicering fungerar igen.';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -2309,7 +2309,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'Ansluter fortfarande till reler. Vänta en liten stund.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -2367,6 +2367,10 @@ class AppLocalizationsTe extends AppLocalizations {
       'రిలేలకు కనెక్ట్ చేయడంలో విఫలమైంది. దయచేసి మీ నెట్‌వర్క్ కనెక్షన్‌ని తనిఖీ చేయండి.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'ఈ పరికరంలో సేవ్ చేయబడింది. రచనలను మళ్లీ ప్రచురించేటప్పుడు మేము దానిని మీ ఖాతాకు సమకాలీకరిస్తాము.';
 

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -2368,7 +2368,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'ఇంకా రిలేలకు కనెక్ట్ అవుతోంది. దయచేసి కొంచెం సేపు వేచి ఉండండి.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -2250,6 +2250,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Rölelere bağlanılamadı. Lütfen ağ bağlantını kontrol et.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'Bu cihazda kaydedildi. Yayınlama tekrar çalıştığında hesabınla eşitleyeceğiz.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -2251,7 +2251,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'Rölelere hâlâ bağlanılıyor. Biraz bekle.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -2315,6 +2315,10 @@ class AppLocalizationsUr extends AppLocalizations {
       'ریلے سے منسلک نہیں ہو سکا۔ براہ کرم اپنا نیٹ ورک کنکشن چیک کریں۔';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'اس ڈیوائس پر محفوظ ہو گیا۔ اشاعت دوبارہ کام کرنے لگے تو ہم اسے آپ کے اکاؤنٹ سے ہم آہنگ کر دیں گے۔';
 

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -2316,7 +2316,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'ریلے سے ابھی بھی منسلک ہو رہا ہے۔ براہ کرم تھوڑا انتظار کریں۔';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -2285,6 +2285,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Không kết nối được với relay. Vui lòng kiểm tra kết nối mạng của bạn.';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       'Đã lưu trên thiết bị này. Chúng tôi sẽ đồng bộ với tài khoản của bạn khi việc đăng lại hoạt động.';
 

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -2286,7 +2286,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+      'Vẫn đang kết nối với relay. Vui lòng chờ một chút.';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -2163,8 +2163,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get relaySettingsFailedToConnectCheck => '连接中继失败。请检查网络连接。';
 
   @override
-  String get relaySettingsStillConnecting =>
-      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+  String get relaySettingsStillConnecting => '仍在连接中继。请稍候。';
 
   @override
   String get relaySettingsSavedLocallyPublishPending =>

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -2163,6 +2163,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get relaySettingsFailedToConnectCheck => '连接中继失败。请检查网络连接。';
 
   @override
+  String get relaySettingsStillConnecting =>
+      'Still connecting. This is taking a moment - your relays will show up here when they land.';
+
+  @override
   String get relaySettingsSavedLocallyPublishPending =>
       '已保存在此设备上。发布恢复正常后，我们会将它同步到你的账号。';
 

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -13,6 +13,7 @@ import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/services/connection_status_service.dart';
+import 'package:openvine/services/connectivity_transition_monitor.dart';
 import 'package:openvine/services/relay_capability_service.dart';
 import 'package:openvine/services/relay_statistics_service.dart';
 import 'package:openvine/services/video_event_service.dart';
@@ -701,39 +702,44 @@ bool _setsEqual<T>(Set<T> a, Set<T> b) {
   return a.containsAll(b);
 }
 
-/// Force-reconnects the relay pool whenever `connectivity_plus` reports the
-/// network returning, so a pool that collapsed to zero connections during an
-/// offline window self-heals app-wide — not only on an app-foreground
-/// transition (#3161). Debounced so a burst of connectivity events collapses
-/// into one reconnect. keepAlive with no UI consumer: activated by
-/// `AppRootSideEffects` so the pool also self-heals on routes outside the
-/// bottom-nav shell.
-final connectivityRelayReconnectProvider = Provider<void>((ref) {
-  final nostrService = ref.watch(nostrServiceProvider);
-  Timer? debounce;
-  final subscription = Connectivity().onConnectivityChanged
-      .where((results) => results.any((r) => r != ConnectivityResult.none))
-      .listen((_) {
-        debounce?.cancel();
-        debounce = Timer(const Duration(seconds: 2), () async {
-          try {
-            await nostrService.forceReconnectAll();
-            Log.info(
-              'Reconnected relays after connectivity returned',
-              name: 'ConnectivityRelayReconnect',
-              category: LogCategory.relay,
-            );
-          } catch (e) {
-            Log.error(
-              'connectivity-triggered relay reconnect failed: $e',
-              name: 'ConnectivityRelayReconnect',
-              category: LogCategory.relay,
-            );
-          }
-        });
-      });
-  ref.onDispose(() {
-    debounce?.cancel();
-    subscription.cancel();
-  });
-});
+/// `connectivity_plus` reports, as a seam for tests.
+final connectivityChangesProvider = Provider<Stream<List<ConnectivityResult>>>(
+  (ref) => Connectivity().onConnectivityChanged,
+);
+
+/// A one-off `connectivity_plus` check, as a seam for tests.
+final connectivityCheckProvider =
+    Provider<Future<List<ConnectivityResult>> Function()>(
+      (ref) => Connectivity().checkConnectivity,
+    );
+
+/// The one app-wide owner of connectivity-driven relay repair, so a pool that
+/// collapsed during an offline window self-heals on every route, not only on
+/// an app-foreground transition (#3161).
+///
+/// It subscribes once and never rebuilds: it watches only its two seams and
+/// reads the current client when a repair fires. Re-subscribing replayed the
+/// current state, which read as a reconnect and tore healthy sockets down
+/// after every launch and sign-in (#8990). A repair waits while that client
+/// is still initializing, and the transitions it emits drive the DM retry
+/// sweep. keepAlive with no UI consumer: activated by `AppRootSideEffects`.
+final connectivityRelayReconnectProvider =
+    Provider<Stream<ConnectivityTransition>>((ref) {
+      final monitor = ConnectivityTransitionMonitor(
+        changes: ref.watch(connectivityChangesProvider),
+        checkConnectivity: ref.watch(connectivityCheckProvider),
+        repair: () async {
+          await ref.read(nostrServiceProvider).forceReconnectAll();
+          Log.info(
+            'Reconnected relays after a connectivity change',
+            name: 'ConnectivityRelayReconnect',
+            category: LogCategory.relay,
+          );
+        },
+        canRepair: () => !ref
+            .read(nostrInitializationInProgressProvider.notifier)
+            .isClientInitializing(ref.read(nostrServiceProvider)),
+      )..start();
+      ref.onDispose(monitor.dispose);
+      return monitor.transitions;
+    });

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -8,7 +8,12 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:meta/meta.dart';
 import 'package:nostr_client/nostr_client.dart'
-    show NostrClient, RelayConnectionStatus, RelayRemoveSource, RelayState;
+    show
+        ForceReconnectOutcome,
+        NostrClient,
+        RelayConnectionStatus,
+        RelayRemoveSource,
+        RelayState;
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
@@ -262,12 +267,26 @@ class _RelaySetChangeCoordinator {
       );
 
       try {
-        await attachment.client.forceReconnectAll();
-        Log.info(
-          'Successfully reconnected all relay WebSockets',
-          name: 'RelaySetChangeBridge',
-          category: LogCategory.relay,
-        );
+        final outcome = await attachment.client.forceReconnectAll();
+        // The cycle keeps running past the budget, so this is not a failure —
+        // but it is not a completed reconnect either, and logging it as one
+        // makes a stalled dial indistinguishable from a healthy one in a
+        // support export.
+        if (outcome == ForceReconnectOutcome.completed) {
+          Log.info(
+            'Successfully reconnected all relay WebSockets',
+            name: 'RelaySetChangeBridge',
+            category: LogCategory.relay,
+          );
+        } else {
+          Log.warning(
+            'Relay reconnect did not finish within its budget; dials remain '
+            'in flight. Resetting feeds anyway so they pick up relays as '
+            'those land.',
+            name: 'RelaySetChangeBridge',
+            category: LogCategory.relay,
+          );
+        }
       } catch (e) {
         Log.error(
           'Failed to reconnect relays: $e',

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -731,7 +731,7 @@ final connectivityRelayReconnectProvider =
         repair: () async {
           await ref.read(nostrServiceProvider).forceReconnectAll();
           Log.info(
-            'Reconnected relays after a connectivity change',
+            'Relay reconnect attempt after a connectivity change ended',
             name: 'ConnectivityRelayReconnect',
             category: LogCategory.relay,
           );

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -266,27 +266,11 @@ class _RelaySetChangeCoordinator {
         category: LogCategory.relay,
       );
 
+      // Only the reconnect is caught here: a fault in the logging below must
+      // not read as a reconnect failure.
+      ForceReconnectOutcome? outcome;
       try {
-        final outcome = await attachment.client.forceReconnectAll();
-        // The cycle keeps running past the budget, so this is not a failure —
-        // but it is not a completed reconnect either, and logging it as one
-        // makes a stalled dial indistinguishable from a healthy one in a
-        // support export.
-        if (outcome == ForceReconnectOutcome.completed) {
-          Log.info(
-            'Successfully reconnected all relay WebSockets',
-            name: 'RelaySetChangeBridge',
-            category: LogCategory.relay,
-          );
-        } else {
-          Log.warning(
-            'Relay reconnect did not finish within its budget; dials remain '
-            'in flight. Resetting feeds anyway so they pick up relays as '
-            'those land.',
-            name: 'RelaySetChangeBridge',
-            category: LogCategory.relay,
-          );
-        }
+        outcome = await attachment.client.forceReconnectAll();
       } catch (e) {
         Log.error(
           'Failed to reconnect relays: $e',
@@ -294,6 +278,7 @@ class _RelaySetChangeCoordinator {
           category: LogCategory.relay,
         );
       }
+      if (outcome != null) _logReconnectOutcome(attachment.client, outcome);
 
       if (!_operationIsCurrent(attachment, transaction, transactionVersion)) {
         _rescheduleAfterOperation = _pendingTransaction != null;
@@ -384,6 +369,31 @@ class _RelaySetChangeCoordinator {
         return const _RelayReconciliationResult.superseded();
       }
       return _RelayReconciliationResult.incomplete(e.toString());
+    }
+  }
+
+  void _logReconnectOutcome(NostrClient client, ForceReconnectOutcome outcome) {
+    final connected =
+        '${client.connectedRelayCount} of ${client.configuredRelayCount}';
+    switch (outcome) {
+      case ForceReconnectOutcome.completed:
+        Log.info(
+          'Relay reconnect finished: $connected relays connected',
+          name: 'RelaySetChangeBridge',
+          category: LogCategory.relay,
+        );
+      case ForceReconnectOutcome.stillDialling:
+        // Not a failure, and not a finished reconnect either: logging it as
+        // one makes a stalled dial indistinguishable from a healthy one in a
+        // support export. The feed reset still goes ahead, because RelayPool
+        // re-sends every active subscription to a relay once its dial lands.
+        Log.warning(
+          'Relay reconnect wait ended with relays still connecting '
+          '($connected connected); resetting feeds, and relays that connect '
+          'later receive the subscriptions then',
+          name: 'RelaySetChangeBridge',
+          category: LogCategory.relay,
+        );
     }
   }
 
@@ -748,9 +758,19 @@ final connectivityRelayReconnectProvider =
         changes: ref.watch(connectivityChangesProvider),
         checkConnectivity: ref.watch(connectivityCheckProvider),
         repair: () async {
-          await ref.read(nostrServiceProvider).forceReconnectAll();
+          final client = ref.read(nostrServiceProvider);
+          final outcome = await client.forceReconnectAll();
+          final connected =
+              '${client.connectedRelayCount} of ${client.configuredRelayCount}';
           Log.info(
-            'Relay reconnect attempt after a connectivity change ended',
+            switch (outcome) {
+              ForceReconnectOutcome.completed =>
+                'Relay reconnect after a connectivity change finished: '
+                    '$connected relays connected',
+              ForceReconnectOutcome.stillDialling =>
+                'Relay reconnect after a connectivity change ended with relays '
+                    'still connecting ($connected connected)',
+            },
             name: 'ConnectivityRelayReconnect',
             category: LogCategory.relay,
           );

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -8,7 +8,6 @@ import 'package:collaborator_repository/collaborator_repository.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:meta/meta.dart';
 import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
 import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
@@ -70,13 +69,6 @@ Stream<void> _dmRetryConnectivityTriggerStream() => Connectivity()
     .onConnectivityChanged
     .where((results) => results.any((r) => r != ConnectivityResult.none))
     .map<void>((_) {});
-
-/// Upper bound on the pool repair awaited inside
-/// [dmMessageRetryTriggerWithRelayRepair] before the sweep trigger is emitted
-/// anyway. `forceReconnectAll` reconnects relays serially, so a slow relay
-/// must not starve the retry sweep indefinitely — on timeout the sweep runs
-/// and the SDK's own OK-timeout remediation backstops any still-stale socket.
-const _relayRepairTimeout = Duration(seconds: 15);
 
 typedef PendingUploadOwnerCleanup = Future<int> Function(String ownerPubkey);
 
@@ -143,66 +135,6 @@ final dmListeningStopProvider = Provider<Future<void> Function()>((ref) {
     await ref.read(dmRepositoryProvider).stopListening();
   };
 });
-
-/// Connectivity trigger for the message retry sweep: fires on EVERY
-/// connectivity transition, including `→ none`. [OutgoingDmRetryService] runs
-/// its own offline probe per pass: an online pass re-drives retryable rows,
-/// and an offline pass surfaces aged still-`pending` rows as red failed
-/// bubbles (a pending row renders identically to a delivered one, so without
-/// this a send that went unconfirmed just before the network dropped stays
-/// sent-looking — and untappable — for the whole offline window). See #6046.
-///
-/// Before an ONLINE transition's trigger is emitted, [repairRelayPool] (wired
-/// to `NostrClient.forceReconnectAll`) is awaited: after an interface change
-/// the pool's WebSockets are half-open zombies that still report `connected`
-/// — publishes buffer into them and no OK ever arrives — and nothing else
-/// repairs the pool while the app stays foregrounded (`forceReconnectAll`
-/// otherwise only runs on app-resume, relay-set change, or a manual settings
-/// action). Without the repair, the sweep fired by the same connectivity
-/// event races the zombie window and every re-driven row soft-fails, leaving
-/// red bubbles unresendable until the 90s idle detector fires. The first
-/// emission after subscribe describes the current state, not a transition,
-/// so it never triggers a repair (app start must not cycle sockets that are
-/// still connecting). Repair failures and timeouts are logged and the
-/// trigger is emitted regardless. Public for testing; production wiring is
-/// in [outgoingDmRetryService].
-@visibleForTesting
-Stream<void> dmMessageRetryTriggerWithRelayRepair({
-  required Stream<List<ConnectivityResult>> connectivityChanges,
-  required Future<void> Function() repairRelayPool,
-}) {
-  // asyncMap rather than an async* generator: a generator suspended at its
-  // `await for` only processes a subscription cancel when the source emits
-  // again, so cancelling on dispose would leave the subscription dangling
-  // until the next connectivity event. asyncMap cancels the source promptly
-  // while keeping the same serialization (the source is paused while a
-  // repair is awaited, so triggers never overtake their repair).
-  List<ConnectivityResult>? previous;
-  return connectivityChanges.asyncMap((results) async {
-    final prior = previous;
-    previous = results;
-    final online = results.any((r) => r != ConnectivityResult.none);
-    if (online && prior != null && !_sameConnectivity(prior, results)) {
-      try {
-        await repairRelayPool().timeout(_relayRepairTimeout);
-      } on Object catch (e) {
-        Log.warning(
-          'Relay pool repair on connectivity change failed: $e',
-          name: 'SocialProviders',
-          category: LogCategory.system,
-        );
-      }
-    }
-  });
-}
-
-/// Whether two connectivity reports describe the same set of transports.
-/// Order-insensitive: `connectivity_plus` gives no ordering guarantee.
-bool _sameConnectivity(List<ConnectivityResult> a, List<ConnectivityResult> b) {
-  final aSet = a.toSet();
-  final bSet = b.toSet();
-  return aSet.length == bSet.length && aSet.containsAll(bSet);
-}
 
 /// Reports whether the device currently has no network connectivity. Wired into
 /// `NIP17MessageService` so an offline DM send fails hard (a red "Not delivered"
@@ -363,19 +295,17 @@ OutgoingDmRetryService? outgoingDmRetryService(Ref ref) {
   final foregroundController = StreamController<bool>();
   ref.onDispose(foregroundController.close);
 
-  // Re-drive undelivered messages the moment connectivity returns, not only on
+  // Re-drive undelivered messages when the network changes, not only on
   // app-foreground transitions — a message queued during a brief network drop
   // would otherwise sit undelivered until the app is backgrounded and
-  // re-foregrounded. Fires on `→ none` too, so the service's offline pass can
-  // surface unconfirmed pending rows as failed the moment the network drops.
-  // Online transitions force-reconnect the relay pool first, so the sweep
-  // publishes on fresh sockets instead of the zombies the old network left
-  // behind (see dmMessageRetryTriggerWithRelayRepair).
-  final nostrService = ref.watch(nostrServiceProvider);
-  final retryTriggerStream = dmMessageRetryTriggerWithRelayRepair(
-    connectivityChanges: Connectivity().onConnectivityChanged,
-    repairRelayPool: nostrService.forceReconnectAll,
-  );
+  // re-foregrounded. `offline` runs the service's offline pass, which surfaces
+  // unconfirmed pending rows as failed the moment the network drops (#6046).
+  // `online` arrives only after the connectivity owner has repaired the relay
+  // pool, so the sweep publishes on fresh sockets instead of the zombies the
+  // old network left behind, and the pool is not reconnected twice (#8990).
+  final retryTriggerStream = ref
+      .watch(connectivityRelayReconnectProvider)
+      .map<void>((_) {});
 
   final service = OutgoingDmRetryService(
     crashReporting: ref.read(crashReportingServiceProvider),

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -300,9 +300,9 @@ OutgoingDmRetryService? outgoingDmRetryService(Ref ref) {
   // would otherwise sit undelivered until the app is backgrounded and
   // re-foregrounded. `offline` runs the service's offline pass, which surfaces
   // unconfirmed pending rows as failed the moment the network drops (#6046).
-  // `online` arrives only after the connectivity owner has repaired the relay
-  // pool, so the sweep publishes on fresh sockets instead of the zombies the
-  // old network left behind, and the pool is not reconnected twice (#8990).
+  // `online` arrives only after the connectivity owner's repair attempt has
+  // finished, failed or hit its cap, so the sweep runs after that reconnect
+  // instead of racing it, and the pool is not reconnected twice (#8990).
   final retryTriggerStream = ref
       .watch(connectivityRelayReconnectProvider)
       .map<void>((_) {});

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -157,7 +157,7 @@ final class OutgoingDmRetryServiceProvider
 }
 
 String _$outgoingDmRetryServiceHash() =>
-    r'8be3ee6c65e8993b5892200a472a9792ca187ebf';
+    r'6fe150ee3a0d6f9787c39abbee464d995bbce694';
 
 /// Auto-sweep service that re-drives undelivered DM reactions (publish failed
 /// or interrupted mid-send) on app-foreground transitions via

--- a/mobile/lib/screens/relay_settings_screen.dart
+++ b/mobile/lib/screens/relay_settings_screen.dart
@@ -855,6 +855,12 @@ Future<void> _retryConnection(BuildContext context) async {
           l10n.relaySettingsConnectedToRelays(outcome.connectedCount),
         ),
       );
+    case RetryConnectionOutcomeKind.stillConnecting:
+      // Not an error: the reconnect is still running and its relays will
+      // report as they land.
+      messenger.showSnackBar(
+        DivineSnackbarContainer.snackBar(l10n.relaySettingsStillConnecting),
+      );
     case RetryConnectionOutcomeKind.notConnected:
     case RetryConnectionOutcomeKind.failed:
       _showError(messenger, l10n.relaySettingsFailedToConnectCheck);

--- a/mobile/lib/services/connectivity_transition_monitor.dart
+++ b/mobile/lib/services/connectivity_transition_monitor.dart
@@ -12,7 +12,7 @@ enum ConnectivityTransition {
   offline,
 
   /// The device regained a network, or switched interfaces while online, and
-  /// the relay pool has been repaired for it.
+  /// a repair of the relay pool for it has finished, failed or hit its cap.
   online,
 }
 

--- a/mobile/lib/services/connectivity_transition_monitor.dart
+++ b/mobile/lib/services/connectivity_transition_monitor.dart
@@ -1,0 +1,160 @@
+// ABOUTME: Turns connectivity_plus reports into relay-pool repairs and the
+// ABOUTME: online/offline transitions the DM retry sweep consumes.
+
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// A network transition that matters to relay connections.
+enum ConnectivityTransition {
+  /// The device lost its last network interface.
+  offline,
+
+  /// The device regained a network, or switched interfaces while online, and
+  /// the relay pool has been repaired for it.
+  online,
+}
+
+/// The one owner of connectivity-driven relay repair (#8990).
+///
+/// A report counts under #6046's rule: offline to online, or a change of
+/// transports while online. The current state a fresh subscription replays,
+/// and a duplicate report, count as nothing: repairing on them tore healthy
+/// sockets down after every launch and sign-in. Offline is reported at once.
+/// A repair waits two seconds so a burst of reports collapses into one, waits
+/// again while `canRepair` says no, is bounded at fifteen seconds, and runs
+/// once more if the network changes meanwhile; `online` follows the last one.
+class ConnectivityTransitionMonitor {
+  /// Creates a monitor; call [start] to begin listening.
+  ConnectivityTransitionMonitor({
+    required Stream<List<ConnectivityResult>> changes,
+    required Future<List<ConnectivityResult>> Function() checkConnectivity,
+    required Future<void> Function() repair,
+    bool Function()? canRepair,
+    Duration repairDebounce = const Duration(seconds: 2),
+    Duration repairCap = const Duration(seconds: 15),
+  }) : _changes = changes,
+       _checkConnectivity = checkConnectivity,
+       _repair = repair,
+       _canRepair = canRepair ?? _always,
+       _repairDebounce = repairDebounce,
+       _repairCap = repairCap;
+
+  final Stream<List<ConnectivityResult>> _changes;
+  final Future<List<ConnectivityResult>> Function() _checkConnectivity;
+  final Future<void> Function() _repair;
+  final bool Function() _canRepair;
+  final Duration _repairDebounce;
+  final Duration _repairCap;
+
+  final _transitions = StreamController<ConnectivityTransition>.broadcast();
+  StreamSubscription<List<ConnectivityResult>>? _subscription;
+  Set<ConnectivityResult>? _current;
+  Timer? _debounce;
+  bool _repairing = false;
+  bool _repairAgain = false;
+  bool _disposed = false;
+
+  /// Each transition once; a new listener hears only later ones.
+  Stream<ConnectivityTransition> get transitions => _transitions.stream;
+
+  /// Subscribes to reports and seeds the baseline from `checkConnectivity`.
+  ///
+  /// Whichever arrives first, the seed or a report, becomes the baseline, so
+  /// a seed that never resolves cannot stop the monitor listening.
+  void start() {
+    if (_subscription != null || _disposed) return;
+    _subscription = _changes.listen(_onReport);
+    unawaited(_seed());
+  }
+
+  /// Stops listening and cancels a pending repair.
+  Future<void> dispose() async {
+    _disposed = true;
+    _debounce?.cancel();
+    _debounce = null;
+    await _subscription?.cancel();
+    await _transitions.close();
+  }
+
+  Future<void> _seed() async {
+    try {
+      final results = await _checkConnectivity();
+      _current ??= results.toSet();
+    } on Object catch (e) {
+      Log.warning(
+        'Connectivity seed failed; the first report becomes the baseline: $e',
+        name: 'ConnectivityTransitionMonitor',
+        category: LogCategory.relay,
+      );
+    }
+  }
+
+  void _onReport(List<ConnectivityResult> results) {
+    final next = results.toSet();
+    final previous = _current;
+    _current = next;
+    if (previous == null) return;
+    final wasOnline = _isOnline(previous);
+    final isOnline = _isOnline(next);
+    if (wasOnline && !isOnline) {
+      _debounce?.cancel();
+      _debounce = null;
+      _repairAgain = false;
+      _transitions.add(ConnectivityTransition.offline);
+    } else if (isOnline && (!wasOnline || !_sameTransports(previous, next))) {
+      _scheduleRepair();
+    }
+  }
+
+  void _scheduleRepair() {
+    if (_repairing) {
+      _repairAgain = true;
+      return;
+    }
+    _debounce?.cancel();
+    _debounce = Timer(_repairDebounce, () {
+      _debounce = null;
+      if (_canRepair()) {
+        unawaited(_runRepair());
+      } else {
+        _scheduleRepair();
+      }
+    });
+  }
+
+  Future<void> _runRepair() async {
+    _repairing = true;
+    try {
+      await _repair().timeout(_repairCap);
+    } on Object catch (e) {
+      Log.warning(
+        'Relay repair after a connectivity change did not finish: $e',
+        name: 'ConnectivityTransitionMonitor',
+        category: LogCategory.relay,
+      );
+    }
+    _repairing = false;
+    if (_disposed) return;
+    if (_repairAgain) {
+      _repairAgain = false;
+      _scheduleRepair();
+      return;
+    }
+    final current = _current;
+    if (current != null && _isOnline(current)) {
+      _transitions.add(ConnectivityTransition.online);
+    }
+  }
+
+  static bool _always() => true;
+
+  static bool _isOnline(Set<ConnectivityResult> results) =>
+      results.any((result) => result != ConnectivityResult.none);
+
+  static bool _sameTransports(
+    Set<ConnectivityResult> a,
+    Set<ConnectivityResult> b,
+  ) => a.length == b.length && a.containsAll(b);
+}

--- a/mobile/lib/startup/app_side_effects.dart
+++ b/mobile/lib/startup/app_side_effects.dart
@@ -74,12 +74,12 @@ class AppRootSideEffects extends ConsumerWidget {
     ref.watch(productEventQueueProvider);
     ref.watch(profileSaveRetryServiceProvider);
 
-    // Force-reconnects the relay pool when connectivity returns (#3161).
-    // The one root-tier member that watches `nostrServiceProvider`: the pool
-    // has to self-heal app-wide, including on routes outside the shell, so it
-    // cannot be deferred to [AppShellSideEffects]. `NostrService.build()` only
-    // dials relays when an identity is present, so a signed-out launch still
-    // pays construction only.
+    // The one owner of connectivity-driven relay repair (#3161, #8990). The
+    // pool has to self-heal on a real network change app-wide, including on
+    // routes outside the shell, so it cannot be deferred to
+    // [AppShellSideEffects]; its transitions also drive the DM retry sweep.
+    // It reads the Nostr client only when a repair fires, so a signed-out
+    // launch pays for a connectivity subscription and nothing more.
     ref.watch(connectivityRelayReconnectProvider);
 
     // Registers the FCM token and drains notification preferences once the

--- a/mobile/lib/widgets/app_lifecycle_handler.dart
+++ b/mobile/lib/widgets/app_lifecycle_handler.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nostr_client/nostr_client.dart' show ForceReconnectOutcome;
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/notifications/services/notification_refresh_coordinator.dart';
 import 'package:openvine/providers/account_enforcement_providers.dart';
@@ -219,9 +220,19 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
   Future<void> _reconnectRelays() async {
     try {
       final nostrClient = ref.read(nostrServiceProvider);
-      await nostrClient.forceReconnectAll();
+      final outcome = await nostrClient.forceReconnectAll();
+      final connected =
+          '${nostrClient.connectedRelayCount} of '
+          '${nostrClient.configuredRelayCount}';
       Log.info(
-        '📱 Relay connections restored after app resume',
+        switch (outcome) {
+          ForceReconnectOutcome.completed =>
+            '📱 Relay reconnect after app resume finished: $connected relays '
+                'connected',
+          ForceReconnectOutcome.stillDialling =>
+            '📱 Relay reconnect after app resume ended with relays still '
+                'connecting ($connected connected)',
+        },
         name: 'AppLifecycleHandler',
         category: LogCategory.system,
       );

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -1609,10 +1609,11 @@ class NostrClient {
     await _relayManager.retryDisconnectedRelays();
   }
 
-  /// Force reconnect all relays (disconnect first, then reconnect)
+  /// Redials every relay on a fresh socket, replacing any dial in flight.
   ///
   /// Use this when WebSocket connections may have been silently dropped
-  /// (e.g., after app backgrounding).
+  /// (e.g., after app backgrounding). Concurrent callers share one cycle;
+  /// see [RelayManager.forceReconnectAll].
   Future<void> forceReconnectAll() async {
     await _relayManager.forceReconnectAll();
   }

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -1614,9 +1614,11 @@ class NostrClient {
   /// Use this when WebSocket connections may have been silently dropped
   /// (e.g., after app backgrounding). Concurrent callers share one cycle;
   /// see [RelayManager.forceReconnectAll].
-  Future<void> forceReconnectAll() async {
-    await _relayManager.forceReconnectAll();
-  }
+  ///
+  /// Returns whether the cycle finished, so a caller reporting the result to
+  /// the user can tell a completed reconnect from one still in flight.
+  Future<ForceReconnectOutcome> forceReconnectAll() =>
+      _relayManager.forceReconnectAll();
 
   /// Gets relay connection status as a simple map.
   ///

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -503,9 +503,8 @@ class RelayManager {
   /// Concurrent callers share the underlying sweep for the full lifetime of
   /// its dials. Each caller stops waiting at the sweep's original aggregate
   /// deadline, while late dial results continue updating their own relay
-  /// status. `_connectToRelay` replaces the prior relay object, so clearing the
-  /// single-flight latch when only the caller deadline expires would let the
-  /// next caller start duplicate sockets against the same hosts (#7091).
+  /// status (#7091). A relay that is already being dialled is joined rather
+  /// than redialled, so no sweep opens a second socket to it (#8991).
   Future<void> retryDisconnectedRelays() {
     final inFlight = _retryInFlight;
     if (inFlight != null) return _waitForRetrySweep(inFlight);
@@ -545,8 +544,9 @@ class RelayManager {
     // First, check health of all "connected" relays to detect dead connections
     _checkRelayHealth();
 
-    // A relay with a dial in flight is joined, never redialled: redialling
-    // tears its socket down mid-handshake and opens a second one (#8991).
+    // A relay with a dial in flight is joined and one the SDK is reconnecting
+    // is left alone: redialling either tears its socket down mid-handshake
+    // and opens a second one (#8991).
     final attempts = <Future<bool>>[];
     for (final url in List<String>.from(_configuredRelays)) {
       final running = _dials[url];
@@ -555,7 +555,9 @@ class RelayManager {
         continue;
       }
       final status = _relayStatuses[url];
-      if (status == null || status.isConnected) continue;
+      if (status == null || status.isConnected || _isSocketConnecting(url)) {
+        continue;
+      }
       attempts.add(_dial(url, failureMessage: 'Reconnection failed'));
     }
     _notifyStatusChange();
@@ -578,6 +580,9 @@ class RelayManager {
   /// died silently (common with WebSockets after ~2 minutes of idle time).
   void _checkRelayHealth() {
     for (final url in _configuredRelays) {
+      // A socket still being dialled fails its idle check by definition, and
+      // demoting it gets the socket torn down mid-handshake (#8991).
+      if (_dials.containsKey(url) || _isSocketConnecting(url)) continue;
       final relay = _relayPool.getRelay(url);
       if (relay == null) continue;
 
@@ -594,6 +599,14 @@ class RelayManager {
         }
       }
     }
+  }
+
+  /// Whether the pooled socket for [url] is mid-handshake, as it is while the
+  /// SDK reconnects it on its own.
+  bool _isSocketConnecting(String url) {
+    final relay = _relayPool.getRelay(url);
+    return relay is RelayBase &&
+        relay.relayStatus.connected == ClientConnected.connecting;
   }
 
   /// Force reconnect all relays (disconnect first, then reconnect)

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -135,6 +135,9 @@ class RelayManager {
   /// Whether the manager has been initialized
   bool _initialized = false;
 
+  /// Whether [dispose] has run.
+  bool _disposed = false;
+
   /// Whether persisted user-removal intent has been loaded.
   bool _userRemovedRelaysLoaded = false;
 
@@ -650,25 +653,39 @@ class RelayManager {
 
   Future<void>? _forceCycle;
   DateTime? _forceCycleDeadline;
+  int _forceCycleCount = 0;
 
   Future<void> _runForceReconnect() async {
     _log('Force reconnecting all relays');
+    final cycle = ++_forceCycleCount;
     final attempts = [
       for (final url in List<String>.from(_configuredRelays))
         _dial(
           url,
           supersede: true,
           failureMessage: 'Force reconnection failed',
-        ).then((success) => _logForceReconnect(url, connected: success)),
+        ).then(
+          (success) =>
+              _logForceReconnect(url, connected: success, cycle: cycle),
+        ),
     ];
     _notifyStatusChange();
     await Future.wait(attempts);
     _notifyStatusChange();
   }
 
-  void _logForceReconnect(String url, {required bool connected}) {
-    // A relay removed mid-cycle was released, not failed.
-    if (!_configuredRelays.contains(url)) return;
+  void _logForceReconnect(
+    String url, {
+    required bool connected,
+    required int cycle,
+  }) {
+    // A relay released by removal or dispose did not fail, and a cycle that a
+    // later one replaced leaves the report to that one.
+    if (_disposed ||
+        cycle != _forceCycleCount ||
+        !_configuredRelays.contains(url)) {
+      return;
+    }
     if (connected) {
       _log('Force reconnected', relayUrl: url);
     } else {
@@ -708,6 +725,7 @@ class RelayManager {
   /// Dispose of resources
   Future<void> dispose() async {
     _log('Disposing RelayManager');
+    _disposed = true;
     _statusPollTimer?.cancel();
     _statusPollTimer = null;
     List<String>.from(_dials.keys).forEach(_releaseDial);
@@ -768,7 +786,18 @@ class RelayManager {
           dial.result.complete(success);
         },
         onError: (Object error, StackTrace stackTrace) {
-          if (!_isLatestDial(url, dial, generation)) return;
+          if (!_isLatestDial(url, dial, generation)) {
+            // Nobody waits on a replaced or released attempt any more, but a
+            // programming error in it still has to be seen.
+            _diagnose(
+              message: 'Relay connection threw after it was replaced',
+              relayUrl: url,
+              level: RelayDiagnosticLevel.error,
+              error: error,
+              stackTrace: stackTrace,
+            );
+            return;
+          }
           _dials.remove(url);
           dial.result.completeError(error, stackTrace);
         },

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -486,7 +486,8 @@ class RelayManager {
   // Reconnection
   // ---------------------------------------------------------------------------
 
-  /// Aggregate bound on how long a caller waits for one reconnect sweep.
+  /// Aggregate bound on how long a caller waits for one reconnect sweep or
+  /// [forceReconnectAll] cycle.
   ///
   /// Parallelising already bounds a healthy sweep at roughly one connect
   /// (a 10s handshake timeout plus a 2s orphan close), but nothing below here
@@ -524,15 +525,25 @@ class RelayManager {
   Future<void>? _retryInFlight;
   DateTime? _retryDeadline;
 
-  Future<void> _waitForRetrySweep(Future<void> sweep) async {
+  Future<void> _waitForRetrySweep(Future<void> sweep) {
     final deadline = _retryDeadline;
     if (deadline == null) return sweep;
+    return _waitUntil(sweep, deadline, 'Reconnect sweep');
+  }
+
+  /// Waits for [work] until [deadline]. Work still running afterwards keeps
+  /// going and keeps writing its relays' status.
+  Future<void> _waitUntil(
+    Future<void> work,
+    DateTime deadline,
+    String label,
+  ) async {
     final remaining = deadline.difference(DateTime.now());
     try {
-      await sweep.timeout(remaining.isNegative ? Duration.zero : remaining);
+      await work.timeout(remaining.isNegative ? Duration.zero : remaining);
     } on TimeoutException {
       _log(
-        'Reconnect sweep exceeded ${reconnectSweepBudget.inSeconds}s; '
+        '$label exceeded ${reconnectSweepBudget.inSeconds}s; '
         'hosts still dialling remain in flight',
       );
     }
@@ -609,44 +620,64 @@ class RelayManager {
         relay.relayStatus.connected == ClientConnected.connecting;
   }
 
-  /// Force reconnect all relays (disconnect first, then reconnect)
+  /// Redials every configured relay on a fresh socket, replacing any dial in
+  /// flight.
   ///
   /// Use this when WebSocket connections may have been silently dropped
-  /// (e.g., after app backgrounding).
-  Future<void> forceReconnectAll() async {
-    _log('Force reconnecting all relays');
-
-    // Create a copy to avoid concurrent modification during async iteration
-    final relaysToReconnect = List<String>.from(_configuredRelays);
-
-    // First disconnect all
-    for (final url in relaysToReconnect) {
-      _relayPool.remove(url);
-      _updateRelayStatus(url, RelayState.connecting);
+  /// (e.g., after app backgrounding). Concurrent callers share one cycle and
+  /// stop waiting at its [reconnectSweepBudget] deadline; a call after that
+  /// deadline starts a new cycle, which replaces any dial still hanging.
+  Future<void> forceReconnectAll() {
+    final running = _forceCycle;
+    final runningDeadline = _forceCycleDeadline;
+    if (running != null &&
+        runningDeadline != null &&
+        DateTime.now().isBefore(runningDeadline)) {
+      return _waitUntil(running, runningDeadline, 'Force reconnect');
     }
-    _notifyStatusChange();
-
-    // Then reconnect all
-    for (final url in relaysToReconnect) {
-      final success = await _connectToRelay(url);
-      if (success) {
-        _updateRelayStatus(url, RelayState.connected);
-        _log('Force reconnected', relayUrl: url);
-      } else {
-        _updateRelayStatus(
-          url,
-          RelayState.error,
-          errorMessage: 'Force reconnection failed',
-        );
-        _log(
-          'Force reconnection failed',
-          relayUrl: url,
-          level: RelayDiagnosticLevel.warning,
-        );
+    final deadline = DateTime.now().add(reconnectSweepBudget);
+    late final Future<void> cycle;
+    cycle = _runForceReconnect().whenComplete(() {
+      if (identical(_forceCycle, cycle)) {
+        _forceCycle = null;
+        _forceCycleDeadline = null;
       }
-    }
+    });
+    _forceCycle = cycle;
+    _forceCycleDeadline = deadline;
+    return _waitUntil(cycle, deadline, 'Force reconnect');
+  }
 
+  Future<void>? _forceCycle;
+  DateTime? _forceCycleDeadline;
+
+  Future<void> _runForceReconnect() async {
+    _log('Force reconnecting all relays');
+    final attempts = [
+      for (final url in List<String>.from(_configuredRelays))
+        _dial(
+          url,
+          supersede: true,
+          failureMessage: 'Force reconnection failed',
+        ).then((success) => _logForceReconnect(url, connected: success)),
+    ];
     _notifyStatusChange();
+    await Future.wait(attempts);
+    _notifyStatusChange();
+  }
+
+  void _logForceReconnect(String url, {required bool connected}) {
+    // A relay removed mid-cycle was released, not failed.
+    if (!_configuredRelays.contains(url)) return;
+    if (connected) {
+      _log('Force reconnected', relayUrl: url);
+    } else {
+      _log(
+        'Force reconnection failed',
+        relayUrl: url,
+        level: RelayDiagnosticLevel.warning,
+      );
+    }
   }
 
   /// Reconnect to a specific relay

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -49,6 +49,20 @@ String? normalizeRelayUrl(String url) {
   return normalized;
 }
 
+/// Whether a force-reconnect cycle finished, or was still dialling when the
+/// caller stopped waiting.
+///
+/// The shared cycle keeps running after the deadline, so `stillDialling` is
+/// "no answer yet", not "failed".
+enum ForceReconnectOutcome {
+  /// The cycle finished inside its budget.
+  completed,
+
+  /// The caller stopped waiting at the shared deadline while dials were still
+  /// open. The cycle keeps running and keeps writing relay status.
+  stillDialling,
+}
+
 /// {@template relay_manager}
 /// Manages relay configuration and connection status.
 ///
@@ -528,15 +542,22 @@ class RelayManager {
   Future<void>? _retryInFlight;
   DateTime? _retryDeadline;
 
-  Future<void> _waitForRetrySweep(Future<void> sweep) {
+  Future<void> _waitForRetrySweep(Future<void> sweep) async {
     final deadline = _retryDeadline;
     if (deadline == null) return sweep;
-    return _waitUntil(sweep, deadline, 'Reconnect sweep');
+    // The retry sweep has no caller that reports an outcome, so its result is
+    // deliberately dropped here rather than widened through that path too.
+    await _waitUntil(sweep, deadline, 'Reconnect sweep');
   }
 
   /// Waits for [work] until [deadline]. Work still running afterwards keeps
   /// going and keeps writing its relays' status.
-  Future<void> _waitUntil(
+  ///
+  /// Returns whether [work] finished inside the deadline. Callers that report
+  /// an outcome need that: an expired deadline and a finished cycle both leave
+  /// this future completing normally, and treating the first as the second
+  /// tells the user the reconnect failed while it is still succeeding.
+  Future<ForceReconnectOutcome> _waitUntil(
     Future<void> work,
     DateTime deadline,
     String label,
@@ -544,11 +565,13 @@ class RelayManager {
     final remaining = deadline.difference(DateTime.now());
     try {
       await work.timeout(remaining.isNegative ? Duration.zero : remaining);
+      return ForceReconnectOutcome.completed;
     } on TimeoutException {
       _log(
         '$label exceeded ${reconnectSweepBudget.inSeconds}s; '
         'hosts still dialling remain in flight',
       );
+      return ForceReconnectOutcome.stillDialling;
     }
   }
 
@@ -630,7 +653,12 @@ class RelayManager {
   /// (e.g., after app backgrounding). Concurrent callers share one cycle and
   /// stop waiting at its [reconnectSweepBudget] deadline; a call after that
   /// deadline starts a new cycle, which replaces any dial still hanging.
-  Future<void> forceReconnectAll() {
+  ///
+  /// Returns [ForceReconnectOutcome.completed] only when the cycle actually
+  /// finished. A caller joining shortly before the shared deadline gets
+  /// [ForceReconnectOutcome.stillDialling] instead of a normal completion it
+  /// would otherwise read as "the reconnect is done and nothing connected".
+  Future<ForceReconnectOutcome> forceReconnectAll() {
     final running = _forceCycle;
     final runningDeadline = _forceCycleDeadline;
     if (running != null &&

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -121,6 +121,10 @@ class RelayManager {
   /// Status for each relay
   final Map<String, RelayConnectionStatus> _relayStatuses = {};
 
+  /// The connection attempt in flight for each relay, shared by every caller
+  /// that asks for that relay while it runs (#8991).
+  final Map<String, _RelayDial> _dials = {};
+
   /// Stream controller for status updates
   final _statusController =
       StreamController<Map<String, RelayConnectionStatus>>.broadcast();
@@ -363,19 +367,10 @@ class RelayManager {
     );
     _notifyStatusChange();
 
-    // Connect to the relay
-    final success = await _connectToRelay(normalizedUrl);
-
-    // Update status based on connection result
-    if (success) {
-      _updateRelayStatus(normalizedUrl, RelayState.connected);
-    } else {
-      _updateRelayStatus(
-        normalizedUrl,
-        RelayState.error,
-        errorMessage: 'Failed to connect',
-      );
-    }
+    final success = await _dial(
+      normalizedUrl,
+      failureMessage: 'Failed to connect',
+    );
     _notifyStatusChange();
 
     // Persist configuration
@@ -412,7 +407,8 @@ class RelayManager {
 
     _log('Removing relay: $normalizedUrl', relayUrl: normalizedUrl);
 
-    // Disconnect from the relay
+    // Release anyone waiting on its dial, then tear the relay down.
+    _releaseDial(normalizedUrl);
     _relayPool.remove(normalizedUrl);
 
     // Remove from configured list and statuses
@@ -549,13 +545,18 @@ class RelayManager {
     // First, check health of all "connected" relays to detect dead connections
     _checkRelayHealth();
 
-    final disconnected = _configuredRelays.where((url) {
+    // A relay with a dial in flight is joined, never redialled: redialling
+    // tears its socket down mid-handshake and opens a second one (#8991).
+    final attempts = <Future<bool>>[];
+    for (final url in List<String>.from(_configuredRelays)) {
+      final running = _dials[url];
+      if (running != null) {
+        attempts.add(running.result.future);
+        continue;
+      }
       final status = _relayStatuses[url];
-      return status != null && !status.isConnected;
-    }).toList();
-
-    for (final url in disconnected) {
-      _updateRelayStatus(url, RelayState.connecting);
+      if (status == null || status.isConnected) continue;
+      attempts.add(_dial(url, failureMessage: 'Reconnection failed'));
     }
     _notifyStatusChange();
 
@@ -564,17 +565,8 @@ class RelayManager {
     // caller deadline must not turn unresolved dials into failures, and a dial
     // that succeeds after that deadline is still the live pooled connection.
     await Future.wait(
-      disconnected.map((url) async {
-        final success = await _connectToRelay(url);
-        if (success) {
-          _updateRelayStatus(url, RelayState.connected);
-        } else {
-          _updateRelayStatus(
-            url,
-            RelayState.error,
-            errorMessage: 'Reconnection failed',
-          );
-        }
+      attempts.map((attempt) async {
+        await attempt;
         _notifyStatusChange();
       }),
     );
@@ -652,25 +644,15 @@ class RelayManager {
     }
 
     _log('Reconnecting to relay', relayUrl: normalizedUrl);
-    _updateRelayStatus(normalizedUrl, RelayState.connecting);
+
+    // The caller asked for a new socket, so a dial in flight is replaced.
+    final attempt = _dial(
+      normalizedUrl,
+      supersede: true,
+      failureMessage: 'Reconnection failed',
+    );
     _notifyStatusChange();
-
-    // Disconnect first
-    _relayPool.remove(normalizedUrl);
-
-    // Reconnect
-    final success = await _connectToRelay(normalizedUrl);
-
-    if (success) {
-      _updateRelayStatus(normalizedUrl, RelayState.connected);
-    } else {
-      _updateRelayStatus(
-        normalizedUrl,
-        RelayState.error,
-        errorMessage: 'Reconnection failed',
-      );
-    }
-
+    final success = await attempt;
     _notifyStatusChange();
     return success;
   }
@@ -684,6 +666,7 @@ class RelayManager {
     _log('Disposing RelayManager');
     _statusPollTimer?.cancel();
     _statusPollTimer = null;
+    List<String>.from(_dials.keys).forEach(_releaseDial);
     await _statusController.close();
     _initialized = false;
   }
@@ -696,33 +679,67 @@ class RelayManager {
     // Create a copy to avoid concurrent modification during async iteration
     final relaysToConnect = List<String>.from(_configuredRelays);
 
-    for (final url in relaysToConnect) {
-      _updateRelayStatus(url, RelayState.connecting);
-    }
-    _notifyStatusChange();
-
     // Connect to all relays in PARALLEL instead of sequential.
     // This reduces startup from O(n * timeout) to O(max timeout).
-    final results = await Future.wait(
-      relaysToConnect.map((url) async {
-        final success = await _connectToRelay(url);
-        return MapEntry(url, success);
-      }),
-    );
-
-    // Update statuses based on results
-    for (final entry in results) {
-      if (entry.value) {
-        _updateRelayStatus(entry.key, RelayState.connected);
-      } else {
-        _updateRelayStatus(
-          entry.key,
-          RelayState.error,
-          errorMessage: 'Failed to connect',
-        );
-      }
-    }
+    final attempts = [
+      for (final url in relaysToConnect)
+        _dial(url, failureMessage: 'Failed to connect'),
+    ];
     _notifyStatusChange();
+    await Future.wait(attempts);
+    _notifyStatusChange();
+  }
+
+  /// Connects [url], or joins the connection attempt already running for it.
+  ///
+  /// With [supersede], a running attempt is replaced instead of joined: the
+  /// relay is redialled, and callers of the replaced attempt receive the
+  /// replacement's result. Only the latest attempt writes the relay's status,
+  /// an attempt whose dial was released writes nothing, and callers emit on
+  /// [statusStream] on their own schedule.
+  Future<bool> _dial(
+    String url, {
+    required String failureMessage,
+    bool supersede = false,
+  }) {
+    final running = _dials[url];
+    if (running != null && !supersede) return running.result.future;
+    final dial = running ?? (_dials[url] = _RelayDial());
+    final generation = ++dial.generation;
+    _updateRelayStatus(url, RelayState.connecting);
+    unawaited(
+      _connectToRelay(url).then(
+        (success) {
+          if (!_isLatestDial(url, dial, generation)) return;
+          _dials.remove(url);
+          if (success) {
+            _updateRelayStatus(url, RelayState.connected);
+          } else {
+            _updateRelayStatus(
+              url,
+              RelayState.error,
+              errorMessage: failureMessage,
+            );
+          }
+          dial.result.complete(success);
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          if (!_isLatestDial(url, dial, generation)) return;
+          _dials.remove(url);
+          dial.result.completeError(error, stackTrace);
+        },
+      ),
+    );
+    return dial.result.future;
+  }
+
+  bool _isLatestDial(String url, _RelayDial dial, int generation) =>
+      identical(_dials[url], dial) && dial.generation == generation;
+
+  /// Answers everyone waiting on [url]'s dial with `false`; the attempt then
+  /// writes nothing when it settles.
+  void _releaseDial(String url) {
+    _dials.remove(url)?.result.complete(false);
   }
 
   Future<bool> _connectToRelay(String url) async {
@@ -961,4 +978,14 @@ class RelayManager {
       ),
     );
   }
+}
+
+/// One connection attempt for a relay, shared by every caller that asks for
+/// that relay while it runs.
+///
+/// Superseding reuses the slot and bumps [generation], so callers that joined
+/// the replaced attempt receive the replacement's result.
+class _RelayDial {
+  int generation = 0;
+  final Completer<bool> result = Completer<bool>();
 }

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 import 'dart:developer' as developer;
 
+import 'package:clock/clock.dart';
 import 'package:meta/meta.dart';
 import 'package:nostr_client/src/models/relay_add_source.dart';
 import 'package:nostr_client/src/models/relay_connection_status.dart';
@@ -526,7 +527,7 @@ class RelayManager {
   Future<void> retryDisconnectedRelays() {
     final inFlight = _retryInFlight;
     if (inFlight != null) return _waitForRetrySweep(inFlight);
-    _retryDeadline = DateTime.now().add(reconnectSweepBudget);
+    _retryDeadline = clock.now().add(reconnectSweepBudget);
     final sweep = _runRetrySweep();
     late final Future<void> tracked;
     tracked = sweep.whenComplete(() {
@@ -562,7 +563,7 @@ class RelayManager {
     DateTime deadline,
     String label,
   ) async {
-    final remaining = deadline.difference(DateTime.now());
+    final remaining = deadline.difference(clock.now());
     try {
       await work.timeout(remaining.isNegative ? Duration.zero : remaining);
       return ForceReconnectOutcome.completed;
@@ -663,10 +664,10 @@ class RelayManager {
     final runningDeadline = _forceCycleDeadline;
     if (running != null &&
         runningDeadline != null &&
-        DateTime.now().isBefore(runningDeadline)) {
+        clock.now().isBefore(runningDeadline)) {
       return _waitUntil(running, runningDeadline, 'Force reconnect');
     }
-    final deadline = DateTime.now().add(reconnectSweepBudget);
+    final deadline = clock.now().add(reconnectSweepBudget);
     late final Future<void> cycle;
     cycle = _runForceReconnect().whenComplete(() {
       if (identical(_forceCycle, cycle)) {

--- a/mobile/packages/nostr_client/pubspec.yaml
+++ b/mobile/packages/nostr_client/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   flutter: ^3.47.0
 
 dependencies:
+  clock: ^1.1.2
   crypto: ^3.0.7
   db_client:
     path: ../db_client

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -3138,7 +3138,9 @@ void main() {
 
     group('forceReconnectAll', () {
       test('delegates to RelayManager', () async {
-        when(mockRelayManager.forceReconnectAll).thenAnswer((_) async {});
+        when(mockRelayManager.forceReconnectAll).thenAnswer(
+          (_) async => ForceReconnectOutcome.completed,
+        );
 
         await client.forceReconnectAll();
 

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -1411,6 +1411,219 @@ void main() {
       });
     });
 
+    group('one dial per relay', () {
+      test('a sweep while the startup connect is pending dials once', () async {
+        // The sweep used to tear down the startup socket mid-handshake and
+        // open a second one to the same relay (#8991).
+        final dials = <Completer<bool>>[];
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) {
+          final dial = Completer<bool>();
+          dials.add(dial);
+          return dial.future;
+        });
+
+        final startup = manager.initialize();
+        final sweep = manager.retryDisconnectedRelays();
+        await pumpEventQueue();
+
+        expect(
+          dials,
+          hasLength(1),
+          reason: 'the sweep must join the startup dial',
+        );
+        verify(() => mockRelayPool.remove(testDefaultRelayUrl)).called(1);
+
+        for (final dial in dials) {
+          dial.complete(true);
+        }
+        await Future.wait([startup, sweep]);
+        expect(
+          manager.getRelayStatus(testDefaultRelayUrl)?.state,
+          RelayState.connected,
+        );
+      });
+
+      test('a sweep joins the dial addRelay started', () async {
+        await manager.initialize();
+        final dial = Completer<bool>();
+        var dialCount = 0;
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) {
+          dialCount++;
+          return dial.future;
+        });
+
+        final adding = manager.addRelay(testCustomRelayUrl);
+        await pumpEventQueue();
+        var swept = false;
+        final sweep = manager.retryDisconnectedRelays().then(
+          (_) => swept = true,
+        );
+        await pumpEventQueue();
+
+        expect(
+          dialCount,
+          equals(1),
+          reason: 'the sweep must join the dial in flight',
+        );
+        expect(
+          swept,
+          isFalse,
+          reason: 'a caller must not proceed while the relay is still dialling',
+        );
+
+        dial.complete(true);
+        await Future.wait([adding, sweep]);
+        expect(swept, isTrue);
+      });
+
+      test('an error thrown while dialling reaches the caller', () async {
+        // A shared dial that swallowed this would leave every caller waiting
+        // on it forever.
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenThrow(StateError('dial failed'));
+
+        await expectLater(manager.initialize(), throwsStateError);
+      });
+
+      test(
+        'removing a relay releases the callers waiting on its dial',
+        () async {
+          await manager.initialize();
+          when(
+            () => mockRelayPool.add(
+              any(),
+              autoSubscribe: any(named: 'autoSubscribe'),
+            ),
+          ).thenAnswer((_) => Completer<bool>().future);
+
+          bool? added;
+          unawaited(
+            manager.addRelay(testCustomRelayUrl).then((ok) => added = ok),
+          );
+          await pumpEventQueue();
+          await manager.removeRelay(
+            testCustomRelayUrl,
+            source: RelayRemoveSource.automatic,
+          );
+          await pumpEventQueue();
+
+          expect(added, isFalse);
+        },
+      );
+
+      test(
+        'a re-added relay dials afresh and ignores the old dial settling late',
+        () async {
+          await manager.initialize();
+          final dials = <Completer<bool>>[];
+          when(
+            () => mockRelayPool.add(
+              any(),
+              autoSubscribe: any(named: 'autoSubscribe'),
+            ),
+          ).thenAnswer((_) {
+            final dial = Completer<bool>();
+            dials.add(dial);
+            return dial.future;
+          });
+
+          unawaited(manager.addRelay(testCustomRelayUrl));
+          await pumpEventQueue();
+          await manager.removeRelay(
+            testCustomRelayUrl,
+            source: RelayRemoveSource.automatic,
+          );
+          unawaited(manager.addRelay(testCustomRelayUrl));
+          await pumpEventQueue();
+          expect(
+            dials,
+            hasLength(2),
+            reason: "the re-added relay must not join the removed relay's dial",
+          );
+
+          dials.first.complete(false);
+          await pumpEventQueue();
+          expect(
+            manager.getRelayStatus(testCustomRelayUrl)?.state,
+            RelayState.connecting,
+            reason:
+                "the removed relay's late result must not reach its "
+                'successor',
+          );
+        },
+      );
+
+      test('dispose releases the callers waiting on a dial', () async {
+        await manager.initialize();
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) => Completer<bool>().future);
+
+        bool? added;
+        unawaited(
+          manager.addRelay(testCustomRelayUrl).then((ok) => added = ok),
+        );
+        await pumpEventQueue();
+        await manager.dispose();
+        await pumpEventQueue();
+
+        expect(added, isFalse);
+      });
+
+      test('reconnectRelay replaces a dial in flight', () async {
+        await manager.initialize();
+        final dials = <Completer<bool>>[];
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) {
+          final dial = Completer<bool>();
+          dials.add(dial);
+          return dial.future;
+        });
+
+        final adding = manager.addRelay(testCustomRelayUrl);
+        await pumpEventQueue();
+        final reconnecting = manager.reconnectRelay(testCustomRelayUrl);
+        await pumpEventQueue();
+        expect(dials, hasLength(2));
+
+        dials.last.complete(true);
+        expect(await reconnecting, isTrue);
+        dials.first.complete(false);
+        await pumpEventQueue();
+        expect(
+          manager.getRelayStatus(testCustomRelayUrl)?.state,
+          RelayState.connected,
+          reason: 'the replaced dial cannot overwrite its replacement',
+        );
+        expect(
+          await adding,
+          isTrue,
+          reason: "a caller of the replaced dial gets the replacement's result",
+        );
+      });
+    });
+
     group('reconnectRelay', () {
       setUp(() async {
         await manager.initialize();
@@ -1428,8 +1641,8 @@ void main() {
 
         await manager.reconnectRelay(testCustomRelayUrl);
 
-        // Called twice: once by reconnectRelay and once by _connectToRelay
-        verify(() => mockRelayPool.remove(testCustomRelayUrl)).called(2);
+        // The old socket is replaced once, as part of the new dial.
+        verify(() => mockRelayPool.remove(testCustomRelayUrl)).called(1);
         verify(
           () => mockRelayPool.add(
             any(),

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -1640,6 +1640,36 @@ void main() {
           reason: "a caller of the replaced dial gets the replacement's result",
         );
       });
+
+      test('forceReconnectAll replaces a dial in flight', () async {
+        final dials = <Completer<bool>>[];
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) {
+          final dial = Completer<bool>();
+          dials.add(dial);
+          return dial.future;
+        });
+
+        final startup = manager.initialize();
+        await pumpEventQueue();
+        final cycle = manager.forceReconnectAll();
+        await pumpEventQueue();
+        expect(dials, hasLength(2));
+
+        dials.last.complete(true);
+        await cycle;
+        dials.first.complete(false);
+        await startup;
+        expect(
+          manager.getRelayStatus(testDefaultRelayUrl)?.state,
+          RelayState.connected,
+          reason: 'the replaced dial cannot overwrite the cycle',
+        );
+      });
     });
 
     group('health check', () {
@@ -1850,7 +1880,7 @@ void main() {
         await manager.addRelay(testCustomRelayUrl2);
       });
 
-      test('disconnects all relays before reconnecting', () async {
+      test('replaces every relay once', () async {
         clearInteractions(mockRelayPool);
         when(
           () => mockRelayPool.add(
@@ -1861,12 +1891,157 @@ void main() {
 
         await manager.forceReconnectAll();
 
-        // Each relay is removed twice: once by forceReconnectAll and once
-        // by _connectToRelay (which clears the stale pool entry before add).
-        verify(() => mockRelayPool.remove(testDefaultRelayUrl)).called(2);
-        verify(() => mockRelayPool.remove(testCustomRelayUrl)).called(2);
-        verify(() => mockRelayPool.remove(testCustomRelayUrl2)).called(2);
+        // Each old socket is replaced once, as part of its relay's new dial.
+        verify(() => mockRelayPool.remove(testDefaultRelayUrl)).called(1);
+        verify(() => mockRelayPool.remove(testCustomRelayUrl)).called(1);
+        verify(() => mockRelayPool.remove(testCustomRelayUrl2)).called(1);
       });
+
+      test('two concurrent calls run one cycle', () async {
+        clearInteractions(mockRelayPool);
+
+        await Future.wait([
+          manager.forceReconnectAll(),
+          manager.forceReconnectAll(),
+        ]);
+
+        verify(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).called(3);
+      });
+
+      test('starts every dial before any completes', () async {
+        final dials = <Completer<bool>>[];
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) {
+          final dial = Completer<bool>();
+          dials.add(dial);
+          return dial.future;
+        });
+
+        final cycle = manager.forceReconnectAll();
+        await pumpEventQueue();
+
+        expect(dials, hasLength(3));
+        for (final dial in dials) {
+          dial.complete(true);
+        }
+        await cycle;
+      });
+
+      test('a sweep during the cycle joins it instead of redialling', () async {
+        final dials = <Completer<bool>>[];
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) {
+          final dial = Completer<bool>();
+          dials.add(dial);
+          return dial.future;
+        });
+
+        final cycle = manager.forceReconnectAll();
+        await pumpEventQueue();
+        final sweep = manager.retryDisconnectedRelays();
+        await pumpEventQueue();
+
+        expect(dials, hasLength(3), reason: 'the sweep must join the cycle');
+        for (final dial in dials) {
+          dial.complete(true);
+        }
+        await Future.wait([cycle, sweep]);
+      });
+
+      test('a relay removed mid-cycle is not dialled again', () async {
+        final pending = <Completer<bool>>[];
+        final dialledAfterRemoval = <String>[];
+        var removed = false;
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((invocation) {
+          if (removed) {
+            dialledAfterRemoval.add(
+              (invocation.positionalArguments.first as Relay).url,
+            );
+          }
+          final dial = Completer<bool>();
+          pending.add(dial);
+          return dial.future;
+        });
+
+        var done = false;
+        final cycle = manager.forceReconnectAll().whenComplete(
+          () => done = true,
+        );
+        await pumpEventQueue();
+        await manager.removeRelay(
+          testCustomRelayUrl,
+          source: RelayRemoveSource.automatic,
+        );
+        removed = true;
+        for (var round = 0; round < 5 && !done; round++) {
+          for (final dial in pending.where((d) => !d.isCompleted).toList()) {
+            dial.complete(true);
+          }
+          await pumpEventQueue();
+        }
+        await cycle;
+
+        expect(dialledAfterRemoval, isNot(contains(testCustomRelayUrl)));
+      });
+
+      test(
+        'a hung dial releases callers at the budget and a later call '
+        'replaces it',
+        () async {
+          final original = RelayManager.reconnectSweepBudget;
+          RelayManager.reconnectSweepBudget = Duration.zero;
+          addTearDown(() => RelayManager.reconnectSweepBudget = original);
+          final hung = Completer<bool>();
+          addTearDown(() {
+            if (!hung.isCompleted) hung.complete(false);
+          });
+          var dials = 0;
+          when(
+            () => mockRelayPool.add(
+              any(),
+              autoSubscribe: any(named: 'autoSubscribe'),
+            ),
+          ).thenAnswer((_) {
+            dials++;
+            return hung.future;
+          });
+
+          var released = false;
+          unawaited(manager.forceReconnectAll().then((_) => released = true));
+          await pumpEventQueue();
+          expect(
+            released,
+            isTrue,
+            reason: 'a caller stops waiting at the budget',
+          );
+
+          unawaited(manager.forceReconnectAll());
+          await pumpEventQueue();
+          expect(
+            dials,
+            equals(6),
+            reason: 'a call after the deadline replaces the hung dials',
+          );
+        },
+      );
 
       test('reconnects all relays after disconnecting', () async {
         clearInteractions(mockRelayPool);

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -1670,6 +1670,50 @@ void main() {
           reason: 'the replaced dial cannot overwrite the cycle',
         );
       });
+
+      test(
+        'a replaced attempt that throws cannot fail its replacement',
+        () async {
+          final diagnostics = <RelayDiagnostic>[];
+          final dialManager = RelayManager(
+            config: config,
+            relayPool: mockRelayPool,
+            diagnosticsSink: diagnostics.add,
+          );
+          await dialManager.initialize();
+          final dials = <Completer<bool>>[];
+          when(
+            () => mockRelayPool.add(
+              any(),
+              autoSubscribe: any(named: 'autoSubscribe'),
+            ),
+          ).thenAnswer((_) {
+            final dial = Completer<bool>();
+            dials.add(dial);
+            return dial.future;
+          });
+
+          final adding = dialManager.addRelay(testCustomRelayUrl);
+          await pumpEventQueue();
+          final reconnecting = dialManager.reconnectRelay(testCustomRelayUrl);
+          await pumpEventQueue();
+          expect(dials, hasLength(2));
+
+          dials.first.completeError(StateError('replaced attempt failed'));
+          await pumpEventQueue();
+          dials.last.complete(true);
+
+          expect(await reconnecting, isTrue);
+          expect(await adding, isTrue);
+          expect(
+            diagnostics
+                .where((entry) => entry.level == RelayDiagnosticLevel.error)
+                .map((entry) => entry.error),
+            contains(isA<StateError>()),
+            reason: "the replaced attempt's error is still reported",
+          );
+        },
+      );
     });
 
     group('health check', () {
@@ -2042,6 +2086,71 @@ void main() {
           );
         },
       );
+
+      test('a cycle cut short by dispose reports no failure', () async {
+        final diagnostics = <RelayDiagnostic>[];
+        final cycleManager = RelayManager(
+          config: config,
+          relayPool: mockRelayPool,
+          diagnosticsSink: diagnostics.add,
+        );
+        await cycleManager.initialize();
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) => Completer<bool>().future);
+
+        unawaited(cycleManager.forceReconnectAll());
+        await pumpEventQueue();
+        await cycleManager.dispose();
+        await pumpEventQueue();
+
+        final messages = diagnostics.map((entry) => entry.message);
+        expect(messages, contains('Force reconnecting all relays'));
+        expect(messages, isNot(contains('Force reconnection failed')));
+      });
+
+      test('a replaced cycle does not report its relay twice', () async {
+        final original = RelayManager.reconnectSweepBudget;
+        RelayManager.reconnectSweepBudget = Duration.zero;
+        addTearDown(() => RelayManager.reconnectSweepBudget = original);
+        final diagnostics = <RelayDiagnostic>[];
+        final cycleManager = RelayManager(
+          config: config,
+          relayPool: mockRelayPool,
+          diagnosticsSink: diagnostics.add,
+        );
+        await cycleManager.initialize();
+        final dials = <Completer<bool>>[];
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) {
+          final dial = Completer<bool>();
+          dials.add(dial);
+          return dial.future;
+        });
+
+        await cycleManager.forceReconnectAll();
+        await cycleManager.forceReconnectAll();
+        for (final dial in dials) {
+          dial.complete(true);
+        }
+        await pumpEventQueue();
+
+        expect(
+          diagnostics.where(
+            (entry) =>
+                entry.message == 'Force reconnected' &&
+                entry.relayUrl == testDefaultRelayUrl,
+          ),
+          hasLength(1),
+        );
+      });
 
       test('reconnects all relays after disconnecting', () async {
         clearInteractions(mockRelayPool);

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -15,6 +15,8 @@ class _MockRelayPool extends Mock implements RelayPool {}
 
 class _MockRelay extends Mock implements Relay {}
 
+class _MockRelayBase extends Mock implements RelayBase {}
+
 class _MockRelayStatus extends Mock implements RelayStatus {}
 
 class _MockRelayStorage extends Mock implements RelayStorage {}
@@ -63,6 +65,22 @@ _MockRelay _createMockRelay(
   when(() => mockStatus.authed).thenReturn(authed);
 
   return mockRelay;
+}
+
+/// A pooled relay whose socket reports [connected] and whose idle check
+/// returns [healthy].
+_MockRelayBase _createPooledRelay(
+  String url, {
+  required int connected,
+  required bool healthy,
+}) {
+  final relay = _MockRelayBase();
+  final status = _MockRelayStatus();
+  when(() => relay.url).thenReturn(url);
+  when(() => relay.relayStatus).thenReturn(status);
+  when(() => status.connected).thenReturn(connected);
+  when(relay.checkHealth).thenReturn(healthy);
+  return relay;
 }
 
 // =============================================================================
@@ -1622,6 +1640,120 @@ void main() {
           reason: "a caller of the replaced dial gets the replacement's result",
         );
       });
+    });
+
+    group('health check', () {
+      test('leaves a relay whose dial is still in flight', () async {
+        // The pooled socket can still read as disconnected before its
+        // handshake starts; a dial in flight is not a failed health check.
+        final dial = Completer<bool>();
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) => dial.future);
+        final relay = _createPooledRelay(
+          testDefaultRelayUrl,
+          connected: ClientConnected.disconnect,
+          healthy: false,
+        );
+        when(
+          () => mockRelayPool.getRelay(testDefaultRelayUrl),
+        ).thenReturn(relay);
+
+        final startup = manager.initialize();
+        final sweep = manager.retryDisconnectedRelays();
+        await pumpEventQueue();
+
+        expect(
+          manager.getRelayStatus(testDefaultRelayUrl)?.state,
+          RelayState.connecting,
+        );
+
+        dial.complete(true);
+        await Future.wait([startup, sweep]);
+      });
+
+      test('leaves a relay whose socket is still connecting', () async {
+        // Demoting it made the sweep tear the socket down mid-handshake and
+        // dial again (#8991).
+        await manager.initialize();
+        final relay = _createPooledRelay(
+          testDefaultRelayUrl,
+          connected: ClientConnected.connecting,
+          healthy: false,
+        );
+        when(
+          () => mockRelayPool.getRelay(testDefaultRelayUrl),
+        ).thenReturn(relay);
+        clearInteractions(mockRelayPool);
+
+        await manager.retryDisconnectedRelays();
+
+        expect(
+          manager.getRelayStatus(testDefaultRelayUrl)?.state,
+          RelayState.connected,
+        );
+        verifyNever(() => mockRelayPool.remove(testDefaultRelayUrl));
+      });
+
+      test('a sweep leaves a relay the SDK is still connecting', () async {
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => false);
+        await manager.initialize();
+        final relay = _createPooledRelay(
+          testDefaultRelayUrl,
+          connected: ClientConnected.connecting,
+          healthy: false,
+        );
+        when(
+          () => mockRelayPool.getRelay(testDefaultRelayUrl),
+        ).thenReturn(relay);
+        clearInteractions(mockRelayPool);
+
+        await manager.retryDisconnectedRelays();
+
+        verifyNever(() => mockRelayPool.remove(testDefaultRelayUrl));
+        verifyNever(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        );
+      });
+
+      for (final (name, connected) in [
+        ('a connected', ClientConnected.connected),
+        ('a disconnected', ClientConnected.disconnect),
+      ]) {
+        test('still redials $name socket that fails its check', () async {
+          await manager.initialize();
+          final relay = _createPooledRelay(
+            testDefaultRelayUrl,
+            connected: connected,
+            healthy: false,
+          );
+          when(
+            () => mockRelayPool.getRelay(testDefaultRelayUrl),
+          ).thenReturn(relay);
+          clearInteractions(mockRelayPool);
+
+          await manager.retryDisconnectedRelays();
+
+          verify(() => mockRelayPool.remove(testDefaultRelayUrl)).called(1);
+          verify(
+            () => mockRelayPool.add(
+              any(),
+              autoSubscribe: any(named: 'autoSubscribe'),
+            ),
+          ).called(1);
+        });
+      }
     });
 
     group('reconnectRelay', () {

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -1957,6 +1957,68 @@ void main() {
         ).called(3);
       });
 
+      test(
+        'a completed cycle reports completed',
+        () async {
+          when(
+            () => mockRelayPool.add(
+              any(),
+              autoSubscribe: any(named: 'autoSubscribe'),
+            ),
+          ).thenAnswer((_) async => true);
+
+          expect(
+            await manager.forceReconnectAll(),
+            ForceReconnectOutcome.completed,
+          );
+        },
+      );
+
+      test(
+        'a caller joining shortly before the shared deadline is told the '
+        'cycle is still dialling, not that it finished',
+        () async {
+          // The bug this pins: the joiner used to get a normal completion
+          // when the shared deadline expired, indistinguishable from a
+          // finished cycle. The Relays screen then read connectedRelayCount
+          // as zero and told the user the retry had failed, while the
+          // reconnect was still running.
+          final dials = <Completer<bool>>[];
+          when(
+            () => mockRelayPool.add(
+              any(),
+              autoSubscribe: any(named: 'autoSubscribe'),
+            ),
+          ).thenAnswer((_) {
+            final dial = Completer<bool>();
+            dials.add(dial);
+            return dial.future;
+          });
+
+          final original = RelayManager.reconnectSweepBudget;
+          RelayManager.reconnectSweepBudget = const Duration(milliseconds: 60);
+          addTearDown(() => RelayManager.reconnectSweepBudget = original);
+
+          final first = manager.forceReconnectAll();
+          await pumpEventQueue();
+          // Joins the running cycle with only part of its budget left.
+          final joiner = manager.forceReconnectAll();
+
+          expect(await joiner, ForceReconnectOutcome.stillDialling);
+          expect(await first, ForceReconnectOutcome.stillDialling);
+          expect(
+            dials.every((dial) => !dial.isCompleted),
+            isTrue,
+            reason: 'the dials are still open; the cycle really did not finish',
+          );
+
+          for (final dial in dials) {
+            dial.complete(true);
+          }
+          await pumpEventQueue();
+        },
+      );
+
       test('starts every dial before any completes', () async {
         final dials = <Completer<bool>>[];
         when(

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_client/src/relay_diagnostics_adapter.dart';
@@ -1971,6 +1972,91 @@ void main() {
             await manager.forceReconnectAll(),
             ForceReconnectOutcome.completed,
           );
+        },
+      );
+
+      test('a cycle whose dials all failed still reports completed', () async {
+        // completed says every dial finished, not that any of them connected;
+        // the Relays screen decides what to show from the relay count.
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => false);
+
+        expect(
+          await manager.forceReconnectAll(),
+          ForceReconnectOutcome.completed,
+        );
+      });
+
+      test('a caller joining is released at the deadline of the cycle it '
+          'joined, not its own', () {
+        // The finding's exact case: with the deadline read off the wall clock
+        // a joiner waited a fresh budget from where it joined, so it could
+        // answer long after the cycle it was waiting on had given up.
+        fakeAsync((async) {
+          var dials = 0;
+          when(
+            () => mockRelayPool.add(
+              any(),
+              autoSubscribe: any(named: 'autoSubscribe'),
+            ),
+          ).thenAnswer((_) {
+            dials++;
+            return Completer<bool>().future;
+          });
+
+          ForceReconnectOutcome? first;
+          ForceReconnectOutcome? joiner;
+          unawaited(manager.forceReconnectAll().then((o) => first = o));
+          async.elapse(const Duration(seconds: 14, milliseconds: 900));
+          unawaited(manager.forceReconnectAll().then((o) => joiner = o));
+          async.elapse(const Duration(milliseconds: 99));
+          expect(joiner, isNull);
+
+          async.elapse(const Duration(milliseconds: 1));
+          expect(first, equals(ForceReconnectOutcome.stillDialling));
+          expect(
+            joiner,
+            equals(ForceReconnectOutcome.stillDialling),
+            reason: 'the joiner waits out the cycle, not a fresh budget',
+          );
+          expect(dials, equals(3), reason: 'the joiner starts no cycle');
+        });
+      });
+
+      test(
+        'a caller joining a cycle that finishes in time hears completed',
+        () {
+          fakeAsync((async) {
+            final dials = <Completer<bool>>[];
+            when(
+              () => mockRelayPool.add(
+                any(),
+                autoSubscribe: any(named: 'autoSubscribe'),
+              ),
+            ).thenAnswer((_) {
+              final dial = Completer<bool>();
+              dials.add(dial);
+              return dial.future;
+            });
+
+            ForceReconnectOutcome? first;
+            ForceReconnectOutcome? joiner;
+            unawaited(manager.forceReconnectAll().then((o) => first = o));
+            async.elapse(const Duration(seconds: 10));
+            unawaited(manager.forceReconnectAll().then((o) => joiner = o));
+            for (final dial in dials) {
+              dial.complete(true);
+            }
+            async.flushMicrotasks();
+
+            expect(dials, hasLength(3));
+            expect(first, equals(ForceReconnectOutcome.completed));
+            expect(joiner, equals(ForceReconnectOutcome.completed));
+          });
         },
       );
 

--- a/mobile/scripts/baseline/async_safety_counts.txt
+++ b/mobile/scripts/baseline/async_safety_counts.txt
@@ -37,7 +37,7 @@ discarded_futures|lib/providers/notifications_providers.dart	4
 discarded_futures|lib/providers/preferences_providers.dart	2
 discarded_futures|lib/providers/protected_minor_providers.dart	3
 discarded_futures|lib/providers/provider_identity_stream.dart	2
-discarded_futures|lib/providers/relay_providers.dart	4
+discarded_futures|lib/providers/relay_providers.dart	3
 discarded_futures|lib/providers/repository_providers.dart	3
 discarded_futures|lib/providers/social_providers.dart	8
 discarded_futures|lib/providers/sounds_providers.dart	1

--- a/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
+++ b/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
@@ -513,6 +513,29 @@ void main() {
     );
 
     blocTest<RelaySettingsCubit, RelaySettingsState>(
+      'retryConnection reports the relays already connected while others '
+      'still dial',
+      setUp: () {
+        // A cycle that has not finished can still have connected some of the
+        // pool; saying only "still connecting" would hide relays the user can
+        // already publish through, and skip the feeds those relays serve.
+        when(
+          nostr.forceReconnectAll,
+        ).thenAnswer((_) async => ForceReconnectOutcome.stillDialling);
+        when(() => nostr.connectedRelayCount).thenReturn(1);
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        final outcome = await cubit.retryConnection();
+        expect(outcome.kind, RetryConnectionOutcomeKind.connected);
+        expect(outcome.connectedCount, 1);
+      },
+      verify: (_) {
+        verify(videos.resetAndResubscribeAll).called(1);
+      },
+    );
+
+    blocTest<RelaySettingsCubit, RelaySettingsState>(
       'retryConnection emits failed and addError on service throw',
       setUp: () {
         when(nostr.forceReconnectAll).thenThrow(StateError('nope'));

--- a/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
+++ b/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
@@ -49,7 +49,9 @@ void main() {
       when(
         relayListRepository.publishConfiguredRelayList,
       ).thenAnswer((_) async => const RelayListPublishResult.published());
-      when(nostr.forceReconnectAll).thenAnswer((_) async {});
+      when(nostr.forceReconnectAll).thenAnswer(
+        (_) async => ForceReconnectOutcome.completed,
+      );
       when(videos.resetAndResubscribeAll).thenAnswer((_) async {});
     });
 
@@ -483,6 +485,27 @@ void main() {
       act: (cubit) async {
         final outcome = await cubit.retryConnection();
         expect(outcome.kind, RetryConnectionOutcomeKind.notConnected);
+      },
+      verify: (_) {
+        verifyNever(videos.resetAndResubscribeAll);
+      },
+    );
+
+    blocTest<RelaySettingsCubit, RelaySettingsState>(
+      'retryConnection reports stillConnecting, not notConnected, when the '
+      'reconnect had not finished',
+      setUp: () {
+        // The shared cycle keeps dialling past the deadline. Zero connected
+        // relays here means "no answer yet", and calling it a failure told the
+        // user the retry failed while it was still succeeding.
+        when(nostr.forceReconnectAll).thenAnswer(
+          (_) async => ForceReconnectOutcome.stillDialling,
+        );
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        final outcome = await cubit.retryConnection();
+        expect(outcome.kind, RetryConnectionOutcomeKind.stillConnecting);
       },
       verify: (_) {
         verifyNever(videos.resetAndResubscribeAll);

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -489,10 +489,6 @@ void main() {
 // Keys intentionally allowed to fall back to English until a translation pass.
 // Keep this list small and reviewable so new translation gaps stay visible.
 const _knownUntranslatedDebt = <String>{
-  // Relay reconnect "still working" copy. Deferred to the next human pass
-  // rather than machine-translated: the reassuring register matters and the
-  // English is likely to be revised with the Relays screen.
-  'relaySettingsStillConnecting',
   // Discord proof-rejection reasons (verifier PR #43). Each names a distinct
   // way a Discord proof can fail, replacing one message that blamed the npub
   // for all of them. Deferred to the next human pass rather than

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -489,6 +489,10 @@ void main() {
 // Keys intentionally allowed to fall back to English until a translation pass.
 // Keep this list small and reviewable so new translation gaps stay visible.
 const _knownUntranslatedDebt = <String>{
+  // Relay reconnect "still working" copy. Deferred to the next human pass
+  // rather than machine-translated: the reassuring register matters and the
+  // English is likely to be revised with the Relays screen.
+  'relaySettingsStillConnecting',
   // Discord proof-rejection reasons (verifier PR #43). Each names a distinct
   // way a Discord proof can fail, replacing one message that blamed the npub
   // for all of them. Deferred to the next human pass rather than

--- a/mobile/test/providers/relay_providers_test.dart
+++ b/mobile/test/providers/relay_providers_test.dart
@@ -12,6 +12,7 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/relay_providers.dart';
 import 'package:openvine/services/connectivity_transition_monitor.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 
@@ -142,6 +143,85 @@ void main() {
         initialization.end(first);
         async.elapse(const Duration(seconds: 2));
         verify(first.forceReconnectAll).called(1);
+      });
+    });
+
+    group('repair log', () {
+      List<String> repairLogs(
+        FakeAsync async, {
+        required ForceReconnectOutcome outcome,
+        required int connected,
+      }) {
+        unawaited(LogCaptureService().clearAllLogs());
+        when(first.forceReconnectAll).thenAnswer((_) async => outcome);
+        when(() => first.connectedRelayCount).thenReturn(connected);
+        when(() => first.configuredRelayCount).thenReturn(2);
+        final connectivity = _FakeConnectivity(const [ConnectivityResult.wifi]);
+        final container = containerFor(connectivity);
+        container.listen(connectivityRelayReconnectProvider, (_, _) {});
+        async.flushMicrotasks();
+
+        connectivity.change(const [ConnectivityResult.mobile]);
+        async.elapse(const Duration(seconds: 2));
+
+        verify(first.forceReconnectAll).called(1);
+        return [
+          for (final entry in LogCaptureService().getRecentLogs())
+            entry.message,
+        ];
+      }
+
+      test('logs how many relays connected when the repair finishes', () {
+        fakeAsync((async) {
+          final messages = repairLogs(
+            async,
+            outcome: ForceReconnectOutcome.completed,
+            connected: 1,
+          );
+
+          expect(
+            messages,
+            contains(
+              'Relay reconnect after a connectivity change finished: 1 of 2 '
+              'relays connected',
+            ),
+          );
+          expect(
+            messages,
+            isNot(
+              contains(
+                'Relay reconnect attempt after a connectivity change ended',
+              ),
+            ),
+          );
+        });
+      });
+
+      test('says relays are still connecting when the repair wait ends '
+          'first', () {
+        fakeAsync((async) {
+          final messages = repairLogs(
+            async,
+            outcome: ForceReconnectOutcome.stillDialling,
+            connected: 0,
+          );
+
+          expect(
+            messages,
+            contains(
+              'Relay reconnect after a connectivity change ended with relays '
+              'still connecting (0 of 2 connected)',
+            ),
+          );
+          expect(
+            messages,
+            isNot(
+              contains(
+                'Relay reconnect attempt after a connectivity change ended',
+              ),
+            ),
+          );
+        });
       });
     });
 

--- a/mobile/test/providers/relay_providers_test.dart
+++ b/mobile/test/providers/relay_providers_test.dart
@@ -60,8 +60,12 @@ void main() {
     setUp(() {
       first = _MockNostrClient();
       second = _MockNostrClient();
-      when(first.forceReconnectAll).thenAnswer((_) async {});
-      when(second.forceReconnectAll).thenAnswer((_) async {});
+      when(first.forceReconnectAll).thenAnswer(
+        (_) async => ForceReconnectOutcome.completed,
+      );
+      when(second.forceReconnectAll).thenAnswer(
+        (_) async => ForceReconnectOutcome.completed,
+      );
     });
 
     ProviderContainer containerFor(_FakeConnectivity connectivity) {

--- a/mobile/test/providers/relay_providers_test.dart
+++ b/mobile/test/providers/relay_providers_test.dart
@@ -1,0 +1,166 @@
+// ABOUTME: Tests for connectivityRelayReconnectProvider, the app-wide owner of
+// ABOUTME: connectivity-driven relay repair (#3161, #8990).
+
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/relay_providers.dart';
+import 'package:openvine/services/connectivity_transition_monitor.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+/// Serves [_initial] and lets a test replace the client the way an account
+/// switch or a failed initialization does.
+class _SwappableNostrService extends NostrService {
+  _SwappableNostrService(this._initial);
+
+  final NostrClient _initial;
+
+  @override
+  NostrClient build() => _initial;
+
+  void replace(NostrClient client) => state = client;
+}
+
+/// Stands in for `connectivity_plus`, which replays the current state to a
+/// new listener when its listener count goes from zero to one.
+class _FakeConnectivity {
+  _FakeConnectivity(this.current) {
+    _reports = StreamController<List<ConnectivityResult>>.broadcast(
+      onListen: () {
+        subscriptions++;
+        _reports.add(current);
+      },
+    );
+  }
+
+  List<ConnectivityResult> current;
+  late final StreamController<List<ConnectivityResult>> _reports;
+  int subscriptions = 0;
+
+  Stream<List<ConnectivityResult>> get changes => _reports.stream;
+
+  void change(List<ConnectivityResult> results) {
+    current = results;
+    _reports.add(results);
+  }
+}
+
+void main() {
+  group('connectivityRelayReconnectProvider', () {
+    late _MockNostrClient first;
+    late _MockNostrClient second;
+
+    setUp(() {
+      first = _MockNostrClient();
+      second = _MockNostrClient();
+      when(first.forceReconnectAll).thenAnswer((_) async {});
+      when(second.forceReconnectAll).thenAnswer((_) async {});
+    });
+
+    ProviderContainer containerFor(_FakeConnectivity connectivity) {
+      final container = ProviderContainer(
+        overrides: [
+          connectivityChangesProvider.overrideWithValue(connectivity.changes),
+          connectivityCheckProvider.overrideWithValue(
+            () async => connectivity.current,
+          ),
+          nostrServiceProvider.overrideWith(
+            () => _SwappableNostrService(first),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    void replaceClient(ProviderContainer container, NostrClient client) {
+      (container.read(nostrServiceProvider.notifier) as _SwappableNostrService)
+          .replace(client);
+    }
+
+    test('neither resubscribes nor repairs when the client is replaced', () {
+      // Re-subscribing replayed the current state, which the old provider
+      // took for a reconnect: ~2 s after every launch and sign-in (#8990).
+      // Listened, as AppRootSideEffects does, so a dependency change would
+      // rebuild it.
+      fakeAsync((async) {
+        final connectivity = _FakeConnectivity(const [ConnectivityResult.wifi]);
+        final container = containerFor(connectivity);
+        container.listen(connectivityRelayReconnectProvider, (_, _) {});
+        async.flushMicrotasks();
+
+        replaceClient(container, second);
+        async.elapse(const Duration(seconds: 5));
+
+        expect(connectivity.subscriptions, equals(1));
+        verifyNever(first.forceReconnectAll);
+        verifyNever(second.forceReconnectAll);
+      });
+    });
+
+    test('repairs the client that is active when the repair fires', () {
+      fakeAsync((async) {
+        final connectivity = _FakeConnectivity(const [ConnectivityResult.wifi]);
+        final container = containerFor(connectivity);
+        container.listen(connectivityRelayReconnectProvider, (_, _) {});
+        async.flushMicrotasks();
+        replaceClient(container, second);
+
+        connectivity.change(const [ConnectivityResult.mobile]);
+        async.elapse(const Duration(seconds: 2));
+
+        verify(second.forceReconnectAll).called(1);
+        verifyNever(first.forceReconnectAll);
+      });
+    });
+
+    test('waits while the active client is still initializing', () {
+      fakeAsync((async) {
+        final connectivity = _FakeConnectivity(const [ConnectivityResult.wifi]);
+        final container = containerFor(connectivity);
+        container.listen(connectivityRelayReconnectProvider, (_, _) {});
+        async.flushMicrotasks();
+        final initialization = container.read(
+          nostrInitializationInProgressProvider.notifier,
+        )..begin(first);
+
+        connectivity.change(const [ConnectivityResult.mobile]);
+        async.elapse(const Duration(seconds: 10));
+        verifyNever(first.forceReconnectAll);
+
+        initialization.end(first);
+        async.elapse(const Duration(seconds: 2));
+        verify(first.forceReconnectAll).called(1);
+      });
+    });
+
+    test('exposes the transitions for the DM retry sweep', () {
+      fakeAsync((async) {
+        final connectivity = _FakeConnectivity(const [ConnectivityResult.wifi]);
+        final container = containerFor(connectivity);
+        final transitions = <ConnectivityTransition>[];
+        container
+            .read(connectivityRelayReconnectProvider)
+            .listen(transitions.add);
+        async.flushMicrotasks();
+
+        connectivity.change(const [ConnectivityResult.none]);
+        async.flushMicrotasks();
+        connectivity.change(const [ConnectivityResult.wifi]);
+        async.elapse(const Duration(seconds: 2));
+
+        expect(transitions, [
+          ConnectivityTransition.offline,
+          ConnectivityTransition.online,
+        ]);
+      });
+    });
+  });
+}

--- a/mobile/test/providers/social_providers_relay_repair_test.dart
+++ b/mobile/test/providers/social_providers_relay_repair_test.dart
@@ -89,7 +89,9 @@ void main() {
       client = _MockNostrClient();
       when(() => client.hasKeys).thenReturn(true);
       when(() => client.publicKey).thenReturn(pubkey);
-      when(client.forceReconnectAll).thenAnswer((_) async {});
+      when(client.forceReconnectAll).thenAnswer(
+        (_) async => ForceReconnectOutcome.completed,
+      );
 
       dao = _MockOutgoingDmsDao();
       when(

--- a/mobile/test/providers/social_providers_relay_repair_test.dart
+++ b/mobile/test/providers/social_providers_relay_repair_test.dart
@@ -1,93 +1,170 @@
-// ABOUTME: Tests for dmMessageRetryTriggerWithRelayRepair — the connectivity
-// ABOUTME: trigger that force-reconnects the relay pool before the DM sweep.
+// ABOUTME: Tests that the DM retry sweep runs on the connectivity owner's
+// ABOUTME: transitions and leaves relay repair to that owner (#6046, #8990).
 
 import 'dart:async';
 
-import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/providers/app_foreground_provider.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/crash_reporting_provider.dart';
+import 'package:openvine/providers/database_provider.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/relay_providers.dart';
+import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/social_providers.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/connectivity_transition_monitor.dart';
+import 'package:openvine/services/crash_reporting_service.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockAppDatabase extends Mock implements AppDatabase {}
+
+class _MockCrashReportingService extends Mock
+    implements CrashReportingService {}
+
+class _MockDmRepository extends Mock implements DmRepository {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockOutgoingDmsDao extends Mock implements OutgoingDmsDao {}
+
+class _ReadyNostrSession extends NostrSession {
+  _ReadyNostrSession(this._readiness);
+
+  final NostrSessionReadiness _readiness;
+
+  @override
+  NostrSessionReadiness build() => _readiness;
+}
+
+class _FixedNostrService extends NostrService {
+  _FixedNostrService(this._client);
+
+  final NostrClient _client;
+
+  @override
+  NostrClient build() => _client;
+}
+
+/// Keeps the foreground trigger quiet, so every sweep comes from connectivity.
+class _Backgrounded extends AppForeground {
+  @override
+  bool build() => false;
+}
 
 void main() {
-  group('dmMessageRetryTriggerWithRelayRepair', () {
-    late StreamController<List<ConnectivityResult>> connectivity;
-    late int repairCalls;
-    late List<Completer<void>> repairGates;
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('outgoingDmRetryServiceProvider', () {
+    const pubkey =
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+    late StreamController<ConnectivityTransition> transitions;
+    late _MockOutgoingDmsDao dao;
+    late _MockNostrClient client;
+    late ProviderContainer container;
 
     setUp(() {
-      connectivity = StreamController<List<ConnectivityResult>>();
-      repairCalls = 0;
-      repairGates = [];
+      // The sweep probes connectivity itself. A real plugin call resolves at
+      // an unpredictable point in a test, so answer it here: online.
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      const channel = MethodChannel('dev.fluttercommunity.plus/connectivity');
+      messenger.setMockMethodCallHandler(
+        channel,
+        (call) async => call.method == 'check' ? ['wifi'] : null,
+      );
+      addTearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+      transitions = StreamController<ConnectivityTransition>.broadcast();
+      addTearDown(transitions.close);
+
+      client = _MockNostrClient();
+      when(() => client.hasKeys).thenReturn(true);
+      when(() => client.publicKey).thenReturn(pubkey);
+      when(client.forceReconnectAll).thenAnswer((_) async {});
+
+      dao = _MockOutgoingDmsDao();
+      when(
+        () => dao.getRetryableForOwner(
+          ownerPubkey: any(named: 'ownerPubkey'),
+          maxRetries: any(named: 'maxRetries'),
+        ),
+      ).thenAnswer((_) async => []);
+      when(
+        () => dao.getStillPendingForOwner(any()),
+      ).thenAnswer((_) async => []);
+      final database = _MockAppDatabase();
+      when(() => database.outgoingDmsDao).thenReturn(dao);
+
+      final dmRepository = _MockDmRepository();
+      when(
+        () => dmRepository.retryableOutgoingWork,
+      ).thenAnswer((_) => const Stream<void>.empty());
+      when(dmRepository.retryableMessageDeletions).thenAnswer((_) async => []);
+
+      final authService = _MockAuthService();
+      when(() => authService.currentPublicKeyHex).thenReturn(pubkey);
+
+      container = ProviderContainer(
+        overrides: [
+          authServiceProvider.overrideWithValue(authService),
+          currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+          nostrSessionProvider.overrideWith(
+            () => _ReadyNostrSession(
+              NostrSessionReadiness.nostrReady(pubkey: pubkey, client: client),
+            ),
+          ),
+          nostrServiceProvider.overrideWith(() => _FixedNostrService(client)),
+          dmRepositoryProvider.overrideWithValue(dmRepository),
+          databaseProvider.overrideWithValue(database),
+          crashReportingServiceProvider.overrideWithValue(
+            _MockCrashReportingService(),
+          ),
+          appForegroundProvider.overrideWith(_Backgrounded.new),
+          connectivityRelayReconnectProvider.overrideWithValue(
+            transitions.stream,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
     });
 
-    tearDown(() {
-      // Not awaited: the per-test addTearDown cancels the generator's
-      // subscription first, and a single-subscription controller with no
-      // live listener never completes its close() future — awaiting it
-      // hangs the teardown until the suite's per-test timeout.
-      unawaited(connectivity.close());
+    test('sweeps once for each connectivity transition', () async {
+      // Each transition, offline included, starts a pass; which pass runs is
+      // the service's own probe, answered online here.
+      container.listen(outgoingDmRetryServiceProvider, (_, _) {});
+      await pumpEventQueue();
+
+      transitions.add(ConnectivityTransition.offline);
+      await pumpEventQueue();
+      transitions.add(ConnectivityTransition.online);
+      await pumpEventQueue();
+
+      verify(
+        () => dao.getRetryableForOwner(
+          ownerPubkey: pubkey,
+          maxRetries: any(named: 'maxRetries'),
+        ),
+      ).called(2);
     });
 
-    Future<void> repair() {
-      repairCalls++;
-      final gate = Completer<void>()..complete();
-      repairGates.add(gate);
-      return gate.future;
-    }
-
-    test('repairs the pool once per real online transition and emits a '
-        'trigger for every connectivity event', () async {
-      final triggers = <void>[];
-      final subscription = dmMessageRetryTriggerWithRelayRepair(
-        connectivityChanges: connectivity.stream,
-        repairRelayPool: repair,
-      ).listen(triggers.add);
-      addTearDown(subscription.cancel);
-
-      // First emission is the current state, not a transition: no repair.
-      connectivity.add(const [ConnectivityResult.wifi]);
-      await pumpEventQueue();
-      expect(repairCalls, 0);
-      expect(triggers, hasLength(1));
-
-      // Going offline: trigger emitted (offline pass), no repair.
-      connectivity.add(const [ConnectivityResult.none]);
-      await pumpEventQueue();
-      expect(repairCalls, 0);
-      expect(triggers, hasLength(2));
-
-      // Back online: repair the zombie sockets BEFORE the sweep trigger.
-      connectivity.add(const [ConnectivityResult.wifi]);
-      await pumpEventQueue();
-      expect(repairCalls, 1);
-      expect(triggers, hasLength(3));
-
-      // Duplicate report of the same transports: no repair churn.
-      connectivity.add(const [ConnectivityResult.wifi]);
-      await pumpEventQueue();
-      expect(repairCalls, 1);
-      expect(triggers, hasLength(4));
-
-      // Interface handoff (wifi → cellular) breaks sockets too: repair.
-      connectivity.add(const [ConnectivityResult.mobile]);
-      await pumpEventQueue();
-      expect(repairCalls, 2);
-      expect(triggers, hasLength(5));
-    });
-
-    test('a failing repair still emits the sweep trigger', () async {
-      final triggers = <void>[];
-      final subscription = dmMessageRetryTriggerWithRelayRepair(
-        connectivityChanges: connectivity.stream,
-        repairRelayPool: () async => throw StateError('pool gone'),
-      ).listen(triggers.add);
-      addTearDown(subscription.cancel);
-
-      connectivity.add(const [ConnectivityResult.none]);
-      await pumpEventQueue();
-      connectivity.add(const [ConnectivityResult.wifi]);
+    test('leaves relay repair to the connectivity owner', () async {
+      // Repairing here as well reconnected the pool twice per network change.
+      container.listen(outgoingDmRetryServiceProvider, (_, _) {});
       await pumpEventQueue();
 
-      expect(triggers, hasLength(2));
+      transitions.add(ConnectivityTransition.online);
+      await pumpEventQueue();
+
+      verifyNever(client.forceReconnectAll);
     });
   });
 }

--- a/mobile/test/screens/relay_settings_screen_layout_test.dart
+++ b/mobile/test/screens/relay_settings_screen_layout_test.dart
@@ -593,4 +593,80 @@ void main() {
       },
     );
   });
+
+  group('Retry connection', () {
+    const relay = 'wss://relay.divine.video';
+
+    Future<void> pumpScreen(
+      WidgetTester tester, {
+      required _MockNostrService nostrService,
+    }) async {
+      SharedPreferences.setMockInitialValues({});
+
+      final capabilityService = _MockRelayCapabilityService();
+      final statsService = _MockRelayStatisticsService();
+      final videoEventService = _MockVideoEventService();
+      final stats = RelayStatistics(relayUrl: relay);
+
+      when(() => nostrService.configuredRelays).thenReturn([relay]);
+      when(() => nostrService.defaultRelayUrl).thenReturn(relay);
+      when(() => statsService.getStatistics(any())).thenReturn(stats);
+      when(statsService.getAllStatistics).thenReturn({relay: stats});
+      when(
+        () => capabilityService.getRelayCapabilities(any()),
+      ).thenThrow(RelayCapabilityException('Not found', relay));
+      when(videoEventService.resetAndResubscribeAll).thenAnswer((_) async {});
+
+      final container = ProviderContainer(
+        overrides: [
+          nostrServiceProvider.overrideWithValue(nostrService),
+          relayCapabilityServiceProvider.overrideWithValue(capabilityService),
+          relayStatisticsServiceProvider.overrideWithValue(statsService),
+          relayStatisticsStreamProvider.overrideWith(
+            (_) => Stream.value({relay: stats}),
+          ),
+          relayListRepositoryProvider.overrideWithValue(
+            _FakeRelayListRepository(),
+          ),
+          videoEventServiceProvider.overrideWithValue(videoEventService),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            theme: VineTheme.theme,
+            home: const RelaySettingsScreen(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('says relays are still connecting when the wait ends '
+        'before any connects', (tester) async {
+      final nostrService = _MockNostrService();
+      when(() => nostrService.connectedRelayCount).thenReturn(0);
+      when(
+        nostrService.forceReconnectAll,
+      ).thenAnswer((_) async => ForceReconnectOutcome.stillDialling);
+
+      await pumpScreen(tester, nostrService: nostrService);
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await tester.tap(find.text(l10n.relaySettingsRetry));
+      await tester.pumpAndSettle();
+      // The result queues behind the "Forcing relay reconnection" snackbar.
+      await tester.pump(const Duration(seconds: 5));
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.relaySettingsStillConnecting), findsOneWidget);
+      expect(find.text(l10n.relaySettingsFailedToConnectCheck), findsNothing);
+      verify(nostrService.forceReconnectAll).called(1);
+    });
+  });
 }

--- a/mobile/test/services/connectivity_transition_monitor_test.dart
+++ b/mobile/test/services/connectivity_transition_monitor_test.dart
@@ -89,6 +89,24 @@ void main() {
           expect(harness.repairs, equals(1));
         });
       });
+
+      test('keeps a report that beats the seed as the baseline', () {
+        // A slow seed must not overwrite it, or the next duplicate report
+        // would read as a change and reconnect every relay (#8990).
+        fakeAsync((async) {
+          final seed = Completer<List<ConnectivityResult>>();
+          final harness = _Harness(check: () => seed.future);
+          harness.report(_mobile);
+          async.flushMicrotasks();
+          seed.complete(_wifi);
+          async.flushMicrotasks();
+
+          harness.report(_mobile);
+          async.elapse(const Duration(seconds: 5));
+
+          expect(harness.repairs, isZero);
+        });
+      });
     });
 
     group('repair', () {
@@ -292,6 +310,26 @@ void main() {
           async.elapse(const Duration(seconds: 5));
 
           expect(harness.repairs, isZero);
+        });
+      });
+
+      test('during a repair stops it reporting or repairing again', () {
+        fakeAsync((async) {
+          final gate = Completer<void>();
+          final harness = _Harness(repair: () => gate.future);
+          async.flushMicrotasks();
+
+          harness.report(_mobile);
+          async.elapse(const Duration(seconds: 2));
+          harness.report(_wifi);
+          async.flushMicrotasks();
+          unawaited(harness.monitor.dispose());
+          async.flushMicrotasks();
+          gate.complete();
+          async.elapse(const Duration(seconds: 5));
+
+          expect(harness.repairs, equals(1));
+          expect(harness.transitions, isEmpty);
         });
       });
     });

--- a/mobile/test/services/connectivity_transition_monitor_test.dart
+++ b/mobile/test/services/connectivity_transition_monitor_test.dart
@@ -1,0 +1,299 @@
+// ABOUTME: Tests for ConnectivityTransitionMonitor — the single owner that
+// ABOUTME: turns connectivity reports into relay repairs and DM sweep triggers.
+
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/connectivity_transition_monitor.dart';
+
+const List<ConnectivityResult> _wifi = [ConnectivityResult.wifi];
+const List<ConnectivityResult> _mobile = [ConnectivityResult.mobile];
+const List<ConnectivityResult> _offline = [ConnectivityResult.none];
+
+/// Drives a monitor inside a fake clock. Construct it inside `fakeAsync` so
+/// the monitor's timers run on that clock.
+class _Harness {
+  _Harness({
+    Future<List<ConnectivityResult>> Function()? check,
+    Future<void> Function()? repair,
+  }) {
+    monitor = ConnectivityTransitionMonitor(
+      changes: changes.stream,
+      checkConnectivity: check ?? () async => _wifi,
+      repair: () {
+        repairs++;
+        return (repair ?? () async {})();
+      },
+      canRepair: () => canRepair,
+    );
+    monitor.transitions.listen(transitions.add);
+    monitor.start();
+  }
+
+  final StreamController<List<ConnectivityResult>> changes =
+      StreamController<List<ConnectivityResult>>();
+  final List<ConnectivityTransition> transitions = [];
+  late final ConnectivityTransitionMonitor monitor;
+  int repairs = 0;
+  bool canRepair = true;
+
+  void report(List<ConnectivityResult> results) => changes.add(results);
+}
+
+void main() {
+  group(ConnectivityTransitionMonitor, () {
+    group('baseline', () {
+      test('ignores the report a fresh subscription replays', () {
+        // Repairing on it tore down healthy sockets ~2 s after every launch
+        // and sign-in (#8990).
+        fakeAsync((async) {
+          final harness = _Harness();
+          async.flushMicrotasks();
+
+          harness.report(_wifi);
+          async.elapse(const Duration(seconds: 5));
+
+          expect(harness.repairs, isZero);
+          expect(harness.transitions, isEmpty);
+        });
+      });
+
+      test('uses the first report as the baseline when the seed fails', () {
+        fakeAsync((async) {
+          final harness = _Harness(
+            check: () async => throw StateError('plugin unavailable'),
+          );
+          async.flushMicrotasks();
+
+          harness.report(_wifi);
+          async.elapse(const Duration(seconds: 5));
+          expect(harness.repairs, isZero);
+
+          harness.report(_mobile);
+          async.elapse(const Duration(seconds: 2));
+          expect(harness.repairs, equals(1));
+        });
+      });
+
+      test('counts a first report that differs from the seed', () {
+        // A new container gets no replay, so its first report is a change.
+        fakeAsync((async) {
+          final harness = _Harness(check: () async => _offline);
+          async.flushMicrotasks();
+
+          harness.report(_wifi);
+          async.elapse(const Duration(seconds: 2));
+
+          expect(harness.repairs, equals(1));
+        });
+      });
+    });
+
+    group('repair', () {
+      test('repairs once, after the debounce, when the network returns', () {
+        fakeAsync((async) {
+          final harness = _Harness(check: () async => _offline);
+          async.flushMicrotasks();
+
+          harness.report(_wifi);
+          async.elapse(const Duration(milliseconds: 1999));
+          expect(harness.repairs, isZero);
+
+          async.elapse(const Duration(milliseconds: 1));
+          expect(harness.repairs, equals(1));
+          expect(harness.transitions, [ConnectivityTransition.online]);
+        });
+      });
+
+      test('repairs once when the transport changes while online', () {
+        fakeAsync((async) {
+          final harness = _Harness();
+          async.flushMicrotasks();
+
+          harness.report(_mobile);
+          async.elapse(const Duration(seconds: 2));
+
+          expect(harness.repairs, equals(1));
+          expect(harness.transitions, [ConnectivityTransition.online]);
+        });
+      });
+
+      test('ignores a duplicate report of the same transports', () {
+        fakeAsync((async) {
+          final harness = _Harness();
+          async.flushMicrotasks();
+
+          harness.report(_mobile);
+          async.elapse(const Duration(seconds: 2));
+          harness.report(_mobile);
+          async.elapse(const Duration(seconds: 5));
+
+          expect(harness.repairs, equals(1));
+        });
+      });
+
+      test('collapses a burst of reports into one repair', () {
+        fakeAsync((async) {
+          final harness = _Harness();
+          async.flushMicrotasks();
+
+          harness.report(_mobile);
+          async.elapse(const Duration(seconds: 1));
+          harness.report(const [
+            ConnectivityResult.wifi,
+            ConnectivityResult.mobile,
+          ]);
+          async.elapse(const Duration(seconds: 1));
+          harness.report(_mobile);
+          async.elapse(const Duration(seconds: 5));
+
+          expect(harness.repairs, equals(1));
+        });
+      });
+
+      test('waits while the client cannot repair yet', () {
+        fakeAsync((async) {
+          final harness = _Harness()..canRepair = false;
+          async.flushMicrotasks();
+
+          harness.report(_mobile);
+          async.elapse(const Duration(seconds: 10));
+          expect(harness.repairs, isZero);
+
+          harness.canRepair = true;
+          async.elapse(const Duration(seconds: 2));
+          expect(harness.repairs, equals(1));
+        });
+      });
+
+      test('reports online even when the repair fails', () {
+        fakeAsync((async) {
+          final harness = _Harness(
+            repair: () async => throw StateError('pool gone'),
+          );
+          async.flushMicrotasks();
+
+          harness.report(_mobile);
+          async.elapse(const Duration(seconds: 2));
+
+          expect(harness.transitions, [ConnectivityTransition.online]);
+        });
+      });
+
+      test('reports online once the repair reaches its cap', () {
+        fakeAsync((async) {
+          final hung = Completer<void>();
+          final harness = _Harness(repair: () => hung.future);
+          async.flushMicrotasks();
+
+          harness.report(_mobile);
+          async.elapse(const Duration(seconds: 2));
+          expect(harness.transitions, isEmpty);
+
+          async.elapse(const Duration(seconds: 15));
+          expect(harness.transitions, [ConnectivityTransition.online]);
+        });
+      });
+
+      test(
+        're-runs once when the network changes mid-repair and reports '
+        'online after the final repair',
+        () {
+          fakeAsync((async) {
+            final gates = <Completer<void>>[];
+            final harness = _Harness(
+              repair: () {
+                final gate = Completer<void>();
+                gates.add(gate);
+                return gate.future;
+              },
+            );
+            async.flushMicrotasks();
+
+            harness.report(_mobile);
+            async.elapse(const Duration(seconds: 2));
+            expect(gates, hasLength(1));
+
+            harness
+              ..report(_wifi)
+              ..report(_mobile);
+            async.flushMicrotasks();
+            gates.single.complete();
+            async.flushMicrotasks();
+            expect(harness.transitions, isEmpty);
+
+            async.elapse(const Duration(seconds: 2));
+            expect(gates, hasLength(2));
+            gates.last.complete();
+            async.flushMicrotasks();
+            expect(harness.transitions, [ConnectivityTransition.online]);
+          });
+        },
+      );
+    });
+
+    group('offline', () {
+      test('is reported at once', () {
+        fakeAsync((async) {
+          final harness = _Harness();
+          async.flushMicrotasks();
+
+          harness.report(_offline);
+          async.flushMicrotasks();
+
+          expect(harness.transitions, [ConnectivityTransition.offline]);
+          expect(harness.repairs, isZero);
+        });
+      });
+
+      test('cancels a pending repair', () {
+        fakeAsync((async) {
+          final harness = _Harness();
+          async.flushMicrotasks();
+
+          harness.report(_mobile);
+          async.elapse(const Duration(seconds: 1));
+          harness.report(_offline);
+          async.elapse(const Duration(seconds: 5));
+
+          expect(harness.repairs, isZero);
+          expect(harness.transitions, [ConnectivityTransition.offline]);
+        });
+      });
+
+      test('during a repair suppresses its online report', () {
+        fakeAsync((async) {
+          final gate = Completer<void>();
+          final harness = _Harness(repair: () => gate.future);
+          async.flushMicrotasks();
+
+          harness.report(_mobile);
+          async.elapse(const Duration(seconds: 2));
+          harness.report(_offline);
+          async.flushMicrotasks();
+          gate.complete();
+          async.elapse(const Duration(seconds: 5));
+
+          expect(harness.transitions, [ConnectivityTransition.offline]);
+        });
+      });
+    });
+
+    group('dispose', () {
+      test('cancels a pending repair', () {
+        fakeAsync((async) {
+          final harness = _Harness();
+          async.flushMicrotasks();
+
+          harness.report(_mobile);
+          unawaited(harness.monitor.dispose());
+          async.elapse(const Duration(seconds: 5));
+
+          expect(harness.repairs, isZero);
+        });
+      });
+    });
+  });
+}

--- a/mobile/test/startup/app_side_effects_test.dart
+++ b/mobile/test/startup/app_side_effects_test.dart
@@ -22,6 +22,7 @@ import 'package:openvine/router/providers/page_context_provider.dart';
 import 'package:openvine/router/providers/route_normalization_provider.dart';
 import 'package:openvine/router/providers/support_route_trail_provider.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/connectivity_transition_monitor.dart';
 import 'package:openvine/services/product_event_queue.dart';
 import 'package:openvine/startup/app_side_effects.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -110,7 +111,9 @@ void main() {
     // Root tier, stubbed: neither reaches the identity mirrors under test.
     routeNormalizationProvider.overrideWithValue(null),
     supportRouteTrailProvider.overrideWith(_EmptySupportRouteTrail.new),
-    connectivityRelayReconnectProvider.overrideWithValue(null),
+    connectivityRelayReconnectProvider.overrideWithValue(
+      const Stream<ConnectivityTransition>.empty(),
+    ),
     outgoingDmRetryServiceProvider.overrideWithValue(null),
     dmReactionRetryServiceProvider.overrideWithValue(null),
     viewEventRetryServiceProvider.overrideWithValue(null),

--- a/mobile/test/unit/providers/relay_set_change_bridge_test.dart
+++ b/mobile/test/unit/providers/relay_set_change_bridge_test.dart
@@ -12,6 +12,7 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class MockNostrClient extends Mock implements NostrClient {}
 
@@ -47,6 +48,12 @@ void stubUserRemovedRelays(
     final relay = call.positionalArguments.single as String;
     return relays.contains(relay);
   });
+}
+
+/// The bridge logs how many relays a forced reconnect left connected.
+void stubRelayCounts(MockNostrClient client) {
+  when(() => client.connectedRelayCount).thenReturn(1);
+  when(() => client.configuredRelayCount).thenReturn(1);
 }
 
 void main() {
@@ -87,6 +94,7 @@ void main() {
       when(() => mockNostrClient.defaultRelayUrl).thenReturn(defaultRelay);
       when(() => mockNostrClient.publicKey).thenAnswer((_) => clientPublicKey);
       stubUserRemovedRelays(mockNostrClient);
+      stubRelayCounts(mockNostrClient);
     });
 
     tearDown(() {
@@ -122,6 +130,7 @@ void main() {
       when(() => client.publicKey).thenReturn(pubkey);
       when(() => client.defaultRelayUrl).thenReturn(relay);
       stubUserRemovedRelays(client);
+      stubRelayCounts(client);
     }
 
     test('does not trigger reset on initial activation', () {
@@ -170,6 +179,90 @@ void main() {
         verify(() => mockNostrClient.forceReconnectAll()).called(1);
         verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
         container.dispose();
+      });
+    });
+
+    group('reconnect outcome', () {
+      const relay1 = 'wss://relay1.example.com';
+      const relay2 = 'wss://relay2.example.com';
+
+      List<String> reconnectAndReset(
+        FakeAsync async, {
+        required ForceReconnectOutcome outcome,
+        required int connected,
+      }) {
+        unawaited(LogCaptureService().clearAllLogs());
+        when(
+          () => mockNostrClient.forceReconnectAll(),
+        ).thenAnswer((_) async => outcome);
+        when(() => mockNostrClient.connectedRelayCount).thenReturn(connected);
+        when(() => mockNostrClient.configuredRelayCount).thenReturn(2);
+        final container = createContainer(
+          initialStatuses: {relay1: RelayConnectionStatus.connected(relay1)},
+        );
+        addTearDown(container.dispose);
+
+        statusController.add({
+          relay1: RelayConnectionStatus.connected(relay1),
+          relay2: RelayConnectionStatus.connected(relay2),
+        });
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        return [
+          for (final entry in LogCaptureService().getRecentLogs())
+            entry.message,
+        ];
+      }
+
+      test('logs how many relays connected when the reconnect finishes', () {
+        fakeAsync((async) {
+          final messages = reconnectAndReset(
+            async,
+            outcome: ForceReconnectOutcome.completed,
+            connected: 1,
+          );
+
+          expect(
+            messages,
+            contains('Relay reconnect finished: 1 of 2 relays connected'),
+          );
+          expect(
+            messages,
+            isNot(contains('Successfully reconnected all relay WebSockets')),
+          );
+          verify(
+            () => mockVideoEventService.resetAndResubscribeAll(),
+          ).called(1);
+        });
+      });
+
+      test('says relays are still connecting and still resets feeds when '
+          'the wait ends first', () {
+        fakeAsync((async) {
+          final messages = reconnectAndReset(
+            async,
+            outcome: ForceReconnectOutcome.stillDialling,
+            connected: 0,
+          );
+
+          expect(
+            messages,
+            contains(
+              'Relay reconnect wait ended with relays still connecting '
+              '(0 of 2 connected); resetting feeds, and relays that connect '
+              'later receive the subscriptions then',
+            ),
+          );
+          expect(
+            messages,
+            isNot(contains('Successfully reconnected all relay WebSockets')),
+          );
+          verify(
+            () => mockVideoEventService.resetAndResubscribeAll(),
+          ).called(1);
+        });
       });
     });
 
@@ -505,6 +598,7 @@ void main() {
           (_) async => ForceReconnectOutcome.completed,
         );
 
+        stubRelayCounts(replacementClient);
         final swappableService = SwappableNostrService(mockNostrClient);
         final container = ProviderContainer(
           overrides: [
@@ -638,6 +732,7 @@ void main() {
             (_) async => ForceReconnectOutcome.completed,
           );
 
+          stubRelayCounts(replacementClient);
           final swappableService = SwappableNostrService(mockNostrClient);
           final container = ProviderContainer(
             overrides: [

--- a/mobile/test/unit/providers/relay_set_change_bridge_test.dart
+++ b/mobile/test/unit/providers/relay_set_change_bridge_test.dart
@@ -81,7 +81,9 @@ void main() {
         () => mockVideoEventService.resetAndResubscribeAll(),
       ).thenAnswer((_) async {});
       when(() => mockNostrClient.isInitialized).thenReturn(true);
-      when(() => mockNostrClient.forceReconnectAll()).thenAnswer((_) async {});
+      when(() => mockNostrClient.forceReconnectAll()).thenAnswer(
+        (_) async => ForceReconnectOutcome.completed,
+      );
       when(() => mockNostrClient.defaultRelayUrl).thenReturn(defaultRelay);
       when(() => mockNostrClient.publicKey).thenAnswer((_) => clientPublicKey);
       stubUserRemovedRelays(mockNostrClient);
@@ -499,7 +501,9 @@ void main() {
           final relay = call.positionalArguments.single as String;
           return replacementRelays.remove(relay);
         });
-        when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
+        when(replacementClient.forceReconnectAll).thenAnswer(
+          (_) async => ForceReconnectOutcome.completed,
+        );
 
         final swappableService = SwappableNostrService(mockNostrClient);
         final container = ProviderContainer(
@@ -630,7 +634,9 @@ void main() {
             final relay = call.positionalArguments.single as String;
             return replacementRelays.remove(relay);
           });
-          when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
+          when(replacementClient.forceReconnectAll).thenAnswer(
+            (_) async => ForceReconnectOutcome.completed,
+          );
 
           final swappableService = SwappableNostrService(mockNostrClient);
           final container = ProviderContainer(
@@ -746,7 +752,9 @@ void main() {
             source: any(named: 'source'),
           ),
         ).thenAnswer((_) async => true);
-        when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
+        when(replacementClient.forceReconnectAll).thenAnswer(
+          (_) async => ForceReconnectOutcome.completed,
+        );
 
         final swappableService = SwappableNostrService(mockNostrClient);
         final container = ProviderContainer(
@@ -832,7 +840,9 @@ void main() {
             source: any(named: 'source'),
           ),
         ).thenAnswer((_) async => true);
-        when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
+        when(replacementClient.forceReconnectAll).thenAnswer(
+          (_) async => ForceReconnectOutcome.completed,
+        );
 
         final swappableService = SwappableNostrService(mockNostrClient);
         final container = ProviderContainer(
@@ -935,7 +945,9 @@ void main() {
           );
           return 1;
         });
-        when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
+        when(replacementClient.forceReconnectAll).thenAnswer(
+          (_) async => ForceReconnectOutcome.completed,
+        );
 
         final swappableService = SwappableNostrService(mockNostrClient);
         final container = ProviderContainer(
@@ -1027,7 +1039,9 @@ void main() {
             final relay = call.positionalArguments.single as String;
             return replacementRelays.remove(relay);
           });
-          when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
+          when(replacementClient.forceReconnectAll).thenAnswer(
+            (_) async => ForceReconnectOutcome.completed,
+          );
 
           final swappableService = SwappableNostrService(mockNostrClient);
           final container = ProviderContainer(
@@ -1112,7 +1126,9 @@ void main() {
           );
           return 1;
         });
-        when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
+        when(replacementClient.forceReconnectAll).thenAnswer(
+          (_) async => ForceReconnectOutcome.completed,
+        );
 
         final swappableService = SwappableNostrService(mockNostrClient);
         final container = ProviderContainer(
@@ -1200,7 +1216,9 @@ void main() {
           if (removeAttempts == 1) return false;
           return replacementRelays.remove(removedRelay);
         });
-        when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
+        when(replacementClient.forceReconnectAll).thenAnswer(
+          (_) async => ForceReconnectOutcome.completed,
+        );
 
         final swappableService = SwappableNostrService(mockNostrClient);
         final container = ProviderContainer(
@@ -1411,7 +1429,9 @@ void main() {
         for (final client in [firstReplacement, secondReplacement]) {
           when(() => client.isInitialized).thenReturn(true);
           stubClientScope(client);
-          when(client.forceReconnectAll).thenAnswer((_) async {});
+          when(client.forceReconnectAll).thenAnswer(
+            (_) async => ForceReconnectOutcome.completed,
+          );
         }
         when(() => firstReplacement.relayStatuses).thenAnswer(
           (_) => {

--- a/mobile/test/widgets/app_lifecycle_handler_test.dart
+++ b/mobile/test/widgets/app_lifecycle_handler_test.dart
@@ -8,12 +8,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_publish/video_publish_provider_state.dart';
 import 'package:openvine/notifications/services/notification_refresh_coordinator.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/services/app_badge_service.dart';
@@ -22,8 +24,11 @@ import 'package:openvine/services/background_activity_manager.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/widgets/app_lifecycle_handler.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
 
 class _MockClipLibraryService extends Mock implements ClipLibraryService {}
 
@@ -295,6 +300,110 @@ void main() {
       expect(container.read(appForegroundProvider), isTrue);
       expect(appBadgeClearer.clearCalls, 2);
       await tester.pump(const Duration(seconds: 31));
+    });
+  });
+
+  group('relay reconnect on resume', () {
+    Future<List<String>> resumeLogs(
+      WidgetTester tester, {
+      required ForceReconnectOutcome outcome,
+      required int connected,
+    }) async {
+      final authService = _MockAuthService();
+      addTearDown(() {
+        BackgroundActivityManager().onAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+      });
+      when(() => authService.isAuthenticated).thenReturn(true);
+      when(
+        () => authService.authStateStream,
+      ).thenAnswer((_) => const Stream<AuthState>.empty());
+      final clipLibraryService = _MockClipLibraryService();
+      when(clipLibraryService.migrateOldClips).thenAnswer((_) async {});
+      when(clipLibraryService.purgeExpiredTrash).thenAnswer((_) async => 0);
+      final draftStorageService = _MockDraftStorageService();
+      when(draftStorageService.migrateOldDrafts).thenAnswer((_) async {});
+      final nostrClient = _MockNostrClient();
+      when(nostrClient.forceReconnectAll).thenAnswer((_) async => outcome);
+      when(() => nostrClient.connectedRelayCount).thenReturn(connected);
+      when(() => nostrClient.configuredRelayCount).thenReturn(2);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            appBadgeServiceProvider.overrideWithValue(
+              _CountingAppBadgeClearer(),
+            ),
+            authServiceProvider.overrideWithValue(authService),
+            notificationRefreshCoordinatorProvider.overrideWithValue(null),
+            videoPublishProvider.overrideWith(_NoopVideoPublishNotifier.new),
+            clipLibraryServiceProvider.overrideWithValue(clipLibraryService),
+            draftStorageServiceProvider.overrideWithValue(draftStorageService),
+            nostrServiceProvider.overrideWithValue(nostrClient),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: AppLifecycleHandler(child: SizedBox.shrink()),
+          ),
+        ),
+      );
+      await tester.pump();
+      unawaited(LogCaptureService().clearAllLogs());
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+
+      verify(nostrClient.forceReconnectAll).called(1);
+      final messages = [
+        for (final entry in LogCaptureService().getRecentLogs()) entry.message,
+      ];
+      await tester.pump(const Duration(seconds: 31));
+      return messages;
+    }
+
+    testWidgets('logs how many relays connected when the reconnect '
+        'finishes', (tester) async {
+      final messages = await resumeLogs(
+        tester,
+        outcome: ForceReconnectOutcome.completed,
+        connected: 1,
+      );
+
+      expect(
+        messages,
+        contains(
+          '📱 Relay reconnect after app resume finished: 1 of 2 relays '
+          'connected',
+        ),
+      );
+      expect(
+        messages,
+        isNot(contains('📱 Relay connections restored after app resume')),
+      );
+    });
+
+    testWidgets('says relays are still connecting when the wait ends '
+        'first', (tester) async {
+      final messages = await resumeLogs(
+        tester,
+        outcome: ForceReconnectOutcome.stillDialling,
+        connected: 0,
+      );
+
+      expect(
+        messages,
+        contains(
+          '📱 Relay reconnect after app resume ended with relays still '
+          'connecting (0 of 2 connected)',
+        ),
+      );
+      expect(
+        messages,
+        isNot(contains('📱 Relay connections restored after app resume')),
+      );
     });
   });
 }


### PR DESCRIPTION
## Description

**The problem.** Two things tore down healthy relay connections at the moments the app needs them most.

- About two seconds after every launch and every sign-in, the app dropped every relay connection and reconnected, although the network never changed (#8990).
- While a relay was still connecting at startup, the app decided it was dead, opened a second connection to the same relay, threw the first away, and logged a connection failure that never happened (#8991).

Each teardown discards whatever was in flight on that socket — a publish's `OK`, a query's end-of-results marker — which is one of the ways a publish the relay accepted gets reported as "no response" (#8380).

**Why it happened, and what changes.**

*The two-second reconnect.* The connectivity listener was rebuilt whenever the Nostr client was, and `connectivity_plus` reports the current state to a new listener. That report looked like "the network came back", so two seconds later the app reconnected everything. A correction to #8990's wording: the plugin only replays to its first listener, so this hit at launch and at sign-in, when the relay listener was the only one — not on every client rebuild.

Now one app-wide owner, `ConnectivityTransitionMonitor` (hosted by `connectivityRelayReconnectProvider`), subscribes once and never rebuilds. It repairs the relay pool only on a real change: offline → online, or a switch of network interface while online — the rule #6046 already used for DM retries. It takes its starting point from `checkConnectivity()`, or from the first report if that arrives sooner, waits 2 s so a burst of reports becomes one repair, waits while the client is still starting up, and reconnects whichever client is current when it fires. Each repair is capped at 15 s and re-runs once if the network changes again mid-repair. Going offline is reported at once.

*Two reconnects per network change.* The DM retry sweep also force-reconnected the pool whenever the network came back or switched interface, so a real change reconnected the pool twice, and the second teardown could land in the middle of the sweep. The DM sweep now runs on the owner's transitions instead: `offline` at once (its offline pass still marks unconfirmed messages as failed), `online` after the owner's single repair attempt.

*The double dial.* The relay manager's retry sweep treated "not connected yet" the same as "unhealthy", so it redialled a relay that was still connecting and disposed the first socket mid-handshake. Now each relay has at most one connection attempt at a time: startup, adding a relay and the retry sweep share it. The health check leaves a socket that is still connecting alone; connected-but-idle and stale disconnected sockets are still redialled, as before (#7355). `reconnectRelay` and `forceReconnectAll` replace an attempt in flight rather than racing it, and removing a relay releases anyone waiting on its attempt.

*`forceReconnectAll`.* It removed every relay and then redialled them one at a time, so each relay counted as disconnected until its turn came, and every publish, query or subscribe in that window started a retry sweep that fought the cycle. It now redials every relay in parallel, and concurrent callers share one cycle. Callers stop waiting after 15 s, the same budget the retry sweep uses; a call after that starts a fresh cycle, which replaces any attempt still hanging. A relay removed mid-cycle is no longer re-added.

*What a caller is told.* Because that wait can end while connections are still being made, the call reports which of the two happened: every dial finished, or the wait ran out with dials still running (those keep going either way). A caller that joins a cycle already under way is released at that cycle's original deadline and hears the same answer. Retry on the Relays screen uses it to say the relays are still connecting instead of reporting a failure, and the relay-set, app-resume and connectivity-repair logs now name the outcome and how many relays connected.

**Related Issue:** Closes #8990. Closes #8991. Part of #8295.

## Out of Scope

- The profile-save and DM-reaction retries keep their current connectivity trigger. They don't reconnect the pool, so they don't cause the double reconnect; moving them onto the owner's transitions would be a separate change.
- Publish outcomes when a relay's `OK` arrives late or is lost (#8380) — separate PR.
- The kind-30005 list sync that still waits for its 10 s timeout after the relay has answered (visible in the device logs) is #8989.
- Dismissing an iOS system alert, such as the notification-permission prompt, still makes the app reconnect every relay: the app-lifecycle handler treats every return to the foreground state as a resume from background. That trigger predates this change and isn't touched by it (#9028); it shows up once in the sign-in run below.

**Behaviour that changes on purpose:**

- After a real network change, the DM retry sweep starts about 2 s plus the repair later. Before, it started at once, but the pool was torn down again 2 s later, mid-sweep. It no longer runs on the report the plugin replays at subscription, or on duplicate reports; the cold-start sweep still comes from the app-foreground trigger.
- App resume, the relay-set change bridge and the Relays screen's retry now join a `forceReconnectAll` cycle already in flight, and stop waiting after 15 s.
- Retry on the Relays screen: when the wait ends with nothing connected but connections still being made, it now says "Still connecting to relays. Give it a moment." instead of "Failed to connect to relays." It still reports the relays that are already connected, and still shows the failure message once every attempt has finished without one.
- Three log lines change wording: the relay-set reset no longer claims "Successfully reconnected all relay WebSockets", and it, the app-resume handler and the connectivity repair now record which outcome happened and how many relays connected.

## Verification

Unit tests — new behaviour was written test-first and watched fail; guards that already existed are proven by mutation instead (removing the guard fails its test):

- `nostr_client` — `relay_manager_test.dart` 155/155 (one dial per relay, the health check, the force-reconnect cycle, its logging and its outcome; the old "removed twice" assertions now say "replaced once"). Whole package 396/396.
- App — 1236 tests across the touched suites: `connectivity_transition_monitor_test.dart` (17, new), `relay_providers_test.dart` (new owner plus its repair logs), `relay_settings_cubit_test.dart`, `relay_settings_screen_layout_test.dart`, `relay_set_change_bridge_test.dart`, `app_lifecycle_handler_test.dart`, `social_providers_relay_repair_test.dart` (rewritten: the DM sweep runs once per transition and never reconnects the pool itself), `app_side_effects_test.dart`, and the l10n suite.
- The deadline is timed with `package:clock`, as `WebSocketConnectionManager` already times its send deadline, so a test can hold a joining caller to the deadline of the cycle it joined — `fakeAsync` cannot move `DateTime.now()`.
- Mutation checks — each of these guards, removed, fails the test that pins it: the health check's and the sweep's "still connecting" skips, the in-flight skip, the 15 s release, supersede, the dial's error path and its "replaced attempt" check; the wall clock in place of `clock.now()`; in the Relays screen, the still-connecting note removed, and the cubit checking the outcome before the connected count; in the relay-set reset, skipping the feed reset and restoring the old success line; in the resume and connectivity-repair logs, each old fixed line restored; in the monitor, "only real changes", "online after the last repair", "offline cancels a pending repair", stopping after dispose, and a slow seed not overwriting the first report; in the provider, re-watching the client (the #8990 shape) and capturing it at build time; in the DM row, reconnecting the pool again.
- `flutter analyze lib test integration_test` clean; `dart analyze --fatal-infos` clean on `nostr_client`; the CI-only ratchet scripts pass, including on a local merge with current `main`.

On a device — iOS 26.5 Simulator, local relay stack, a frame-logging proxy in front of the relay:

| | Before (`main`) | After (this branch) |
|---|---|---|
| Relaunch: reconnect after the client is created | every relay dropped and reopened 2.0–2.09 s later (3 of 3 runs) | none in 45 s |
| Relaunch: connections to the pool relay | two opened 0.9 ms apart; the first closed 22 ms later and logged as a failure | one; it carried the list query's EOSE 39 ms after the request and stayed open |
| Relaunch with the relay's handshake held 1.5 s, same data and build flags | a retry sweep marked the still-connecting relay dead 26 ms into the dial and dialled again; three sockets in 3.4 s — the first closed as "failed", the second torn down by the 2 s reconnect | one socket; no relay marked dead; no reconnect |
| App resume with the handshake held 20 s, so resume traffic starts a retry sweep mid-dial | the sweep marked the relay dead 48 ms into the reconnect and dialled a second socket (two held connections, 4 ms apart) | one connection, no relay marked dead; the dial failed at 12 s and the log recorded "0 of 1 relays connected" |
| First sign-in on a fresh install | the relay marked dead mid-dial and dialled twice; every relay dropped and reopened 2.0 s after sign-in | one connection, which carried the account's subscriptions; no connectivity reconnect at sign-in or at the signed-out start |
| Retry on the Relays screen | — | relay reachable: "Connected to 1 relay!"; handshake held 20 s: "Failed to connect to relays…" once the dial had actually failed |

Sign-in and resume were re-run on this branch's head. In the sign-in run the one reconnect came 0.4 s after the notification prompt was dismissed — the lifecycle trigger noted under Out of Scope (#9028) — and it logged "1 of 1 relays connected".

The new "still connecting" message needs a dial that outlasts the 15 s budget, and a single dial is bounded at about 12 s (a 10 s handshake timeout plus the orphan close), so two scenarios ran on a build identical to this branch apart from one uncommitted line shortening the budget to 5 s: Retry with the handshake held 7 s showed the message 5 s in and then connected; and a Retry tapped 2.06 s into a resume cycle joined that cycle — no second cycle, no second socket — with both callers released together at the cycle's own deadline and the held dial still running afterwards.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
