### PR TITLE
fix(perf): keep concurrent feed timings accurate

### DIFF
--- a/mobile/docs/FEED_INTERACTIVE_LATENCY.md
+++ b/mobile/docs/FEED_INTERACTIVE_LATENCY.md
@@ -33,6 +33,12 @@ location fields to this event contract.
 `feed_load_complete` remains emitted for dashboard compatibility. Its duration
 now ends at the fresh result; new analysis should use the phase-specific event.
 
+Each accepted load owns an independent telemetry session, including concurrent
+loads for the same feed type. A superseded, cancelled, failed, or disposed load
+is abandoned without a completion event, so `feed_load_started` and completion
+counts are deliberately not one-to-one. Compare phase latency only across
+completed loads, and monitor the completion ratio separately.
+
 ## Initial service target
 
 For each feed type, initiation reason, cache state, platform, and coarse region:

--- a/mobile/lib/blocs/hashtag_search/hashtag_search_bloc.dart
+++ b/mobile/lib/blocs/hashtag_search/hashtag_search_bloc.dart
@@ -98,7 +98,7 @@ class HashtagSearchBloc extends Bloc<HashtagSearchEvent, HashtagSearchState> {
       ),
     );
 
-    _feedTracker?.startFeedLoad('hashtag_search');
+    final feedLoad = _feedTracker?.startFeedLoad('hashtag_search');
 
     try {
       final results = await _hashtagRepository.searchHashtags(
@@ -106,7 +106,9 @@ class HashtagSearchBloc extends Bloc<HashtagSearchEvent, HashtagSearchState> {
         limit: _pageSize,
       );
 
-      _feedTracker?.markFirstVideosReceived('hashtag_search', results.length);
+      if (feedLoad != null) {
+        _feedTracker?.markFirstVideosReceived(feedLoad, results.length);
+      }
 
       emit(
         state.copyWith(
@@ -119,7 +121,9 @@ class HashtagSearchBloc extends Bloc<HashtagSearchEvent, HashtagSearchState> {
         ),
       );
 
-      _feedTracker?.markFeedDisplayed('hashtag_search', results.length);
+      if (feedLoad != null) {
+        _feedTracker?.markFeedDisplayed(feedLoad, results.length);
+      }
     } on Exception catch (e) {
       // Defensive: repository.searchHashtags should never throw per its
       // contract, but we guard against unexpected violations to avoid
@@ -130,6 +134,8 @@ class HashtagSearchBloc extends Bloc<HashtagSearchEvent, HashtagSearchState> {
         errorMessage: e.toString(),
       );
       emit(state.copyWith(status: HashtagSearchStatus.failure));
+    } finally {
+      if (feedLoad != null) _feedTracker?.abandonFeedLoad(feedLoad);
     }
   }
 

--- a/mobile/lib/blocs/user_search/user_search_bloc.dart
+++ b/mobile/lib/blocs/user_search/user_search_bloc.dart
@@ -118,7 +118,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
       ),
     );
 
-    _feedTracker?.startFeedLoad('user_search');
+    final feedLoad = _feedTracker?.startFeedLoad('user_search');
     var trackedFirst = false;
     var latestUnfilteredCount = 0;
     int? nextRestOffset;
@@ -174,10 +174,12 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
           final visibleProfiles = _visibleProfiles(result.profiles);
           if (!trackedFirst && visibleProfiles.isNotEmpty) {
             trackedFirst = true;
-            _feedTracker?.markFirstVideosReceived(
-              'user_search',
-              visibleProfiles.length,
-            );
+            if (feedLoad != null) {
+              _feedTracker?.markFirstVideosReceived(
+                feedLoad,
+                visibleProfiles.length,
+              );
+            }
           }
           for (final entry in result.sources.entries) {
             if (entry.value is! SearchSourcePending &&
@@ -210,7 +212,9 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
         ),
       );
 
-      _feedTracker?.markFeedDisplayed('user_search', state.results.length);
+      if (feedLoad != null) {
+        _feedTracker?.markFeedDisplayed(feedLoad, state.results.length);
+      }
       reachedTerminalState = true;
     } on TimeoutException {
       // Outer stream timed out. Promote every source still in pending
@@ -260,6 +264,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
       emit(state.copyWith(status: UserSearchStatus.failure));
       reachedTerminalState = true;
     } finally {
+      if (feedLoad != null) _feedTracker?.abandonFeedLoad(feedLoad);
       cancellationToken.cancel();
       Log.debug(
         '${cancellationToken.correlationId} '

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -245,13 +245,13 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       ),
     );
 
-    _feedTracker?.startFeedLoad(source.mode.name);
+    final feedLoad = _feedTracker?.startFeedLoad(source.mode.name);
 
     final initialFollowingPubkeys = List<String>.unmodifiable(
       _followRepository.followingPubkeys,
     );
 
-    await _loadVideos(source, emit, revalidate: true);
+    await _loadVideos(source, emit, feedLoad: feedLoad, revalidate: true);
     if (emit.isDone) return;
 
     // After the initial load, check for the "no follows" CTA. Needed for
@@ -348,7 +348,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       return;
     }
 
-    _feedTracker?.startFeedLoad(
+    final feedLoad = _feedTracker?.startFeedLoad(
       source.mode.name,
       reason: FeedLoadReason.sourceSwitch,
     );
@@ -370,7 +370,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       ),
     );
 
-    await _loadVideos(source, emit, revalidate: true);
+    await _loadVideos(source, emit, feedLoad: feedLoad, revalidate: true);
   }
 
   bool _listsEqual(List<String> a, List<String> b) {
@@ -402,7 +402,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     }
 
     final source = state.source;
-    _feedTracker?.startFeedLoad(
+    final feedLoad = _feedTracker?.startFeedLoad(
       source.mode.name,
       reason: FeedLoadReason.pagination,
     );
@@ -480,18 +480,22 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       );
 
       if (updatedVideos.isNotEmpty) {
-        _feedTracker?.markFirstVisibleContent(
-          source.mode.name,
+        if (feedLoad != null) {
+          _feedTracker?.markFirstVisibleContent(
+            feedLoad,
+            updatedVideos.length,
+            servedFromCache: false,
+          );
+        }
+      }
+      if (feedLoad != null) {
+        _feedTracker?.markFreshResultCompleted(
+          feedLoad,
           updatedVideos.length,
-          servedFromCache: false,
+          recommendationPageCount: result.recommendationPageCount,
+          followingPageCount: result.followingPageCount,
         );
       }
-      _feedTracker?.markFreshResultCompleted(
-        source.mode.name,
-        updatedVideos.length,
-        recommendationPageCount: result.recommendationPageCount,
-        followingPageCount: result.followingPageCount,
-      );
 
       _scheduleNostrEnrichment(source: source, videos: updatedVideos);
 
@@ -510,6 +514,8 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         category: LogCategory.video,
       );
       emit(state.copyWith(isLoadingMore: false));
+    } finally {
+      if (feedLoad != null) _feedTracker?.abandonFeedLoad(feedLoad);
     }
   }
 
@@ -518,7 +524,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     VideoFeedRefreshRequested event,
     Emitter<VideoFeedBlocState> emit,
   ) async {
-    _feedTracker?.startFeedLoad(
+    final feedLoad = _feedTracker?.startFeedLoad(
       state.source.mode.name,
       reason: FeedLoadReason.refresh,
     );
@@ -536,7 +542,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       ),
     );
 
-    await _loadVideos(state.source, emit, skipCache: true);
+    await _loadVideos(state.source, emit, feedLoad: feedLoad, skipCache: true);
   }
 
   /// Handle auto-refresh request (dispatched by UI on app resume).
@@ -580,7 +586,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       ),
     );
 
-    _feedTracker?.startFeedLoad(
+    final feedLoad = _feedTracker?.startFeedLoad(
       state.source.mode.name,
       reason: FeedLoadReason.refresh,
     );
@@ -588,6 +594,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     await _loadVideos(
       state.source,
       emit,
+      feedLoad: feedLoad,
       skipCache: state.source.type != VideoFeedSourceType.newVideos,
       revalidate: state.source.type == VideoFeedSourceType.newVideos,
     );
@@ -626,11 +633,11 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     }
 
     // Silent refresh — keep current videos visible, replace when done.
-    _feedTracker?.startFeedLoad(
+    final feedLoad = _feedTracker?.startFeedLoad(
       state.source.mode.name,
       reason: FeedLoadReason.refresh,
     );
-    await _loadVideos(state.source, emit, skipCache: true);
+    await _loadVideos(state.source, emit, feedLoad: feedLoad, skipCache: true);
   }
 
   /// Handle curated list subscription changes from [CuratedListRepository].
@@ -683,12 +690,12 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       ),
     );
 
-    _feedTracker?.startFeedLoad(
+    final feedLoad = _feedTracker?.startFeedLoad(
       nextSource.mode.name,
       reason: FeedLoadReason.refresh,
     );
 
-    await _loadVideos(nextSource, emit, skipCache: true);
+    await _loadVideos(nextSource, emit, feedLoad: feedLoad, skipCache: true);
   }
 
   /// Handle blocklist changes.
@@ -738,13 +745,19 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   Future<void> _loadVideos(
     VideoFeedSource source,
     Emitter<VideoFeedBlocState> emit, {
+    FeedLoadHandle? feedLoad,
     bool skipCache = false,
     bool revalidate = false,
   }) async {
-    final servedCache = await _maybeServeCachedFeed(source, emit, skipCache);
-    if (!_canEmitForSource(source, emit)) return;
-
     try {
+      final servedCache = await _maybeServeCachedFeed(
+        source,
+        emit,
+        skipCache,
+        feedLoad,
+      );
+      if (!_canEmitForSource(source, emit)) return;
+
       // `revalidate` serves the cached window *and* forces a fresh fetch.
       // `skipCache` alone cannot express that: it also suppresses the served
       // window, which would blank the screen, and at the repository layer it
@@ -780,10 +793,9 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
             )
           : validVideos;
 
-      _feedTracker?.markFirstVideosReceived(
-        source.mode.name,
-        displayedVideos.length,
-      );
+      if (feedLoad != null) {
+        _feedTracker?.markFirstVideosReceived(feedLoad, displayedVideos.length);
+      }
       emit(
         state.copyWith(
           status: VideoFeedStatus.success,
@@ -806,21 +818,25 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       );
 
       if (!servedCache && displayedVideos.isNotEmpty) {
-        _feedTracker?.markFirstVisibleContent(
-          source.mode.name,
-          displayedVideos.length,
-          servedFromCache: false,
-        );
+        if (feedLoad != null) {
+          _feedTracker?.markFirstVisibleContent(
+            feedLoad,
+            displayedVideos.length,
+            servedFromCache: false,
+          );
+        }
       }
 
       _scheduleNostrEnrichment(source: source, videos: displayedVideos);
 
-      _feedTracker?.markFreshResultCompleted(
-        source.mode.name,
-        displayedVideos.length,
-        recommendationPageCount: result.recommendationPageCount,
-        followingPageCount: result.followingPageCount,
-      );
+      if (feedLoad != null) {
+        _feedTracker?.markFreshResultCompleted(
+          feedLoad,
+          displayedVideos.length,
+          recommendationPageCount: result.recommendationPageCount,
+          followingPageCount: result.followingPageCount,
+        );
+      }
 
       // Batch-fetch creator profiles to warm the Drift cache.
       await _fetchCreatorProfiles(validVideos, source, emit);
@@ -861,6 +877,8 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
           ),
         );
       }
+    } finally {
+      if (feedLoad != null) _feedTracker?.abandonFeedLoad(feedLoad);
     }
   }
 
@@ -873,6 +891,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     VideoFeedSource source,
     Emitter<VideoFeedBlocState> emit,
     bool skipCache,
+    FeedLoadHandle? feedLoad,
   ) async {
     if (skipCache || !_serveCachedHomeFeed || !_usesHomeFeedCache(source)) {
       return false;
@@ -888,7 +907,9 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
 
     // The cached window already starts at the resume position (already-watched
     // videos were dropped on write), so it is served at index 0.
-    _feedTracker?.markFirstVideosReceived(mode, cachedValid.length);
+    if (feedLoad != null) {
+      _feedTracker?.markFirstVideosReceived(feedLoad, cachedValid.length);
+    }
     emit(
       state.copyWith(
         status: VideoFeedStatus.success,
@@ -899,11 +920,13 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         clearError: true,
       ),
     );
-    _feedTracker?.markFirstVisibleContent(
-      mode,
-      cachedValid.length,
-      servedFromCache: true,
-    );
+    if (feedLoad != null) {
+      _feedTracker?.markFirstVisibleContent(
+        feedLoad,
+        cachedValid.length,
+        servedFromCache: true,
+      );
+    }
     // Advance the resume point immediately so a quick reopen (before the fresh
     // fetch lands and the load-time write runs) still opens on the next video
     // rather than this one again.

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Profile screen for viewing other users with bottom navigation
 // ABOUTME: Pushed on stack from video feeds, profiles, search results, etc.
 
+import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter/material.dart';
@@ -161,11 +162,14 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
 
   /// Whether the profile feed load has been tracked.
   bool _hasTrackedFeedLoad = false;
+  late final FeedPerformanceTracker _feedTracker;
+  late final FeedLoadHandle _feedLoad;
 
   @override
   void initState() {
     super.initState();
-    ref.read(feedPerformanceTrackerProvider).startFeedLoad('profile');
+    _feedTracker = ref.read(feedPerformanceTrackerProvider);
+    _feedLoad = _feedTracker.startFeedLoad('profile');
     // The feed cubit cold-loads on mount (via ProfileFeedScope below); reading
     // it here would be a cross-route ProviderNotFoundException because the
     // cubit lives under build.
@@ -173,6 +177,7 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
 
   @override
   void dispose() {
+    _feedTracker.abandonFeedLoad(_feedLoad);
     _scrollController.dispose();
     _refreshNotifier.dispose();
     super.dispose();
@@ -435,9 +440,8 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
             if (!_hasTrackedFeedLoad) {
               _hasTrackedFeedLoad = true;
               final count = feedState.videos.length;
-              final tracker = ref.read(feedPerformanceTrackerProvider);
-              tracker.markFirstVideosReceived('profile', count);
-              tracker.markFeedDisplayed('profile', count);
+              _feedTracker.markFirstVideosReceived(_feedLoad, count);
+              _feedTracker.markFeedDisplayed(_feedLoad, count);
             }
           }
 

--- a/mobile/lib/widgets/classic_vines_tab.dart
+++ b/mobile/lib/widgets/classic_vines_tab.dart
@@ -46,6 +46,7 @@ class ClassicVinesTab extends ConsumerStatefulWidget {
 class _ClassicVinesTabState extends ConsumerState<ClassicVinesTab> {
   late final FeedPerformanceTracker? _feedTracker;
   DateTime? _feedLoadStartTime;
+  FeedLoadHandle? _feedLoad;
 
   @override
   void initState() {
@@ -82,7 +83,7 @@ class _ClassicVinesTabState extends ConsumerState<ClassicVinesTab> {
     // Track feed loading start
     if (classicVinesAsync.isLoading && _feedLoadStartTime == null) {
       _feedLoadStartTime = DateTime.now();
-      _feedTracker?.startFeedLoad('classics');
+      _feedLoad = _feedTracker?.startFeedLoad('classics');
     }
 
     // Check hasValue FIRST before isLoading
@@ -96,6 +97,9 @@ class _ClassicVinesTabState extends ConsumerState<ClassicVinesTab> {
         errorType: 'load_failed',
         errorMessage: classicVinesAsync.error.toString(),
       );
+      final feedLoad = _feedLoad;
+      if (feedLoad != null) _feedTracker?.abandonFeedLoad(feedLoad);
+      _feedLoad = null;
       _feedLoadStartTime = null;
       return RefreshableFeedStateView(
         onRefresh: _refreshClassics,
@@ -120,8 +124,12 @@ class _ClassicVinesTabState extends ConsumerState<ClassicVinesTab> {
 
     // Track feed loaded with videos
     if (_feedLoadStartTime != null) {
-      _feedTracker?.markFirstVideosReceived('classics', videos.length);
-      _feedTracker?.markFeedDisplayed('classics', videos.length);
+      final feedLoad = _feedLoad;
+      if (feedLoad != null) {
+        _feedTracker?.markFirstVideosReceived(feedLoad, videos.length);
+        _feedTracker?.markFeedDisplayed(feedLoad, videos.length);
+      }
+      _feedLoad = null;
       _feedLoadStartTime = null;
     }
 
@@ -153,6 +161,13 @@ class _ClassicVinesTabState extends ConsumerState<ClassicVinesTab> {
     await ref.read(classicVinesAvailableProvider.future);
     if (!mounted) return;
     await ref.read(classicVinesFeedProvider.notifier).refresh();
+  }
+
+  @override
+  void dispose() {
+    final feedLoad = _feedLoad;
+    if (feedLoad != null) _feedTracker?.abandonFeedLoad(feedLoad);
+    super.dispose();
   }
 }
 

--- a/mobile/lib/widgets/for_you_tab.dart
+++ b/mobile/lib/widgets/for_you_tab.dart
@@ -41,6 +41,7 @@ class ForYouTab extends ConsumerStatefulWidget {
 class _ForYouTabState extends ConsumerState<ForYouTab> {
   late final FeedPerformanceTracker? _feedTracker;
   DateTime? _feedLoadStartTime;
+  FeedLoadHandle? _feedLoad;
 
   @override
   void initState() {
@@ -73,7 +74,7 @@ class _ForYouTabState extends ConsumerState<ForYouTab> {
     // Track feed loading start
     if (forYouAsync.isLoading && _feedLoadStartTime == null) {
       _feedLoadStartTime = DateTime.now();
-      _feedTracker?.startFeedLoad('for_you');
+      _feedLoad = _feedTracker?.startFeedLoad('for_you');
     }
 
     // Check hasValue FIRST before isLoading
@@ -87,6 +88,9 @@ class _ForYouTabState extends ConsumerState<ForYouTab> {
         errorType: 'load_failed',
         errorMessage: forYouAsync.error.toString(),
       );
+      final feedLoad = _feedLoad;
+      if (feedLoad != null) _feedTracker?.abandonFeedLoad(feedLoad);
+      _feedLoad = null;
       _feedLoadStartTime = null;
       return RefreshableFeedStateView(
         onRefresh: _refreshForYou,
@@ -109,8 +113,12 @@ class _ForYouTabState extends ConsumerState<ForYouTab> {
 
     // Track feed loaded with videos
     if (_feedLoadStartTime != null) {
-      _feedTracker?.markFirstVideosReceived('for_you', videos.length);
-      _feedTracker?.markFeedDisplayed('for_you', videos.length);
+      final feedLoad = _feedLoad;
+      if (feedLoad != null) {
+        _feedTracker?.markFirstVideosReceived(feedLoad, videos.length);
+        _feedTracker?.markFeedDisplayed(feedLoad, videos.length);
+      }
+      _feedLoad = null;
       _feedLoadStartTime = null;
     }
 
@@ -129,6 +137,13 @@ class _ForYouTabState extends ConsumerState<ForYouTab> {
     ref.read(funnelcakeAvailableProvider.notifier).refresh();
     await ref.read(funnelcakeAvailableProvider.future);
     await ref.read(forYouFeedProvider.notifier).refresh();
+  }
+
+  @override
+  void dispose() {
+    final feedLoad = _feedLoad;
+    if (feedLoad != null) _feedTracker?.abandonFeedLoad(feedLoad);
+    super.dispose();
   }
 }
 

--- a/mobile/lib/widgets/new_videos_tab.dart
+++ b/mobile/lib/widgets/new_videos_tab.dart
@@ -49,6 +49,7 @@ class _NewVideosTabState extends ConsumerState<NewVideosTab> {
   late final FeedPerformanceTracker _feedTracker;
   late final ErrorAnalyticsTracker _errorTracker;
   DateTime? _feedLoadStartTime;
+  FeedLoadHandle? _feedLoad;
 
   @override
   void initState() {
@@ -75,7 +76,7 @@ class _NewVideosTabState extends ConsumerState<NewVideosTab> {
     // Track feed loading start
     if (newVideosAsync.isLoading && _feedLoadStartTime == null) {
       _feedLoadStartTime = DateTime.now();
-      _feedTracker.startFeedLoad('new_vines');
+      _feedLoad = _feedTracker.startFeedLoad('new_vines');
     }
 
     // CRITICAL: Check hasValue FIRST before isLoading
@@ -96,8 +97,12 @@ class _NewVideosTabState extends ConsumerState<NewVideosTab> {
 
       // Track feed loaded with videos
       if (_feedLoadStartTime != null) {
-        _feedTracker.markFirstVideosReceived('new_vines', videos.length);
-        _feedTracker.markFeedDisplayed('new_vines', videos.length);
+        final feedLoad = _feedLoad;
+        if (feedLoad != null) {
+          _feedTracker.markFirstVideosReceived(feedLoad, videos.length);
+          _feedTracker.markFeedDisplayed(feedLoad, videos.length);
+        }
+        _feedLoad = null;
         _screenAnalytics.markDataLoaded(
           'explore_screen',
           dataMetrics: {'tab': 'new_vines', 'video_count': videos.length},
@@ -181,7 +186,17 @@ class _NewVideosTabState extends ConsumerState<NewVideosTab> {
       errorMessage: error.toString(),
       loadTimeMs: loadTime,
     );
+    final feedLoad = _feedLoad;
+    if (feedLoad != null) _feedTracker.abandonFeedLoad(feedLoad);
+    _feedLoad = null;
     _feedLoadStartTime = null;
+  }
+
+  @override
+  void dispose() {
+    final feedLoad = _feedLoad;
+    if (feedLoad != null) _feedTracker.abandonFeedLoad(feedLoad);
+    super.dispose();
   }
 }
 

--- a/mobile/lib/widgets/popular_videos_tab.dart
+++ b/mobile/lib/widgets/popular_videos_tab.dart
@@ -71,6 +71,7 @@ class _PopularVideosTabState extends ConsumerState<PopularVideosTab> {
   late final FeedPerformanceTracker _feedTracker;
   late final ErrorAnalyticsTracker _errorTracker;
   DateTime? _feedLoadStartTime;
+  FeedLoadHandle? _feedLoad;
   bool _slowFeedLoadReported = false;
 
   /// Page currently painted, together with the variant it belongs to.
@@ -111,7 +112,7 @@ class _PopularVideosTabState extends ConsumerState<PopularVideosTab> {
     if (feedAsync.isLoading && _feedLoadStartTime == null) {
       _feedLoadStartTime = DateTime.now();
       _slowFeedLoadReported = false;
-      _feedTracker.startFeedLoad('popular');
+      _feedLoad = _feedTracker.startFeedLoad('popular');
     }
 
     // A held page outranks an in-flight load. A hard error outranks both.
@@ -182,8 +183,12 @@ class _PopularVideosTabState extends ConsumerState<PopularVideosTab> {
 
     // Track feed loaded with videos
     if (_feedLoadStartTime != null) {
-      _feedTracker.markFirstVideosReceived('popular', videos.length);
-      _feedTracker.markFeedDisplayed('popular', videos.length);
+      final feedLoad = _feedLoad;
+      if (feedLoad != null) {
+        _feedTracker.markFirstVideosReceived(feedLoad, videos.length);
+        _feedTracker.markFeedDisplayed(feedLoad, videos.length);
+      }
+      _feedLoad = null;
       _screenAnalytics.markDataLoaded(
         'explore_screen',
         dataMetrics: {'tab': 'popular', 'video_count': videos.length},
@@ -218,6 +223,9 @@ class _PopularVideosTabState extends ConsumerState<PopularVideosTab> {
       errorMessage: error.toString(),
       loadTimeMs: loadTime,
     );
+    final feedLoad = _feedLoad;
+    if (feedLoad != null) _feedTracker.abandonFeedLoad(feedLoad);
+    _feedLoad = null;
     _feedLoadStartTime = null;
   }
 
@@ -255,6 +263,13 @@ class _PopularVideosTabState extends ConsumerState<PopularVideosTab> {
       thresholdMs: widget.slowLoadThresholdMs,
       location: 'explore_popular',
     );
+  }
+
+  @override
+  void dispose() {
+    final feedLoad = _feedLoad;
+    if (feedLoad != null) _feedTracker.abandonFeedLoad(feedLoad);
+    super.dispose();
   }
 }
 

--- a/mobile/packages/analytics/lib/src/feed_performance_tracker.dart
+++ b/mobile/packages/analytics/lib/src/feed_performance_tracker.dart
@@ -24,21 +24,39 @@ const _maxSessionAge = Duration(seconds: 60);
 /// Why a user-visible feed load began.
 enum FeedLoadReason { appStart, sourceSwitch, refresh, pagination }
 
+/// Opaque identity for one feed-load telemetry session.
+///
+/// Keep this handle with the asynchronous operation that started the load and
+/// pass it to every milestone or terminal call for that operation.
+class FeedLoadHandle {
+  const FeedLoadHandle._({required int id, required this.feedType}) : _id = id;
+
+  final int _id;
+
+  /// Destination whose load is being measured.
+  final String feedType;
+}
+
 /// Service for tracking feed performance and user engagement
 ///
-/// Feed-load sessions are keyed by feed type and shared across consumers — one
-/// widget starts a load that another completes — so the app resolves one
+/// Feed-load sessions are shared across consumers, so the app resolves one
 /// instance through `feedPerformanceTrackerProvider` rather than constructing
-/// this per widget.
+/// this per widget. Each load is identified by its returned [FeedLoadHandle].
 class FeedPerformanceTracker {
   /// Creates a tracker. Defaults to the Firebase analytics sink in production;
   /// pass a [sink] (e.g. [NoOpAnalyticsEventSink]) in tests.
-  FeedPerformanceTracker({AnalyticsEventSink? sink})
-    : _analytics = sink ?? FirebaseAnalyticsEventSink();
+  FeedPerformanceTracker({
+    AnalyticsEventSink? sink,
+    DateTime Function()? now,
+  }) : _analytics = sink ?? FirebaseAnalyticsEventSink(),
+       _now = now ?? DateTime.now;
 
   final AnalyticsEventSink _analytics;
+  final DateTime Function() _now;
 
-  final Map<String, _FeedLoadSession> _activeSessions = {};
+  final Map<int, _FeedLoadSession> _activeSessions = {};
+  final Map<String, FeedLoadHandle> _activeSwipeSessions = {};
+  static int _nextSessionId = 0;
 
   /// Number of active tracking sessions (exposed for testing).
   int get activeSessionCount => _activeSessions.length;
@@ -55,11 +73,12 @@ class FeedPerformanceTracker {
         name: 'FeedPerformance',
       );
       _activeSessions.clear();
+      _activeSwipeSessions.clear();
     }
   }
 
   /// Start tracking feed load
-  void startFeedLoad(
+  FeedLoadHandle startFeedLoad(
     String feedType, {
     FeedLoadReason reason = FeedLoadReason.appStart,
     Map<String, dynamic>? params,
@@ -73,18 +92,23 @@ class FeedPerformanceTracker {
       name: 'feed_load_started',
       parameters: {'feed_type': feedType, ...session.params},
     );
+    return session.handle;
   }
 
   _FeedLoadSession _startSession(
     String feedType,
     Map<String, dynamic> params,
   ) {
-    final session = _FeedLoadSession(
+    final handle = FeedLoadHandle._(
+      id: _nextSessionId++,
       feedType: feedType,
-      startTime: DateTime.now(),
+    );
+    final session = _FeedLoadSession(
+      handle: handle,
+      startTime: _now(),
       params: params,
     );
-    _activeSessions[feedType] = session;
+    _activeSessions[handle._id] = session;
     UnifiedLogger.info(
       '📺 Feed load started: $feedType',
       name: 'FeedPerformance',
@@ -97,19 +121,19 @@ class FeedPerformanceTracker {
   /// This does not close the session: a cache-first load remains active until
   /// [markFreshResultCompleted] records the later network result.
   void markFirstVisibleContent(
-    String feedType,
+    FeedLoadHandle handle,
     int count, {
     required bool servedFromCache,
   }) {
-    final session = _activeSessions[feedType];
+    final session = _activeSessions[handle._id];
     if (session == null || session.firstVisibleTime != null) return;
     if (_isStale(session)) {
-      _discardStaleSession(feedType);
+      _discardStaleSession(handle);
       return;
     }
 
     session
-      ..firstVisibleTime = DateTime.now()
+      ..firstVisibleTime = _now()
       ..servedFromCache = servedFromCache;
     final elapsed = session.firstVisibleTime!
         .difference(session.startTime)
@@ -117,7 +141,7 @@ class FeedPerformanceTracker {
     _analytics.logEvent(
       name: 'feed_first_content_visible',
       parameters: {
-        'feed_type': feedType,
+        'feed_type': handle.feedType,
         'time_to_first_visible_ms': elapsed,
         'video_count': count,
         'served_from_cache': servedFromCache ? 1 : 0,
@@ -128,25 +152,25 @@ class FeedPerformanceTracker {
 
   /// Records the fresh repository result and closes the user-visible load.
   void markFreshResultCompleted(
-    String feedType,
+    FeedLoadHandle handle,
     int totalCount, {
     int recommendationPageCount = 0,
     int followingPageCount = 0,
   }) {
-    final session = _activeSessions[feedType];
+    final session = _activeSessions[handle._id];
     if (session == null) return;
     if (_isStale(session)) {
-      _discardStaleSession(feedType);
+      _discardStaleSession(handle);
       return;
     }
 
-    final now = DateTime.now();
+    final now = _now();
     final freshResultTimeMs = now.difference(session.startTime).inMilliseconds;
     final firstVisibleTimeMs = session.firstVisibleTime
         ?.difference(session.startTime)
         .inMilliseconds;
     final parameters = <String, Object>{
-      'feed_type': feedType,
+      'feed_type': handle.feedType,
       'fresh_result_time_ms': freshResultTimeMs,
       'total_videos': totalCount,
       'served_from_cache': session.servedFromCache ? 1 : 0,
@@ -164,27 +188,27 @@ class FeedPerformanceTracker {
     _analytics.logEvent(
       name: 'feed_load_complete',
       parameters: {
-        'feed_type': feedType,
+        'feed_type': handle.feedType,
         'total_load_time_ms': freshResultTimeMs,
         'total_videos': totalCount,
         'first_batch_count': session.firstBatchCount ?? 0,
         ...session.params,
       },
     );
-    _activeSessions.remove(feedType);
+    _activeSessions.remove(handle._id);
   }
 
   /// Mark when first videos arrive from Nostr
-  void markFirstVideosReceived(String feedType, int count) {
-    final session = _activeSessions[feedType];
+  void markFirstVideosReceived(FeedLoadHandle handle, int count) {
+    final session = _activeSessions[handle._id];
     if (session == null) return;
 
     if (_isStale(session)) {
-      _discardStaleSession(feedType);
+      _discardStaleSession(handle);
       return;
     }
 
-    session.firstVideosReceivedTime = DateTime.now();
+    session.firstVideosReceivedTime = _now();
     session.firstBatchCount = count;
 
     final timeToFirstVideos = session.firstVideosReceivedTime!
@@ -192,14 +216,14 @@ class FeedPerformanceTracker {
         .inMilliseconds;
 
     UnifiedLogger.info(
-      '📬 First $count videos received for $feedType in ${timeToFirstVideos}ms',
+      '📬 First $count videos received for ${handle.feedType} in ${timeToFirstVideos}ms',
       name: 'FeedPerformance',
     );
 
     _analytics.logEvent(
       name: 'feed_first_batch_received',
       parameters: {
-        'feed_type': feedType,
+        'feed_type': handle.feedType,
         'time_to_first_ms': timeToFirstVideos,
         'video_count': count,
         ...session.params,
@@ -208,16 +232,16 @@ class FeedPerformanceTracker {
   }
 
   /// Mark when feed is fully loaded and displayed
-  void markFeedDisplayed(String feedType, int totalCount) {
-    final session = _activeSessions[feedType];
+  void markFeedDisplayed(FeedLoadHandle handle, int totalCount) {
+    final session = _activeSessions[handle._id];
     if (session == null) return;
 
     if (_isStale(session)) {
-      _discardStaleSession(feedType);
+      _discardStaleSession(handle);
       return;
     }
 
-    session.displayedTime = DateTime.now();
+    session.displayedTime = _now();
     session.totalVideosDisplayed = totalCount;
 
     final totalLoadTime = session.displayedTime!
@@ -225,14 +249,14 @@ class FeedPerformanceTracker {
         .inMilliseconds;
 
     UnifiedLogger.info(
-      '✅ Feed displayed: $feedType with $totalCount videos in ${totalLoadTime}ms',
+      '✅ Feed displayed: ${handle.feedType} with $totalCount videos in ${totalLoadTime}ms',
       name: 'FeedPerformance',
     );
 
     _analytics.logEvent(
       name: 'feed_load_complete',
       parameters: {
-        'feed_type': feedType,
+        'feed_type': handle.feedType,
         'total_load_time_ms': totalLoadTime,
         'total_videos': totalCount,
         'first_batch_count': session.firstBatchCount ?? 0,
@@ -241,7 +265,15 @@ class FeedPerformanceTracker {
     );
 
     // Clean up session
-    _activeSessions.remove(feedType);
+    _activeSessions.remove(handle._id);
+  }
+
+  /// Stop tracking a load that can no longer produce a visible completion.
+  ///
+  /// Abandonment is intentionally silent and idempotent. A completed, stale,
+  /// reset, or already-abandoned handle is a no-op.
+  void abandonFeedLoad(FeedLoadHandle handle) {
+    _activeSessions.remove(handle._id);
   }
 
   /// Track feed refresh action
@@ -377,15 +409,20 @@ class FeedPerformanceTracker {
   /// when [markVideoSwipeComplete] is called.
   void startVideoSwipeTracking(String videoId) {
     final feedType = 'video_swipe_$videoId';
-    _startSession(feedType, const {});
+    final previous = _activeSwipeSessions.remove(videoId);
+    if (previous != null) abandonFeedLoad(previous);
+    _activeSwipeSessions[videoId] = _startSession(
+      feedType,
+      const {},
+    ).handle;
   }
 
   /// Mark a video swipe as complete (video is now playing).
   ///
   /// Closes the session started by [startVideoSwipeTracking].
   void markVideoSwipeComplete(String videoId) {
-    final feedType = 'video_swipe_$videoId';
-    markFeedDisplayed(feedType, 1);
+    final handle = _activeSwipeSessions.remove(videoId);
+    if (handle != null) markFeedDisplayed(handle, 1);
   }
 
   /// Track terminal outcome of one source in user-profile search.
@@ -433,17 +470,17 @@ class FeedPerformanceTracker {
 
   /// Whether a session's start time is older than [_maxSessionAge].
   bool _isStale(_FeedLoadSession session) {
-    return DateTime.now().difference(session.startTime) > _maxSessionAge;
+    return _now().difference(session.startTime) > _maxSessionAge;
   }
 
   /// Remove a stale session and log a warning instead of recording garbage
   /// data.
-  void _discardStaleSession(String feedType) {
-    final session = _activeSessions.remove(feedType);
+  void _discardStaleSession(FeedLoadHandle handle) {
+    final session = _activeSessions.remove(handle._id);
     if (session != null) {
-      final age = DateTime.now().difference(session.startTime);
+      final age = _now().difference(session.startTime);
       UnifiedLogger.warning(
-        'Discarding stale feed session "$feedType" '
+        'Discarding stale feed session "${handle.feedType}" '
         '(started ${age.inSeconds}s ago)',
         name: 'FeedPerformance',
       );
@@ -454,12 +491,12 @@ class FeedPerformanceTracker {
 /// Internal session tracking for feed loading
 class _FeedLoadSession {
   _FeedLoadSession({
-    required this.feedType,
+    required this.handle,
     required this.startTime,
     required this.params,
   });
 
-  final String feedType;
+  final FeedLoadHandle handle;
   final DateTime startTime;
   final Map<String, dynamic> params;
 

--- a/mobile/packages/analytics/test/feed_performance_tracker_stale_session_test.dart
+++ b/mobile/packages/analytics/test/feed_performance_tracker_stale_session_test.dart
@@ -38,63 +38,78 @@ void main() {
     });
 
     group('stale session detection', () {
+      test('discards a session older than the maximum age', () {
+        var now = DateTime(2026, 9, 10, 12);
+        tracker = FeedPerformanceTracker(
+          sink: const NoOpAnalyticsEventSink(),
+          now: () => now,
+        );
+        final handle = tracker.startFeedLoad('home');
+        now = now.add(const Duration(seconds: 61));
+
+        tracker.markFirstVideosReceived(handle, 5);
+
+        expect(tracker.activeSessionCount, 0);
+      });
+
       test('markFirstVideosReceived processes fresh session normally', () {
-        tracker.startFeedLoad('home');
+        final handle = tracker.startFeedLoad('home');
         expect(tracker.activeSessionCount, 1);
 
-        tracker.markFirstVideosReceived('home', 5);
+        tracker.markFirstVideosReceived(handle, 5);
 
         // Session should still be active (not yet displayed)
         expect(tracker.activeSessionCount, 1);
       });
 
       test('markFeedDisplayed removes session on completion', () {
-        tracker.startFeedLoad('home');
+        final handle = tracker.startFeedLoad('home');
         expect(tracker.activeSessionCount, 1);
 
-        tracker.markFeedDisplayed('home', 5);
+        tracker.markFeedDisplayed(handle, 5);
 
         expect(tracker.activeSessionCount, 0);
       });
 
-      test('markFirstVideosReceived is no-op for unknown feed type', () {
-        tracker.markFirstVideosReceived('unknown', 5);
-        expect(tracker.activeSessionCount, 0);
-      });
-
-      test('markFeedDisplayed is no-op for unknown feed type', () {
-        tracker.markFeedDisplayed('unknown', 5);
+      test('milestones are no-ops after reset', () {
+        final handle = tracker.startFeedLoad('home');
+        tracker.resetAllSessions();
+        tracker
+          ..markFirstVideosReceived(handle, 5)
+          ..markFeedDisplayed(handle, 5);
         expect(tracker.activeSessionCount, 0);
       });
     });
 
     group('session lifecycle', () {
       test('sessions do not leak between instances', () {
-        tracker.startFeedLoad('home');
+        final handle = tracker.startFeedLoad('home');
 
         final other = FeedPerformanceTracker(
           sink: const NoOpAnalyticsEventSink(),
         );
+        final otherHandle = other.startFeedLoad('home');
 
         // Guards the reason the app resolves one shared instance through
         // `feedPerformanceTrackerProvider`: a second instance cannot complete
         // a session the first one started.
-        expect(other.activeSessionCount, 0);
-        other.markFeedDisplayed('home', 3);
+        expect(other.activeSessionCount, 1);
+        other.markFeedDisplayed(handle, 3);
         expect(tracker.activeSessionCount, 1);
+        expect(other.activeSessionCount, 1);
+        other.abandonFeedLoad(otherHandle);
       });
 
       test('tracks multiple independent sessions', () {
-        tracker
-          ..startFeedLoad('home')
-          ..startFeedLoad('explore');
+        final home = tracker.startFeedLoad('home');
+        final explore = tracker.startFeedLoad('explore');
 
         expect(tracker.activeSessionCount, 2);
 
-        tracker.markFeedDisplayed('home', 5);
+        tracker.markFeedDisplayed(home, 5);
         expect(tracker.activeSessionCount, 1);
 
-        tracker.markFeedDisplayed('explore', 10);
+        tracker.markFeedDisplayed(explore, 10);
         expect(tracker.activeSessionCount, 0);
       });
     });

--- a/mobile/packages/analytics/test/feed_performance_tracker_test.dart
+++ b/mobile/packages/analytics/test/feed_performance_tracker_test.dart
@@ -45,9 +45,11 @@ void main() {
       });
 
       test('records initiation reason and keeps cache-first session open', () {
-        tracker
-          ..startFeedLoad('forYou', reason: FeedLoadReason.sourceSwitch)
-          ..markFirstVisibleContent('forYou', 5, servedFromCache: true);
+        final handle = tracker.startFeedLoad(
+          'forYou',
+          reason: FeedLoadReason.sourceSwitch,
+        );
+        tracker.markFirstVisibleContent(handle, 5, servedFromCache: true);
 
         expect(tracker.activeSessionCount, 1);
         expect(sink.events.first.name, 'feed_load_started');
@@ -59,11 +61,11 @@ void main() {
       });
 
       test('records fresh completion separately with traversal counts', () {
+        final handle = tracker.startFeedLoad('forYou');
         tracker
-          ..startFeedLoad('forYou')
-          ..markFirstVisibleContent('forYou', 4, servedFromCache: false)
+          ..markFirstVisibleContent(handle, 4, servedFromCache: false)
           ..markFreshResultCompleted(
-            'forYou',
+            handle,
             12,
             recommendationPageCount: 3,
           );
@@ -88,10 +90,10 @@ void main() {
       });
 
       test('only records the first visible-content milestone', () {
+        final handle = tracker.startFeedLoad('following');
         tracker
-          ..startFeedLoad('following')
-          ..markFirstVisibleContent('following', 3, servedFromCache: true)
-          ..markFirstVisibleContent('following', 8, servedFromCache: false);
+          ..markFirstVisibleContent(handle, 3, servedFromCache: true)
+          ..markFirstVisibleContent(handle, 8, servedFromCache: false);
 
         expect(
           sink.events.where(
@@ -99,6 +101,84 @@ void main() {
           ),
           hasLength(1),
         );
+      });
+
+      test('keeps overlapping loads for the same feed independent', () {
+        var now = DateTime(2026, 9, 10, 12);
+        tracker = FeedPerformanceTracker(sink: sink, now: () => now);
+
+        final first = tracker.startFeedLoad(
+          'forYou',
+          reason: FeedLoadReason.refresh,
+        );
+        now = now.add(const Duration(milliseconds: 10));
+        final second = tracker.startFeedLoad(
+          'forYou',
+          reason: FeedLoadReason.pagination,
+        );
+        now = now.add(const Duration(milliseconds: 20));
+        tracker.markFreshResultCompleted(first, 4);
+
+        expect(tracker.activeSessionCount, 1);
+        final firstCompletion = sink.events.firstWhere(
+          (event) => event.name == 'feed_fresh_result_complete',
+        );
+        expect(
+          firstCompletion.parameters,
+          containsPair('load_reason', 'refresh'),
+        );
+        expect(
+          firstCompletion.parameters,
+          containsPair('fresh_result_time_ms', 30),
+        );
+
+        now = now.add(const Duration(milliseconds: 15));
+        tracker.markFirstVisibleContent(
+          second,
+          8,
+          servedFromCache: false,
+        );
+        now = now.add(const Duration(milliseconds: 5));
+        tracker.markFreshResultCompleted(second, 8);
+
+        expect(tracker.activeSessionCount, 0);
+        final secondVisible = sink.events.firstWhere(
+          (event) =>
+              event.name == 'feed_first_content_visible' &&
+              event.parameters['load_reason'] == 'pagination',
+        );
+        expect(
+          secondVisible.parameters,
+          containsPair('time_to_first_visible_ms', 35),
+        );
+        final completions = sink.events
+            .where((event) => event.name == 'feed_fresh_result_complete')
+            .toList();
+        expect(completions, hasLength(2));
+        expect(
+          completions.last.parameters,
+          containsPair('fresh_result_time_ms', 40),
+        );
+      });
+
+      test('completed and abandoned handles are idempotent no-ops', () {
+        final completed = tracker.startFeedLoad('forYou');
+        tracker.markFreshResultCompleted(completed, 4);
+        final eventCountAfterCompletion = sink.events.length;
+
+        tracker
+          ..markFreshResultCompleted(completed, 4)
+          ..abandonFeedLoad(completed);
+        expect(sink.events, hasLength(eventCountAfterCompletion));
+
+        final abandoned = tracker.startFeedLoad('following');
+        final eventCountAfterStart = sink.events.length;
+        tracker
+          ..abandonFeedLoad(abandoned)
+          ..markFeedDisplayed(abandoned, 3);
+
+        expect(tracker.activeSessionCount, 0);
+        expect(sink.events, hasLength(eventCountAfterStart));
       });
     });
 

--- a/mobile/test/blocs/hashtag_search/hashtag_search_bloc_test.dart
+++ b/mobile/test/blocs/hashtag_search/hashtag_search_bloc_test.dart
@@ -628,6 +628,7 @@ void main() {
     group('feed performance tracking', () {
       late _MockHashtagRepository mockRepo;
       late _MockFeedPerformanceTracker mockTracker;
+      late FeedLoadHandle feedLoad;
 
       // Debounce duration used in the BLoC + buffer
       const debounceDuration = Duration(milliseconds: 400);
@@ -635,6 +636,10 @@ void main() {
       setUp(() {
         mockRepo = _MockHashtagRepository();
         mockTracker = _MockFeedPerformanceTracker();
+        feedLoad = FeedPerformanceTracker(
+          sink: const NoOpAnalyticsEventSink(),
+        ).startFeedLoad('test');
+        when(() => mockTracker.startFeedLoad(any())).thenReturn(feedLoad);
 
         when(
           () => mockRepo.searchHashtags(
@@ -664,10 +669,10 @@ void main() {
         verify: (_) {
           verify(() => mockTracker.startFeedLoad('hashtag_search')).called(1);
           verify(
-            () => mockTracker.markFirstVideosReceived('hashtag_search', 3),
+            () => mockTracker.markFirstVideosReceived(feedLoad, 3),
           ).called(1);
           verify(
-            () => mockTracker.markFeedDisplayed('hashtag_search', 3),
+            () => mockTracker.markFeedDisplayed(feedLoad, 3),
           ).called(1);
         },
       );
@@ -691,8 +696,10 @@ void main() {
               errorMessage: any(named: 'errorMessage'),
             ),
           ).called(1);
-          verifyNever(() => mockTracker.markFirstVideosReceived(any(), any()));
-          verifyNever(() => mockTracker.markFeedDisplayed(any(), any()));
+          verifyNever(
+            () => mockTracker.markFirstVideosReceived(feedLoad, any()),
+          );
+          verifyNever(() => mockTracker.markFeedDisplayed(feedLoad, any()));
         },
       );
 

--- a/mobile/test/blocs/user_search/user_search_bloc_test.dart
+++ b/mobile/test/blocs/user_search/user_search_bloc_test.dart
@@ -1471,6 +1471,7 @@ void main() {
     group('feed performance tracking', () {
       late _MockProfileRepository mockRepo;
       late _MockFeedPerformanceTracker mockTracker;
+      late FeedLoadHandle feedLoad;
 
       // Debounce duration used in the BLoC + buffer
       const debounceDuration = Duration(milliseconds: 400);
@@ -1478,6 +1479,10 @@ void main() {
       setUp(() {
         mockRepo = _MockProfileRepository();
         mockTracker = _MockFeedPerformanceTracker();
+        feedLoad = FeedPerformanceTracker(
+          sink: const NoOpAnalyticsEventSink(),
+        ).startFeedLoad('test');
+        when(() => mockTracker.startFeedLoad(any())).thenReturn(feedLoad);
       });
 
       UserSearchBloc createBlocWithTracker() => UserSearchBloc(
@@ -1521,10 +1526,10 @@ void main() {
         verify: (_) {
           verify(() => mockTracker.startFeedLoad('user_search')).called(1);
           verify(
-            () => mockTracker.markFirstVideosReceived('user_search', 1),
+            () => mockTracker.markFirstVideosReceived(feedLoad, 1),
           ).called(1);
           verify(
-            () => mockTracker.markFeedDisplayed('user_search', 1),
+            () => mockTracker.markFeedDisplayed(feedLoad, 1),
           ).called(1);
         },
       );
@@ -1557,8 +1562,10 @@ void main() {
               errorMessage: any(named: 'errorMessage'),
             ),
           ).called(1);
-          verifyNever(() => mockTracker.markFirstVideosReceived(any(), any()));
-          verifyNever(() => mockTracker.markFeedDisplayed(any(), any()));
+          verifyNever(
+            () => mockTracker.markFirstVideosReceived(feedLoad, any()),
+          );
+          verifyNever(() => mockTracker.markFeedDisplayed(feedLoad, any()));
         },
       );
 

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -120,11 +120,13 @@ void main() {
 
     VideoFeedBloc createBloc({
       FeedTuningRepository? feedTuningRepository,
+      FeedPerformanceTracker? feedTracker,
     }) => VideoFeedBloc(
       videosRepository: mockVideosRepository,
       followRepository: mockFollowRepository,
       curatedListRepository: mockCuratedListRepository,
       feedTuningRepository: feedTuningRepository,
+      feedTracker: feedTracker,
     );
 
     VideoEvent createTestVideo(
@@ -1428,7 +1430,7 @@ void main() {
       );
 
       test(
-        'keeps startup subscriptions when initial source load becomes stale',
+        'abandons the telemetry session when a source load becomes stale',
         () async {
           final followingVideos = createTestVideos(2, idPrefix: 'following');
           final newVideos = createTestVideos(2, idPrefix: 'new');
@@ -1456,7 +1458,10 @@ void main() {
             ),
           ).thenAnswer((_) => newVideosResult.future);
 
-          final bloc = createBloc();
+          final feedTracker = FeedPerformanceTracker(
+            sink: const NoOpAnalyticsEventSink(),
+          );
+          final bloc = createBloc(feedTracker: feedTracker);
           addTearDown(bloc.close);
 
           bloc.add(const VideoFeedStarted(mode: FeedMode.following));
@@ -1474,6 +1479,7 @@ void main() {
           expect(bloc.state.source, const VideoFeedSource.newVideos());
           expect(followingController.hasListener, isTrue);
           expect(curatedListsController.hasListener, isTrue);
+          expect(feedTracker.activeSessionCount, 0);
         },
       );
     });
@@ -3616,9 +3622,14 @@ void main() {
 
     group('feed performance tracking', () {
       late _MockFeedPerformanceTracker mockTracker;
+      late FeedLoadHandle feedLoad;
 
       setUp(() {
         mockTracker = _MockFeedPerformanceTracker();
+        feedLoad = FeedPerformanceTracker(
+          sink: const NoOpAnalyticsEventSink(),
+        ).startFeedLoad('test');
+        when(() => mockTracker.startFeedLoad(any())).thenReturn(feedLoad);
       });
 
       VideoFeedBloc createBlocWithTracker() => VideoFeedBloc(
@@ -3676,18 +3687,18 @@ void main() {
             bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
         verify: (_) {
           verify(
-            () => mockTracker.markFirstVideosReceived('following', 3),
+            () => mockTracker.markFirstVideosReceived(feedLoad, 3),
           ).called(1);
           verify(
             () => mockTracker.markFirstVisibleContent(
-              'following',
+              feedLoad,
               3,
               servedFromCache: false,
             ),
           ).called(1);
           verify(
             () => mockTracker.markFreshResultCompleted(
-              'following',
+              feedLoad,
               3,
               followingPageCount: 2,
             ),
@@ -3720,9 +3731,11 @@ void main() {
               errorMessage: any(named: 'errorMessage'),
             ),
           ).called(1);
-          verifyNever(() => mockTracker.markFirstVideosReceived(any(), any()));
           verifyNever(
-            () => mockTracker.markFreshResultCompleted(any(), any()),
+            () => mockTracker.markFirstVideosReceived(feedLoad, any()),
+          );
+          verifyNever(
+            () => mockTracker.markFreshResultCompleted(feedLoad, any()),
           );
         },
       );
@@ -3745,10 +3758,10 @@ void main() {
         verify: (_) {
           verify(() => mockTracker.startFeedLoad('latest')).called(1);
           verify(
-            () => mockTracker.markFirstVideosReceived('latest', 3),
+            () => mockTracker.markFirstVideosReceived(feedLoad, 3),
           ).called(1);
           verify(
-            () => mockTracker.markFreshResultCompleted('latest', 3),
+            () => mockTracker.markFreshResultCompleted(feedLoad, 3),
           ).called(1);
         },
       );


### PR DESCRIPTION
## Problem\n\nFeed telemetry sessions are keyed by feed type, so concurrent loads for the same destination overwrite each other. That can shorten phase timings, attach the wrong load reason, drop an entire load from completion data, and leave failed or superseded sessions active until a later reset.\n\n## Fix\n\nGive every feed load an opaque, monotonic handle and require that handle at each milestone and completion boundary. The tracker now keys sessions by per-load identity, while blocs and feed surfaces retain and abandon their own handles on failure, disposal, or source supersession.\n\nThis keeps overlapping loads independent without changing event names or event parameters. It also preserves the existing swipe API; deciding whether to wire or remove the currently incomplete swipe metric is tracked separately in #9027.\n\n## Verification\n\n- Added deterministic analytics tests for interleaved same-feed loads, replayed handles, abandoned handles, stale sessions, and cross-tracker isolation.\n- Added BLoC regression coverage for source supersession and overlapping load attribution.\n- Ran all affected analytics, BLoC, widget, profile, provider, and router tests.\n- Ran targeted analysis for every changed Dart file.\n- Ran the repository pre-push analyzer and changed-file test gate.\n- Ran localization consistency and hard-coded English checks.\n- Ran .\n\nCloses #9026\nRefs #9027