### PR TITLE
fix(dm): recover message history when one relay never answers

### DIFF
--- a/mobile/packages/bookmarks_repository/test/src/bookmarks_repository_test.dart
+++ b/mobile/packages/bookmarks_repository/test/src/bookmarks_repository_test.dart
@@ -95,7 +95,13 @@ void main() {
           requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
         ),
       ).thenAnswer(
-        (_) async => (events: events, timedOut: timedOut, noRelays: noRelays),
+        (_) async => (
+          events: events,
+          timedOut: timedOut,
+          noRelays: noRelays,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
     }
 
@@ -115,7 +121,13 @@ void main() {
           requireAllRelaysSettled: fullSettlement,
         ),
       ).thenAnswer(
-        (_) async => (events: events, timedOut: timedOut, noRelays: noRelays),
+        (_) async => (
+          events: events,
+          timedOut: timedOut,
+          noRelays: noRelays,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
     }
 
@@ -1249,9 +1261,21 @@ void main() {
           ).thenAnswer((_) async {
             if (++queries == 1) {
               await releaseRead.future;
-              return (events: [staleRead], timedOut: false, noRelays: false);
+              return (
+                events: [staleRead],
+                timedOut: false,
+                noRelays: false,
+                anyRelayAnswered: false,
+                unsettledRelays: const <String>[],
+              );
             }
-            return (events: [relayHeld], timedOut: false, noRelays: false);
+            return (
+              events: [relayHeld],
+              timedOut: false,
+              noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
+            );
           });
           when(() => nostrClient.publishEventAwaitOk(any())).thenAnswer((
             invocation,
@@ -1338,7 +1362,13 @@ void main() {
             requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
         ).thenAnswer(
-          (_) async => (events: [relayHeld], timedOut: false, noRelays: false),
+          (_) async => (
+            events: [relayHeld],
+            timedOut: false,
+            noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
+          ),
         );
         when(() => nostrClient.publishEventAwaitOk(any())).thenAnswer((
           invocation,

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -29,6 +29,8 @@ class _MockNostrClient extends Mock implements NostrClient {
         events: await queryEvents(filters),
         timedOut: false,
         noRelays: false,
+        anyRelayAnswered: false,
+        unsettledRelays: const <String>[],
       );
     });
   }
@@ -1205,6 +1207,8 @@ void main() {
             events: <Event>[],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
         when(
@@ -3369,6 +3373,8 @@ void main() {
             events: events,
             timedOut: timedOut,
             noRelays: noRelays,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
       }
@@ -3731,6 +3737,8 @@ void main() {
             events: <Event>[],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
       }
@@ -3742,7 +3750,13 @@ void main() {
             requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
         ).thenAnswer(
-          (_) async => (events: <Event>[], timedOut: true, noRelays: false),
+          (_) async => (
+            events: <Event>[],
+            timedOut: true,
+            noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
+          ),
         );
       }
 
@@ -4306,6 +4320,8 @@ void main() {
                 events: [clockSkewedList],
                 timedOut: false,
                 noRelays: false,
+                anyRelayAnswered: false,
+                unsettledRelays: const <String>[],
               ),
             );
             when(
@@ -4365,6 +4381,8 @@ void main() {
                 events: [clockSkewedList],
                 timedOut: false,
                 noRelays: false,
+                anyRelayAnswered: false,
+                unsettledRelays: const <String>[],
               ),
             );
 
@@ -4425,6 +4443,8 @@ void main() {
                 events: [clockSkewedList],
                 timedOut: false,
                 noRelays: false,
+                anyRelayAnswered: false,
+                unsettledRelays: const <String>[],
               ),
             );
 
@@ -4483,6 +4503,8 @@ void main() {
                 events: [landedList],
                 timedOut: false,
                 noRelays: false,
+                anyRelayAnswered: false,
+                unsettledRelays: const <String>[],
               ),
             );
             when(
@@ -4540,6 +4562,8 @@ void main() {
                 events: [invalidFutureList],
                 timedOut: false,
                 noRelays: false,
+                anyRelayAnswered: false,
+                unsettledRelays: const <String>[],
               ),
             );
 
@@ -4598,6 +4622,8 @@ void main() {
               events: [clockSkewedList],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             ),
           );
           when(
@@ -5643,7 +5669,13 @@ void main() {
           requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
         ),
       ).thenAnswer(
-        (_) async => (events: <Event>[], timedOut: true, noRelays: false),
+        (_) async => (
+          events: <Event>[],
+          timedOut: true,
+          noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
 
       final service = ContentBlocklistRepository(prefs: prefs);

--- a/mobile/packages/creator_sync/lib/src/vault_key_service.dart
+++ b/mobile/packages/creator_sync/lib/src/vault_key_service.dart
@@ -185,7 +185,14 @@ class VaultKeyService {
   /// uses [NostrClient.queryEventsDetailed] and fails closed on
   /// `noRelays`/`timedOut` instead.
   Future<Event?> _fetchRemote(String pubkey) async {
-    final ({List<Event> events, bool timedOut, bool noRelays}) result;
+    final ({
+      List<Event> events,
+      bool timedOut,
+      bool noRelays,
+      bool anyRelayAnswered,
+      List<String> unsettledRelays,
+    })
+    result;
     try {
       result = await _client.queryEventsDetailed(
         [

--- a/mobile/packages/creator_sync/test/src/sync_index_client_test.dart
+++ b/mobile/packages/creator_sync/test/src/sync_index_client_test.dart
@@ -17,9 +17,22 @@ class _MockClient extends Mock implements NostrClient {}
 
 /// Shapes a `queryEventsDetailed` answer with a live (non-failed) relay
 /// pool returning [events].
-({List<Event> events, bool timedOut, bool noRelays}) _confirmed(
+({
   List<Event> events,
-) => (events: events, timedOut: false, noRelays: false);
+  bool timedOut,
+  bool noRelays,
+  bool anyRelayAnswered,
+  List<String> unsettledRelays,
+})
+_confirmed(
+  List<Event> events,
+) => (
+  events: events,
+  timedOut: false,
+  noRelays: false,
+  anyRelayAnswered: false,
+  unsettledRelays: const <String>[],
+);
 
 /// A publish one relay answered `OK true`.
 PublishOutcome _accepted(Event event) => PublishOutcome(
@@ -514,7 +527,13 @@ void main() {
         'when no relays are connected',
         () async {
           when(() => client.queryEventsDetailed(any())).thenAnswer(
-            (_) async => (events: <Event>[], timedOut: false, noRelays: true),
+            (_) async => (
+              events: <Event>[],
+              timedOut: false,
+              noRelays: true,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
+            ),
           );
 
           await expectLater(
@@ -529,7 +548,13 @@ void main() {
         'when the relay query times out',
         () async {
           when(() => client.queryEventsDetailed(any())).thenAnswer(
-            (_) async => (events: <Event>[], timedOut: true, noRelays: false),
+            (_) async => (
+              events: <Event>[],
+              timedOut: true,
+              noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
+            ),
           );
 
           await expectLater(

--- a/mobile/packages/creator_sync/test/src/vault_key_service_test.dart
+++ b/mobile/packages/creator_sync/test/src/vault_key_service_test.dart
@@ -30,9 +30,22 @@ class _FakeCache implements VaultKeyCache {
 
 /// Shapes a `queryEventsDetailed` answer with a live (non-failed) relay
 /// pool returning [events].
-({List<Event> events, bool timedOut, bool noRelays}) _confirmed(
+({
   List<Event> events,
-) => (events: events, timedOut: false, noRelays: false);
+  bool timedOut,
+  bool noRelays,
+  bool anyRelayAnswered,
+  List<String> unsettledRelays,
+})
+_confirmed(
+  List<Event> events,
+) => (
+  events: events,
+  timedOut: false,
+  noRelays: false,
+  anyRelayAnswered: false,
+  unsettledRelays: const <String>[],
+);
 
 void main() {
   group(VaultKeyService, () {
@@ -428,7 +441,13 @@ void main() {
         ).thenAnswer(
           (_) async => stored.isEmpty
               ? _confirmed(const [])
-              : (events: <Event>[], timedOut: true, noRelays: false),
+              : (
+                  events: <Event>[],
+                  timedOut: true,
+                  noRelays: false,
+                  anyRelayAnswered: false,
+                  unsettledRelays: const <String>[],
+                ),
         );
 
         await expectLater(
@@ -522,7 +541,13 @@ void main() {
         ).thenAnswer((_) async {
           queryCount++;
           if (queryCount == 1) {
-            return (events: <Event>[], timedOut: true, noRelays: false);
+            return (
+              events: <Event>[],
+              timedOut: true,
+              noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
+            );
           }
           return _confirmed([...stored]);
         });
@@ -574,7 +599,13 @@ void main() {
             useCache: any(named: 'useCache'),
           ),
         ).thenAnswer(
-          (_) async => (events: <Event>[], timedOut: false, noRelays: true),
+          (_) async => (
+            events: <Event>[],
+            timedOut: false,
+            noRelays: true,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
+          ),
         );
 
         await expectLater(
@@ -604,7 +635,13 @@ void main() {
             useCache: any(named: 'useCache'),
           ),
         ).thenAnswer(
-          (_) async => (events: <Event>[], timedOut: true, noRelays: false),
+          (_) async => (
+            events: <Event>[],
+            timedOut: true,
+            noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
+          ),
         );
 
         await expectLater(

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -135,8 +135,13 @@ abstract class DmHistoryDrainConfig {
   /// unchanged. But a relay can be silent *permanently*, and deferring forever
   /// on that never flips the completion latch, which is what gates restoring
   /// read state and splitting message requests. Three runs is the smallest
-  /// count that is not a single flap, and the drain re-arms and re-reads the
-  /// held window whenever the holdout speaks again.
+  /// count that is not a single flap, and the count restarts whenever the set
+  /// of silent relays changes, so a rotating cast of holdouts cannot reach it.
+  ///
+  /// A completion reached this way is not the end of the story: it records
+  /// which relays it excluded and the window they never answered, and
+  /// [DmRepository.backfillHistoryIfNeeded] clears the completion latch and
+  /// re-reads that window once one of those relays is reachable again.
   static const int silentHoldoutRunsBeforeQuorumCompletion = 3;
 
   /// Maximum NIP-44 decryption attempts for a single gift wrap before the
@@ -1893,6 +1898,40 @@ class DmRepository {
         }
       }
     }
+    // A previous run completed against the relays that answered while a
+    // holdout stayed silent. If that holdout is reachable again, the window it
+    // never answered is readable again — so clear the latch and re-drain from
+    // exactly that window. Without this the completion latch would hide the
+    // window permanently, trading the stall this feature fixes for a silent
+    // gap, which is the worse of the two.
+    final quorumHoldouts = syncState.drainQuorumHoldouts(pubkey);
+    if (syncState.historyDrainComplete(pubkey) && quorumHoldouts.isNotEmpty) {
+      final connected = <String>{
+        for (final entry in _nostrClient.relayStatuses.entries)
+          if (entry.value.isConnected) entry.key,
+      };
+      final returned = quorumHoldouts.where(connected.contains).toList();
+      if (returned.isNotEmpty) {
+        // Cleared before the re-drain, not after: a holdout that goes silent
+        // again mid-pass records a fresh completion of its own, so dropping
+        // the old record here is what keeps a permanently flaky relay from
+        // re-arming the drain on every inbox open.
+        // Read the held window BEFORE clearing the record that stores it.
+        final heldWindow = syncState.drainQuorumCursor(pubkey);
+        await syncState.clearDrainQuorumCompletion(pubkey);
+        await syncState.clearDrainSilentHoldoutRuns(pubkey);
+        await syncState.rearmDrainFromCursor(
+          pubkey,
+          heldWindow ?? DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        );
+        Log.info(
+          'Re-arming the DM history drain for ${pubkeyForLogs(pubkey)}: '
+          'previously skipped relays are reachable again '
+          '(${returned.join(', ')})',
+          category: LogCategory.system,
+        );
+      }
+    }
     if (syncState.historyDrainComplete(pubkey)) {
       Log.info(
         'DM history drain skipped for ${pubkeyForLogs(pubkey)}: already '
@@ -1993,6 +2032,9 @@ class DmRepository {
       // [DmHistoryDrainConfig.silentHoldoutRunsBeforeQuorumCompletion].
       var completedOnQuorum = false;
       var silentHoldouts = const <String>[];
+      // The window a quorum completion stops at, kept so a holdout that comes
+      // back can have exactly that window re-requested.
+      var quorumCursor = 0;
       var partialViewReason = 'an earlier page was not fully settled';
       if (sawUnansweredPage) {
         partialViewReason =
@@ -2057,10 +2099,14 @@ class DmRepository {
               // relays already handed over.
               const budget =
                   DmHistoryDrainConfig.silentHoldoutRunsBeforeQuorumCompletion;
-              final runs = await syncState.recordDrainSilentHoldoutRun(pubkey);
+              final runs = await syncState.recordDrainSilentHoldoutRun(
+                pubkey,
+                holdouts: historyPage.unsettledRelays,
+              );
               if (runs >= budget) {
                 completedOnQuorum = true;
                 silentHoldouts = historyPage.unsettledRelays;
+                quorumCursor = cursor;
                 reachedEnd = true;
                 break;
               }
@@ -2196,6 +2242,13 @@ class DmRepository {
           // last-sent floor + any read markers stashed during the drain. #4977.
           await _restoreReadStateAfterDrain(pubkey, gen);
           if (completedOnQuorum) {
+            // After markHistoryDrainComplete, which clears the cursor — this
+            // is the only remaining record of what was skipped.
+            await syncState.recordDrainQuorumCompletion(
+              pubkey,
+              holdouts: silentHoldouts,
+              cursor: quorumCursor,
+            );
             Log.warning(
               'DM history drain complete for ${pubkeyForLogs(pubkey)} on the '
               'relays that answered: pages=$pagesRun, '

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -126,6 +126,19 @@ abstract class DmHistoryDrainConfig {
   /// Maximum pages fetched in a single drain (≈ [pageSize] × this events).
   static const int maxPages = 50;
 
+  /// Consecutive drain runs that must end with every reachable relay answering
+  /// and only a silent holdout unaccounted for, before the drain completes
+  /// against the relays that did answer.
+  ///
+  /// One such run proves nothing: a relay that never sends `EOSE` looks exactly
+  /// like one that is about to, so the first runs defer — #8209's guarantee,
+  /// unchanged. But a relay can be silent *permanently*, and deferring forever
+  /// on that never flips the completion latch, which is what gates restoring
+  /// read state and splitting message requests. Three runs is the smallest
+  /// count that is not a single flap, and the drain re-arms and re-reads the
+  /// held window whenever the holdout speaks again.
+  static const int silentHoldoutRunsBeforeQuorumCompletion = 3;
+
   /// Maximum NIP-44 decryption attempts for a single gift wrap before the
   /// failed-decrypt retry queue gives up on it. Generous so a transient
   /// remote-signer (Keycast RPC) outage spanning several inbox opens still
@@ -1383,7 +1396,22 @@ class DmRepository {
   /// the REQ, a relay refused it with `CLOSED`, the client was disposed, or
   /// only some relays answered. An empty page is proof of exhaustion only when
   /// it is authoritative; see the guard in [_runHistoryDrain]. See #8209.
-  Future<({List<Event> events, bool authoritative})?> _fetchHistoryPage({
+  ///
+  /// `anyRelayAnswered` splits the two shapes a non-authoritative page can
+  /// have. With `true` the relays that could be reached settled and said they
+  /// hold nothing more, and only `unsettledRelays` are unaccounted for; with
+  /// `false` nothing made a claim at all. The first can be waited out forever
+  /// by a relay that is permanently silent, which is what
+  /// [DmHistoryDrainConfig.silentHoldoutRunsBeforeQuorumCompletion] bounds.
+  Future<
+    ({
+      List<Event> events,
+      bool authoritative,
+      bool anyRelayAnswered,
+      List<String> unsettledRelays,
+    })?
+  >
+  _fetchHistoryPage({
     required int until,
     required int limit,
     required String subscriptionId,
@@ -1448,7 +1476,12 @@ class DmRepository {
       }
       await _maybeYieldDuringDrain(i);
     }
-    return (events: events, authoritative: authoritative);
+    return (
+      events: events,
+      authoritative: authoritative,
+      anyRelayAnswered: result.anyRelayAnswered,
+      unsettledRelays: result.unsettledRelays,
+    );
   }
 
   /// Recovers the user's OWN outgoing NIP-04 (kind-4) messages after a wipe.
@@ -1470,7 +1503,11 @@ class DmRepository {
   /// drain complete, mirroring the gift-wrap drain's authoritative-page guard
   /// so a momentary outage in this window doesn't silently skip recovery *and*
   /// permanently strand the user's outgoing NIP-04 history. See #5304, #8209.
-  Future<bool> _recoverOutgoingNip04(String pubkey, int generation) async {
+  Future<bool> _recoverOutgoingNip04(
+    String pubkey,
+    int generation, {
+    bool tolerateSilentHoldouts = false,
+  }) async {
     try {
       var cursor = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       var sawUnansweredPage = false;
@@ -1491,7 +1528,15 @@ class DmRepository {
         );
         final events = result.events;
         if (_ingestSessionEnded(pubkey, generation)) return false;
-        final authoritative = !result.noRelays && !result.timedOut;
+        // A page the reachable relays settled while a holdout stayed silent
+        // counts as answered once the paged drain has already given up on that
+        // holdout; otherwise the caller's quorum completion would defer here
+        // instead. A page NOTHING answered is never tolerated.
+        final authoritative =
+            (!result.noRelays && !result.timedOut) ||
+            (tolerateSilentHoldouts &&
+                !result.noRelays &&
+                result.anyRelayAnswered);
         if (events.isEmpty) {
           // An empty page is genuine exhaustion only if a relay actually
           // ANSWERED it. Nothing answering — no relay took the REQ, a relay
@@ -1937,6 +1982,17 @@ class DmRepository {
       // one relay in it staying silent — and it must not latch completion
       // either.
       var sawUnansweredPage = !inbox.conclusive;
+      // Set only by a gap that is NOT one relay staying silent: a fan-out no
+      // relay took, or an inbox list this run could not read. Those are
+      // whole-relays-missing defects, and quorum completion must never paper
+      // over them — it is an answer from the relays that spoke, and here
+      // nothing spoke.
+      var sawNonHoldoutGap = !inbox.conclusive;
+      // Set when this run gives up on a permanently silent relay and completes
+      // against the ones that answered. See
+      // [DmHistoryDrainConfig.silentHoldoutRunsBeforeQuorumCompletion].
+      var completedOnQuorum = false;
+      var silentHoldouts = const <String>[];
       var partialViewReason = 'an earlier page was not fully settled';
       if (sawUnansweredPage) {
         partialViewReason =
@@ -1989,6 +2045,33 @@ class DmRepository {
           // Defer instead: leave historyDrainComplete unset and resume on the
           // next inbox open from the window this run pins below.
           if (!historyPage.authoritative) {
+            if (historyPage.anyRelayAnswered && !sawNonHoldoutGap) {
+              // Every relay that could be reached settled and reported
+              // nothing older; only `unsettledRelays` never spoke. One run of
+              // this proves nothing — a relay that never sends `EOSE` looks
+              // exactly like one that is about to — so the first runs still
+              // defer. But a relay can be silent forever, and deferring
+              // forever never flips the completion latch that gates restoring
+              // read state and splitting message requests, leaving the inbox
+              // permanently marked incomplete over history the reachable
+              // relays already handed over.
+              const budget =
+                  DmHistoryDrainConfig.silentHoldoutRunsBeforeQuorumCompletion;
+              final runs = await syncState.recordDrainSilentHoldoutRun(pubkey);
+              if (runs >= budget) {
+                completedOnQuorum = true;
+                silentHoldouts = historyPage.unsettledRelays;
+                reachedEnd = true;
+                break;
+              }
+              Log.warning(
+                'DM history drain for ${pubkeyForLogs(pubkey)} was held by '
+                'relays that never settled '
+                '(${historyPage.unsettledRelays.join(', ')}); run $runs of '
+                '$budget before completing on the relays that answered.',
+                category: LogCategory.system,
+              );
+            }
             if (!sawUnansweredPage) {
               // Pin the resume point at this window before giving up on the
               // run. Falling back to the seed is not safe: with no cursor
@@ -1996,21 +2079,34 @@ class DmRepository {
               // run's own persisted messages drag downward (recordSeen), so
               // the window would be skipped by the events it did return.
               await syncState.setHistoryDrainCursor(pubkey, cursor);
-              Log.warning(
-                'DM history drain saw an empty page that no relay answered for '
-                '${pubkeyForLogs(pubkey)}; holding the resume cursor at '
-                '$cursor and deferring completion to the next inbox open.',
-                category: LogCategory.system,
-              );
+              // Only when nothing answered. A holdout page has already logged
+              // who stayed silent, and claiming "no relay answered" beside it
+              // would contradict that line in the same export.
+              if (!historyPage.anyRelayAnswered) {
+                Log.warning(
+                  'DM history drain saw an empty page that no relay answered '
+                  'for ${pubkeyForLogs(pubkey)}; holding the resume cursor at '
+                  '$cursor and deferring completion to the next inbox open.',
+                  category: LogCategory.system,
+                );
+              }
             }
+            if (!historyPage.anyRelayAnswered) sawNonHoldoutGap = true;
             _resumeDrainWhenRelayConnects(pubkey, gen);
             return;
           }
+          // A fully settled page proves every relay — holdouts included —
+          // answered, so no run before this one was blocked by a persistent
+          // silence.
+          await syncState.clearDrainSilentHoldoutRuns(pubkey);
           reachedEnd = true;
           break;
         }
 
-        if (!historyPage.authoritative) {
+        if (historyPage.authoritative) {
+          await syncState.clearDrainSilentHoldoutRuns(pubkey);
+        } else {
+          if (!historyPage.anyRelayAnswered) sawNonHoldoutGap = true;
           // A page that carried events but which not every relay settled: one
           // relay answered while another never did, so this window can still
           // hold events this page did not see. The events it did return are
@@ -2063,7 +2159,13 @@ class DmRepository {
         }
       }
 
-      if (reachedEnd && !sawUnansweredPage) {
+      // `completedOnQuorum` is the one case where a run completes despite
+      // `sawUnansweredPage`. It is reachable only when every gap this run saw
+      // was a relay staying silent (never a fan-out nobody took, and never an
+      // unreadable inbox list), and only after
+      // [DmHistoryDrainConfig.silentHoldoutRunsBeforeQuorumCompletion]
+      // consecutive runs said the same thing.
+      if (reachedEnd && (!sawUnansweredPage || completedOnQuorum)) {
         // Before declaring history complete, recover the user's OWN outgoing
         // NIP-04 messages. The paged drain above filters `p:[self]`, which
         // matches incoming NIP-04 and the user's NIP-17 self-wraps but never
@@ -2076,7 +2178,14 @@ class DmRepository {
         // (e.g. a momentary disconnect in this window) so a flaky network
         // never silently skips recovery AND marks the drain complete — it
         // resumes on the next inbox open instead.
-        final nip04Recovered = await _recoverOutgoingNip04(pubkey, gen);
+        // A permanently silent relay holds this pass open exactly as it holds
+        // the paged drain open, so a quorum completion that did not extend to
+        // it would defer forever one step later.
+        final nip04Recovered = await _recoverOutgoingNip04(
+          pubkey,
+          gen,
+          tolerateSilentHoldouts: completedOnQuorum,
+        );
         if (nip04Recovered) {
           // This run reached a conclusive answer about the account's own
           // inbox relays — completion is only reachable when it did — so a
@@ -2086,11 +2195,21 @@ class DmRepository {
           // Restore read state now that the full conversation set is present:
           // last-sent floor + any read markers stashed during the drain. #4977.
           await _restoreReadStateAfterDrain(pubkey, gen);
-          Log.info(
-            'DM history drain complete for ${pubkeyForLogs(pubkey)}: '
-            'pages=$pagesRun, eventsFetched=$totalEvents',
-            category: LogCategory.system,
-          );
+          if (completedOnQuorum) {
+            Log.warning(
+              'DM history drain complete for ${pubkeyForLogs(pubkey)} on the '
+              'relays that answered: pages=$pagesRun, '
+              'eventsFetched=$totalEvents. These relays never settled a page '
+              'and were not represented: ${silentHoldouts.join(', ')}.',
+              category: LogCategory.system,
+            );
+          } else {
+            Log.info(
+              'DM history drain complete for ${pubkeyForLogs(pubkey)}: '
+              'pages=$pagesRun, eventsFetched=$totalEvents',
+              category: LogCategory.system,
+            );
+          }
         } else {
           Log.warning(
             'DM history drain reached the end for ${pubkeyForLogs(pubkey)} but '

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -34,6 +34,7 @@ class DmSyncState {
   static const _groupRecoveryVersionPrefix = 'dm.groupRecoveryVersion.';
   static const _drainInboxCoveredPrefix = 'dm.drainCoveredOwnInbox.';
   static const _drainCompletedBeforePrefix = 'dm.historyDrainCompletedBefore.';
+  static const _drainSilentHoldoutRunsPrefix = 'dm.drainSilentHoldoutRuns.';
   static const _drainCompletionMigrationPrefix =
       'dm.historyDrainCompletionMigration.';
 
@@ -261,6 +262,7 @@ class DmSyncState {
     await _prefs.setBool('$_drainCompletePrefix$pubkey', true);
     await _prefs.setBool('$_drainCompletedBeforePrefix$pubkey', true);
     await _prefs.remove('$_drainCursorPrefix$pubkey');
+    await _prefs.remove('$_drainSilentHoldoutRunsPrefix$pubkey');
   }
 
   /// Whether a full-history drain has completed for [pubkey] at least once
@@ -428,6 +430,36 @@ class DmSyncState {
   /// check at most once and never again.
   bool drainCoveredOwnInbox(String pubkey) =>
       _prefs.getBool('$_drainInboxCoveredPrefix$pubkey') ?? false;
+
+  /// Consecutive drain runs for [pubkey] that ended with every reachable relay
+  /// answering and only a silent holdout unaccounted for.
+  ///
+  /// A relay that never sends `EOSE` is indistinguishable from one that is
+  /// about to, so a single such run proves nothing and must defer — that is
+  /// #8209's guarantee and it is unchanged. What the counter adds is the case
+  /// #8209 could not see: a relay that is *persistently* silent. Deferring
+  /// forever on it never completes, so the completion latch never flips and
+  /// the inbox stays permanently flagged incomplete even though the reachable
+  /// relays have already handed over everything they hold.
+  ///
+  /// Reset to zero by any run that reaches a fully-settled answer, so a
+  /// transient outage can never accumulate toward
+  /// `DmHistoryDrainConfig.silentHoldoutRunsBeforeQuorumCompletion`.
+  int drainSilentHoldoutRuns(String pubkey) =>
+      _prefs.getInt('$_drainSilentHoldoutRunsPrefix$pubkey') ?? 0;
+
+  /// Records one more consecutive silent-holdout run for [pubkey] and returns
+  /// the new total.
+  Future<int> recordDrainSilentHoldoutRun(String pubkey) async {
+    final next = drainSilentHoldoutRuns(pubkey) + 1;
+    await _prefs.setInt('$_drainSilentHoldoutRunsPrefix$pubkey', next);
+    return next;
+  }
+
+  /// Clears the consecutive silent-holdout run count for [pubkey].
+  Future<void> clearDrainSilentHoldoutRuns(String pubkey) async {
+    await _prefs.remove('$_drainSilentHoldoutRunsPrefix$pubkey');
+  }
 
   /// Records that the drain for [pubkey] reached a conclusive answer about the
   /// user's own DM inbox relays. See [drainCoveredOwnInbox].

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -35,6 +35,9 @@ class DmSyncState {
   static const _drainInboxCoveredPrefix = 'dm.drainCoveredOwnInbox.';
   static const _drainCompletedBeforePrefix = 'dm.historyDrainCompletedBefore.';
   static const _drainSilentHoldoutRunsPrefix = 'dm.drainSilentHoldoutRuns.';
+  static const _drainSilentHoldoutRelaysPrefix = 'dm.drainSilentHoldoutRelays.';
+  static const _drainQuorumHoldoutsPrefix = 'dm.drainQuorumHoldouts.';
+  static const _drainQuorumCursorPrefix = 'dm.drainQuorumCursor.';
   static const _drainCompletionMigrationPrefix =
       'dm.historyDrainCompletionMigration.';
 
@@ -448,10 +451,33 @@ class DmSyncState {
   int drainSilentHoldoutRuns(String pubkey) =>
       _prefs.getInt('$_drainSilentHoldoutRunsPrefix$pubkey') ?? 0;
 
-  /// Records one more consecutive silent-holdout run for [pubkey] and returns
-  /// the new total.
-  Future<int> recordDrainSilentHoldoutRun(String pubkey) async {
-    final next = drainSilentHoldoutRuns(pubkey) + 1;
+  /// The relays that were silent across the counted runs for [pubkey].
+  List<String> drainSilentHoldoutRelays(String pubkey) =>
+      _prefs.getStringList('$_drainSilentHoldoutRelaysPrefix$pubkey') ??
+      const <String>[];
+
+  /// Records one more silent-holdout run for [pubkey] and returns the new
+  /// total, restarting the count when [holdouts] differs from the previous
+  /// run's.
+  ///
+  /// The count means "the SAME relay has been silent this many runs", not
+  /// "some relay was silent this many times". Those differ: a run whose
+  /// holdout answered an earlier window is no evidence about the window this
+  /// run is holding, so letting a rotating cast of holdouts accumulate could
+  /// complete over a window the final holdout never answered.
+  Future<int> recordDrainSilentHoldoutRun(
+    String pubkey, {
+    required List<String> holdouts,
+  }) async {
+    final key = '$_drainSilentHoldoutRelaysPrefix$pubkey';
+    final previous = drainSilentHoldoutRelays(pubkey);
+    final sorted = [...holdouts]..sort();
+    var unchanged = previous.length == sorted.length;
+    for (var i = 0; unchanged && i < sorted.length; i++) {
+      unchanged = previous[i] == sorted[i];
+    }
+    final next = unchanged ? drainSilentHoldoutRuns(pubkey) + 1 : 1;
+    await _prefs.setStringList(key, sorted);
     await _prefs.setInt('$_drainSilentHoldoutRunsPrefix$pubkey', next);
     return next;
   }
@@ -459,6 +485,52 @@ class DmSyncState {
   /// Clears the consecutive silent-holdout run count for [pubkey].
   Future<void> clearDrainSilentHoldoutRuns(String pubkey) async {
     await _prefs.remove('$_drainSilentHoldoutRunsPrefix$pubkey');
+    await _prefs.remove('$_drainSilentHoldoutRelaysPrefix$pubkey');
+  }
+
+  /// Relays a quorum completion for [pubkey] finished without, or empty when
+  /// the last completion represented every relay.
+  ///
+  /// Kept so a holdout that later comes back can be noticed and the window it
+  /// never answered re-read. Without it the completion latch would hide that
+  /// window permanently, which is the same unreachable-history symptom the
+  /// quorum completion exists to end.
+  List<String> drainQuorumHoldouts(String pubkey) =>
+      _prefs.getStringList('$_drainQuorumHoldoutsPrefix$pubkey') ??
+      const <String>[];
+
+  /// The window a quorum completion stopped at, for the re-read above.
+  int? drainQuorumCursor(String pubkey) =>
+      _prefs.getInt('$_drainQuorumCursorPrefix$pubkey');
+
+  /// Records that the drain for [pubkey] completed without [holdouts], holding
+  /// [cursor] as the window they never answered.
+  Future<void> recordDrainQuorumCompletion(
+    String pubkey, {
+    required List<String> holdouts,
+    required int cursor,
+  }) async {
+    await _prefs.setStringList(
+      '$_drainQuorumHoldoutsPrefix$pubkey',
+      holdouts,
+    );
+    await _prefs.setInt('$_drainQuorumCursorPrefix$pubkey', cursor);
+  }
+
+  /// Forgets the recorded quorum completion for [pubkey].
+  Future<void> clearDrainQuorumCompletion(String pubkey) async {
+    await _prefs.remove('$_drainQuorumHoldoutsPrefix$pubkey');
+    await _prefs.remove('$_drainQuorumCursorPrefix$pubkey');
+  }
+
+  /// Clears the completion latch for [pubkey] and re-drains from [cursor].
+  ///
+  /// Unlike [rearmDrainForOwnInbox] this resumes at a specific window rather
+  /// than from now, because the window a quorum completion skipped is exactly
+  /// what this pass has to re-request.
+  Future<void> rearmDrainFromCursor(String pubkey, int cursor) async {
+    await _prefs.remove('$_drainCompletePrefix$pubkey');
+    await _prefs.setInt('$_drainCursorPrefix$pubkey', cursor);
   }
 
   /// Records that the drain for [pubkey] reached a conclusive answer about the
@@ -504,6 +576,10 @@ class DmSyncState {
     await _prefs.remove('$_drainInboxCoveredPrefix$pubkey');
     await _prefs.remove('$_drainCompletedBeforePrefix$pubkey');
     await _prefs.remove('$_drainCompletionMigrationPrefix$pubkey');
+    await _prefs.remove('$_drainSilentHoldoutRunsPrefix$pubkey');
+    await _prefs.remove('$_drainSilentHoldoutRelaysPrefix$pubkey');
+    await _prefs.remove('$_drainQuorumHoldoutsPrefix$pubkey');
+    await _prefs.remove('$_drainQuorumCursorPrefix$pubkey');
   }
 
   /// Removes all DM sync state entries for every pubkey.
@@ -525,7 +601,11 @@ class DmSyncState {
               key.startsWith(_groupRecoveryVersionPrefix) ||
               key.startsWith(_drainInboxCoveredPrefix) ||
               key.startsWith(_drainCompletedBeforePrefix) ||
-              key.startsWith(_drainCompletionMigrationPrefix),
+              key.startsWith(_drainCompletionMigrationPrefix) ||
+              key.startsWith(_drainSilentHoldoutRunsPrefix) ||
+              key.startsWith(_drainSilentHoldoutRelaysPrefix) ||
+              key.startsWith(_drainQuorumHoldoutsPrefix) ||
+              key.startsWith(_drainQuorumCursorPrefix),
         )
         .toList();
     for (final key in keysToRemove) {

--- a/mobile/packages/dm_repository/test/src/dm_advertised_inbox_unlatch_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_advertised_inbox_unlatch_test.dart
@@ -75,8 +75,13 @@ void main() {
           timeout: any(named: 'timeout'),
         ),
       ).thenAnswer(
-        (_) async =>
-            (events: const <Event>[], timedOut: false, noRelays: false),
+        (_) async => (
+          events: const <Event>[],
+          timedOut: false,
+          noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
       // The leg OK-confirms its kind 4 (#8262), so it calls
       // `publishEventAwaitOk`. Stubbing `publishEvent` here would leave the
@@ -186,12 +191,26 @@ void main() {
               ],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             );
           case DmInboxResolution.absent:
-            return (events: const <Event>[], timedOut: false, noRelays: false);
+            return (
+              events: const <Event>[],
+              timedOut: false,
+              noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
+            );
           case DmInboxResolution.unreadable:
             // A failed read, not an answer.
-            return (events: const <Event>[], timedOut: true, noRelays: false);
+            return (
+              events: const <Event>[],
+              timedOut: true,
+              noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
+            );
         }
       });
     }
@@ -377,11 +396,25 @@ void main() {
               ],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             );
           case DmInboxResolution.absent:
-            return (events: const <Event>[], timedOut: false, noRelays: false);
+            return (
+              events: const <Event>[],
+              timedOut: false,
+              noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
+            );
           case DmInboxResolution.unreadable:
-            return (events: const <Event>[], timedOut: true, noRelays: false);
+            return (
+              events: const <Event>[],
+              timedOut: true,
+              noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
+            );
         }
       });
     }

--- a/mobile/packages/dm_repository/test/src/dm_cross_protocol_twin_claim_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_cross_protocol_twin_claim_test.dart
@@ -77,8 +77,13 @@ void main() {
           timeout: any(named: 'timeout'),
         ),
       ).thenAnswer(
-        (_) async =>
-            (events: const <Event>[], timedOut: false, noRelays: false),
+        (_) async => (
+          events: const <Event>[],
+          timedOut: false,
+          noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
       when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
       when(

--- a/mobile/packages/dm_repository/test/src/dm_future_dated_created_at_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_future_dated_created_at_test.dart
@@ -74,6 +74,8 @@ void main() {
           events: const <Event>[],
           timedOut: false,
           noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
         ),
       );
       when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});

--- a/mobile/packages/dm_repository/test/src/dm_identical_text_repeat_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_identical_text_repeat_test.dart
@@ -82,6 +82,8 @@ void main() {
           events: const <Event>[],
           timedOut: false,
           noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
         ),
       );
       when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});

--- a/mobile/packages/dm_repository/test/src/dm_legacy_own_send_shape_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_legacy_own_send_shape_test.dart
@@ -70,8 +70,13 @@ void main() {
           timeout: any(named: 'timeout'),
         ),
       ).thenAnswer(
-        (_) async =>
-            (events: const <Event>[], timedOut: false, noRelays: false),
+        (_) async => (
+          events: const <Event>[],
+          timedOut: false,
+          noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
       when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
       when(

--- a/mobile/packages/dm_repository/test/src/dm_nip04_reply_tag_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_nip04_reply_tag_test.dart
@@ -75,8 +75,13 @@ void main() {
           timeout: any(named: 'timeout'),
         ),
       ).thenAnswer(
-        (_) async =>
-            (events: const <Event>[], timedOut: false, noRelays: false),
+        (_) async => (
+          events: const <Event>[],
+          timedOut: false,
+          noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
       // The leg OK-confirms its kind 4 (#8262), so it calls
       // `publishEventAwaitOk`. Stubbing `publishEvent` here would leave the

--- a/mobile/packages/dm_repository/test/src/dm_persist_transaction_rollback_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_persist_transaction_rollback_test.dart
@@ -145,8 +145,13 @@ void main() {
           timeout: any(named: 'timeout'),
         ),
       ).thenAnswer(
-        (_) async =>
-            (events: const <Event>[], timedOut: false, noRelays: false),
+        (_) async => (
+          events: const <Event>[],
+          timedOut: false,
+          noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
       when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
       when(

--- a/mobile/packages/dm_repository/test/src/dm_protocol_latch_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_protocol_latch_test.dart
@@ -75,8 +75,13 @@ void main() {
           timeout: any(named: 'timeout'),
         ),
       ).thenAnswer(
-        (_) async =>
-            (events: const <Event>[], timedOut: false, noRelays: false),
+        (_) async => (
+          events: const <Event>[],
+          timedOut: false,
+          noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
       when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
       when(

--- a/mobile/packages/dm_repository/test/src/dm_protocol_unlatch_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_protocol_unlatch_test.dart
@@ -74,8 +74,13 @@ void main() {
           timeout: any(named: 'timeout'),
         ),
       ).thenAnswer(
-        (_) async =>
-            (events: const <Event>[], timedOut: false, noRelays: false),
+        (_) async => (
+          events: const <Event>[],
+          timedOut: false,
+          noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
       when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
       when(

--- a/mobile/packages/dm_repository/test/src/dm_read_cursor_retry_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_read_cursor_retry_test.dart
@@ -83,8 +83,13 @@ void main() {
             timeout: any(named: 'timeout'),
           ),
         ).thenAnswer(
-          (_) async =>
-              (events: const <Event>[], timedOut: false, noRelays: false),
+          (_) async => (
+            events: const <Event>[],
+            timedOut: false,
+            noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
+          ),
         );
         when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
         when(

--- a/mobile/packages/dm_repository/test/src/dm_repository_self_wrap_relays_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_self_wrap_relays_test.dart
@@ -107,7 +107,13 @@ void main() {
           timeout: any(named: 'timeout'),
         ),
       ).thenAnswer(
-        (_) async => (events: events, timedOut: false, noRelays: false),
+        (_) async => (
+          events: events,
+          timedOut: false,
+          noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
     }
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -275,43 +275,116 @@ class _SinceEnforcingRelay {
 /// Shapes a `queryEventsDetailed` answer to a kind-10050 lookup that the relays
 /// actually gave: an empty [events] is genuine absence, which is the only thing
 /// the RC3 publisher may act on (#8212).
-({List<Event> events, bool timedOut, bool noRelays}) answeredList(
+({
   List<Event> events,
-) => (events: events, timedOut: false, noRelays: false);
+  bool timedOut,
+  bool noRelays,
+  bool anyRelayAnswered,
+  List<String> unsettledRelays,
+})
+answeredList(
+  List<Event> events,
+) => (
+  events: events,
+  timedOut: false,
+  noRelays: false,
+  anyRelayAnswered: true,
+  unsettledRelays: const <String>[],
+);
 
 /// Shapes a kind-10050 lookup nothing answered: a fan-out no relay took
 /// ([noRelays]), or a relay that refused the REQ with `CLOSED` / a settle window
 /// that completed while the relay holding the list stayed silent ([timedOut]).
 /// The empty list means nothing — RC3 must NOT read it as absence (#8212).
-({List<Event> events, bool timedOut, bool noRelays}) unansweredList({
+({
+  List<Event> events,
+  bool timedOut,
+  bool noRelays,
+  bool anyRelayAnswered,
+  List<String> unsettledRelays,
+})
+unansweredList({
   bool noRelays = false,
   bool timedOut = false,
-}) => (events: const <Event>[], timedOut: timedOut, noRelays: noRelays);
+  bool anyRelayAnswered = false,
+  List<String> unsettledRelays = const <String>[],
+}) => (
+  events: const <Event>[],
+  timedOut: timedOut,
+  noRelays: noRelays,
+  anyRelayAnswered: anyRelayAnswered,
+  unsettledRelays: unsettledRelays,
+);
 
 /// Shapes a `queryEventsDetailed` answer a relay actually gave: [events] is
 /// the whole truth, so an empty list is genuine exhaustion. This is what the
 /// history drain requires before it may mark itself complete (#8209).
-({List<Event> events, bool timedOut, bool noRelays}) answeredPage(
+({
   List<Event> events,
-) => (events: events, timedOut: false, noRelays: false);
+  bool timedOut,
+  bool noRelays,
+  bool anyRelayAnswered,
+  List<String> unsettledRelays,
+})
+answeredPage(
+  List<Event> events,
+) => (
+  events: events,
+  timedOut: false,
+  noRelays: false,
+  anyRelayAnswered: true,
+  unsettledRelays: const <String>[],
+);
 
 /// Shapes a page that carries real [events] but which NOT every relay settled:
 /// one relay answered while another never did, so the window may still hold
 /// events this page could not see. The drain may persist these events, but must
 /// not advance its durable cursor past them or mark itself complete (#8209).
-({List<Event> events, bool timedOut, bool noRelays}) partialPage(
+({
   List<Event> events,
-) => (events: events, timedOut: true, noRelays: false);
+  bool timedOut,
+  bool noRelays,
+  bool anyRelayAnswered,
+  List<String> unsettledRelays,
+})
+partialPage(
+  List<Event> events, {
+  List<String> unsettledRelays = const ['wss://silent'],
+}) => (
+  events: events,
+  timedOut: true,
+  noRelays: false,
+  // "Partial" means one relay answered while another never did, so a relay
+  // did make a data claim here — that is what separates this from a page
+  // nothing answered.
+  anyRelayAnswered: true,
+  unsettledRelays: unsettledRelays,
+);
 
 /// Shapes a `queryEventsDetailed` answer that nothing gave: a fan-out no relay
 /// took ([noRelays]), or a relay that refused the REQ with `CLOSED` / a page
 /// the settle window completed without every relay answering ([timedOut]).
 /// The events list is empty and means nothing — the drain must defer, not
 /// conclude exhaustion.
-({List<Event> events, bool timedOut, bool noRelays}) unansweredPage({
+({
+  List<Event> events,
+  bool timedOut,
+  bool noRelays,
+  bool anyRelayAnswered,
+  List<String> unsettledRelays,
+})
+unansweredPage({
   bool noRelays = false,
   bool timedOut = false,
-}) => (events: const <Event>[], timedOut: timedOut, noRelays: noRelays);
+  bool anyRelayAnswered = false,
+  List<String> unsettledRelays = const <String>[],
+}) => (
+  events: const <Event>[],
+  timedOut: timedOut,
+  noRelays: noRelays,
+  anyRelayAnswered: anyRelayAnswered,
+  unsettledRelays: unsettledRelays,
+);
 
 class _MockNIP17MessageService extends Mock implements NIP17MessageService {}
 
@@ -461,6 +534,8 @@ class _FakeDmSyncState implements DmSyncState {
   final List<String> inboxCoveredPubkeys = <String>[];
   final List<String> rearmedForInboxPubkeys = <String>[];
   final List<String> drainPreambleOperations = <String>[];
+  final Map<String, int> silentHoldoutRunsOverride = <String, int>{};
+  final List<String> clearedSilentHoldoutPubkeys = <String>[];
 
   @override
   int? newestSyncedAt(String pubkey) => newestOverride;
@@ -484,6 +559,23 @@ class _FakeDmSyncState implements DmSyncState {
 
   @override
   bool historyDrainCompletedBefore(String pubkey) => completedBeforeOverride;
+
+  @override
+  int drainSilentHoldoutRuns(String pubkey) =>
+      silentHoldoutRunsOverride[pubkey] ?? 0;
+
+  @override
+  Future<int> recordDrainSilentHoldoutRun(String pubkey) async {
+    final next = drainSilentHoldoutRuns(pubkey) + 1;
+    silentHoldoutRunsOverride[pubkey] = next;
+    return next;
+  }
+
+  @override
+  Future<void> clearDrainSilentHoldoutRuns(String pubkey) async {
+    silentHoldoutRunsOverride.remove(pubkey);
+    clearedSilentHoldoutPubkeys.add(pubkey);
+  }
 
   @override
   Future<void> migrateHistoryDrainCompletion(String pubkey) async {
@@ -4764,11 +4856,25 @@ void main() {
           addTearDown(() => DmRepository.inboxResolutionBudget = original);
 
           final stalledRead =
-              Completer<({List<Event> events, bool timedOut, bool noRelays})>();
+              Completer<
+                ({
+                  List<Event> events,
+                  bool timedOut,
+                  bool noRelays,
+                  bool anyRelayAnswered,
+                  List<String> unsettledRelays,
+                })
+              >();
           addTearDown(() {
             if (!stalledRead.isCompleted) {
               stalledRead.complete(
-                (events: const <Event>[], timedOut: true, noRelays: false),
+                (
+                  events: const <Event>[],
+                  timedOut: true,
+                  noRelays: false,
+                  anyRelayAnswered: false,
+                  unsettledRelays: const <String>[],
+                ),
               );
             }
           });
@@ -5028,7 +5134,14 @@ void main() {
       );
 
       void stubQueryDetailed(
-        ({List<Event> events, bool timedOut, bool noRelays}) answer,
+        ({
+          List<Event> events,
+          bool timedOut,
+          bool noRelays,
+          bool anyRelayAnswered,
+          List<String> unsettledRelays,
+        })
+        answer,
       ) {
         when(
           () => mockNostrClient.queryEventsDetailed(
@@ -5185,6 +5298,8 @@ void main() {
             ],
             timedOut: true,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ));
           final repository = createRepository();
           final resolved = await repository.resolveDmInboxRelaysDetailed(
@@ -5525,9 +5640,25 @@ void main() {
           // stopped calling it, so the read fell through to the shared
           // answered-empty default and returned before the switch.
           final resolveA =
-              Completer<({List<Event> events, bool timedOut, bool noRelays})>();
+              Completer<
+                ({
+                  List<Event> events,
+                  bool timedOut,
+                  bool noRelays,
+                  bool anyRelayAnswered,
+                  List<String> unsettledRelays,
+                })
+              >();
           final resolveB =
-              Completer<({List<Event> events, bool timedOut, bool noRelays})>();
+              Completer<
+                ({
+                  List<Event> events,
+                  bool timedOut,
+                  bool noRelays,
+                  bool anyRelayAnswered,
+                  List<String> unsettledRelays,
+                })
+              >();
           var resolveCalls = 0;
           when(
             () => mockNostrClient.queryEventsDetailed(
@@ -6127,7 +6258,14 @@ void main() {
 
       group('own kind-10050 authoritative read (#8212)', () {
         void stubOwnInbox(
-          ({List<Event> events, bool timedOut, bool noRelays}) answer,
+          ({
+            List<Event> events,
+            bool timedOut,
+            bool noRelays,
+            bool anyRelayAnswered,
+            List<String> unsettledRelays,
+          })
+          answer,
         ) {
           when(
             () => mockNostrClient.queryEventsDetailed(
@@ -6226,6 +6364,8 @@ void main() {
               ],
               timedOut: true,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             ));
             stubAcceptedPublish();
 
@@ -6449,6 +6589,193 @@ void main() {
           (_) async => unansweredPage(noRelays: noRelays, timedOut: timedOut),
         );
       }
+
+      group('a relay that never settles any page', () {
+        /// Stubs every drain page as one the reachable relays answered while
+        /// [silent] never settled.
+        void stubSilentHoldout({List<String> silent = const ['wss://silent']}) {
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer(
+            (_) async => unansweredPage(
+              timedOut: true,
+              anyRelayAnswered: true,
+              unsettledRelays: silent,
+            ),
+          );
+        }
+
+        _FakeDmSyncState freshSyncState() => _FakeDmSyncState()
+          ..oldestOverride = 100
+          ..drainVersionOverride = DmSyncState.currentDrainVersion;
+
+        setUp(() {
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(6);
+        });
+
+        test(
+          'defers on the runs before the budget, exactly as #8209 requires',
+          () async {
+            stubSilentHoldout();
+            final syncState = freshSyncState();
+            final repository = createRepository(syncState: syncState);
+
+            for (
+              var run = 1;
+              run <
+                  DmHistoryDrainConfig.silentHoldoutRunsBeforeQuorumCompletion;
+              run++
+            ) {
+              await repository.backfillHistoryIfNeeded();
+              expect(
+                syncState.markedCompletePubkeys,
+                isEmpty,
+                reason: 'run $run must still defer',
+              );
+            }
+            // The counter is what carries the deferrals forward; without it
+            // every run would look like the first one, forever.
+            expect(
+              syncState.drainSilentHoldoutRuns(_validPubkeyA),
+              DmHistoryDrainConfig.silentHoldoutRunsBeforeQuorumCompletion - 1,
+            );
+          },
+        );
+
+        test(
+          'completes on the relays that answered once the budget is spent, so '
+          'a permanently silent relay cannot strand the inbox forever',
+          () async {
+            stubSilentHoldout();
+            final syncState = freshSyncState();
+            final repository = createRepository(syncState: syncState);
+
+            for (
+              var run = 0;
+              run <
+                  DmHistoryDrainConfig.silentHoldoutRunsBeforeQuorumCompletion;
+              run++
+            ) {
+              await repository.backfillHistoryIfNeeded();
+            }
+
+            expect(syncState.markedCompletePubkeys, contains(_validPubkeyA));
+            expect(syncState.drainCompleteOverride, isTrue);
+          },
+        );
+
+        test(
+          'never completes when NOTHING answered, however many runs — an empty '
+          'box no relay claimed is evidence of nothing (#5202)',
+          () async {
+            // Same timeout, same run count, only `anyRelayAnswered` differs.
+            // This is the discriminator the whole change rests on: without it
+            // the budget below would latch completion over unread history.
+            stubUnansweredHistory(timedOut: true);
+            final syncState = freshSyncState();
+            final repository = createRepository(syncState: syncState);
+
+            for (
+              var run = 0;
+              run <
+                  DmHistoryDrainConfig.silentHoldoutRunsBeforeQuorumCompletion +
+                      2;
+              run++
+            ) {
+              await repository.backfillHistoryIfNeeded();
+            }
+
+            expect(syncState.markedCompletePubkeys, isEmpty);
+            expect(syncState.drainSilentHoldoutRuns(_validPubkeyA), 0);
+          },
+        );
+
+        test(
+          'completes even when an earlier page carried events the holdout did '
+          'not settle, so the strand cannot just move one window down',
+          () async {
+            // The empty-page tests above leave `sawUnansweredPage` false, so
+            // the ordinary completion gate would let them through on its own.
+            // This is the shape that needs the quorum clause: a first page
+            // that returned events without full settlement latches
+            // `sawUnansweredPage`, and every later run repeats it.
+            var page = 0;
+            when(
+              () => mockNostrClient.queryEventsDetailed(
+                any(),
+                subscriptionId: any(named: 'subscriptionId'),
+                useCache: any(named: 'useCache'),
+                tempRelays: any(named: 'tempRelays'),
+                requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              ),
+            ).thenAnswer((inv) async {
+              final filters =
+                  inv.positionalArguments.first as List<nostr_filter.Filter>;
+              final filter = filters.single;
+              // Let the outgoing-NIP-04 pass answer, so this test dies to the
+              // gift-wrap gate rather than to that pass.
+              if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
+                return answeredPage(const <Event>[]);
+              }
+              // First gift-wrap page of each run: real events, not settled.
+              if ((page++).isEven) return partialPage([deletion(90)]);
+              return unansweredPage(
+                timedOut: true,
+                anyRelayAnswered: true,
+                unsettledRelays: const ['wss://silent'],
+              );
+            });
+
+            final syncState = freshSyncState();
+            final repository = createRepository(syncState: syncState);
+            for (
+              var run = 0;
+              run <
+                  DmHistoryDrainConfig.silentHoldoutRunsBeforeQuorumCompletion;
+              run++
+            ) {
+              page = 0;
+              await repository.backfillHistoryIfNeeded();
+            }
+
+            expect(syncState.markedCompletePubkeys, contains(_validPubkeyA));
+          },
+        );
+
+        test(
+          'a fully settled page clears the count, so a flapping relay never '
+          'accumulates toward the budget',
+          () async {
+            final syncState = freshSyncState();
+            final repository = createRepository(syncState: syncState);
+
+            stubSilentHoldout();
+            await repository.backfillHistoryIfNeeded();
+            expect(syncState.drainSilentHoldoutRuns(_validPubkeyA), 1);
+
+            // The holdout speaks: this run settles on every relay.
+            when(
+              () => mockNostrClient.queryEventsDetailed(
+                any(),
+                subscriptionId: any(named: 'subscriptionId'),
+                useCache: any(named: 'useCache'),
+                tempRelays: any(named: 'tempRelays'),
+                requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              ),
+            ).thenAnswer((_) async => answeredPage(const <Event>[]));
+            await repository.backfillHistoryIfNeeded();
+
+            expect(syncState.clearedSilentHoldoutPubkeys, isNotEmpty);
+            expect(syncState.drainSilentHoldoutRuns(_validPubkeyA), 0);
+          },
+        );
+      });
 
       test(
         'does NOT mark complete when a fan-out reached no relay — defers to '
@@ -15550,7 +15877,14 @@ void main() {
 
       group('#8515 an unreadable recipient inbox is not delivery', () {
         void stubInboxLookup(
-          ({List<Event> events, bool timedOut, bool noRelays}) answer,
+          ({
+            List<Event> events,
+            bool timedOut,
+            bool noRelays,
+            bool anyRelayAnswered,
+            List<String> unsettledRelays,
+          })
+          answer,
         ) {
           when(
             () => mockNostrClient.queryEventsDetailed(

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -535,6 +535,12 @@ class _FakeDmSyncState implements DmSyncState {
   final List<String> rearmedForInboxPubkeys = <String>[];
   final List<String> drainPreambleOperations = <String>[];
   final Map<String, int> silentHoldoutRunsOverride = <String, int>{};
+  final Map<String, List<String>> silentHoldoutRelaysOverride =
+      <String, List<String>>{};
+  final Map<String, List<String>> quorumHoldoutsOverride =
+      <String, List<String>>{};
+  final Map<String, int> quorumCursorOverride = <String, int>{};
+  final List<int> rearmedFromCursors = <int>[];
   final List<String> clearedSilentHoldoutPubkeys = <String>[];
 
   @override
@@ -565,8 +571,22 @@ class _FakeDmSyncState implements DmSyncState {
       silentHoldoutRunsOverride[pubkey] ?? 0;
 
   @override
-  Future<int> recordDrainSilentHoldoutRun(String pubkey) async {
-    final next = drainSilentHoldoutRuns(pubkey) + 1;
+  List<String> drainSilentHoldoutRelays(String pubkey) =>
+      silentHoldoutRelaysOverride[pubkey] ?? const <String>[];
+
+  @override
+  Future<int> recordDrainSilentHoldoutRun(
+    String pubkey, {
+    required List<String> holdouts,
+  }) async {
+    final previous = drainSilentHoldoutRelays(pubkey);
+    final sorted = [...holdouts]..sort();
+    var unchanged = previous.length == sorted.length;
+    for (var i = 0; unchanged && i < sorted.length; i++) {
+      unchanged = previous[i] == sorted[i];
+    }
+    final next = unchanged ? drainSilentHoldoutRuns(pubkey) + 1 : 1;
+    silentHoldoutRelaysOverride[pubkey] = sorted;
     silentHoldoutRunsOverride[pubkey] = next;
     return next;
   }
@@ -574,7 +594,38 @@ class _FakeDmSyncState implements DmSyncState {
   @override
   Future<void> clearDrainSilentHoldoutRuns(String pubkey) async {
     silentHoldoutRunsOverride.remove(pubkey);
+    silentHoldoutRelaysOverride.remove(pubkey);
     clearedSilentHoldoutPubkeys.add(pubkey);
+  }
+
+  @override
+  List<String> drainQuorumHoldouts(String pubkey) =>
+      quorumHoldoutsOverride[pubkey] ?? const <String>[];
+
+  @override
+  int? drainQuorumCursor(String pubkey) => quorumCursorOverride[pubkey];
+
+  @override
+  Future<void> recordDrainQuorumCompletion(
+    String pubkey, {
+    required List<String> holdouts,
+    required int cursor,
+  }) async {
+    quorumHoldoutsOverride[pubkey] = holdouts;
+    quorumCursorOverride[pubkey] = cursor;
+  }
+
+  @override
+  Future<void> clearDrainQuorumCompletion(String pubkey) async {
+    quorumHoldoutsOverride.remove(pubkey);
+    quorumCursorOverride.remove(pubkey);
+  }
+
+  @override
+  Future<void> rearmDrainFromCursor(String pubkey, int cursor) async {
+    drainCompleteOverride = false;
+    drainCursorOverride = cursor;
+    rearmedFromCursors.add(cursor);
   }
 
   @override
@@ -6745,6 +6796,104 @@ void main() {
             }
 
             expect(syncState.markedCompletePubkeys, contains(_validPubkeyA));
+          },
+        );
+
+        test(
+          'a rotating cast of holdouts never reaches the budget, because each '
+          'run only speaks for the window its own holdout was silent on',
+          () async {
+            // A different relay is silent on each run. Three such runs are NOT
+            // three runs of evidence about one window: the relay silent on the
+            // final window may have answered only earlier ones, so completing
+            // here would latch over history it never reported.
+            final holdouts = <List<String>>[
+              const ['wss://a'],
+              const ['wss://b'],
+              const ['wss://c'],
+            ];
+            var run = 0;
+            when(
+              () => mockNostrClient.queryEventsDetailed(
+                any(),
+                subscriptionId: any(named: 'subscriptionId'),
+                useCache: any(named: 'useCache'),
+                tempRelays: any(named: 'tempRelays'),
+                requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              ),
+            ).thenAnswer(
+              (_) async => unansweredPage(
+                timedOut: true,
+                anyRelayAnswered: true,
+                unsettledRelays: holdouts[run % holdouts.length],
+              ),
+            );
+
+            final syncState = freshSyncState();
+            final repository = createRepository(syncState: syncState);
+            for (
+              run = 0;
+              run <
+                  DmHistoryDrainConfig.silentHoldoutRunsBeforeQuorumCompletion +
+                      2;
+              run++
+            ) {
+              await repository.backfillHistoryIfNeeded();
+            }
+
+            expect(syncState.markedCompletePubkeys, isEmpty);
+            // Restarted every run, never accumulated.
+            expect(syncState.drainSilentHoldoutRuns(_validPubkeyA), 1);
+          },
+        );
+
+        test(
+          're-reads the held window once a skipped relay is reachable again, '
+          'so the completion latch cannot hide it permanently',
+          () async {
+            stubSilentHoldout();
+            final syncState = freshSyncState();
+            final repository = createRepository(syncState: syncState);
+            for (
+              var run = 0;
+              run <
+                  DmHistoryDrainConfig.silentHoldoutRunsBeforeQuorumCompletion;
+              run++
+            ) {
+              await repository.backfillHistoryIfNeeded();
+            }
+            expect(syncState.markedCompletePubkeys, contains(_validPubkeyA));
+            expect(
+              syncState.drainQuorumHoldouts(_validPubkeyA),
+              const ['wss://silent'],
+            );
+            final heldWindow = syncState.drainQuorumCursor(_validPubkeyA);
+            expect(heldWindow, isNotNull);
+
+            // The holdout comes back. The next inbox open must re-drain from
+            // exactly the window it never answered.
+            when(() => mockNostrClient.relayStatuses).thenReturn({
+              'wss://silent': const RelayConnectionStatus(
+                url: 'wss://silent',
+                state: RelayState.connected,
+              ),
+            });
+            when(
+              () => mockNostrClient.queryEventsDetailed(
+                any(),
+                subscriptionId: any(named: 'subscriptionId'),
+                useCache: any(named: 'useCache'),
+                tempRelays: any(named: 'tempRelays'),
+                requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              ),
+            ).thenAnswer((_) async => answeredPage(const <Event>[]));
+
+            await repository.backfillHistoryIfNeeded();
+
+            expect(syncState.rearmedFromCursors, contains(heldWindow));
+            // The record is consumed, so a relay that goes quiet again cannot
+            // re-arm the drain on every inbox open.
+            expect(syncState.drainQuorumHoldouts(_validPubkeyA), isEmpty);
           },
         );
 

--- a/mobile/packages/dm_repository/test/src/dm_retry_rumor_identity_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_retry_rumor_identity_test.dart
@@ -80,8 +80,13 @@ void main() {
           timeout: any(named: 'timeout'),
         ),
       ).thenAnswer(
-        (_) async =>
-            (events: const <Event>[], timedOut: false, noRelays: false),
+        (_) async => (
+          events: const <Event>[],
+          timedOut: false,
+          noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
       when(() => messageService.canSendTo(any())).thenAnswer((_) async => true);
       when(
@@ -299,8 +304,13 @@ void main() {
           timeout: any(named: 'timeout'),
         ),
       ).thenAnswer(
-        (_) async =>
-            (events: const <Event>[], timedOut: false, noRelays: false),
+        (_) async => (
+          events: const <Event>[],
+          timedOut: false,
+          noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
       when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
       when(

--- a/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
@@ -767,5 +767,187 @@ void main() {
         expect(state.newestWireSyncedAt(pkB), isNull);
       });
     });
+    group('silent-holdout run counting', () {
+      test('starts at zero', () {
+        expect(state.drainSilentHoldoutRuns(pkA), 0);
+        expect(state.drainSilentHoldoutRelays(pkA), isEmpty);
+      });
+
+      test('accumulates while the same relay stays silent', () async {
+        expect(
+          await state.recordDrainSilentHoldoutRun(
+            pkA,
+            holdouts: const ['wss://a'],
+          ),
+          1,
+        );
+        expect(
+          await state.recordDrainSilentHoldoutRun(
+            pkA,
+            holdouts: const ['wss://a'],
+          ),
+          2,
+        );
+        expect(state.drainSilentHoldoutRuns(pkA), 2);
+      });
+
+      test('ignores the order the relays are reported in', () async {
+        await state.recordDrainSilentHoldoutRun(
+          pkA,
+          holdouts: const ['wss://a', 'wss://b'],
+        );
+        expect(
+          await state.recordDrainSilentHoldoutRun(
+            pkA,
+            holdouts: const ['wss://b', 'wss://a'],
+          ),
+          2,
+        );
+      });
+
+      test(
+        'restarts when a different relay is the holdout, so a rotating cast '
+        'never accumulates toward the budget',
+        () async {
+          await state.recordDrainSilentHoldoutRun(
+            pkA,
+            holdouts: const ['wss://a'],
+          );
+          await state.recordDrainSilentHoldoutRun(
+            pkA,
+            holdouts: const ['wss://a'],
+          );
+
+          expect(
+            await state.recordDrainSilentHoldoutRun(
+              pkA,
+              holdouts: const ['wss://b'],
+            ),
+            1,
+            reason: 'run 2 said nothing about the window wss://b held',
+          );
+          expect(state.drainSilentHoldoutRelays(pkA), const ['wss://b']);
+        },
+      );
+
+      test('restarts when the holdout set grows', () async {
+        await state.recordDrainSilentHoldoutRun(
+          pkA,
+          holdouts: const ['wss://a'],
+        );
+        expect(
+          await state.recordDrainSilentHoldoutRun(
+            pkA,
+            holdouts: const ['wss://a', 'wss://b'],
+          ),
+          1,
+        );
+      });
+
+      test('is scoped per pubkey', () async {
+        await state.recordDrainSilentHoldoutRun(
+          pkA,
+          holdouts: const ['wss://a'],
+        );
+        expect(state.drainSilentHoldoutRuns(pkB), 0);
+      });
+
+      test('clear resets both the count and the recorded set', () async {
+        await state.recordDrainSilentHoldoutRun(
+          pkA,
+          holdouts: const ['wss://a'],
+        );
+        await state.clearDrainSilentHoldoutRuns(pkA);
+
+        expect(state.drainSilentHoldoutRuns(pkA), 0);
+        expect(state.drainSilentHoldoutRelays(pkA), isEmpty);
+      });
+
+      test('markHistoryDrainComplete clears the count', () async {
+        await state.recordDrainSilentHoldoutRun(
+          pkA,
+          holdouts: const ['wss://a'],
+        );
+        await state.markHistoryDrainComplete(pkA);
+
+        expect(state.drainSilentHoldoutRuns(pkA), 0);
+      });
+    });
+
+    group('quorum completion record', () {
+      test('round-trips the excluded relays and the held window', () async {
+        await state.recordDrainQuorumCompletion(
+          pkA,
+          holdouts: const ['wss://silent'],
+          cursor: tsMid,
+        );
+
+        expect(state.drainQuorumHoldouts(pkA), const ['wss://silent']);
+        expect(state.drainQuorumCursor(pkA), tsMid);
+      });
+
+      test(
+        'rearmDrainFromCursor clears the latch and seeds the window',
+        () async {
+          await state.markHistoryDrainComplete(pkA);
+          expect(state.historyDrainComplete(pkA), isTrue);
+
+          await state.rearmDrainFromCursor(pkA, tsMid);
+
+          expect(state.historyDrainComplete(pkA), isFalse);
+          expect(state.historyDrainCursor(pkA), tsMid);
+        },
+      );
+
+      test('clear removes the record', () async {
+        await state.recordDrainQuorumCompletion(
+          pkA,
+          holdouts: const ['wss://silent'],
+          cursor: tsMid,
+        );
+        await state.clearDrainQuorumCompletion(pkA);
+
+        expect(state.drainQuorumHoldouts(pkA), isEmpty);
+        expect(state.drainQuorumCursor(pkA), isNull);
+      });
+    });
+
+    group('account-boundary cleanup', () {
+      test('clear removes every drain key this account owns', () async {
+        await state.recordDrainSilentHoldoutRun(
+          pkA,
+          holdouts: const ['wss://a'],
+        );
+        await state.recordDrainQuorumCompletion(
+          pkA,
+          holdouts: const ['wss://a'],
+          cursor: tsMid,
+        );
+
+        await state.clear(pkA);
+
+        expect(state.drainSilentHoldoutRuns(pkA), 0);
+        expect(state.drainSilentHoldoutRelays(pkA), isEmpty);
+        expect(state.drainQuorumHoldouts(pkA), isEmpty);
+        expect(state.drainQuorumCursor(pkA), isNull);
+      });
+
+      test('clearAll removes them for every account', () async {
+        await state.recordDrainSilentHoldoutRun(
+          pkA,
+          holdouts: const ['wss://a'],
+        );
+        await state.recordDrainQuorumCompletion(
+          pkB,
+          holdouts: const ['wss://b'],
+          cursor: tsMid,
+        );
+
+        await state.clearAll();
+
+        expect(state.drainSilentHoldoutRuns(pkA), 0);
+        expect(state.drainQuorumHoldouts(pkB), isEmpty);
+      });
+    });
   });
 }

--- a/mobile/packages/follow_repository/test/src/follow_repository_cached_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_cached_test.dart
@@ -31,7 +31,13 @@ class _MockNostrClient extends Mock implements NostrClient {
         timeout: any(named: 'timeout'),
       ),
     ).thenAnswer(
-      (_) async => (events: <Event>[], timedOut: false, noRelays: false),
+      (_) async => (
+        events: <Event>[],
+        timedOut: false,
+        noRelays: false,
+        anyRelayAnswered: false,
+        unsettledRelays: const <String>[],
+      ),
     );
   }
 }

--- a/mobile/packages/follow_repository/test/src/follow_repository_contact_list_freshness_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_contact_list_freshness_test.dart
@@ -21,7 +21,13 @@ class _MockNostrClient extends Mock implements NostrClient {
         timeout: any(named: 'timeout'),
       ),
     ).thenAnswer(
-      (_) async => (events: <Event>[], timedOut: false, noRelays: false),
+      (_) async => (
+        events: <Event>[],
+        timedOut: false,
+        noRelays: false,
+        anyRelayAnswered: false,
+        unsettledRelays: const <String>[],
+      ),
     );
   }
 }
@@ -204,6 +210,8 @@ void main() {
           events: <Event>[authoritative],
           timedOut: false,
           noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
         ),
       );
 
@@ -280,6 +288,8 @@ void main() {
           ],
           timedOut: false,
           noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
         ),
       );
 
@@ -344,8 +354,13 @@ void main() {
           timeout: any(named: 'timeout'),
         ),
       ).thenAnswer(
-        (_) async =>
-            (events: <Event>[existing], timedOut: false, noRelays: false),
+        (_) async => (
+          events: <Event>[existing],
+          timedOut: false,
+          noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
 
       final publishedContent = <String>[];

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -36,7 +36,13 @@ class _MockNostrClient extends Mock implements NostrClient {
         timeout: any(named: 'timeout'),
       ),
     ).thenAnswer(
-      (_) async => (events: <Event>[], timedOut: false, noRelays: false),
+      (_) async => (
+        events: <Event>[],
+        timedOut: false,
+        noRelays: false,
+        anyRelayAnswered: false,
+        unsettledRelays: const <String>[],
+      ),
     );
   }
 }
@@ -727,6 +733,8 @@ void main() {
             events: events,
             timedOut: timedOut,
             noRelays: noRelays,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
       }

--- a/mobile/packages/likes_repository/test/src/likes_repository_pre_column_db_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_pre_column_db_test.dart
@@ -123,6 +123,8 @@ void main() {
             events: queryCall == 1 ? [createReaction()] : <Event>[],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           );
         });
         final repository = LikesRepository(

--- a/mobile/packages/likes_repository/test/src/likes_repository_repeat_publish_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_repeat_publish_test.dart
@@ -15,7 +15,13 @@ class _MockLikesLocalStorage extends Mock implements LikesLocalStorage {}
 
 class _MockEvent extends Mock implements Event {}
 
-typedef _RelaySnapshot = ({List<Event> events, bool timedOut, bool noRelays});
+typedef _RelaySnapshot = ({
+  List<Event> events,
+  bool timedOut,
+  bool noRelays,
+  bool anyRelayAnswered,
+  List<String> unsettledRelays,
+});
 
 /// Holds the startup relay snapshot open so a tap can race it.
 class _GatedRelaySnapshot {
@@ -28,10 +34,22 @@ class _GatedRelaySnapshot {
     List<Event> deletions = const [],
   }) {
     this.reactions.complete(
-      (events: reactions, timedOut: false, noRelays: false),
+      (
+        events: reactions,
+        timedOut: false,
+        noRelays: false,
+        anyRelayAnswered: false,
+        unsettledRelays: const <String>[],
+      ),
     );
     this.deletions.complete(
-      (events: deletions, timedOut: false, noRelays: false),
+      (
+        events: deletions,
+        timedOut: false,
+        noRelays: false,
+        anyRelayAnswered: false,
+        unsettledRelays: const <String>[],
+      ),
     );
   }
 }
@@ -124,6 +142,8 @@ void main() {
           events: kinds.contains(EventKind.reaction) ? reactions : deletions,
           timedOut: timedOut,
           noRelays: noRelays,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
         );
       });
     }

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -99,6 +99,8 @@ void main() {
           events: responses[callCount++ % responses.length],
           timedOut: false,
           noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
         );
       });
     }

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -904,7 +904,15 @@ class NostrClient {
   /// A client disposed *mid-call* is deliberately not in that list: the relays
   /// were reachable and only this one query was dropped, so it arrives as
   /// `timedOut` for a full-settlement caller instead.
-  Future<({List<Event> events, bool timedOut, bool noRelays})>
+  Future<
+    ({
+      List<Event> events,
+      bool timedOut,
+      bool noRelays,
+      bool anyRelayAnswered,
+      List<String> unsettledRelays,
+    })
+  >
   queryEventsDetailed(
     List<Filter> filters, {
     String? subscriptionId,
@@ -922,7 +930,13 @@ class NostrClient {
     // right before `withResource` (see below) closes the residual race
     // where dispose() runs during the awaits in between. See #5952.
     if (_isDisposed) {
-      return (events: <Event>[], timedOut: false, noRelays: true);
+      return (
+        events: <Event>[],
+        timedOut: false,
+        noRelays: true,
+        anyRelayAnswered: false,
+        unsettledRelays: const <String>[],
+      );
     }
 
     // One deadline for the whole call, spent by every awaited step below.
@@ -1002,7 +1016,15 @@ class NostrClient {
     final noConnectedRelays =
         _relayManager.connectedRelays.isEmpty && !canAnswerWithoutPool;
     final filtersJson = filters.map((f) => f.toJson()).toList();
-    Future<({List<Event> events, bool timedOut, bool noRelaysParticipated})>
+    Future<
+      ({
+        List<Event> events,
+        bool timedOut,
+        bool noRelaysParticipated,
+        bool anyRelayAnswered,
+        List<String> unsettledRelays,
+      })
+    >
     runWebSocketQuery() => _nostr.queryEventsDetailed(
       filtersJson,
       id: subscriptionId,
@@ -1016,7 +1038,15 @@ class NostrClient {
       requireAllRelaysSettled: requireAllRelaysSettled,
     );
 
-    Future<({List<Event> events, bool timedOut, bool noRelaysParticipated})>
+    Future<
+      ({
+        List<Event> events,
+        bool timedOut,
+        bool noRelaysParticipated,
+        bool anyRelayAnswered,
+        List<String> unsettledRelays,
+      })
+    >
     runPooledWebSocketQuery() async {
       final acquisition = _queryPool.request();
       PoolResource resource;
@@ -1050,7 +1080,13 @@ class NostrClient {
     // the NIP-50 search relays and leak temp relays nothing would clean up.
     // This check-then-call has no await before the query, so it closes the
     // race rather than narrowing it. See #5952.
-    ({List<Event> events, bool timedOut, bool noRelaysParticipated})
+    ({
+      List<Event> events,
+      bool timedOut,
+      bool noRelaysParticipated,
+      bool anyRelayAnswered,
+      List<String> unsettledRelays,
+    })
     websocketResult;
     if (_queryPool.isClosed) {
       // Nothing was asked of the relays here, which is a different thing from
@@ -1063,6 +1099,9 @@ class NostrClient {
         events: <Event>[],
         timedOut: requireAllRelaysSettled,
         noRelaysParticipated: false,
+        // Nothing was asked, so nothing answered.
+        anyRelayAnswered: false,
+        unsettledRelays: const <String>[],
       );
     } else {
       try {
@@ -1080,6 +1119,11 @@ class NostrClient {
           events: <Event>[],
           timedOut: true,
           noRelaysParticipated: false,
+          // The client's own budget expired before the relay leg reported, so
+          // whether a relay answered is unknown here — and unknown must read
+          // as "no claim was made", or a caller would latch on it.
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
         );
       }
     }
@@ -1107,6 +1151,8 @@ class NostrClient {
       events: _mergeEvents(cacheResults, websocketEvents, limit: limit),
       timedOut: websocketResult.timedOut,
       noRelays: noConnectedRelays || websocketResult.noRelaysParticipated,
+      anyRelayAnswered: websocketResult.anyRelayAnswered,
+      unsettledRelays: websocketResult.unsettledRelays,
     );
   }
 

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -29,7 +29,15 @@ class _MockNostr extends Mock implements Nostr {
   /// list-returning method that tests stub. Tests that care about the timeout
   /// signal set [timedOut] instead of stubbing a second method.
   @override
-  Future<({List<Event> events, bool timedOut, bool noRelaysParticipated})>
+  Future<
+    ({
+      List<Event> events,
+      bool timedOut,
+      bool noRelaysParticipated,
+      bool anyRelayAnswered,
+      List<String> unsettledRelays,
+    })
+  >
   queryEventsDetailed(
     List<Map<String, dynamic>> filters, {
     String? id,
@@ -52,6 +60,8 @@ class _MockNostr extends Mock implements Nostr {
       events: events,
       timedOut: timedOut,
       noRelaysParticipated: noRelaysParticipated,
+      anyRelayAnswered: false,
+      unsettledRelays: const <String>[],
     );
   }
 }

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -344,7 +344,23 @@ class Nostr {
   /// an empty `events` on its own cannot distinguish from every relay holding
   /// nothing. It stays `false` when the fan-out itself ran out of time, since
   /// that leaves participation genuinely unknown.
-  Future<({List<Event> events, bool timedOut, bool noRelaysParticipated})>
+  ///
+  /// `anyRelayAnswered` splits the two ways a full-settlement read times out.
+  /// A relay that sends `EOSE` has made a data claim, so an empty box with
+  /// `anyRelayAnswered: true` means the relays that could be reached hold
+  /// nothing older and only a silent holdout is unaccounted for. With `false`
+  /// nothing made a claim at all, and the empty box is evidence of nothing.
+  /// `unsettledRelays` names the holdouts; relay urls are configuration, not
+  /// user data, so they are safe to log.
+  Future<
+    ({
+      List<Event> events,
+      bool timedOut,
+      bool noRelaysParticipated,
+      bool anyRelayAnswered,
+      List<String> unsettledRelays,
+    })
+  >
   queryEventsDetailed(
     List<Map<String, dynamic>> filters, {
     String? id,
@@ -360,6 +376,8 @@ class Nostr {
     final deadline = DateTime.now().add(timeout);
     var timedOut = false;
     var noRelaysParticipated = false;
+    var anyRelayAnswered = false;
+    var unsettledRelays = const <String>[];
 
     Duration remainingTimeout() {
       final remaining = deadline.difference(DateTime.now());
@@ -390,6 +408,11 @@ class Nostr {
       await completer.future.timeout(remainingTimeout());
     } on TimeoutException {
       timedOut = true;
+      // Sample before `unsubscribe`, which sweeps the pool's per-query
+      // settlement bookkeeping.
+      final settlement = _pool.querySettlement(subscriptionId);
+      anyRelayAnswered = settlement.anyRelayAnswered;
+      unsettledRelays = settlement.unsettledRelays;
       unsubscribe(subscriptionId);
     }
 
@@ -401,6 +424,10 @@ class Nostr {
       // hold and keeps its prompt empty answer.
       timedOut: timedOut || (requireAllRelaysSettled && noRelaysParticipated),
       noRelaysParticipated: noRelaysParticipated,
+      // A query that completed rather than timed out settled on every relay
+      // that took it, so participation is the whole answer.
+      anyRelayAnswered: timedOut ? anyRelayAnswered : !noRelaysParticipated,
+      unsettledRelays: unsettledRelays,
     );
   }
 

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1208,10 +1208,27 @@ class RelayPool {
         _armQuerySettleWindow(subId);
         return;
       }
-      log(
-        'Query $subId settled without ${_queryStragglers(subId)} — '
-        'completing on the relays that answered',
-      );
+      final stragglers = _queryStragglers(subId);
+      assert(() {
+        log(
+          'Query $subId settled without $stragglers — '
+          'completing on the relays that answered',
+        );
+        return true;
+      }());
+      // Which relay went silent is the one fact support cannot reconstruct
+      // from a stalled read, so it goes to the injected sink rather than only
+      // to the debug console. One diagnostic per straggler keeps the relay url
+      // in the structured `relayUrl` field instead of interpolated into text.
+      for (final straggler in stragglers) {
+        _diagnose(
+          RelayDiagnosticSite.requestSettlement,
+          RelayDiagnosticLevel.warning,
+          straggler,
+          'Relay never settled request $subId; completing on the relays that '
+          'answered',
+        );
+      }
       _completeQuery(subId, callback);
     });
   }
@@ -1240,6 +1257,23 @@ class RelayPool {
     armed.cancel();
     _armQuerySettleWindow(subId);
   }
+
+  /// Settlement evidence for a one-shot query that is still in flight.
+  ///
+  /// Read by [queryEventsDetailed] on its timeout path, where the query has
+  /// by definition not completed, so [_queryAnswered] has not yet been swept
+  /// by [_completeQuery]. A caller that required full settlement gets an empty
+  /// box either way; this is what tells it whether the box is empty because
+  /// the reachable relays said so, or because nothing said anything.
+  ///
+  /// [unsettledRelays] names the relays still holding the REQ. Relay urls are
+  /// configuration, not user data, so they are safe to log and export.
+  ({bool anyRelayAnswered, List<String> unsettledRelays}) querySettlement(
+    String subId,
+  ) => (
+    anyRelayAnswered: _queryAnswered.contains(subId),
+    unsettledRelays: _queryStragglers(subId),
+  );
 
   /// Relay urls that never answered [subId]; diagnostic only.
   List<String> _queryStragglers(String subId) => [

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_zombie_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_zombie_test.dart
@@ -38,7 +38,15 @@ void main() {
       await nostr.relayPool.add(relay);
     });
 
-    Future<({List<Event> events, bool timedOut, bool noRelaysParticipated})>
+    Future<
+      ({
+        List<Event> events,
+        bool timedOut,
+        bool noRelaysParticipated,
+        bool anyRelayAnswered,
+        List<String> unsettledRelays,
+      })
+    >
     queryOnce() {
       return nostr.queryEventsDetailed([
         {

--- a/mobile/packages/people_lists_repository/test/notify_subscriptions_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/notify_subscriptions_repository_impl_test.dart
@@ -33,11 +33,24 @@ Event _notifyEvent(List<String> pubkeys, {int createdAt = 1710000000}) => Event(
 );
 
 /// Shapes a `queryEventsDetailed` answer.
-({List<Event> events, bool timedOut, bool noRelays}) _readResult(
+({
+  List<Event> events,
+  bool timedOut,
+  bool noRelays,
+  bool anyRelayAnswered,
+  List<String> unsettledRelays,
+})
+_readResult(
   List<Event> events, {
   bool timedOut = false,
   bool noRelays = false,
-}) => (events: events, timedOut: timedOut, noRelays: noRelays);
+}) => (
+  events: events,
+  timedOut: timedOut,
+  noRelays: noRelays,
+  anyRelayAnswered: false,
+  unsettledRelays: const <String>[],
+);
 
 /// Member pubkeys carried on the event handed to `publishEvent`.
 List<String> _publishedMembers(Event event) => event.tags

--- a/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
@@ -34,6 +34,8 @@ class _MockNostrClient extends Mock implements NostrClient {
         events: await queryEvents(filters),
         timedOut: false,
         noRelays: false,
+        anyRelayAnswered: false,
+        unsettledRelays: const <String>[],
       );
     });
   }
@@ -248,7 +250,13 @@ void main() {
             timeout: any(named: 'timeout'),
           ),
         ).thenAnswer(
-          (_) async => (events: [remote], timedOut: false, noRelays: false),
+          (_) async => (
+            events: [remote],
+            timedOut: false,
+            noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
+          ),
         );
         when(() => client.publishEvent(any())).thenAnswer((invocation) async {
           final event = invocation.positionalArguments.first as Event;
@@ -302,6 +310,8 @@ void main() {
               events: [staleRemote],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             ),
           );
           when(() => client.publishEvent(any())).thenAnswer((invocation) async {
@@ -364,7 +374,13 @@ void main() {
               timeout: any(named: 'timeout'),
             ),
           ).thenAnswer(
-            (_) async => (events: [remote], timedOut: false, noRelays: false),
+            (_) async => (
+              events: [remote],
+              timedOut: false,
+              noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
+            ),
           );
           // NostrClient appends the NIP-89 client tag during publish and
           // rebinds event.tags to a new list, so the caller's pre-publish
@@ -627,7 +643,13 @@ void main() {
               timeout: any(named: 'timeout'),
             ),
           ).thenAnswer(
-            (_) async => (events: [remote], timedOut: false, noRelays: false),
+            (_) async => (
+              events: [remote],
+              timedOut: false,
+              noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
+            ),
           );
           when(() => client.publishEvent(any())).thenAnswer((invocation) async {
             final event = invocation.positionalArguments.first as Event;
@@ -689,7 +711,13 @@ void main() {
             timeout: any(named: 'timeout'),
           ),
         ).thenAnswer(
-          (_) async => (events: events, timedOut: timedOut, noRelays: noRelays),
+          (_) async => (
+            events: events,
+            timedOut: timedOut,
+            noRelays: noRelays,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
+          ),
         );
       }
 
@@ -1070,6 +1098,8 @@ void main() {
               events: [newer, older],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             ),
           );
           final repository = buildRepository(nostrClient: client);
@@ -1122,6 +1152,8 @@ void main() {
             events: [higherId, lowerId],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
         final repository = buildRepository(nostrClient: client);

--- a/mobile/test/providers/dm_repository_provider_test.dart
+++ b/mobile/test/providers/dm_repository_provider_test.dart
@@ -97,6 +97,8 @@ void main() {
           events: const <Event>[],
           noRelays: false,
           timedOut: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
         ),
       );
 

--- a/mobile/test/providers/moderation_label_provider_session_test.dart
+++ b/mobile/test/providers/moderation_label_provider_session_test.dart
@@ -113,7 +113,13 @@ void main() {
           requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
         ),
       ).thenAnswer(
-        (_) async => (events: <Event>[], timedOut: false, noRelays: false),
+        (_) async => (
+          events: <Event>[],
+          timedOut: false,
+          noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
       when(
         () => nostrClient.subscribe(

--- a/mobile/test/services/account_deletion_service_test.dart
+++ b/mobile/test/services/account_deletion_service_test.dart
@@ -21,7 +21,15 @@ class _MockNostrClient extends Mock implements NostrClient {
   bool? queryRequiresAllRelaysSettled;
 
   @override
-  Future<({List<Event> events, bool timedOut, bool noRelays})>
+  Future<
+    ({
+      List<Event> events,
+      bool timedOut,
+      bool noRelays,
+      bool anyRelayAnswered,
+      List<String> unsettledRelays,
+    })
+  >
   queryEventsDetailed(
     List<Filter> filters, {
     String? subscriptionId,
@@ -40,6 +48,8 @@ class _MockNostrClient extends Mock implements NostrClient {
       events: events,
       timedOut: queryTimedOut,
       noRelays: connectedRelays.isEmpty,
+      anyRelayAnswered: false,
+      unsettledRelays: const <String>[],
     );
   }
 }

--- a/mobile/test/services/corrupted_video_repair_service_test.dart
+++ b/mobile/test/services/corrupted_video_repair_service_test.dart
@@ -16,16 +16,42 @@ class _MockVideoEventService extends Mock implements VideoEventService {}
 /// Shapes a `queryEventsDetailed` answer a relay actually gave, so an empty
 /// [events] list is genuine "this account has no corrupted videos" — the only
 /// result the repair may latch on (#8213).
-({List<Event> events, bool timedOut, bool noRelays}) _answeredScan(
+({
   List<Event> events,
-) => (events: events, timedOut: false, noRelays: false);
+  bool timedOut,
+  bool noRelays,
+  bool anyRelayAnswered,
+  List<String> unsettledRelays,
+})
+_answeredScan(
+  List<Event> events,
+) => (
+  events: events,
+  timedOut: false,
+  noRelays: false,
+  anyRelayAnswered: false,
+  unsettledRelays: const <String>[],
+);
 
 /// Shapes a scan nothing answered: a fan-out no relay took ([noRelays]), or a
 /// relay that refused the REQ with `CLOSED` / a partial fan-out ([timedOut]).
-({List<Event> events, bool timedOut, bool noRelays}) _unansweredScan({
+({
+  List<Event> events,
+  bool timedOut,
+  bool noRelays,
+  bool anyRelayAnswered,
+  List<String> unsettledRelays,
+})
+_unansweredScan({
   bool noRelays = false,
   bool timedOut = false,
-}) => (events: const <Event>[], timedOut: timedOut, noRelays: noRelays);
+}) => (
+  events: const <Event>[],
+  timedOut: timedOut,
+  noRelays: noRelays,
+  anyRelayAnswered: false,
+  unsettledRelays: const <String>[],
+);
 
 class _FakeEvent extends Fake implements Event {}
 

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -223,7 +223,13 @@ void main() {
           requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
         ),
       ).thenAnswer(
-        (_) async => (events: <Event>[], timedOut: false, noRelays: false),
+        (_) async => (
+          events: <Event>[],
+          timedOut: false,
+          noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
       final service = buildService(canQueryRelays: true);
 
@@ -327,6 +333,8 @@ void main() {
             ],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
 
@@ -363,6 +371,8 @@ void main() {
             ],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
 
@@ -396,6 +406,8 @@ void main() {
             ],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
 
@@ -431,6 +443,8 @@ void main() {
             ],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
 
@@ -468,6 +482,8 @@ void main() {
               ],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             ),
           );
 
@@ -503,6 +519,8 @@ void main() {
               ],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             ),
           );
 
@@ -536,6 +554,8 @@ void main() {
             ],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
 
@@ -571,6 +591,8 @@ void main() {
             ],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
 
@@ -620,6 +642,8 @@ void main() {
               ],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             ),
           );
 
@@ -680,6 +704,8 @@ void main() {
               ],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             ),
           );
 
@@ -730,6 +756,8 @@ void main() {
             ],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
 
@@ -767,6 +795,8 @@ void main() {
             ],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
 
@@ -798,6 +828,8 @@ void main() {
             ],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
 
@@ -829,6 +861,8 @@ void main() {
             ],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
 
@@ -880,6 +914,8 @@ void main() {
             ],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
 
@@ -921,6 +957,8 @@ void main() {
             ],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
 
@@ -960,7 +998,15 @@ void main() {
         const labeler =
             'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
         final events =
-            Completer<({List<Event> events, bool timedOut, bool noRelays})>();
+            Completer<
+              ({
+                List<Event> events,
+                bool timedOut,
+                bool noRelays,
+                bool anyRelayAnswered,
+                List<String> unsettledRelays,
+              })
+            >();
         when(
           () => mockNostrClient.queryEventsDetailed(
             any(),
@@ -992,6 +1038,8 @@ void main() {
           ],
           timedOut: false,
           noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
         ));
         await Future.wait([firstSubscribe, secondSubscribe]);
 
@@ -1002,7 +1050,15 @@ void main() {
         const labeler =
             'abababababababababababababababababababababababababababababababab';
         final firstPage =
-            Completer<({List<Event> events, bool timedOut, bool noRelays})>();
+            Completer<
+              ({
+                List<Event> events,
+                bool timedOut,
+                bool noRelays,
+                bool anyRelayAnswered,
+                List<String> unsettledRelays,
+              })
+            >();
         var queryCount = 0;
         when(
           () => mockNostrClient.queryEventsDetailed(
@@ -1025,6 +1081,8 @@ void main() {
             ],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ));
         });
 
@@ -1040,6 +1098,8 @@ void main() {
           events: <Event>[],
           timedOut: false,
           noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
         ));
         await Future.wait([initialFollow, refollow]);
 
@@ -1069,6 +1129,8 @@ void main() {
             ],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
 
@@ -1108,6 +1170,8 @@ void main() {
               ],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             ),
           );
 
@@ -1153,6 +1217,8 @@ void main() {
               ],
               timedOut: true,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             ),
           );
 
@@ -1206,7 +1272,13 @@ void main() {
               requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
           ).thenAnswer(
-            (_) async => (events: <Event>[], timedOut: true, noRelays: false),
+            (_) async => (
+              events: <Event>[],
+              timedOut: true,
+              noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
+            ),
           );
 
           await service.subscribeToLabeler(labeler);
@@ -1222,6 +1294,8 @@ void main() {
               events: <Event>[labelFor('timed_out_event')],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             ),
           );
 
@@ -1238,7 +1312,13 @@ void main() {
             requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
         ).thenAnswer(
-          (_) async => (events: <Event>[], timedOut: false, noRelays: true),
+          (_) async => (
+            events: <Event>[],
+            timedOut: false,
+            noRelays: true,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
+          ),
         );
 
         await service.subscribeToLabeler(labeler);
@@ -1254,6 +1334,8 @@ void main() {
             events: <Event>[labelFor('no_relay_event')],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
 
@@ -1271,7 +1353,13 @@ void main() {
               requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
           ).thenAnswer(
-            (_) async => (events: <Event>[], timedOut: false, noRelays: false),
+            (_) async => (
+              events: <Event>[],
+              timedOut: false,
+              noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
+            ),
           );
 
           await service.subscribeToLabeler(labeler);
@@ -1302,7 +1390,13 @@ void main() {
             requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
         ).thenAnswer(
-          (_) async => (events: <Event>[], timedOut: true, noRelays: false),
+          (_) async => (
+            events: <Event>[],
+            timedOut: true,
+            noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
+          ),
         );
 
         await service.subscribeToLabeler(labeler);
@@ -1318,6 +1412,8 @@ void main() {
             events: <Event>[labelFor('relay_ready_event')],
             timedOut: false,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
 
@@ -1351,7 +1447,13 @@ void main() {
             requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
         ).thenAnswer(
-          (_) async => (events: <Event>[], timedOut: true, noRelays: false),
+          (_) async => (
+            events: <Event>[],
+            timedOut: true,
+            noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
+          ),
         );
 
         await service.subscribeToLabeler(labeler);
@@ -1386,7 +1488,13 @@ void main() {
             ),
           ).thenAnswer((_) async {
             calls++;
-            return (events: <Event>[], timedOut: true, noRelays: false);
+            return (
+              events: <Event>[],
+              timedOut: true,
+              noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
+            );
           });
 
           await service.subscribeToLabeler(labeler);
@@ -1416,7 +1524,13 @@ void main() {
               requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
           ).thenAnswer(
-            (_) async => (events: <Event>[], timedOut: true, noRelays: false),
+            (_) async => (
+              events: <Event>[],
+              timedOut: true,
+              noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
+            ),
           );
 
           await service.subscribeToLabeler(labeler);
@@ -1461,6 +1575,8 @@ void main() {
               events: <Event>[labelFor('cached_event')],
               timedOut: true,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             ),
           );
 
@@ -1487,7 +1603,15 @@ void main() {
         ).thenAnswer((_) => statuses.stream);
         when(() => mockNostrClient.connectedRelayCount).thenReturn(0);
         final inFlight =
-            Completer<({List<Event> events, bool timedOut, bool noRelays})>();
+            Completer<
+              ({
+                List<Event> events,
+                bool timedOut,
+                bool noRelays,
+                bool anyRelayAnswered,
+                List<String> unsettledRelays,
+              })
+            >();
         when(
           () => mockNostrClient.queryEventsDetailed(
             any(),
@@ -1500,7 +1624,13 @@ void main() {
 
         service.dispose();
 
-        inFlight.complete((events: <Event>[], timedOut: true, noRelays: false));
+        inFlight.complete((
+          events: <Event>[],
+          timedOut: true,
+          noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ));
         await pending;
         await pumpEventQueue();
 
@@ -1529,6 +1659,8 @@ void main() {
               events: <Event>[labelFor('repeat_event')],
               timedOut: true,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             ),
           );
           await service.subscribeToLabeler(labeler);
@@ -1545,6 +1677,8 @@ void main() {
               events: <Event>[labelFor('repeat_event')],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             ),
           );
           await service.subscribeToLabeler(labeler);
@@ -1572,6 +1706,8 @@ void main() {
             events: <Event>[labelFor('preserved_event')],
             timedOut: true,
             noRelays: false,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
           ),
         );
         await service.subscribeToLabeler(labeler);
@@ -1583,7 +1719,13 @@ void main() {
             requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
         ).thenAnswer(
-          (_) async => (events: <Event>[], timedOut: false, noRelays: true),
+          (_) async => (
+            events: <Event>[],
+            timedOut: false,
+            noRelays: true,
+            anyRelayAnswered: false,
+            unsettledRelays: const <String>[],
+          ),
         );
         await service.subscribeToLabeler(labeler);
 
@@ -1636,7 +1778,13 @@ void main() {
             capturedFilters.add(
               invocation.positionalArguments.first as List<Filter>,
             );
-            return (events: <Event>[], timedOut: false, noRelays: false);
+            return (
+              events: <Event>[],
+              timedOut: false,
+              noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
+            );
           });
 
           await service.subscribeToLabeler(labeler);
@@ -1674,6 +1822,8 @@ void main() {
                 ],
                 timedOut: false,
                 noRelays: false,
+                anyRelayAnswered: false,
+                unsettledRelays: const <String>[],
               );
             }
             if (until == 90) {
@@ -1684,6 +1834,8 @@ void main() {
                 ],
                 timedOut: false,
                 noRelays: false,
+                anyRelayAnswered: false,
+                unsettledRelays: const <String>[],
               );
             }
             // until == 80: only the boundary repeats -> short page ends paging.
@@ -1691,6 +1843,8 @@ void main() {
               events: <Event>[labelEvent('id_c', 80, 'target_c')],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             );
           });
 
@@ -1727,6 +1881,8 @@ void main() {
               ],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             );
           });
 
@@ -1768,10 +1924,18 @@ void main() {
                 ],
                 timedOut: false,
                 noRelays: false,
+                anyRelayAnswered: false,
+                unsettledRelays: const <String>[],
               );
             }
             // The second page never settles.
-            return (events: <Event>[], timedOut: true, noRelays: false);
+            return (
+              events: <Event>[],
+              timedOut: true,
+              noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
+            );
           });
 
           await paged.subscribeToLabeler(labeler);
@@ -1821,6 +1985,8 @@ void main() {
               events: matching.take(2).toList(),
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             );
           });
 
@@ -1868,6 +2034,8 @@ void main() {
               ],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             );
           });
 
@@ -1916,6 +2084,8 @@ void main() {
               ],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             );
           });
 
@@ -1962,6 +2132,8 @@ void main() {
                 ],
                 timedOut: false,
                 noRelays: false,
+                anyRelayAnswered: false,
+                unsettledRelays: const <String>[],
               );
             }
             // The user unfollows the labeler while the walk is mid-flight.
@@ -1970,6 +2142,8 @@ void main() {
               events: <Event>[labelEvent('id_b', 90, 'target_b')],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             );
           });
 
@@ -2018,6 +2192,8 @@ void main() {
               ],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             );
           });
 
@@ -2057,6 +2233,8 @@ void main() {
               ],
               timedOut: false,
               noRelays: false,
+              anyRelayAnswered: false,
+              unsettledRelays: const <String>[],
             );
           });
 
@@ -2100,7 +2278,13 @@ void main() {
           requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
         ),
       ).thenAnswer(
-        (_) async => (events: <Event>[], timedOut: false, noRelays: false),
+        (_) async => (
+          events: <Event>[],
+          timedOut: false,
+          noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
+        ),
       );
     }
 
@@ -2236,6 +2420,8 @@ void main() {
           ],
           timedOut: false,
           noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
         ),
       );
 

--- a/mobile/test/services/nsfw_content_filter_test.dart
+++ b/mobile/test/services/nsfw_content_filter_test.dart
@@ -87,6 +87,8 @@ void main() {
           ],
           timedOut: false,
           noRelays: false,
+          anyRelayAnswered: false,
+          unsettledRelays: const <String>[],
         ),
       );
 

--- a/mobile/test/services/video_event_service_content_filter_test.dart
+++ b/mobile/test/services/video_event_service_content_filter_test.dart
@@ -90,6 +90,8 @@ void main() {
         ],
         timedOut: false,
         noRelays: false,
+        anyRelayAnswered: false,
+        unsettledRelays: const <String>[],
       ),
     );
 


### PR DESCRIPTION
## The problem

Message history that is older than a few days is unreachable, and it stays unreachable. Older conversations never appear, legacy conversations stay filed under "Message requests", read state is never restored, and the inbox keeps telling the user it has not finished restoring.

The backfill that recovers that history asks every relay for a page of messages and treats an incomplete answer as no answer at all. When one relay stays silent, the whole page is discarded, the backfill gives up for that session, and its cursor never moves. On the build this was found in, that happened on the very first page, three times in one session, five seconds each — the cursor never left early July.

Nothing rescues it, because the retry only re-arms when a relay *newly* connects. With every relay already connected and one of them simply not answering, that never fires.

## Why this fix

Refusing to finish on an incomplete answer is deliberate and correct (#8209). A relay that has not answered yet looks exactly like one that never will, and finishing on the first incomplete page would declare history complete over messages that were never fetched — the strand this behaviour was written to prevent.

What was missing is the case where the silence is permanent. Waiting forever for a relay that will never speak is not caution; it is the same strand arrived at from the other direction, and it is what users are hitting.

So the backfill now counts consecutive runs in which every reachable relay answered and only a silent holdout was left over. After three such runs it finishes against the relays that did answer, and records which ones it left out. Any fully answered page resets the count, so a relay that merely flaps never accumulates toward it.

Telling those two situations apart needs a fact the relay layer had but never reported: whether *any* relay answered. A page nothing answered is still never enough to finish on, at any count — that is the distinction the whole change rests on, and it is the one the tests are built around.

Support exports could not name the silent relay, which is the single fact needed to diagnose this from a bug report. The relay pool now reports each unanswered relay through the diagnostics sink instead of only to the debug console.

## What this deliberately leaves alone

- A page that **nothing** answered still never completes the backfill, however many times it repeats.
- The durable cursor still never moves below a window that was only partly seen.
- The other callers that require every relay to answer — account deletion, moderation labels, blocklists, bookmarks — are untouched in behaviour; they only gained two extra fields on a result record they already used.
- The retry still arms only when a relay newly connects. With the run budget in place the stuck case now resolves after three inbox opens, which is what a user in this state already does; re-arming on the holdout's first answer is a smaller follow-up, not part of this fix.

## How it was verified

- `dm_repository` 952 tests, `nostr_sdk` 695, `nostr_client` 370, plus the six other packages whose test doubles build the affected result record — all green.
- The new tests were checked by mutation rather than trusted: removing the run budget, removing the any-relay-answered check, or dropping the completion clause each turns them red. A first attempt at one test passed against a deliberately broken build and was rewritten until it did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Relates to #5178
