### PR TITLE
fix(account-deletion): stop the deletion wait restarting on every launch

### DIFF
--- a/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart
+++ b/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart
@@ -75,6 +75,17 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
   Timer? _pollTimer;
   var _generation = 0;
 
+  /// Whether this cubit has spent its one refresh against an already-exhausted
+  /// budget.
+  ///
+  /// A durable budget means a relaunch can find it already spent, and pausing
+  /// immediately would then never notice a deletion that finished while the app
+  /// was closed — the screen would offer "contact support" for an account the
+  /// server had already deleted. One status read on the way to pausing closes
+  /// that, and belongs to the cubit's lifetime rather than the budget, so
+  /// resume and account-transition operations do not renew it.
+  var _overdueRefreshUsed = false;
+
   /// Wall-clock start of this attempt's polling budget, cached from
   /// [_pollBudgetStore]. Null until an attempt that polls has been handled.
   DateTime? _pollBudgetStartedAt;
@@ -638,6 +649,11 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
     final delay = AccountDeletionRecoveryPolling.delayForTick(tickIndex);
     final spent = _pollingSpent;
     if (spent + delay > AccountDeletionRecoveryPolling.sessionBound) {
+      if (!_overdueRefreshUsed) {
+        _overdueRefreshUsed = true;
+        _pollTimer = _timerFactory(Duration.zero, () => _poll(generation));
+        return;
+      }
       emitIfOpen(
         AccountDeletionRecoveryState(
           status: state.status,

--- a/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart
+++ b/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart
@@ -44,11 +44,11 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
     required AccountDeletionRecoveryRepository repository,
     required AuthService authService,
     required Future<void> Function() onAttemptResolved,
+    required AccountDeletionRecoveryPollBudgetStore pollBudgetStore,
     Future<void> Function(AccountDeletionAttempt attempt)? onAttemptUpdated,
     String? receiptPubkeyHex,
     String? receiptVanishEventId,
     RecoveryTimerFactory timerFactory = Timer.new,
-    AccountDeletionRecoveryPollBudgetStore? pollBudgetStore,
     DateTime Function() clock = DateTime.now,
   }) : _repository = repository,
        _authService = authService,
@@ -57,8 +57,7 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
        _receiptPubkeyHex = receiptPubkeyHex,
        _receiptVanishEventId = receiptVanishEventId,
        _timerFactory = timerFactory,
-       _pollBudgetStore =
-           pollBudgetStore ?? InMemoryAccountDeletionRecoveryPollBudgetStore(),
+       _pollBudgetStore = pollBudgetStore,
        _clock = clock,
        super(const AccountDeletionRecoveryState());
 

--- a/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart
+++ b/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart
@@ -7,6 +7,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart'
     show SecureKeyStorageException;
+import 'package:openvine/blocs/account_deletion_recovery/account_deletion_recovery_poll_budget.dart';
 import 'package:openvine/blocs/close_guard.dart';
 import 'package:openvine/models/account_deletion_attempt.dart';
 import 'package:openvine/models/signer_readiness.dart';
@@ -47,6 +48,8 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
     String? receiptPubkeyHex,
     String? receiptVanishEventId,
     RecoveryTimerFactory timerFactory = Timer.new,
+    AccountDeletionRecoveryPollBudgetStore? pollBudgetStore,
+    DateTime Function() clock = DateTime.now,
   }) : _repository = repository,
        _authService = authService,
        _onAttemptResolved = onAttemptResolved,
@@ -54,6 +57,9 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
        _receiptPubkeyHex = receiptPubkeyHex,
        _receiptVanishEventId = receiptVanishEventId,
        _timerFactory = timerFactory,
+       _pollBudgetStore =
+           pollBudgetStore ?? InMemoryAccountDeletionRecoveryPollBudgetStore(),
+       _clock = clock,
        super(const AccountDeletionRecoveryState());
 
   final AccountDeletionRecoveryRepository _repository;
@@ -64,10 +70,29 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
   final String? _receiptPubkeyHex;
   final String? _receiptVanishEventId;
   final RecoveryTimerFactory _timerFactory;
+  final AccountDeletionRecoveryPollBudgetStore _pollBudgetStore;
+  final DateTime Function() _clock;
 
   Timer? _pollTimer;
   var _generation = 0;
-  Duration _pollingElapsed = Duration.zero;
+
+  /// Wall-clock start of this attempt's polling budget, cached from
+  /// [_pollBudgetStore]. Null until an attempt that polls has been handled.
+  DateTime? _pollBudgetStartedAt;
+
+  /// How much of [AccountDeletionRecoveryPolling.sessionBound] this attempt
+  /// has spent, measured in elapsed time rather than in timer delays this
+  /// process happened to run. That distinction is the fix: the old
+  /// accumulator only advanced while the app was foregrounded and alive, so
+  /// backgrounding — the natural thing to do while waiting on a server — reset
+  /// the budget on every launch and the "contact support" message was
+  /// unreachable no matter how long the wait actually was.
+  Duration get _pollingSpent {
+    final startedAt = _pollBudgetStartedAt;
+    if (startedAt == null) return Duration.zero;
+    final spent = _clock().difference(startedAt);
+    return spent.isNegative ? Duration.zero : spent;
+  }
 
   Future<void> load() async {
     final generation = _beginOperation();
@@ -93,6 +118,10 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
   }
 
   Future<void> retry() async {
+    // An explicit retry is the user asking for another round, so it restarts
+    // the budget. A relaunch is not — that path goes through [load], which
+    // re-reads the same attempt's persisted start and keeps counting.
+    await _restartPollBudget();
     if (_authService.signerReadiness == SignerReadiness.unavailable) {
       final attempt = state.attempt;
       final generation = _beginOperation();
@@ -475,6 +504,8 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
     switch (attempt.status) {
       case AccountDeletionAttemptStatus.preparing:
         if (attempt.isCancellationInFlight) {
+          await _loadPollBudget(attempt.id);
+          if (!_isCurrent(generation)) return;
           _emitPollingState(
             AccountDeletionRecoveryStatus.cancelInFlight,
             attempt,
@@ -496,6 +527,8 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
           ),
         );
       case AccountDeletionAttemptStatus.processing:
+        await _loadPollBudget(attempt.id);
+        if (!_isCurrent(generation)) return;
         if (!await _updateAttemptOrRetry(attempt, generation)) return;
         _emitPollingState(
           AccountDeletionRecoveryStatus.processing,
@@ -548,6 +581,26 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
     }
   }
 
+  /// Forgets this attempt's polling budget so the next poll starts a new one.
+  Future<void> _restartPollBudget() async {
+    final attemptId = state.attempt?.id;
+    if (attemptId != null) await _pollBudgetStore.clear(attemptId);
+    _pollBudgetStartedAt = null;
+  }
+
+  /// Reads this attempt's polling start, beginning one on first sight.
+  ///
+  /// Keyed by attempt id, so a relaunch against the same attempt continues the
+  /// budget it already spent while a genuinely new attempt starts fresh.
+  Future<void> _loadPollBudget(String attemptId) async {
+    await _pollBudgetStore.recordStartIfAbsent(attemptId, _clock());
+    // Always take the store's value, never the cache: [_schedulePoll] can seed
+    // the cache with `now` on a path that reached it before this ran, and the
+    // store is the one that knows when a previous launch started. Earliest
+    // wins, which is what `recordStartIfAbsent` guarantees.
+    _pollBudgetStartedAt = await _pollBudgetStore.startedAt(attemptId);
+  }
+
   void _emitPollingState(
     AccountDeletionRecoveryStatus status,
     AccountDeletionAttempt attempt,
@@ -559,6 +612,7 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
         attempt: attempt,
         failure: state.failure,
         pollTickIndex: state.pollTickIndex,
+        pollingElapsed: _pollingSpent,
       ),
     );
     _schedulePoll(generation);
@@ -566,9 +620,25 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
 
   void _schedulePoll(int generation) {
     _pollTimer?.cancel();
+    // Polling is also scheduled from paths that never went through the
+    // `processing` branch of [_handleAttempt] — a failed submission confirm,
+    // a cleanup failure — so the budget has to start here too. Without this
+    // the budget on those paths would read as zero forever and the bound
+    // would never be reached, which is the same trap in a different place.
+    if (_pollBudgetStartedAt == null) {
+      final startedAt = _clock();
+      _pollBudgetStartedAt = startedAt;
+      final attemptId = state.attempt?.id;
+      if (attemptId != null) {
+        unawaited(
+          _pollBudgetStore.recordStartIfAbsent(attemptId, startedAt),
+        );
+      }
+    }
     final tickIndex = state.pollTickIndex;
     final delay = AccountDeletionRecoveryPolling.delayForTick(tickIndex);
-    if (_pollingElapsed + delay > AccountDeletionRecoveryPolling.sessionBound) {
+    final spent = _pollingSpent;
+    if (spent + delay > AccountDeletionRecoveryPolling.sessionBound) {
       emitIfOpen(
         AccountDeletionRecoveryState(
           status: state.status,
@@ -576,11 +646,11 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
           failure: state.failure,
           pollTickIndex: tickIndex,
           pollingPaused: true,
+          pollingElapsed: spent,
         ),
       );
       return;
     }
-    _pollingElapsed += delay;
     _pollTimer = _timerFactory(delay, () => _poll(generation));
   }
 
@@ -662,7 +732,9 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
   int _beginOperation({bool resetPollingProgress = true}) {
     _pollTimer?.cancel();
     _pollTimer = null;
-    if (resetPollingProgress) _pollingElapsed = Duration.zero;
+    // Drops the CACHE, not the record. A reload re-reads the same attempt's
+    // persisted start, so only a different attempt gets a fresh budget.
+    if (resetPollingProgress) _pollBudgetStartedAt = null;
     return ++_generation;
   }
 
@@ -687,6 +759,11 @@ class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
 
   Future<void> _resolve() async {
     _pollTimer?.cancel();
+    final resolvedAttemptId = state.attempt?.id;
+    if (resolvedAttemptId != null) {
+      await _pollBudgetStore.clear(resolvedAttemptId);
+    }
+    _pollBudgetStartedAt = null;
     await _onAttemptResolved();
     if (isClosed) return;
     emitIfOpen(

--- a/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_poll_budget.dart
+++ b/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_poll_budget.dart
@@ -82,3 +82,51 @@ class SharedPreferencesAccountDeletionRecoveryPollBudgetStore
     await _prefs.remove('$keyPrefix$attemptId');
   }
 }
+
+/// Anchors on the durable deletion receipt when this install has one for the
+/// attempt, and falls back to [fallback] when it does not.
+///
+/// The receipt is the better home: it already exists, is already cleaned up
+/// with the attempt, and needs no preference key of its own. But the recovery
+/// screen is reachable *without* a receipt — the router gates on the server's
+/// attempt status, not on local state, so a reinstall mid-deletion, a receipt
+/// cleared as corrupt, or a deletion submitted from another device all land on
+/// the screen with nothing stored locally. Those are exactly the long waits
+/// this budget exists for, so they get a keyed fallback rather than a
+/// process-local anchor that restarts every launch.
+class ReceiptAnchoredPollBudgetStore
+    implements AccountDeletionRecoveryPollBudgetStore {
+  ReceiptAnchoredPollBudgetStore({
+    required this.readReceiptAnchor,
+    required this.fallback,
+  });
+
+  /// The receipt's attempt id and anchor, or `null` when none is stored.
+  final ({String attemptId, DateTime startedAt})? Function() readReceiptAnchor;
+
+  final AccountDeletionRecoveryPollBudgetStore fallback;
+
+  ({String attemptId, DateTime startedAt})? _anchorFor(String attemptId) {
+    final anchor = readReceiptAnchor();
+    return anchor != null && anchor.attemptId == attemptId ? anchor : null;
+  }
+
+  @override
+  Future<DateTime?> startedAt(String attemptId) async =>
+      _anchorFor(attemptId)?.startedAt ?? await fallback.startedAt(attemptId);
+
+  @override
+  Future<void> recordStartIfAbsent(String attemptId, DateTime at) async {
+    // A receipt always carries an anchor once read, so there is nothing to
+    // record on that path.
+    if (_anchorFor(attemptId) != null) return;
+    await fallback.recordStartIfAbsent(attemptId, at);
+  }
+
+  @override
+  Future<void> clear(String attemptId) async {
+    // The receipt's anchor goes when the receipt does, so only the fallback
+    // key needs clearing here.
+    await fallback.clear(attemptId);
+  }
+}

--- a/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_poll_budget.dart
+++ b/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_poll_budget.dart
@@ -1,0 +1,80 @@
+// ABOUTME: Durable start time for the deletion-recovery polling budget.
+// ABOUTME: Keyed per attempt so relaunching cannot hand the user a fresh one.
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Remembers when polling for one deletion attempt began.
+///
+/// The recovery screen polls the server for a bounded time and then offers
+/// "contact support". Measuring that bound by accumulating timer delays in a
+/// field spends it only while the process lives, so a user who backgrounds the
+/// app — the likely thing to do while waiting — restarts the budget at zero on
+/// every launch and can never reach the support message however long they
+/// wait. Recording a wall-clock start instead makes the bound mean elapsed
+/// time.
+///
+/// Keyed by attempt id, so a genuinely new deletion attempt starts a fresh
+/// budget while a relaunch against the same attempt continues the old one.
+abstract class AccountDeletionRecoveryPollBudgetStore {
+  /// When polling for [attemptId] began, or `null` if it has not yet.
+  Future<DateTime?> startedAt(String attemptId);
+
+  /// Records [at] as the start for [attemptId], keeping any existing value so
+  /// a relaunch cannot push the deadline out.
+  Future<void> recordStartIfAbsent(String attemptId, DateTime at);
+
+  /// Forgets [attemptId]'s budget once the attempt is resolved.
+  Future<void> clear(String attemptId);
+}
+
+/// Process-local store. The default so a cubit built without wiring behaves as
+/// it did before, and the shape tests use directly.
+class InMemoryAccountDeletionRecoveryPollBudgetStore
+    implements AccountDeletionRecoveryPollBudgetStore {
+  final Map<String, DateTime> _startedAt = <String, DateTime>{};
+
+  @override
+  Future<DateTime?> startedAt(String attemptId) async => _startedAt[attemptId];
+
+  @override
+  Future<void> recordStartIfAbsent(String attemptId, DateTime at) async {
+    _startedAt.putIfAbsent(attemptId, () => at);
+  }
+
+  @override
+  Future<void> clear(String attemptId) async {
+    _startedAt.remove(attemptId);
+  }
+}
+
+/// Durable store. This is the one that makes the budget survive a relaunch.
+class SharedPreferencesAccountDeletionRecoveryPollBudgetStore
+    implements AccountDeletionRecoveryPollBudgetStore {
+  SharedPreferencesAccountDeletionRecoveryPollBudgetStore(this._prefs);
+
+  final SharedPreferences _prefs;
+
+  /// Interpolated with the attempt id, so each attempt owns its own slot and
+  /// no fixed key can carry one account's budget into another's session.
+  static const keyPrefix = 'account_deletion.pollBudgetStartedAt.';
+
+  @override
+  Future<DateTime?> startedAt(String attemptId) async {
+    final millis = _prefs.getInt('$keyPrefix$attemptId');
+    return millis == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(millis, isUtc: true);
+  }
+
+  @override
+  Future<void> recordStartIfAbsent(String attemptId, DateTime at) async {
+    final key = '$keyPrefix$attemptId';
+    if (_prefs.containsKey(key)) return;
+    await _prefs.setInt(key, at.toUtc().millisecondsSinceEpoch);
+  }
+
+  @override
+  Future<void> clear(String attemptId) async {
+    await _prefs.remove('$keyPrefix$attemptId');
+  }
+}

--- a/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_poll_budget.dart
+++ b/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_poll_budget.dart
@@ -27,8 +27,12 @@ abstract class AccountDeletionRecoveryPollBudgetStore {
   Future<void> clear(String attemptId);
 }
 
-/// Process-local store. The default so a cubit built without wiring behaves as
-/// it did before, and the shape tests use directly.
+/// Process-local store.
+///
+/// Deliberately NOT a default on the cubit: the whole point of this type is
+/// that the budget outlives the process, and a store that silently forgets is
+/// exactly the bug being fixed. Production must pass the durable store, which
+/// the constructor now requires. This exists for tests.
 class InMemoryAccountDeletionRecoveryPollBudgetStore
     implements AccountDeletionRecoveryPollBudgetStore {
   final Map<String, DateTime> _startedAt = <String, DateTime>{};

--- a/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_state.dart
+++ b/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_state.dart
@@ -34,6 +34,7 @@ final class AccountDeletionRecoveryState extends Equatable {
     this.failure,
     this.pollTickIndex = 0,
     this.pollingPaused = false,
+    this.pollingElapsed = Duration.zero,
   });
 
   final AccountDeletionRecoveryStatus status;
@@ -42,6 +43,13 @@ final class AccountDeletionRecoveryState extends Equatable {
   final int pollTickIndex;
   final bool pollingPaused;
 
+  /// How long this deletion attempt has been waiting on the server.
+  ///
+  /// Surfaced so the recovery screen can show the wait it is asking for. There
+  /// is deliberately no estimate: the remaining work is server-side and has no
+  /// client-visible bound, so a countdown here would be invented.
+  final Duration pollingElapsed;
+
   @override
   List<Object?> get props => [
     status,
@@ -49,5 +57,6 @@ final class AccountDeletionRecoveryState extends Equatable {
     failure,
     pollTickIndex,
     pollingPaused,
+    pollingElapsed,
   ];
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4519,6 +4519,8 @@
   "@accountDeletionRestoreUsername": {"description": "Button that cancels an interrupted account deletion and restores its pending username."},
   "accountDeletionFinishingBody": "Your deletion request is still being processed. You can use another account while we finish.",
   "@accountDeletionFinishingBody": {"description": "Shown while the server is durably completing an account deletion."},
+  "accountDeletionFinishingElapsed": "{minutes, plural, =0{This finishes on our servers, so it is safe to close the app.} =1{Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.} other{Waiting on our servers for {minutes} minutes. It is safe to close the app — this finishes without you.}}",
+  "@accountDeletionFinishingElapsed": {"description": "How long an account deletion has been waiting on the server. There is deliberately no estimate: the remaining work is server-side with no client-visible bound.", "placeholders": {"minutes": {"type": "int"}}},
   "accountDeletionOtherAccountPending": "Another account deletion is still being processed on this device. Wait for it to finish before deleting this account.",
   "@accountDeletionOtherAccountPending": {"description": "Snackbar shown when this installation already holds a pending deletion receipt for a different account."},
   "accountDeletionCancellingBody": "We're cancelling your deletion. Check again before leaving this screen.",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -12010,6 +12010,12 @@ abstract class AppLocalizations {
   /// **'Your deletion request is still being processed. You can use another account while we finish.'**
   String get accountDeletionFinishingBody;
 
+  /// How long an account deletion has been waiting on the server. There is deliberately no estimate: the remaining work is server-side with no client-visible bound.
+  ///
+  /// In en, this message translates to:
+  /// **'{minutes, plural, =0{This finishes on our servers, so it is safe to close the app.} =1{Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.} other{Waiting on our servers for {minutes} minutes. It is safe to close the app — this finishes without you.}}'**
+  String accountDeletionFinishingElapsed(int minutes);
+
   /// Snackbar shown when this installation already holds a pending deletion receipt for a different account.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -6853,6 +6853,19 @@ class AppLocalizationsAm extends AppLocalizations {
       'የመለያዎ ስረዛ ጥያቄ አሁንም በሂደት ላይ ነው። እስክናጠናቅቅ ድረስ ሌላ መለያ መጠቀም ይችላሉ።';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'በዚህ መሣሪያ ላይ የሌላ መለያ ስረዛ አሁንም በሂደት ላይ ነው። ይህን መለያ ከመሰረዝዎ በፊት እስኪጠናቀቅ ይጠብቁ።';
 

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -6970,6 +6970,19 @@ class AppLocalizationsAr extends AppLocalizations {
       'لا يزال طلب حذف حسابك قيد المعالجة. يمكنك استخدام حساب آخر إلى أن ننتهي.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'لا تزال عملية حذف حساب آخر قيد المعالجة على هذا الجهاز. انتظر حتى تنتهي قبل حذف هذا الحساب.';
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -7090,6 +7090,19 @@ class AppLocalizationsBg extends AppLocalizations {
       'Заявката ти за изтриване все още се обработва. Можеш да използваш друг акаунт, докато приключим.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'Изтриването на друг акаунт все още се обработва на това устройство. Изчакай да приключи, преди да изтриеш този акаунт.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -7107,6 +7107,19 @@ class AppLocalizationsDe extends AppLocalizations {
       'Deine Löschanfrage wird noch bearbeitet. Währenddessen kannst du ein anderes Konto verwenden.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'Die Löschung eines anderen Kontos wird auf diesem Gerät noch bearbeitet. Warte, bis sie abgeschlossen ist, bevor du dieses Konto löschst.';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -7122,6 +7122,19 @@ class AppLocalizationsEn extends AppLocalizations {
       'Your deletion request is still being processed. You can use another account while we finish.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'Another account deletion is still being processed on this device. Wait for it to finish before deleting this account.';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -7088,6 +7088,19 @@ class AppLocalizationsEs extends AppLocalizations {
       'Tu solicitud de eliminación todavía se está procesando. Podés usar otra cuenta mientras terminamos.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'En este dispositivo todavía se está procesando la eliminación de otra cuenta. Esperá a que termine antes de eliminar esta cuenta.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -7067,6 +7067,19 @@ class AppLocalizationsFil extends AppLocalizations {
       'Pinoproseso pa ang request na i-delete ang account mo. Puwede kang gumamit ng ibang account habang tinatapos namin ito.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'Pinoproseso pa sa device na ito ang pag-delete ng ibang account. Hintayin itong matapos bago i-delete ang account na ito.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -7111,6 +7111,19 @@ class AppLocalizationsFr extends AppLocalizations {
       'Ta demande de suppression est toujours en cours de traitement. Tu peux utiliser un autre compte pendant que nous terminons.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'La suppression d’un autre compte est toujours en cours sur cet appareil. Attends qu’elle soit terminée avant de supprimer ce compte.';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6944,6 +6944,19 @@ class AppLocalizationsId extends AppLocalizations {
       'Permintaan penghapusanmu masih diproses. Kamu bisa menggunakan akun lain sementara kami menyelesaikannya.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'Penghapusan akun lain masih diproses di perangkat ini. Tunggu hingga selesai sebelum menghapus akun ini.';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -7091,6 +7091,19 @@ class AppLocalizationsIt extends AppLocalizations {
       'La tua richiesta di eliminazione è ancora in fase di elaborazione. Puoi usare un altro account mentre terminiamo.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'L\'eliminazione di un altro account è ancora in corso su questo dispositivo. Attendi che termini prima di eliminare questo account.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -6655,6 +6655,19 @@ class AppLocalizationsJa extends AppLocalizations {
       '削除リクエストはまだ処理中です。処理が完了するまで、別のアカウントを使用できます。';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'このデバイスでは、別のアカウントの削除がまだ処理中です。処理が完了してから、このアカウントを削除してください。';
 

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -6672,6 +6672,19 @@ class AppLocalizationsKo extends AppLocalizations {
       '계정 삭제 요청이 아직 처리 중이에요. 처리가 완료될 때까지 다른 계정을 사용할 수 있어요.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       '이 기기에서 다른 계정의 삭제가 아직 처리 중이에요. 처리가 완료된 후 이 계정을 삭제해 주세요.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -7027,6 +7027,19 @@ class AppLocalizationsMs extends AppLocalizations {
       'Permintaan pemadaman anda masih diproses. Anda boleh menggunakan akaun lain sementara kami menyelesaikannya.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'Pemadaman akaun lain masih diproses pada peranti ini. Tunggu sehingga selesai sebelum memadamkan akaun ini.';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7050,6 +7050,19 @@ class AppLocalizationsNl extends AppLocalizations {
       'Je verwijderverzoek wordt nog verwerkt. Je kunt een ander account gebruiken terwijl wij dit afronden.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'De verwijdering van een ander account wordt nog verwerkt op dit apparaat. Wacht tot die is afgerond voordat je dit account verwijdert.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -7183,6 +7183,19 @@ class AppLocalizationsPl extends AppLocalizations {
       'Twoje żądanie usunięcia jest nadal przetwarzane. W tym czasie możesz korzystać z innego konta.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'Usuwanie innego konta jest nadal przetwarzane na tym urządzeniu. Zaczekaj na zakończenie, zanim usuniesz to konto.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7071,6 +7071,19 @@ class AppLocalizationsPt extends AppLocalizations {
       'Seu pedido de exclusão ainda está sendo processado. Você pode usar outra conta enquanto concluímos.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'A exclusão de outra conta ainda está sendo processada neste dispositivo. Aguarde a conclusão antes de excluir esta conta.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -7195,6 +7195,19 @@ class AppLocalizationsRo extends AppLocalizations {
       'Cererea ta de ștergere este încă în curs de procesare. Poți folosi alt cont până terminăm.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'Ștergerea altui cont este încă în curs de procesare pe acest dispozitiv. Așteaptă să se termine înainte de a șterge acest cont.';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7012,6 +7012,19 @@ class AppLocalizationsSv extends AppLocalizations {
       'Din begäran om radering behandlas fortfarande. Du kan använda ett annat konto medan vi slutför processen.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'Raderingen av ett annat konto behandlas fortfarande på den här enheten. Vänta tills den är klar innan du raderar det här kontot.';
 

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -7249,6 +7249,19 @@ class AppLocalizationsTe extends AppLocalizations {
       'మీ ఖాతా తొలగింపు అభ్యర్థన ఇప్పటికీ ప్రాసెస్ చేయబడుతోంది. మేము దీన్ని పూర్తి చేసే వరకు మీరు మరొక ఖాతాను ఉపయోగించవచ్చు.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'ఈ పరికరంలో మరొక ఖాతా తొలగింపు ఇప్పటికీ ప్రాసెస్ చేయబడుతోంది. ఈ ఖాతాను తొలగించే ముందు అది పూర్తయ్యే వరకు వేచి ఉండండి.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6942,6 +6942,19 @@ class AppLocalizationsTr extends AppLocalizations {
       'Silme isteğin hâlâ işleniyor. Biz işlemi tamamlarken başka bir hesap kullanabilirsin.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'Bu cihazda başka bir hesabın silme işlemi hâlâ devam ediyor. Bu hesabı silmeden önce işlemin tamamlanmasını bekle.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -7016,6 +7016,19 @@ class AppLocalizationsUr extends AppLocalizations {
       'آپ کے اکاؤنٹ کو حذف کرنے کی درخواست پر ابھی کارروائی ہو رہی ہے۔ ہمارے مکمل کرنے تک آپ کوئی دوسرا اکاؤنٹ استعمال کر سکتے ہیں۔';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'اس ڈیوائس پر کسی دوسرے اکاؤنٹ کو حذف کرنے کی کارروائی ابھی جاری ہے۔ اس اکاؤنٹ کو حذف کرنے سے پہلے اس کے مکمل ہونے کا انتظار کریں۔';
 

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -6988,6 +6988,19 @@ class AppLocalizationsVi extends AppLocalizations {
       'Yêu cầu xóa tài khoản của bạn vẫn đang được xử lý. Bạn có thể dùng một tài khoản khác trong lúc chúng tôi hoàn tất.';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       'Việc xóa một tài khoản khác vẫn đang được xử lý trên thiết bị này. Hãy đợi quá trình đó hoàn tất trước khi xóa tài khoản này.';
 

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -6608,6 +6608,19 @@ class AppLocalizationsZh extends AppLocalizations {
   String get accountDeletionFinishingBody => '你的账号删除请求仍在处理中。处理完成前，你可以使用其他账号。';
 
   @override
+  String accountDeletionFinishingElapsed(int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other:
+          'Waiting on our servers for $minutes minutes. It is safe to close the app — this finishes without you.',
+      one: 'Waiting on our servers for 1 minute. It is safe to close the app — this finishes without you.',
+      zero: 'This finishes on our servers, so it is safe to close the app.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get accountDeletionOtherAccountPending =>
       '此设备上另一个账号的删除仍在处理中。请等待处理完成后再删除此账号。';
 

--- a/mobile/lib/providers/account_deletion_recovery_providers.dart
+++ b/mobile/lib/providers/account_deletion_recovery_providers.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
 import 'package:openvine/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart';
+import 'package:openvine/blocs/account_deletion_recovery/account_deletion_recovery_poll_budget.dart';
 import 'package:openvine/models/account_deletion_attempt.dart';
 import 'package:openvine/models/signer_readiness.dart';
 import 'package:openvine/providers/auth_providers.dart';
@@ -16,6 +17,18 @@ import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/repositories/account_deletion_recovery_repository.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:unified_logger/unified_logger.dart';
+
+/// Durable store for the recovery polling budget.
+///
+/// Wired here rather than defaulted inside the cubit so the budget is measured
+/// against wall-clock time that survives a relaunch; the cubit's in-memory
+/// fallback would restart it on every launch.
+final accountDeletionRecoveryPollBudgetProvider =
+    Provider<AccountDeletionRecoveryPollBudgetStore>(
+      (ref) => SharedPreferencesAccountDeletionRecoveryPollBudgetStore(
+        ref.watch(sharedPreferencesProvider),
+      ),
+    );
 
 final accountDeletionRecoveryRepositoryProvider =
     Provider<AccountDeletionRecoveryRepository>((ref) {
@@ -224,6 +237,7 @@ submittedAccountDeletionMonitorProvider =
       );
       var disposed = false;
       final cubit = AccountDeletionRecoveryCubit(
+        pollBudgetStore: ref.watch(accountDeletionRecoveryPollBudgetProvider),
         repository: ref.watch(accountDeletionRecoveryRepositoryProvider),
         authService: ref.watch(authServiceProvider),
         onAttemptResolved: () async {

--- a/mobile/lib/providers/account_deletion_recovery_providers.dart
+++ b/mobile/lib/providers/account_deletion_recovery_providers.dart
@@ -25,8 +25,19 @@ import 'package:unified_logger/unified_logger.dart';
 /// fallback would restart it on every launch.
 final accountDeletionRecoveryPollBudgetProvider =
     Provider<AccountDeletionRecoveryPollBudgetStore>(
-      (ref) => SharedPreferencesAccountDeletionRecoveryPollBudgetStore(
-        ref.watch(sharedPreferencesProvider),
+      (ref) => ReceiptAnchoredPollBudgetStore(
+        readReceiptAnchor: () {
+          final receipt = ref.read(submittedAccountDeletionAttemptProvider);
+          return receipt == null
+              ? null
+              : (
+                  attemptId: receipt.attempt.id,
+                  startedAt: receipt.recoveryWatchStartedAt,
+                );
+        },
+        fallback: SharedPreferencesAccountDeletionRecoveryPollBudgetStore(
+          ref.watch(sharedPreferencesProvider),
+        ),
       ),
     );
 
@@ -45,27 +56,49 @@ final accountDeletionRecoveryRepositoryProvider =
       );
     });
 
+/// Wall clock for deletion-recovery timing, injectable for tests.
+final accountDeletionRecoveryClockProvider = Provider<DateTime Function()>(
+  (_) => DateTime.now,
+);
+
 /// Durable receipt for a deletion this installation submitted.
 final class SubmittedAccountDeletionAttempt {
   const SubmittedAccountDeletionAttempt({
     required this.pubkeyHex,
     required this.attempt,
     required this.vanishEventId,
+    required this.recoveryWatchStartedAt,
     this.submissionOwnedLocally = false,
   });
 
-  factory SubmittedAccountDeletionAttempt.fromJson(Map<String, dynamic> json) =>
-      SubmittedAccountDeletionAttempt(
-        pubkeyHex: json['pubkey_hex'] as String,
-        vanishEventId: json['vanish_event_id'] as String,
-        attempt: AccountDeletionAttempt.fromJson(
-          json['attempt'] as Map<String, dynamic>,
-        ),
-      );
+  factory SubmittedAccountDeletionAttempt.fromJson(
+    Map<String, dynamic> json, {
+    DateTime Function() now = DateTime.now,
+  }) {
+    final startedAtMs = (json['recovery_watch_started_at_ms'] as num?)?.toInt();
+    return SubmittedAccountDeletionAttempt(
+      pubkeyHex: json['pubkey_hex'] as String,
+      vanishEventId: json['vanish_event_id'] as String,
+      attempt: AccountDeletionAttempt.fromJson(
+        json['attempt'] as Map<String, dynamic>,
+      ),
+      // A receipt written before this field existed anchors from the first
+      // read that adopts it, and the notifier persists that stamp so the
+      // anchor stops moving.
+      recoveryWatchStartedAt: startedAtMs == null
+          ? now().toUtc()
+          : DateTime.fromMillisecondsSinceEpoch(startedAtMs, isUtc: true),
+    );
+  }
 
   final String pubkeyHex;
   final AccountDeletionAttempt attempt;
   final String vanishEventId;
+
+  /// When this install started watching the deletion, used as the durable
+  /// anchor for the support-escape budget. Carried on the receipt so the
+  /// common path needs no preference key of its own.
+  final DateTime recoveryWatchStartedAt;
 
   /// True only while this process's deletion dialog owns submission and cleanup.
   /// It is deliberately not persisted, so an app restart adopts the receipt.
@@ -76,15 +109,21 @@ final class SubmittedAccountDeletionAttempt {
     'pubkey_hex': pubkeyHex,
     'vanish_event_id': vanishEventId,
     'attempt': attempt.toJson(),
+    'recovery_watch_started_at_ms': recoveryWatchStartedAt
+        .toUtc()
+        .millisecondsSinceEpoch,
   };
 
   SubmittedAccountDeletionAttempt copyWith({
     AccountDeletionAttempt? attempt,
+    DateTime? recoveryWatchStartedAt,
     bool? submissionOwnedLocally,
   }) => SubmittedAccountDeletionAttempt(
     pubkeyHex: pubkeyHex,
     attempt: attempt ?? this.attempt,
     vanishEventId: vanishEventId,
+    recoveryWatchStartedAt:
+        recoveryWatchStartedAt ?? this.recoveryWatchStartedAt,
     submissionOwnedLocally:
         submissionOwnedLocally ?? this.submissionOwnedLocally,
   );
@@ -113,9 +152,15 @@ class SubmittedAccountDeletionAttemptNotifier
     Map<String, dynamic>? decoded;
     try {
       decoded = jsonDecode(encoded) as Map<String, dynamic>;
-      return SubmittedAccountDeletionAttempt.fromJson(
+      final needsBackfill = decoded['recovery_watch_started_at_ms'] == null;
+      final receipt = SubmittedAccountDeletionAttempt.fromJson(
         decoded,
+        now: ref.read(accountDeletionRecoveryClockProvider),
       );
+      // Persist the stamp a legacy receipt was just given, or every read would
+      // re-anchor it to now and the budget would never advance.
+      if (needsBackfill) unawaited(_persistLegacyWatchStart(receipt));
+      return receipt;
     } on Object catch (error) {
       final encodedPubkey = decoded?['pubkey_hex'];
       Log.error(
@@ -127,6 +172,24 @@ class SubmittedAccountDeletionAttemptNotifier
       );
       unawaited(_removeCorruptReceipt());
       return null;
+    }
+  }
+
+  Future<void> _persistLegacyWatchStart(
+    SubmittedAccountDeletionAttempt receipt,
+  ) async {
+    try {
+      final saved = await ref
+          .read(sharedPreferencesProvider)
+          .setString(_storageKey, jsonEncode(receipt.toJson()));
+      if (!saved) throw StateError('Could not backfill recovery watch start');
+    } on Object catch (error) {
+      Log.error(
+        'Failed to backfill account deletion recovery watch start for '
+        '${pubkeyForLogs(receipt.pubkeyHex)}: $error',
+        name: 'AccountDeletionRecovery',
+        category: LogCategory.auth,
+      );
     }
   }
 
@@ -156,27 +219,36 @@ class SubmittedAccountDeletionAttemptNotifier
         'Another account deletion receipt is already pending',
       );
     }
-    final receipt = SubmittedAccountDeletionAttempt(
-      pubkeyHex: pubkeyHex,
-      attempt: attempt,
-      vanishEventId: vanishEventId,
-      submissionOwnedLocally: submissionOwnedLocally,
+    // Re-recording the SAME attempt keeps its original anchor; a different
+    // attempt is a new wait and starts its own.
+    final recoveryWatchStartedAt =
+        existing != null && existing.attempt.id == attempt.id
+        ? existing.recoveryWatchStartedAt
+        : ref.read(accountDeletionRecoveryClockProvider)().toUtc();
+    await _persist(
+      SubmittedAccountDeletionAttempt(
+        pubkeyHex: pubkeyHex,
+        attempt: attempt,
+        vanishEventId: vanishEventId,
+        recoveryWatchStartedAt: recoveryWatchStartedAt,
+        submissionOwnedLocally: submissionOwnedLocally,
+      ),
     );
-    final saved = await ref
-        .read(sharedPreferencesProvider)
-        .setString(_storageKey, jsonEncode(receipt.toJson()));
-    if (!saved) throw StateError('Could not persist account deletion receipt');
-    state = receipt;
   }
 
   Future<void> updateAttempt(AccountDeletionAttempt attempt) async {
     final receipt = state;
     if (receipt == null || receipt.attempt.id != attempt.id) return;
-    await record(
-      pubkeyHex: receipt.pubkeyHex,
-      attempt: attempt,
-      vanishEventId: receipt.vanishEventId,
-    );
+    // copyWith, not record: a status update must not restamp the anchor.
+    await _persist(receipt.copyWith(attempt: attempt));
+  }
+
+  Future<void> _persist(SubmittedAccountDeletionAttempt receipt) async {
+    final saved = await ref
+        .read(sharedPreferencesProvider)
+        .setString(_storageKey, jsonEncode(receipt.toJson()));
+    if (!saved) throw StateError('Could not persist account deletion receipt');
+    state = receipt;
   }
 
   void releaseSubmissionOwnership() {

--- a/mobile/lib/screens/account_deletion_recovery_screen.dart
+++ b/mobile/lib/screens/account_deletion_recovery_screen.dart
@@ -53,6 +53,9 @@ class AccountDeletionRecoveryScreen extends ConsumerWidget {
       create: (_) {
         final expectedPubkeyHex = authService.currentPublicKeyHex;
         final cubit = AccountDeletionRecoveryCubit(
+          pollBudgetStore: ref.read(
+            accountDeletionRecoveryPollBudgetProvider,
+          ),
           repository: repository,
           authService: authService,
           onAttemptResolved: () async {
@@ -203,6 +206,7 @@ class _RecoveryStateContent extends StatelessWidget {
         state.pollingPaused
             ? _RecoveryContent(
                 body: context.l10n.accountDeletionFinishingBody,
+                detail: _elapsedDetail(context, state),
                 actionLabel: context.l10n.supportContactSupport,
                 onPressed: () => context.push(RoutePaths.supportCenter),
                 secondaryActionLabel: context.l10n.authUseAnotherAccount,
@@ -210,6 +214,7 @@ class _RecoveryStateContent extends StatelessWidget {
               )
             : _RecoveryContent(
                 body: context.l10n.accountDeletionFinishingBody,
+                detail: _elapsedDetail(context, state),
                 actionLabel: context.l10n.authUseAnotherAccount,
                 onPressed: () => _switchAccount(context, cubit),
               ),
@@ -341,16 +346,31 @@ String _failureBody(
   _ => context.l10n.accountDeletionTerminalFailureBody,
 };
 
+/// How long the server has been working, in whole minutes.
+///
+/// Deliberately not an estimate or a countdown: the remaining work is
+/// server-side with no client-visible bound, so anything that looked like a
+/// deadline would be invented. Elapsed time is the honest thing to show, and
+/// it is what tells the user the wait is real rather than a stuck screen.
+String _elapsedDetail(
+  BuildContext context,
+  AccountDeletionRecoveryState state,
+) => context.l10n.accountDeletionFinishingElapsed(
+  state.pollingElapsed.inMinutes,
+);
+
 class _RecoveryContent extends StatelessWidget {
   const _RecoveryContent({
     required this.body,
     required this.actionLabel,
     required this.onPressed,
+    this.detail,
     this.secondaryActionLabel,
     this.onSecondaryPressed,
   });
 
   final String body;
+  final String? detail;
   final String actionLabel;
   final VoidCallback? onPressed;
   final String? secondaryActionLabel;
@@ -369,6 +389,14 @@ class _RecoveryContent extends StatelessWidget {
           textAlign: TextAlign.center,
           style: VineTheme.bodyLargeFont(color: context.vineColors.primaryText),
         ),
+        if (detail != null)
+          Text(
+            detail!,
+            textAlign: TextAlign.center,
+            style: VineTheme.bodyMediumFont(
+              color: context.vineColors.secondaryText,
+            ),
+          ),
         DivineButton(
           label: actionLabel,
           onPressed: onPressed,

--- a/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_cubit_test.dart
+++ b/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_cubit_test.dart
@@ -843,12 +843,30 @@ void main() {
             greaterThan(AccountDeletionRecoveryPolling.sessionBound),
             reason: 'the wait carries across the relaunch',
           );
+
+          // A spent budget does not pause on the spot. The deletion may have
+          // finished while the app was closed, and pausing without looking
+          // would offer "contact support" for an account the server had
+          // already deleted — so one status read comes first.
+          expect(relaunched.state.pollingPaused, isFalse);
+          expect(
+            timers.timers.where((timer) => timer.isActive),
+            hasLength(1),
+            reason: 'the overdue refresh is scheduled',
+          );
+          await timers.fireNext();
+
           expect(
             relaunched.state.pollingPaused,
             isTrue,
             reason:
                 'the budget was already spent before this launch started, so '
-                'the support message must be reachable immediately',
+                'the support message must be reachable after that one read',
+          );
+          expect(
+            timers.timers.any((timer) => timer.isActive),
+            isFalse,
+            reason: 'the allowance is spent once per cubit, not renewed',
           );
         },
       );

--- a/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_cubit_test.dart
+++ b/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_cubit_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:openvine/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart';
+import 'package:openvine/blocs/account_deletion_recovery/account_deletion_recovery_poll_budget.dart';
 import 'package:openvine/models/account_deletion_attempt.dart';
 import 'package:openvine/models/signer_readiness.dart';
 import 'package:openvine/repositories/account_deletion_recovery_repository.dart';
@@ -44,6 +45,15 @@ class _ManualTimer implements Timer {
 class _ManualTimers {
   final timers = <_ManualTimer>[];
 
+  /// Virtual clock the cubit reads for its polling budget.
+  ///
+  /// The budget is measured in elapsed wall-clock time so it survives a
+  /// relaunch, so a harness that fires timers instantly would never advance it
+  /// and every "pauses at the bound" test would spin forever. Firing a timer
+  /// advances this by that timer's own delay, which is what real time would
+  /// have done.
+  DateTime now = DateTime.utc(2026);
+
   Timer create(Duration delay, void Function() callback) {
     final timer = _ManualTimer(delay, callback);
     timers.add(timer);
@@ -51,7 +61,9 @@ class _ManualTimers {
   }
 
   Future<void> fireNext() async {
-    timers.firstWhere((timer) => timer.isActive).fire();
+    final timer = timers.firstWhere((timer) => timer.isActive);
+    now = now.add(timer.delay);
+    timer.fire();
     await Future<void>.delayed(Duration.zero);
   }
 }
@@ -93,6 +105,7 @@ void main() {
 
   AccountDeletionRecoveryCubit buildCubit({
     bool withReceipt = false,
+    AccountDeletionRecoveryPollBudgetStore? pollBudgetStore,
     Future<void> Function()? onAttemptResolved,
     Future<void> Function(AccountDeletionAttempt)? onAttemptUpdated,
   }) => AccountDeletionRecoveryCubit(
@@ -103,6 +116,8 @@ void main() {
     receiptPubkeyHex: withReceipt ? 'a' * 64 : null,
     receiptVanishEventId: withReceipt ? 'b' * 64 : null,
     timerFactory: timers.create,
+    pollBudgetStore: pollBudgetStore,
+    clock: () => timers.now,
   );
 
   setUpAll(() {
@@ -780,6 +795,102 @@ void main() {
       verify(() => authService.deleteLocalAccount('a' * 64)).called(1);
       expect(cubit.state.status, AccountDeletionRecoveryStatus.resolved);
       await cubit.close();
+    });
+
+    group('polling budget across launches', () {
+      /// Drives one cubit to the session bound and returns the store it used,
+      /// so a second cubit can be built against the same durable state the way
+      /// a relaunch would.
+      Future<AccountDeletionRecoveryPollBudgetStore> spendBudget(
+        AccountDeletionRecoveryPollBudgetStore store,
+      ) async {
+        final cubit = buildCubit(pollBudgetStore: store);
+        await cubit.load();
+        while (timers.timers.any((timer) => timer.isActive)) {
+          await timers.fireNext();
+        }
+        expect(
+          cubit.state.pollingPaused,
+          isTrue,
+          reason: 'the first run must reach the bound',
+        );
+        await cubit.close();
+        return store;
+      }
+
+      test(
+        'a relaunch keeps the budget already spent, so the support message '
+        'stays reachable for someone who backgrounds the app',
+        () async {
+          when(repository.fetchCurrent).thenAnswer((_) async => _processing);
+          final store = await spendBudget(
+            InMemoryAccountDeletionRecoveryPollBudgetStore(),
+          );
+
+          // The user backgrounds the app and comes back later. Nothing runs in
+          // between, which is exactly the time the old timer-delay accumulator
+          // could not see pass.
+          timers.now = timers.now.add(const Duration(minutes: 5));
+
+          // Same attempt, same durable store, fresh cubit: a relaunch.
+          final relaunched = buildCubit(pollBudgetStore: store);
+          addTearDown(relaunched.close);
+          await relaunched.load();
+
+          expect(
+            relaunched.state.pollingElapsed,
+            greaterThan(AccountDeletionRecoveryPolling.sessionBound),
+            reason: 'the wait carries across the relaunch',
+          );
+          expect(
+            relaunched.state.pollingPaused,
+            isTrue,
+            reason:
+                'the budget was already spent before this launch started, so '
+                'the support message must be reachable immediately',
+          );
+        },
+      );
+
+      test(
+        'a different attempt starts its own budget, so a new deletion is not '
+        'charged for the previous one',
+        () async {
+          when(repository.fetchCurrent).thenAnswer((_) async => _processing);
+          final store = await spendBudget(
+            InMemoryAccountDeletionRecoveryPollBudgetStore(),
+          );
+
+          const laterAttempt = AccountDeletionAttempt(
+            id: 'a-different-attempt',
+            status: AccountDeletionAttemptStatus.processing,
+          );
+          when(repository.fetchCurrent).thenAnswer((_) async => laterAttempt);
+          final fresh = buildCubit(pollBudgetStore: store);
+          addTearDown(fresh.close);
+          await fresh.load();
+
+          expect(fresh.state.pollingPaused, isFalse);
+          expect(fresh.state.pollingElapsed, Duration.zero);
+        },
+      );
+
+      test('surfaces the elapsed wait so the screen can show it', () async {
+        when(repository.fetchCurrent).thenAnswer((_) async => _processing);
+        final cubit = buildCubit(
+          pollBudgetStore: InMemoryAccountDeletionRecoveryPollBudgetStore(),
+        );
+        addTearDown(cubit.close);
+        await cubit.load();
+
+        expect(cubit.state.status, AccountDeletionRecoveryStatus.processing);
+        expect(cubit.state.pollingElapsed, Duration.zero);
+        await timers.fireNext();
+        await timers.fireNext();
+
+        // Two ticks of the schedule have elapsed on the virtual clock.
+        expect(cubit.state.pollingElapsed, greaterThan(Duration.zero));
+      });
     });
 
     test(

--- a/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_cubit_test.dart
+++ b/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_cubit_test.dart
@@ -116,7 +116,8 @@ void main() {
     receiptPubkeyHex: withReceipt ? 'a' * 64 : null,
     receiptVanishEventId: withReceipt ? 'b' * 64 : null,
     timerFactory: timers.create,
-    pollBudgetStore: pollBudgetStore,
+    pollBudgetStore:
+        pollBudgetStore ?? InMemoryAccountDeletionRecoveryPollBudgetStore(),
     clock: () => timers.now,
   );
 

--- a/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_poll_budget_test.dart
+++ b/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_poll_budget_test.dart
@@ -1,0 +1,73 @@
+// ABOUTME: Pins the durable half of the deletion-recovery polling budget.
+// ABOUTME: The cubit tests use the in-memory store, so this covers prefs.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/account_deletion_recovery/account_deletion_recovery_poll_budget.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group(SharedPreferencesAccountDeletionRecoveryPollBudgetStore, () {
+    late SharedPreferences prefs;
+    late SharedPreferencesAccountDeletionRecoveryPollBudgetStore store;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      prefs = await SharedPreferences.getInstance();
+      store = SharedPreferencesAccountDeletionRecoveryPollBudgetStore(prefs);
+    });
+
+    test('reports no start before one is recorded', () async {
+      expect(await store.startedAt('attempt-a'), isNull);
+    });
+
+    test('records a start and reads it back', () async {
+      final at = DateTime.utc(2026, 3, 4, 5, 6, 7);
+      await store.recordStartIfAbsent('attempt-a', at);
+
+      expect(await store.startedAt('attempt-a'), at);
+    });
+
+    test(
+      'keeps the earliest start, so a relaunch cannot push the deadline out',
+      () async {
+        final first = DateTime.utc(2026, 3, 4, 5);
+        await store.recordStartIfAbsent('attempt-a', first);
+        await store.recordStartIfAbsent(
+          'attempt-a',
+          first.add(const Duration(minutes: 30)),
+        );
+
+        expect(await store.startedAt('attempt-a'), first);
+      },
+    );
+
+    test('scopes the start to one attempt', () async {
+      final at = DateTime.utc(2026, 3, 4, 5);
+      await store.recordStartIfAbsent('attempt-a', at);
+
+      expect(await store.startedAt('attempt-b'), isNull);
+    });
+
+    test('clear forgets one attempt and leaves the other', () async {
+      final at = DateTime.utc(2026, 3, 4, 5);
+      await store.recordStartIfAbsent('attempt-a', at);
+      await store.recordStartIfAbsent('attempt-b', at);
+
+      await store.clear('attempt-a');
+
+      expect(await store.startedAt('attempt-a'), isNull);
+      expect(await store.startedAt('attempt-b'), at);
+    });
+
+    test('survives a new store over the same preferences', () async {
+      final at = DateTime.utc(2026, 3, 4, 5);
+      await store.recordStartIfAbsent('attempt-a', at);
+
+      // What a relaunch looks like: same durable prefs, fresh store object.
+      final relaunched =
+          SharedPreferencesAccountDeletionRecoveryPollBudgetStore(prefs);
+
+      expect(await relaunched.startedAt('attempt-a'), at);
+    });
+  });
+}

--- a/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_poll_budget_test.dart
+++ b/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_poll_budget_test.dart
@@ -70,4 +70,73 @@ void main() {
       expect(await relaunched.startedAt('attempt-a'), at);
     });
   });
+
+  group(ReceiptAnchoredPollBudgetStore, () {
+    late InMemoryAccountDeletionRecoveryPollBudgetStore fallback;
+
+    setUp(() {
+      fallback = InMemoryAccountDeletionRecoveryPollBudgetStore();
+    });
+
+    ReceiptAnchoredPollBudgetStore storeWith(
+      ({String attemptId, DateTime startedAt})? anchor,
+    ) => ReceiptAnchoredPollBudgetStore(
+      readReceiptAnchor: () => anchor,
+      fallback: fallback,
+    );
+
+    test('prefers the receipt anchor for the matching attempt', () async {
+      final anchored = DateTime.utc(2026, 3, 4, 5);
+      final store = storeWith((attemptId: 'a', startedAt: anchored));
+
+      expect(await store.startedAt('a'), anchored);
+    });
+
+    test('writes nothing to preferences when the receipt covers it', () async {
+      final anchored = DateTime.utc(2026, 3, 4, 5);
+      final store = storeWith((attemptId: 'a', startedAt: anchored));
+
+      await store.recordStartIfAbsent('a', DateTime.utc(2026, 3, 4, 9));
+
+      // The receipt is the anchor; a second key would be a second source of
+      // truth for the same fact.
+      expect(await fallback.startedAt('a'), isNull);
+      expect(await store.startedAt('a'), anchored);
+    });
+
+    test(
+      'falls back to the keyed store when this install has no receipt, which '
+      'is how the screen is reached after a reinstall',
+      () async {
+        final store = storeWith(null);
+        final at = DateTime.utc(2026, 3, 4, 5);
+
+        await store.recordStartIfAbsent('a', at);
+
+        expect(await store.startedAt('a'), at);
+        expect(await fallback.startedAt('a'), at);
+      },
+    );
+
+    test('falls back when the receipt is for a different attempt', () async {
+      final store = storeWith((
+        attemptId: 'other',
+        startedAt: DateTime.utc(2026),
+      ));
+      final at = DateTime.utc(2026, 3, 4, 5);
+
+      await store.recordStartIfAbsent('a', at);
+
+      expect(await store.startedAt('a'), at);
+    });
+
+    test('clear removes the fallback key', () async {
+      final store = storeWith(null);
+      await store.recordStartIfAbsent('a', DateTime.utc(2026, 3, 4, 5));
+
+      await store.clear('a');
+
+      expect(await store.startedAt('a'), isNull);
+    });
+  });
 }

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -489,6 +489,11 @@ void main() {
 // Keys intentionally allowed to fall back to English until a translation pass.
 // Keep this list small and reviewable so new translation gaps stay visible.
 const _knownUntranslatedDebt = <String>{
+  // Elapsed-wait copy on the account-deletion recovery screen. Deferred to the
+  // next human pass rather than machine-translated: it is an ICU plural whose
+  // wording has to stay reassuring in each locale, and the English is likely to
+  // be revised once we can show a real server-side estimate.
+  'accountDeletionFinishingElapsed',
   // Discord proof-rejection reasons (verifier PR #43). Each names a distinct
   // way a Discord proof can fail, replacing one message that blamed the npub
   // for all of them. Deferred to the next human pass rather than

--- a/mobile/test/providers/account_deletion_recovery_providers_test.dart
+++ b/mobile/test/providers/account_deletion_recovery_providers_test.dart
@@ -364,8 +364,8 @@ void main() {
                 .recoveryWatchStartedAt,
             adopted,
           );
-          // Let the backfill write land.
-          await Future<void>.delayed(Duration.zero);
+          // Settle the unawaited backfill write rather than sleeping on it.
+          await pumpEventQueue();
 
           final later = adoptAt(adopted.add(const Duration(hours: 1)));
           expect(

--- a/mobile/test/providers/account_deletion_recovery_providers_test.dart
+++ b/mobile/test/providers/account_deletion_recovery_providers_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies lookup readiness remains fail-closed until signing works.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -217,6 +218,166 @@ void main() {
       );
       addTearDown(subscription.close);
     }
+
+    group('recovery watch anchor', () {
+      /// A container whose clock the test drives, so "later" is exact.
+      ProviderContainer containerAt(DateTime now) {
+        final made = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(preferences),
+            authServiceProvider.overrideWithValue(authService),
+            currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+            currentAuthRpcCapabilityProvider.overrideWithValue(
+              AuthRpcCapability.rpcReady,
+            ),
+            accountDeletionRecoveryRepositoryProvider.overrideWithValue(
+              repository,
+            ),
+            accountDeletionRecoveryClockProvider.overrideWithValue(() => now),
+          ],
+        );
+        addTearDown(made.dispose);
+        return made;
+      }
+
+      test('is stamped when the receipt is first recorded', () async {
+        final at = DateTime.utc(2026, 3, 4, 5);
+        final scoped = containerAt(at);
+        await scoped
+            .read(submittedAccountDeletionAttemptProvider.notifier)
+            .record(
+              pubkeyHex: pubkey,
+              attempt: processing,
+              vanishEventId: _vanishEventId,
+            );
+
+        expect(
+          scoped
+              .read(submittedAccountDeletionAttemptProvider)!
+              .recoveryWatchStartedAt,
+          at,
+        );
+      });
+
+      test(
+        're-recording the same attempt keeps the original anchor, so the '
+        'support budget cannot be pushed out by a status refresh',
+        () async {
+          final first = DateTime.utc(2026, 3, 4, 5);
+          final scoped = containerAt(first);
+          final notifier = scoped.read(
+            submittedAccountDeletionAttemptProvider.notifier,
+          );
+          await notifier.record(
+            pubkeyHex: pubkey,
+            attempt: processing,
+            vanishEventId: _vanishEventId,
+          );
+
+          // Same attempt id, recorded again half an hour later.
+          final later = containerAt(first.add(const Duration(minutes: 30)));
+          await later
+              .read(submittedAccountDeletionAttemptProvider.notifier)
+              .record(
+                pubkeyHex: pubkey,
+                attempt: processing,
+                vanishEventId: _vanishEventId,
+              );
+
+          expect(
+            later
+                .read(submittedAccountDeletionAttemptProvider)!
+                .recoveryWatchStartedAt,
+            first,
+          );
+        },
+      );
+
+      test('updateAttempt does not restamp the anchor', () async {
+        final first = DateTime.utc(2026, 3, 4, 5);
+        final scoped = containerAt(first);
+        await scoped
+            .read(submittedAccountDeletionAttemptProvider.notifier)
+            .record(
+              pubkeyHex: pubkey,
+              attempt: processing,
+              vanishEventId: _vanishEventId,
+            );
+
+        final later = containerAt(first.add(const Duration(minutes: 30)));
+        await later
+            .read(submittedAccountDeletionAttemptProvider.notifier)
+            .updateAttempt(
+              const AccountDeletionAttempt(
+                id: 'attempt-id',
+                status: AccountDeletionAttemptStatus.completed,
+              ),
+            );
+
+        final receipt = later.read(submittedAccountDeletionAttemptProvider)!;
+        expect(receipt.recoveryWatchStartedAt, first);
+        expect(receipt.attempt.status, AccountDeletionAttemptStatus.completed);
+      });
+
+      test(
+        'a legacy receipt is stamped once on adoption and that stamp sticks, '
+        'so the budget is not re-anchored on every read',
+        () async {
+          // A receipt written before the field existed.
+          SharedPreferences.setMockInitialValues({
+            'account_deletion_receipt_v1': jsonEncode({
+              'pubkey_hex': pubkey,
+              'vanish_event_id': _vanishEventId,
+              'attempt': processing.toJson(),
+            }),
+          });
+          final legacyPrefs = await SharedPreferences.getInstance();
+
+          ProviderContainer adoptAt(DateTime now) {
+            final made = ProviderContainer(
+              overrides: [
+                sharedPreferencesProvider.overrideWithValue(legacyPrefs),
+                authServiceProvider.overrideWithValue(authService),
+                currentAuthStateProvider.overrideWithValue(
+                  AuthState.authenticated,
+                ),
+                currentAuthRpcCapabilityProvider.overrideWithValue(
+                  AuthRpcCapability.rpcReady,
+                ),
+                accountDeletionRecoveryRepositoryProvider.overrideWithValue(
+                  repository,
+                ),
+                accountDeletionRecoveryClockProvider.overrideWithValue(
+                  () => now,
+                ),
+              ],
+            );
+            addTearDown(made.dispose);
+            return made;
+          }
+
+          final adopted = DateTime.utc(2026, 3, 4, 5);
+          final first = adoptAt(adopted);
+          expect(
+            first
+                .read(submittedAccountDeletionAttemptProvider)!
+                .recoveryWatchStartedAt,
+            adopted,
+          );
+          // Let the backfill write land.
+          await Future<void>.delayed(Duration.zero);
+
+          final later = adoptAt(adopted.add(const Duration(hours: 1)));
+          expect(
+            later
+                .read(submittedAccountDeletionAttemptProvider)!
+                .recoveryWatchStartedAt,
+            adopted,
+            reason: 'the adoption stamp was persisted, not recomputed',
+          );
+        },
+      );
+    });
 
     test(
       'a recorded attempt is the current attempt without a lookup',

--- a/mobile/test/router/minor_account_review_router_test.dart
+++ b/mobile/test/router/minor_account_review_router_test.dart
@@ -115,6 +115,7 @@ void main() {
             pubkeyHex: 'first-account',
             attempt: retained.value!,
             vanishEventId: 'vanish-event-id',
+            recoveryWatchStartedAt: DateTime.utc(2026),
           ),
           authState: AuthState.authenticated,
           currentPubkeyHex: 'second-account',
@@ -131,14 +132,15 @@ void main() {
       expect(
         accountDeletionRecoveryGateActive(
           const AsyncData<AccountDeletionAttempt?>(lookup),
-          submittedAttempt: const SubmittedAccountDeletionAttempt(
+          submittedAttempt: SubmittedAccountDeletionAttempt(
             pubkeyHex: 'first-account',
-            attempt: AccountDeletionAttempt(
+            attempt: const AccountDeletionAttempt(
               id: 'first-account-attempt',
               status: AccountDeletionAttemptStatus.processing,
               failureCode: 'x',
             ),
             vanishEventId: 'vanish-event-id',
+            recoveryWatchStartedAt: DateTime.utc(2026),
           ),
           authState: AuthState.authenticated,
           currentPubkeyHex: 'second-account',
@@ -156,13 +158,14 @@ void main() {
               status: AccountDeletionAttemptStatus.processing,
             ),
           ),
-          submittedAttempt: const SubmittedAccountDeletionAttempt(
+          submittedAttempt: SubmittedAccountDeletionAttempt(
             pubkeyHex: 'first-account',
-            attempt: AccountDeletionAttempt(
+            attempt: const AccountDeletionAttempt(
               id: 'first-account-attempt',
               status: AccountDeletionAttemptStatus.processing,
             ),
             vanishEventId: 'vanish-event-id',
+            recoveryWatchStartedAt: DateTime.utc(2026),
           ),
           authState: AuthState.authenticated,
           currentPubkeyHex: 'second-account',
@@ -247,13 +250,14 @@ void main() {
           authenticatedDeletionLookupSettled(
             AuthState.authenticated,
             const AsyncLoading<AccountDeletionAttempt?>(),
-            submittedAttempt: const SubmittedAccountDeletionAttempt(
+            submittedAttempt: SubmittedAccountDeletionAttempt(
               pubkeyHex: 'user-pubkey',
-              attempt: AccountDeletionAttempt(
+              attempt: const AccountDeletionAttempt(
                 id: 'attempt-id',
                 status: AccountDeletionAttemptStatus.processing,
               ),
               vanishEventId: 'vanish-event-id',
+              recoveryWatchStartedAt: DateTime.utc(2026),
             ),
             currentPubkeyHex: 'user-pubkey',
           ),


### PR DESCRIPTION
## The problem

When a deletion is still being processed on the server, the user is held on the account recovery screen. That screen shows a spinner, no indication of progress, and one way out ("Use another account"). After fifteen minutes it is supposed to offer "Contact support".

It never gets there. Those fifteen minutes were measured by adding up polling delays in a field that only advances while the app is running, so backgrounding the app — the obvious thing to do while waiting on a server — restarted the count at zero on the next launch. A user who checks back periodically can wait an arbitrarily long time and never once see the support message.

## Why this fix

The budget is meant to express "you have been waiting a long time". That is elapsed time, not time this process happened to be alive. It is now recorded as a wall-clock start against the attempt id and kept in preferences, so it measures the wait itself and survives a relaunch.

Two things deliberately still start a fresh budget:

- **A genuinely new deletion attempt**, because it is a new wait — hence keying on the attempt id rather than a single global slot.
- **An explicit Retry**, because that is the user asking for another round. A relaunch is not, and that is precisely the distinction the old code could not make.

The screen now says how long the wait has been and that it is safe to close the app. There is deliberately **no estimate and no countdown**: the remaining work is server-side with no client-visible bound, and the client-side portion is not reliably short either, so any deadline shown here would be invented. Elapsed time is the honest thing to show, and it is what distinguishes a real wait from a screen that has hung.

## What this deliberately leaves alone

- The router still sends an account with an in-progress deletion to this screen. That account genuinely cannot be used yet, so the redirect is right; who owns it is #8641.
- The polling schedule, the fifteen-minute bound, and the "Use another account" exit are unchanged.
- No copy for the existing states changed.

## Notes for review

- One new ARB key, an ICU plural. It is recorded as untranslated debt for the next human pass rather than machine-translated, since the wording needs to stay reassuring per locale and is likely to be revised if we ever get a real server-side estimate.
- The polling budget is stored under a key that includes the attempt id, so it cannot carry one account's wait into another's session, and it is cleared when the attempt resolves.
- The test harness gained a virtual clock. It had to: the budget is now elapsed time, so a harness that fires timers instantly would never advance it and the existing "pauses at the bound" tests would spin forever.

## Reconciled with #9034

#9034 fixed the same bug independently, opened ~20 minutes before this one. They cannot both merge. This PR is the survivor and now carries everything from #9034 that was worth having:

**Taken:** the durable anchor on the deletion receipt (no new preference key on the common path, cleaned up with the attempt, original stamp preserved across status refreshes, legacy receipts stamped once on adoption); the injectable clock provider, which is what makes those rules testable across the provider boundary; and the one-shot status read when the budget is already spent — without it a relaunch would pause immediately and never notice a deletion that finished while the app was closed, offering "contact support" for an account the server had already deleted.

**Kept from this PR:** the attempt-id keyed store, now as the *fallback* rather than the only mechanism, because the recovery screen is reachable without a receipt. The router gates on server attempt status, not local state — `currentAccountDeletionAttemptProvider` falls through to `fetchCurrent()` when nothing is stored — so a reinstall mid-deletion, a receipt cleared as corrupt, or a deletion submitted from another device all land on a screen that builds its own cubit with nothing local to anchor on. #9034 documents that case as out of scope; these are the long waits the budget exists for. Also kept: the elapsed-wait UI, which addresses the "no progress, no ETA" half of the original report.

**Not taken:** #9034's `sessionBound` → `supportEscapeAfter` rename — a better name, but churn across an already-reviewed diff; worth doing separately.

## How it was verified

- Recovery cubit, recovery screen, the new poll-budget store, and ARB consistency: 64 + 13 tests, green.
- The new tests were checked by mutation: making the cubit ignore the persisted start hangs the "pauses at the bound" tests rather than passing them.
- One earlier version of the relaunch test passed for the wrong reason (the first run stops a few seconds short of the bound, so a relaunch legitimately gets the remainder) and was rewritten to move the clock forward the way a backgrounded app does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Closes #9031
Relates to #8126
Relates to #8641


