### PR TITLE
fix(audio): stop repeated warnings for unavailable sounds

### DIFF
--- a/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
+++ b/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
@@ -43,26 +43,13 @@ class AudioAttributionRow extends ConsumerWidget {
     return audioAsync.when(
       data: (audio) {
         if (audio == null) {
-          Log.warning(
-            'Audio event not found for video ${video.id} '
-            '(audioEventId: ${video.audioEventId})',
-            name: 'AudioAttributionRow',
-            category: LogCategory.ui,
-          );
           return _UnresolvedAudioAttribution(video: video);
         }
 
         return _AudioAttributionContent(audio: audio, sourceVideo: video);
       },
       loading: () => const _AudioAttributionSkeleton(),
-      error: (error, stack) {
-        Log.error(
-          'Failed to load audio for video ${video.id}: $error',
-          name: 'AudioAttributionRow',
-          category: LogCategory.ui,
-        );
-        return _UnresolvedAudioAttribution(video: video);
-      },
+      error: (error, stack) => _UnresolvedAudioAttribution(video: video),
     );
   }
 }

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -72,19 +72,12 @@ class _SharedAudioSection extends ConsumerWidget {
         label: context.l10n.metadataSoundsLabel,
         child: const _SoundSkeleton(),
       ),
-      error: (error, stack) {
-        Log.error(
-          'Failed to load audio for metadata sheet: $error',
-          name: 'MetadataSoundsSection',
-          category: LogCategory.ui,
-        );
-        return _OriginalSoundSection(
-          video: video,
-          reusedCreatorPubkey: AudioAttributionCredit.reusedCreatorPubkeyFor(
-            video,
-          ),
-        );
-      },
+      error: (error, stack) => _OriginalSoundSection(
+        video: video,
+        reusedCreatorPubkey: AudioAttributionCredit.reusedCreatorPubkeyFor(
+          video,
+        ),
+      ),
     );
   }
 }

--- a/mobile/packages/sounds_repository/lib/src/sounds_repository.dart
+++ b/mobile/packages/sounds_repository/lib/src/sounds_repository.dart
@@ -54,6 +54,9 @@ class SoundsRepository {
   /// In-memory cache of audio events by event ID
   final Map<String, AudioEvent> _cache = {};
 
+  /// Event IDs whose stable unresolved result was already reported.
+  final Set<String> _loggedUnresolvedSoundIds = {};
+
   /// Active subscription for real-time updates
   StreamSubscription<Event>? _subscription;
   String? _subscriptionId;
@@ -123,6 +126,7 @@ class SoundsRepository {
     }
     await _soundsSubject.close();
     _cache.clear();
+    _loggedUnresolvedSoundIds.clear();
   }
 
   /// Fetch trending/recent sounds from relays.
@@ -242,11 +246,7 @@ class SoundsRepository {
       final event = await _nostrClient.fetchEventById(eventId);
 
       if (event == null) {
-        Log.debug(
-          'Sound not found: $eventId',
-          name: 'SoundsRepository',
-          category: LogCategory.api,
-        );
+        _logUnresolvedSoundOnce(eventId, 'Sound not found: $eventId');
         return null;
       }
 
@@ -279,21 +279,19 @@ class SoundsRepository {
           // strictly typed), so this is unreachable in practice; kept to
           // downgrade a hypothetical parse failure to a warning + null instead
           // of the outer error + rethrow.
-          Log.warning(
+          _logUnresolvedSoundOnce(
+            eventId,
             'Failed to synthesize original sound from video $eventId: $e',
-            name: 'SoundsRepository',
-            category: LogCategory.api,
           );
           return null;
           // coverage:ignore-end
         }
       }
 
-      Log.warning(
+      _logUnresolvedSoundOnce(
+        eventId,
         'Event $eventId is not a Kind $audioEventKind audio event '
         '(got Kind ${event.kind})',
-        name: 'SoundsRepository',
-        category: LogCategory.api,
       );
       return null;
     } catch (e) {
@@ -311,6 +309,15 @@ class SoundsRepository {
   /// Returns null if the sound is not in the cache.
   AudioEvent? getSoundFromCache(String eventId) {
     return _cache[eventId];
+  }
+
+  void _logUnresolvedSoundOnce(String eventId, String message) {
+    if (!_loggedUnresolvedSoundIds.add(eventId)) return;
+    Log.warning(
+      message,
+      name: 'SoundsRepository',
+      category: LogCategory.api,
+    );
   }
 
   /// Fetch the count of videos using a specific sound, via NIP-45 COUNT.
@@ -603,6 +610,7 @@ class SoundsRepository {
   /// Useful for debugging or forcing a refresh.
   void clearCache() {
     _cache.clear();
+    _loggedUnresolvedSoundIds.clear();
     _emitSounds();
   }
 

--- a/mobile/packages/sounds_repository/test/src/sounds_repository_test.dart
+++ b/mobile/packages/sounds_repository/test/src/sounds_repository_test.dart
@@ -9,6 +9,7 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:sounds_repository/sounds_repository.dart';
 import 'package:test/test.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 
@@ -103,6 +104,17 @@ void main() {
         'sig': '',
       });
     }
+
+    int unresolvedWarningCount(String eventId) => LogCaptureService()
+        .getRecentLogs(minLevel: LogLevel.warning)
+        .where(
+          (entry) =>
+              entry.name == 'SoundsRepository' &&
+              entry.message.contains(eventId) &&
+              (entry.message.startsWith('Sound not found') ||
+                  entry.message.contains('is not a Kind')),
+        )
+        .length;
 
     group('initialization', () {
       test('initializes with empty cache', () async {
@@ -324,6 +336,27 @@ void main() {
         expect(sound, isNull);
       });
 
+      test('warns once per missing event until the cache is cleared', () async {
+        when(
+          () => mockNostrClient.fetchEventById(any()),
+        ).thenAnswer((_) async => null);
+        final firstBaseline = unresolvedWarningCount(testEventId1);
+
+        expect(await repository.fetchSoundById(testEventId1), isNull);
+        expect(unresolvedWarningCount(testEventId1), firstBaseline + 1);
+
+        expect(await repository.fetchSoundById(testEventId1), isNull);
+        expect(unresolvedWarningCount(testEventId1), firstBaseline + 1);
+
+        final secondBaseline = unresolvedWarningCount(testEventId2);
+        expect(await repository.fetchSoundById(testEventId2), isNull);
+        expect(unresolvedWarningCount(testEventId2), secondBaseline + 1);
+
+        repository.clearCache();
+        expect(await repository.fetchSoundById(testEventId1), isNull);
+        expect(unresolvedWarningCount(testEventId1), firstBaseline + 2);
+      });
+
       test('returns null when event is wrong kind', () async {
         final wrongKindEvent = Event.fromJson({
           'id': testEventId1,
@@ -342,6 +375,28 @@ void main() {
         final sound = await repository.fetchSoundById(testEventId1);
 
         expect(sound, isNull);
+      });
+
+      test('warns once per unsupported event kind', () async {
+        final wrongKindEvent = Event.fromJson({
+          'id': testEventId1,
+          'pubkey': testPubkey1,
+          'kind': 1,
+          'tags': <List<dynamic>>[],
+          'content': 'Not audio',
+          'created_at': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          'sig': '',
+        });
+        when(
+          () => mockNostrClient.fetchEventById(testEventId1),
+        ).thenAnswer((_) async => wrongKindEvent);
+        final baseline = unresolvedWarningCount(testEventId1);
+
+        expect(await repository.fetchSoundById(testEventId1), isNull);
+        expect(unresolvedWarningCount(testEventId1), baseline + 1);
+
+        expect(await repository.fetchSoundById(testEventId1), isNull);
+        expect(unresolvedWarningCount(testEventId1), baseline + 1);
       });
 
       test(

--- a/mobile/test/widgets/audio_attribution_row_test.dart
+++ b/mobile/test/widgets/audio_attribution_row_test.dart
@@ -74,7 +74,6 @@ void main() {
       List<Override> additionalOverrides = const [],
       ValueNotifier<int>? rebuilds,
     }) {
-      final attribution = AudioAttributionRow(video: video);
       return ProviderScope(
         overrides: [
           if (video.hasAudioReference)
@@ -91,13 +90,13 @@ void main() {
           home: Scaffold(
             backgroundColor: Colors.black,
             body: rebuilds == null
-                ? attribution
+                ? AudioAttributionRow(video: video)
                 : ValueListenableBuilder<int>(
                     valueListenable: rebuilds,
                     builder: (context, rebuild, child) => Column(
                       children: [
                         Text('Rebuild $rebuild'),
-                        attribution,
+                        AudioAttributionRow(video: video),
                       ],
                     ),
                   ),
@@ -264,13 +263,14 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.textContaining('Sound unavailable'), findsOneWidget);
-        expect(renderPathLogCount(), logsBefore);
+        final logsAfterInitialRender = renderPathLogCount();
 
         rebuilds.value = 1;
         await tester.pump();
 
         expect(find.text('Rebuild 1'), findsOneWidget);
-        expect(renderPathLogCount(), logsBefore);
+        expect(renderPathLogCount(), logsAfterInitialRender);
+        expect(logsAfterInitialRender, logsBefore);
       });
 
       testWidgets('does not log when the error fallback rebuilds', (
@@ -290,13 +290,14 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.textContaining('Sound unavailable'), findsOneWidget);
-        expect(renderPathLogCount(), logsBefore);
+        final logsAfterInitialRender = renderPathLogCount();
 
         rebuilds.value = 1;
         await tester.pump();
 
         expect(find.text('Rebuild 1'), findsOneWidget);
-        expect(renderPathLogCount(), logsBefore);
+        expect(renderPathLogCount(), logsAfterInitialRender);
+        expect(logsAfterInitialRender, logsBefore);
       });
 
       testWidgets('shows a neutral label when the audio event is null', (

--- a/mobile/test/widgets/audio_attribution_row_test.dart
+++ b/mobile/test/widgets/audio_attribution_row_test.dart
@@ -10,6 +10,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/widgets/video_feed_item/audio_attribution_row.dart';
 import 'package:riverpod/misc.dart' show Override;
+import 'package:unified_logger/unified_logger.dart';
 
 void main() {
   group(AudioAttributionRow, () {
@@ -71,7 +72,9 @@ void main() {
       bool resolvesAudio = true,
       Object? audioError,
       List<Override> additionalOverrides = const [],
+      ValueNotifier<int>? rebuilds,
     }) {
+      final attribution = AudioAttributionRow(video: video);
       return ProviderScope(
         overrides: [
           if (video.hasAudioReference)
@@ -87,11 +90,31 @@ void main() {
           theme: VineTheme.theme,
           home: Scaffold(
             backgroundColor: Colors.black,
-            body: AudioAttributionRow(video: video),
+            body: rebuilds == null
+                ? attribution
+                : ValueListenableBuilder<int>(
+                    valueListenable: rebuilds,
+                    builder: (context, rebuild, child) => Column(
+                      children: [
+                        Text('Rebuild $rebuild'),
+                        attribution,
+                      ],
+                    ),
+                  ),
           ),
         ),
       );
     }
+
+    int renderPathLogCount() => LogCaptureService()
+        .getRecentLogs()
+        .where(
+          (entry) =>
+              entry.name == 'AudioAttributionRow' &&
+              (entry.message.startsWith('Audio event not found') ||
+                  entry.message.startsWith('Failed to load audio')),
+        )
+        .length;
 
     group('Original sound (no audio reference)', () {
       testWidgets('renders nothing for videos without audio reference', (
@@ -224,6 +247,58 @@ void main() {
     // referenced event can't be fetched the credit must degrade rather than
     // vanish (#6185).
     group('Unresolvable audio reference', () {
+      testWidgets('does not log when the null fallback rebuilds', (
+        tester,
+      ) async {
+        final rebuilds = ValueNotifier<int>(0);
+        addTearDown(rebuilds.dispose);
+        final logsBefore = renderPathLogCount();
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            video: createVideoWithAudio(),
+            resolvesAudio: false,
+            rebuilds: rebuilds,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('Sound unavailable'), findsOneWidget);
+        expect(renderPathLogCount(), logsBefore);
+
+        rebuilds.value = 1;
+        await tester.pump();
+
+        expect(find.text('Rebuild 1'), findsOneWidget);
+        expect(renderPathLogCount(), logsBefore);
+      });
+
+      testWidgets('does not log when the error fallback rebuilds', (
+        tester,
+      ) async {
+        final rebuilds = ValueNotifier<int>(0);
+        addTearDown(rebuilds.dispose);
+        final logsBefore = renderPathLogCount();
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            video: createVideoWithAudio(),
+            audioError: StateError('relay unavailable'),
+            rebuilds: rebuilds,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('Sound unavailable'), findsOneWidget);
+        expect(renderPathLogCount(), logsBefore);
+
+        rebuilds.value = 1;
+        await tester.pump();
+
+        expect(find.text('Rebuild 1'), findsOneWidget);
+        expect(renderPathLogCount(), logsBefore);
+      });
+
       testWidgets('shows a neutral label when the audio event is null', (
         tester,
       ) async {

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/screens/sound_detail_screen.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_sounds_section.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 import '../helpers/test_provider_overrides.dart';
 
@@ -90,10 +91,14 @@ void main() {
       required VideoEvent video,
       AudioEvent? audioOverride,
       String? viewerPubkey,
+      Object? audioError,
+      ValueNotifier<int>? rebuilds,
     }) {
+      final soundsSection = MetadataSoundsSection(video: video);
       return ProviderScope(
         overrides: [
           soundByIdProvider(testAudioEventId).overrideWith((ref) async {
+            if (audioError != null) throw audioError;
             return audioOverride ?? testAudio;
           }),
           authServiceProvider.overrideWithValue(
@@ -106,13 +111,58 @@ void main() {
           theme: VineTheme.theme,
           home: Scaffold(
             backgroundColor: Colors.black,
-            body: MetadataSoundsSection(video: video),
+            body: rebuilds == null
+                ? soundsSection
+                : ValueListenableBuilder<int>(
+                    valueListenable: rebuilds,
+                    builder: (context, rebuild, child) => Column(
+                      children: [
+                        Text('Rebuild $rebuild'),
+                        soundsSection,
+                      ],
+                    ),
+                  ),
           ),
         ),
       );
     }
 
+    int renderPathLogCount() => LogCaptureService()
+        .getRecentLogs()
+        .where(
+          (entry) =>
+              entry.name == 'MetadataSoundsSection' &&
+              entry.message.startsWith('Failed to load audio'),
+        )
+        .length;
+
     group('Shared audio', () {
+      testWidgets('does not log when the error fallback rebuilds', (
+        tester,
+      ) async {
+        final rebuilds = ValueNotifier<int>(0);
+        addTearDown(rebuilds.dispose);
+        final logsBefore = renderPathLogCount();
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            video: createVideoWithAudio(),
+            audioError: StateError('relay unavailable'),
+            rebuilds: rebuilds,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Original sound'), findsOneWidget);
+        expect(renderPathLogCount(), logsBefore);
+
+        rebuilds.value = 1;
+        await tester.pump();
+
+        expect(find.text('Rebuild 1'), findsOneWidget);
+        expect(renderPathLogCount(), logsBefore);
+      });
+
       testWidgets('shows sound title for video with audio reference', (
         tester,
       ) async {

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -94,7 +94,6 @@ void main() {
       Object? audioError,
       ValueNotifier<int>? rebuilds,
     }) {
-      final soundsSection = MetadataSoundsSection(video: video);
       return ProviderScope(
         overrides: [
           soundByIdProvider(testAudioEventId).overrideWith((ref) async {
@@ -112,13 +111,13 @@ void main() {
           home: Scaffold(
             backgroundColor: Colors.black,
             body: rebuilds == null
-                ? soundsSection
+                ? MetadataSoundsSection(video: video)
                 : ValueListenableBuilder<int>(
                     valueListenable: rebuilds,
                     builder: (context, rebuild, child) => Column(
                       children: [
                         Text('Rebuild $rebuild'),
-                        soundsSection,
+                        MetadataSoundsSection(video: video),
                       ],
                     ),
                   ),
@@ -154,13 +153,14 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('Original sound'), findsOneWidget);
-        expect(renderPathLogCount(), logsBefore);
+        final logsAfterInitialRender = renderPathLogCount();
 
         rebuilds.value = 1;
         await tester.pump();
 
         expect(find.text('Rebuild 1'), findsOneWidget);
-        expect(renderPathLogCount(), logsBefore);
+        expect(renderPathLogCount(), logsAfterInitialRender);
+        expect(logsAfterInitialRender, logsBefore);
       });
 
       testWidgets('shows sound title for video with audio reference', (


### PR DESCRIPTION
## Description

Unavailable shared-audio references were logged from synchronous widget render branches. Every feed or metadata rebuild repeated the same warning or error, allowing an expected fallback state to crowd useful warnings out of support-report summaries.

This change removes those render-path side effects and records unresolved references at the repository boundary instead. The repository emits one warning per unresolved event ID during its cache lifetime, and explicit cache clearing allows the warning to be reported again. Missing events, unsupported event kinds, and defensive synthesis failures share that deduplication policy; transport exceptions remain logged per failed fetch.

The regression coverage forces real widget rebuilds for both `data(null)` and error fallbacks, verifies that the fallback remains visible, and filters the shared log buffer for the specific render-path diagnostics. Repository tests cover the first warning, repeated lookup suppression, distinct IDs, cache reset, and unsupported event kinds.

**Related Issue:** Closes #9032

## Out of Scope

The fallback attribution UI, reuse/navigation behavior, and event-driven navigation logging are unchanged. This does not address unrelated build-path logging outside audio attribution.

## Verification

- `flutter analyze lib test integration_test`
- `flutter test test/widgets/audio_attribution_row_test.dart test/widgets/metadata_sounds_section_test.dart` (39 tests)
- Full `sounds_repository` test suite with coverage (74 tests, 314/314 lines / 100%)
- Mutation check: temporarily restoring the old render-path logs makes all three rebuild assertions fail with a +1 log delta
- Repository pre-push checks: analyzer clean and all 84 affected tests passed
- `scripts/check_unpinned_unchanged_assertions.sh`
- `scripts/check_future_delayed_ceiling.sh`
- `scripts/check_empty_catch_ceiling.sh`
- `scripts/check_package_coverage_floor.sh`

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature which causes existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
