### PR TITLE
perf(reposts): stop unresolved reposts from delaying feed loads

### DIFF
--- a/mobile/lib/services/repost_resolver.dart
+++ b/mobile/lib/services/repost_resolver.dart
@@ -1,8 +1,6 @@
 // ABOUTME: Resolves Nostr kind 16 repost events to their original video content.
 // ABOUTME: Provides clean abstraction for repost handling with caching and relay fetching.
 
-import 'dart:async';
-
 import 'package:models/models.dart' hide NIP71VideoKinds;
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
@@ -24,22 +22,49 @@ typedef VideoByAddressableLookup = VideoEvent? Function(
 /// Callback to lookup cached videos by event ID
 typedef VideoByIdLookup = VideoEvent? Function(String eventId);
 
-/// Callback to subscribe to Nostr events
-typedef NostrSubscribe = Stream<Event> Function(List<Filter> filters);
+/// Result of a bounded Nostr query.
+typedef NostrQueryResult = ({List<Event> events, bool timedOut, bool noRelays});
+
+/// Callback to run a bounded Nostr query.
+typedef NostrQuery = Future<NostrQueryResult> Function(
+  List<Filter> filters, {
+  required Duration timeout,
+  required bool requireAllRelaysSettled,
+});
+
+class _MissRecord {
+  const _MissRecord({required this.recordedAt, required this.conclusive});
+
+  final DateTime recordedAt;
+  final bool conclusive;
+}
 
 /// Resolves kind 16 repost events to their original video content
 class RepostResolver {
   RepostResolver({
-    required NostrSubscribe subscribe,
+    required NostrQuery queryEvents,
     required VideoByAddressableLookup findByAddressable,
     required VideoByIdLookup findById,
-  }) : _subscribe = subscribe,
+    DateTime Function()? now,
+    Duration missTtl = const Duration(minutes: 10),
+    Duration inconclusiveMissTtl = const Duration(seconds: 30),
+  }) : _queryEvents = queryEvents,
        _findByAddressable = findByAddressable,
-       _findById = findById;
+       _findById = findById,
+       _now = now ?? DateTime.now,
+       _missTtl = missTtl,
+       _inconclusiveMissTtl = inconclusiveMissTtl;
 
-  final NostrSubscribe _subscribe;
+  static const _maxMissEntries = 512;
+
+  final NostrQuery _queryEvents;
   final VideoByAddressableLookup _findByAddressable;
   final VideoByIdLookup _findById;
+  final DateTime Function() _now;
+  final Duration _missTtl;
+  final Duration _inconclusiveMissTtl;
+  final Map<String, _MissRecord> _misses = {};
+  final Map<String, Future<NostrQueryResult>> _inFlightQueries = {};
 
   static const _videoKeywords = [
     'video',
@@ -74,11 +99,22 @@ class RepostResolver {
     if (parts.length < 3) return null;
     final kind = int.tryParse(parts[0]);
     if (kind == null) return null;
-    return (kind: kind, pubkey: parts[1], dTag: parts[2]);
+    return (kind: kind, pubkey: parts[1], dTag: parts.sublist(2).join(':'));
   }
 
   /// Check if a repost event is likely to reference video content
   bool isLikelyVideoRepost(Event repostEvent) {
+    // An explicit, valid kind is authoritative. Missing or malformed kind tags
+    // keep the permissive fallback used for older reposts.
+    for (final tag in repostEvent.tags) {
+      if (tag.length > 1 && tag[0] == 'k') {
+        final referencedKind = int.tryParse(tag[1]);
+        if (referencedKind != null) {
+          return NIP71VideoKinds.isVideoKind(referencedKind);
+        }
+      }
+    }
+
     final content = repostEvent.content.toLowerCase();
 
     // Check content for video-related keywords
@@ -91,17 +127,6 @@ class RepostResolver {
       if (tag.isNotEmpty && tag[0] == 't' && tag.length > 1) {
         final hashtag = tag[1].toLowerCase();
         if (_videoKeywords.any(hashtag.contains)) {
-          return true;
-        }
-      }
-    }
-
-    // Check for 'k' tag indicating original event kind
-    for (final tag in repostEvent.tags) {
-      if (tag.isNotEmpty && tag[0] == 'k' && tag.length > 1) {
-        final referencedKind = int.tryParse(tag[1]);
-        if (referencedKind != null &&
-            NIP71VideoKinds.isVideoKind(referencedKind)) {
           return true;
         }
       }
@@ -129,7 +154,10 @@ class RepostResolver {
   /// - Not a likely video repost
   /// - Original video not found in cache and fetchFromRelay is false
   ///
-  /// If fetchFromRelay is true and original not cached, fetches from relay.
+  /// If [fetchFromRelay] is true and the original is not cached, performs one
+  /// bounded query for every unresolved reference. Relay misses are cached for
+  /// a short period when settlement is inconclusive and longer when every
+  /// serving relay settles the query.
   Future<VideoEvent?> resolve(
     Event repostEvent, {
     bool fetchFromRelay = true,
@@ -146,27 +174,85 @@ class RepostResolver {
 
     final tags = extractTags(repostEvent);
 
-    // Try addressable ID first (kind:pubkey:d-tag format)
-    if (tags.addressableId != null) {
-      final result = await _resolveByAddressable(
-        tags.addressableId!,
-        repostEvent,
-        fetchFromRelay: fetchFromRelay,
-        timeout: timeout,
-      );
-      if (result != null) return result;
+    final addressableId = tags.addressableId;
+    final addressable = addressableId == null
+        ? null
+        : parseAddressableId(addressableId);
+    final hasUsableAddressable =
+        addressable != null && NIP71VideoKinds.isVideoKind(addressable.kind);
+
+    if (hasUsableAddressable) {
+      final cached = _findByAddressable(addressable.pubkey, addressable.dTag);
+      if (cached != null) {
+        return createRepostVideoEvent(cached, repostEvent);
+      }
     }
 
-    // Try event ID
-    if (tags.eventId != null) {
-      final result = await _resolveByEventId(
-        tags.eventId!,
-        repostEvent,
-        fetchFromRelay: fetchFromRelay,
-        timeout: timeout,
-      );
-      if (result != null) return result;
+    final eventId = tags.eventId;
+    if (eventId != null) {
+      final cached = _findById(eventId);
+      if (cached != null) {
+        return createRepostVideoEvent(cached, repostEvent);
+      }
     }
+
+    if (!fetchFromRelay) return null;
+
+    final filters = <Filter>[];
+    final missKeys = <String>[];
+    if (hasUsableAddressable &&
+        !_hasActiveMiss(_addressableMissKey(addressableId!))) {
+      filters.add(
+        Filter(
+          kinds: [addressable.kind],
+          authors: [addressable.pubkey],
+          d: [addressable.dTag],
+          limit: 1,
+        ),
+      );
+      missKeys.add(_addressableMissKey(addressableId));
+    }
+    if (eventId != null && !_hasActiveMiss(_eventMissKey(eventId))) {
+      filters.add(
+        Filter(
+          ids: [eventId],
+          kinds: NIP71VideoKinds.getAllVideoKinds(),
+          limit: 1,
+        ),
+      );
+      missKeys.add(_eventMissKey(eventId));
+    }
+
+    if (filters.isEmpty) return null;
+
+    NostrQueryResult queryResult;
+    try {
+      queryResult = await _runCoalescedQuery(filters, missKeys, timeout);
+    } catch (error) {
+      Log.error(
+        'Error fetching original for repost: $error',
+        name: 'RepostResolver',
+        category: LogCategory.video,
+      );
+      _recordMisses(missKeys, conclusive: false);
+      return null;
+    }
+
+    final resolved = _resolveQueryEvents(
+      queryResult.events,
+      repostEvent,
+      addressable: hasUsableAddressable ? addressable : null,
+      eventId: eventId,
+    );
+    if (resolved != null) {
+      missKeys.forEach(_misses.remove);
+      return resolved;
+    }
+
+    _recordMisses(
+      missKeys,
+      conclusive: !queryResult.timedOut && !queryResult.noRelays,
+    );
 
     Log.debug(
       '⏩ Repost has no resolvable reference: ${repostEvent.id}',
@@ -176,138 +262,93 @@ class RepostResolver {
     return null;
   }
 
-  Future<VideoEvent?> _resolveByAddressable(
-    String addressableId,
-    Event repostEvent, {
-    required bool fetchFromRelay,
-    required Duration timeout,
-  }) async {
-    final parsed = parseAddressableId(addressableId);
-    if (parsed == null || !NIP71VideoKinds.isVideoKind(parsed.kind)) {
-      return null;
-    }
-
-    // Check cache first
-    final cached = _findByAddressable(parsed.pubkey, parsed.dTag);
-    if (cached != null) {
-      return createRepostVideoEvent(cached, repostEvent);
-    }
-
-    if (!fetchFromRelay) return null;
-
-    // Fetch from relay
-    return _fetchAddressableEvent(addressableId, repostEvent, timeout);
-  }
-
-  Future<VideoEvent?> _resolveByEventId(
-    String eventId,
-    Event repostEvent, {
-    required bool fetchFromRelay,
-    required Duration timeout,
-  }) async {
-    // Check cache first
-    final cached = _findById(eventId);
-    if (cached != null) {
-      return createRepostVideoEvent(cached, repostEvent);
-    }
-
-    if (!fetchFromRelay) return null;
-
-    // Fetch from relay
-    return _fetchEventById(eventId, repostEvent, timeout);
-  }
-
-  Future<VideoEvent?> _fetchAddressableEvent(
-    String addressableId,
-    Event repostEvent,
+  Future<NostrQueryResult> _runCoalescedQuery(
+    List<Filter> filters,
+    List<String> missKeys,
     Duration timeout,
   ) async {
-    final parsed = parseAddressableId(addressableId);
-    if (parsed == null) return null;
+    final sortedKeys = [...missKeys]..sort();
+    final encodedKeys = sortedKeys.map((key) => '${key.length}:$key').join();
+    final queryKey = '${timeout.inMicroseconds}:$encodedKeys';
+    final existing = _inFlightQueries[queryKey];
+    if (existing != null) return existing;
 
-    final filter = Filter(
-      kinds: [parsed.kind],
-      authors: [parsed.pubkey],
-      d: [parsed.dTag],
-      limit: 1,
+    final query = _queryEvents(
+      filters,
+      timeout: timeout,
+      requireAllRelaysSettled: true,
     );
-
-    return _fetchAndResolve(filter, repostEvent, timeout);
+    _inFlightQueries[queryKey] = query;
+    try {
+      return await query;
+    } finally {
+      if (identical(_inFlightQueries[queryKey], query)) {
+        _inFlightQueries.remove(queryKey);
+      }
+    }
   }
 
-  Future<VideoEvent?> _fetchEventById(
-    String eventId,
-    Event repostEvent,
-    Duration timeout,
-  ) async {
-    final filter = Filter(ids: [eventId]);
-    return _fetchAndResolve(filter, repostEvent, timeout);
-  }
+  VideoEvent? _resolveQueryEvents(
+    List<Event> events,
+    Event repostEvent, {
+    required AddressableIdParts? addressable,
+    required String? eventId,
+  }) {
+    final candidates = <Event>[
+      if (addressable != null)
+        ...events.where((event) => _matchesAddressable(event, addressable)),
+      if (eventId != null) ...events.where((event) => event.id == eventId),
+    ];
 
-  Future<VideoEvent?> _fetchAndResolve(
-    Filter filter,
-    Event repostEvent,
-    Duration timeout,
-  ) async {
-    final completer = Completer<VideoEvent?>();
-
-    late StreamSubscription<Event> subscription;
-    subscription = _subscribe([filter]).listen(
-      (originalEvent) {
-        if (!NIP71VideoKinds.isVideoKind(originalEvent.kind)) {
-          return;
+    for (final event in candidates) {
+      if (!NIP71VideoKinds.isVideoKind(event.kind)) continue;
+      try {
+        final original = VideoEvent.fromNostrEvent(event);
+        if (original.hasVideo) {
+          return createRepostVideoEvent(original, repostEvent);
         }
-
-        try {
-          final originalVideo = VideoEvent.fromNostrEvent(originalEvent);
-          if (originalVideo.hasVideo) {
-            final repostVideo = createRepostVideoEvent(
-              originalVideo,
-              repostEvent,
-            );
-            if (!completer.isCompleted) {
-              completer.complete(repostVideo);
-            }
-          }
-        } catch (e) {
-          Log.error(
-            'Failed to parse original video for repost: $e',
-            name: 'RepostResolver',
-            category: LogCategory.video,
-          );
-        }
-        subscription.cancel();
-      },
-      onError: (error) {
+      } catch (error) {
         Log.error(
-          'Error fetching original for repost: $error',
+          'Failed to parse original video for repost: $error',
           name: 'RepostResolver',
           category: LogCategory.video,
         );
-        if (!completer.isCompleted) {
-          completer.complete(null);
-        }
-        subscription.cancel();
-      },
-      onDone: () {
-        if (!completer.isCompleted) {
-          completer.complete(null);
-        }
-      },
-    );
+      }
+    }
+    return null;
+  }
 
-    // Timeout handling
-    return completer.future.timeout(
-      timeout,
-      onTimeout: () {
-        subscription.cancel();
-        Log.debug(
-          'Timeout fetching original for repost ${repostEvent.id}',
-          name: 'RepostResolver',
-          category: LogCategory.video,
-        );
-        return null;
-      },
+  bool _matchesAddressable(Event event, AddressableIdParts addressable) {
+    if (event.kind != addressable.kind || event.pubkey != addressable.pubkey) {
+      return false;
+    }
+    return event.tags.any(
+      (tag) => tag.length > 1 && tag[0] == 'd' && tag[1] == addressable.dTag,
     );
   }
+
+  bool _hasActiveMiss(String key) {
+    final miss = _misses[key];
+    if (miss == null) return false;
+    final ttl = miss.conclusive ? _missTtl : _inconclusiveMissTtl;
+    if (_now().isBefore(miss.recordedAt.add(ttl))) return true;
+    _misses.remove(key);
+    return false;
+  }
+
+  void _recordMisses(List<String> keys, {required bool conclusive}) {
+    final recordedAt = _now();
+    for (final key in keys) {
+      _misses
+        ..remove(key)
+        ..[key] = _MissRecord(recordedAt: recordedAt, conclusive: conclusive);
+    }
+    while (_misses.length > _maxMissEntries) {
+      _misses.remove(_misses.keys.first);
+    }
+  }
+
+  String _addressableMissKey(String addressableId) => 'a:$addressableId';
+
+  String _eventMissKey(String eventId) => 'e:$eventId';
 }

--- a/mobile/lib/services/repost_resolver.dart
+++ b/mobile/lib/services/repost_resolver.dart
@@ -283,7 +283,7 @@ class RepostResolver {
       return await query;
     } finally {
       if (identical(_inFlightQueries[queryKey], query)) {
-        _inFlightQueries.remove(queryKey);
+        final _ = _inFlightQueries.remove(queryKey);
       }
     }
   }

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -829,7 +829,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// Initialize the repost resolver with callbacks to this service
   void _initializeRepostResolver() {
     _repostResolver = RepostResolver(
-      subscribe: _nostrService.subscribe,
+      queryEvents: _nostrService.queryEventsDetailed,
       findByAddressable: _findCachedVideoByAddressable,
       findById: _findCachedVideoById,
     );

--- a/mobile/scripts/baseline/async_safety_counts.txt
+++ b/mobile/scripts/baseline/async_safety_counts.txt
@@ -137,7 +137,6 @@ discarded_futures|lib/services/outage_diagnosis_service.dart	1
 discarded_futures|lib/services/password_reset_listener.dart	3
 discarded_futures|lib/services/pending_action_service.dart	2
 discarded_futures|lib/services/push_notification_session_coordinator.dart	1
-discarded_futures|lib/services/repost_resolver.dart	3
 discarded_futures|lib/services/shake_detector_service.dart	3
 discarded_futures|lib/services/startup_performance_service.dart	4
 discarded_futures|lib/services/subscription_manager.dart	2

--- a/mobile/test/services/repost_resolver_test.dart
+++ b/mobile/test/services/repost_resolver_test.dart
@@ -96,6 +96,17 @@ void main() {
 
         expect(resolver.parseAddressableId('notanumber:pubkey:dtag'), isNull);
       });
+
+      test('preserves colons in the d tag', () {
+        final resolver = _createResolver();
+
+        final parsed = resolver.parseAddressableId(
+          '34236:pubkey123:d-tag:with:colons',
+        );
+
+        expect(parsed, isNotNull);
+        expect(parsed!.dTag, equals('d-tag:with:colons'));
+      });
     });
 
     group('isLikelyVideoRepost', () {
@@ -170,19 +181,16 @@ void main() {
 
     group('resolve', () {
       test(
-        'returns null for non-video reposts when filtering is strict',
+        'returns null when the repost has no references',
         () async {
-          // This test verifies the isLikelyVideoRepost check
-          // Currently defaults to true, but structure is in place for stricter filtering
           final resolver = _createResolver();
           final event = _createRepostEvent(
             content: 'not a video',
-            tags: [], // No video indicators
+            tags: [],
           );
 
           final result = await resolver.resolve(event, fetchFromRelay: false);
 
-          // Currently returns null because no tags to resolve
           expect(result, isNull);
         },
       );
@@ -196,7 +204,7 @@ void main() {
           );
 
           final resolver = RepostResolver(
-            subscribe: (_) => const Stream.empty(),
+            queryEvents: _emptyQuery,
             findByAddressable: (pubkey, dTag) {
               if (pubkey == 'author123' && dTag == 'my-video') {
                 return cachedVideo;
@@ -232,7 +240,7 @@ void main() {
           );
 
           final resolver = RepostResolver(
-            subscribe: (_) => const Stream.empty(),
+            queryEvents: _emptyQuery,
             findByAddressable: (_, _) => null,
             findById: (eventId) {
               if (eventId == 'event-123') {
@@ -276,22 +284,330 @@ void main() {
           expect(result, isNull);
         },
       );
+
+      test('queries both references once with one caller budget', () async {
+        final eventId = _syntheticId(1);
+        final pubkey = _syntheticId(2);
+        const timeout = Duration(seconds: 3);
+        var calls = 0;
+        late List<Filter> capturedFilters;
+        late Duration capturedTimeout;
+        var requiredFullSettlement = false;
+        final resolver = _createResolver(
+          queryEvents:
+              (
+                filters, {
+                required timeout,
+                required requireAllRelaysSettled,
+              }) async {
+                calls++;
+                capturedFilters = filters;
+                capturedTimeout = timeout;
+                requiredFullSettlement = requireAllRelaysSettled;
+                return (events: <Event>[], timedOut: false, noRelays: false);
+              },
+        );
+
+        await resolver.resolve(
+          _createRepostEvent(
+            tags: [
+              ['a', '34236:$pubkey:video:cut'],
+              ['e', eventId],
+            ],
+          ),
+          timeout: timeout,
+        );
+
+        expect(calls, 1);
+        expect(capturedFilters, hasLength(2));
+        expect(capturedFilters.first.authors, [pubkey]);
+        expect(capturedFilters.first.d, ['video:cut']);
+        expect(capturedFilters.last.ids, [eventId]);
+        expect(capturedFilters.last.kinds, [34236]);
+        expect(capturedTimeout, timeout);
+        expect(requiredFullSettlement, isTrue);
+      });
+
+      test('caches a conclusively settled miss', () async {
+        var calls = 0;
+        final resolver = _createResolver(
+          queryEvents:
+              (_, {required timeout, required requireAllRelaysSettled}) async {
+                calls++;
+                return (events: <Event>[], timedOut: false, noRelays: false);
+              },
+        );
+        final repost = _createRepostEvent(
+          tags: [
+            ['e', _syntheticId(3)],
+          ],
+        );
+
+        await resolver.resolve(repost);
+        await resolver.resolve(repost);
+
+        expect(calls, 1);
+      });
+
+      test('retries an inconclusive miss after its short TTL', () async {
+        var now = DateTime.utc(2026);
+        var calls = 0;
+        final resolver = _createResolver(
+          now: () => now,
+          queryEvents:
+              (_, {required timeout, required requireAllRelaysSettled}) async {
+                calls++;
+                return (events: <Event>[], timedOut: true, noRelays: false);
+              },
+        );
+        final repost = _createRepostEvent(
+          tags: [
+            ['e', _syntheticId(4)],
+          ],
+        );
+
+        await resolver.resolve(repost);
+        now = now.add(const Duration(seconds: 29));
+        await resolver.resolve(repost);
+        expect(calls, 1);
+
+        now = now.add(const Duration(seconds: 1));
+        await resolver.resolve(repost);
+        expect(calls, 2);
+      });
+
+      test('resolves a recovered original after the long TTL', () async {
+        var now = DateTime.utc(2026);
+        var calls = 0;
+        final eventId = _syntheticId(5);
+        final original = _createOriginalEvent(id: eventId);
+        final resolver = _createResolver(
+          now: () => now,
+          queryEvents:
+              (_, {required timeout, required requireAllRelaysSettled}) async {
+                calls++;
+                return (
+                  events: calls == 1 ? <Event>[] : [original],
+                  timedOut: false,
+                  noRelays: false,
+                );
+              },
+        );
+        final repost = _createRepostEvent(
+          tags: [
+            ['e', eventId],
+          ],
+        );
+
+        expect(await resolver.resolve(repost), isNull);
+        now = now.add(const Duration(minutes: 10));
+
+        final result = await resolver.resolve(repost);
+
+        expect(calls, 2);
+        expect(result, isNotNull);
+        expect(result!.id, eventId);
+        expect(result.isRepost, isTrue);
+      });
+
+      test('a positive memory lookup overrides an active miss', () async {
+        final eventId = _syntheticId(6);
+        var calls = 0;
+        VideoEvent? cached;
+        final resolver = _createResolver(
+          findById: (_) => cached,
+          queryEvents:
+              (_, {required timeout, required requireAllRelaysSettled}) async {
+                calls++;
+                return (events: <Event>[], timedOut: false, noRelays: false);
+              },
+        );
+        final repost = _createRepostEvent(
+          tags: [
+            ['e', eventId],
+          ],
+        );
+
+        expect(await resolver.resolve(repost), isNull);
+        cached = _createVideoEvent(id: eventId);
+
+        final result = await resolver.resolve(repost);
+
+        expect(calls, 1);
+        expect(result, isNotNull);
+        expect(result!.id, eventId);
+      });
+
+      test('coalesces concurrent lookups for the same references', () async {
+        final queryCompleter = Completer<NostrQueryResult>();
+        var calls = 0;
+        final resolver = _createResolver(
+          queryEvents:
+              (_, {required timeout, required requireAllRelaysSettled}) {
+                calls++;
+                return queryCompleter.future;
+              },
+        );
+        final repost = _createRepostEvent(
+          tags: [
+            ['e', _syntheticId(7)],
+          ],
+        );
+
+        final first = resolver.resolve(repost);
+        final second = resolver.resolve(repost);
+        expect(calls, 1);
+
+        queryCompleter.complete((
+          events: <Event>[],
+          timedOut: false,
+          noRelays: false,
+        ));
+        await Future.wait([first, second]);
+        expect(calls, 1);
+      });
+
+      test('treats an answered non-video event as a conclusive miss', () async {
+        final eventId = _syntheticId(8);
+        var calls = 0;
+        final resolver = _createResolver(
+          queryEvents:
+              (_, {required timeout, required requireAllRelaysSettled}) async {
+                calls++;
+                return (
+                  events: [_createOriginalEvent(id: eventId, kind: 1)],
+                  timedOut: false,
+                  noRelays: false,
+                );
+              },
+        );
+        final repost = _createRepostEvent(
+          tags: [
+            ['e', eventId],
+          ],
+        );
+
+        await resolver.resolve(repost);
+        await resolver.resolve(repost);
+
+        expect(calls, 1);
+      });
+
+      test('bounds the miss cache and evicts the oldest reference', () async {
+        var calls = 0;
+        final resolver = _createResolver(
+          queryEvents:
+              (_, {required timeout, required requireAllRelaysSettled}) async {
+                calls++;
+                return (events: <Event>[], timedOut: false, noRelays: false);
+              },
+        );
+
+        for (var index = 0; index < 513; index++) {
+          await resolver.resolve(
+            _createRepostEvent(
+              id: _syntheticId(1000 + index),
+              tags: [
+                ['e', _syntheticId(2000 + index)],
+              ],
+            ),
+          );
+        }
+        expect(calls, 513);
+
+        await resolver.resolve(
+          _createRepostEvent(
+            tags: [
+              ['e', _syntheticId(2000)],
+            ],
+          ),
+        );
+        expect(calls, 514);
+
+        await resolver.resolve(
+          _createRepostEvent(
+            tags: [
+              ['e', _syntheticId(2512)],
+            ],
+          ),
+        );
+        expect(calls, 514);
+      });
+
+      test('does not long-cache query errors', () async {
+        var now = DateTime.utc(2026);
+        var calls = 0;
+        final resolver = _createResolver(
+          now: () => now,
+          queryEvents:
+              (_, {required timeout, required requireAllRelaysSettled}) async {
+                calls++;
+                throw StateError('query failed');
+              },
+        );
+        final repost = _createRepostEvent(
+          tags: [
+            ['e', _syntheticId(9)],
+          ],
+        );
+
+        await resolver.resolve(repost);
+        await resolver.resolve(repost);
+        expect(calls, 1);
+
+        now = now.add(const Duration(seconds: 30));
+        await resolver.resolve(repost);
+        expect(calls, 2);
+      });
+
+      test('explicit non-video kind skips a misleading video repost', () async {
+        var calls = 0;
+        final resolver = _createResolver(
+          queryEvents:
+              (_, {required timeout, required requireAllRelaysSettled}) async {
+                calls++;
+                return (events: <Event>[], timedOut: false, noRelays: false);
+              },
+        );
+        final repost = _createRepostEvent(
+          content: 'Watch this video',
+          tags: [
+            ['k', '1'],
+            ['e', _syntheticId(10)],
+          ],
+        );
+
+        expect(await resolver.resolve(repost), isNull);
+        expect(calls, 0);
+      });
     });
   });
 }
 
 /// Helper to create a resolver with empty/null callbacks
 RepostResolver _createResolver({
-  Stream<Event> Function(List<Filter>)? subscribe,
+  NostrQuery? queryEvents,
   VideoEvent? Function(String, String)? findByAddressable,
   VideoEvent? Function(String)? findById,
+  DateTime Function()? now,
+  Duration missTtl = const Duration(minutes: 10),
+  Duration inconclusiveMissTtl = const Duration(seconds: 30),
 }) {
   return RepostResolver(
-    subscribe: subscribe ?? (_) => const Stream.empty(),
+    queryEvents: queryEvents ?? _emptyQuery,
     findByAddressable: findByAddressable ?? (_, _) => null,
     findById: findById ?? (_) => null,
+    now: now,
+    missTtl: missTtl,
+    inconclusiveMissTtl: inconclusiveMissTtl,
   );
 }
+
+Future<NostrQueryResult> _emptyQuery(
+  List<Filter> filters, {
+  required Duration timeout,
+  required bool requireAllRelaysSettled,
+}) async => (events: <Event>[], timedOut: false, noRelays: false);
 
 /// Helper to create a repost event (kind 16)
 Event _createRepostEvent({
@@ -326,3 +642,25 @@ VideoEvent _createVideoEvent({
     videoUrl: 'https://example.com/video.mp4',
   );
 }
+
+Event _createOriginalEvent({
+  required String id,
+  String? pubkey,
+  String dTag = 'video',
+  int kind = 34236,
+}) {
+  return Event.fromJson({
+    'id': id,
+    'pubkey': pubkey ?? _syntheticId(99),
+    'created_at': 1700000000,
+    'kind': kind,
+    'tags': [
+      ['d', dTag],
+      ['url', 'https://example.com/video.mp4'],
+    ],
+    'content': 'Video content',
+    'sig': _syntheticId(100),
+  });
+}
+
+String _syntheticId(int value) => value.toRadixString(16).padLeft(64, '0');


### PR DESCRIPTION
## Problem

Feeds containing reposts whose originals are unavailable could pause each repost for two serial five-second relay lookups. Reloads repeated the same misses, and concurrent feed subscriptions could launch duplicate lookups before either completed.

## Why this fix

The resolver now uses the client's bounded one-shot query API and sends addressable and event-ID references together under one end-to-end timeout. It requires full relay settlement before classifying a miss as conclusive, coalesces concurrent requests for the same references, and keeps a bounded TTL cache with shorter retention for timeouts, relayless queries, and errors.

Positive in-memory lookups still run first, so a newly available original is never hidden by a cached miss. Explicit non-video kind tags skip relay work, and addressable identifiers preserve colons in their d tag.

## Deliberately unchanged

- Repost resolution remains strict to Divine's current kind-34236 video policy; accepting other NIP-71 kinds is a separate product decision.
- The multi-filter query does not use the client's single-filter Drift lookup. The resolver checks VideoEventService's in-memory video lists before querying relays.
- Tag extraction continues to use the final e/a tag, matching the existing NIP-18 assumption.

## Verification

- `flutter test test/services/repost_resolver_test.dart test/services/repost_system_test.dart test/services/video_event_service_repost_test.dart test/providers/video_event_service_dispose_test.dart` — 35 passed, 7 existing skips
- `flutter analyze lib test`
- Service god-file, Future.delayed production/test, ungrouped-test, Nostr-ID logging, empty-catch, and uncancellable-timer guards
- Pre-push analyzer and changed-test hook

Closes #9033