### PR TITLE
fix(dm): resume message history recovery after silent relays

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -629,10 +629,21 @@ class DmRepository {
   Timer? _reconnectTimer;
 
   /// Backoff retry paired with [_drainRelayReadySubscription]. Whichever fires
-  /// first cancels the other, and the finite delay list bounds a permanently
-  /// unsettled relay to three automatic resumes per listening session. #9030.
+  /// first cancels the other. The finite delay list bounds consecutive
+  /// no-progress deferrals; durable cursor progress or completion replenishes
+  /// the budget for a later, independent outage. #9030.
   Timer? _drainRetryTimer;
   int _automaticDrainRetryCount = 0;
+
+  /// Replenishes deferred retries only after the drain durably made progress.
+  ///
+  /// An authoritative empty gift-wrap page is not enough on its own: outgoing
+  /// NIP-04 recovery can still fail immediately afterward. Resetting before
+  /// that pass would turn a permanent NIP-04 outage into an unbounded sequence
+  /// of first-delay retries.
+  void _resetAutomaticDrainRetriesAfterProgress() {
+    _automaticDrainRetryCount = 0;
+  }
 
   /// One-shot relay-status listener armed by a deferred history drain, so
   /// the drain resumes when a relay connects instead of waiting for the next
@@ -2101,6 +2112,7 @@ class DmRepository {
         // point never moves below a window that page may not have seen whole.
         if (!sawUnansweredPage) {
           await syncState.setHistoryDrainCursor(pubkey, cursor);
+          _resetAutomaticDrainRetriesAfterProgress();
         }
       }
 
@@ -2124,6 +2136,7 @@ class DmRepository {
           // later session never has to spend a read finding that out.
           await syncState.setDrainCoveredOwnInbox(pubkey);
           await syncState.markHistoryDrainComplete(pubkey);
+          _resetAutomaticDrainRetriesAfterProgress();
           // Restore read state now that the full conversation set is present:
           // last-sent floor + any read markers stashed during the drain. #4977.
           await _restoreReadStateAfterDrain(pubkey, gen);

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -126,6 +126,19 @@ abstract class DmHistoryDrainConfig {
   /// Maximum pages fetched in a single drain (≈ [pageSize] × this events).
   static const int maxPages = 50;
 
+  /// Additional attempts shared by the whole drain run when a page does not
+  /// fully settle. This is deliberately a run budget, not a per-page budget:
+  /// one bad relay must not multiply the 5-second query deadline by every
+  /// page in a large history. See #9030.
+  static const int unsettledPageRetriesPerRun = 2;
+
+  /// Automatic retries after a drain defers without a relay status edge.
+  static const List<Duration> deferredRetryDelays = [
+    Duration(seconds: 5),
+    Duration(seconds: 15),
+    Duration(seconds: 30),
+  ];
+
   /// Maximum NIP-44 decryption attempts for a single gift wrap before the
   /// failed-decrypt retry queue gives up on it. Generous so a transient
   /// remote-signer (Keycast RPC) outage spanning several inbox opens still
@@ -615,6 +628,12 @@ class DmRepository {
   StreamSubscription<Event>? _giftWrapSubscription;
   Timer? _reconnectTimer;
 
+  /// Backoff retry paired with [_drainRelayReadySubscription]. Whichever fires
+  /// first cancels the other, and the finite delay list bounds a permanently
+  /// unsettled relay to three automatic resumes per listening session. #9030.
+  Timer? _drainRetryTimer;
+  int _automaticDrainRetryCount = 0;
+
   /// One-shot relay-status listener armed by a deferred history drain, so
   /// the drain resumes when a relay connects instead of waiting for the next
   /// inbox open. See [_resumeDrainWhenRelayConnects].
@@ -996,6 +1015,9 @@ class DmRepository {
     _eventLock = null;
     unawaited(_drainRelayReadySubscription?.cancel());
     _drainRelayReadySubscription = null;
+    _drainRetryTimer?.cancel();
+    _drainRetryTimer = null;
+    _automaticDrainRetryCount = 0;
     // Drop the in-flight history drain and decrypt-retry pass so the next
     // user can start fresh; the running loops bail on the _userPubkey change.
     _historyDrain = null;
@@ -1956,18 +1978,35 @@ class DmRepository {
       }
       var pagesRun = 0;
       var totalEvents = 0;
+      var unsettledRetriesRemaining =
+          DmHistoryDrainConfig.unsettledPageRetriesPerRun;
       for (var page = 0; page < DmHistoryDrainConfig.maxPages; page++) {
         // Bail if the user switched or the repository was torn down.
         if (_ingestSessionEnded(pubkey, gen)) return;
-        final historyPage = await _fetchHistoryPage(
+        final subscriptionId = dmHistoryDrainSubscriptionId(pubkey, page);
+        final firstHistoryPage = await _fetchHistoryPage(
           until: cursor,
           limit: DmHistoryDrainConfig.pageSize,
-          subscriptionId: dmHistoryDrainSubscriptionId(pubkey, page),
+          subscriptionId: subscriptionId,
           pubkey: pubkey,
           generation: gen,
           tempRelays: ownInbox,
         );
-        if (historyPage == null) return;
+        if (firstHistoryPage == null) return;
+        var historyPage = firstHistoryPage;
+        while (!historyPage.authoritative && unsettledRetriesRemaining > 0) {
+          unsettledRetriesRemaining--;
+          final retryPage = await _fetchHistoryPage(
+            until: cursor,
+            limit: DmHistoryDrainConfig.pageSize,
+            subscriptionId: subscriptionId,
+            pubkey: pubkey,
+            generation: gen,
+            tempRelays: ownInbox,
+          );
+          if (retryPage == null) return;
+          historyPage = retryPage;
+        }
         final events = historyPage.events;
         // _fetchHistoryPage's own guard sits at the top of its persist loop,
         // so the last event's persist and the yield after it are both
@@ -1997,7 +2036,8 @@ class DmRepository {
               // the window would be skipped by the events it did return.
               await syncState.setHistoryDrainCursor(pubkey, cursor);
               Log.warning(
-                'DM history drain saw an empty page that no relay answered for '
+                'DM history drain request $subscriptionId saw an empty page '
+                'that no relay answered for '
                 '${pubkeyForLogs(pubkey)}; holding the resume cursor at '
                 '$cursor and deferring completion to the next inbox open.',
                 category: LogCategory.system,
@@ -2033,7 +2073,8 @@ class DmRepository {
             // already dragged below the window we still need to re-read.
             await syncState.setHistoryDrainCursor(pubkey, cursor);
             Log.warning(
-              'DM history drain saw a page not every relay settled for '
+              'DM history drain request $subscriptionId saw a page not every '
+              'relay settled for '
               '${pubkeyForLogs(pubkey)}; holding the resume cursor at '
               '$cursor and deferring completion to the next inbox open.',
               category: LogCategory.system,
@@ -2189,6 +2230,8 @@ class DmRepository {
   void _resumeDrainWhenRelayConnects(String pubkey, int generation) {
     unawaited(_drainRelayReadySubscription?.cancel());
     _drainRelayReadySubscription = null;
+    _drainRetryTimer?.cancel();
+    _drainRetryTimer = null;
     if (_ingestSessionEnded(pubkey, generation)) return;
     final lastConnected = <String>{
       for (final entry in _nostrClient.relayStatuses.entries)
@@ -2216,6 +2259,8 @@ class DmRepository {
       if (!newlyConnected) return;
       unawaited(_drainRelayReadySubscription?.cancel());
       _drainRelayReadySubscription = null;
+      _drainRetryTimer?.cancel();
+      _drainRetryTimer = null;
       if (_ingestSessionEnded(pubkey, generation)) return;
       Log.info(
         'Resuming DM history drain for ${pubkeyForLogs(pubkey)} after a relay '
@@ -2224,6 +2269,23 @@ class DmRepository {
       );
       unawaited(backfillHistoryIfNeeded());
     });
+    if (_automaticDrainRetryCount <
+        DmHistoryDrainConfig.deferredRetryDelays.length) {
+      final delay =
+          DmHistoryDrainConfig.deferredRetryDelays[_automaticDrainRetryCount++];
+      _drainRetryTimer = Timer(delay, () {
+        _drainRetryTimer = null;
+        unawaited(_drainRelayReadySubscription?.cancel());
+        _drainRelayReadySubscription = null;
+        if (_ingestSessionEnded(pubkey, generation)) return;
+        Log.info(
+          'Resuming DM history drain for ${pubkeyForLogs(pubkey)} after the '
+          'bounded retry delay',
+          category: LogCategory.system,
+        );
+        unawaited(backfillHistoryIfNeeded());
+      });
+    }
   }
 
   /// Stops listening for incoming DMs and tears this repository down.
@@ -2249,6 +2311,9 @@ class DmRepository {
     _resetGeneration++;
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
+    _drainRetryTimer?.cancel();
+    _drainRetryTimer = null;
+    _automaticDrainRetryCount = 0;
     await _drainRelayReadySubscription?.cancel();
     _drainRelayReadySubscription = null;
     // Drop the loop handles so a later startListening() starts a fresh pass

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -8507,6 +8507,118 @@ void main() {
         });
       });
 
+      test('durable cursor progress replenishes automatic timer resumes', () {
+        fakeAsync((async) {
+          stubRelayStatus(
+            connectedNow: connected(['wss://silent.example']),
+          );
+          var stage = 0;
+          var stageGiftWrapPages = 0;
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(
+                named: 'requireAllRelaysSettled',
+              ),
+            ),
+          ).thenAnswer((inv) async {
+            final filter =
+                (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                    .single;
+            if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
+              return answeredPage(const <Event>[]);
+            }
+            stageGiftWrapPages++;
+            if (stage == 0) return unansweredPage(noRelays: true);
+            if (stage == 1 && stageGiftWrapPages == 1) {
+              return answeredPage([deletion(90)]);
+            }
+            if (stage == 1) return unansweredPage(noRelays: true);
+            return answeredPage(const <Event>[]);
+          });
+          final syncState = armedSyncState();
+          final repository = createRepository(syncState: syncState);
+
+          // Spend the complete retry budget without moving the cursor.
+          unawaited(repository.backfillHistoryIfNeeded());
+          async.flushMicrotasks();
+          for (final delay in DmHistoryDrainConfig.deferredRetryDelays) {
+            async
+              ..elapse(delay)
+              ..flushMicrotasks();
+          }
+          expect(syncState.drainCursorOverride, 100);
+          expect(syncState.markedCompletePubkeys, isEmpty);
+
+          // A later manual run advances the durable boundary, then encounters
+          // another outage. That progress must replenish the timer budget.
+          stage = 1;
+          stageGiftWrapPages = 0;
+          unawaited(repository.backfillHistoryIfNeeded());
+          async.flushMicrotasks();
+          expect(syncState.drainCursorOverride, 90);
+          expect(syncState.markedCompletePubkeys, isEmpty);
+
+          stage = 2;
+          async
+            ..elapse(DmHistoryDrainConfig.deferredRetryDelays.first)
+            ..flushMicrotasks();
+
+          expect(syncState.markedCompletePubkeys, [_validPubkeyA]);
+        });
+      });
+
+      test('failed NIP-04 recovery cannot replenish retries forever', () {
+        fakeAsync((async) {
+          stubRelayStatus(
+            connectedNow: connected(['wss://silent.example']),
+          );
+          var giftWrapPages = 0;
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(
+                named: 'requireAllRelaysSettled',
+              ),
+            ),
+          ).thenAnswer((inv) async {
+            final filter =
+                (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                    .single;
+            if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
+              return unansweredPage(noRelays: true);
+            }
+            giftWrapPages++;
+            return answeredPage(const <Event>[]);
+          });
+          final syncState = armedSyncState();
+          final repository = createRepository(syncState: syncState);
+
+          unawaited(repository.backfillHistoryIfNeeded());
+          async.flushMicrotasks();
+          for (final delay in DmHistoryDrainConfig.deferredRetryDelays) {
+            async
+              ..elapse(delay)
+              ..flushMicrotasks();
+          }
+          async
+            ..elapse(const Duration(minutes: 5))
+            ..flushMicrotasks();
+
+          expect(
+            giftWrapPages,
+            DmHistoryDrainConfig.deferredRetryDelays.length + 1,
+          );
+          expect(syncState.markedCompletePubkeys, isEmpty);
+        });
+      });
+
       test('teardown cancels the deferred drain timer', () {
         fakeAsync((async) {
           stubRelayStatus();

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 
 import 'package:db_client/db_client.dart';
 import 'package:dm_repository/dm_repository.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
@@ -6685,7 +6686,10 @@ void main() {
 
           await repository.backfillHistoryIfNeeded();
 
-          expect(giftWrapPages, 2);
+          expect(
+            giftWrapPages,
+            DmHistoryDrainConfig.unsettledPageRetriesPerRun + 1,
+          );
           expect(syncState.persistedDrainCursors, [100]);
           expect(syncState.drainCursorOverride, 100);
           expect(syncState.drainCompleteOverride, isFalse);
@@ -7709,7 +7713,11 @@ void main() {
 
           await repository.backfillHistoryIfNeeded();
 
-          expect(calls, DmHistoryDrainConfig.maxPages);
+          expect(
+            calls,
+            DmHistoryDrainConfig.maxPages +
+                DmHistoryDrainConfig.unsettledPageRetriesPerRun,
+          );
           expect(syncState.persistedDrainCursors, [1000000]);
 
           const loopCursor = 1000000 - DmHistoryDrainConfig.maxPages;
@@ -8296,9 +8304,8 @@ void main() {
         for (final url in urls) url: RelayConnectionStatus.connected(url),
       };
 
-      /// Answers the first gift-wrap page as one nothing answered and every
-      /// later page (gift-wrap and NIP-04 alike) as authoritative and empty,
-      /// so a resumed run can complete.
+      /// Exhausts one run's global retry budget, then lets the resumed run
+      /// complete. NIP-04 pages are authoritative and empty throughout.
       void stubUnansweredThenExhausted() {
         var giftWrapPages = 0;
         when(
@@ -8317,7 +8324,8 @@ void main() {
             return answeredPage(const <Event>[]);
           }
           giftWrapPages++;
-          return giftWrapPages == 1
+          return giftWrapPages <=
+                  DmHistoryDrainConfig.unsettledPageRetriesPerRun + 1
               ? unansweredPage(noRelays: true)
               : answeredPage(const <Event>[]);
         });
@@ -8339,6 +8347,206 @@ void main() {
           await Future<void>.delayed(Duration.zero);
         }
       }
+
+      test(
+        'bounds unsettled page retries across the whole drain run',
+        () async {
+          stubRelayStatus();
+          var giftWrapPages = 0;
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((inv) async {
+            final filter =
+                (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                    .single;
+            if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
+              return answeredPage(const <Event>[]);
+            }
+            giftWrapPages++;
+            return partialPage([deletion(1000 - giftWrapPages)]);
+          });
+          final syncState = armedSyncState();
+          final cursorBefore = syncState.oldestOverride;
+          expect(cursorBefore, isNotNull);
+
+          await createRepository(
+            syncState: syncState,
+          ).backfillHistoryIfNeeded();
+
+          expect(
+            giftWrapPages,
+            DmHistoryDrainConfig.maxPages +
+                DmHistoryDrainConfig.unsettledPageRetriesPerRun,
+          );
+          expect(syncState.drainCursorOverride, cursorBefore);
+          expect(syncState.markedCompletePubkeys, isEmpty);
+        },
+      );
+
+      test('timer resumes a deferred drain without a relay status change', () {
+        fakeAsync((async) {
+          final relayStatus = stubRelayStatus(
+            connectedNow: connected(['wss://a.example']),
+          );
+          stubUnansweredThenExhausted();
+          final syncState = armedSyncState();
+          final repository = createRepository(syncState: syncState);
+
+          unawaited(repository.backfillHistoryIfNeeded());
+          async.flushMicrotasks();
+          expect(syncState.markedCompletePubkeys, isEmpty);
+          expect(relayStatus.hasListener, isTrue);
+
+          async
+            ..elapse(DmHistoryDrainConfig.deferredRetryDelays.first)
+            ..flushMicrotasks();
+
+          expect(syncState.markedCompletePubkeys, [_validPubkeyA]);
+          expect(relayStatus.hasListener, isFalse);
+        });
+      });
+
+      test('relay edge and timer cannot both resume the same deferral', () {
+        fakeAsync((async) {
+          final relayStatus = stubRelayStatus();
+          var giftWrapPages = 0;
+          stubUnansweredThenExhausted();
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(
+                named: 'requireAllRelaysSettled',
+              ),
+            ),
+          ).thenAnswer((inv) async {
+            final filter =
+                (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                    .single;
+            if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
+              return answeredPage(const <Event>[]);
+            }
+            giftWrapPages++;
+            return giftWrapPages <= 3
+                ? unansweredPage(noRelays: true)
+                : answeredPage(const <Event>[]);
+          });
+          final syncState = armedSyncState();
+          final repository = createRepository(syncState: syncState);
+
+          unawaited(repository.backfillHistoryIfNeeded());
+          async.flushMicrotasks();
+          relayStatus.add(connected(['wss://relay.example']));
+          async.flushMicrotasks();
+          expect(syncState.markedCompletePubkeys, [_validPubkeyA]);
+
+          async
+            ..elapse(DmHistoryDrainConfig.deferredRetryDelays.first)
+            ..flushMicrotasks();
+          expect(giftWrapPages, 4);
+        });
+      });
+
+      test('automatic timer resumes stop at the session cap', () {
+        fakeAsync((async) {
+          stubRelayStatus(
+            connectedNow: connected(['wss://silent.example']),
+          );
+          var giftWrapPages = 0;
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(
+                named: 'requireAllRelaysSettled',
+              ),
+            ),
+          ).thenAnswer((inv) async {
+            final filter =
+                (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                    .single;
+            if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
+              return answeredPage(const <Event>[]);
+            }
+            giftWrapPages++;
+            return unansweredPage(noRelays: true);
+          });
+          final syncState = armedSyncState();
+          final cursorBefore = syncState.oldestOverride;
+          expect(cursorBefore, isNotNull);
+          final repository = createRepository(syncState: syncState);
+
+          unawaited(repository.backfillHistoryIfNeeded());
+          async.flushMicrotasks();
+          for (final delay in DmHistoryDrainConfig.deferredRetryDelays) {
+            async
+              ..elapse(delay)
+              ..flushMicrotasks();
+          }
+          async
+            ..elapse(const Duration(minutes: 5))
+            ..flushMicrotasks();
+
+          expect(
+            giftWrapPages,
+            (DmHistoryDrainConfig.deferredRetryDelays.length + 1) *
+                (DmHistoryDrainConfig.unsettledPageRetriesPerRun + 1),
+          );
+          expect(syncState.drainCursorOverride, cursorBefore);
+          expect(syncState.markedCompletePubkeys, isEmpty);
+        });
+      });
+
+      test('teardown cancels the deferred drain timer', () {
+        fakeAsync((async) {
+          stubRelayStatus();
+          stubUnansweredThenExhausted();
+          final syncState = armedSyncState();
+          final repository = createRepository(syncState: syncState);
+
+          unawaited(repository.backfillHistoryIfNeeded());
+          async.flushMicrotasks();
+          unawaited(repository.stopListening());
+          async
+            ..flushMicrotasks()
+            ..elapse(DmHistoryDrainConfig.deferredRetryDelays.first)
+            ..flushMicrotasks();
+
+          expect(syncState.markedCompletePubkeys, isEmpty);
+        });
+      });
+
+      test('switching users cancels the deferred drain timer', () {
+        fakeAsync((async) {
+          stubRelayStatus();
+          stubUnansweredThenExhausted();
+          final syncState = armedSyncState();
+          final repository = createRepository(syncState: syncState);
+
+          unawaited(repository.backfillHistoryIfNeeded());
+          async.flushMicrotasks();
+          repository.setCredentials(
+            userPubkey: _validPubkeyB,
+            signer: LocalNostrSigner(_validPrivateKey),
+            messageService: mockMessageService,
+          );
+          async
+            ..elapse(DmHistoryDrainConfig.deferredRetryDelays.first)
+            ..flushMicrotasks();
+
+          expect(syncState.markedCompletePubkeys, isEmpty);
+        });
+      });
 
       test(
         'resumes on its own once a relay connects after a page no relay '
@@ -8474,9 +8682,10 @@ void main() {
               return answeredPage(const <Event>[]);
             }
             giftWrapPages++;
-            // Run 1: one relay answered a page, another never did; the next
-            // page is authoritative and empty. Run 2: exhausted at once.
-            return giftWrapPages == 1
+            // Run 1 exhausts its retry budget on a partial first page, then
+            // reaches an authoritative empty page. Run 2 exhausts at once.
+            return giftWrapPages <=
+                    DmHistoryDrainConfig.unsettledPageRetriesPerRun + 1
                 ? partialPage([deletion(500)])
                 : answeredPage(const <Event>[]);
           });

--- a/mobile/packages/nostr_client/test/src/relay_diagnostics_adapter_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_diagnostics_adapter_test.dart
@@ -48,6 +48,24 @@ void main() {
       expect(entry.level, LogLevel.info);
     });
 
+    test('groups pool summaries under the reserved pool scope', () {
+      final adapter = RelayDiagnosticsAdapter(clock: () => now);
+
+      adapter(
+        diagnostic(
+          relayUrl: RelayDiagnostic.poolScope,
+          site: RelayDiagnosticSite.requestSettlement,
+          message: 'Full-settlement request ended inconclusively',
+          level: RelayDiagnosticLevel.warning,
+        ),
+      );
+
+      final entry = capture.getRecentLogs().single;
+      expect(entry.message, startsWith('[${RelayDiagnostic.poolScope}]'));
+      expect(entry.message, isNot(contains('wss://')));
+      expect(entry.level, LogLevel.warning);
+    });
+
     test('bounds repeated relay and site diagnostics', () {
       final adapter = RelayDiagnosticsAdapter(
         maxEventsPerWindow: 2,

--- a/mobile/packages/nostr_sdk/lib/relay/relay_diagnostics.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_diagnostics.dart
@@ -29,8 +29,17 @@ class RelayDiagnostic {
     this.stackTrace,
   });
 
+  /// Reserved [relayUrl] value for a diagnostic about the pool as a whole.
+  ///
+  /// Real relay diagnostics always carry their WebSocket URL. Pool-level
+  /// summaries use this stable key so consumers can group and rate-limit them
+  /// without presenting it as a configured relay.
+  static const String poolScope = 'relay-pool';
+
   final RelayDiagnosticSite site;
   final RelayDiagnosticLevel level;
+
+  /// The relay WebSocket URL, or [poolScope] for a pool-level summary.
   final String relayUrl;
   final String message;
   final Object? error;

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -2370,12 +2370,12 @@ class RelayPool {
     _diagnose(
       RelayDiagnosticSite.requestSettlement,
       RelayDiagnosticLevel.warning,
-      'relay-pool',
+      RelayDiagnostic.poolScope,
       'Full-settlement request $subId ended inconclusively '
-          '(answered=$answered, closedWithoutAnswer=$closedWithoutAnswer, '
-          'noRelayTookRequest=$noRelayTookRequest, '
-          'strandedOnBlockedRelay=$strandedOnBlockedRelay, '
-          'unsettledRelays=${unsettled.length})',
+      '(answered=$answered, closedWithoutAnswer=$closedWithoutAnswer, '
+      'noRelayTookRequest=$noRelayTookRequest, '
+      'strandedOnBlockedRelay=$strandedOnBlockedRelay, '
+      'unsettledRelays=${unsettled.length})',
     );
   }
 

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1252,6 +1252,7 @@ class RelayPool {
   ];
 
   void _completeQuery(String subId, Function callback) {
+    _diagnoseInconclusiveFullSettlementQuery(subId);
     _queryCompleteCallbacks.remove(subId);
     _queryAnswered.remove(subId);
     _queryClosedWithoutAnswer.remove(subId);
@@ -2310,6 +2311,7 @@ class RelayPool {
       _repairRelaysThatNeverServedSubscription(id);
       _releaseSubscription(id);
     } else {
+      _diagnoseInconclusiveFullSettlementQuery(id);
       // No matching subscription — treat [id] as a one-shot query. Drop its
       // completion callback so a query cancelled before EOSE doesn't leak a
       // never-fired callback in [_queryCompleteCallbacks].
@@ -2322,6 +2324,59 @@ class RelayPool {
       _querySettleTimers.remove(id)?.cancel();
       _releaseQuery(id);
     }
+  }
+
+  /// Reports settlement evidence before query teardown destroys it.
+  ///
+  /// Full-settlement queries reach this path when their caller's deadline
+  /// expires. Socket repair and observability deliberately have different
+  /// gates: a relay can remain connected and receive unrelated frames while
+  /// still never settling this request, which makes it ineligible for zombie
+  /// repair but no less important in a support export. See #9030.
+  void _diagnoseInconclusiveFullSettlementQuery(String subId) {
+    if (!_queriesRequiringFullSettlement.contains(subId)) return;
+
+    final relays = [
+      ..._relaysSnapshot(),
+      ..._tempRelaysSnapshot(),
+      ..._cacheRelaysSnapshot(),
+    ];
+    final unsettled = <Relay>[];
+    for (final relay in relays) {
+      if (relay.checkQuery(subId)) unsettled.add(relay);
+    }
+    for (final relay in unsettled) {
+      _diagnose(
+        RelayDiagnosticSite.requestSettlement,
+        RelayDiagnosticLevel.warning,
+        relay.url,
+        'Relay did not settle request $subId within the caller window',
+      );
+    }
+
+    final answered = _queryAnswered.contains(subId);
+    final closedWithoutAnswer = _queryClosedWithoutAnswer.contains(subId);
+    final noRelayTookRequest = _queryReachedNoRelay.contains(subId);
+    final strandedOnBlockedRelay = unsettled.any(
+      (relay) => !_canStillSettleQuery(relay),
+    );
+    if (answered &&
+        !closedWithoutAnswer &&
+        !noRelayTookRequest &&
+        !strandedOnBlockedRelay &&
+        unsettled.isEmpty) {
+      return;
+    }
+    _diagnose(
+      RelayDiagnosticSite.requestSettlement,
+      RelayDiagnosticLevel.warning,
+      'relay-pool',
+      'Full-settlement request $subId ended inconclusively '
+          '(answered=$answered, closedWithoutAnswer=$closedWithoutAnswer, '
+          'noRelayTookRequest=$noRelayTookRequest, '
+          'strandedOnBlockedRelay=$strandedOnBlockedRelay, '
+          'unsettledRelays=${unsettled.length})',
+    );
   }
 
   // different relay use different filter

--- a/mobile/packages/nostr_sdk/test/unit/relay_diagnostics_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_diagnostics_test.dart
@@ -88,6 +88,122 @@ void main() {
       );
     });
 
+    test('reports a full-settlement relay that never settles', () async {
+      final relay = _DiagnosticRelay('wss://silent.example');
+      expect(await nostr.relayPool.add(relay), isTrue);
+
+      await nostr.relayPool.query(
+        const [
+          {
+            'kinds': [1],
+          },
+        ],
+        (_) {},
+        id: 'silent-full-settlement-id',
+        onComplete: () {},
+        requireAllRelaysSettled: true,
+      );
+      nostr.unsubscribe('silent-full-settlement-id');
+
+      final settlements = diagnostics.where(
+        (entry) => entry.site == RelayDiagnosticSite.requestSettlement,
+      );
+      expect(
+        settlements.where(
+          (entry) =>
+              entry.relayUrl == relay.url &&
+              entry.message.contains('did not settle request'),
+        ),
+        hasLength(1),
+      );
+      expect(
+        settlements.map((entry) => entry.message),
+        contains(
+          contains(
+            'answered=false, closedWithoutAnswer=false, '
+            'noRelayTookRequest=false',
+          ),
+        ),
+      );
+    });
+
+    test('reports a full-settlement query that no relay took', () async {
+      await nostr.relayPool.query(
+        const [
+          {
+            'kinds': [1],
+          },
+        ],
+        (_) {},
+        id: 'no-relay-full-settlement-id',
+        onComplete: () {},
+        requireAllRelaysSettled: true,
+      );
+
+      expect(
+        diagnostics.map((entry) => entry.message),
+        contains(contains('noRelayTookRequest=true')),
+      );
+    });
+
+    test(
+      'classifies a refused full-settlement query before teardown',
+      () async {
+        final relay = _DiagnosticRelay('wss://refused.example');
+        expect(await nostr.relayPool.add(relay), isTrue);
+
+        await nostr.relayPool.query(
+          const [
+            {
+              'kinds': [1],
+            },
+          ],
+          (_) {},
+          id: 'refused-full-settlement-id',
+          onComplete: () {},
+          requireAllRelaysSettled: true,
+        );
+        await relay.deliver([
+          'CLOSED',
+          'refused-full-settlement-id',
+          'error: unavailable',
+        ]);
+        nostr.unsubscribe('refused-full-settlement-id');
+
+        expect(
+          diagnostics.map((entry) => entry.message),
+          contains(contains('closedWithoutAnswer=true')),
+        );
+      },
+    );
+
+    test('does not warn when every full-settlement relay settles', () async {
+      final relay = _DiagnosticRelay('wss://settled.example');
+      expect(await nostr.relayPool.add(relay), isTrue);
+
+      await nostr.relayPool.query(
+        const [
+          {
+            'kinds': [1],
+          },
+        ],
+        (_) {},
+        id: 'settled-full-settlement-id',
+        onComplete: () {},
+        requireAllRelaysSettled: true,
+      );
+      await relay.deliver(['EOSE', 'settled-full-settlement-id']);
+
+      expect(
+        diagnostics.where(
+          (entry) =>
+              entry.site == RelayDiagnosticSite.requestSettlement &&
+              entry.level == RelayDiagnosticLevel.warning,
+        ),
+        isEmpty,
+      );
+    });
+
     test(
       'does not copy raw NOTICE or CLOSED bodies into diagnostics',
       () async {

--- a/mobile/packages/nostr_sdk/test/unit/relay_diagnostics_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_diagnostics_test.dart
@@ -144,6 +144,17 @@ void main() {
         diagnostics.map((entry) => entry.message),
         contains(contains('noRelayTookRequest=true')),
       );
+      expect(
+        diagnostics
+            .where(
+              (entry) =>
+                  entry.site == RelayDiagnosticSite.requestSettlement &&
+                  entry.message.contains('noRelayTookRequest=true'),
+            )
+            .single
+            .relayUrl,
+        RelayDiagnostic.poolScope,
+      );
     });
 
     test(


### PR DESCRIPTION
## Problem

Direct-message history recovery can stall indefinitely when one relay accepts a request but stays connected without producing a terminal response. Each inbox open then repeats the same timed-out page while the durable cursor correctly remains pinned.

## Why this fix

This keeps the existing full-settlement safety rule intact and changes only when recovery tries again:

- each drain run gets two additional attempts shared across the whole run, so a transient relay failure can recover without multiplying the timeout across every page;
- a deferred drain gets three bounded, backoff timer resumes even when relay connection status never changes;
- durable cursor progress or completion replenishes that timer budget for a later independent outage, while repeated no-progress deferrals remain capped;
- the relay edge and timer are paired so only one can resume a given deferral;
- relay settlement evidence is emitted before query teardown clears it, including the relay that stayed unsettled and the pool-level outcome classification;
- drain deferral logs include the full request subscription id so support exports can join the repository verdict to relay diagnostics.

## Deliberately unchanged

Full settlement is still required before an empty page can prove exhaustion. Partial or unanswered pages cannot advance the durable cursor or mark the drain complete. This does not adopt quorum completion, change the drain version, add a migration, or alter user-visible copy.

A relay that remains permanently silent can therefore still prevent the completion latch from flipping. The available evidence does not yet distinguish permanent silence from a response that exceeds the current five-second window. #9046 tracks the evidence-driven, pool-level policy decision rather than weakening settlement in this fix.

## Verification

- dm_repository test suite: 955 passed
- nostr_sdk test suite: 699 passed
- nostr_client test suite: 371 passed
- dm_repository, nostr_sdk, and nostr_client analysis: no issues
- pre-push repository analyzer and affected-test selection: passed
- future-delay, cancellable-timer, pinned-assertion, shared-stub, Nostr-id, and pubkey-log guards: passed
- retry replenishment regression mutation-checked by removing the progress reset and confirming the test fails
- pre-teardown diagnostic path mutation-checked in the original implementation

Closes #9030

Follow-up: #9046
