### PR TITLE
chore(release): open the 1.0.23 version train

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.22+820
+version: 1.0.23+820
 
 environment:
   sdk: ^3.13.0


### PR DESCRIPTION
Closes #9051

## What

Opens the 1.0.23 marketing-version train by bumping `mobile/pubspec.yaml` from `1.0.22+820` to `1.0.23+820`.

## Why

`1.0.22` is the latest shipped marketing version. `scripts/ios_store_version_preflight.rb` requires every new iOS build to carry a strictly greater marketing version than the latest approved one, so a new build cannot be cut until the version moves forward. This unblocks the 1.0.23 release train.

## Scope

Only the marketing version changes. The `+820` build suffix is inert — Codemagic reads the build number from `PROJECT_BUILD_NUMBER` — so it is left alone, matching the 1.0.22 bump (#7981).

## Verification

`version:` line only; no code, dependency, or generated-file changes.