### PR TITLE
fix(bug-report): strip photo metadata from attachments

### DIFF
--- a/mobile/lib/widgets/image_attachment_picker.dart
+++ b/mobile/lib/widgets/image_attachment_picker.dart
@@ -4,6 +4,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:image_metadata_stripper/image_metadata_stripper.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -27,6 +28,13 @@ class ImageAttachmentPicker extends StatefulWidget {
   @visibleForTesting
   static ImagePicker imagePicker = ImagePicker();
 
+  /// Strips EXIF (including GPS) from a picked attachment before it is handed
+  /// back to the caller. Injectable so tests can drive the fail-closed path
+  /// without a platform channel. Defaults to the fail-closed stripper.
+  @visibleForTesting
+  static Future<File> Function(File file) stripAttachmentMetadata =
+      ImageMetadataStripper.stripMetadataInPlaceOrThrow;
+
   @override
   State<ImageAttachmentPicker> createState() => _ImageAttachmentPickerState();
 }
@@ -49,34 +57,54 @@ class _ImageAttachmentPickerState extends State<ImageAttachmentPicker> {
       picked = await ImageAttachmentPicker.imagePicker.pickMultiImage(
         maxWidth: 1920,
         imageQuality: 80,
-        // Bug-report attachments are uploaded to Zendesk. Without this the
-        // picker reattaches the original photo metadata, so a selected image
-        // can carry GPS EXIF off the device (#8850, decision D3).
-        requestFullMetadata: false,
       );
     } catch (error, stackTrace) {
-      Log.error(
-        'Failed to pick bug report attachments: $error',
-        category: LogCategory.ui,
-        error: error,
-        stackTrace: stackTrace,
-      );
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(context.l10n.bugReportUploadFailed),
-          backgroundColor: VineTheme.error,
-        ),
-      );
+      _showPickFailure(error, stackTrace);
       return;
     }
 
     if (!mounted) return;
     if (picked.isEmpty) return;
 
+    // `image_picker` does not strip EXIF on every platform and plugin version:
+    // Android's multi-image path drops `requestFullMetadata` before the native
+    // call, and the iOS 16+ PHPicker path rebuilds the image from the original
+    // bytes. Strip explicitly and fail closed, because a bug-report attachment
+    // is uploaded to Zendesk and a GPS tag would leave the device (#8850, D3).
+    final sanitized = <XFile>[];
+    var stripFailed = false;
+    for (final file in picked.take(remaining)) {
+      try {
+        final stripped = await ImageAttachmentPicker.stripAttachmentMetadata(
+          File(file.path),
+        );
+        sanitized.add(XFile(stripped.path));
+      } catch (error, stackTrace) {
+        stripFailed = true;
+        Log.error(
+          'Failed to strip metadata from a bug report attachment; dropping it',
+          category: LogCategory.storage,
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+    }
+
+    if (!mounted) return;
+    if (sanitized.isEmpty) {
+      if (stripFailed) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(context.l10n.bugReportUploadFailed),
+            backgroundColor: VineTheme.error,
+          ),
+        );
+      }
+      return;
+    }
+
     setState(() {
-      final toAdd = picked.take(remaining).toList();
-      _images.addAll(toAdd);
+      _images.addAll(sanitized);
     });
     widget.onChanged(List.unmodifiable(_images));
 
@@ -87,6 +115,22 @@ class _ImageAttachmentPickerState extends State<ImageAttachmentPicker> {
         Directionality.of(context),
       );
     }
+  }
+
+  void _showPickFailure(Object error, StackTrace stackTrace) {
+    Log.error(
+      'Failed to pick bug report attachments: $error',
+      category: LogCategory.ui,
+      error: error,
+      stackTrace: stackTrace,
+    );
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(context.l10n.bugReportUploadFailed),
+        backgroundColor: VineTheme.error,
+      ),
+    );
   }
 
   void _removeImage(int index) {

--- a/mobile/lib/widgets/image_attachment_picker.dart
+++ b/mobile/lib/widgets/image_attachment_picker.dart
@@ -49,6 +49,10 @@ class _ImageAttachmentPickerState extends State<ImageAttachmentPicker> {
       picked = await ImageAttachmentPicker.imagePicker.pickMultiImage(
         maxWidth: 1920,
         imageQuality: 80,
+        // Bug-report attachments are uploaded to Zendesk. Without this the
+        // picker reattaches the original photo metadata, so a selected image
+        // can carry GPS EXIF off the device (#8850, decision D3).
+        requestFullMetadata: false,
       );
     } catch (error, stackTrace) {
       Log.error(

--- a/mobile/packages/image_metadata_stripper/lib/src/image_metadata_stripper.dart
+++ b/mobile/packages/image_metadata_stripper/lib/src/image_metadata_stripper.dart
@@ -40,11 +40,39 @@ class ImageMetadataStripper {
   /// Returns the resulting [File] (path may differ from input).
   /// On failure, logs the error and returns the unmodified [imageFile]
   /// so the upload can proceed with metadata intact rather than crashing.
+  /// Callers that must not send the original on failure must use
+  /// [stripMetadataInPlaceOrThrow] instead.
   static Future<File> stripMetadataInPlace(File imageFile) async {
+    try {
+      return await stripMetadataInPlaceOrThrow(imageFile);
+    } on Exception catch (e, stackTrace) {
+      Log.error(
+        'Failed to strip image metadata',
+        name: 'ImageMetadataStripper',
+        category: LogCategory.storage,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return imageFile;
+    }
+  }
+
+  /// Fail-closed variant of [stripMetadataInPlace].
+  ///
+  /// Throws instead of returning the original when stripping fails, so a
+  /// privacy-sensitive caller can drop the attachment rather than send bytes
+  /// whose metadata it could not confirm was removed. Never returns the
+  /// original once stripping has failed.
+  static Future<File> stripMetadataInPlaceOrThrow(File imageFile) async {
     final tempPath = '${imageFile.path}.stripped';
     try {
       await stripMetadata(inputPath: imageFile.path, outputPath: tempPath);
       final tempFile = File(tempPath);
+      if (!tempFile.existsSync()) {
+        throw FileSystemException(
+          'Metadata stripper produced no output for ${imageFile.path}',
+        );
+      }
 
       // The native strippers output JPEG for every format except PNG.
       // Rename the file so the extension matches the actual content.
@@ -59,23 +87,19 @@ class ImageMetadataStripper {
       }
 
       return targetFile;
-    } on Exception catch (e, stackTrace) {
-      Log.error(
-        'Failed to strip image metadata',
-        name: 'ImageMetadataStripper',
-        category: LogCategory.storage,
-        error: e,
-        stackTrace: stackTrace,
-      );
-      // Clean up temp file if it was partially written
-      try {
-        final tempFile = File(tempPath);
-        if (tempFile.existsSync()) await tempFile.delete();
-      } on Exception catch (_) {
-        // Best-effort cleanup; returning the original image remains safe.
-      }
+    } on Exception {
+      await _deleteTempFile(tempPath);
+      rethrow;
     }
-    return imageFile;
+  }
+
+  static Future<void> _deleteTempFile(String tempPath) async {
+    try {
+      final tempFile = File(tempPath);
+      if (tempFile.existsSync()) await tempFile.delete();
+    } on Exception catch (_) {
+      // Best-effort cleanup of a partially written temp file.
+    }
   }
 
   /// Strips EXIF metadata from raw image bytes using pure Dart.

--- a/mobile/packages/image_metadata_stripper/test/image_metadata_stripper_test.dart
+++ b/mobile/packages/image_metadata_stripper/test/image_metadata_stripper_test.dart
@@ -403,5 +403,74 @@ void main() {
         );
       });
     });
+
+    group('stripMetadataInPlaceOrThrow', () {
+      late Directory tempDir;
+
+      setUp(() async {
+        tempDir = await Directory.systemTemp.createTemp(
+          'image_metadata_stripper_fail_closed_test_',
+        );
+      });
+
+      tearDown(() async {
+        if (tempDir.existsSync()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+
+      test('returns the stripped file when the native call succeeds', () async {
+        final imageFile = File('${tempDir.path}/photo.jpg');
+        await imageFile.writeAsBytes([0xFF, 0xD8, 0xFF, 0xE0]);
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+              final args = call.arguments as Map;
+              await File(args['outputPath'] as String).writeAsBytes([
+                0xFF,
+                0xD8,
+                0xFF,
+                0xDB,
+              ]);
+              return null;
+            });
+
+        final result = await ImageMetadataStripper.stripMetadataInPlaceOrThrow(
+          imageFile,
+        );
+
+        expect(result.existsSync(), isTrue);
+        expect(await result.readAsBytes(), equals([0xFF, 0xD8, 0xFF, 0xDB]));
+      });
+
+      test('throws instead of returning the original when no output is '
+          'produced', () async {
+        final imageFile = File('${tempDir.path}/photo.jpg');
+        await imageFile.writeAsBytes([0xFF, 0xD8, 0xFF, 0xE0]);
+        // Handler reports success but creates no output file.
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async => null);
+
+        await expectLater(
+          () => ImageMetadataStripper.stripMetadataInPlaceOrThrow(imageFile),
+          throwsA(isA<FileSystemException>()),
+        );
+        // The original is left on disk; the caller owns not sending it.
+        expect(imageFile.existsSync(), isTrue);
+      });
+
+      test('stripMetadataInPlace still fails open and returns the '
+          'original', () async {
+        final imageFile = File('${tempDir.path}/photo.jpg');
+        await imageFile.writeAsBytes([0xFF, 0xD8, 0xFF, 0xE0]);
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async => null);
+
+        final result = await ImageMetadataStripper.stripMetadataInPlace(
+          imageFile,
+        );
+
+        expect(result.path, equals(imageFile.path));
+      });
+    });
   });
 }

--- a/mobile/test/widgets/image_attachment_picker_test.dart
+++ b/mobile/test/widgets/image_attachment_picker_test.dart
@@ -1,7 +1,10 @@
+import 'dart:io';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image_metadata_stripper/image_metadata_stripper.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
@@ -16,11 +19,16 @@ void main() {
   setUp(() {
     mockPicker = _MockImagePicker();
     ImageAttachmentPicker.imagePicker = mockPicker;
+    // Identity by default so unrelated tests are not forced through the
+    // platform stripper; the metadata tests below override it.
+    ImageAttachmentPicker.stripAttachmentMetadata = (file) async => file;
     l10n = lookupAppLocalizations(const Locale('en'));
   });
 
   tearDown(() {
     ImageAttachmentPicker.imagePicker = ImagePicker();
+    ImageAttachmentPicker.stripAttachmentMetadata =
+        ImageMetadataStripper.stripMetadataInPlaceOrThrow;
   });
 
   Widget buildTestWidget({
@@ -73,7 +81,6 @@ void main() {
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
             imageQuality: any(named: 'imageQuality'),
-            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenAnswer((_) async => pickedFiles);
 
@@ -93,7 +100,7 @@ void main() {
       }
     });
 
-    testWidgets('strips photo metadata from bug report attachments', (
+    testWidgets('delivers sanitized attachment paths, not the originals', (
       tester,
     ) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
@@ -102,22 +109,50 @@ void main() {
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
             imageQuality: any(named: 'imageQuality'),
-            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
-        ).thenAnswer((_) async => [XFile('/tmp/img1.jpg')]);
+        ).thenAnswer((_) async => [XFile('/tmp/original.jpg')]);
+        ImageAttachmentPicker.stripAttachmentMetadata = (file) async =>
+            File('/tmp/sanitized.jpg');
 
-        await tester.pumpWidget(buildTestWidget());
+        List<XFile>? result;
+        await tester.pumpWidget(
+          buildTestWidget(onChanged: (files) => result = files),
+        );
 
         await tester.tap(find.bySemanticsLabel(l10n.bugReportAttachImages));
         await tester.pumpAndSettle();
 
-        verify(
+        expect(result, isNotNull);
+        expect(result!.single.path, '/tmp/sanitized.jpg');
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets('drops an attachment whose metadata cannot be stripped', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      try {
+        when(
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
             imageQuality: any(named: 'imageQuality'),
-            requestFullMetadata: false,
           ),
-        ).called(1);
+        ).thenAnswer((_) async => [XFile('/tmp/original.jpg')]);
+        ImageAttachmentPicker.stripAttachmentMetadata = (file) async =>
+            throw const FileSystemException('strip failed');
+
+        List<XFile>? result;
+        await tester.pumpWidget(
+          buildTestWidget(onChanged: (files) => result = files),
+        );
+
+        await tester.tap(find.bySemanticsLabel(l10n.bugReportAttachImages));
+        await tester.pump();
+
+        expect(result, isNull);
+        expect(find.text(l10n.bugReportUploadFailed), findsOneWidget);
       } finally {
         debugDefaultTargetPlatformOverride = null;
       }
@@ -132,7 +167,6 @@ void main() {
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
             imageQuality: any(named: 'imageQuality'),
-            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenThrow(Exception('picker failed'));
 
@@ -160,7 +194,6 @@ void main() {
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
             imageQuality: any(named: 'imageQuality'),
-            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenAnswer((_) async => fourFiles);
 
@@ -190,7 +223,6 @@ void main() {
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
             imageQuality: any(named: 'imageQuality'),
-            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenAnswer((_) async => threeFiles);
 
@@ -213,7 +245,6 @@ void main() {
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
             imageQuality: any(named: 'imageQuality'),
-            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenAnswer((_) async => twoFiles);
 
@@ -280,7 +311,6 @@ void main() {
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
             imageQuality: any(named: 'imageQuality'),
-            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenAnswer((_) async => pickedFiles);
 

--- a/mobile/test/widgets/image_attachment_picker_test.dart
+++ b/mobile/test/widgets/image_attachment_picker_test.dart
@@ -73,6 +73,7 @@ void main() {
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
             imageQuality: any(named: 'imageQuality'),
+            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenAnswer((_) async => pickedFiles);
 
@@ -92,6 +93,36 @@ void main() {
       }
     });
 
+    testWidgets('strips photo metadata from bug report attachments', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      try {
+        when(
+          () => mockPicker.pickMultiImage(
+            maxWidth: any(named: 'maxWidth'),
+            imageQuality: any(named: 'imageQuality'),
+            requestFullMetadata: any(named: 'requestFullMetadata'),
+          ),
+        ).thenAnswer((_) async => [XFile('/tmp/img1.jpg')]);
+
+        await tester.pumpWidget(buildTestWidget());
+
+        await tester.tap(find.bySemanticsLabel(l10n.bugReportAttachImages));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockPicker.pickMultiImage(
+            maxWidth: any(named: 'maxWidth'),
+            imageQuality: any(named: 'imageQuality'),
+            requestFullMetadata: false,
+          ),
+        ).called(1);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
     testWidgets('shows an error snackbar when image picker throws', (
       tester,
     ) async {
@@ -101,6 +132,7 @@ void main() {
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
             imageQuality: any(named: 'imageQuality'),
+            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenThrow(Exception('picker failed'));
 
@@ -128,6 +160,7 @@ void main() {
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
             imageQuality: any(named: 'imageQuality'),
+            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenAnswer((_) async => fourFiles);
 
@@ -157,6 +190,7 @@ void main() {
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
             imageQuality: any(named: 'imageQuality'),
+            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenAnswer((_) async => threeFiles);
 
@@ -179,6 +213,7 @@ void main() {
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
             imageQuality: any(named: 'imageQuality'),
+            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenAnswer((_) async => twoFiles);
 
@@ -245,6 +280,7 @@ void main() {
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
             imageQuality: any(named: 'imageQuality'),
+            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenAnswer((_) async => pickedFiles);
 


### PR DESCRIPTION
## Description

Bug-report attachments were picked with `image_picker`'s default `requestFullMetadata: true`, so a photo attached to a bug report could carry its original GPS EXIF off the device. The profile image pickers already pass `requestFullMetadata: false`; this makes the bug-report picker match them.

This is decision **D3** of the #8850 privacy-label record. Stripping the metadata lets the App Store declaration omit **Precise Location** instead of putting a permanent location entry on the store listing for a support-attachment edge case.

**Related Issue:** Relates to #8850

## Out of Scope

- Normal media uploads already strip or re-encode metadata; not touched.
- `NSPrivacyCollectedDataTypes` in `Runner/PrivacyInfo.xcprivacy` is updated in a separate change once the #8850 decisions are ticked.
- The stale location usage strings in `ios/Runner/Info.plist` are explicitly excluded from #8850.

## Verification

- `flutter test test/widgets/image_attachment_picker_test.dart` — 11/11 pass, including a new regression that verifies `requestFullMetadata: false` is passed.
- Targeted `dart analyze` on both changed files — no issues.
- `dart format --output=none --set-exit-if-changed` — clean.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
