### PR TITLE
test(router): stop the hashtag route test from hanging cache recovery tests in CI

### DIFF
--- a/mobile/test/router/app_shell_integration_test.dart
+++ b/mobile/test/router/app_shell_integration_test.dart
@@ -27,6 +27,7 @@ import 'package:openvine/screens/hashtag_feed_screen.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/hashtag_service.dart';
 import 'package:openvine/widgets/vine_bottom_nav.dart';
 
 import '../helpers/test_provider_overrides.dart';
@@ -47,6 +48,8 @@ class _MockBackgroundPublishBloc
 
 class _MockPeopleListsBloc extends MockBloc<PeopleListsEvent, PeopleListsState>
     implements PeopleListsBloc {}
+
+class _MockHashtagService extends Mock implements HashtagService {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -76,6 +79,17 @@ void main() {
     return mockAuth;
   }
 
+  // What HashtagFeedScreen calls on open: the cached bucket for the tag and a
+  // live subscription to it.
+  HashtagService hashtagServiceWithoutHive() {
+    final service = _MockHashtagService();
+    when(() => service.getVideosByHashtags(any())).thenReturn(const []);
+    when(
+      () => service.subscribeToHashtagVideos(any()),
+    ).thenAnswer((_) async {});
+    return service;
+  }
+
   // The shell reads SharedPreferences, the app version and the relay-status
   // surface through Riverpod. A bare ProviderContainer throws inside
   // AppShellSideEffects before anything renders.
@@ -98,6 +112,11 @@ void main() {
       relayListDirtyPublishBridgeProvider.overrideWith((ref) {}),
       contactListDirtyBroadcastBridgeProvider.overrideWith((ref) {}),
       blocklistSyncBridgeProvider.overrideWith((ref) {}),
+      // The real provider builds HashtagCacheService, whose initialize()
+      // opens the hashtag_stats Hive box. Under fake async that open never
+      // completes, and Hive keeps it pending by name for the rest of the
+      // isolate, so every later suite that opens the box hangs (#9022).
+      hashtagServiceProvider.overrideWithValue(hashtagServiceWithoutHive()),
     ],
   );
 
@@ -160,9 +179,8 @@ void main() {
   /// Unmounts the shell and disposes [c] so provider-owned timers stop.
   ///
   /// Has to run inside the test body rather than in addTearDown: the
-  /// pending-timer check fires first. Disposing the container is what stops
-  /// the long-lived ones — HashtagService, for instance, starts a 60s
-  /// periodic timer in its constructor that no amount of pumping drains.
+  /// pending-timer check fires first, and pumping never drains a periodic
+  /// timer that a provider owns.
   Future<void> unmount(WidgetTester tester, ProviderContainer c) async {
     await tester.pumpWidget(const SizedBox.shrink());
     c.dispose();


### PR DESCRIPTION
## Problem

`Tests (shard 2/4)` keeps timing out on pull requests that have nothing to do with caching. Two tests in `test/services/cache_recovery_service_test.dart` — "preserves pending uploads while clearing disposable Hive caches" and "preserves durable notification preferences while clearing caches" — each wait out the full 10-minute test timeout, so the shard loses 20 minutes and needs a re-run. #9022 records it on #8540, #8994 and #9018 within four hours, each under a different shuffle seed.

The hang is caused by a different test. CI runs every untagged test file in one merged process, and Hive tracks boxes by name for the whole process. The test `navigating to /hashtag/rust leaves the shell entirely` in `test/router/app_shell_integration_test.dart` (re-enabled by #8950) mounts the real `HashtagFeedScreen`. That screen's provider chain builds `HashtagCacheService`, whose `initialize()` calls `Hive.openBox('hashtag_stats')`. Inside the fake-async zone `testWidgets` runs in, that open never completes. Hive then keeps `hashtag_stats` in its private registry of in-flight opens for the rest of the process. `Hive.isBoxOpen` cannot see that registry, so neither the victim's own cleanup nor the root Hive harness in `flutter_test_config.dart` can clear it. Any later test that opens `hashtag_stats` waits on the stranded open until it times out, and both hanging tests open `hashtag_stats`. Whether the victim runs after the leaker depends on the shuffle seed, which is why only some seeds hang.

## Fix

`app_shell_integration_test.dart` now overrides `hashtagServiceProvider` with a mock stubbed for the two calls the screen makes when it opens (`getVideosByHashtags` and `subscribeToHashtagVideos`). The five `hashtag_feed_*` screen tests already use this pattern. The test still asserts that the route lands on `HashtagFeedScreen` outside the shell; it just no longer touches Hive.

The `unmount()` doc comment cited HashtagService's 60-second periodic timer as the reason the container has to be disposed inside the test body. With the service mocked, no provider timer is left pending in this file, so the comment keeps the general rule and drops that example.

## What this leaves alone

- No production code changes. `HashtagCacheService` opens its box normally in the app; the hang exists only because a widget test started real Hive I/O inside fake async.
- #9022's suggested direction is not attempted here: making the harness able to see, and then await or fail, a pending `openBox`. This PR removes the test behind the current occurrences. The harness gap that lets a future leaker hide the same way stays open.
- The other test files that mention hashtag routes were checked. The five `hashtag_feed_*` screen tests already override the provider. The router tests that navigate to a hashtag path never mount a widget tree, so none of them reach Hive.

## Verification

A two-file bundle reproduces the merged-process order locally. It runs the leaker first and then the victim in one process, calls `Hive.init` in `setUpAll` the way an earlier suite does in CI, passes `--dart-define=DIVINE_STRICT_CHANNELS=true` as CI does, and uses `--timeout=120s` so the hang stops after two minutes instead of ten:

```dart
import 'router/app_shell_integration_test.dart' as leaker;
import 'services/cache_recovery_service_test.dart' as victim;

void main() {
  setUpAll(() {
    Hive.init(Directory.systemTemp.createTempSync('repro_9022').path);
  });
  group('router/app_shell_integration_test.dart', leaker.main);
  group('services/cache_recovery_service_test.dart', victim.main);
}
```

| Run | Before | After |
|---|---|---|
| Full bundle | 17 passed, 2 failed: both #9022 tests hit `TimeoutException after 0:02:00` (4m04s) | 19 passed (4s) |
| Only the `/hashtag/rust` test, plus the victim file | The same two tests time out | — |
| Every other test in the leaker file, plus the victim file | 18 passed, no hang | — |

The two narrowed runs pin the leak to that single test.

On the rebased head:

- `app_shell_integration_test.dart` (8/8) and `cache_recovery_service_test.dart` (11/11) pass on their own.
- The logged `type 'Null' is not a subtype` lines, which come from unrelated mocks, are the same set with the same counts before and after. The new mock swallows no errors of its own.
- A probe copy of the leaker file with `c.dispose()` removed passed 8/8, which confirms no provider timer is left pending in this file.
- `flutter analyze lib test integration_test` and `dart format` are clean.
- These ratchet checks pass: `check_shared_setup_stubs`, `check_placeholder_tests`, `check_unpinned_unchanged_assertions`, `check_ungrouped_tests`, `check_skip_ceiling`, `check_l10n_delegates_ceiling`, `check_nostr_id_log_truncation`, `check_future_delayed_ceiling`, `check_process_global_mutations`, `check_shared_channel_overrides` and `check_http_overrides_isolation`.

Closes #9022


Follow-up: #9053 tracks the pending-`openBox` harness gap left outside this point fix.