### PR TITLE
docs(privacy): record the iOS privacy-label decisions

### DIFF
--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -95,7 +95,7 @@ the manifest rules and the release checklist.
 | D2 — linked set | Approved as listed. | Name, Email Address, Contacts, public profile/user content, Photos or Videos, Audio Data, Customer Support, User ID, Device ID, Product Interaction, Crash Data, and Other Diagnostic Data are declared linked. |
 | D3 — bug-report attachment location | Strip attachment metadata instead of declaring Precise Location. | Implemented in #9049 (`requestFullMetadata: false` on the bug-report picker). Precise Location is omitted. |
 | D4 — Search History | Not linked. | Declare Search History, purpose App Functionality, tracking false, linked false. |
-| D5 — private-message linkage | Pending. NIP-17 hides the sender, but the legacy kind-4 fallback exposes author/recipient to relays and the signer's key custody is unverified. | `Emails or Text Messages` stays declared; the linked value is settled once both confirmations are signed off. |
+| D5 — private-message linkage | Linked. NIP-17 hides the sender, but the legacy kind-4 fallback exposes author/recipient to relays, and Keycast (managed key custody) holds server-side keys and can decrypt for users who opt in. | `Emails or Text Messages` declared linked, purpose App Functionality, tracking false. |
 | D6 — Performance Data | Linked (conservative). | Performance Data declared linked, tracking false. |
 | D7 — Shorebird | SDK-owned collection, disclosed in App Store Connect only. | Do not duplicate Shorebird's Device ID / Product Interaction / Other Diagnostic Data in the Runner manifest. |
 

--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -96,8 +96,8 @@ the manifest rules and the release checklist.
 | D3 — bug-report attachment location | Approved; implemented in #9049 | Strip attachment metadata instead of declaring Precise Location. | The bug-report picker strips EXIF explicitly and fails closed (#9049); Precise Location is omitted. |
 | D4 — Search History | Approved | Not linked. | Declare Search History, purpose App Functionality, tracking false, linked false. |
 | D5 — private-message linkage | Approved | Linked. NIP-17 hides the sender, but the legacy kind-4 fallback exposes author/recipient to relays, and Keycast (managed key custody) holds server-side keys and can decrypt for users who opt in. | `Emails or Text Messages` declared linked, purpose App Functionality, tracking false. |
-| D6 — Performance Data | Pending | Proposed: linked (conservative), purposes Analytics and App Functionality, tracking false. | Not authoritative until approved; the manifest value is provisional. |
-| D7 — Shorebird | Pending | Proposed: not linked, not tracking, conditional on neither Divine nor Shorebird joining the installation identifier to Divine account data. | Disclose Device ID / Product Interaction / Other Diagnostic Data in App Store Connect (#7980); do not duplicate them in the Runner manifest. |
+| D6 — Performance Data | Approved | Linked (conservative), purposes Analytics and App Functionality, tracking false. | Performance Data declared linked. |
+| D7 — Shorebird | Approved | Not linked, not tracking. | Disclose Device ID / Product Interaction / Other Diagnostic Data in App Store Connect (#7980); not duplicated in the Runner manifest. |
 
 ### Tracking posture before each candidate
 

--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -71,7 +71,8 @@ declaration described below.
 `NSPrivacyCollectedDataTypes` is empty in the app manifest and is **not** a
 claim that Divine collects nothing. Filling it is a product/legal decision that
 must match the App Store Connect privacy label, and was deliberately out of
-scope for the required-reason API audit.
+scope for the required-reason API audit. Its outcome is recorded under
+[Privacy-label decisions](#privacy-label-decisions-8850) below.
 
 `LibProofMode`'s collected-data section is empty because Divine constructs
 `ProofGenerationOptions(showDeviceIds: false, showLocation: false,
@@ -80,6 +81,33 @@ corresponding blocks in `Proof.swift` (`buildProof`, lines 408 / 430 / 439), so
 no device ID, location or carrier data enters the proof. **If any of those flags
 is ever flipped to `true`, this manifest and the App Store privacy label must be
 updated in the same change.**
+
+## Privacy-label decisions (#8850)
+
+Filling the app-target `NSPrivacyCollectedDataTypes` is a product/legal decision
+that must match the App Store Connect label. The decisions and their rationale
+are recorded on #8850; this table keeps the engineering-facing outcome next to
+the manifest rules and the release checklist.
+
+| Decision | Outcome | Manifest / release impact |
+|---|---|---|
+| D1 — advertising / `NSPrivacyTracking` | Personalized advertising is disabled and the ad-tech account link has been removed from the analytics property; personal advertising is off in every region and Google signals is off. | Keep `NSPrivacyTracking = false` and `NSPrivacyTrackingDomains` empty. No ATT prompt. Re-check the property before every candidate. |
+| D2 — linked set | Approved as listed. | Name, Email Address, Contacts, public profile/user content, Photos or Videos, Audio Data, Customer Support, User ID, Device ID, Product Interaction, Crash Data, and Other Diagnostic Data are declared linked. |
+| D3 — bug-report attachment location | Strip attachment metadata instead of declaring Precise Location. | Implemented in #9049 (`requestFullMetadata: false` on the bug-report picker). Precise Location is omitted. |
+| D4 — Search History | Not linked. | Declare Search History, purpose App Functionality, tracking false, linked false. |
+| D5 — private-message linkage | Pending. NIP-17 hides the sender, but the legacy kind-4 fallback exposes author/recipient to relays and the signer's key custody is unverified. | `Emails or Text Messages` stays declared; the linked value is settled once both confirmations are signed off. |
+| D6 — Performance Data | Linked (conservative). | Performance Data declared linked, tracking false. |
+| D7 — Shorebird | SDK-owned collection, disclosed in App Store Connect only. | Do not duplicate Shorebird's Device ID / Product Interaction / Other Diagnostic Data in the Runner manifest. |
+
+### Tracking posture before each candidate
+
+Every candidate is evaluated against its own analytics configuration, so before
+building a release candidate confirm on the analytics property that personalized
+advertising is still disabled and no ad account is linked (D1). A change there
+can flip the required `NSPrivacyTracking` answer.
+
+`NSPrivacyCollectedDataTypes` is populated from the final table once every
+decision above is ticked.
 
 ## Apple's catalogue
 
@@ -214,5 +242,7 @@ document still matches the catalogue.
 - `divine_device_attestation` was resolved in #8779. Its owning package now
   ships the `UserDefaults` / `CA92.1` declaration described above.
 - App-target `NSPrivacyCollectedDataTypes` reconciliation with the aggregate
-  privacy report and App Store Connect label is tracked in #8850.
+  privacy report and App Store Connect label is tracked in #8850. The decisions
+  are recorded under [Privacy-label decisions](#privacy-label-decisions-8850);
+  the reconciliation stays open until #8850's post-build verification passes.
 - Upstreaming Divine's LibProofMode manifest is tracked in #8851.

--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -89,15 +89,15 @@ that must match the App Store Connect label. The decisions and their rationale
 are recorded on #8850; this table keeps the engineering-facing outcome next to
 the manifest rules and the release checklist.
 
-| Decision | Outcome | Manifest / release impact |
-|---|---|---|
-| D1 — advertising / `NSPrivacyTracking` | Personalized advertising is disabled and the ad-tech account link has been removed from the analytics property; personal advertising is off in every region and Google signals is off. | Keep `NSPrivacyTracking = false` and `NSPrivacyTrackingDomains` empty. No ATT prompt. Re-check the property before every candidate. |
-| D2 — linked set | Approved as listed. | Name, Email Address, Contacts, public profile/user content, Photos or Videos, Audio Data, Customer Support, User ID, Device ID, Product Interaction, Crash Data, and Other Diagnostic Data are declared linked. |
-| D3 — bug-report attachment location | Strip attachment metadata instead of declaring Precise Location. | Implemented in #9049 (`requestFullMetadata: false` on the bug-report picker). Precise Location is omitted. |
-| D4 — Search History | Not linked. | Declare Search History, purpose App Functionality, tracking false, linked false. |
-| D5 — private-message linkage | Linked. NIP-17 hides the sender, but the legacy kind-4 fallback exposes author/recipient to relays, and Keycast (managed key custody) holds server-side keys and can decrypt for users who opt in. | `Emails or Text Messages` declared linked, purpose App Functionality, tracking false. |
-| D6 — Performance Data | Linked (conservative). | Performance Data declared linked, tracking false. |
-| D7 — Shorebird | SDK-owned collection, disclosed in App Store Connect only. | Do not duplicate Shorebird's Device ID / Product Interaction / Other Diagnostic Data in the Runner manifest. |
+| Decision | Status | Outcome | Manifest / release impact |
+|---|---|---|---|
+| D1 — advertising / `NSPrivacyTracking` | Approved | Personalized advertising is disabled and the ad-tech account link has been removed from the analytics property; personal advertising is off in every region and Google signals is off. | Keep `NSPrivacyTracking = false` and `NSPrivacyTrackingDomains` empty. No ATT prompt. Re-check the property before every candidate. |
+| D2 — linked set | Approved | The linked set is approved as listed. | Name, Email Address, Contacts, public profile/user content, Photos or Videos, Audio Data, Customer Support, User ID, Device ID, Product Interaction, Crash Data, and Other Diagnostic Data are declared linked. |
+| D3 — bug-report attachment location | Approved; implemented in #9049 | Strip attachment metadata instead of declaring Precise Location. | The bug-report picker strips EXIF explicitly and fails closed (#9049); Precise Location is omitted. |
+| D4 — Search History | Approved | Not linked. | Declare Search History, purpose App Functionality, tracking false, linked false. |
+| D5 — private-message linkage | Approved | Linked. NIP-17 hides the sender, but the legacy kind-4 fallback exposes author/recipient to relays, and Keycast (managed key custody) holds server-side keys and can decrypt for users who opt in. | `Emails or Text Messages` declared linked, purpose App Functionality, tracking false. |
+| D6 — Performance Data | Pending | Proposed: linked (conservative), purposes Analytics and App Functionality, tracking false. | Not authoritative until approved; the manifest value is provisional. |
+| D7 — Shorebird | Pending | Proposed: not linked, not tracking, conditional on neither Divine nor Shorebird joining the installation identifier to Divine account data. | Disclose Device ID / Product Interaction / Other Diagnostic Data in App Store Connect (#7980); do not duplicate them in the Runner manifest. |
 
 ### Tracking posture before each candidate
 
@@ -106,8 +106,11 @@ building a release candidate confirm on the analytics property that personalized
 advertising is still disabled and no ad account is linked (D1). A change there
 can flip the required `NSPrivacyTracking` answer.
 
-`NSPrivacyCollectedDataTypes` is populated from the final table once every
-decision above is ticked.
+The app manifest is populated from this table, then verified: build the
+Shorebird store candidate, collect the embedded manifests and Xcode's aggregate
+privacy report, and reconcile both against this table and the intended App Store
+Connect answers. Correct and rebuild on any mismatch; #8850 stays open until the
+post-build verification passes.
 
 ## Apple's catalogue
 


### PR DESCRIPTION
## Description

`mobile/docs/IOS_PRIVACY_MANIFESTS.md` told readers that filling the app-target `NSPrivacyCollectedDataTypes` was a pending product/legal decision, but not where that outcome would be recorded or what it affects. This adds a decision table to that doc so the manifest rules, the release checklist, and the intended App Store Connect answers stay in sync with the decisions recorded on #8850.

It records D1 (personalized advertising disabled; `NSPrivacyTracking` stays false), D2 (linked set approved), D3 (bug-report metadata stripped, implemented in #9049), D4 (Search History not linked), D5 (private-message linkage **linked** — Keycast managed custody can decrypt for opt-in users, and the kind-4 fallback exposes author/recipient), D6 (Performance Data linked), D7 (Shorebird SDK-owned), plus a per-candidate tracking-posture check.

**Related Issue:** Relates to #8850

## Out of Scope

- Populating `NSPrivacyCollectedDataTypes` itself — that lands once the post-build verification in #8850 runs.
- The D3 code change, which is #9049.
- Any change to the manifest, the required-reason audit, or App Store Connect.

## Verification

- Documentation only; no code or manifest paths changed.
- The new section uses the doc's existing heading/table style and anchors the placeholder paragraph to it.

## Type of Change

- [x] 📝 Documentation
