### PR TITLE
fix(nostr): keep the events relays already sent when another relay never answers

### DIFF
--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -173,6 +173,15 @@ class NostrClient {
   @visibleForTesting
   static int maxConcurrentQueries = 6;
 
+  /// How long [queryEventsDetailed] lets a websocket leg run past the caller's
+  /// deadline before abandoning it, and every event it holds.
+  ///
+  /// A leg ends itself at that deadline, so this only catches one that does
+  /// not. It must exceed timer latency, or an honest leg would lose the race.
+  static const Duration _websocketLegOverrunGrace = Duration(
+    milliseconds: 250,
+  );
+
   late final Pool _queryPool = Pool(maxConcurrentQueries);
 
   /// The signer used by this client for event signing and NIP-44 encryption.
@@ -874,7 +883,8 @@ class NostrClient {
   ///
   /// [timeout] is an end-to-end deadline for the cache read, reconnect sweep,
   /// query-pool acquisition, and WebSocket query together. Exhausting it
-  /// returns `timedOut: true`. A pool waiter that expires remains in the
+  /// returns `timedOut: true` alongside whatever the relays that did answer
+  /// had delivered by then. A pool waiter that expires remains in the
   /// package's FIFO only until a resource reaches it; it releases that resource
   /// without dispatching network work.
   ///
@@ -1002,6 +1012,9 @@ class NostrClient {
     final noConnectedRelays =
         _relayManager.connectedRelays.isEmpty && !canAnswerWithoutPool;
     final filtersJson = filters.map((f) => f.toJson()).toList();
+    // Spend only what is left of the deadline. A leg handed the whole
+    // `timeout` outlived the backstop below, which then dropped everything the
+    // relays that did answer had sent (#9030).
     Future<({List<Event> events, bool timedOut, bool noRelaysParticipated})>
     runWebSocketQuery() => _nostr.queryEventsDetailed(
       filtersJson,
@@ -1009,12 +1022,12 @@ class NostrClient {
       tempRelays: effectiveTempRelays,
       relayTypes: relayTypes,
       sendAfterAuth: sendAfterAuth,
-      // Its own subscription budget. The caller's end-to-end contract is
-      // enforced by the deadline applied to this call below, not by shrinking
-      // the argument here.
-      timeout: timeout,
+      timeout: remainingTimeout(),
       requireAllRelaysSettled: requireAllRelaysSettled,
     );
+
+    Duration overrunBackstop() =>
+        remainingTimeout() + _websocketLegOverrunGrace;
 
     Future<({List<Event> events, bool timedOut, bool noRelaysParticipated})>
     runPooledWebSocketQuery() async {
@@ -1029,7 +1042,7 @@ class NostrClient {
         rethrow;
       }
       try {
-        return await runWebSocketQuery().timeout(remainingTimeout());
+        return await runWebSocketQuery().timeout(overrunBackstop());
       } finally {
         resource.release();
       }
@@ -1068,7 +1081,7 @@ class NostrClient {
       try {
         websocketResult = useQueryPool
             ? await runPooledWebSocketQuery()
-            : await runWebSocketQuery().timeout(remainingTimeout());
+            : await runWebSocketQuery().timeout(overrunBackstop());
       } on TimeoutException {
         // The budget expired before the query settled. This is the same
         // inconclusive answer a relay that never settled gives — not a

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -884,9 +884,11 @@ class NostrClient {
   /// [timeout] is an end-to-end deadline for the cache read, reconnect sweep,
   /// query-pool acquisition, and WebSocket query together. Exhausting it
   /// returns `timedOut: true` alongside whatever the relays that did answer
-  /// had delivered by then. A pool waiter that expires remains in the
-  /// package's FIFO only until a resource reaches it; it releases that resource
-  /// without dispatching network work.
+  /// had delivered by then. A WebSocket query that does not honor its own
+  /// budget may run for up to 250 ms beyond that deadline before its partial
+  /// events are abandoned. A pool waiter that expires remains in the package's
+  /// FIFO only until a resource reaches it; it releases that resource without
+  /// dispatching network work.
   ///
   /// `timedOut: false` with an empty `events` normally means "the relays
   /// answered and there is nothing", but only for a caller that is content to

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1329,6 +1329,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => events);
 
@@ -1342,6 +1343,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).called(1);
       });
@@ -1358,6 +1360,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => []);
 
@@ -1380,6 +1383,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => events);
 
@@ -1402,6 +1406,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => events);
 
@@ -1420,6 +1425,7 @@ void main() {
             tempRelays: tempRelays,
             relayTypes: [RelayType.normal],
             sendAfterAuth: true,
+            timeout: any(named: 'timeout'),
           ),
         ).called(1);
       });
@@ -1466,6 +1472,7 @@ void main() {
               tempRelays: any(named: 'tempRelays'),
               relayTypes: any(named: 'relayTypes'),
               sendAfterAuth: any(named: 'sendAfterAuth'),
+              timeout: any(named: 'timeout'),
             ),
           );
         },
@@ -1518,6 +1525,7 @@ void main() {
               tempRelays: any(named: 'tempRelays'),
               relayTypes: any(named: 'relayTypes'),
               sendAfterAuth: any(named: 'sendAfterAuth'),
+              timeout: any(named: 'timeout'),
             ),
           );
         },
@@ -1572,6 +1580,7 @@ void main() {
               tempRelays: any(named: 'tempRelays'),
               relayTypes: any(named: 'relayTypes'),
               sendAfterAuth: any(named: 'sendAfterAuth'),
+              timeout: any(named: 'timeout'),
             ),
           );
         },
@@ -1592,6 +1601,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => events);
       }
@@ -1835,6 +1845,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => [event]);
 
@@ -1855,6 +1866,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => [event]);
 
@@ -1867,6 +1879,7 @@ void main() {
             tempRelays: [relayUrl],
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).called(1);
       });
@@ -1881,6 +1894,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => []);
 
@@ -1906,6 +1920,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => [profileEvent]);
 
@@ -1924,6 +1939,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => []);
 
@@ -4416,6 +4432,7 @@ void main() {
               tempRelays: any(named: 'tempRelays'),
               relayTypes: any(named: 'relayTypes'),
               sendAfterAuth: any(named: 'sendAfterAuth'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenAnswer((_) async => websocketEvents);
           when(
@@ -4449,6 +4466,7 @@ void main() {
               tempRelays: any(named: 'tempRelays'),
               relayTypes: any(named: 'relayTypes'),
               sendAfterAuth: any(named: 'sendAfterAuth'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenAnswer((_) async => wsEvents);
           when(
@@ -4480,6 +4498,7 @@ void main() {
               tempRelays: any(named: 'tempRelays'),
               relayTypes: any(named: 'relayTypes'),
               sendAfterAuth: any(named: 'sendAfterAuth'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenAnswer((_) async => wsEvents);
           when(
@@ -4509,6 +4528,7 @@ void main() {
               tempRelays: any(named: 'tempRelays'),
               relayTypes: any(named: 'relayTypes'),
               sendAfterAuth: any(named: 'sendAfterAuth'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenAnswer((_) async => []);
 
@@ -4531,6 +4551,7 @@ void main() {
               tempRelays: any(named: 'tempRelays'),
               relayTypes: any(named: 'relayTypes'),
               sendAfterAuth: any(named: 'sendAfterAuth'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenAnswer((_) async => wsEvents);
 
@@ -4557,6 +4578,7 @@ void main() {
               tempRelays: any(named: 'tempRelays'),
               relayTypes: any(named: 'relayTypes'),
               sendAfterAuth: any(named: 'sendAfterAuth'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenAnswer((_) async => wsEvents);
           when(
@@ -4600,6 +4622,7 @@ void main() {
               tempRelays: any(named: 'tempRelays'),
               relayTypes: any(named: 'relayTypes'),
               sendAfterAuth: any(named: 'sendAfterAuth'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenAnswer((_) async => [wsEvent]);
           when(
@@ -4654,6 +4677,7 @@ void main() {
               tempRelays: any(named: 'tempRelays'),
               relayTypes: any(named: 'relayTypes'),
               sendAfterAuth: any(named: 'sendAfterAuth'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenAnswer((_) async => [wsProfile]);
           when(
@@ -5053,6 +5077,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => [profileEvent]);
 
@@ -5072,6 +5097,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => []);
 
@@ -5084,6 +5110,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).captured;
 
@@ -5102,6 +5129,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => []);
 
@@ -5114,6 +5142,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).captured;
 
@@ -5132,6 +5161,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => []);
 
@@ -5144,6 +5174,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).captured;
 
@@ -5161,6 +5192,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => []);
 
@@ -5187,6 +5219,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => [profileEvent1, profileEvent2]);
 
@@ -5207,6 +5240,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => []);
 
@@ -5219,6 +5253,7 @@ void main() {
             tempRelays: captureAny(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).captured;
 
@@ -5370,6 +5405,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => [_createTestEvent(), _createTestEvent()]);
 
@@ -5384,6 +5420,7 @@ void main() {
             tempRelays: any(named: 'tempRelays'),
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
           ),
         );
       });
@@ -5805,6 +5842,96 @@ void main() {
         );
 
         expect(result.timedOut, isTrue);
+      });
+
+      group('when a relay never answers', () {
+        late Event delivered;
+
+        setUp(() async {
+          // What the relays that did answer sent before the deadline.
+          final signer = LocalNostrSigner(generatePrivateKey());
+          final author = (await signer.getPublicKey())!;
+          delivered = (await signer.signEvent(
+            Event(author, EventKind.giftWrap, [
+              ['p', testPublicKey],
+            ], 'answered'),
+          ))!;
+          mockNostr.timedOut = true;
+          // The SDK query ends itself at the deadline it is handed and returns
+          // what arrived, resolving a moment after it as a real one does.
+          when(
+            () => mockNostr.queryEvents(
+              any(),
+              id: any(named: 'id'),
+              tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              sendAfterAuth: any(named: 'sendAfterAuth'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((invocation) {
+            final budget = invocation.namedArguments[#timeout] as Duration;
+            final settled = Completer<List<Event>>();
+            Timer(
+              budget + const Duration(milliseconds: 20),
+              () => settled.complete([delivered]),
+            );
+            return settled.future;
+          });
+        });
+
+        Future<({List<Event> events, bool timedOut, bool noRelays})> read(
+          NostrClient via, {
+          bool useQueryPool = true,
+          Duration timeout = const Duration(milliseconds: 200),
+        }) => via.queryEventsDetailed(
+          [
+            Filter(kinds: const [EventKind.giftWrap], p: [testPublicKey]),
+          ],
+          useCache: false,
+          useQueryPool: useQueryPool,
+          requireAllRelaysSettled: true,
+          timeout: timeout,
+        );
+
+        test('keeps the events the other relays delivered (#9030)', () async {
+          final result = await read(client);
+
+          expect(result.timedOut, isTrue);
+          expect(result.events.map((event) => event.id), [delivered.id]);
+        });
+
+        test('keeps them on the non-pooled path too', () async {
+          final result = await read(client, useQueryPool: false);
+
+          expect(result.timedOut, isTrue);
+          expect(result.events.map((event) => event.id), [delivered.id]);
+        });
+
+        test('keeps them after waiting for a query slot', () async {
+          final originalMax = NostrClient.maxConcurrentQueries;
+          NostrClient.maxConcurrentQueries = 1;
+          addTearDown(() => NostrClient.maxConcurrentQueries = originalMax);
+          final pooledClient = NostrClient.forTesting(
+            nostr: mockNostr,
+            relayManager: mockRelayManager,
+          );
+          addTearDown(pooledClient.dispose);
+          // Holds the only slot for longer than the overrun grace, so the read
+          // below reaches the relays with much of its deadline already spent.
+          final occupant = read(
+            pooledClient,
+            timeout: const Duration(milliseconds: 400),
+          );
+
+          final result = await read(
+            pooledClient,
+            timeout: const Duration(milliseconds: 800),
+          );
+          await occupant;
+
+          expect(result.timedOut, isTrue);
+          expect(result.events.map((event) => event.id), [delivered.id]);
+        });
       });
     });
   });

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -5846,8 +5846,10 @@ void main() {
 
       group('when a relay never answers', () {
         late Event delivered;
+        late List<Duration> handedBudgets;
 
         setUp(() async {
+          handedBudgets = [];
           // What the relays that did answer sent before the deadline.
           final signer = LocalNostrSigner(generatePrivateKey());
           final author = (await signer.getPublicKey())!;
@@ -5870,6 +5872,7 @@ void main() {
             ),
           ).thenAnswer((invocation) {
             final budget = invocation.namedArguments[#timeout] as Duration;
+            handedBudgets.add(budget);
             final settled = Completer<List<Event>>();
             Timer(
               budget + const Duration(milliseconds: 20),
@@ -5931,6 +5934,11 @@ void main() {
 
           expect(result.timedOut, isTrue);
           expect(result.events.map((event) => event.id), [delivered.id]);
+          expect(handedBudgets, hasLength(2));
+          expect(
+            handedBudgets.last,
+            lessThan(const Duration(milliseconds: 800)),
+          );
         });
       });
     });


### PR DESCRIPTION
## Problem

When a read asks several relays and one of them never finishes answering, `NostrClient.queryEventsDetailed` returns no events at all — not even the ones the other relays already delivered. It correctly reports `timedOut: true`, but the event list comes back empty.

The DM history drain is where this bites hardest. With one silent relay in the pool, every history page came back empty even when a healthy relay had answered it with messages, so history held by the healthy relay never appeared. (#9030: #9039 fixed the drain getting stuck there; this fixes the pages it retries coming back empty.)

## Why

#8448 turned `timeout` into an end-to-end deadline for the whole call, which was the right fix for #7091. To enforce it, it wrapped the SDK query in `.timeout(remainingTimeout())` — but it kept handing the SDK query the caller's full `timeout`. The SDK query already ends itself at its own deadline and returns what arrived. Given a longer budget than the outer cut, it never got there: the outer cut always fired first, threw `TimeoutException`, and the partial list was dropped.

```
caller deadline      ───────────────┤  outer .timeout fires → events: []
SDK query deadline   ───────────────────────┤  (would have returned what arrived)
```

#8448 considered handing the remaining budget down and backed it out because 34 existing tests stubbed the SDK call with matchers that fit only the default 5 s timeout. Its outer deadline did enforce the contract, but it also discarded the data.

This change:

- hands the SDK query what is left of the deadline, so it ends itself at the caller's deadline and returns what the answering relays sent;
- moves the outer backstop 250 ms past the deadline, so it only catches a query that overruns its own deadline instead of racing one that honours it.

A timed-out read again carries its partial events alongside `timedOut: true`, as it did before #8448, and as callers are written to expect. `dm_repository`'s DM inbox lookup, which routes every DM send, says so explicitly: *"A read that DID return the list stays `found` even when some relay never settled"*. Since #8448 that lookup came back empty whenever one relay was slow to settle, even with the list in hand from another. The send then goes to the default pool, is not counted as delivered (#7317), and the retry sweep publishes it again later.

A read that reaches the relays with most of its budget already spent — a long wait for a query slot, a slow reconnect — now also closes its REQ at the caller's deadline instead of leaving it open for a full timeout nobody is waiting on, and its query-pool slot stays held until then rather than being released while the REQ is still open.

## What this leaves alone

- **`timedOut` itself.** Who counts as having answered is computed exactly as before; this only stops the events from being thrown away. The history drain still pins its durable cursor on a timed-out page (#8209), so partial pages are stored but never mark history complete.
- **Callers that must not act on partial data.** I read all 15 full-settlement call sites. The ones that publish over a replaceable list or latch a one-time job — follow list, people lists, mute list and its legacy migration, corrupted-video repair, and the DM inbox list — never publish or latch on an answer with `timedOut` or `noRelays` set, and the list readers only ever move to a *newer* relay revision. Account deletion deletes whatever the sweep found and reports the enumeration as incomplete; it now also deletes the events the answering relays returned. Likes, repost resolution, moderation labels and DM history apply the events they get back. For every one of them the change is "cached rows only" → "cached rows plus what arrived", with the flag unchanged.
- **Plain `queryEvents`**, which drops the flag, again returns what arrived on a timeout, as before #8448. That fail-open contract is #6238, which stays open and is not changed here.
- **The end-to-end deadline from #7091.** A query that honours its deadline returns at it; only one that overruns can extend the call, by at most 250 ms.
- **#9039's retry policy** — untouched, and re-verified below.

## Tests

- Three regression tests in `nostr_client_test.dart` (*when a relay never answers*): the pooled path, the non-pooled path, and a read that first waits for a query slot. The SDK double ends its query at the budget it is handed and returns what arrived.
  - On the pre-fix code all three fail with `Actual: []`, while the existing #7091 tests pass.
  - Reverting only the budget line, keeping the new backstop, fails the query-slot test alone — the case the grace period cannot cover.
- 37 existing stubs and verifications in the same file listed every argument except `timeout`, so mocktail matched only the default 5 s. They now use `timeout: any(named: 'timeout')`. Four were `verifyNever`, which would otherwise have passed without checking anything.
- `nostr_client` 377/377, `nostr_sdk` 713/713, `dm_repository` 959/959, `flutter analyze lib test integration_test` clean.

## Reproduction with real relays

A throwaway harness (not committed) ran the real `DmRepository` history drain over the real `NostrClient` / `RelayPool` and an in-memory Drift database, against loopback relays and the funnelcake relay container behind a fault proxy:

| Scenario | `main` (includes #9039) | This branch |
|---|---|---|
| A healthy relay holds 3 history messages; the other relay never answers | 0 of 3 recovered — every page reads as "no relay answered" | 3 of 3 recovered; drain correctly stays incomplete |
| History only on a relay whose socket stops answering (#9039's case) | 2 of 2, complete | 2 of 2, complete |
| Same, with the socket half-open | 2 of 2, complete | 2 of 2, complete |
| Same, served by the funnelcake container | 2 of 2, complete | 2 of 2, complete |

On an iPhone running the #9039 build against production relays, `relay.divine.video` repeatedly left full-settlement requests unsettled past the caller window while other relays had answered (`ended inconclusively (answered=true …)`) — the condition in which this dropped their events.

Refs #9030, #9039, #8448, #6238.
