### PR TITLE
test(router): prove route recovery keeps navigation usable

### DIFF
--- a/mobile/test/router/restoration_safe_router_config_test.dart
+++ b/mobile/test/router/restoration_safe_router_config_test.dart
@@ -185,39 +185,6 @@ void main() {
       });
     });
 
-    group('restorationSafeRouterConfig', () {
-      testWidgets('keeps a router mounted again alive when its state no longer '
-          'decodes', (tester) async {
-        final saved = await _savedStateFromRetiredLocation(tester);
-
-        final router = _buildRouter(withRetiredRoute: false);
-        addTearDown(router.dispose);
-        final reporter = _RecordingCrashReporter();
-        final config = restorationSafeRouterConfig(
-          router,
-          crashReporter: reporter,
-        );
-        Widget app(Key key) => MaterialApp.router(
-          key: key,
-          routerConfig: config,
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-        );
-        await tester.pumpWidget(app(const ValueKey(1)));
-        await tester.pumpAndSettle();
-
-        // The router reports every location it lands on, so its provider
-        // holds an encoded state. A Router mounted again over the same
-        // GoRouter decodes it from Router.restoreState — the #7869 stack.
-        router.routeInformationProvider.routerReportsNewRouteInformation(saved);
-        await tester.pumpWidget(app(const ValueKey(2)));
-        await tester.pumpAndSettle();
-
-        expect(tester.takeException(), isNull);
-        expect(reporter.recorded, hasLength(1));
-      });
-    });
-
     group('restoreRouteInformation', () {
       testWidgets('delegates encoding unchanged', (tester) async {
         final router = _buildRouter(withRetiredRoute: false);
@@ -243,6 +210,39 @@ void main() {
               ?.uri,
         );
       });
+    });
+  });
+
+  group('restorationSafeRouterConfig', () {
+    testWidgets('keeps a router mounted again alive when its state no longer '
+        'decodes', (tester) async {
+      final saved = await _savedStateFromRetiredLocation(tester);
+
+      final router = _buildRouter(withRetiredRoute: false);
+      addTearDown(router.dispose);
+      final reporter = _RecordingCrashReporter();
+      final config = restorationSafeRouterConfig(
+        router,
+        crashReporter: reporter,
+      );
+      Widget app(Key key) => MaterialApp.router(
+        key: key,
+        routerConfig: config,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+      );
+      await tester.pumpWidget(app(const ValueKey(1)));
+      await tester.pumpAndSettle();
+
+      // The router reports every location it lands on, so its provider
+      // holds an encoded state. A Router mounted again over the same
+      // GoRouter decodes it from Router.restoreState — the #7869 stack.
+      router.routeInformationProvider.routerReportsNewRouteInformation(saved);
+      await tester.pumpWidget(app(const ValueKey(2)));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(reporter.recorded, hasLength(1));
     });
   });
 }

--- a/mobile/test/startup/divine_material_app_test.dart
+++ b/mobile/test/startup/divine_material_app_test.dart
@@ -41,6 +41,7 @@ class _RecordingCrashReportingService extends Fake
 
 GoRouter _shellRouter({required bool withRetiredRoute}) => GoRouter(
   initialLocation: '/home',
+  errorBuilder: (_, _) => const Text('not found'),
   routes: <RouteBase>[
     if (withRetiredRoute)
       GoRoute(path: '/retired', builder: (_, _) => const Text('retired')),
@@ -119,6 +120,12 @@ void main() {
       await tester.pumpWidget(app(const ValueKey(2)));
       await tester.pumpAndSettle();
 
+      expect(find.byType(Navigator), findsWidgets);
+      expect(find.text('not found'), findsOneWidget);
+      expect(
+        router.routerDelegate.currentConfiguration.uri.path,
+        '/retired',
+      );
       expect(tester.takeException(), isNull);
       expect(crashReporting.reasons, [
         'RestorationSafeRouter.parseRouteInformation',


### PR DESCRIPTION
## Problem

The route-state regression coverage proved that an undecodable saved route no longer crashes during an app remount, but it did not prove the recovery left usable navigation on screen. A wrong fallback could therefore preserve the exception and reporting expectations while routing somewhere unintended. The lower-level router-config test was also nested under the parser class, which made its reported ownership misleading.

## Why this change

The app-level fixture now owns a stable not-found sentinel and asserts that recovery renders a Navigator, shows that fallback, and preserves the original `/retired` location. The router-config group now sits beside the parser group so test output identifies the function under test.

This is test-only. It does not change production routing, extract the similar fixtures, or add refresh-path coverage.

## Verification

- `flutter test test/router/restoration_safe_router_config_test.dart test/startup/divine_material_app_test.dart`
- `flutter analyze lib test integration_test`
- Mutation check: forcing recovery to `/home` fails at the new not-found assertion

Closes #9054