### PR TITLE
docs(release): stop premature marketing-version bumps

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -13,7 +13,7 @@ freeze — Divine does not run release freezes, including before launch. See
 
 - [ ] Confirm the target commit is on `main` or the intended release branch.
 - [ ] Confirm `mobile/pubspec.yaml` has the release version and build number you expect.
-- [ ] Confirm the marketing version is still the current train before changing it. Do **not** bump `mobile/pubspec.yaml` to a new marketing version (`1.0.22` → `1.0.23`) while the current version is still in TestFlight or awaiting approval on App Store Connect: TestFlight builds stay on the same marketing version with a higher build number. A new version train is opened only once the current one is approved and released, because `scripts/ios_store_version_preflight.rb` requires a marketing version strictly greater than the latest approved one, and a higher build number cannot reopen a closed train. Treat editing this version as a release decision, not an implementation detail.
+- [ ] Keep the current marketing version while its train is in TestFlight or awaiting approval. Changing `mobile/pubspec.yaml` is a release decision: ask a maintainer first, then follow [Cutting a release](../mobile/docs/SHOREBIRD_CODE_PUSH.md#cutting-a-release).
 - [ ] Review `git status` and remove temporary files, logs, or unfinished work.
 - [ ] Confirm launch-critical docs are updated:
   - [ ] [docs/P1_LAUNCH_HUB.md](P1_LAUNCH_HUB.md)

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -13,6 +13,7 @@ freeze — Divine does not run release freezes, including before launch. See
 
 - [ ] Confirm the target commit is on `main` or the intended release branch.
 - [ ] Confirm `mobile/pubspec.yaml` has the release version and build number you expect.
+- [ ] Confirm the marketing version is still the current train before changing it. Do **not** bump `mobile/pubspec.yaml` to a new marketing version (`1.0.22` → `1.0.23`) while the current version is still in TestFlight or awaiting approval on App Store Connect: TestFlight builds stay on the same marketing version with a higher build number. A new version train is opened only once the current one is approved and released, because `scripts/ios_store_version_preflight.rb` requires a marketing version strictly greater than the latest approved one, and a higher build number cannot reopen a closed train. Treat editing this version as a release decision, not an implementation detail.
 - [ ] Review `git status` and remove temporary files, logs, or unfinished work.
 - [ ] Confirm launch-critical docs are updated:
   - [ ] [docs/P1_LAUNCH_HUB.md](P1_LAUNCH_HUB.md)

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -151,11 +151,14 @@ Run `ios-build` or `android-build` in Codemagic as usual. They now produce
 Shorebird releases as a side effect of building the store artifact — no extra
 step, no change to how you ship.
 
-Before starting a store build, update `mobile/pubspec.yaml` to the intended
-marketing version. The iOS preflight reads the latest approved App Store
-version and refuses a candidate that is equal or lower before Shorebird builds
-or records a release. Increasing only the build number cannot reopen a closed
-App Store version train.
+Before starting a store build, confirm `mobile/pubspec.yaml` has the intended
+marketing version. Keep the current marketing version while its train is in
+TestFlight or awaiting approval, using a higher build number for each build.
+Changing the marketing version is a release decision, not an implementation
+detail, so ask a maintainer before changing it. Once App Store Connect approves
+the current version and closes that train, move to a newer marketing version:
+the iOS preflight reads the latest approved App Store version and refuses a
+candidate that is equal or lower before Shorebird builds or records a release.
 
 iOS publishing deliberately stops after uploading the Shorebird IPA to App
 Store Connect (`submit_to_testflight: false`, `submit_to_app_store: false`).

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -16,6 +16,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
+# Marketing-version changes are release decisions. Keep the current train until
+# approval; ask a maintainer and follow ../docs/RELEASE_CHECKLIST.md before editing.
 version: 1.0.22+820
 
 environment:


### PR DESCRIPTION
Closes #9062

## Problem

The repository did not clearly say when the marketing version in `mobile/pubspec.yaml` may move. A recent attempt bumped `1.0.22` to `1.0.23` while `1.0.22` was still the active TestFlight train, even though no new marketing-version train was intended.

## Why this change

Marketing-version changes are release decisions. While a version is still in TestFlight or awaiting approval, builds stay on that marketing version and use higher build numbers. A maintainer should confirm the decision before anyone opens the next train.

After App Store approval closes the current train, `mobile/scripts/ios_store_version_preflight.rb` enforces the separate store constraint: the next candidate must use a marketing version newer than the latest approved version because a higher build number cannot reopen a closed train.

The concise rule now appears in the release checklist and beside the `version:` field where contributors make the edit. The Shorebird guide carries the full explanation so the checklist can link to one source instead of duplicating the mechanism.

## Scope

Documentation and comments only. The value in `mobile/pubspec.yaml` remains `1.0.22+820`; there is no runtime, dependency, generated-code, or release-automation change.

## Verification

- `git diff --check`
- `flutter pub get` with Flutter 3.47.2
- `flutter analyze lib test integration_test tools` — no issues
- Verified the checklist link resolves to `mobile/docs/SHOREBIRD_CODE_PUSH.md#cutting-a-release`

Refs #9056.