### PR TITLE
fix(nostr): prevent COUNT retries past caller deadline

### DIFF
--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -1202,12 +1202,18 @@ class NostrClient {
       } on CountNotSentException catch (e) {
         // No relay took the COUNT, so the pool is idle or down. Redial once,
         // as queries do, and ask again within what is left of the budget.
+        var deadlineExpired = false;
         try {
-          await retryDisconnectedRelays().timeout(remainingTimeout());
+          await retryDisconnectedRelays().timeout(
+            remainingTimeout(),
+            onTimeout: () {
+              deadlineExpired = true;
+            },
+          );
         } on TimeoutException {
-          // The redial outlived the budget; nothing is left to ask with.
+          // An independently thrown reconnect timeout may leave caller budget.
         }
-        if (remainingTimeout() == Duration.zero) {
+        if (deadlineExpired || remainingTimeout() == Duration.zero) {
           throw CountUnavailableException(e.reason);
         }
         response = await askRelays(remainingTimeout());

--- a/mobile/packages/nostr_client/pubspec.yaml
+++ b/mobile/packages/nostr_client/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
     path: ../unified_logger
 
 dev_dependencies:
+  fake_async: ^1.3.3
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'dart:convert';
 
 import 'package:db_client/db_client.dart' hide Filter;
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
@@ -5519,6 +5520,66 @@ void main() {
         },
         timeout: const Timeout(Duration(seconds: 3)),
       );
+
+      // Deterministic regression guard for the redial deadline. Under
+      // FakeAsync the `.timeout` timer fires on elapse() while the wall
+      // clock that remainingTimeout() reads barely advances, so the
+      // re-sampled residue is reliably positive. That reproduces the
+      // pre-fix bug: the old code read the residue as leftover budget and
+      // dispatched a second COUNT. The onTimeout deadline flag must stop
+      // after one COUNT, so reverting it fails this test on every run,
+      // not only on the rare live-timer race from #9063.
+      test('does not ask again after the redial deadline fires', () {
+        fakeAsync((async) {
+          when(
+            () => mockNostr.countEvents(
+              any(),
+              id: any(named: 'id'),
+              tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenThrow(CountNotSentException('No relay accepted COUNT'));
+          when(
+            mockRelayManager.retryDisconnectedRelays,
+          ).thenAnswer((_) => Completer<void>().future);
+
+          Object? caught;
+          var settled = false;
+          unawaited(
+            client
+                .countEvents(
+                  [
+                    Filter(kinds: [EventKind.textNote]),
+                  ],
+                  timeout: const Duration(milliseconds: 200),
+                )
+                .then<void>(
+                  (_) => settled = true,
+                  onError: (Object error) {
+                    caught = error;
+                    settled = true;
+                  },
+                ),
+          );
+
+          async
+            ..elapse(const Duration(milliseconds: 200))
+            ..flushMicrotasks();
+
+          expect(settled, isTrue);
+          expect(caught, isA<CountUnavailableException>());
+          verify(
+            () => mockNostr.countEvents(
+              any(),
+              id: any(named: 'id'),
+              tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).called(1);
+        });
+      });
 
       test('asks again after an earlier reconnect timeout', () async {
         var attempts = 0;

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -5520,6 +5520,43 @@ void main() {
         timeout: const Timeout(Duration(seconds: 3)),
       );
 
+      test('asks again after an earlier reconnect timeout', () async {
+        var attempts = 0;
+        when(
+          () => mockNostr.countEvents(
+            any(),
+            id: any(named: 'id'),
+            tempRelays: any(named: 'tempRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async {
+          attempts++;
+          if (attempts == 1) {
+            throw CountNotSentException('No relay accepted COUNT');
+          }
+          return const CountResponse(count: 7);
+        });
+        when(
+          mockRelayManager.retryDisconnectedRelays,
+        ).thenThrow(TimeoutException('Reconnect timed out'));
+
+        final result = await client.countEvents([
+          Filter(kinds: [EventKind.textNote]),
+        ]);
+
+        expect(result.count, equals(7));
+        verify(
+          () => mockNostr.countEvents(
+            any(),
+            id: any(named: 'id'),
+            tempRelays: any(named: 'tempRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).called(2);
+      });
+
       test('passes subscriptionId parameter', () async {
         final filters = [
           Filter(kinds: [EventKind.textNote]),


### PR DESCRIPTION
## Problem

`NostrClient.countEvents` could dispatch a second COUNT after its end-to-end timeout had fired. The timeout callback and a later `DateTime.now()` sample can disagree at the deadline boundary, allowing work to escape the caller contract and intermittently failing CI.

## Why this fix

The reconnect timeout callback now records expiration as an authoritative fact. The existing remaining-budget check stays in place for budget consumed before or outside that callback. An independently thrown reconnect `TimeoutException` still permits the one allowed retry when caller time remains.

## Deliberately unchanged

This does not lengthen production timeouts, change successful reconnect behavior, or broaden the retry limit. It does not attempt the separate monotonic-clock refactor.

## Verification

- 20 randomized runs of the 14-test `countEvents` group
- `very_good test --coverage` (375 tests)
- `flutter analyze`
- formatting and diff checks

Closes #9063