### PR TITLE
feat(analytics): tag view events with the app version

### DIFF
--- a/mobile/docs/NOSTR_VIDEO_EVENTS.md
+++ b/mobile/docs/NOSTR_VIDEO_EVENTS.md
@@ -352,6 +352,7 @@ The `.content` field is optional and could contain a free-form note.
 | `loops` | `["loops", "<playthrough-fraction>"]` | Exact finite, non-negative playthrough count emitted by mobile, including partial loops. Funnelcake does not read this tag — it derives loops from `viewed` — so it is informational for other consumers | Optional |
 | `source` | `["source", "<source-type>"]` | Traffic source: `home`, `discovery`, `profile`, `share`, `search` | Optional |
 | `client` | `["client", "<name>", "31990:<app-pubkey>:<d-identifier>", "<relay-url>"]` | NIP-89 client attribution for Divine | Optional |
+| `version` | `["version", "<app-version>"]` | Shipped app version (`PackageInfo.version`, e.g. `1.0.23`), so a view-reporting regression attributes to a release. Kept separate from `client`, whose exact value keys Funnelcake's view-volume detector | Optional |
 
 ### Two-phase sessions
 
@@ -386,6 +387,7 @@ with no new playback emits nothing. An app kill mid-session still leaves the
     ["viewed", "0", "5"],
     ["loops", "0.75"],
     ["source", "discovery"],
+    ["version", "1.0.23"],
     ["client", "Divine", "31990:d95aa8fc0eff8e488952495b8064991d27fb96ed8652f12cdedc5a4e8b5ae540:divine-mobile", "wss://relay.divine.video"]
   ]
 }

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -11,6 +11,7 @@ import 'package:openvine/features/feature_flags/providers/feature_flag_providers
 import 'package:openvine/l10n/current_app_l10n.dart';
 import 'package:openvine/models/view_event_drop_reason.dart';
 import 'package:openvine/observability/reportable_error.dart';
+import 'package:openvine/providers/app_version_provider.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/crash_reporting_provider.dart';
 import 'package:openvine/providers/creator_sync_provider.dart';
@@ -333,6 +334,7 @@ ViewEventPublisher viewEventPublisher(Ref ref) {
   return ViewEventPublisher(
     nostrService: nostrService,
     authService: authService,
+    appVersion: ref.watch(appVersionProvider),
     onDrop: (reason, {required String videoId, required String method}) {
       if (!reason.isStructural) return;
       ref

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -435,7 +435,7 @@ final class ViewEventPublisherProvider
 }
 
 String _$viewEventPublisherHash() =>
-    r'00aaa657c3238bb3718bd1839f48febb15d82841';
+    r'd8502c00768c8f3c7577d29ab8c1f0e97c958bf5';
 
 /// Subscribed list video cache for merging subscribed list videos into home feed
 /// Depends on CuratedListService which is async, so watch the state provider

--- a/mobile/lib/services/view_event_publisher.dart
+++ b/mobile/lib/services/view_event_publisher.dart
@@ -45,10 +45,12 @@ class ViewEventPublisher {
   ViewEventPublisher({
     required NostrClient nostrService,
     required AuthService authService,
+    required String appVersion,
     String? defaultRelayHint,
     ViewEventDropReporter? onDrop,
   }) : _nostrService = nostrService,
        _authService = authService,
+       _appVersion = appVersion.trim(),
        _onDrop = onDrop,
        _defaultRelayHint = defaultRelayHint ?? 'wss://relay.divine.video';
 
@@ -56,6 +58,16 @@ class ViewEventPublisher {
   final AuthService _authService;
   final String _defaultRelayHint;
   final ViewEventDropReporter? _onDrop;
+
+  /// Shipped app version written into the `version` tag of every view event.
+  ///
+  /// `view_interactions.client` only says "Divine": it cannot tell a 1.0.19
+  /// view from a 1.0.20 one, so a reporting regression could not be pinned to
+  /// the release that shipped it (#7921). The NIP-89 `client` tag is left
+  /// untouched on purpose — Funnelcake's view-volume detector keys on its
+  /// exact value. An empty version omits the tag rather than sending a
+  /// placeholder.
+  final String _appVersion;
 
   /// Records a dropped view event and returns `false` for the caller.
   ///
@@ -162,6 +174,8 @@ class ViewEventPublisher {
         // Fractional to preserve partial passes (median 0.75) per spec.
         if (phase != ViewEventPhase.start && loopCount != null && loopCount > 0)
           ['loops', loopCount.toString()],
+        // App version, so reporting regressions attribute to a release.
+        if (_appVersion.isNotEmpty) ['version', _appVersion],
       ];
 
       Log.debug(
@@ -191,7 +205,8 @@ class ViewEventPublisher {
 
       if (sentEvent is PublishSuccess) {
         Log.info(
-          'View event published: video=${video.id}, watched=${endSeconds - startSeconds}s',
+          'View event published: video=${video.id}, '
+          'watched=${endSeconds - startSeconds}s, version=$_appVersion',
           name: 'ViewEventPublisher',
           category: LogCategory.video,
         );

--- a/mobile/test/services/view_event_publisher_test.dart
+++ b/mobile/test/services/view_event_publisher_test.dart
@@ -34,6 +34,7 @@ void main() {
         'viewer_pubkey_abcdef1234567890abcdef1234567890abcdef1234567890abcdef12345678';
     const creatorPubkey =
         'creator_pubkey_abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234';
+    const appVersion = '1.0.23';
 
     setUp(() {
       mockNostr = _MockNostrClient();
@@ -71,6 +72,7 @@ void main() {
       publisher = ViewEventPublisher(
         nostrService: mockNostr,
         authService: mockAuth,
+        appVersion: appVersion,
       );
     });
 
@@ -176,6 +178,7 @@ void main() {
           publisher = ViewEventPublisher(
             nostrService: mockNostr,
             authService: mockAuth,
+            appVersion: appVersion,
             onDrop:
                 (reason, {required String videoId, required String method}) {
                   drops.add((reason: reason, videoId: videoId, method: method));
@@ -219,6 +222,7 @@ void main() {
           publisher = ViewEventPublisher(
             nostrService: mockNostr,
             authService: mockAuth,
+            appVersion: appVersion,
             onDrop:
                 (reason, {required String videoId, required String method}) {
                   drops.add((reason: reason, videoId: videoId, method: method));
@@ -314,6 +318,53 @@ void main() {
         expect(tags.where((t) => t[0] == 'client'), isEmpty);
       });
 
+      test('tags the event with the shipped app version', () async {
+        await publisher.publishViewEvent(
+          video: createTestVideoEvent(pubkey: creatorPubkey),
+          startSeconds: 0,
+          endSeconds: 5,
+          phase: ViewEventPhase.start,
+        );
+
+        final captured = verify(
+          () => mockAuth.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: captureAny(named: 'tags'),
+          ),
+        ).captured;
+
+        final tags = captured[0] as List<List<String>>;
+        expect(tags.where((t) => t[0] == 'version'), [
+          ['version', appVersion],
+        ]);
+      });
+
+      test('omits the version tag when the app version is blank', () async {
+        publisher = ViewEventPublisher(
+          nostrService: mockNostr,
+          authService: mockAuth,
+          appVersion: '  ',
+        );
+
+        await publisher.publishViewEvent(
+          video: createTestVideoEvent(pubkey: creatorPubkey),
+          startSeconds: 0,
+          endSeconds: 5,
+        );
+
+        final captured = verify(
+          () => mockAuth.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: captureAny(named: 'tags'),
+          ),
+        ).captured;
+
+        final tags = captured[0] as List<List<String>>;
+        expect(tags.where((t) => t[0] == 'version'), isEmpty);
+      });
+
       test(
         'does not fall back to event ID when the real d tag is absent',
         () async {
@@ -367,6 +418,7 @@ void main() {
           publisher = ViewEventPublisher(
             nostrService: mockNostr,
             authService: mockAuth,
+            appVersion: appVersion,
             onDrop:
                 (reason, {required String videoId, required String method}) {
                   drops.add((reason: reason, videoId: videoId, method: method));
@@ -414,6 +466,7 @@ void main() {
           publisher = ViewEventPublisher(
             nostrService: mockNostr,
             authService: mockAuth,
+            appVersion: appVersion,
             onDrop:
                 (reason, {required String videoId, required String method}) {
                   drops.add((reason: reason, videoId: videoId, method: method));
@@ -457,6 +510,7 @@ void main() {
           publisher = ViewEventPublisher(
             nostrService: mockNostr,
             authService: mockAuth,
+            appVersion: appVersion,
             onDrop:
                 (reason, {required String videoId, required String method}) {
                   drops.add((reason: reason, videoId: videoId, method: method));
@@ -501,6 +555,7 @@ void main() {
           publisher = ViewEventPublisher(
             nostrService: mockNostr,
             authService: mockAuth,
+            appVersion: appVersion,
             onDrop:
                 (reason, {required String videoId, required String method}) {
                   drops.add((reason: reason, videoId: videoId, method: method));

--- a/mobile/test/services/view_event_queue_publish_repro_test.dart
+++ b/mobile/test/services/view_event_queue_publish_repro_test.dart
@@ -81,6 +81,7 @@ void main() {
       publisher = ViewEventPublisher(
         nostrService: mockNostr,
         authService: mockAuth,
+        appVersion: '1.0.23',
         onDrop: (reason, {required String videoId, required String method}) =>
             drops.add(reason),
       );


### PR DESCRIPTION
## Description

A view-reporting regression cannot currently be attributed to the release that shipped it. Funnelcake stores every mobile view in `view_interactions` with `client = "Divine"` and no app-version field, so the release involved in the 1.0.19 to 1.0.20 reporting drop had to be reconstructed from Git history.

Every kind-22236 view event now carries a `["version", "<app version>"]` tag containing `PackageInfo.version`. In production, this is the same release value reported by the HTTP User-Agent and the first-party product-event envelope. Staging smoke builds are deliberately different: product events use their `staging-smoke-<32hex>` marker, while view events retain the shipped runtime version.

The version uses a separate tag because the existing NIP-89 `client` tag is also the exact value used by the Funnelcake view-volume regression detector. Changing that value would silently re-key the detector. The relay ignores unknown tags, so the mobile change is inert until the server change lands. Shipping the app first also allows version-tagged events to begin arriving while the app rollout progresses.

An empty version omits the tag instead of sending a placeholder. The successful-publish log line includes the version so device logs show what was sent.

Companion server change: divinevideo/divine-funnelcake#1257 parses the tag into `view_interactions.client_version`.

Of the three items in #7921, the first two were resolved before this PR: the ingest endpoint now exists in production, and #7938 deliberately chose bounded retries for a 404 rather than immediate dead-lettering. This PR addresses the remaining app-version attribution item.

**Related issue:** Closes #7921

## Out of Scope

- Durable outbox rows currently carry the version of the build that replays them, not the build that originally recorded them. The outbox is flushed immediately in the healthy path, but rows retained across an app update can be attributed to the successor release. Persisting the recording version requires a Drift migration and is tracked separately.
- Web continues to send its static `client = "divine-web/1.0"` value without a version tag.
- Platform attribution such as iOS versus Android is not included; #7921 requests release attribution only.

## Verification

- `dart format` and targeted `flutter analyze`: clean.
- 141 tests passed across the publisher, queue, retry service, analytics service, product-release provider, and provider-container suites. The publisher suite includes tests for a populated version tag and omission when the injected version is blank.
- Device verification on a Samsung Galaxy covered feed playback and outbox replay: 74 start/end events published with `version=1.0.22` and no observed drops.
- No visual change.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore