### PR TITLE
feat(video-editor): green screen for detached clips with a see-through cutout

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3805,6 +3805,7 @@
     "videoEditorChromaKeyBackgroundImage": "ምስል",
     "videoEditorChromaKeyBackgroundVideo": "ቅንጥብ",
     "videoEditorChromaKeyTransparentHint": "ቪዲዮ ግልጽነት መያዝ አይችልም፣ ስለዚህ ሲወጣ ጥቁር ይሆናል።",
+    "videoEditorChromaKeyCanvasTransparentHint": "ከቅንጥቡ ጀርባ ያለው ነገር በውስጡ ይታያል።",
     "videoEditorChromaKeySurfaceHint": "ከኋላዎ ያለ ማንኛውም ለስላሳ ገጽ ይሠራል — ግድግዳም በቂ ነው — ሙሉ ፍሬሙን እስከሸፈነ ድረስ።",
     "videoEditorChromaKeyDetectFailed": "ስክሪን አልተገኘም፦ ከኋላዎ ያለውን ሙሉ ፍሬም መሸፈን አለበት። ለስላሳ ግድግዳም ይበቃል። ወይም ቀለሙን በእጅ መምረጥ ይችላሉ።",
     "videoEditorChromaKeyPickClipTitle": "ቅንጥብ ምረጥ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3673,6 +3673,7 @@
     "videoEditorChromaKeyBackgroundImage": "صورة",
     "videoEditorChromaKeyBackgroundVideo": "مقطع",
     "videoEditorChromaKeyTransparentHint": "الفيديو لا يحفظ الشفافية، لذا سيخرج هذا الجزء أسود.",
+    "videoEditorChromaKeyCanvasTransparentHint": "ما خلف المقطع يظهر من خلاله.",
     "videoEditorChromaKeySurfaceHint": "أي سطح أملس في الخلفية يصلح — حتى الجدار — ما دام يملأ الإطار بالكامل.",
     "videoEditorChromaKeyDetectFailed": "لم يتم العثور على خلفية: يجب أن تملأ الإطار بالكامل. الجدار الأملس يكفي. أو يمكن اختيار اللون يدويًا.",
     "videoEditorChromaKeyPickClipTitle": "اختر مقطعًا",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3811,6 +3811,7 @@
     "videoEditorChromaKeyBackgroundImage": "Изображение",
     "videoEditorChromaKeyBackgroundVideo": "Клип",
     "videoEditorChromaKeyTransparentHint": "Видеото не може да носи прозрачност, затова това ще излезе черно при експорт.",
+    "videoEditorChromaKeyCanvasTransparentHint": "Каквото е зад клипа, прозира през него.",
     "videoEditorChromaKeySurfaceHint": "Всяка равна повърхност зад теб върши работа — и стена става — стига да запълва целия кадър.",
     "videoEditorChromaKeyDetectFailed": "Не открихме фон: трябва да запълва целия кадър зад теб. Равна стена също става. Или избери цвета ръчно.",
     "videoEditorChromaKeyPickClipTitle": "Избери клип",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3673,6 +3673,7 @@
     "videoEditorChromaKeyBackgroundImage": "Bild",
     "videoEditorChromaKeyBackgroundVideo": "Clip",
     "videoEditorChromaKeyTransparentHint": "Video kann keine Transparenz speichern – das wird beim Export schwarz.",
+    "videoEditorChromaKeyCanvasTransparentHint": "Was hinter dem Clip liegt, scheint durch.",
     "videoEditorChromaKeySurfaceHint": "Jede glatte Fläche hinter dir funktioniert – eine Wand reicht –, solange sie das ganze Bild füllt.",
     "videoEditorChromaKeyDetectFailed": "Kein Screen gefunden – er muss das ganze Bild hinter dir füllen. Eine glatte Wand zählt. Oder wähl die Farbe von Hand.",
     "videoEditorChromaKeyPickClipTitle": "Clip auswählen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -5801,6 +5801,10 @@
   "videoEditorChromaKeyBackgroundImage": "Image",
   "videoEditorChromaKeyBackgroundVideo": "Clip",
   "videoEditorChromaKeyTransparentHint": "Video can't hold transparency, so this exports as black.",
+  "videoEditorChromaKeyCanvasTransparentHint": "Whatever's behind the clip shows through.",
+  "@videoEditorChromaKeyCanvasTransparentHint": {
+    "description": "Shown under the background chips of the green-screen screen when \"Nothing\" is selected for a clip that was detached onto the editor canvas. Unlike videoEditorChromaKeyTransparentHint, this is a reassurance, not a warning: a detached clip is composited over the rest of the video at export, so the removed area really is see-through. Keep the same noun for the clip as this locale's videoEditorChromaKeyPickClipTitle."
+  },
   "videoEditorChromaKeySurfaceHint": "Any plain surface behind you works — a wall is fine — as long as it fills the frame.",
   "@videoEditorChromaKeySurfaceHint": {
     "description": "Standing hint in the chroma key controls, directly above the Auto-detect button. States the feature's one prerequisite — a uniform surface behind the subject that reaches every edge of the frame — as soon as the controls open. Naming a wall is the point: most people own no green screen and do not know an ordinary wall keys. Keep all three facts when translating: that an ordinary wall qualifies, that the surface must fill the frame, and the plain register."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3673,6 +3673,7 @@
     "videoEditorChromaKeyBackgroundImage": "Imagen",
     "videoEditorChromaKeyBackgroundVideo": "Clip",
     "videoEditorChromaKeyTransparentHint": "El vídeo no admite transparencia, así que esto se exporta en negro.",
+    "videoEditorChromaKeyCanvasTransparentHint": "Lo que hay detrás del clip se ve a través.",
     "videoEditorChromaKeySurfaceHint": "Sirve cualquier superficie lisa detrás tuyo — una pared alcanza — siempre que llene todo el cuadro.",
     "videoEditorChromaKeyDetectFailed": "No encontramos ningún fondo: tiene que llenar todo el cuadro detrás tuyo. Una pared lisa sirve. O elegí el color a mano.",
     "videoEditorChromaKeyPickClipTitle": "Elegir un clip",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2643,6 +2643,7 @@
     "videoEditorChromaKeyBackgroundImage": "Larawan",
     "videoEditorChromaKeyBackgroundVideo": "Clip",
     "videoEditorChromaKeyTransparentHint": "Hindi kayang magdala ng transparency ang video, kaya magiging itim ito sa export.",
+    "videoEditorChromaKeyCanvasTransparentHint": "Kahit anong nasa likod ng clip, makikita sa pagitan.",
     "videoEditorChromaKeySurfaceHint": "Kahit anong plain na surface sa likod mo, pwede — pader lang, okay na — basta punong-puno ang frame.",
     "videoEditorChromaKeyDetectFailed": "Walang nahanap na screen: kailangang punuin nito ang buong frame sa likod mo. Pwede ang plain na pader. O pumili ng kulay nang manual.",
     "videoEditorChromaKeyPickClipTitle": "Pumili ng clip",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3673,6 +3673,7 @@
     "videoEditorChromaKeyBackgroundImage": "Image",
     "videoEditorChromaKeyBackgroundVideo": "Clip",
     "videoEditorChromaKeyTransparentHint": "La vidéo ne gère pas la transparence : à l'export, ce sera du noir.",
+    "videoEditorChromaKeyCanvasTransparentHint": "Ce qu'il y a derrière le clip apparaît à travers.",
     "videoEditorChromaKeySurfaceHint": "N'importe quelle surface unie derrière toi fait l'affaire — un mur suffit — tant qu'elle remplit tout le cadre.",
     "videoEditorChromaKeyDetectFailed": "Aucun fond trouvé : il doit remplir tout le cadre derrière toi. Un mur uni fait l'affaire. Ou choisis la couleur à la main.",
     "videoEditorChromaKeyPickClipTitle": "Choisir un clip",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3673,6 +3673,7 @@
     "videoEditorChromaKeyBackgroundImage": "Gambar",
     "videoEditorChromaKeyBackgroundVideo": "Klip",
     "videoEditorChromaKeyTransparentHint": "Video tidak bisa menyimpan transparansi, jadi hasil ekspornya hitam.",
+    "videoEditorChromaKeyCanvasTransparentHint": "Apa pun yang ada di belakang klip akan terlihat tembus.",
     "videoEditorChromaKeySurfaceHint": "Permukaan polos apa pun di belakang kamu bisa dipakai — tembok juga boleh — asal memenuhi seluruh bingkai.",
     "videoEditorChromaKeyDetectFailed": "Layar tidak ditemukan: harus memenuhi seluruh bingkai di belakang kamu. Tembok polos juga bisa. Atau pilih warnanya sendiri.",
     "videoEditorChromaKeyPickClipTitle": "Pilih klip",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3673,6 +3673,7 @@
     "videoEditorChromaKeyBackgroundImage": "Immagine",
     "videoEditorChromaKeyBackgroundVideo": "Clip",
     "videoEditorChromaKeyTransparentHint": "Il video non supporta la trasparenza, quindi in esportazione diventa nero.",
+    "videoEditorChromaKeyCanvasTransparentHint": "Quello che c'è dietro la clip si vede in trasparenza.",
     "videoEditorChromaKeySurfaceHint": "Va bene qualsiasi superficie liscia dietro di te — anche un muro — purché riempia tutta l'inquadratura.",
     "videoEditorChromaKeyDetectFailed": "Nessuno sfondo trovato: deve riempire tutta l'inquadratura dietro di te. Un muro liscio va bene. Oppure scegli il colore a mano.",
     "videoEditorChromaKeyPickClipTitle": "Scegli una clip",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3673,6 +3673,7 @@
     "videoEditorChromaKeyBackgroundImage": "画像",
     "videoEditorChromaKeyBackgroundVideo": "クリップ",
     "videoEditorChromaKeyTransparentHint": "動画は透明を保持できないため、書き出すと黒くなります。",
+    "videoEditorChromaKeyCanvasTransparentHint": "クリップの後ろにあるものが透けて見えます。",
     "videoEditorChromaKeySurfaceHint": "後ろに無地の面があれば使えます。壁でも大丈夫です。ただし画面いっぱいに広がっている必要があります。",
     "videoEditorChromaKeyDetectFailed": "背景が見つかりませんでした。後ろの面が画面いっぱいに広がっている必要があります。無地の壁でも大丈夫です。手動で色を選ぶこともできます。",
     "videoEditorChromaKeyPickClipTitle": "クリップを選ぶ",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3211,6 +3211,7 @@
     "videoEditorChromaKeyBackgroundImage": "이미지",
     "videoEditorChromaKeyBackgroundVideo": "클립",
     "videoEditorChromaKeyTransparentHint": "영상은 투명도를 담을 수 없어서 내보내면 검게 나옵니다.",
+    "videoEditorChromaKeyCanvasTransparentHint": "클립 뒤에 있는 것이 그대로 비쳐 보여요.",
     "videoEditorChromaKeySurfaceHint": "뒤에 있는 단색 면이면 뭐든 돼요. 벽도 괜찮아요. 다만 화면을 가득 채워야 해요.",
     "videoEditorChromaKeyDetectFailed": "배경을 찾지 못했어요. 뒤쪽 면이 화면을 가득 채워야 해요. 단색 벽도 괜찮아요. 색을 직접 골라도 돼요.",
     "videoEditorChromaKeyPickClipTitle": "클립 고르기",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -4803,6 +4803,7 @@
   "videoEditorChromaKeyBackgroundImage": "Imej",
   "videoEditorChromaKeyBackgroundVideo": "Klip",
   "videoEditorChromaKeyTransparentHint": "Video tidak boleh menyimpan ketelusan, jadi ini dieksport sebagai hitam.",
+  "videoEditorChromaKeyCanvasTransparentHint": "Apa sahaja di belakang klip akan kelihatan menembusinya.",
   "videoEditorChromaKeySurfaceHint": "Mana-mana permukaan rata di belakang anda boleh digunakan — dinding pun memadai — asalkan ia memenuhi seluruh bingkai.",
   "videoEditorChromaKeyDetectFailed": "Skrin tidak dijumpai: ia perlu memenuhi seluruh bingkai di belakang anda. Dinding rata pun dikira. Atau pilih warnanya secara manual.",
   "videoEditorChromaKeyPickClipTitle": "Pilih klip",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3673,6 +3673,7 @@
     "videoEditorChromaKeyBackgroundImage": "Afbeelding",
     "videoEditorChromaKeyBackgroundVideo": "Clip",
     "videoEditorChromaKeyTransparentHint": "Video kan geen transparantie bevatten, dus dit wordt zwart geëxporteerd.",
+    "videoEditorChromaKeyCanvasTransparentHint": "Wat achter de clip zit, schijnt erdoorheen.",
     "videoEditorChromaKeySurfaceHint": "Elk effen vlak achter je werkt — een muur is prima — zolang het het hele beeld vult.",
     "videoEditorChromaKeyDetectFailed": "Geen achtergrond gevonden: het moet het hele beeld achter je vullen. Een effen muur telt ook. Of kies de kleur zelf.",
     "videoEditorChromaKeyPickClipTitle": "Kies een clip",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3673,6 +3673,7 @@
     "videoEditorChromaKeyBackgroundImage": "Obraz",
     "videoEditorChromaKeyBackgroundVideo": "Klip",
     "videoEditorChromaKeyTransparentHint": "Wideo nie przechowuje przezroczystości, więc w eksporcie będzie czarne.",
+    "videoEditorChromaKeyCanvasTransparentHint": "To, co jest za klipem, prześwituje.",
     "videoEditorChromaKeySurfaceHint": "Wystarczy dowolna gładka powierzchnia za tobą — ściana też — o ile wypełnia cały kadr.",
     "videoEditorChromaKeyDetectFailed": "Nie znaleziono tła — musi wypełniać cały kadr za tobą. Gładka ściana wystarczy. Albo wybierz kolor ręcznie.",
     "videoEditorChromaKeyPickClipTitle": "Wybierz klip",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3673,6 +3673,7 @@
     "videoEditorChromaKeyBackgroundImage": "Imagem",
     "videoEditorChromaKeyBackgroundVideo": "Clipe",
     "videoEditorChromaKeyTransparentHint": "O vídeo não guarda transparência, por isso isto é exportado a preto.",
+    "videoEditorChromaKeyCanvasTransparentHint": "O que estiver atrás do clipe aparece através dele.",
     "videoEditorChromaKeySurfaceHint": "Qualquer superfície lisa atrás de você funciona — uma parede já serve — desde que preencha todo o quadro.",
     "videoEditorChromaKeyDetectFailed": "Nenhum fundo encontrado: ele precisa preencher todo o quadro atrás de você. Uma parede lisa vale. Ou escolha a cor na mão.",
     "videoEditorChromaKeyPickClipTitle": "Escolher um clipe",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3673,6 +3673,7 @@
     "videoEditorChromaKeyBackgroundImage": "Imagine",
     "videoEditorChromaKeyBackgroundVideo": "Clip",
     "videoEditorChromaKeyTransparentHint": "Videoclipul nu poate păstra transparența, așa că la export iese negru.",
+    "videoEditorChromaKeyCanvasTransparentHint": "Ce se află în spatele clipului se vede prin el.",
     "videoEditorChromaKeySurfaceHint": "Merge orice suprafață simplă din spatele tău — și un perete — atâta timp cât umple tot cadrul.",
     "videoEditorChromaKeyDetectFailed": "Nu am găsit niciun fundal: trebuie să umple tot cadrul din spatele tău. Un perete simplu e suficient. Sau alege culoarea manual.",
     "videoEditorChromaKeyPickClipTitle": "Alege un clip",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3673,6 +3673,7 @@
     "videoEditorChromaKeyBackgroundImage": "Bild",
     "videoEditorChromaKeyBackgroundVideo": "Klipp",
     "videoEditorChromaKeyTransparentHint": "Video kan inte spara transparens, så det här exporteras som svart.",
+    "videoEditorChromaKeyCanvasTransparentHint": "Det som ligger bakom klippet syns igenom.",
     "videoEditorChromaKeySurfaceHint": "Vilken slät yta som helst bakom dig fungerar — en vägg duger — så länge den fyller hela bilden.",
     "videoEditorChromaKeyDetectFailed": "Hittade ingen bakgrund – den måste fylla hela bilden bakom dig. En slät vägg räcker. Eller välj färgen för hand.",
     "videoEditorChromaKeyPickClipTitle": "Välj ett klipp",

--- a/mobile/lib/l10n/app_te.arb
+++ b/mobile/lib/l10n/app_te.arb
@@ -5708,6 +5708,7 @@
   "videoEditorChromaKeyBackgroundImage": "చిత్రం",
   "videoEditorChromaKeyBackgroundVideo": "క్లిప్",
   "videoEditorChromaKeyTransparentHint": "వీడియో పారదర్శకతను కలిగి ఉండదు, కనుక ఇది నలుపు రంగులో ఎగుమతి అవుతుంది.",
+  "videoEditorChromaKeyCanvasTransparentHint": "క్లిప్ వెనుక ఉన్నది దాని ద్వారా కనిపిస్తుంది.",
   "videoEditorChromaKeySurfaceHint": "మీ వెనుక ఉన్న ఏదైనా నునుపైన ఉపరితలం పని చేస్తుంది — గోడ అయినా సరిపోతుంది — అది ఫ్రేమ్‌ను పూర్తిగా నింపినంత వరకు.",
   "videoEditorChromaKeyDetectFailed": "స్క్రీన్ కనిపించలేదు: అది మీ వెనుక ఉన్న ఫ్రేమ్‌ను పూర్తిగా నింపాలి. నునుపైన గోడ కూడా సరిపోతుంది. లేదా రంగును మీరే ఎంచుకోండి.",
   "videoEditorChromaKeyPickClipTitle": "క్లిప్‌ను ఎంచుకోండి",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3673,6 +3673,7 @@
     "videoEditorChromaKeyBackgroundImage": "Görsel",
     "videoEditorChromaKeyBackgroundVideo": "Klip",
     "videoEditorChromaKeyTransparentHint": "Video saydamlık tutamaz, bu yüzden dışa aktarımda siyah olur.",
+    "videoEditorChromaKeyCanvasTransparentHint": "Klibin arkasında ne varsa görünür.",
     "videoEditorChromaKeySurfaceHint": "Arkandaki düz herhangi bir yüzey işe yarar — bir duvar da olur — yeter ki kareyi tamamen doldursun.",
     "videoEditorChromaKeyDetectFailed": "Perde bulunamadı: arkandaki kareyi tamamen doldurması gerek. Düz bir duvar da olur. Ya da rengi elle seç.",
     "videoEditorChromaKeyPickClipTitle": "Bir klip seç",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -4803,6 +4803,7 @@
   "videoEditorChromaKeyBackgroundImage": "تصویر",
   "videoEditorChromaKeyBackgroundVideo": "کلپ",
   "videoEditorChromaKeyTransparentHint": "ویڈیو شفافیت محفوظ نہیں رکھ سکتی، اس لیے یہ سیاہ ایکسپورٹ ہوگی۔",
+  "videoEditorChromaKeyCanvasTransparentHint": "کلپ کے پیچھے جو کچھ ہے، وہ اس کے آر پار نظر آئے گا۔",
   "videoEditorChromaKeySurfaceHint": "آپ کے پیچھے کوئی بھی سادہ سطح کام کر جاتی ہے — دیوار بھی چلے گی — بس وہ پورے فریم کو بھر دے۔",
   "videoEditorChromaKeyDetectFailed": "کوئی اسکرین نہیں ملی: اسے آپ کے پیچھے پورا فریم بھرنا ہوگا۔ سادہ دیوار بھی کافی ہے۔ یا رنگ خود منتخب کریں۔",
   "videoEditorChromaKeyPickClipTitle": "کلپ چنیں",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -4803,6 +4803,7 @@
   "videoEditorChromaKeyBackgroundImage": "Ảnh",
   "videoEditorChromaKeyBackgroundVideo": "Clip",
   "videoEditorChromaKeyTransparentHint": "Video không giữ được độ trong suốt, nên phần này sẽ xuất ra màu đen.",
+  "videoEditorChromaKeyCanvasTransparentHint": "Bất cứ thứ gì phía sau clip sẽ hiện xuyên qua.",
   "videoEditorChromaKeySurfaceHint": "Bất kỳ bề mặt phẳng nào phía sau bạn đều được — một bức tường cũng ổn — miễn là nó lấp kín khung hình.",
   "videoEditorChromaKeyDetectFailed": "Không tìm thấy phông nền: nó phải lấp kín khung hình phía sau bạn. Một bức tường phẳng là đủ. Hoặc tự chọn màu.",
   "videoEditorChromaKeyPickClipTitle": "Chọn một clip",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -4803,6 +4803,7 @@
   "videoEditorChromaKeyBackgroundImage": "图片",
   "videoEditorChromaKeyBackgroundVideo": "片段",
   "videoEditorChromaKeyTransparentHint": "视频存不了透明，所以导出会是黑色。",
+  "videoEditorChromaKeyCanvasTransparentHint": "片段后面的内容会透出来。",
   "videoEditorChromaKeySurfaceHint": "你身后任何一块纯色平面都可以，墙也行，只要能铺满整个画面。",
   "videoEditorChromaKeyDetectFailed": "没找到幕布：它得铺满你身后的整个画面。一面纯色的墙就够了。也可以手动选颜色。",
   "videoEditorChromaKeyPickClipTitle": "选个片段",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -15290,6 +15290,12 @@ abstract class AppLocalizations {
   /// **'Video can\'t hold transparency, so this exports as black.'**
   String get videoEditorChromaKeyTransparentHint;
 
+  /// Shown under the background chips of the green-screen screen when "Nothing" is selected for a clip that was detached onto the editor canvas. Unlike videoEditorChromaKeyTransparentHint, this is a reassurance, not a warning: a detached clip is composited over the rest of the video at export, so the removed area really is see-through. Keep the same noun for the clip as this locale's videoEditorChromaKeyPickClipTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Whatever\'s behind the clip shows through.'**
+  String get videoEditorChromaKeyCanvasTransparentHint;
+
   /// Standing hint in the chroma key controls, directly above the Auto-detect button. States the feature's one prerequisite — a uniform surface behind the subject that reaches every edge of the frame — as soon as the controls open. Naming a wall is the point: most people own no green screen and do not know an ordinary wall keys. Keep all three facts when translating: that an ordinary wall qualifies, that the surface must fill the frame, and the plain register.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -8754,6 +8754,10 @@ class AppLocalizationsAm extends AppLocalizations {
       'ቪዲዮ ግልጽነት መያዝ አይችልም፣ ስለዚህ ሲወጣ ጥቁር ይሆናል።';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'ከቅንጥቡ ጀርባ ያለው ነገር በውስጡ ይታያል።';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'ከኋላዎ ያለ ማንኛውም ለስላሳ ገጽ ይሠራል — ግድግዳም በቂ ነው — ሙሉ ፍሬሙን እስከሸፈነ ድረስ።';
 

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -8912,6 +8912,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'الفيديو لا يحفظ الشفافية، لذا سيخرج هذا الجزء أسود.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'ما خلف المقطع يظهر من خلاله.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'أي سطح أملس في الخلفية يصلح — حتى الجدار — ما دام يملأ الإطار بالكامل.';
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -9043,6 +9043,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Видеото не може да носи прозрачност, затова това ще излезе черно при експорт.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'Каквото е зад клипа, прозира през него.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'Всяка равна повърхност зад теб върши работа — и стена става — стига да запълва целия кадър.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -9077,6 +9077,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Video kann keine Transparenz speichern – das wird beim Export schwarz.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'Was hinter dem Clip liegt, scheint durch.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'Jede glatte Fläche hinter dir funktioniert – eine Wand reicht –, solange sie das ganze Bild füllt.';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -9063,6 +9063,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Video can\'t hold transparency, so this exports as black.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'Whatever\'s behind the clip shows through.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'Any plain surface behind you works — a wall is fine — as long as it fills the frame.';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -9049,6 +9049,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'El vídeo no admite transparencia, así que esto se exporta en negro.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'Lo que hay detrás del clip se ve a través.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'Sirve cualquier superficie lisa detrás tuyo — una pared alcanza — siempre que llene todo el cuadro.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -9033,6 +9033,10 @@ class AppLocalizationsFil extends AppLocalizations {
       'Hindi kayang magdala ng transparency ang video, kaya magiging itim ito sa export.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'Kahit anong nasa likod ng clip, makikita sa pagitan.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'Kahit anong plain na surface sa likod mo, pwede — pader lang, okay na — basta punong-puno ang frame.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -9094,6 +9094,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'La vidéo ne gère pas la transparence : à l\'export, ce sera du noir.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'Ce qu\'il y a derrière le clip apparaît à travers.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'N\'importe quelle surface unie derrière toi fait l\'affaire — un mur suffit — tant qu\'elle remplit tout le cadre.';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -8880,6 +8880,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Video tidak bisa menyimpan transparansi, jadi hasil ekspornya hitam.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'Apa pun yang ada di belakang klip akan terlihat tembus.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'Permukaan polos apa pun di belakang kamu bisa dipakai — tembok juga boleh — asal memenuhi seluruh bingkai.';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -9062,6 +9062,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Il video non supporta la trasparenza, quindi in esportazione diventa nero.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'Quello che c\'è dietro la clip si vede in trasparenza.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'Va bene qualsiasi superficie liscia dietro di te — anche un muro — purché riempia tutta l\'inquadratura.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -8527,6 +8527,10 @@ class AppLocalizationsJa extends AppLocalizations {
       '動画は透明を保持できないため、書き出すと黒くなります。';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'クリップの後ろにあるものが透けて見えます。';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       '後ろに無地の面があれば使えます。壁でも大丈夫です。ただし画面いっぱいに広がっている必要があります。';
 

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -8539,6 +8539,10 @@ class AppLocalizationsKo extends AppLocalizations {
       '영상은 투명도를 담을 수 없어서 내보내면 검게 나옵니다.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      '클립 뒤에 있는 것이 그대로 비쳐 보여요.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       '뒤에 있는 단색 면이면 뭐든 돼요. 벽도 괜찮아요. 다만 화면을 가득 채워야 해요.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -8974,6 +8974,10 @@ class AppLocalizationsMs extends AppLocalizations {
       'Video tidak boleh menyimpan ketelusan, jadi ini dieksport sebagai hitam.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'Apa sahaja di belakang klip akan kelihatan menembusinya.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'Mana-mana permukaan rata di belakang anda boleh digunakan — dinding pun memadai — asalkan ia memenuhi seluruh bingkai.';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -9004,6 +9004,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Video kan geen transparantie bevatten, dus dit wordt zwart geëxporteerd.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'Wat achter de clip zit, schijnt erdoorheen.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'Elk effen vlak achter je werkt — een muur is prima — zolang het het hele beeld vult.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -9146,6 +9146,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Wideo nie przechowuje przezroczystości, więc w eksporcie będzie czarne.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'To, co jest za klipem, prześwituje.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'Wystarczy dowolna gładka powierzchnia za tobą — ściana też — o ile wypełnia cały kadr.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -9031,6 +9031,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'O vídeo não guarda transparência, por isso isto é exportado a preto.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'O que estiver atrás do clipe aparece através dele.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'Qualquer superfície lisa atrás de você funciona — uma parede já serve — desde que preencha todo o quadro.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -9170,6 +9170,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Videoclipul nu poate păstra transparența, așa că la export iese negru.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'Ce se află în spatele clipului se vede prin el.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'Merge orice suprafață simplă din spatele tău — și un perete — atâta timp cât umple tot cadrul.';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -8961,6 +8961,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Video kan inte spara transparens, så det här exporteras som svart.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'Det som ligger bakom klippet syns igenom.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'Vilken slät yta som helst bakom dig fungerar — en vägg duger — så länge den fyller hela bilden.';
 

--- a/mobile/lib/l10n/generated/app_localizations_te.dart
+++ b/mobile/lib/l10n/generated/app_localizations_te.dart
@@ -9229,6 +9229,10 @@ class AppLocalizationsTe extends AppLocalizations {
       'వీడియో పారదర్శకతను కలిగి ఉండదు, కనుక ఇది నలుపు రంగులో ఎగుమతి అవుతుంది.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'క్లిప్ వెనుక ఉన్నది దాని ద్వారా కనిపిస్తుంది.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'మీ వెనుక ఉన్న ఏదైనా నునుపైన ఉపరితలం పని చేస్తుంది — గోడ అయినా సరిపోతుంది — అది ఫ్రేమ్‌ను పూర్తిగా నింపినంత వరకు.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -8881,6 +8881,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Video saydamlık tutamaz, bu yüzden dışa aktarımda siyah olur.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'Klibin arkasında ne varsa görünür.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'Arkandaki düz herhangi bir yüzey işe yarar — bir duvar da olur — yeter ki kareyi tamamen doldursun.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -8958,6 +8958,10 @@ class AppLocalizationsUr extends AppLocalizations {
       'ویڈیو شفافیت محفوظ نہیں رکھ سکتی، اس لیے یہ سیاہ ایکسپورٹ ہوگی۔';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'کلپ کے پیچھے جو کچھ ہے، وہ اس کے آر پار نظر آئے گا۔';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'آپ کے پیچھے کوئی بھی سادہ سطح کام کر جاتی ہے — دیوار بھی چلے گی — بس وہ پورے فریم کو بھر دے۔';
 

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -8926,6 +8926,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Video không giữ được độ trong suốt, nên phần này sẽ xuất ra màu đen.';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint =>
+      'Bất cứ thứ gì phía sau clip sẽ hiện xuyên qua.';
+
+  @override
   String get videoEditorChromaKeySurfaceHint =>
       'Bất kỳ bề mặt phẳng nào phía sau bạn đều được — một bức tường cũng ổn — miễn là nó lấp kín khung hình.';
 

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -8449,6 +8449,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get videoEditorChromaKeyTransparentHint => '视频存不了透明，所以导出会是黑色。';
 
   @override
+  String get videoEditorChromaKeyCanvasTransparentHint => '片段后面的内容会透出来。';
+
+  @override
   String get videoEditorChromaKeySurfaceHint => '你身后任何一块纯色平面都可以，墙也行，只要能铺满整个画面。';
 
   @override

--- a/mobile/lib/models/video_editor/clip_chroma_key.dart
+++ b/mobile/lib/models/video_editor/clip_chroma_key.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Chroma-key (green screen) settings while the editor screen is open.
+// ABOUTME: Chroma-key settings used by baked timeline clips and live layers.
 // ABOUTME: Wraps pro_video_editor's ChromaKey and adds the video-background
 // ABOUTME: mode, which a single-track render cannot express on its own.
 
@@ -30,11 +30,12 @@ enum ClipChromaKeyBackgroundType {
   video,
 }
 
-/// A clip's chroma-key settings while the green-screen screen is open.
+/// A clip's chroma-key settings.
 ///
-/// Purely in-memory: the settings drive the preview shader, and on confirm they
-/// are baked into a new clip file. Nothing carries them afterwards — the keyed
-/// footage *is* the state.
+/// For a timeline clip these settings drive the preview and are then recorded
+/// alongside the key baked into the clip file, so the screen can restore the
+/// user's choices. For a detached clip they remain live layer state: the canvas
+/// preview and export composition both apply the persisted settings directly.
 @immutable
 class ClipChromaKey {
   const ClipChromaKey({required this.key, this.backgroundVideoPath})
@@ -87,10 +88,11 @@ class ClipChromaKey {
   /// inside [ChromaKey].
   ClipChromaKey withKey(ChromaKey key) => ClipChromaKey(key: key);
 
-  /// Serializes the settings so re-opening the editor can restore them.
+  /// Serializes the settings for persisted editor state.
   ///
-  /// The key is already baked into the clip's video; this is only what the
-  /// screen needs to show the user their last choices again.
+  /// A timeline clip stores them to restore the screen choices associated with
+  /// its baked key. A detached clip stores them as the live key applied by the
+  /// canvas preview and export composition.
   Map<String, dynamic> toJson() {
     // Paths are stored as basenames: iOS rewrites the container path on app
     // update, so an absolute path in a persisted draft goes stale.

--- a/mobile/lib/models/video_editor/detached_clip_layer.dart
+++ b/mobile/lib/models/video_editor/detached_clip_layer.dart
@@ -2,6 +2,7 @@
 // ABOUTME: timeline, so the canvas and the renderer can treat it as video
 
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/clip_chroma_key.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 /// Marks a [WidgetLayer]'s export meta as a clip that was detached from the
@@ -37,6 +38,18 @@ const String detachedClipLayerIdKey = 'layerId';
 /// clip's first frame at its own start.
 const String detachedClipLayerSourceOffsetKey = 'sourceOffsetUs';
 
+/// Key under which the layer's green-screen settings are written, as
+/// [ClipChromaKey.toJson]. Absent when the layer carries no key.
+///
+/// Unlike a timeline clip's key, this one is never baked into a file. The
+/// export composites a detached clip as a `VideoLayer` over the finished
+/// track, and a key on that layer makes the removed area genuinely see-through
+/// — which a single H.264 track cannot do, and which is the reason to detach a
+/// green-screen clip in the first place. So the settings stay live: the canvas
+/// applies them through the preview shader and the export through the
+/// composition, and both read the same values from here.
+const String detachedClipLayerChromaKeyKey = 'chromaKey';
+
 /// A clip lifted out of the timeline and turned into a freely placeable layer
 /// on the editor canvas.
 ///
@@ -50,6 +63,7 @@ class DetachedClipLayerData {
     required this.clip,
     required this.layerId,
     this.sourceOffset = Duration.zero,
+    this.chromaKey,
   });
 
   /// The detached clip.
@@ -61,6 +75,13 @@ class DetachedClipLayerData {
   /// Where this layer starts inside the clip, in playback time.
   final Duration sourceOffset;
 
+  /// The green screen applied to this layer live, or `null` for none.
+  ///
+  /// Separate from [DivineVideoClip.chromaKey] on purpose: that one records a
+  /// key already burned into the clip's file, while this one is applied on top
+  /// of whatever the file holds — see [detachedClipLayerChromaKeyKey].
+  final ClipChromaKey? chromaKey;
+
   /// Serializes to the map stored in `WidgetLayer.exportConfigs.meta`.
   ///
   /// Paths inside are basenames — [DivineVideoClip.toJson]'s contract — so the
@@ -71,6 +92,7 @@ class DetachedClipLayerData {
     detachedClipLayerDurationKey: clip.playbackDuration.inMicroseconds,
     detachedClipLayerIdKey: layerId,
     detachedClipLayerSourceOffsetKey: sourceOffset.inMicroseconds,
+    if (chromaKey case final key?) detachedClipLayerChromaKeyKey: key.toJson(),
   };
 
   /// Whether [meta] describes a detached clip rather than a sticker.
@@ -101,10 +123,85 @@ class DetachedClipLayerData {
         ),
         layerId: meta[detachedClipLayerIdKey] as String? ?? '',
         sourceOffset: sourceOffsetOf(meta) ?? Duration.zero,
+        chromaKey: chromaKeyOf(
+          meta,
+          documentsPath,
+          useOriginalPath: useOriginalPath,
+        ),
       );
     } on FormatException {
       return null;
     }
+  }
+
+  /// Whether [meta] is a detached clip carrying a live green screen.
+  ///
+  /// Reads the map alone, so the timeline's action bar can highlight the
+  /// action without resolving a documents path.
+  static bool hasChromaKey(Map<String, dynamic>? meta) =>
+      isDetachedClipMeta(meta) && meta![detachedClipLayerChromaKeyKey] is Map;
+
+  /// The live green screen [meta] carries, with its background image path
+  /// resolved against [documentsPath], or `null` when there is none.
+  ///
+  /// A key that cannot be read is treated as no key: the layer then plays
+  /// unkeyed rather than taking the whole layer down with it, the same
+  /// tolerance [fromMeta] applies to the clip payload.
+  static ClipChromaKey? chromaKeyOf(
+    Map<String, dynamic>? meta,
+    String documentsPath, {
+    bool useOriginalPath = false,
+  }) {
+    if (!isDetachedClipMeta(meta)) return null;
+    final raw = meta![detachedClipLayerChromaKeyKey];
+    if (raw is! Map) return null;
+    try {
+      return ClipChromaKey.fromJson(
+        Map<String, dynamic>.from(raw),
+        documentsPath,
+        useOriginalPath: useOriginalPath,
+      );
+    } catch (_) {
+      // A malformed key payload (a wrong type, an out-of-range tolerance) is
+      // dropped rather than rethrown, for the reason given above.
+      return null;
+    }
+  }
+
+  /// [meta] with its live green screen replaced by [chromaKey], or removed
+  /// when that is `null`.
+  ///
+  /// Edits the map rather than rebuilding through [fromMeta], so the clip
+  /// payload travels across untouched and no documents path is needed.
+  static Map<String, dynamic>? withChromaKey(
+    Map<String, dynamic>? meta,
+    ClipChromaKey? chromaKey,
+  ) {
+    if (!isDetachedClipMeta(meta)) return null;
+    final copy = {...meta!}..remove(detachedClipLayerChromaKeyKey);
+    if (chromaKey != null) {
+      copy[detachedClipLayerChromaKeyKey] = chromaKey.toJson();
+    }
+    return copy;
+  }
+
+  /// [meta] carrying [clip] in place of the clip it had.
+  ///
+  /// For a re-render that swaps the footage — a crop — but leaves the layer
+  /// itself alone: its id, where it starts inside the clip and its green
+  /// screen all stay as they were. Rebuilding the meta from the clip alone
+  /// would silently reset a split tail to the clip's first frame and drop the
+  /// key the user set.
+  static Map<String, dynamic>? withClip(
+    Map<String, dynamic>? meta,
+    DivineVideoClip clip,
+  ) {
+    if (!isDetachedClipMeta(meta)) return null;
+    return {
+      ...meta!,
+      detachedClipLayerClipKey: clip.toJson(),
+      detachedClipLayerDurationKey: clip.playbackDuration.inMicroseconds,
+    };
   }
 
   /// How long the clip plays, read straight from [meta].
@@ -216,9 +313,12 @@ class DetachedClipLayerData {
             final data = fromMeta(map, documentsPath);
             if (data != null) {
               paths.addAll(
-                data.clip.ownedFilePaths.whereType<String>().where(
-                  (path) => path.isNotEmpty,
-                ),
+                [
+                  ...data.clip.ownedFilePaths,
+                  // The layer's own key can point at a backdrop photo that no
+                  // clip references — it belongs to the layer, not the clip.
+                  data.chromaKey?.backgroundImagePath,
+                ].whereType<String>().where((path) => path.isNotEmpty),
               );
             }
           } on Object {

--- a/mobile/lib/models/video_editor/detached_clip_window.dart
+++ b/mobile/lib/models/video_editor/detached_clip_window.dart
@@ -1,0 +1,39 @@
+// ABOUTME: Where a freshly detached clip's layer sits on the timeline, kept
+// ABOUTME: inside the composition so the layer never lands past its end
+
+import 'dart:math' as math;
+
+/// The time window a clip's layer gets the moment it is detached.
+///
+/// [slotStart] is where the clip sat on the timeline, [playbackDuration] how
+/// long it plays, and [compositionDuration] how long the timeline is *after*
+/// the detach. With a placeholder left in the slot the timeline keeps its
+/// length and the window is simply the slot. With the slot closed the
+/// timeline shrank by the clip's own length, so a clip from the tail end would
+/// start at — or past — the new end and never be on screen: the last clip
+/// vanished into a window nothing plays. The window is pulled back so it ends
+/// on the composition's end instead, overlapping whatever now sits there,
+/// which is the closest the layer can get to where the clip was.
+///
+/// A composition shorter than the clip cuts the window to the composition;
+/// the export cuts the clip to its window in turn.
+({Duration start, Duration end}) detachedClipWindow({
+  required Duration slotStart,
+  required Duration playbackDuration,
+  required Duration compositionDuration,
+}) {
+  final latestStart = compositionDuration - playbackDuration;
+  final start = Duration(
+    microseconds: math.max(
+      0,
+      math.min(slotStart.inMicroseconds, latestStart.inMicroseconds),
+    ),
+  );
+  final end = Duration(
+    microseconds: math.min(
+      (start + playbackDuration).inMicroseconds,
+      compositionDuration.inMicroseconds,
+    ),
+  );
+  return (start: start, end: end);
+}

--- a/mobile/lib/screens/video_editor/video_clip_chroma_key_screen.dart
+++ b/mobile/lib/screens/video_editor/video_clip_chroma_key_screen.dart
@@ -31,24 +31,80 @@ import 'package:pro_video_editor/pro_video_editor.dart'
     show ChromaKey, EditorVideo, ProVideoEditor, ProgressModel;
 import 'package:unified_logger/unified_logger.dart';
 
+/// What the green-screen screen hands back for a detached clip.
+///
+/// A timeline clip's screen returns nothing — it bakes through the bloc and
+/// stays up until the render lands. A detached clip's key is never baked, so
+/// the screen pops with the settings instead and the caller writes them onto
+/// the layer.
+sealed class DetachedClipChromaKeyResult {
+  const DetachedClipChromaKeyResult();
+}
+
+/// The user confirmed [chromaKey] for the layer.
+class DetachedClipChromaKeyApplied extends DetachedClipChromaKeyResult {
+  const DetachedClipChromaKeyApplied(this.chromaKey);
+
+  final ClipChromaKey chromaKey;
+}
+
+/// The user took the layer's green screen off again.
+class DetachedClipChromaKeyRemoved extends DetachedClipChromaKeyResult {
+  const DetachedClipChromaKeyRemoved();
+}
+
 /// Sets up a clip's green screen.
 ///
-/// Tuning is free, driven by the preview shader. Confirming dispatches the
-/// bake to [ClipEditorBloc] and keeps the screen up — blocked, with the
-/// render's progress — until the clip's new file lands, so the user sees the
-/// work finish instead of being dropped back onto an unchanged timeline.
+/// Tuning is free, driven by the preview shader. For a timeline clip,
+/// confirming dispatches the bake to [ClipEditorBloc] and keeps the screen up
+/// — blocked, with the render's progress — until the clip's new file lands, so
+/// the user sees the work finish instead of being dropped back onto an
+/// unchanged timeline.
 ///
 /// Re-opening a clip that already has a key restores its settings and previews
 /// the footage as it was *before* the bake, so adjusting the key is a fresh
 /// pass over clean pixels rather than a second key stacked on the first.
+///
+/// [VideoClipChromaKeyScreen.detached] is the same screen for a clip that was
+/// detached onto the canvas. Nothing is baked there: the key stays live on the
+/// layer, applied by the canvas shader and by the export composition, so
+/// confirming pops with a [DetachedClipChromaKeyResult] straight away and the
+/// panel offers only the backdrops a live key can carry.
 class VideoClipChromaKeyScreen extends StatefulWidget {
   const VideoClipChromaKeyScreen({
     required this.clip,
     @visibleForTesting this.detect = ChromaKey.detect,
     super.key,
-  });
+  }) : _layerChromaKey = null,
+       surface = ChromaKeySurface.track;
+
+  /// The screen for a clip detached onto the canvas, starting from the
+  /// [chromaKey] its layer carries — `null` for a layer without one.
+  ///
+  /// The clip's own [DivineVideoClip.chromaKey] is deliberately not consulted:
+  /// if the clip was keyed while still on the timeline, that key is already in
+  /// its footage, and the layer's key goes on top of that.
+  const VideoClipChromaKeyScreen.detached({
+    required this.clip,
+    required ClipChromaKey? chromaKey,
+    @visibleForTesting this.detect = ChromaKey.detect,
+    super.key,
+  }) : _layerChromaKey = chromaKey,
+       surface = ChromaKeySurface.canvas;
 
   final DivineVideoClip clip;
+
+  final ClipChromaKey? _layerChromaKey;
+
+  /// Where the keyed clip sits, which decides how the result leaves the
+  /// screen and which backdrops the panel offers.
+  final ChromaKeySurface surface;
+
+  /// The key the screen opens on, or `null` to measure one off the footage.
+  ClipChromaKey? get initialChromaKey => switch (surface) {
+    ChromaKeySurface.track => clip.chromaKey,
+    ChromaKeySurface.canvas => _layerChromaKey,
+  };
 
   /// The screen-colour measurement implementation.
   ///
@@ -85,23 +141,39 @@ class _VideoClipChromaKeyScreenState extends State<VideoClipChromaKeyScreen> {
     super.initState();
     _cubit = ChromaKeyEditorCubit(
       video: EditorVideo.file(_previewPath),
-      initialChromaKey: widget.clip.chromaKey,
+      initialChromaKey: widget.initialChromaKey,
       detect: widget.detect,
     );
     unawaited(_initializePlayer());
   }
 
+  bool get _isDetached => widget.surface == ChromaKeySurface.canvas;
+
   /// Whether the pre-key footage is still on disk to preview and restore.
+  ///
+  /// Always false for a detached clip: its key is not in the footage, so there
+  /// is no earlier file to go back to.
   late final bool _hasKeySource = () {
+    if (_isDetached) return false;
     final source = widget.clip.chromaKeySourcePath;
     return source != null && File(source).existsSync();
   }();
 
+  /// Whether the clip already has a key this screen can take off again.
+  ///
+  /// Undoing a timeline clip's key is a file swap, so it needs the pre-key
+  /// footage on disk. A detached clip's key is a layer setting and can always
+  /// be removed.
+  bool get _canRemove => _isDetached
+      ? widget.initialChromaKey != null
+      : widget.clip.chromaKey != null && _hasKeySource;
+
   /// The footage the preview and the measurement run on.
   ///
-  /// For an already-keyed clip that is the pre-bake original: keying the baked
-  /// video again would show a key applied twice, and measuring it would sample
-  /// the replaced background instead of the screen.
+  /// For an already-keyed timeline clip that is the pre-bake original: keying
+  /// the baked video again would show a key applied twice, and measuring it
+  /// would sample the replaced background instead of the screen. A detached
+  /// clip's key sits on top of its footage as it is, so that is what is shown.
   String get _previewPath {
     final source = widget.clip.chromaKeySourcePath;
     if (source != null && _hasKeySource) return source;
@@ -292,9 +364,13 @@ class _VideoClipChromaKeyScreenState extends State<VideoClipChromaKeyScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final bakingRenderId = context.select<ClipEditorBloc, String?>(
-      (bloc) => _bakeInFlight(bloc.state),
-    );
+    // A detached clip never bakes, and its route carries no clip bloc: the
+    // key leaves through the pop instead.
+    final bakingRenderId = _isDetached
+        ? null
+        : context.select<ClipEditorBloc, String?>(
+            (bloc) => _bakeInFlight(bloc.state),
+          );
     final isBaking = bakingRenderId != null;
 
     return BlocProvider<ChromaKeyEditorCubit>.value(
@@ -326,15 +402,16 @@ class _VideoClipChromaKeyScreenState extends State<VideoClipChromaKeyScreen> {
                         .acknowledgeDetectionFailure();
                   },
                 ),
-                BlocListener<ClipEditorBloc, ClipEditorState>(
-                  listenWhen: (previous, current) =>
-                      !identical(
-                        previous.lastChromaKeyResult,
-                        current.lastChromaKeyResult,
-                      ) &&
-                      current.lastChromaKeyResult != null,
-                  listener: _onBakeResult,
-                ),
+                if (!_isDetached)
+                  BlocListener<ClipEditorBloc, ClipEditorState>(
+                    listenWhen: (previous, current) =>
+                        !identical(
+                          previous.lastChromaKeyResult,
+                          current.lastChromaKeyResult,
+                        ) &&
+                        current.lastChromaKeyResult != null,
+                    listener: _onBakeResult,
+                  ),
               ],
               child: Stack(
                 children: [
@@ -358,15 +435,17 @@ class _VideoClipChromaKeyScreenState extends State<VideoClipChromaKeyScreen> {
                       ),
                       Expanded(
                         child: _Preview(
-                          aspectRatio: widget.clip.targetAspectRatio.value,
+                          // A detached clip is a free-floating box in its
+                          // own shape; a timeline clip fills the
+                          // composition's frame.
+                          aspectRatio: _isDetached
+                              ? widget.clip.originalAspectRatio
+                              : widget.clip.targetAspectRatio.value,
                           player: _player,
                           backdropSync: _player == null ? null : _backdropSync,
                         ),
                       ),
-                      // Undoing a key is a file swap, not a render — the clip
-                      // kept the footage it was applied to. Only offered when
-                      // that footage is still there to go back to.
-                      if (widget.clip.chromaKey != null && _hasKeySource)
+                      if (_canRemove)
                         Padding(
                           padding: const EdgeInsets.symmetric(horizontal: 16),
                           child: DivineButton(
@@ -380,6 +459,7 @@ class _VideoClipChromaKeyScreenState extends State<VideoClipChromaKeyScreen> {
                       Flexible(
                         child: ChromaKeyControls(
                           onPickBackground: _pickBackground,
+                          surface: widget.surface,
                         ),
                       ),
                     ],
@@ -396,9 +476,16 @@ class _VideoClipChromaKeyScreenState extends State<VideoClipChromaKeyScreen> {
   }
 
   void _confirm(BuildContext context) {
+    final chromaKey = _cubit.state.chromaKey;
+    if (_isDetached) {
+      // Nothing to render: the layer takes the settings as they are, so the
+      // image they point at is the one to keep.
+      _keptImagePath = chromaKey.backgroundImagePath;
+      Navigator.of(context).pop(DetachedClipChromaKeyApplied(chromaKey));
+      return;
+    }
     // The bloc owns the render so it survives this screen; the screen stays up
     // and blocked until the result lands, which is what makes the wait legible.
-    final chromaKey = _cubit.state.chromaKey;
     _pendingImagePath = chromaKey.backgroundImagePath;
     context.read<ClipEditorBloc>().add(
       ClipEditorChromaKeyRequested(
@@ -413,6 +500,10 @@ class _VideoClipChromaKeyScreenState extends State<VideoClipChromaKeyScreen> {
     // no background image survives it — including one an earlier failed bake
     // had queued.
     _pendingImagePath = null;
+    if (_isDetached) {
+      Navigator.of(context).pop(const DetachedClipChromaKeyRemoved());
+      return;
+    }
     context.read<ClipEditorBloc>().add(
       ClipEditorChromaKeyRemoved(widget.clip.id),
     );

--- a/mobile/lib/services/video_editor/detached_clip_composite.dart
+++ b/mobile/lib/services/video_editor/detached_clip_composite.dart
@@ -4,6 +4,7 @@
 import 'dart:ui' show Offset, Size;
 
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/clip_chroma_key.dart';
 import 'package:openvine/models/video_editor/detached_clip_layer.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:pro_image_editor/pro_image_editor.dart'
@@ -18,6 +19,7 @@ class DetachedClipExportLayer {
     required this.layer,
     required this.logicalSize,
     this.sourceOffset = Duration.zero,
+    this.chromaKey,
   });
 
   /// The clip's own media, with its trim, volume and speed.
@@ -32,6 +34,13 @@ class DetachedClipExportLayer {
   /// Where this layer starts inside the clip, in playback time — non-zero for
   /// the tail half of a split.
   final Duration sourceOffset;
+
+  /// The green screen the layer applies live, or `null` for none.
+  ///
+  /// Keyed by the composition as the clip is placed over the base track, so
+  /// the removed area shows the track underneath — the one place a transparent
+  /// key can be honoured literally, since H.264 carries no alpha of its own.
+  final ClipChromaKey? chromaKey;
 }
 
 /// The captured layers sorted into what renders under the detached clips, the
@@ -82,6 +91,7 @@ PartitionedLayers partitionDetachedClipLayers(
         layer: item.layer,
         logicalSize: item.logicalSize,
         sourceOffset: data!.sourceOffset,
+        chromaKey: data.chromaKey,
       ),
     );
   }
@@ -103,6 +113,13 @@ PartitionedLayers partitionDetachedClipLayers(
 /// Time is mapped through [timelineMap] like every other overlay window: an
 /// overlap transition shortens the output, and without the mapping a clip near
 /// the end would be placed past the real video end.
+///
+/// A live green screen goes on the layer as its `chromaKey`. The composition
+/// keys each clip on its own frame before placing it, so a transparent key
+/// lets the base track show through the removed area; a colour or image fill
+/// travels inside the key itself. A library-clip backdrop has no second track
+/// to play on here and is not offered for a detached clip — were one to arrive
+/// anyway, its key is transparent and the track shows through instead.
 VideoLayer buildDetachedClipVideoLayer({
   required DetachedClipExportLayer item,
   required EditorVideo resolvedVideo,
@@ -150,6 +167,7 @@ VideoLayer buildDetachedClipVideoLayer({
   final span = windowed < available ? windowed : available;
 
   return VideoLayer(
+    chromaKey: item.chromaKey?.key,
     clips: [
       VideoSegment(
         video: resolvedVideo,

--- a/mobile/lib/widgets/video_editor/chroma_key/chroma_key_backdrop.dart
+++ b/mobile/lib/widgets/video_editor/chroma_key/chroma_key_backdrop.dart
@@ -47,6 +47,7 @@ class ChromaKeyBackdrop extends StatelessWidget {
   const ChromaKeyBackdrop({
     required this.chromaKey,
     this.sync,
+    this.previewTransparency = true,
     super.key,
   });
 
@@ -56,6 +57,14 @@ class ChromaKeyBackdrop extends StatelessWidget {
   /// [ChromaKeyBackdropSync].
   final ChromaKeyBackdropSync? sync;
 
+  /// Whether "nothing behind the subject" is drawn as a checkerboard.
+  ///
+  /// Off when the widget sits on the editor canvas, where what is underneath is
+  /// the real backdrop and must stay visible — see
+  /// `ChromaKeyedVideo.previewTransparency`. Also covers a backdrop whose own
+  /// source is gone, which reads as "nothing" either way.
+  final bool previewTransparency;
+
   @override
   Widget build(BuildContext context) {
     final backgroundColor = chromaKey.key.backgroundColor;
@@ -64,17 +73,21 @@ class ChromaKeyBackdrop extends StatelessWidget {
     final imagePath = chromaKey.key.backgroundImage?.file?.path;
     final videoPath = chromaKey.backgroundVideoPath;
 
+    final transparent = previewTransparency
+        ? const ChromaKeyTransparencyCheckerboard()
+        : const SizedBox.shrink();
+
     return switch (chromaKey.backgroundType) {
       ClipChromaKeyBackgroundType.color when backgroundColor != null =>
         ColoredBox(color: backgroundColor),
       ClipChromaKeyBackgroundType.image when imagePath != null =>
-        _ImageBackdrop(path: imagePath),
+        _ImageBackdrop(path: imagePath, fallback: transparent),
       ClipChromaKeyBackgroundType.video when videoPath != null =>
         _VideoBackdrop(path: videoPath, sync: sync),
       // Transparent — and the degenerate cases where a background type's own
       // source went missing (a deleted library clip, a pruned cache file),
       // which read as "no backdrop" rather than as a crash.
-      _ => const ChromaKeyTransparencyCheckerboard(),
+      _ => transparent,
     };
   }
 }
@@ -82,18 +95,20 @@ class ChromaKeyBackdrop extends StatelessWidget {
 /// A still image backdrop, stretched to the frame the way the renderer
 /// stretches the key's background image.
 class _ImageBackdrop extends StatelessWidget {
-  const _ImageBackdrop({required this.path});
+  const _ImageBackdrop({required this.path, required this.fallback});
 
   final String path;
+
+  /// Shown in place of a file that cannot be loaded, so the user still sees
+  /// the matte — which is the point of the preview.
+  final Widget fallback;
 
   @override
   Widget build(BuildContext context) {
     return Image.file(
       File(path),
       fit: BoxFit.fill,
-      // A missing file degrades to the checkerboard: the user still sees the
-      // matte, which is the point of the preview.
-      errorBuilder: (_, _, _) => const ChromaKeyTransparencyCheckerboard(),
+      errorBuilder: (_, _, _) => fallback,
     );
   }
 }

--- a/mobile/lib/widgets/video_editor/chroma_key/chroma_key_controls.dart
+++ b/mobile/lib/widgets/video_editor/chroma_key/chroma_key_controls.dart
@@ -10,13 +10,39 @@ import 'package:openvine/models/video_editor/clip_chroma_key.dart';
 import 'package:openvine/widgets/video_editor/chroma_key/chroma_key_shader.dart';
 import 'package:openvine/widgets/video_editor/video_editor_color_picker_sheet.dart';
 
+/// What the clip being keyed sits on, which decides what "Nothing" behind the
+/// subject means and which backdrops can be offered.
+enum ChromaKeySurface {
+  /// The clip is the timeline track, and the key is baked into its file.
+  ///
+  /// Nothing lies below the track, so a transparent key flattens to black in
+  /// the H.264 file — which the panel warns about — and a library clip can be
+  /// put behind the subject by baking a second track under it.
+  track,
+
+  /// The clip is a layer over the editor canvas, and the key is applied live.
+  ///
+  /// A transparent key lets whatever is underneath show through, which is the
+  /// point of detaching a green-screen clip. A library clip is not offered:
+  /// the key goes on the layer at export rather than into a file, and a layer
+  /// has no second track of its own to play a backdrop on.
+  canvas,
+}
+
 /// Everything below the preview on the chroma-key screen.
 class ChromaKeyControls extends StatelessWidget {
-  const ChromaKeyControls({required this.onPickBackground, super.key});
+  const ChromaKeyControls({
+    required this.onPickBackground,
+    this.surface = ChromaKeySurface.track,
+    super.key,
+  });
 
   /// Opens the picker for [type]. Owned by the screen because an image is shot
   /// with the camera and a video comes from the clip library.
   final ValueChanged<ClipChromaKeyBackgroundType> onPickBackground;
+
+  /// What the keyed clip sits on. See [ChromaKeySurface].
+  final ChromaKeySurface surface;
 
   @override
   Widget build(BuildContext context) {
@@ -33,7 +59,10 @@ class ChromaKeyControls extends StatelessWidget {
           const _Gutter(child: _ToleranceSliders()),
           // Unpadded: the section insets its own text but lets the chips
           // scroll past the gutter to the screen edge.
-          _BackgroundSection(onPickBackground: onPickBackground),
+          _BackgroundSection(
+            onPickBackground: onPickBackground,
+            surface: surface,
+          ),
         ],
       ),
     );
@@ -370,9 +399,22 @@ class _LabeledSlider extends StatelessWidget {
 
 /// Picks what fills the area the key removed.
 class _BackgroundSection extends StatelessWidget {
-  const _BackgroundSection({required this.onPickBackground});
+  const _BackgroundSection({
+    required this.onPickBackground,
+    required this.surface,
+  });
 
   final ValueChanged<ClipChromaKeyBackgroundType> onPickBackground;
+  final ChromaKeySurface surface;
+
+  /// The backdrops that can be offered on [surface].
+  List<ClipChromaKeyBackgroundType> get _options => switch (surface) {
+    ChromaKeySurface.track => ClipChromaKeyBackgroundType.values,
+    ChromaKeySurface.canvas =>
+      ClipChromaKeyBackgroundType.values
+          .where((type) => type != ClipChromaKeyBackgroundType.video)
+          .toList(growable: false),
+  };
 
   @override
   Widget build(BuildContext context) {
@@ -404,7 +446,7 @@ class _BackgroundSection extends StatelessWidget {
           child: Row(
             spacing: 8,
             children: [
-              for (final option in ClipChromaKeyBackgroundType.values)
+              for (final option in _options)
                 _BackgroundChip(
                   option: option,
                   isSelected: option == type,
@@ -416,7 +458,15 @@ class _BackgroundSection extends StatelessWidget {
         if (type == ClipChromaKeyBackgroundType.transparent)
           _Gutter(
             child: Text(
-              context.l10n.videoEditorChromaKeyTransparentHint,
+              // A warning on the track, where the removed area exports as
+              // black; a reassurance on the canvas, where it really is
+              // see-through.
+              switch (surface) {
+                ChromaKeySurface.track =>
+                  context.l10n.videoEditorChromaKeyTransparentHint,
+                ChromaKeySurface.canvas =>
+                  context.l10n.videoEditorChromaKeyCanvasTransparentHint,
+              },
               // `onSurfaceMuted` is only 3.05:1 on the light canvas, so this
               // hint takes the variant token instead of the muted one.
               style: VineTheme.bodySmallFont(

--- a/mobile/lib/widgets/video_editor/chroma_key/chroma_keyed_video.dart
+++ b/mobile/lib/widgets/video_editor/chroma_key/chroma_keyed_video.dart
@@ -23,6 +23,7 @@ class ChromaKeyedVideo extends StatefulWidget {
     required this.child,
     this.chromaKey,
     this.backdropSync,
+    this.previewTransparency = true,
     super.key,
   });
 
@@ -32,6 +33,16 @@ class ChromaKeyedVideo extends StatefulWidget {
   /// Keeps a video backdrop in step with [child] instead of letting the two
   /// drift. See [ChromaKeyBackdropSync].
   final ChromaKeyBackdropSync? backdropSync;
+
+  /// Whether a transparent key is shown over a checkerboard, the way an image
+  /// editor stands in for "nothing here".
+  ///
+  /// On by default, for the green-screen screen: its preview has nothing real
+  /// behind the clip, so the checkerboard is what makes the matte legible. Off
+  /// on the editor canvas, where a detached clip sits over the composition and
+  /// whatever is underneath *is* the backdrop — a checkerboard there would hide
+  /// exactly what the key is meant to reveal.
+  final bool previewTransparency;
 
   @override
   State<ChromaKeyedVideo> createState() => _ChromaKeyedVideoState();
@@ -114,6 +125,7 @@ class _ChromaKeyedVideoState extends State<ChromaKeyedVideo> {
           child: ChromaKeyBackdrop(
             chromaKey: chromaKey,
             sync: widget.backdropSync,
+            previewTransparency: widget.previewTransparency,
           ),
         ),
         ImageFiltered(

--- a/mobile/lib/widgets/video_editor/detached_clip/detached_clip_chroma_key.dart
+++ b/mobile/lib/widgets/video_editor/detached_clip/detached_clip_chroma_key.dart
@@ -1,0 +1,87 @@
+// ABOUTME: Green-screen action for a clip detached onto the canvas
+// ABOUTME: Opens the chroma-key screen and writes the live key onto its layer
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:openvine/models/video_editor/clip_chroma_key.dart';
+import 'package:openvine/models/video_editor/detached_clip_layer.dart';
+import 'package:openvine/screens/video_editor/video_clip_chroma_key_screen.dart';
+import 'package:openvine/utils/path_resolver.dart';
+import 'package:openvine/widgets/video_editor/detached_clip/detached_clip_layer_view.dart';
+import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
+import 'package:pro_image_editor/pro_image_editor.dart' show Layer, WidgetLayer;
+
+/// Opens the green-screen editor for the detached clip on [layer] and writes
+/// the result onto that layer.
+///
+/// The same screen a timeline clip gets, with one difference in what happens
+/// on confirm: nothing is rendered. A timeline clip bakes its key into a new
+/// file because a single H.264 track has nothing underneath for a transparent
+/// key to reveal. A detached clip is composited over the finished track at
+/// export, so its key stays a *setting* on the layer — applied live by the
+/// canvas shader and by the export composition — and the removed area is
+/// genuinely see-through, which is what detaching a green-screen clip is for.
+///
+/// The write-back is one editor-history entry, so undo restores the previous
+/// key (or the absence of one) together with everything else on the layer.
+Future<void> editDetachedClipChromaKey(
+  BuildContext context,
+  Layer layer,
+) async {
+  final meta = DetachedClipLayerData.metaOf(layer);
+  if (meta == null) return;
+
+  // Captured before the await: the scope is an inherited widget, and reading
+  // it through a context that may have unmounted while the screen was up is
+  // what the mounted check below cannot save.
+  final scope = VideoEditorScope.of(context);
+  final documentsPath = await getDocumentsPath();
+  if (!context.mounted) return;
+
+  final data = DetachedClipLayerData.fromMeta(meta, documentsPath);
+  final clip = data?.clip;
+  if (clip == null || clip.video?.file?.path == null) return;
+
+  final result = await Navigator.of(context).push<DetachedClipChromaKeyResult>(
+    PageRouteBuilder<DetachedClipChromaKeyResult>(
+      settings: const RouteSettings(name: 'detached_clip_chroma_key'),
+      opaque: false,
+      barrierColor: VineTheme.backgroundCamera,
+      pageBuilder: (_, _, _) => VideoClipChromaKeyScreen.detached(
+        clip: clip,
+        chromaKey: data!.chromaKey,
+      ),
+      transitionsBuilder: (_, animation, _, child) =>
+          FadeTransition(opacity: animation, child: child),
+    ),
+  );
+  if (result == null) return;
+
+  final editor = scope.editor;
+  if (editor == null) return;
+  final index = editor.activeLayers.indexWhere((l) => l.id == layer.id);
+  if (index < 0) return;
+  final current = editor.activeLayers[index];
+  if (current is! WidgetLayer) return;
+
+  final ClipChromaKey? chromaKey = switch (result) {
+    DetachedClipChromaKeyApplied(:final chromaKey) => chromaKey,
+    DetachedClipChromaKeyRemoved() => null,
+  };
+  // Edited from the layer's *current* meta rather than the one captured
+  // above, so a crop that landed while the screen was open is kept.
+  final updated = DetachedClipLayerData.withChromaKey(
+    DetachedClipLayerData.metaOf(current),
+    chromaKey,
+  );
+  if (updated == null) return;
+
+  editor.replaceLayer(
+    index: index,
+    layer: current.copyWith(
+      widget: DetachedClipLayerView(meta: updated),
+      meta: updated,
+      exportConfigs: current.exportConfigs.copyWith(meta: updated),
+    ),
+  );
+}

--- a/mobile/lib/widgets/video_editor/detached_clip/detached_clip_layer_view.dart
+++ b/mobile/lib/widgets/video_editor/detached_clip/detached_clip_layer_view.dart
@@ -4,14 +4,17 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:collection/collection.dart' show DeepCollectionEquality;
 import 'package:divine_ui/divine_ui.dart';
 import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/clip_chroma_key.dart';
 import 'package:openvine/models/video_editor/detached_clip_layer.dart';
 import 'package:openvine/utils/path_resolver.dart';
+import 'package:openvine/widgets/video_editor/chroma_key/chroma_keyed_video.dart';
 import 'package:openvine/widgets/video_editor/detached_clip/detached_clip_player.dart';
 import 'package:openvine/widgets/video_editor/detached_clip/detached_clip_player_registry.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
@@ -96,6 +99,13 @@ class DetachedClipLayerView extends StatefulWidget {
 
 class _DetachedClipLayerViewState extends State<DetachedClipLayerView> {
   DivineVideoClip? _clip;
+
+  /// The layer's live green screen, resolved from the meta alongside the clip.
+  ///
+  /// Held here rather than parsed in `build`: the preview rebuilds its shader
+  /// whenever the key object changes, and a fresh parse per build would hand
+  /// it a new one every frame of a drag.
+  ClipChromaKey? _chromaKey;
   DetachedClipPlayer? _player;
 
   /// The registry key currently held, so the release matches the acquire even
@@ -122,20 +132,30 @@ class _DetachedClipLayerViewState extends State<DetachedClipLayerView> {
     // first frame after the remount draws the video and nothing flashes.
     final key = detachedClipPlayerKey(widget.meta);
     final ready = key == null ? null : detachedClipPlayers.acquireIfReady(key);
+    final documentsPath = cachedDocumentsPath;
     if (ready != null) {
       _heldKey = key;
       _player = ready;
       _clip = ready.clip;
       _resumed = true;
+      // The player carries the clip but not the layer's key, which is the
+      // layer's own and has to be read off the meta the remount arrived with.
+      if (documentsPath != null) {
+        _chromaKey = DetachedClipLayerData.chromaKeyOf(
+          widget.meta,
+          documentsPath,
+        );
+      }
       return;
     }
     // No pooled player — but the clip itself is usually resolvable without an
     // await, and drawing its poster in the first frame is what makes an undo
     // put the layer straight back. Without it the layer is an empty box until
     // the decoder opens, which reads as the undo having lost it.
-    final documentsPath = cachedDocumentsPath;
     if (documentsPath != null) {
-      _clip = DetachedClipLayerData.fromMeta(widget.meta, documentsPath)?.clip;
+      final data = DetachedClipLayerData.fromMeta(widget.meta, documentsPath);
+      _clip = data?.clip;
+      _chromaKey = data?.chromaKey;
     }
     unawaited(_load());
   }
@@ -149,7 +169,28 @@ class _DetachedClipLayerViewState extends State<DetachedClipLayerView> {
     if (detachedClipPlayerKey(oldWidget.meta) !=
         detachedClipPlayerKey(widget.meta)) {
       unawaited(_load());
+    } else if (!_chromaKeyEquality.equals(
+      oldWidget.meta[detachedClipLayerChromaKeyKey],
+      widget.meta[detachedClipLayerChromaKeyKey],
+    )) {
+      // Only the green screen changed: re-read it without touching the
+      // player, which would restart the clip on every slider nudge.
+      unawaited(_reloadChromaKey());
     }
+  }
+
+  static const _chromaKeyEquality = DeepCollectionEquality();
+
+  Future<void> _reloadChromaKey() async {
+    final generation = _loadGeneration;
+    final documentsPath = await getDocumentsPath();
+    if (!mounted || generation != _loadGeneration) return;
+    setState(() {
+      _chromaKey = DetachedClipLayerData.chromaKeyOf(
+        widget.meta,
+        documentsPath,
+      );
+    });
   }
 
   @override
@@ -222,15 +263,16 @@ class _DetachedClipLayerViewState extends State<DetachedClipLayerView> {
     final documentsPath = await getDocumentsPath();
     if (superseded()) return;
 
-    final clip = DetachedClipLayerData.fromMeta(
-      widget.meta,
-      documentsPath,
-    )?.clip;
+    final data = DetachedClipLayerData.fromMeta(widget.meta, documentsPath);
+    final clip = data?.clip;
     if (clip == null || key == null) {
       if (previousKey != null) detachedClipPlayers.release(previousKey);
       return;
     }
-    setState(() => _clip = clip);
+    setState(() {
+      _clip = clip;
+      _chromaKey = data?.chromaKey;
+    });
 
     final player = await detachedClipPlayers.acquire(
       key,
@@ -263,7 +305,11 @@ class _DetachedClipLayerViewState extends State<DetachedClipLayerView> {
     if (player == null || playhead == null) {
       return _DetachedClipFrame(
         clip: clip,
-        child: _ClipThumbnail(clip: clip),
+        child: ChromaKeyedVideo(
+          chromaKey: _chromaKey,
+          previewTransparency: false,
+          child: _ClipThumbnail(clip: clip),
+        ),
       );
     }
 
@@ -277,25 +323,33 @@ class _DetachedClipLayerViewState extends State<DetachedClipLayerView> {
       onChanged: _follow,
       child: _DetachedClipFrame(
         clip: clip,
-        // The poster sits under the surface rather than beside it, so a frame
-        // the texture has not painted yet shows the clip's own still instead
-        // of a hole. The player is mounted once and kept: rebuilding it per
-        // playhead tick — 60 times a second — is what a `builder` around it
-        // would do.
-        child: Stack(
-          fit: StackFit.expand,
-          children: [
-            _ClipThumbnail(clip: clip),
-            _WindowVisibility(
-              playhead: playhead,
-              isVisible: player.isWithinWindow,
-              child: DivineVideoPlayer(
-                controller: player.controller,
-                placeholder: _resumed ? null : _ClipThumbnail(clip: clip),
-                crossFadePlaceholder: !_resumed,
+        // The key wraps the poster as well as the surface: both show the same
+        // footage, and a poster left unkeyed would fill the removed area with
+        // the very screen the key takes out. Transparent stays transparent —
+        // the canvas underneath is the backdrop here, not a checkerboard.
+        child: ChromaKeyedVideo(
+          chromaKey: _chromaKey,
+          previewTransparency: false,
+          // The poster sits under the surface rather than beside it, so a
+          // frame the texture has not painted yet shows the clip's own still
+          // instead of a hole. The player is mounted once and kept:
+          // rebuilding it per playhead tick — 60 times a second — is what a
+          // `builder` around it would do.
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              _ClipThumbnail(clip: clip),
+              _WindowVisibility(
+                playhead: playhead,
+                isVisible: player.isWithinWindow,
+                child: DivineVideoPlayer(
+                  controller: player.controller,
+                  placeholder: _resumed ? null : _ClipThumbnail(clip: clip),
+                  crossFadePlaceholder: !_resumed,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls.dart
@@ -13,6 +13,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/timeline_overlay_item.dart';
 import 'package:openvine/models/video_editor/detached_clip_layer.dart';
 import 'package:openvine/screens/video_editor/video_audio_editor_timing_screen.dart';
+import 'package:openvine/widgets/video_editor/detached_clip/detached_clip_chroma_key.dart';
 import 'package:openvine/widgets/video_editor/detached_clip/detached_clip_layer_view.dart';
 import 'package:openvine/widgets/video_editor/detached_clip/detached_clip_transform.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
@@ -93,6 +94,17 @@ class _LayerOverlayControls extends StatelessWidget {
       onTransform: isDetachedClip
           ? () => transformDetachedClip(context, layer)
           : null,
+      // Green screen, for a detached clip only — and, unlike the timeline's,
+      // never baked: the export composites the layer over the track, so the
+      // removed area can be left genuinely see-through.
+      onChromaKey: isDetachedClip
+          ? () => editDetachedClipChromaKey(context, layer)
+          : null,
+      hasChromaKey:
+          isDetachedClip &&
+          DetachedClipLayerData.hasChromaKey(
+            DetachedClipLayerData.metaOf(layer),
+          ),
       // Animations are off for a detached clip: the export composites it as a
       // `VideoLayer`, and neither that nor the `VideoSegment` under it carries
       // an `animations` field the way a rasterized `ImageLayer` does. Offering

--- a/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
@@ -495,7 +495,14 @@ class _DetachedClipTransformResultListener extends StatelessWidget {
     final layer = editor.activeLayers[index];
     if (layer is! WidgetLayer) return;
 
-    final meta = DetachedClipLayerData(clip: clip, layerId: layerId).toMeta();
+    // Only the clip is swapped. The layer's own settings — where a split tail
+    // starts inside the clip, and its live green screen — describe the layer,
+    // not the footage, and a crop changes neither.
+    final meta = DetachedClipLayerData.withClip(
+      DetachedClipLayerData.metaOf(layer),
+      clip,
+    );
+    if (meta == null) return;
 
     // The layer keeps its width; the crop changes the content's aspect ratio,
     // so the height follows on its own through the frame that lays it out. A

--- a/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
@@ -12,6 +12,7 @@ import 'package:openvine/extensions/video_editor_history_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/detached_clip_layer.dart';
+import 'package:openvine/models/video_editor/detached_clip_window.dart';
 import 'package:openvine/widgets/branded_loading_scaffold.dart';
 import 'package:openvine/widgets/video_editor/detached_clip/detached_clip_layer_view.dart';
 import 'package:openvine/widgets/video_editor/draw_editor/video_editor_draw_bottom_bar.dart';
@@ -406,9 +407,18 @@ class _ClipDetachResultListener extends StatelessWidget {
     // time, is hidden outside it, and the export draws it over exactly the same
     // stretch. Without a window the clip sat frozen on its last frame for the
     // rest of the composition while the export showed nothing there.
+    //
+    // Measured against the composition as it is *now*: closing the slot
+    // shortened it, and a slot at the old tail end would otherwise sit past
+    // the new end where nothing plays it.
     final slotStart = previousClips
         .takeWhile((c) => c.id != detachedClip.id)
         .fold(Duration.zero, (total, c) => total + c.playbackDuration);
+    final window = detachedClipWindow(
+      slotStart: slotStart,
+      playbackDuration: detachedClip.playbackDuration,
+      compositionDuration: state.totalDuration,
+    );
 
     final layerId = 'detached_${detachedClip.id}';
     final meta = DetachedClipLayerData(
@@ -417,8 +427,8 @@ class _ClipDetachResultListener extends StatelessWidget {
     ).toMeta();
     final layer = WidgetLayer(
       id: layerId,
-      startTime: slotStart,
-      endTime: slotStart + detachedClip.playbackDuration,
+      startTime: window.start,
+      endTime: window.end,
       width: width,
       widget: DetachedClipLayerView(meta: meta),
       meta: meta,

--- a/mobile/test/models/video_editor/detached_clip_layer_test.dart
+++ b/mobile/test/models/video_editor/detached_clip_layer_test.dart
@@ -2,9 +2,11 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/clip_chroma_key.dart';
 import 'package:openvine/models/video_editor/detached_clip_layer.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
-import 'package:pro_video_editor/pro_video_editor.dart' show EditorVideo;
+import 'package:pro_video_editor/pro_video_editor.dart'
+    show ChromaKey, EditorLayerImage, EditorVideo;
 
 DivineVideoClip _clip({
   String id = 'clip-1',
@@ -77,6 +79,36 @@ void main() {
       },
     );
 
+    test(
+      "protects the backdrop photo a layer's own green screen points at",
+      () {
+        final history = <String, dynamic>{
+          'history': [
+            {
+              'layers': [
+                DetachedClipLayerData(
+                  clip: _clip(filePath: '/old/clip-1.mp4'),
+                  layerId: 'layer-1',
+                  chromaKey: ClipChromaKey(
+                    key: ChromaKey(
+                      backgroundImage: EditorLayerImage.file('/old/wall.png'),
+                    ),
+                  ),
+                ).toMeta(),
+              ],
+            },
+          ],
+        };
+
+        // No clip references the photo — it belongs to the layer's key — so
+        // without this the draft sweep would reap it.
+        expect(
+          DetachedClipLayerData.ownedFilePathsInHistory(history, '/documents'),
+          {'/documents/clip-1.mp4', '/documents/wall.png'},
+        );
+      },
+    );
+
     group('toMeta', () {
       test('marks the map as a detached clip and carries the clip', () {
         final meta = DetachedClipLayerData(
@@ -118,6 +150,7 @@ void main() {
         expect(restored.clip.video?.file?.path, '/new-docs/clip-1.mp4');
         expect(restored.clip.trimStart, const Duration(seconds: 1));
         expect(restored.clip.volume, 0.5);
+        expect(restored.chromaKey, isNull);
       });
 
       test('returns null for a sticker meta', () {
@@ -144,6 +177,171 @@ void main() {
             detachedClipLayerKindKey: detachedClipLayerKind,
             detachedClipLayerClipKey: 'nonsense',
           }, '/docs'),
+          isNull,
+        );
+      });
+    });
+
+    group('chromaKey', () {
+      final keyed = DetachedClipLayerData(
+        clip: _clip(),
+        layerId: 'layer-1',
+        chromaKey: ClipChromaKey(
+          key: ChromaKey(
+            color: const Color(0xFF19A55B),
+            similarity: 0.1,
+            backgroundImage: EditorLayerImage.file('/old/wall.png'),
+          ),
+        ),
+      ).toMeta();
+
+      test('round-trips through the meta, re-anchoring the backdrop photo', () {
+        final restored = DetachedClipLayerData.fromMeta(keyed, '/new-docs');
+
+        final key = restored!.chromaKey!.key;
+        expect(key.color, const Color(0xFF19A55B));
+        expect(key.similarity, 0.1);
+        // Stored as a basename like every other clip asset, so an iOS
+        // container move cannot strand the layer's backdrop.
+        expect(
+          restored.chromaKey!.backgroundImagePath,
+          '/new-docs/wall.png',
+        );
+      });
+
+      test('hasChromaKey reads the map without resolving paths', () {
+        expect(DetachedClipLayerData.hasChromaKey(keyed), isTrue);
+        expect(
+          DetachedClipLayerData.hasChromaKey(
+            DetachedClipLayerData(clip: _clip(), layerId: 'l').toMeta(),
+          ),
+          isFalse,
+        );
+        expect(
+          DetachedClipLayerData.hasChromaKey({'kind': 'sticker'}),
+          isFalse,
+        );
+      });
+
+      test('drops an unreadable key rather than the whole layer', () {
+        final corrupt = {...keyed, detachedClipLayerChromaKeyKey: 'nope'};
+
+        final restored = DetachedClipLayerData.fromMeta(corrupt, '/docs');
+
+        expect(restored, isNotNull);
+        expect(restored!.clip.id, 'clip-1');
+        expect(restored.chromaKey, isNull);
+      });
+
+      test('withChromaKey puts a key on a layer that had none', () {
+        final meta = DetachedClipLayerData(
+          clip: _clip(),
+          layerId: 'layer-1',
+          sourceOffset: const Duration(seconds: 2),
+        ).toMeta();
+
+        final updated = DetachedClipLayerData.withChromaKey(
+          meta,
+          const ClipChromaKey(key: ChromaKey.blueScreen()),
+        );
+
+        expect(DetachedClipLayerData.hasChromaKey(updated), isTrue);
+        expect(
+          DetachedClipLayerData.fromMeta(
+            updated,
+            '/docs',
+          )!.chromaKey!.key.color,
+          const ChromaKey.blueScreen().color,
+        );
+        // The rest of the layer is untouched.
+        expect(DetachedClipLayerData.layerIdOf(updated), 'layer-1');
+        expect(
+          DetachedClipLayerData.sourceOffsetOf(updated),
+          const Duration(seconds: 2),
+        );
+        expect(
+          updated![detachedClipLayerClipKey],
+          meta[detachedClipLayerClipKey],
+        );
+      });
+
+      test('withChromaKey takes the key off again', () {
+        final updated = DetachedClipLayerData.withChromaKey(keyed, null);
+
+        expect(DetachedClipLayerData.hasChromaKey(updated), isFalse);
+        expect(updated, isNot(contains(detachedClipLayerChromaKeyKey)));
+      });
+
+      test('withChromaKey leaves a sticker alone', () {
+        expect(
+          DetachedClipLayerData.withChromaKey({'kind': 'sticker'}, null),
+          isNull,
+        );
+      });
+
+      test('rebase carries the key onto a copy', () {
+        final copy = DetachedClipLayerData.rebase(keyed, layerId: 'copy');
+
+        expect(DetachedClipLayerData.hasChromaKey(copy), isTrue);
+      });
+    });
+
+    group('withClip', () {
+      test("swaps the footage and keeps the layer's own settings", () {
+        final meta = DetachedClipLayerData(
+          clip: _clip(),
+          layerId: 'layer-1',
+          sourceOffset: const Duration(seconds: 2),
+          chromaKey: const ClipChromaKey(key: ChromaKey.greenScreen()),
+        ).toMeta();
+        // A crop re-renders to a new file with a new shape.
+        final cropped = DivineVideoClip(
+          id: 'clip-1',
+          video: EditorVideo.file('/docs/clip-1_cropped.mp4'),
+          duration: const Duration(seconds: 6),
+          recordedAt: DateTime(2026),
+          targetAspectRatio: model.AspectRatio.square,
+          originalAspectRatio: 0.5,
+          trimStart: const Duration(seconds: 1),
+        );
+
+        final updated = DetachedClipLayerData.withClip(meta, cropped);
+        final restored = DetachedClipLayerData.fromMeta(updated, '/docs')!;
+
+        expect(restored.clip.video?.file?.path, '/docs/clip-1_cropped.mp4');
+        expect(restored.clip.originalAspectRatio, 0.5);
+        // Rebuilding the meta from the clip alone reset both of these: the
+        // split tail rewound to the clip's first frame and the key was gone.
+        expect(restored.layerId, 'layer-1');
+        expect(restored.sourceOffset, const Duration(seconds: 2));
+        expect(restored.chromaKey, isNotNull);
+      });
+
+      test('re-snapshots how long the new footage plays', () {
+        final meta = DetachedClipLayerData(
+          clip: _clip(),
+          layerId: 'layer-1',
+        ).toMeta();
+        final shorter = DivineVideoClip(
+          id: 'clip-1',
+          video: EditorVideo.file('/docs/clip-1.mp4'),
+          duration: const Duration(seconds: 3),
+          recordedAt: DateTime(2026),
+          targetAspectRatio: model.AspectRatio.square,
+          originalAspectRatio: 1,
+        );
+
+        final updated = DetachedClipLayerData.withClip(meta, shorter);
+
+        expect(
+          DetachedClipLayerData.playbackDurationOf(updated),
+          const Duration(seconds: 3),
+        );
+      });
+
+      test('leaves a sticker alone', () {
+        expect(
+          DetachedClipLayerData.withClip({'kind': 'sticker'}, _clip()),
           isNull,
         );
       });

--- a/mobile/test/models/video_editor/detached_clip_window_test.dart
+++ b/mobile/test/models/video_editor/detached_clip_window_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/video_editor/detached_clip_window.dart';
+
+void main() {
+  group('detachedClipWindow', () {
+    test("keeps the slot when a placeholder holds the timeline's length", () {
+      final window = detachedClipWindow(
+        slotStart: const Duration(seconds: 4),
+        playbackDuration: const Duration(seconds: 3),
+        compositionDuration: const Duration(seconds: 10),
+      );
+
+      expect(window, (
+        start: const Duration(seconds: 4),
+        end: const Duration(seconds: 7),
+      ));
+    });
+
+    test('pulls the last clip back inside a timeline that just lost it', () {
+      // Clips of 4 s and 3 s; the 3 s tail was detached and its slot closed,
+      // so the timeline is now 4 s and the slot starts exactly at its end —
+      // a window nothing would ever play.
+      final window = detachedClipWindow(
+        slotStart: const Duration(seconds: 4),
+        playbackDuration: const Duration(seconds: 3),
+        compositionDuration: const Duration(seconds: 4),
+      );
+
+      expect(window, (
+        start: const Duration(seconds: 1),
+        end: const Duration(seconds: 4),
+      ));
+    });
+
+    test('pulls a middle clip back when the tail behind it is too short', () {
+      // 2 s, 5 s (detached, slot closed), 1 s: the timeline is 3 s and the
+      // slot's own 5 s would run 4 s past it.
+      final window = detachedClipWindow(
+        slotStart: const Duration(seconds: 2),
+        playbackDuration: const Duration(seconds: 5),
+        compositionDuration: const Duration(seconds: 3),
+      );
+
+      expect(window, (start: Duration.zero, end: const Duration(seconds: 3)));
+    });
+
+    test('leaves a slot alone that still fits after the gap closed', () {
+      // 3 s (detached, slot closed), 6 s: the 3 s window overlaps the clip
+      // that moved up into the slot and needs no shifting.
+      final window = detachedClipWindow(
+        slotStart: Duration.zero,
+        playbackDuration: const Duration(seconds: 3),
+        compositionDuration: const Duration(seconds: 6),
+      );
+
+      expect(window, (start: Duration.zero, end: const Duration(seconds: 3)));
+    });
+  });
+}

--- a/mobile/test/screens/video_editor/video_clip_chroma_key_screen_test.dart
+++ b/mobile/test/screens/video_editor/video_clip_chroma_key_screen_test.dart
@@ -18,9 +18,14 @@ import 'package:openvine/blocs/video_editor/chroma_key/chroma_key_editor_cubit.d
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/clip_chroma_key.dart';
 import 'package:openvine/screens/video_editor/video_clip_chroma_key_screen.dart';
 import 'package:pro_video_editor/pro_video_editor.dart'
-    show ChromaKeyDetection, ChromaKeyDetectionException, EditorVideo;
+    show
+        ChromaKey,
+        ChromaKeyDetection,
+        ChromaKeyDetectionException,
+        EditorVideo;
 
 import '../../helpers/shared_channel_override.dart';
 
@@ -82,6 +87,48 @@ void main() {
         ),
       );
       await tester.pump();
+    }
+
+    /// Pushes the detached-clip variant from a plain page and captures what it
+    /// pops with. No [ClipEditorBloc] anywhere in the tree: a detached clip
+    /// never bakes, so the screen must not reach for one.
+    Future<DetachedClipChromaKeyResult? Function()> pumpDetached(
+      WidgetTester tester, {
+      required ChromaKeyDetectFn detect,
+      ClipChromaKey? chromaKey,
+    }) async {
+      DetachedClipChromaKeyResult? result;
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Builder(
+              builder: (context) => TextButton(
+                onPressed: () async {
+                  result = await Navigator.of(context)
+                      .push<DetachedClipChromaKeyResult>(
+                        MaterialPageRoute(
+                          builder: (_) => VideoClipChromaKeyScreen.detached(
+                            clip: clip,
+                            chromaKey: chromaKey,
+                            detect: detect,
+                          ),
+                        ),
+                      );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      // Two pumps for the route transition; `pumpAndSettle` would wait on the
+      // looping spinner a pending measurement shows.
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      return () => result;
     }
 
     // A measurement the screen never asked to be told about: the colour is
@@ -175,6 +222,75 @@ void main() {
       // The key the sliders and swatch act on has to survive, or the user is
       // left with nothing to adjust by hand.
       expect(screenColor(tester, l10n), const Color(0xFF00B140));
+    });
+
+    group('detached', () {
+      testWidgets('pops with the key on Done instead of baking', (
+        tester,
+      ) async {
+        final result = await pumpDetached(
+          tester,
+          detect: (_) async => measured,
+        );
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        // Whatever is under the layer shows through, so a library clip has
+        // no track to play on and is not offered.
+        expect(
+          find.text(l10n.videoEditorChromaKeyBackgroundVideo),
+          findsNothing,
+        );
+        expect(
+          find.text(l10n.videoEditorChromaKeyCanvasTransparentHint),
+          findsOneWidget,
+        );
+        // Nothing to take off yet.
+        expect(find.text(l10n.videoEditorChromaKeyRemove), findsNothing);
+
+        await tester.tap(
+          find.bySemanticsLabel(l10n.videoEditorChromaKeyDoneSemanticLabel),
+        );
+        await tester.pumpAndSettle();
+
+        final applied = result();
+        expect(applied, isA<DetachedClipChromaKeyApplied>());
+        // The measured key, not the preset: proves the settings on screen are
+        // what leaves through the pop.
+        expect(
+          (applied! as DetachedClipChromaKeyApplied).chromaKey.key.color,
+          const Color(0xFF19A55B),
+        );
+        expect(find.byType(VideoClipChromaKeyScreen), findsNothing);
+      });
+
+      testWidgets("opens on the layer's own key and can take it off", (
+        tester,
+      ) async {
+        var detectCalls = 0;
+        final result = await pumpDetached(
+          tester,
+          chromaKey: const ClipChromaKey(key: ChromaKey.blueScreen()),
+          detect: (_) async {
+            detectCalls++;
+            return measured;
+          },
+        );
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        // A key the user already tuned is restored, not re-measured over.
+        expect(detectCalls, 0);
+        expect(screenColor(tester, l10n), const ChromaKey.blueScreen().color);
+
+        final remove = find.text(l10n.videoEditorChromaKeyRemove);
+        await tester.ensureVisible(remove);
+        await tester.tap(remove);
+        await tester.pumpAndSettle();
+
+        expect(result(), isA<DetachedClipChromaKeyRemoved>());
+        expect(find.byType(VideoClipChromaKeyScreen), findsNothing);
+      });
     });
 
     testWidgets('shoots the background photo instead of opening the gallery', (

--- a/mobile/test/services/video_editor/detached_clip_composite_test.dart
+++ b/mobile/test/services/video_editor/detached_clip_composite_test.dart
@@ -4,12 +4,13 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/clip_chroma_key.dart';
 import 'package:openvine/models/video_editor/detached_clip_layer.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/services/video_editor/detached_clip_composite.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_video_editor/pro_video_editor.dart'
-    show EditorVideo, SegmentFit;
+    show ChromaKey, EditorVideo, SegmentFit;
 
 DivineVideoClip _clip({
   String id = 'clip-1',
@@ -39,8 +40,13 @@ WidgetLayer _detachedLayer(
   Offset offset = Offset.zero,
   Duration? startTime,
   Duration? endTime,
+  ClipChromaKey? chromaKey,
 }) {
-  final meta = DetachedClipLayerData(clip: clip, layerId: 'layer-1').toMeta();
+  final meta = DetachedClipLayerData(
+    clip: clip,
+    layerId: 'layer-1',
+    chromaKey: chromaKey,
+  ).toMeta();
   return WidgetLayer(
     widget: const SizedBox.shrink(),
     offset: offset,
@@ -123,6 +129,18 @@ void main() {
       expect(result.below, hasLength(1));
     });
 
+    test("carries the layer's live green screen", () {
+      const key = ClipChromaKey(key: ChromaKey.blueScreen());
+
+      final result = partitionDetachedClipLayers([
+        _exported(_detachedLayer(_clip(), chromaKey: key)),
+        _exported(_detachedLayer(_clip(id: 'plain'))),
+      ], '/docs');
+
+      expect(result.detached.first.chromaKey, key);
+      expect(result.detached.last.chromaKey, isNull);
+    });
+
     test('puts a layer between two detached clips in the above group', () {
       final middle = _exported(TextLayer(text: 'middle'));
 
@@ -153,6 +171,7 @@ void main() {
       Duration? startTime,
       Duration? endTime,
       Duration sourceOffset = Duration.zero,
+      ClipChromaKey? chromaKey,
     }) => DetachedClipExportLayer(
       clip: clip,
       layer: _detachedLayer(
@@ -160,9 +179,11 @@ void main() {
         offset: offset,
         startTime: startTime,
         endTime: endTime,
+        chromaKey: chromaKey,
       ),
       logicalSize: logicalSize,
       sourceOffset: sourceOffset,
+      chromaKey: chromaKey,
     );
 
     test('starts a split tail partway into the clip', () {
@@ -365,6 +386,38 @@ void main() {
       // 5 s of source at 2× is 2.5 s of playback.
       expect(segment.endTime, const Duration(milliseconds: 2500));
       expect(segment.video.file?.path, '/cache/flat.mp4');
+    });
+
+    test('keys the layer with its live green screen', () {
+      const key = ChromaKey(color: Color(0xFF19A55B), similarity: 0.1);
+
+      final layer = buildDetachedClipVideoLayer(
+        item: item(_clip(), chromaKey: const ClipChromaKey(key: key)),
+        resolvedVideo: EditorVideo.file('/docs/clip-1.mp4'),
+        bodySize: bodySize,
+        videoSize: videoSize,
+        timelineMap: identityMap,
+        speedFlattened: false,
+      );
+
+      // On the layer, where the composition keys the clip before placing it
+      // over the base track — so a transparent key really shows the track
+      // through, which a single H.264 track could never do.
+      expect(layer.chromaKey, key);
+      expect(layer.chromaKey!.isTransparent, isTrue);
+    });
+
+    test('leaves a layer without a green screen unkeyed', () {
+      final layer = buildDetachedClipVideoLayer(
+        item: item(_clip()),
+        resolvedVideo: EditorVideo.file('/docs/clip-1.mp4'),
+        bodySize: bodySize,
+        videoSize: videoSize,
+        timelineMap: identityMap,
+        speedFlattened: false,
+      );
+
+      expect(layer.chromaKey, isNull);
     });
 
     test('never carries a playback speed the composition would reject', () {

--- a/mobile/test/widgets/video_editor/chroma_key/chroma_key_backdrop_test.dart
+++ b/mobile/test/widgets/video_editor/chroma_key/chroma_key_backdrop_test.dart
@@ -36,6 +36,25 @@ void main() {
       expect(find.byType(ChromaKeyTransparencyCheckerboard), findsOneWidget);
     });
 
+    testWidgets('draws nothing for a transparent key on the canvas', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: ChromaKeyBackdrop(
+            chromaKey: ClipChromaKey(key: ChromaKey.greenScreen()),
+            previewTransparency: false,
+          ),
+        ),
+      );
+
+      // On the editor canvas what is underneath the clip *is* the backdrop; a
+      // checkerboard there would hide exactly what the key is meant to reveal.
+      expect(find.byType(ChromaKeyTransparencyCheckerboard), findsNothing);
+      expect(find.byType(ColoredBox), findsNothing);
+    });
+
     testWidgets('fills with the chosen colour', (tester) async {
       await pump(
         tester,

--- a/mobile/test/widgets/video_editor/chroma_key/chroma_key_controls_test.dart
+++ b/mobile/test/widgets/video_editor/chroma_key/chroma_key_controls_test.dart
@@ -35,6 +35,7 @@ void main() {
       ThemeData theme, {
       TextScaler textScaler = TextScaler.noScaling,
       Locale? locale,
+      ChromaKeySurface surface = ChromaKeySurface.track,
     }) async {
       // A phone, not the 800x600 default. The panel is a narrow column of
       // rows, so a surface 2.2x a phone's width cannot show one overflowing
@@ -64,7 +65,10 @@ void main() {
               backgroundColor: theme
                   .extension<VineThemeColors>()!
                   .surfaceContainerHigh,
-              body: ChromaKeyControls(onPickBackground: (_) {}),
+              body: ChromaKeyControls(
+                onPickBackground: (_) {},
+                surface: surface,
+              ),
             ),
           ),
         ),
@@ -99,6 +103,42 @@ void main() {
             'do not know an ordinary wall keys. Epic #8543 ratified that '
             'framing.',
       );
+    });
+
+    testWidgets('offers every backdrop and warns about black on the track', (
+      tester,
+    ) async {
+      await pump(tester, VineTheme.theme);
+
+      final en = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(en.videoEditorChromaKeyBackgroundVideo), findsOneWidget);
+      // A single H.264 track has nothing under it, so "Nothing" flattens to
+      // black and the panel has to say so.
+      expect(find.text(en.videoEditorChromaKeyTransparentHint), findsOneWidget);
+      expect(
+        find.text(en.videoEditorChromaKeyCanvasTransparentHint),
+        findsNothing,
+      );
+    });
+
+    testWidgets('drops the clip backdrop and reassures on the canvas', (
+      tester,
+    ) async {
+      await pump(tester, VineTheme.theme, surface: ChromaKeySurface.canvas);
+
+      final en = lookupAppLocalizations(const Locale('en'));
+      // A live key has no second track to play a library clip on.
+      expect(find.text(en.videoEditorChromaKeyBackgroundVideo), findsNothing);
+      expect(find.text(en.videoEditorChromaKeyBackgroundNone), findsOneWidget);
+      expect(find.text(en.videoEditorChromaKeyBackgroundColor), findsOneWidget);
+      expect(find.text(en.videoEditorChromaKeyBackgroundImage), findsOneWidget);
+      // The layer is composited over the track, so "Nothing" really is
+      // see-through — the black warning would be wrong here.
+      expect(
+        find.text(en.videoEditorChromaKeyCanvasTransparentHint),
+        findsOneWidget,
+      );
+      expect(find.text(en.videoEditorChromaKeyTransparentHint), findsNothing);
     });
 
     testWidgets('resolves the hint through l10n rather than a literal', (

--- a/mobile/test/widgets/video_editor/detached_clip/detached_clip_chroma_key_test.dart
+++ b/mobile/test/widgets/video_editor/detached_clip/detached_clip_chroma_key_test.dart
@@ -1,0 +1,288 @@
+// ABOUTME: Drives the detached clip's green-screen action end to end: the
+// ABOUTME: screen it opens, and what it writes back onto the layer.
+
+import 'dart:io';
+
+import 'package:divine_video_player/divine_video_player.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/clip_chroma_key.dart';
+import 'package:openvine/models/video_editor/detached_clip_layer.dart';
+import 'package:openvine/screens/video_editor/video_clip_chroma_key_screen.dart';
+import 'package:openvine/widgets/video_editor/detached_clip/detached_clip_chroma_key.dart';
+import 'package:openvine/widgets/video_editor/detached_clip/detached_clip_layer_view.dart';
+import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+import '../../../helpers/divine_video_player_channel.dart';
+
+class _FakePathProvider extends Fake
+    with MockPlatformInterfaceMixin
+    implements PathProviderPlatform {
+  _FakePathProvider(this.documentsPath);
+
+  final String documentsPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => documentsPath;
+}
+
+/// Keeps the screen's on-open measurement off the platform channel.
+///
+/// Reporting no screen is the ordinary outcome for footage without one, so
+/// the screen opens on the green preset and the test drives it from there.
+class _StubProVideoEditor extends ProVideoEditor {
+  @override
+  void initializeStream() {
+    // Intentional no-op: nothing native to stream from in a widget test.
+  }
+
+  @override
+  Future<VideoMetadata> getMetadata(
+    EditorVideo value, {
+    bool checkStreamingOptimization = false,
+    NativeLogLevel? nativeLogLevel,
+  }) async {
+    throw const ChromaKeyDetectionException('no screen in test footage');
+  }
+}
+
+class _MockProImageEditorState extends Mock implements ProImageEditorState {
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      '_MockProImageEditorState';
+}
+
+class _FakeLayer extends Fake implements Layer {}
+
+DivineVideoClip _clip() => DivineVideoClip(
+  id: 'clip-1',
+  video: EditorVideo.file('/old/clip-1.mp4'),
+  duration: const Duration(seconds: 6),
+  recordedAt: DateTime(2026),
+  targetAspectRatio: model.AspectRatio.square,
+  originalAspectRatio: 1,
+);
+
+WidgetLayer _detachedLayer({ClipChromaKey? chromaKey}) {
+  final meta = DetachedClipLayerData(
+    clip: _clip(),
+    layerId: 'layer-1',
+    sourceOffset: const Duration(seconds: 2),
+    chromaKey: chromaKey,
+  ).toMeta();
+  return WidgetLayer(
+    id: 'layer-1',
+    widget: const SizedBox.shrink(),
+    meta: meta,
+    exportConfigs: WidgetLayerExportConfigs(id: 'layer-1', meta: meta),
+  );
+}
+
+void main() {
+  group('editDetachedClipChromaKey', () {
+    late Directory tempDir;
+    late PathProviderPlatform originalPathProvider;
+    late ProVideoEditor originalProVideoEditor;
+    late _MockProImageEditorState editor;
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
+    setUpAll(() {
+      registerFallbackValue(_FakeLayer());
+    });
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('detached_chroma');
+      originalPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+      originalProVideoEditor = ProVideoEditor.instance;
+      ProVideoEditor.instance = _StubProVideoEditor();
+
+      // The screen opens a preview player on the clip's file; both halves of
+      // the native player are mocked so it initializes without a plugin.
+      DivineVideoPlayerController.resetIdCounterForTesting();
+      installMockDivineVideoPlayer();
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      messenger.setMockMethodCallHandler(
+        const MethodChannel('divine_video_player'),
+        (call) async =>
+            call.method == 'create' ? <String, Object?>{'textureId': 1} : null,
+      );
+      addTearDown(() {
+        messenger.setMockMethodCallHandler(
+          const MethodChannel('divine_video_player'),
+          null,
+        );
+      });
+
+      editor = _MockProImageEditorState();
+      when(
+        () => editor.replaceLayer(
+          index: any(named: 'index'),
+          layer: any(named: 'layer'),
+        ),
+      ).thenAnswer((_) {});
+    });
+
+    tearDown(() {
+      PathProviderPlatform.instance = originalPathProvider;
+      ProVideoEditor.instance = originalProVideoEditor;
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    /// A page with one button that runs the action for [layer], inside the
+    /// scope the timeline's action bar would provide.
+    Future<void> pump(WidgetTester tester, Layer layer) async {
+      when(() => editor.activeLayers).thenReturn([layer]);
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: VideoEditorScope(
+            editorKey: GlobalKey(),
+            removeAreaKey: GlobalKey(),
+            originalClipAspectRatio: 1,
+            bodySizeNotifier: ValueNotifier(const Size(400, 600)),
+            zoomMatrixNotifier: ValueNotifier(Matrix4.identity()),
+            playTimeNotifier: ValueNotifier(Duration.zero),
+            playheadAdvancingNotifier: ValueNotifier<bool>(false),
+            fromLibrary: false,
+            onOpenCamera: () {},
+            onOpenClipsEditor: () {},
+            onAddStickers: () {},
+            onAddEditTextLayer: ([layer]) async => null,
+            onOpenMusicLibrary: () {},
+            onOpenVoiceOver: () {},
+            onOpenCaptions: () {},
+            editorOverride: editor,
+            child: Builder(
+              builder: (context) => TextButton(
+                onPressed: () => editDetachedClipChromaKey(context, layer),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      // Documents path, then the route's fade. Bounded rather than settled:
+      // the screen's controls carry a spinner while it measures.
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+    }
+
+    /// The layer the action wrote back, read off the editor.
+    WidgetLayer written() =>
+        verify(
+              () => editor.replaceLayer(
+                index: 0,
+                layer: captureAny(named: 'layer'),
+              ),
+            ).captured.single
+            as WidgetLayer;
+
+    testWidgets('opens the detached variant of the green-screen screen', (
+      tester,
+    ) async {
+      await pump(tester, _detachedLayer());
+
+      expect(find.byType(VideoClipChromaKeyScreen), findsOneWidget);
+      // A live key has no second track for a library clip to play on.
+      expect(find.text(l10n.videoEditorChromaKeyBackgroundVideo), findsNothing);
+      expect(
+        find.text(l10n.videoEditorChromaKeyCanvasTransparentHint),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('writes the confirmed key onto the layer, keeping the rest', (
+      tester,
+    ) async {
+      await pump(tester, _detachedLayer());
+
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoEditorChromaKeyDoneSemanticLabel),
+      );
+      await tester.pumpAndSettle();
+
+      final layer = written();
+      final meta = DetachedClipLayerData.metaOf(layer);
+      expect(DetachedClipLayerData.hasChromaKey(meta), isTrue);
+      // Both meta slots and the live widget follow, the way a crop's
+      // write-back does, so a draft round-trip and the canvas agree.
+      expect(DetachedClipLayerData.hasChromaKey(layer.meta), isTrue);
+      expect(
+        DetachedClipLayerData.hasChromaKey(layer.exportConfigs.meta),
+        isTrue,
+      );
+      expect(layer.widget, isA<DetachedClipLayerView>());
+      // The layer's own settings survive: the key is added, not the meta
+      // rebuilt.
+      expect(DetachedClipLayerData.layerIdOf(meta), 'layer-1');
+      expect(
+        DetachedClipLayerData.sourceOffsetOf(meta),
+        const Duration(seconds: 2),
+      );
+      expect(find.byType(VideoClipChromaKeyScreen), findsNothing);
+    });
+
+    testWidgets('takes the key off the layer on Remove', (tester) async {
+      await pump(
+        tester,
+        _detachedLayer(
+          chromaKey: const ClipChromaKey(key: ChromaKey.blueScreen()),
+        ),
+      );
+
+      final remove = find.text(l10n.videoEditorChromaKeyRemove);
+      await tester.ensureVisible(remove);
+      await tester.tap(remove);
+      await tester.pumpAndSettle();
+
+      final meta = DetachedClipLayerData.metaOf(written());
+      expect(DetachedClipLayerData.hasChromaKey(meta), isFalse);
+      expect(DetachedClipLayerData.layerIdOf(meta), 'layer-1');
+    });
+
+    testWidgets('leaves the layer alone when the screen is dismissed', (
+      tester,
+    ) async {
+      await pump(tester, _detachedLayer());
+
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoEditorChromaKeyCloseSemanticLabel),
+      );
+      await tester.pumpAndSettle();
+
+      verifyNever(
+        () => editor.replaceLayer(
+          index: any(named: 'index'),
+          layer: any(named: 'layer'),
+        ),
+      );
+    });
+
+    testWidgets('does nothing for a layer that is not a detached clip', (
+      tester,
+    ) async {
+      await pump(tester, TextLayer(text: 'caption'));
+
+      expect(find.byType(VideoClipChromaKeyScreen), findsNothing);
+      verifyNever(
+        () => editor.replaceLayer(
+          index: any(named: 'index'),
+          layer: any(named: 'layer'),
+        ),
+      );
+    });
+  });
+}

--- a/mobile/test/widgets/video_editor/detached_clip/detached_clip_layer_view_test.dart
+++ b/mobile/test/widgets/video_editor/detached_clip/detached_clip_layer_view_test.dart
@@ -7,12 +7,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/clip_chroma_key.dart';
 import 'package:openvine/models/video_editor/detached_clip_layer.dart';
+import 'package:openvine/utils/path_resolver.dart';
+import 'package:openvine/widgets/video_editor/chroma_key/chroma_keyed_video.dart';
 import 'package:openvine/widgets/video_editor/detached_clip/detached_clip_layer_view.dart';
 import 'package:openvine/widgets/video_editor/detached_clip/detached_clip_player.dart';
+import 'package:openvine/widgets/video_editor/detached_clip/detached_clip_player_registry.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
-import 'package:pro_video_editor/pro_video_editor.dart' show EditorVideo;
+import 'package:pro_video_editor/pro_video_editor.dart'
+    show ChromaKey, EditorVideo;
 
 class _FakePathProvider extends Fake
     with MockPlatformInterfaceMixin
@@ -186,6 +191,90 @@ void main() {
     });
   });
 
+  group(DetachedClipLayerView, () {
+    late Directory tempDir;
+    late PathProviderPlatform originalPathProvider;
+
+    setUp(() async {
+      tempDir = Directory.systemTemp.createTempSync('detached_layer_view');
+      originalPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+      detachedClipPlayers.resetForTesting();
+      resetCachedDocumentsPath();
+      await getDocumentsPath();
+    });
+
+    tearDown(() {
+      resetCachedDocumentsPath();
+      PathProviderPlatform.instance = originalPathProvider;
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    Map<String, dynamic> keyedMeta(ChromaKey key) => DetachedClipLayerData(
+      clip: _clip(),
+      layerId: 'layer-1',
+      chromaKey: ClipChromaKey(key: key),
+    ).toMeta();
+
+    ChromaKeyedVideo keyedVideo(WidgetTester tester) =>
+        tester.widget(find.byType(ChromaKeyedVideo).first);
+
+    Future<void> disposeLayerView(WidgetTester tester) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      detachedClipPlayers.resetForTesting();
+    }
+
+    testWidgets(
+      'applies the layer key over the canvas without a checkerboard',
+      (tester) async {
+        await tester.pumpWidget(
+          _app(
+            _layerHost(
+              DetachedClipLayerView(
+                meta: keyedMeta(const ChromaKey.greenScreen()),
+              ),
+            ),
+          ),
+        );
+
+        final preview = keyedVideo(tester);
+        expect(preview.chromaKey?.key, const ChromaKey.greenScreen());
+        expect(preview.previewTransparency, isFalse);
+        await disposeLayerView(tester);
+      },
+    );
+
+    testWidgets('re-reads a changed layer key without replacing the view', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _app(
+          _layerHost(
+            DetachedClipLayerView(
+              meta: keyedMeta(const ChromaKey.greenScreen()),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(
+        _app(
+          _layerHost(
+            DetachedClipLayerView(
+              meta: keyedMeta(const ChromaKey.blueScreen()),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final preview = keyedVideo(tester);
+      expect(preview.chromaKey?.key, const ChromaKey.blueScreen());
+      expect(preview.previewTransparency, isFalse);
+      await disposeLayerView(tester);
+    });
+  });
+
   group(DetachedClipPoster, () {
     late Directory tempDir;
     late PathProviderPlatform originalPathProvider;
@@ -257,9 +346,7 @@ void main() {
         layerId: 'layer-1',
       ).toMeta();
 
-      await tester.pumpWidget(
-        _app(DetachedClipPoster(meta: meta)),
-      );
+      await tester.pumpWidget(_app(DetachedClipPoster(meta: meta)));
       await tester.pumpAndSettle();
 
       // The draft render path mounts every layer offscreen just to rasterize

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls_test.dart
@@ -3,6 +3,7 @@
 // ABOUTME: VideoEditorScope in the tree.
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -16,12 +17,14 @@ import 'package:openvine/blocs/video_editor/tune_editor/video_editor_tune_bloc.d
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/timeline_overlay_item.dart';
+import 'package:openvine/models/video_editor/clip_chroma_key.dart';
 import 'package:openvine/models/video_editor/detached_clip_layer.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_layer_animation_sheet.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:pro_video_editor/pro_video_editor.dart' show ChromaKey;
 
 class _MockTimelineOverlayBloc
     extends MockBloc<TimelineOverlayEvent, TimelineOverlayState>
@@ -185,10 +188,79 @@ void main() {
       expect(find.text(l10n.videoEditorDuplicateLabel), findsOneWidget);
       expect(find.text(l10n.videoEditorSplitLabel), findsOneWidget);
       expect(find.text(l10n.videoEditorTransformLabel), findsOneWidget);
+      expect(find.text(l10n.videoEditorChromaKeyLabel), findsOneWidget);
       // A detached clip is composited as a VideoLayer, which carries no
       // animations field — offering the action would animate it in the editor
       // and drop it silently from the file.
       expect(find.text(l10n.videoEditorLayerAnimationLabel), findsNothing);
+    });
+
+    testWidgets('keeps the green screen off every other layer', (
+      tester,
+    ) async {
+      const item = TimelineOverlayItem(
+        id: 'text-layer',
+        type: TimelineOverlayType.layer,
+        startTime: Duration.zero,
+        endTime: Duration(seconds: 3),
+      );
+      final editor = _MockProImageEditorState();
+      final mainBloc = _MockVideoEditorMainBloc();
+      when(
+        () => editor.activeLayers,
+      ).thenReturn([TextLayer(id: item.id, text: 'hi')]);
+      when(() => mainBloc.state).thenReturn(const VideoEditorMainState());
+
+      await tester.pumpWidget(buildWithEditor(item, editor, mainBloc));
+
+      // Only a detached clip carries footage a key can be applied to.
+      expect(find.text(l10n.videoEditorChromaKeyLabel), findsNothing);
+    });
+
+    testWidgets('highlights the green screen once the layer carries one', (
+      tester,
+    ) async {
+      const item = TimelineOverlayItem(
+        id: 'detached-layer',
+        type: TimelineOverlayType.layer,
+        startTime: Duration.zero,
+        endTime: Duration(seconds: 3),
+      );
+      DivineIconButton chromaKeyButton() => tester.widget<DivineIconButton>(
+        find.byWidgetPredicate(
+          (w) =>
+              w is DivineIconButton &&
+              w.semanticLabel == l10n.videoEditorChromaKeySemanticLabel,
+        ),
+      );
+      WidgetLayer layerWith(Map<String, dynamic> meta) => WidgetLayer(
+        id: item.id,
+        widget: const SizedBox.shrink(),
+        meta: meta,
+        exportConfigs: WidgetLayerExportConfigs(id: item.id, meta: meta),
+      );
+      final editor = _MockProImageEditorState();
+      final mainBloc = _MockVideoEditorMainBloc();
+      when(() => mainBloc.state).thenReturn(const VideoEditorMainState());
+
+      when(() => editor.activeLayers).thenReturn([
+        layerWith(const {detachedClipLayerKindKey: detachedClipLayerKind}),
+      ]);
+      await tester.pumpWidget(buildWithEditor(item, editor, mainBloc));
+      expect(chromaKeyButton().type, DivineIconButtonType.secondary);
+
+      when(() => editor.activeLayers).thenReturn([
+        layerWith({
+          detachedClipLayerKindKey: detachedClipLayerKind,
+          detachedClipLayerChromaKeyKey: const ClipChromaKey(
+            key: ChromaKey.greenScreen(),
+          ).toJson(),
+        }),
+      ]);
+      await tester.pumpWidget(buildWithEditor(item, editor, mainBloc));
+      // Same treatment the timeline gives a baked key: the effect is visible
+      // from the action bar without opening the screen.
+      expect(chromaKeyButton().type, DivineIconButtonType.primary);
     });
 
     testWidgets('renders $VideoEditorTimelineControls for filter', (

--- a/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
+++ b/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
@@ -631,6 +631,97 @@ void main() {
       },
     );
 
+    testWidgets(
+      'keeps a detached last clip on the timeline when its slot closes',
+      (tester) async {
+        registerFallbackValue(_FakeLayer());
+        final clipBloc = _MockClipEditorBloc();
+        final mockEditor = _MockProImageEditorState();
+        final mockStateManager = _MockStateManager();
+        // 4 s then 3 s; the 3 s tail is detached and its slot closed, so
+        // the timeline is 4 s long afterwards.
+        final head = DivineVideoClip(
+          id: 'head',
+          video: EditorVideo.file('/docs/head.mp4'),
+          duration: const Duration(seconds: 4),
+          recordedAt: DateTime(2026),
+          targetAspectRatio: .square,
+          originalAspectRatio: 1,
+        );
+        final tail = DivineVideoClip(
+          id: 'tail',
+          video: EditorVideo.file('/docs/tail.mp4'),
+          duration: const Duration(seconds: 3),
+          recordedAt: DateTime(2026),
+          targetAspectRatio: .square,
+          originalAspectRatio: 1,
+        );
+        final detached = ClipEditorState(
+          clips: [head],
+          lastDetachResult: ClipDetachSuccess(
+            previousClips: [head, tail],
+            detachedClip: tail,
+          ),
+        );
+
+        when(() => clipBloc.state).thenReturn(const ClipEditorState());
+        whenListen(
+          clipBloc,
+          Stream<ClipEditorState>.fromIterable([detached]),
+          initialState: const ClipEditorState(),
+        );
+        when(() => mockEditor.stateManager).thenReturn(mockStateManager);
+        when(() => mockStateManager.activeMeta).thenReturn(const {});
+        when(
+          () => mockEditor.addHistory(
+            layers: any(named: 'layers'),
+            filters: any(named: 'filters'),
+            meta: any(named: 'meta'),
+            newLayer: any(named: 'newLayer'),
+            transformConfigs: any(named: 'transformConfigs'),
+            tuneAdjustments: any(named: 'tuneAdjustments'),
+            blur: any(named: 'blur'),
+            heroScreenshotRequired: any(named: 'heroScreenshotRequired'),
+            blockCaptureScreenshot: any(named: 'blockCaptureScreenshot'),
+          ),
+        ).thenAnswer((_) {});
+
+        await tester.pumpWidget(
+          buildWidget(
+            isLoading: true,
+            clipBlocOverride: clipBloc,
+            editorOverride: mockEditor,
+          ),
+        );
+        await tester.pump();
+
+        final layer =
+            verify(
+                  () => mockEditor.addHistory(
+                    layers: any(named: 'layers'),
+                    filters: any(named: 'filters'),
+                    meta: any(named: 'meta'),
+                    newLayer: captureAny(named: 'newLayer'),
+                    transformConfigs: any(named: 'transformConfigs'),
+                    tuneAdjustments: any(named: 'tuneAdjustments'),
+                    blur: any(named: 'blur'),
+                    heroScreenshotRequired: any(
+                      named: 'heroScreenshotRequired',
+                    ),
+                    blockCaptureScreenshot: any(
+                      named: 'blockCaptureScreenshot',
+                    ),
+                  ),
+                ).captured.single
+                as Layer;
+        // The slot started at 4 s — the new end of the timeline — so a
+        // window kept there would never be on screen. It is pulled back to
+        // end on the composition's end instead.
+        expect(layer.startTime, const Duration(seconds: 1));
+        expect(layer.endTime, const Duration(seconds: 4));
+      },
+    );
+
     testWidgets('shows a snackbar when a clip transform has no local file', (
       tester,
     ) async {

--- a/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
+++ b/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
@@ -15,11 +15,16 @@ import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.d
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/clip_chroma_key.dart';
+import 'package:openvine/models/video_editor/detached_clip_layer.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/widgets/branded_loading_scaffold.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/video_editor_scaffold.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:pro_video_editor/pro_video_editor.dart'
+    show ChromaKey, EditorVideo;
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockClipEditorBloc extends MockBloc<ClipEditorEvent, ClipEditorState>
@@ -32,6 +37,17 @@ class _MockProImageEditorState extends Mock implements ProImageEditorState {
 }
 
 class _MockStateManager extends Mock implements StateManager {}
+
+class _FakeLayer extends Fake implements Layer {}
+
+DivineVideoClip _detachedClip({String file = 'clip-1.mp4'}) => DivineVideoClip(
+  id: 'clip-1',
+  video: EditorVideo.file('/docs/$file'),
+  duration: const Duration(seconds: 6),
+  recordedAt: DateTime(2026),
+  targetAspectRatio: .square,
+  originalAspectRatio: 1,
+);
 
 void main() {
   group(VideoEditorScaffold, () {
@@ -540,6 +556,80 @@ void main() {
       final l10n = lookupAppLocalizations(const Locale('en'));
       expect(find.text(l10n.videoEditorTransformFailed), findsOneWidget);
     });
+
+    testWidgets(
+      "writes a cropped detached clip back without dropping the layer's "
+      'own settings',
+      (tester) async {
+        registerFallbackValue(_FakeLayer());
+        final clipBloc = _MockClipEditorBloc();
+        final mockEditor = _MockProImageEditorState();
+        // A split tail with a live green screen: both belong to the layer,
+        // not to the footage the crop replaces.
+        final meta = DetachedClipLayerData(
+          clip: _detachedClip(),
+          layerId: 'layer-1',
+          sourceOffset: const Duration(seconds: 2),
+          chromaKey: const ClipChromaKey(key: ChromaKey.blueScreen()),
+        ).toMeta();
+        final layer = WidgetLayer(
+          id: 'layer-1',
+          widget: const SizedBox.shrink(),
+          meta: meta,
+          exportConfigs: WidgetLayerExportConfigs(id: 'layer-1', meta: meta),
+        );
+        final result = ClipEditorState(
+          lastDetachedClipTransformResult: DetachedClipTransformSuccess(
+            layerId: 'layer-1',
+            clip: _detachedClip(file: 'clip-1_cropped.mp4'),
+          ),
+        );
+
+        when(() => clipBloc.state).thenReturn(const ClipEditorState());
+        whenListen(
+          clipBloc,
+          Stream<ClipEditorState>.fromIterable([result]),
+          initialState: const ClipEditorState(),
+        );
+        when(() => mockEditor.activeLayers).thenReturn([layer]);
+        when(
+          () => mockEditor.replaceLayer(
+            index: any(named: 'index'),
+            layer: any(named: 'layer'),
+          ),
+        ).thenAnswer((_) {});
+
+        await tester.pumpWidget(
+          buildWidget(
+            isLoading: true,
+            clipBlocOverride: clipBloc,
+            editorOverride: mockEditor,
+          ),
+        );
+        await tester.pump();
+
+        final written =
+            verify(
+                  () => mockEditor.replaceLayer(
+                    index: 0,
+                    layer: captureAny(named: 'layer'),
+                  ),
+                ).captured.single
+                as WidgetLayer;
+        final restored = DetachedClipLayerData.fromMeta(
+          DetachedClipLayerData.metaOf(written),
+          '/docs',
+        )!;
+        expect(restored.clip.video?.file?.path, '/docs/clip-1_cropped.mp4');
+        // Rebuilding the meta from the clip alone used to rewind the tail
+        // to the clip's first frame and drop the key with it.
+        expect(restored.sourceOffset, const Duration(seconds: 2));
+        expect(
+          restored.chromaKey?.key.color,
+          const ChromaKey.blueScreen().color,
+        );
+      },
+    );
 
     testWidgets('shows a snackbar when a clip transform has no local file', (
       tester,


### PR DESCRIPTION
Closes #9070

## Description

**Problem.** A clip that was detached onto the editor canvas had no green-screen action, so the one thing you would detach a green-screen clip *for* — overlaying just the subject on top of the rest of the video — was not possible. The timeline's green screen does not help here either: it bakes the key into a new H.264 file, which carries no alpha, so choosing "Nothing" behind the subject flattens the removed area to black.

**What changes.** Detached clips get a **Green screen** action in the layer action bar. The key is *not* baked into the footage. It is stored as a setting on the layer's meta and applied live: on the canvas through the existing `chroma_key.frag` preview shader, and at export as `VideoLayer.chromaKey` on the composition layer the export already builds for every detached clip. Because that layer sits over the finished track, a transparent key genuinely shows the track through the cutout — which is why this is a layer setting rather than a second bake.

**Why a separate field rather than `DivineVideoClip.chromaKey`.** That field records a key already burned into the clip's file (with the pre-bake source so it can be re-tuned). Overloading it with "applied live" semantics would double-apply a key on a clip that was keyed on the timeline before being detached. The layer field is applied on top of whatever the footage holds, so a clip that already carries a baked colour backdrop keeps it and can still get a live cutout on top.

**Screen and controls.** `VideoClipChromaKeyScreen.detached` reuses the whole screen, pops with `DetachedClipChromaKeyResult` instead of dispatching a bake, previews the clip in its own aspect ratio (a detached clip is a free-floating box, not the composition frame), and hides the library-clip backdrop — a live key has no second track to play one on. The transparent hint under the backdrop chips is a reassurance ("Whatever's behind the clip shows through.") instead of the black warning; new key `videoEditorChromaKeyCanvasTransparentHint`, translated into all 22 locales. Undo restores the previous key together with the rest of the layer because the write-back is one `replaceLayer` history entry. Splitting and duplicating a layer carry the key along; a draft round-trip keeps it, with the backdrop photo stored by basename and protected by the orphan sweep like every other layer asset.

**Second commit — detaching the last clip.** Detaching a clip and choosing "Nothing" for its slot shortens the composition by the clip's length, but the new layer kept the window of the slot it came out of. For the last clip that window started exactly at the new end of the timeline, so the clip vanished. The window is now measured against the composition *after* the detach and pulled back to end on the composition's end when it would run past it (`detachedClipWindow`); a placeholder keeps the timeline's length, so that path is unchanged.

**Also in the first commit.** The crop write-back for a detached clip rebuilt the layer meta from the clip alone, which reset a split tail's source offset to zero and would have dropped the new key as well. It now edits the layer's existing meta (`DetachedClipLayerData.withClip`).

**Related Issue:** 

## Out of Scope

- A key already baked into a timeline clip is not converted into a live key when the clip is detached (reverse renders and thumbnails make that conversion lossy). The path is: detach first, then apply the green screen on the layer.
- A library-clip backdrop for a detached clip. It would need a second composition layer with its own tiling and timing under the detached clip; nothing in the UI asks for it yet.
- The timeline strip thumbnails of a detached layer still show the unkeyed frames.

## Verification

- `flutter analyze lib test integration_test` — clean
- New and extended tests: `DetachedClipLayerData` (round-trip, `hasChromaKey`, `withChromaKey`, `withClip`, owned backdrop photo), `partitionDetachedClipLayers` / `buildDetachedClipVideoLayer` (key on the `VideoLayer`), `ChromaKeyBackdrop` (no checkerboard on the canvas), `ChromaKeyControls` (per-surface chips and hint), `VideoClipChromaKeyScreen` detached mode (pops with the key / removed, no bloc in the tree), `editDetachedClipChromaKey` end to end (opens the screen, writes the layer, dismiss leaves it alone), `TimelineOverlayControls` (action offered only for detached clips, highlighted when set), `VideoEditorScaffold` (crop write-back keeps offset and key; last-clip detach window), `detachedClipWindow`
- Surrounding suites (`test/widgets/video_editor/detached_clip`, `chroma_key`, timeline controls, `detached_clip_render_pass`, `chroma_key_bake_service`, clip-editor detach/transform blocs, `draft_storage_service`, `arb_consistency_test`) — 500+ tests green
- All `mobile/scripts/check_*.sh` ratchets green (orphaned ARB keys, l10n delegates, raw colours/textstyles/buttons/dialogs/icons, empty catch, post-close emit, skip/placeholder/unpinned tests, maestro copy, layer direction, …)
- Tested on a real Samsung Galaxy (S25 Ultra, Android 16) with `--enable-impeller`: detach → Green screen → auto-detect → Nothing shows the canvas through the cutout live; colour/image backdrops, crop after keying, split/duplicate, undo, and the last-clip detach with "Nothing" all behave; export composites the cutout over the track. Note that a plain debug build disables Impeller (emulator workaround in `src/debug/AndroidManifest.xml`), so the live preview only appears with that flag; release and profile builds render with Impeller.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore