### PR TITLE
docs(privacy): fix iOS privacy notes that no longer match the app's manifest

### DIFF
--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -96,7 +96,7 @@ the manifest rules and the release checklist.
 | D4 — Search History | Approved | Not linked. | Declare Search History, purpose App Functionality, tracking false, linked false. |
 | D5 — private-message linkage | Approved | Linked. NIP-17 hides the sender, but the legacy kind-4 fallback exposes author/recipient to relays, and Keycast (managed key custody) holds server-side keys and can decrypt for users who opt in. | `Emails or Text Messages` declared linked, purpose App Functionality, tracking false. |
 | D6 — Performance Data | Approved | Linked (conservative), purposes Analytics and App Functionality, tracking false. | Performance Data declared linked. |
-| D7 — Shorebird | Approved | Not linked, not tracking. | Disclose Device ID / Product Interaction / Other Diagnostic Data in App Store Connect (#7980); not duplicated in the Runner manifest. |
+| D7 — Shorebird | Approved | Not linked, not tracking. | Disclose Device ID / Product Interaction / Other Diagnostic Data in App Store Connect (#7980); not duplicated in the Runner manifest. Not linked holds only while neither Divine nor Shorebird joins the installation identifier to Divine account data; revisit D7 if that changes. |
 
 ### Tracking posture before each candidate
 

--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -68,11 +68,10 @@ declaration described below.
 | App (`Runner`) | *(none)* | — | The Runner target's own Release code calls no required-reason API. Its single `UserDefaults` call is inside `#if DEBUG`. |
 | `divine_quick_actions` | *(none)* | — | No required-reason API detected. |
 
-`NSPrivacyCollectedDataTypes` is empty in the app manifest and is **not** a
-claim that Divine collects nothing. Filling it is a product/legal decision that
-must match the App Store Connect privacy label, and was deliberately out of
-scope for the required-reason API audit. Its outcome is recorded under
-[Privacy-label decisions](#privacy-label-decisions-8850) below.
+The app manifest's `NSPrivacyCollectedDataTypes` is filled in from the
+[Privacy-label decisions](#privacy-label-decisions-8850) below. Choosing those
+values was a product/legal decision that must match the App Store Connect
+privacy label, which is why it was kept out of the required-reason API audit.
 
 `LibProofMode`'s collected-data section is empty because Divine constructs
 `ProofGenerationOptions(showDeviceIds: false, showLocation: false,

--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -98,6 +98,36 @@ the manifest rules and the release checklist.
 | D6 — Performance Data | Approved | Linked (conservative), purposes Analytics and App Functionality, tracking false. | Performance Data declared linked. |
 | D7 — Shorebird | Approved | Not linked, not tracking. | Disclose Device ID / Product Interaction / Other Diagnostic Data in App Store Connect (#7980); not duplicated in the Runner manifest. Not linked holds only while neither Divine nor Shorebird joins the installation identifier to Divine account data; revisit D7 if that changes. |
 
+### How the App Store Connect label combines these
+
+App Store Connect asks, for each data type, whether it is linked to the user's
+identity "by you and/or your third-party partners"
+([Apple](https://developer.apple.com/app-store/app-privacy-details/)). So each
+data type gets one answer covering the app and every SDK: it is linked if any
+collector links it, and its purposes are the union of every collector's
+purposes. Device ID, Crash Data and Other Diagnostic Data are declared linked
+by the Runner manifest (D2) and not linked by Firebase's own manifests, so the
+label answers linked for all three.
+
+Xcode's aggregate privacy report only shows collection that some bundle
+declares, and several SDKs in this app declare none. Their collection has to be
+added to the App Store Connect answers by hand, from the vendor's guidance:
+
+- Shorebird (D7): the engine's privacy manifest is Flutter's stock one, which
+  declares no collected data, and the updater ships no manifest.
+- Firebase Analytics (with GoogleAppMeasurement), Google's on-device
+  conversion measurement SDK (GoogleAdsOnDeviceConversion), Firebase
+  Performance and Firebase Sessions ship no privacy manifest. Google's
+  guidance is its
+  [App Store data disclosure page](https://firebase.google.com/docs/ios/app-store-data-collection).
+
+The report does show one type that the Runner manifest does not repeat: Other
+Data Types, declared by Firebase Cloud Messaging (not linked, Analytics). It
+belongs on the label like any other SDK-declared type.
+
+Checked on 2026-09-11 against firebase-ios-sdk 12.12.0, GoogleAppMeasurement
+12.11.0 and Shorebird 1.6.120. Re-check whenever one of them changes.
+
 ### Tracking posture before each candidate
 
 Every candidate is evaluated against its own analytics configuration, so before

--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -107,7 +107,10 @@ data type gets one answer covering the app and every SDK: it is linked if any
 collector links it, and its purposes are the union of every collector's
 purposes. Device ID, Crash Data and Other Diagnostic Data are declared linked
 by the Runner manifest (D2) and not linked by Firebase's own manifests, so the
-label answers linked for all three.
+label answers linked for all three. D7 works the same way: Shorebird's own
+Device ID, Product Interaction and Other Diagnostic Data stay not linked, but
+the label answers linked for those types because the Runner manifest declares
+them linked.
 
 Xcode's aggregate privacy report only shows collection that some bundle
 declares, and several SDKs in this app declare none. Their collection has to be

--- a/mobile/ios/Runner/PrivacyInfo.xcprivacy
+++ b/mobile/ios/Runner/PrivacyInfo.xcprivacy
@@ -18,11 +18,12 @@
   duplicated here.
 
   NSPrivacyCollectedDataTypes is populated from the decisions recorded in
-  #8850 and mirrored in mobile/docs/IOS_PRIVACY_MANIFESTS.md. All entries are
-  declared linked because they are associated with the authenticated account,
-  and all are tracking=false: D1 disabled personalized advertising and removed
-  the ad-tech account link, so NSPrivacyTracking stays false and no ATT prompt
-  is required. Precise Location is deliberately absent because the bug-report
+  #8850 and mirrored in mobile/docs/IOS_PRIVACY_MANIFESTS.md. Every entry
+  except Search History (D4) is declared linked because it is associated with
+  the authenticated account, and all are tracking=false: D1 disabled
+  personalized advertising and removed the ad-tech account link, so
+  NSPrivacyTracking stays false and no ATT prompt is required. Precise
+  Location is deliberately absent because the bug-report
   picker strips attachment metadata (#9049). SDK-owned collection (for example
   Shorebird's Device ID / Product Interaction / Other Diagnostic Data) is
   disclosed in App Store Connect, not repeated here.


### PR DESCRIPTION
## Description

The iOS privacy notes merged in #9052 and #9058 now contradict the manifest they describe. That matters because the next App Store privacy label is checked against them (#8850). Three places are wrong:

- The privacy-manifest doc still says the app's list of collected data types is empty. #9058 filled it with 15 types.
- The manifest's own header comment says every entry is linked to the user. Search History is declared not linked (decision D4).
- The Shorebird row (D7) lost the condition its "not linked" answer depends on. It holds only while neither Divine nor Shorebird joins Shorebird's install ID to a Divine account. #8850 states that condition, and it is the trigger for revisiting D7.

This PR fixes those three. It also adds a short section on how the App Store Connect answers are combined, because the current plan in #7980 gets it wrong:

- App Store Connect takes one linked/tracking answer per data type, covering the app and every SDK. So Device ID, Crash Data and Other Diagnostic Data go on the label as linked, even though Firebase's own manifests say not linked.
- Several SDKs ship no privacy manifest, so Xcode's privacy report can't show their collection and it has to be added by hand. They are Shorebird, Firebase Analytics, Google's on-device conversion SDK, Firebase Performance and Firebase Sessions.
- Firebase Cloud Messaging declares Other Data Types. The report will show it, and the app manifest doesn't repeat it.

**Related Issue:** Relates to #8850

## Out of Scope

- No manifest values change; the only manifest edit is its XML comment. Parsing the file before and after gives identical values.
- D6/D7's "Approved" status is unchanged. Whether product/legal still need to countersign is asked on #8850.
- The App Store Connect answers live in #7980. The correction is posted there, not made here.
- Open label questions are raised on #8850, not decided here.

## Verification

- `plutil -lint` and a strict `plistlib` parse of `mobile/ios/Runner/PrivacyInfo.xcprivacy`. Values are identical to `origin/main`, and the XML comment contains no `--`.
- `bash mobile/scripts/check_privacy_manifest_coverage.sh` passes.
- `python3 mobile/scripts/lib/render_required_reason_catalogue.py --check` passes, so the generated catalogue tables are untouched.
- Every decision-table row keeps its four columns.
- I checked the SDK facts in the new section against the linked packages (firebase-ios-sdk 12.12.0, GoogleAppMeasurement 12.11.0, GoogleAdsOnDeviceConversion 3.4.x) and against the engine source for Shorebird 1.6.120.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
