### PR TITLE
fix(player): stop keeping a second, unreclaimable copy of cached videos

### DIFF
--- a/mobile/docs/VIDEO_CACHE.md
+++ b/mobile/docs/VIDEO_CACHE.md
@@ -1,0 +1,98 @@
+# Video caches
+
+Status: Current
+Validated against: `mobile/lib/services/openvine_media_cache.dart`,
+`mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart`,
+`mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/VideoCache.kt`,
+and `mobile/lib/services/storage_management_service.dart` on 2026-09-11.
+
+Two caches can hold video bytes on disk. They serve different paths and only
+one of them is meant to hold a given video.
+
+| Cache | Owner | Where | Budget | Holds |
+|---|---|---|---|---|
+| Media cache | Dart, `openVineMediaCache` (`media_cache`) | `<temp>/openvine_video_cache` | User setting, Settings → Storage (2 GB default) | Whole files the feed prefetched ahead of the viewer |
+| Player cache | Android only, ExoPlayer `SimpleCache` (`VideoCache.kt`) | `<cacheDir>/divine_video_cache` | 500 MB, `configureCache()` at startup | Byte ranges ExoPlayer streamed from an HTTP(S) URL |
+
+Settings → Storage counts both and "Clear cache" empties both
+(`StorageManagementService`, categories `video` and `player`).
+
+## Which cache serves a feed video
+
+`InfiniteVideoFeed._initController` asks the media cache first. On a hit the
+player opens `VideoClip.file(cachedFile.path)`; on a miss it opens
+`VideoClip.network(url)` and ExoPlayer streams it, filling the player cache as
+it goes. The disk prefetcher downloads `index + 1 … index + prefetchCount` into
+the media cache sequentially, one HTTP download at a time, so a miss happens
+when the viewer moves faster than that queue drains.
+
+The player cache therefore only adds value on the **miss** path, and on a
+scroll back to a video that was a miss the first time — the prefetcher only
+looks forward, so the media cache never fetches it after the fact.
+
+## What bypasses the player cache
+
+`CacheBypassDataSource` routes a request around `SimpleCache` when either:
+
+- it is not `http`/`https` — a `file://` URI, the bare path a `VideoClip.file`
+  arrives as, `content://`, `asset://`. The bytes are already on the device.
+  Before #8029 every media-cache hit went through the write-through cache and
+  ExoPlayer stored a second copy of the file, invisible to Settings → Storage
+  and outside its "Clear cache".
+- it carries viewer-auth headers (age-gated content). The origin serves those
+  `no-store` and the bytes are never persisted.
+
+## iOS and macOS
+
+There is no player cache. AVFoundation loads media through its own stack and
+does not consult `URLCache`, so `configureCache()` is a no-op on Apple
+platforms. A build before #8029 replaced `URLCache.shared` with a 500 MB cache
+whose disk-path component was `divine_video_cache`, even though the player
+never read it. On upgraded installs, Settings makes a best-effort check for
+that component directly under the application cache directory and removes it
+when present. Foundation chooses the final on-disk placement, so this does not
+claim to find every legacy Apple cache without device verification.
+
+## Measuring the feed hit rate
+
+Every feed activation logs one line under the `FeedFirstFrame` logger name
+ending in `cache=hit` or `cache=miss` (`FeedFirstFrameMetric.loadedFromCache`).
+Nothing forwards it to analytics, so the rate is measured on a device:
+
+```bash
+adb logcat -c
+adb logcat -v time | grep --line-buffered FeedFirstFrame > /tmp/feed.log
+# scroll the fullscreen feed, then
+grep -c 'cache=hit' /tmp/feed.log; grep -c 'cache=miss' /tmp/feed.log
+```
+
+## Decision: the player cache stays, on Android only
+
+Measured on 2026-09-11 with a debug build of the #8029 branch on a Samsung
+Galaxy (SM-S942B) over Wi-Fi, driving the "For You" feed forward with
+`adb shell input swipe` and reading the per-index `Init player index N … from
+cache|network` lines the feed logs:
+
+| Run | Videos | Interval | From cache | From network | Player-cache growth |
+|---|---|---|---|---|---|
+| Warm caches | 40 | 2.5 s | 40 | 0 | 0 B |
+| Warm caches | 60 | 1.0 s | 60 | 0 | 0 B |
+| Warm caches | 60 | 0.5 s | 60 | 0 | 0 B |
+| Both caches just cleared | 30 | 1.0 s | 30 | 0 | 0 B |
+
+The only network plays were the three players the feed rebuilt when it was
+re-entered right after "Clear cache" (the active video and its neighbours,
+before the prefetcher's first download landed); ExoPlayer wrote 4.5 MB for
+them. Over the 190 scroll activations the player cache did not grow at all,
+while before the fix the same device had accumulated 315 MB in it against
+17 MB in the media cache.
+
+So on Wi-Fi the prefetcher never falls behind a scroll, and the miss path is
+confined to feed entry. What the player cache still buys is exactly that
+entry — the first video plays as a progressive stream and a second play of it
+comes from disk — and whatever the miss rate is on a slow cellular link, which
+this run did not measure. That is a bounded 500 MB budget that Settings →
+Storage now counts and "Clear cache" reclaims, so it is kept rather than
+removed. Two things would reopen the question: a cellular measurement showing
+the miss path is as rare there as on Wi-Fi, or a prefetcher that also fetches
+the active index on entry, which would leave the player cache nothing to add.

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -464,6 +464,7 @@ class BugReportService {
         buffer.writeln(
           'Cache: '
           'video ${_formatCacheUsageCategory(usage.video)} · '
+          'player ${_formatCacheUsageCategory(usage.player)} · '
           'images ${_formatCacheUsageCategory(usage.images)} · '
           'seams ${_formatCacheUsageCategory(usage.transitionSeams)} · '
           'temp ${_formatCacheUsageCategory(usage.tempRenders)}',

--- a/mobile/lib/services/storage_management_service.dart
+++ b/mobile/lib/services/storage_management_service.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:db_client/db_client.dart';
+import 'package:divine_video_player/divine_video_player.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:media_cache/media_cache.dart';
@@ -39,6 +40,7 @@ class CacheUsage extends Equatable {
   /// Creates a cache usage breakdown.
   const CacheUsage({
     required this.video,
+    required this.player,
     required this.images,
     required this.transitionSeams,
     required this.tempRenders,
@@ -50,6 +52,10 @@ class CacheUsage extends Equatable {
       usedBytes: 0,
       limitBytes: kCacheLimitDefaultBytes,
     ),
+    player: CacheUsageCategory(
+      usedBytes: 0,
+      limitBytes: kDefaultCacheMaxSizeBytes,
+    ),
     images: CacheUsageCategory(usedBytes: 0),
     transitionSeams: CacheUsageCategory(
       usedBytes: 0,
@@ -60,6 +66,11 @@ class CacheUsage extends Equatable {
 
   /// Feed video download cache.
   final CacheUsageCategory video;
+
+  /// The native player's own disk cache: what ExoPlayer kept of the HTTP(S)
+  /// sources it streamed on Android, under its separate 500 MB budget. Empty
+  /// on other platforms, apart from what an older iOS build left behind.
+  final CacheUsageCategory player;
 
   /// Image and thumbnail cache.
   final CacheUsageCategory images;
@@ -76,12 +87,19 @@ class CacheUsage extends Equatable {
   /// Total bytes currently held by all clearable categories.
   int get totalBytes =>
       video.usedBytes +
+      player.usedBytes +
       images.usedBytes +
       transitionSeams.usedBytes +
       tempRenders.usedBytes;
 
   @override
-  List<Object?> get props => [video, images, transitionSeams, tempRenders];
+  List<Object?> get props => [
+    video,
+    player,
+    images,
+    transitionSeams,
+    tempRenders,
+  ];
 }
 
 /// Documents-directory usage split by who can reclaim it.
@@ -158,11 +176,12 @@ class _DocumentsScan {
 /// Clears re-downloadable / regenerable media caches, measures and sweeps the
 /// documents directory, and audits the clip library for broken entries.
 ///
-/// What [clearCaches] clears: the feed video download cache, the
-/// image/thumbnail cache, leftover temp render files and scratch directories,
-/// and the regenerable transition previews. What it never touches: the user's
-/// clip-library files (recorded/imported videos), drafts, sounds, keys, or
-/// preferences — those live outside the cleared directories.
+/// What [clearCaches] clears: the feed video download cache, the native
+/// player's disk cache, the image/thumbnail cache, leftover temp render files
+/// and scratch directories, and the regenerable transition previews. What it
+/// never touches: the user's clip-library files (recorded/imported videos),
+/// drafts, sounds, keys, or preferences — those live outside the cleared
+/// directories.
 ///
 /// What [removeOrphanedFiles] removes: media files directly under the
 /// documents root that no clip row, draft row, or pending upload references —
@@ -291,16 +310,19 @@ class StorageManagementService {
   Future<CacheUsage> cacheUsage() async {
     final temp = await _temporaryDirectoryProvider();
     final docs = await _documentsDirectoryProvider();
+    final playerCache = await _playerCacheDirectory();
     final protectedPaths = _normalizedProtectedPaths();
     var transitionBytes = 0;
     for (final dir in _documentsCacheDirs) {
-      transitionBytes += (await _dirSize(Directory(p.join(docs.path, dir))))
-          .bytes;
+      transitionBytes += (await _dirSize(
+        Directory(p.join(docs.path, dir)),
+      )).bytes;
     }
     var tempRenderBytes = await _tempRenderBytes(temp, protectedPaths);
     for (final dir in TempRenderDirectories.all) {
-      tempRenderBytes += (await _dirSize(Directory(p.join(temp.path, dir))))
-          .bytes;
+      tempRenderBytes += (await _dirSize(
+        Directory(p.join(temp.path, dir)),
+      )).bytes;
     }
     return CacheUsage(
       video: CacheUsageCategory(
@@ -308,6 +330,12 @@ class StorageManagementService {
           Directory(p.join(temp.path, kVideoCacheDirectoryName)),
         )).bytes,
         limitBytes: videoCacheLimitBytes(),
+      ),
+      player: CacheUsageCategory(
+        usedBytes: playerCache == null
+            ? 0
+            : (await _dirSize(playerCache)).bytes,
+        limitBytes: kDefaultCacheMaxSizeBytes,
       ),
       images: CacheUsageCategory(
         usedBytes: (await _dirSize(
@@ -335,6 +363,13 @@ class StorageManagementService {
     await _deleteDirContents(
       Directory(p.join(temp.path, kVideoCacheDirectoryName)),
     );
+    final playerCache = await _playerCacheDirectory();
+    if (playerCache != null) {
+      await _deleteDirContents(
+        playerCache,
+        keep: (entity) => entity is File && p.extension(entity.path) == '.uid',
+      );
+    }
     await _deleteDirContents(Directory(p.join(temp.path, _imageCacheDir)));
     final protectedPaths = _normalizedProtectedPaths();
     await _forEachTempRender(
@@ -451,6 +486,32 @@ class StorageManagementService {
     return StorageFootprint(roots: roots);
   }
 
+  /// Where the native player keeps its own disk cache, or null when the
+  /// platform cannot resolve a cache directory.
+  ///
+  /// ExoPlayer writes `<cacheDir>/divine_video_cache` on Android (see
+  /// `VideoCache.kt`, which owns the name through
+  /// [kNativeVideoCacheDirectoryName]). On Apple platforms, this is also the
+  /// best-effort location checked for leftovers from the `URLCache` configured
+  /// by builds before #8029. Foundation chooses its final on-disk placement,
+  /// so no cleanup is claimed when that directory is absent.
+  Future<Directory?> _playerCacheDirectory() async {
+    final caches = await _resolveRoot(
+      'Caches',
+      _applicationCacheDirectoryProvider,
+    );
+    if (caches == null) return null;
+    return Directory(p.join(caches.path, kNativeVideoCacheDirectoryName));
+  }
+
+  /// Empties the native player cache while ExoPlayer may still hold it open.
+  ///
+  /// `SimpleCache` tolerates its span files vanishing underneath it — a read
+  /// that finds a shorter file than the index recorded drops the stale spans
+  /// and falls through to the network — but it identifies its on-disk index
+  /// by a `.uid` marker in the same directory. Deleting that marker would make
+  /// the next launch open a fresh index and orphan the old one in the shared
+  /// ExoPlayer database, so it is the one file left in place.
   /// The directory [provider] points at, or null when the platform has no
   /// such root — a missing root must not fail the whole measurement.
   Future<Directory?> _resolveRoot(
@@ -740,10 +801,14 @@ class StorageManagementService {
 
   String _normalizePath(String filePath) => p.normalize(p.absolute(filePath));
 
-  Future<void> _deleteDirContents(Directory dir) async {
+  Future<void> _deleteDirContents(
+    Directory dir, {
+    bool Function(FileSystemEntity entity)? keep,
+  }) async {
     if (!dir.existsSync()) return;
     try {
       await for (final entity in dir.list(followLinks: false)) {
+        if (keep?.call(entity) ?? false) continue;
         await _deleteQuietly(entity);
       }
     } on Object catch (error) {

--- a/mobile/lib/startup/app_bootstrap.dart
+++ b/mobile/lib/startup/app_bootstrap.dart
@@ -213,17 +213,19 @@ Future<void> startOpenVineApp({
   // They initialize automatically when a DivineVideoPlayerController is
   // first created.
 
-  // Configure the native video player disk cache (500 MB, LRU eviction).
-  // Skip on web/Linux/Windows — divine_video_player has no native plugin
-  // on those targets and `configureCache` is a bare method-channel call.
+  // Configure the Android player's disk cache (500 MB, LRU eviction). It is
+  // Android-only: AVFoundation never reads a URLCache, so the Apple plugin
+  // has nothing to configure (#8029). Skip on web/Linux/Windows —
+  // divine_video_player has no native plugin on those targets and
+  // `configureCache` is a bare method-channel call.
   await configureVideoPlayerCacheForStartup(
     skip: !hasNativeVideoPlayer,
     configureCache: DivineVideoPlayerController.configureCache,
   );
 
-  // Dispose any zombie native players from a previous Dart VM
-  // (e.g. hot restart). Must happen after configureCache so the
-  // global method channel is already registered.
+  // Dispose any zombie native players from a previous Dart VM (e.g. hot
+  // restart). Plugin registration, rather than configureCache, makes the
+  // global method channel available on each native platform.
   await disposeVideoPlayersForStartup(
     skip: !hasNativeVideoPlayer,
     disposeAll: DivineVideoPlayerController.disposeAll,
@@ -263,9 +265,7 @@ Future<void> startOpenVineApp({
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       try {
         startupPerformance.startPhase('window_manager');
-        crashReporting.logInitializationStep(
-          'Initializing window manager',
-        );
+        crashReporting.logInitializationStep('Initializing window manager');
         await windowManager.ensureInitialized();
 
         // Set initial window size for desktop vine experience
@@ -333,10 +333,7 @@ Future<void> startOpenVineApp({
       if (message.contains('[EXTERNAL-EVENT]') &&
           message.contains('already exists in database or was rejected')) {
         // Use our batcher for these specific messages
-        logMessageBatcher.tryBatchMessage(
-          message,
-          category: LogCategory.relay,
-        );
+        logMessageBatcher.tryBatchMessage(message, category: LogCategory.relay);
         return; // Don't print the individual message
       } else if (message.contains('[EXTERNAL-EVENT]') &&
           message.contains('matches subscription')) {
@@ -682,12 +679,8 @@ Future<void> startOpenVineApp({
   Log.info('Divine starting...', name: 'Main');
   Log.info('Log level: ${UnifiedLogger.currentLevel.name}', name: 'Main');
   final initDuration = DateTime.now().difference(startTime).inMilliseconds;
-  crashReporting.log(
-    '[STARTUP] Blocking setup took ${initDuration}ms',
-  );
-  crashReporting.logInitializationStep(
-    'Blocking startup complete',
-  );
+  crashReporting.log('[STARTUP] Blocking setup took ${initDuration}ms');
+  crashReporting.logInitializationStep('Blocking startup complete');
   startupPerformance.checkpoint('pre_app_launch');
 
   await initializeDateFormatting();
@@ -760,16 +753,10 @@ Future<void> _recordBuildProvenance({
     Log.info(provenance.summary, name: 'Main', category: LogCategory.system);
     crashReporting.log(provenance.summary);
     unawaited(
-      crashReporting.setCustomKey(
-        'environment',
-        provenance.environment.name,
-      ),
+      crashReporting.setCustomKey('environment', provenance.environment.name),
     );
     unawaited(
-      crashReporting.setCustomKey(
-        'build_mode',
-        provenance.buildMode.name,
-      ),
+      crashReporting.setCustomKey('build_mode', provenance.buildMode.name),
     );
     unawaited(
       crashReporting.setCustomKey(
@@ -784,10 +771,7 @@ Future<void> _recordBuildProvenance({
       ),
     );
     unawaited(
-      crashReporting.setCustomKey(
-        'shorebird_patch',
-        provenance.patchLabel,
-      ),
+      crashReporting.setCustomKey('shorebird_patch', provenance.patchLabel),
     );
   } catch (error, stack) {
     Log.warning(

--- a/mobile/packages/divine_video_player/README.md
+++ b/mobile/packages/divine_video_player/README.md
@@ -111,16 +111,32 @@ await controller.dispose();
 Pre-buffer upcoming videos so playback starts instantly:
 
 ```dart
-// Configure the native cache (call once at app startup)
+// Configure the Android player's disk cache (call once at app startup)
 await DivineVideoPlayerController.configureCache(
   maxSizeBytes: 500 * 1024 * 1024, // 500 MB
 );
 
-// Preload into the cache without creating a player
+// Preload without creating a player
 await DivineVideoPlayerController.preload([
   VideoClip(uri: 'https://example.com/next-video.mp4'),
 ]);
 ```
+
+The disk cache exists on Android only. ExoPlayer streams HTTP(S) sources
+through a write-through `SimpleCache` at `<cacheDir>/divine_video_cache`
+(`kNativeVideoCacheDirectoryName`), so a URL it has already streamed is
+served from disk the next time. Two kinds of source deliberately bypass it:
+
+- Local sources — `VideoClip.file`, or any URI that is not `http`/`https`.
+  The bytes are already on the device; caching them would only store a
+  second copy. An app that hands the player files from its own download
+  cache therefore pays for one copy, not two.
+- Viewer-authenticated sources, which the origin serves `no-store`; those
+  bytes are never persisted.
+
+On iOS and macOS there is no cache to configure: AVFoundation loads media
+through its own stack and does not consult `URLCache`, so `configureCache`
+is a no-op there and `preload` only makes a best-effort metadata request.
 
 ### Texture rendering
 

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/VideoCache.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/VideoCache.kt
@@ -22,9 +22,13 @@ import java.io.File
  * Initialised once via [configure] at app startup. All player instances
  * share the same cache directory and eviction policy.
  *
- * When configured, [dataSourceFactory] returns a [CacheDataSource.Factory]
- * that reads from cache first and fills it progressively on cache misses.
+ * When configured, [dataSourceFactory] returns a factory whose sources read
+ * HTTP(S) media from cache first and fill it progressively on cache misses.
  * When **not** configured, it falls back to a plain [DefaultDataSource.Factory].
+ *
+ * The cache lives at `<cacheDir>/divine_video_cache`. The app's storage
+ * screen counts and clears that directory by name, so a rename here must be
+ * mirrored in `StorageManagementService`.
  */
 @UnstableApi
 internal object VideoCache {
@@ -64,6 +68,9 @@ internal object VideoCache {
      * Returns a [DataSource.Factory] that hits the cache when available,
      * or a plain [DefaultDataSource.Factory] if the cache has not been
      * configured.
+     *
+     * Only anonymous HTTP(S) requests go through the cache; see
+     * [CacheBypassDataSource] for what is routed around it and why.
      */
     fun dataSourceFactory(
         context: Context,
@@ -72,7 +79,7 @@ internal object VideoCache {
         val cachedFactory = cacheDataSourceFactory ?: upstreamFactory(context)
         val uncachedFactory = upstreamFactory(context)
         return DataSource.Factory {
-            AuthAwareCacheBypassDataSource(
+            CacheBypassDataSource(
                 cachedFactory = cachedFactory,
                 uncachedFactory = uncachedFactory,
                 httpHeadersForUri = httpHeadersForUri,
@@ -141,7 +148,33 @@ internal class ProcessingResponseDataSource(
     }
 }
 
-internal class AuthAwareCacheBypassDataSource(
+/**
+ * Whether a request for [scheme] can usefully go through [SimpleCache].
+ *
+ * Only remote HTTP(S) bytes are worth keeping: everything else Media3 can
+ * open — `file`, a bare path (no scheme), `content`, `asset`, `data` — is
+ * already on the device. Routing those through a write-through cache copies
+ * every local read into `divine_video_cache` a second time, which is exactly
+ * what happened to each feed video played from the Dart-side media cache
+ * (#8029).
+ */
+internal fun isCacheableScheme(scheme: String?): Boolean =
+    scheme.equals("http", ignoreCase = true) ||
+        scheme.equals("https", ignoreCase = true)
+
+/**
+ * Routes each request either through [cachedFactory] or straight to
+ * [uncachedFactory], deciding per `open()` so HLS segments are judged on
+ * their own URI rather than the manifest's.
+ *
+ * Two kinds of request bypass the cache:
+ *  - Viewer-authenticated (age-gated) content, which the origin serves
+ *    `no-store`; the auth headers are attached and the private bytes are
+ *    never persisted.
+ *  - Anything that is not an HTTP(S) URL, which is already local and would
+ *    only be duplicated on disk (see [isCacheableScheme]).
+ */
+internal class CacheBypassDataSource(
     private val cachedFactory: DataSource.Factory,
     private val uncachedFactory: DataSource.Factory,
     private val httpHeadersForUri: (Uri) -> Map<String, String>,
@@ -160,12 +193,10 @@ internal class AuthAwareCacheBypassDataSource(
         val resolvedDataSpec = if (httpHeaders.isEmpty()) {
             dataSpec
         } else {
-            // Authenticated age-gated responses are served no-store by the
-            // origin. Attach the viewer auth headers but bypass SimpleCache so
-            // those private bytes are not persisted on disk.
             dataSpec.withRequestHeaders(dataSpec.httpRequestHeaders + httpHeaders)
         }
-        val selectedDelegate = if (httpHeaders.isEmpty()) {
+        val useCache = httpHeaders.isEmpty() && isCacheableScheme(dataSpec.uri.scheme)
+        val selectedDelegate = if (useCache) {
             cachedFactory.createDataSource()
         } else {
             uncachedFactory.createDataSource()

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/VideoCacheTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/VideoCacheTest.kt
@@ -10,25 +10,34 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Pins the transport contract of [AuthAwareCacheBypassDataSource]: gated
+ * Pins the transport contract of [CacheBypassDataSource]: gated
  * (viewer-authenticated) requests attach the auth header AND bypass the disk
- * cache so private bytes are never persisted, while anonymous requests use the
- * cache and add no headers. This is the per-request half of the gated-HLS fix
- * (#4884 / #4897) — the resolver runs on every `open()`, so HLS media segments
- * authenticate alongside the master manifest.
+ * cache so private bytes are never persisted, while anonymous HTTP(S) requests
+ * use the cache and add no headers. This is the per-request half of the
+ * gated-HLS fix (#4884 / #4897) — the resolver runs on every `open()`, so HLS
+ * media segments authenticate alongside the master manifest.
+ *
+ * Local sources bypass the cache too (#8029): a `file://` URI or a bare path
+ * is already on disk, and routing it through the write-through cache stored a
+ * second copy of every feed video played from the Dart-side media cache.
  */
 @UnstableApi
 class VideoCacheTest {
 
     private val authHeaders = mapOf("Authorization" to "Nostr token")
 
-    private fun dataSpec(): DataSpec =
-        DataSpec.Builder().setUri(mockk<Uri>(relaxed = true)).build()
+    private fun dataSpec(uriScheme: String? = "https"): DataSpec {
+        val uri = mockk<Uri>(relaxed = true) {
+            every { scheme } returns uriScheme
+        }
+        return DataSpec.Builder().setUri(uri).build()
+    }
 
     @Test
     fun `open attaches viewer headers and bypasses the cache for gated content`() {
@@ -43,7 +52,7 @@ class VideoCacheTest {
         val openedSpec = slot<DataSpec>()
         every { uncachedDelegate.open(capture(openedSpec)) } returns 0L
 
-        val source = AuthAwareCacheBypassDataSource(
+        val source = CacheBypassDataSource(
             cachedFactory = cachedFactory,
             uncachedFactory = uncachedFactory,
             httpHeadersForUri = { authHeaders },
@@ -74,17 +83,72 @@ class VideoCacheTest {
         val openedSpec = slot<DataSpec>()
         every { cachedDelegate.open(capture(openedSpec)) } returns 0L
 
-        val source = AuthAwareCacheBypassDataSource(
+        val source = CacheBypassDataSource(
             cachedFactory = cachedFactory,
             uncachedFactory = uncachedFactory,
             httpHeadersForUri = { emptyMap() },
         )
 
-        source.open(dataSpec())
+        source.open(dataSpec(uriScheme = "https"))
 
         verify(exactly = 1) { cachedFactory.createDataSource() }
         verify(exactly = 0) { uncachedFactory.createDataSource() }
         assertTrue(openedSpec.captured.httpRequestHeaders.isEmpty())
+    }
+
+    @Test
+    fun `open bypasses the cache for a file URI`() {
+        val cachedFactory = mockk<DataSource.Factory> {
+            every { createDataSource() } returns mockk(relaxed = true)
+        }
+        val uncachedFactory = mockk<DataSource.Factory> {
+            every { createDataSource() } returns mockk(relaxed = true)
+        }
+
+        val source = CacheBypassDataSource(
+            cachedFactory = cachedFactory,
+            uncachedFactory = uncachedFactory,
+            httpHeadersForUri = { emptyMap() },
+        )
+
+        source.open(dataSpec(uriScheme = "file"))
+
+        // The bytes are already on disk; a cache pass would only copy them.
+        verify(exactly = 1) { uncachedFactory.createDataSource() }
+        verify(exactly = 0) { cachedFactory.createDataSource() }
+    }
+
+    @Test
+    fun `open bypasses the cache for a bare path`() {
+        val cachedFactory = mockk<DataSource.Factory> {
+            every { createDataSource() } returns mockk(relaxed = true)
+        }
+        val uncachedFactory = mockk<DataSource.Factory> {
+            every { createDataSource() } returns mockk(relaxed = true)
+        }
+
+        val source = CacheBypassDataSource(
+            cachedFactory = cachedFactory,
+            uncachedFactory = uncachedFactory,
+            httpHeadersForUri = { emptyMap() },
+        )
+
+        // `VideoClip.file(path)` reaches the player as a scheme-less path,
+        // which Media3 resolves to a local file.
+        source.open(dataSpec(uriScheme = null))
+
+        verify(exactly = 1) { uncachedFactory.createDataSource() }
+        verify(exactly = 0) { cachedFactory.createDataSource() }
+    }
+
+    @Test
+    fun `only http and https schemes are cacheable`() {
+        assertTrue(isCacheableScheme("http"))
+        assertTrue(isCacheableScheme("https"))
+        assertTrue(isCacheableScheme("HTTPS"))
+        assertFalse(isCacheableScheme("file"))
+        assertFalse(isCacheableScheme("content"))
+        assertFalse(isCacheableScheme(null))
     }
 
     @Test

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerPlugin.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerPlugin.swift
@@ -224,25 +224,20 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
             let clips = args["clips"] as? [[String: Any]] ?? []
             Self.handlePreload(clips: clips, result: result)
 
-        case "configureCache":
-            let maxSizeBytes = args["maxSizeBytes"] as? Int ?? (500 * 1024 * 1024)
-            // 10% of disk budget for in-memory cache, rest on disk.
-            let memoryCapacity = maxSizeBytes / 10
-            URLCache.shared = URLCache(
-                memoryCapacity: memoryCapacity,
-                diskCapacity: maxSizeBytes,
-                diskPath: "divine_video_cache"
-            )
-            result(nil)
-
         default:
             result(FlutterMethodNotImplemented)
         }
     }
 
-    /// Preloads video metadata and initial buffer data by loading
-    /// `AVURLAsset` properties asynchronously. The OS-level URL cache
-    /// retains the fetched data so that a real player starts faster.
+    /// Best-effort preload of video metadata by loading `AVURLAsset`
+    /// properties asynchronously before a real player requests them.
+    ///
+    /// There is no disk cache behind this on Apple platforms: AVFoundation
+    /// loads media through its own stack and never consults `URLCache`, so
+    /// the plugin deliberately configures none. Playback caching is the
+    /// app's job (the Dart-side media cache hands the player local files).
+    /// The temporary asset is discarded when its task finishes, so this does
+    /// not promise that metadata remains warm for a later player.
     private static func handlePreload(
         clips: [[String: Any]],
         result: @escaping FlutterResult

--- a/mobile/packages/divine_video_player/docs/GATED_HLS_QA.md
+++ b/mobile/packages/divine_video_player/docs/GATED_HLS_QA.md
@@ -10,7 +10,7 @@ Header transport differs per platform and is unit-tested only where it can be:
 
 - **Android** — ExoPlayer keys request headers per URI, so HLS segments (a
   different URI than the manifest) need an explicit hash fallback. Covered by
-  `httpHeadersForRequest` + `AuthAwareCacheBypassDataSource` (unit-tested in
+  `httpHeadersForRequest` + `CacheBypassDataSource` (unit-tested in
   `DivineVideoPlayerInstanceTest` / `VideoCacheTest`, CI-gated via the
   `android-unit-tests` job).
 - **iOS / macOS** — headers set under `avURLAssetHTTPHeaderFieldsKey`
@@ -39,7 +39,7 @@ will reject so playback falls over to HLS (or temporarily force the HLS source).
 - [ ] **Negative:** as a **signed-out / non-verified** viewer, the same gated
       content is refused (401 → age-gate UX), confirming the gate is real.
 - [ ] **Android cache:** the gated bytes are **not** persisted to the disk cache
-      (served no-store; `AuthAwareCacheBypassDataSource` bypasses `SimpleCache`).
+      (served no-store; `CacheBypassDataSource` bypasses `SimpleCache`).
 
 ## If iOS/macOS segments 401 in QA
 

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -12,8 +12,19 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-/// Default maximum cache size on disk (500 MB).
+/// Default maximum size of the Android player's disk cache (500 MB).
+///
+/// The cache lives at `<cacheDir>/divine_video_cache`, see
+/// [kNativeVideoCacheDirectoryName].
 const int kDefaultCacheMaxSizeBytes = 500 * 1024 * 1024;
+
+/// Directory under the platform cache directory that holds the Android
+/// player's own disk cache (ExoPlayer's `SimpleCache`).
+///
+/// Nothing is written there on other platforms. The app's storage screen
+/// counts and clears the directory by this name, so it is part of the
+/// package's contract with `VideoCache.kt`.
+const String kNativeVideoCacheDirectoryName = 'divine_video_cache';
 
 /// Logger name for the Dart half of the player.
 ///
@@ -267,12 +278,17 @@ class DivineVideoPlayerController {
     return _globalChannel.invokeMethod<void>('disposeAll');
   }
 
-  /// Configures the native video cache.
+  /// Configures the Android player's disk cache.
   ///
-  /// Call once at app startup before creating any controllers.
-  /// On Android this sets up ExoPlayer's disk-backed `SimpleCache`
-  /// that allows progressive caching (stream and cache simultaneously).
-  /// On iOS/macOS it configures the shared `URLCache` disk capacity.
+  /// Call once at app startup before creating any controllers. On Android
+  /// this sets up ExoPlayer's disk-backed `SimpleCache`, which fills
+  /// progressively while an HTTP(S) source streams and serves later reads
+  /// of the same URL from disk. Local sources (`VideoClip.file`, or any
+  /// non-HTTP URI) are played directly and never copied into it.
+  ///
+  /// A no-op everywhere else. AVFoundation loads media through its own
+  /// stack and never reads `URLCache`, so there is nothing to configure on
+  /// iOS or macOS; web and Linux have no native plugin.
   ///
   /// [maxSizeBytes] is the maximum cache size on disk. Defaults to
   /// [kDefaultCacheMaxSizeBytes] (500 MB). Least-recently-used entries
@@ -288,7 +304,7 @@ class DivineVideoPlayerController {
   static Future<void> configureCache({
     int maxSizeBytes = kDefaultCacheMaxSizeBytes,
   }) {
-    if (kIsWeb || defaultTargetPlatform == TargetPlatform.linux) {
+    if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) {
       return Future.value();
     }
     return _globalChannel.invokeMethod<void>('configureCache', {
@@ -296,13 +312,14 @@ class DivineVideoPlayerController {
     });
   }
 
-  /// Pre-loads video metadata and initial buffer data into the native
-  /// cache without creating a player instance.
+  /// Pre-loads video metadata, and on Android the initial buffer of an
+  /// HTTP(S) source into the disk cache, without creating a player instance.
   ///
   /// Call this for upcoming videos (e.g. the next item in a feed) so
   /// that playback starts instantly when the user reaches them.
   /// No controller needs to be alive — the work happens on the native
-  /// side and the OS-level cache retains the result.
+  /// side. On iOS and macOS this only makes a best-effort metadata request;
+  /// nothing is retained by this plugin or written to disk there.
   ///
   /// ```dart
   /// await DivineVideoPlayerController.preload([

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
@@ -1019,7 +1019,11 @@ void main() {
     });
 
     group('static methods', () {
-      test('configureCache invokes global channel', () async {
+      test('configureCache invokes global channel on Android', () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        addTearDown(
+          () => debugDefaultTargetPlatformOverride = null,
+        );
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(
               const MethodChannel('divine_video_player'),
@@ -1042,6 +1046,10 @@ void main() {
       });
 
       test('configureCache uses default size', () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        addTearDown(
+          () => debugDefaultTargetPlatformOverride = null,
+        );
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(
               const MethodChannel('divine_video_player'),
@@ -1117,6 +1125,46 @@ void main() {
 
       test('configureCache is a no-op on Linux', () async {
         debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+        addTearDown(
+          () => debugDefaultTargetPlatformOverride = null,
+        );
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('divine_video_player'),
+              (call) async {
+                globalCalls.add(call);
+                return null;
+              },
+            );
+
+        await DivineVideoPlayerController.configureCache();
+
+        expect(globalCalls, isEmpty);
+      });
+
+      // AVFoundation never reads URLCache, so the Apple plugin has no cache
+      // to configure; an earlier build replaced URLCache.shared for nothing.
+      test('configureCache is a no-op on iOS', () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(
+          () => debugDefaultTargetPlatformOverride = null,
+        );
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('divine_video_player'),
+              (call) async {
+                globalCalls.add(call);
+                return null;
+              },
+            );
+
+        await DivineVideoPlayerController.configureCache();
+
+        expect(globalCalls, isEmpty);
+      });
+
+      test('configureCache is a no-op on macOS', () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
         addTearDown(
           () => debugDefaultTargetPlatformOverride = null,
         );

--- a/mobile/test/blocs/storage/storage_cubit_test.dart
+++ b/mobile/test/blocs/storage/storage_cubit_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as model;
@@ -43,6 +44,10 @@ void main() {
         usedBytes: 1024,
         limitBytes: configuredVideoLimit,
       ),
+      player: CacheUsageCategory(
+        usedBytes: 128,
+        limitBytes: kDefaultCacheMaxSizeBytes,
+      ),
       images: CacheUsageCategory(usedBytes: 512, limitBytes: 4 * 1024),
       transitionSeams: CacheUsageCategory(usedBytes: 256, limitBytes: 8 * 1024),
       tempRenders: CacheUsageCategory(usedBytes: 256),
@@ -68,7 +73,7 @@ void main() {
           ),
           StorageState(
             cacheStatus: StorageCacheStatus.ready,
-            cacheSizeBytes: 2048,
+            cacheSizeBytes: 2176,
             cacheUsage: cacheUsage,
             videoCacheLimitBytes: configuredVideoLimit,
           ),
@@ -308,6 +313,10 @@ void main() {
           when(service.cacheUsage).thenAnswer(
             (_) async => const CacheUsage(
               video: CacheUsageCategory(usedBytes: 512, limitBytes: oneGb),
+              player: CacheUsageCategory(
+                usedBytes: 0,
+                limitBytes: kDefaultCacheMaxSizeBytes,
+              ),
               images: CacheUsageCategory(usedBytes: 0),
               transitionSeams: CacheUsageCategory(
                 usedBytes: 0,
@@ -331,6 +340,10 @@ void main() {
             cacheSizeBytes: 512,
             cacheUsage: CacheUsage(
               video: CacheUsageCategory(usedBytes: 512, limitBytes: oneGb),
+              player: CacheUsageCategory(
+                usedBytes: 0,
+                limitBytes: kDefaultCacheMaxSizeBytes,
+              ),
               images: CacheUsageCategory(usedBytes: 0),
               transitionSeams: CacheUsageCategory(
                 usedBytes: 0,

--- a/mobile/test/screens/settings/storage/storage_management_view_test.dart
+++ b/mobile/test/screens/settings/storage/storage_management_view_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:divine_ui/divine_ui.dart';
+import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -52,6 +53,10 @@ void main() {
         video: CacheUsageCategory(
           usedBytes: 3 * 1024 * 1024,
           limitBytes: kCacheLimitDefaultBytes,
+        ),
+        player: CacheUsageCategory(
+          usedBytes: 0,
+          limitBytes: kDefaultCacheMaxSizeBytes,
         ),
         images: CacheUsageCategory(usedBytes: 0),
         transitionSeams: CacheUsageCategory(
@@ -417,17 +422,16 @@ void main() {
     ) async {
       final announcements = <String>[];
       tester.binding.defaultBinaryMessenger
-          .setMockDecodedMessageHandler<Object?>(
-            SystemChannels.accessibility,
-            (message) async {
-              if (message is Map) {
-                final data = message['data'] as Map<Object?, Object?>?;
-                final text = data?['message'];
-                if (text is String) announcements.add(text);
-              }
-              return null;
-            },
-          );
+          .setMockDecodedMessageHandler<Object?>(SystemChannels.accessibility, (
+            message,
+          ) async {
+            if (message is Map) {
+              final data = message['data'] as Map<Object?, Object?>?;
+              final text = data?['message'];
+              if (text is String) announcements.add(text);
+            }
+            return null;
+          });
       addTearDown(
         () => tester.binding.defaultBinaryMessenger
             .setMockDecodedMessageHandler<Object?>(

--- a/mobile/test/services/bug_report_log_export_test.dart
+++ b/mobile/test/services/bug_report_log_export_test.dart
@@ -415,6 +415,10 @@ void main() {
             usedBytes: 1536 * 1024 * 1024,
             limitBytes: 2 * 1024 * 1024 * 1024,
           ),
+          player: CacheUsageCategory(
+            usedBytes: 100 * 1024 * 1024,
+            limitBytes: 500 * 1024 * 1024,
+          ),
           images: CacheUsageCategory(
             usedBytes: 128 * 1024 * 1024,
             limitBytes: 256 * 1024 * 1024,
@@ -436,6 +440,8 @@ void main() {
         contains(
           'Cache: video 1.5 GB/2.0 GB '
           '(75.0%, within limit, 1610612736/2147483648 bytes) · '
+          'player 100.0 MB/500.0 MB '
+          '(20.0%, within limit, 104857600/524288000 bytes) · '
           'images 128.0 MB/256.0 MB '
           '(50.0%, within limit, 134217728/268435456 bytes) · '
           'seams 64.0 MB/200.0 MB '
@@ -454,6 +460,10 @@ void main() {
           video: CacheUsageCategory(
             usedBytes: 2 * 1024 * 1024 * 1024,
             limitBytes: 2 * 1024 * 1024 * 1024,
+          ),
+          player: CacheUsageCategory(
+            usedBytes: 0,
+            limitBytes: 500 * 1024 * 1024,
           ),
           images: CacheUsageCategory(
             usedBytes: 300 * 1024 * 1024,

--- a/mobile/test/services/storage_management_service_test.dart
+++ b/mobile/test/services/storage_management_service_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:db_client/db_client.dart';
+import 'package:divine_video_player/divine_video_player.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:media_cache/media_cache.dart';
@@ -40,6 +41,7 @@ void main() {
     late AppDatabase db;
     late Directory temp;
     late Directory docs;
+    late Directory caches;
     late SharedPreferences prefs;
     late StorageManagementService service;
 
@@ -62,7 +64,8 @@ void main() {
       temporaryDirectoryProvider: () async => temp,
       documentsDirectoryProvider: () async => docs,
       applicationSupportDirectoryProvider: applicationSupportDirectoryProvider,
-      applicationCacheDirectoryProvider: applicationCacheDirectoryProvider,
+      applicationCacheDirectoryProvider:
+          applicationCacheDirectoryProvider ?? () async => caches,
       fileLengthProvider: fileLengthProvider,
       now: () => now,
       protectedPaths: protectedPaths,
@@ -75,6 +78,7 @@ void main() {
       db = AppDatabase.test(NativeDatabase.memory());
       temp = Directory.systemTemp.createTempSync('storage_temp_');
       docs = Directory.systemTemp.createTempSync('storage_docs_');
+      caches = Directory.systemTemp.createTempSync('storage_caches_');
       SharedPreferences.setMockInitialValues({});
       prefs = await SharedPreferences.getInstance();
       when(() => videoCache.clearCache()).thenAnswer((_) async {});
@@ -87,6 +91,7 @@ void main() {
       await db.close();
       if (temp.existsSync()) temp.deleteSync(recursive: true);
       if (docs.existsSync()) docs.deleteSync(recursive: true);
+      if (caches.existsSync()) caches.deleteSync(recursive: true);
     });
 
     File writeFile(String path, int bytes, {Duration? age}) {
@@ -125,6 +130,7 @@ void main() {
       test('sums cache dirs, seams and temp renders, ignoring other '
           'files', () async {
         writeFile('${temp.path}/openvine_video_cache/a.mp4', 100);
+        writeFile('${caches.path}/divine_video_cache/1/2.0.3.v3.exo', 70);
         writeFile('${temp.path}/openvine_image_cache/b.jpg', 50);
         writeFile('${docs.path}/transition_seams/s.mp4', 30);
         writeFile('${temp.path}/watermarked_1.mp4', 20);
@@ -133,7 +139,10 @@ void main() {
         writeFile('${temp.path}/unrelated.txt', 5);
         writeFile('${docs.path}/my_clip.mp4', 999);
 
-        expect(await service.cacheSizeBytes(), 100 + 50 + 30 + 20 + 10 + 40);
+        expect(
+          await service.cacheSizeBytes(),
+          100 + 70 + 50 + 30 + 20 + 10 + 40,
+        );
       });
 
       test('returns zero when nothing is cached', () async {
@@ -143,16 +152,26 @@ void main() {
       test('reports per-category usage against matching budgets', () async {
         await prefs.setInt(kCacheLimitPrefKey, 3 * 1024);
         writeFile('${temp.path}/openvine_video_cache/a.mp4', 100);
+        writeFile('${caches.path}/divine_video_cache/1/2.0.3.v3.exo', 70);
         writeFile('${temp.path}/openvine_image_cache/b.jpg', 50);
         writeFile('${docs.path}/transition_seams/s.mp4', 30);
         writeFile('${temp.path}/merged_2.mp4', 10);
 
         final usage = await service.cacheUsage();
 
-        expect(usage.totalBytes, 190);
+        expect(usage.totalBytes, 260);
         expect(
           usage.video,
           const CacheUsageCategory(usedBytes: 100, limitBytes: 3 * 1024),
+        );
+        // The player's own cache runs under its own budget, not the
+        // user-configured video-cache limit.
+        expect(
+          usage.player,
+          const CacheUsageCategory(
+            usedBytes: 70,
+            limitBytes: kDefaultCacheMaxSizeBytes,
+          ),
         );
         expect(
           usage.images,
@@ -180,6 +199,20 @@ void main() {
         // Nothing cleared transition_frames before #7641; it is the same
         // kind of regenerable preview as the seams and lives beside them.
         expect(usage.transitionSeams.usedBytes, 42);
+      });
+
+      test('reports an empty player cache when the platform has no cache '
+          'directory', () async {
+        writeFile('${temp.path}/openvine_video_cache/a.mp4', 100);
+        service = buildService(
+          applicationCacheDirectoryProvider: () async =>
+              throw UnsupportedError('no cache directory'),
+        );
+
+        final usage = await service.cacheUsage();
+
+        expect(usage.player.usedBytes, 0);
+        expect(usage.totalBytes, 100);
       });
 
       test('keeps scanning temp renders when one vanishes mid-walk', () async {
@@ -299,6 +332,28 @@ void main() {
 
         expect(orphanVideo.existsSync(), isFalse);
         expect(orphanImage.existsSync(), isFalse);
+        expect(await service.cacheSizeBytes(), 0);
+      });
+
+      test('empties the player cache but keeps its index marker', () async {
+        // ExoPlayer's SimpleCache lays flat <id>.<pos>.<ts>.v3.exo spans next
+        // to a <uid>.uid marker that names its index in the shared database.
+        // Deleting the marker would orphan that index.
+        final span = writeFile(
+          '${caches.path}/divine_video_cache/1.0.1700000000.v3.exo',
+          70,
+        );
+        final marker = writeFile(
+          '${caches.path}/divine_video_cache/2a1b3c4d.uid',
+          0,
+        );
+        expect(await service.cacheSizeBytes(), 70);
+
+        await service.clearCaches();
+
+        expect(span.existsSync(), isFalse);
+        expect(span.parent.existsSync(), isTrue);
+        expect(marker.existsSync(), isTrue, reason: 'index marker kept');
         expect(await service.cacheSizeBytes(), 0);
       });
 
@@ -605,7 +660,6 @@ void main() {
 
     group('measureFootprint', () {
       late Directory appSupport;
-      late Directory caches;
 
       StorageManagementService footprintService({Directory? cacheDirectory}) =>
           buildService(
@@ -616,12 +670,10 @@ void main() {
 
       setUp(() {
         appSupport = Directory.systemTemp.createTempSync('storage_support_');
-        caches = Directory.systemTemp.createTempSync('storage_caches_');
       });
 
       tearDown(() {
         if (appSupport.existsSync()) appSupport.deleteSync(recursive: true);
-        if (caches.existsSync()) caches.deleteSync(recursive: true);
       });
 
       test('totals each root and ranks its children largest first', () async {


### PR DESCRIPTION
## Description

Every feed video that plays from the Dart media cache was being written to disk a second time. The feed hands ExoPlayer a local file (`VideoClip.file`), but the player's `DataSource.Factory` wrapped every request — local ones included — in a write-through `CacheDataSource`, so reading the file filled ExoPlayer's own `SimpleCache` under `<cacheDir>/divine_video_cache`. That directory had its own 500 MB LRU budget on top of the media cache's, and Settings → Storage neither counted it nor cleared it. On the test device the hidden copy had grown to **315 MB** while the visible video cache held 17 MB.

**What changes**

- **Android:** `CacheBypassDataSource` (formerly `AuthAwareCacheBypassDataSource`) routes only anonymous `http`/`https` requests through the cache. A `file://` URI, a bare path, `content://` or any other scheme goes straight to the upstream source — the bytes are already on the device. Viewer-authenticated (age-gated) requests keep bypassing it as before. `preload()` shares the factory, so the recorder's `preload([VideoClip.file(...)])` stops copying recordings into the cache too.
- **Settings → Storage:** `StorageManagementService` gains a `player` category that counts `divine_video_cache` against its 500 MB budget, and "Clear cache" empties it. It deliberately leaves SimpleCache's `.uid` marker in place: the cache tolerates its span files vanishing (a read that finds a shorter file than the index recorded drops the stale spans and falls through to the network, verified against media3 1.10.0), but the marker names its index table in the shared ExoPlayer database, and deleting it would orphan that table on the next launch. The bug-report diagnostics line shows the new category as well.
- **iOS / macOS:** `configureCache` no longer calls into the plugin, and the Swift handler that replaced `URLCache.shared` with a 500 MB cache is gone. AVFoundation never reads `URLCache`, so the player got nothing from it; what it did affect was every `NSURLSession` in the process, including the one `media_cache` downloads through. On upgraded installs, Settings makes a best-effort check for the old `divine_video_cache` component under the application cache directory and reclaims it when present; Foundation chooses the final Apple disk placement, which was not device-verified here.
- **Docs:** `mobile/docs/VIDEO_CACHE.md` records both caches, the bypass rules, the measurement recipe, and the decision below. The plugin README's caching section now says the cache is Android-only.

**Decision on keeping the native cache (acceptance criterion 4)**

Measured on a Samsung Galaxy (SM-S942B) over Wi-Fi, scrolling the "For You" feed forward with scripted swipes and counting the feed's per-index `from cache` / `from network` init lines:

| Run | Videos | Interval | From cache | From network | Player-cache growth |
|---|---|---|---|---|---|
| Warm caches | 40 | 2.5 s | 40 | 0 | 0 B |
| Warm caches | 60 | 1.0 s | 60 | 0 | 0 B |
| Warm caches | 60 | 0.5 s | 60 | 0 | 0 B |
| Both caches just cleared | 30 | 1.0 s | 30 | 0 | 0 B |

The only network plays were the three players the feed rebuilt on re-entry right after "Clear cache"; ExoPlayer wrote 4.5 MB for them. On Wi-Fi the prefetcher never falls behind a scroll, so the miss path is confined to feed entry. The cache is kept for that and for slow cellular links, which this run did not measure; it is now bounded, visible and reclaimable, which is what made keeping it acceptable. A cellular measurement showing misses are equally rare there would be the reason to remove it — that is a judgment call for the reviewer as much as for me.

**Related Issue:** Closes #8029

## Out of Scope

- `media_cache` on Apple platforms downloads through `URLSessionConfiguration.default`, which stores cacheable responses in `URLCache.shared`. This PR shrinks that to the OS default by no longer inflating the shared cache; opting the session out of `URLCache` entirely is a separate `media_cache` change that needs an iOS device to verify.
- No cellular hit-rate measurement.
- The Storage screen copy ("Cached feed videos, thumbnails and temporary renders") was left as is; it already covers the new category without a change to 22 locales.

## Verification

- `gradle :divine_video_player:testDebugUnitTest` — 89/89, including three new `VideoCacheTest` cases (file URI, bare path, scheme helper). Mutation-checked: with the scheme check removed, the two bypass tests fail.
- `flutter test --coverage` in `divine_video_player` — 306/306; the controller file is fully covered, with new tests for the iOS/macOS no-op and an explicit Android case.
- `flutter test` for `storage_management_service_test`, `storage_cubit_test`, `storage_management_view_test`, `bug_report_log_export_test`, `video_cache_startup_test` — all green; the storage service gains tests for counting the player cache, clearing it while keeping the `.uid` marker, and an unresolvable cache directory.
- `flutter analyze lib test integration_test` and package analyze — clean. All `mobile/scripts/check_*.sh` ratchets pass except three that fail for environmental reasons unrelated to this diff (POC endpoint probe, an unset `IOS_EXTENSION_BUNDLE_IDS`, and a Ruby locale issue that passes under `LC_ALL=en_US.UTF-8`).
- **Tested on a real Samsung Galaxy (SM-S942B):** debug build installed over the existing account. Before the change the device held 315 MB in `divine_video_cache`; across 190 cache-hit playbacks after it, the directory did not grow by a byte. Settings → Storage reported 552 MB (previously it would have shown ~230 MB), "Clear cache" brought it to 0 B and left only the `.uid` marker, and the feed kept playing afterwards with no player errors in logcat.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore

