### PR TITLE
fix(proofmode): stop iOS proofs from recording the phone's network addresses

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -162,6 +162,8 @@ jobs:
         # exists to catch. The check is pure python3 with no package installs,
         # so running it every time costs well under a second.
         run: bash scripts/check_privacy_manifest_coverage.sh
+      - name: 📵 Verify LibProofMode network fields stay privacy-gated
+        run: python3 scripts/check_libproofmode_network_privacy.py
       - name: 🐘 Verify the tracked Gradle wrapper is the pinned artifact
         # The wrapper is tracked (#7201) so a fresh clone or worktree can run
         # gradle tooling without a prior `flutter build`. That makes

--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -56,9 +56,10 @@ when refreshing it until each change is present upstream:
   `DataType`, `Network` and `NetworkType`) only when `showMobileNetwork` is
   true. Upstream records them in every proof whatever the options say, so a
   refresh that drops this change puts the phone's IP addresses back into every
-  signed proof (#9073). `LibProofModeNetworkFieldsTests` in
-  `ios/RunnerTests/RunnerTests.swift` fails when the change is missing. No CI
-  job runs `RunnerTests`, so run it after every refresh.
+  signed proof (#9073). `check_libproofmode_network_privacy.py` protects the
+  vendor delta in CI, and `LibProofModeNetworkFieldsTests` in
+  `ios/RunnerTests/RunnerTests.swift` verifies the generated proof when the
+  native test suite runs.
 
 The Podfile selects LibProofMode's existing `PrivacyProtected` subspec. Divine
 sets `showDeviceIds: false`, so compiling out `AdSupport` and

--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -52,6 +52,13 @@ when refreshing it until each change is present upstream:
 - `Resources/PrivacyInfo.xcprivacy` declares the required file-timestamp API,
   and `LibProofMode.podspec` bundles that manifest. The upstream contribution
   remains tracked in #8851.
+- `Classes/Proof.swift` records the network fields (`IPv4`, `IPv6`,
+  `DataType`, `Network` and `NetworkType`) only when `showMobileNetwork` is
+  true. Upstream records them in every proof whatever the options say, so a
+  refresh that drops this change puts the phone's IP addresses back into every
+  signed proof (#9073). `LibProofModeNetworkFieldsTests` in
+  `ios/RunnerTests/RunnerTests.swift` fails when the change is missing. No CI
+  job runs `RunnerTests`, so run it after every refresh.
 
 The Podfile selects LibProofMode's existing `PrivacyProtected` subspec. Divine
 sets `showDeviceIds: false`, so compiling out `AdSupport` and
@@ -75,11 +82,19 @@ privacy label, which is why it was kept out of the required-reason API audit.
 
 `LibProofMode`'s collected-data section is empty because Divine constructs
 `ProofGenerationOptions(showDeviceIds: false, showLocation: false,
-showMobileNetwork: false, notarizationProviders: [])`. Those flags gate the
-corresponding blocks in `Proof.swift` (`buildProof`, lines 408 / 430 / 439), so
-no device ID, location or carrier data enters the proof. **If any of those flags
-is ever flipped to `true`, this manifest and the App Store privacy label must be
-updated in the same change.**
+showMobileNetwork: false, notarizationProviders: [])`. In `Proof.swift`'s
+`buildProof`, `showDeviceIds` gates the device IDs, `showLocation` gates the
+location, and `showMobileNetwork` gates the carrier and network fields: cell
+info, IP addresses, connection status and type, and radio technology. Only the
+cell-info gate is upstream; the rest is Divine's own (see the vendor delta
+above). So no device ID, location or network data enters the proof. It still
+records the file name, hash and timestamps, the hardware model, screen size,
+language and region. **If any of those flags is ever flipped to `true`, this
+manifest and the App Store privacy label must be updated in the same change.**
+
+The proof files themselves stay on the device: the published `proofmode` tag
+carries the media hash and signature, not this CSV. Publishing the CSV would be
+new collection, and needs the same manifest and label review.
 
 ## Privacy-label decisions (#8850)
 

--- a/mobile/ios/LocalPods/LibProofMode/Classes/Proof.swift
+++ b/mobile/ios/LocalPods/LibProofMode/Classes/Proof.swift
@@ -413,13 +413,18 @@ open class Proof: NSObject {
             proof[.deviceId] = ""
         }
         
-        proof[.ipv4] = DeviceInfo.getDeviceInfo(device: .DEVICE_IP_ADDRESS_IPV4)
-        proof[.ipv6] = DeviceInfo.getDeviceInfo(device: .DEVICE_IP_ADDRESS_IPV6)
-        
-        proof[.dataType] = DeviceInfo.getDeviceInfo(device: .DEVICE_DATA_TYPE)
-        proof[.network] = DeviceInfo.getDeviceInfo(device: .DEVICE_NETWORK)
-        
-        proof[.networkType] = DeviceInfo.getDeviceInfo(device: .DEVICE_NETWORK_TYPE)
+        // Divine-local (#9073): upstream records these on every proof, whatever
+        // the options say. The proof is signed, so they must not be written at all.
+        if showMobileNetwork {
+            proof[.ipv4] = DeviceInfo.getDeviceInfo(device: .DEVICE_IP_ADDRESS_IPV4)
+            proof[.ipv6] = DeviceInfo.getDeviceInfo(device: .DEVICE_IP_ADDRESS_IPV6)
+
+            proof[.dataType] = DeviceInfo.getDeviceInfo(device: .DEVICE_DATA_TYPE)
+            proof[.network] = DeviceInfo.getDeviceInfo(device: .DEVICE_NETWORK)
+
+            proof[.networkType] = DeviceInfo.getDeviceInfo(device: .DEVICE_NETWORK_TYPE)
+        }
+
         proof[.hardware] = DeviceInfo.getDeviceInfo(device: .DEVICE_HARDWARE_MODEL)
         proof[.manufacturer] = "Apple"
         proof[.screenSize] = DeviceInfo.getDeviceInfo(device: .DEVICE_SCREEN_SIZE)

--- a/mobile/ios/LocalPods/LibProofMode/Classes/Proof.swift
+++ b/mobile/ios/LocalPods/LibProofMode/Classes/Proof.swift
@@ -414,7 +414,8 @@ open class Proof: NSObject {
         }
         
         // Divine-local (#9073): upstream records these on every proof, whatever
-        // the options say. The proof is signed, so they must not be written at all.
+        // the options say. The proof is signed as it is written, so this is the
+        // only place they can be left out.
         if showMobileNetwork {
             proof[.ipv4] = DeviceInfo.getDeviceInfo(device: .DEVICE_IP_ADDRESS_IPV4)
             proof[.ipv6] = DeviceInfo.getDeviceInfo(device: .DEVICE_IP_ADDRESS_IPV6)

--- a/mobile/ios/RunnerTests/RunnerTests.swift
+++ b/mobile/ios/RunnerTests/RunnerTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import WebKit
 import divine_camera
 import LibProofMode
+import ObjectivePGP
 @testable import Runner
 
 /// Native coverage for the Nostr bridge frame-attestation plugin. The plugin's
@@ -281,6 +282,7 @@ final class MediaSessionScopePolicyTests: XCTestCase {
 final class LibProofModeNetworkFieldsTests: XCTestCase {
   private var folder: URL!
   private var originalDocumentFolder: URL?
+  private var originalPgpKey: Key?
 
   override func setUpWithError() throws {
     folder = FileManager.default.temporaryDirectory
@@ -291,12 +293,13 @@ final class LibProofModeNetworkFieldsTests: XCTestCase {
     // Generate the throwaway signing key here, not in the host app's
     // Documents folder.
     originalDocumentFolder = Proof.shared.defaultDocumentFolder
+    originalPgpKey = Proof.shared.pgpKey
     Proof.shared.defaultDocumentFolder = folder
     Proof.shared.pgpKey = nil
   }
 
   override func tearDownWithError() throws {
-    Proof.shared.pgpKey = nil
+    Proof.shared.pgpKey = originalPgpKey
     Proof.shared.defaultDocumentFolder = originalDocumentFolder
     try? FileManager.default.removeItem(at: folder)
   }

--- a/mobile/ios/RunnerTests/RunnerTests.swift
+++ b/mobile/ios/RunnerTests/RunnerTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import WebKit
 import divine_camera
+import LibProofMode
 @testable import Runner
 
 /// Native coverage for the Nostr bridge frame-attestation plugin. The plugin's
@@ -270,5 +271,66 @@ final class MediaSessionScopePolicyTests: XCTestCase {
     var policy = MediaSessionScopePolicy()
     XCTAssertFalse(policy.onDisable())
     XCTAssertFalse(policy.isEnabled)
+  }
+}
+
+/// Pins what `AppDelegate`'s ProofMode options keep out of the signed proof
+/// (#9073). Upstream LibProofMode records the Wi-Fi addresses and connection
+/// details whatever the options say, so this fails if a vendor refresh drops
+/// Divine's `showMobileNetwork` gate. The proof is signed, so the fields must
+/// never be written: stripping them later would break verification.
+final class LibProofModeNetworkFieldsTests: XCTestCase {
+  private var folder: URL!
+  private var originalDocumentFolder: URL?
+
+  override func setUpWithError() throws {
+    folder = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: folder, withIntermediateDirectories: true
+    )
+    // Generate the throwaway signing key here, not in the host app's
+    // Documents folder.
+    originalDocumentFolder = Proof.shared.defaultDocumentFolder
+    Proof.shared.defaultDocumentFolder = folder
+    Proof.shared.pgpKey = nil
+  }
+
+  override func tearDownWithError() throws {
+    Proof.shared.pgpKey = nil
+    Proof.shared.defaultDocumentFolder = originalDocumentFolder
+    try? FileManager.default.removeItem(at: folder)
+  }
+
+  func testDivineOptionsKeepNetworkFieldsOutOfTheSignedProof() throws {
+    let item = MediaItem(mediaData: Data("clip".utf8))
+    item.proofFolder = folder
+    let options = ProofGenerationOptions(
+      showDeviceIds: false,
+      showLocation: false,
+      showMobileNetwork: false,
+      notarizationProviders: []
+    )
+
+    let hash = try XCTUnwrap(
+      Proof.shared.getProof(for: item, force: true, options: options)
+    )
+    let csv = try String(
+      contentsOf: folder.appendingPathComponent("\(hash).proof.csv"),
+      encoding: .utf8
+    )
+    let header = try XCTUnwrap(csv.split(separator: "\n").first)
+    let columns = Set(header.split(separator: ",").map(String.init))
+
+    XCTAssertTrue(
+      columns.contains("File Hash SHA256"),
+      "the proof CSV was not written"
+    )
+    for field in ["IPv4", "IPv6", "Network", "NetworkType", "DataType"] {
+      XCTAssertFalse(
+        columns.contains(field),
+        "\(field) must not enter the signed proof"
+      )
+    }
   }
 }

--- a/mobile/ios/RunnerTests/RunnerTests.swift
+++ b/mobile/ios/RunnerTests/RunnerTests.swift
@@ -274,11 +274,10 @@ final class MediaSessionScopePolicyTests: XCTestCase {
   }
 }
 
-/// Pins what `AppDelegate`'s ProofMode options keep out of the signed proof
-/// (#9073). Upstream LibProofMode records the Wi-Fi addresses and connection
-/// details whatever the options say, so this fails if a vendor refresh drops
-/// Divine's `showMobileNetwork` gate. The proof is signed, so the fields must
-/// never be written: stripping them later would break verification.
+/// Divine passes every ProofMode option as false (see `AppDelegate`), and the
+/// network fields must then stay out of the signed proof (#9073). Upstream
+/// LibProofMode records them whatever the options say, so this fails if a
+/// vendor refresh drops Divine's `showMobileNetwork` gate.
 final class LibProofModeNetworkFieldsTests: XCTestCase {
   private var folder: URL!
   private var originalDocumentFolder: URL?

--- a/mobile/scripts/check_libproofmode_network_privacy.py
+++ b/mobile/scripts/check_libproofmode_network_privacy.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Fail when vendored LibProofMode records network fields outside its privacy gate."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+FIELDS = ("ipv4", "ipv6", "dataType", "network", "networkType")
+DEFAULT_SOURCE = Path("ios/LocalPods/LibProofMode/Classes/Proof.swift")
+
+
+def matching_brace(source: str, opening: int) -> int:
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+    raise ValueError("unclosed brace")
+
+
+def validate(source: str) -> list[str]:
+    failures: list[str] = []
+    function_marker = "private func buildProof("
+    function_start = source.find(function_marker)
+    if function_start == -1:
+        return ["buildProof was not found"]
+
+    function_open = source.find("{", function_start)
+    try:
+        function_close = matching_brace(source, function_open)
+    except ValueError:
+        return ["buildProof has an unclosed body"]
+    function_body = source[function_open + 1 : function_close]
+
+    gate_marker = "if showMobileNetwork {"
+    gate_start = function_body.find(gate_marker)
+    if gate_start == -1:
+        return ["buildProof has no showMobileNetwork gate"]
+
+    gate_open = function_body.find("{", gate_start)
+    try:
+        gate_close = matching_brace(function_body, gate_open)
+    except ValueError:
+        return ["showMobileNetwork has an unclosed body"]
+
+    for field in FIELDS:
+        assignment = f"proof[.{field}] ="
+        positions: list[int] = []
+        cursor = 0
+        while (position := function_body.find(assignment, cursor)) != -1:
+            positions.append(position)
+            cursor = position + len(assignment)
+
+        if len(positions) != 1:
+            failures.append(
+                f"{assignment} must appear exactly once in buildProof; "
+                f"found {len(positions)}"
+            )
+        elif not gate_open < positions[0] < gate_close:
+            failures.append(f"{assignment} must stay inside the showMobileNetwork gate")
+
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source", nargs="?", type=Path, default=DEFAULT_SOURCE)
+    args = parser.parse_args()
+
+    if not args.source.is_file():
+        print(f"ERROR: missing {args.source}")
+        return 1
+
+    failures = validate(args.source.read_text(encoding="utf-8"))
+    if failures:
+        print("ERROR: LibProofMode network-field privacy gate regressed.")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    print("LibProofMode network fields remain behind showMobileNetwork.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mobile/test/tools/libproofmode_network_privacy_test.dart
+++ b/mobile/test/tools/libproofmode_network_privacy_test.dart
@@ -1,0 +1,90 @@
+// ABOUTME: Pins the CI guard for Divine's vendored LibProofMode privacy patch.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LibProofMode network privacy guard', () {
+    late Directory temporaryDirectory;
+    late String scriptPath;
+
+    setUp(() {
+      temporaryDirectory = Directory.systemTemp.createTempSync(
+        'libproofmode_network_privacy_',
+      );
+      scriptPath = File(
+        'scripts/check_libproofmode_network_privacy.py',
+      ).absolute.path;
+    });
+
+    tearDown(() {
+      temporaryDirectory.deleteSync(recursive: true);
+    });
+
+    Future<ProcessResult> runGuard(String buildProofBody) {
+      final source = File('${temporaryDirectory.path}/Proof.swift')
+        ..writeAsStringSync('''
+open class Proof {
+  private func buildProof() -> ProofCollection {
+$buildProofBody
+  }
+}
+''');
+      return Process.run('python3', [scriptPath, source.path]);
+    }
+
+    const assignments = '''
+      proof[.ipv4] = value
+      proof[.ipv6] = value
+      proof[.dataType] = value
+      proof[.network] = value
+      proof[.networkType] = value
+''';
+
+    test('passes when every sensitive assignment is inside the gate', () async {
+      final result = await runGuard('''
+    if showMobileNetwork {
+$assignments
+    }
+''');
+
+      expect(result.exitCode, 0, reason: result.stderr as String?);
+    });
+
+    test('fails when a sensitive assignment moves outside the gate', () async {
+      final result = await runGuard('''
+    proof[.ipv4] = value
+    if showMobileNetwork {
+      proof[.ipv6] = value
+      proof[.dataType] = value
+      proof[.network] = value
+      proof[.networkType] = value
+    }
+''');
+
+      expect(result.exitCode, isNot(0));
+      expect(
+        result.stdout,
+        contains('proof[.ipv4] = must stay inside the showMobileNetwork gate'),
+      );
+    });
+
+    test('fails closed when a sensitive assignment disappears', () async {
+      final result = await runGuard('''
+    if showMobileNetwork {
+      proof[.ipv4] = value
+      proof[.ipv6] = value
+      proof[.dataType] = value
+      proof[.network] = value
+    }
+''');
+
+      expect(result.exitCode, isNot(0));
+      expect(
+        result.stdout,
+        contains('proof[.networkType] = must appear exactly once'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem

On iOS, every ProofMode proof records the phone's Wi-Fi IPv4 and IPv6 addresses, whether it is online, its connection type (Wi-Fi, Ethernet or cellular) and its cellular radio technology. Divine turns all three of the library's privacy options off (device IDs, location, mobile network), but the vendored library writes these fields whatever the options say. Only the cell-tower info honoured the "mobile network" option.

The fields go into the proof files the library signs and keeps in the app's Documents folder. They are **not** published today. The app looks for the proof data under a file name the library never writes, so the published `proofmode` tag carries only the media hash, the media signature, the C2PA id and the device attestation. I checked 675 videos published with ProofMode data between November 2025 and this week: none carries the proof data.

That file-name mismatch is the only thing keeping the addresses off public relays, though. Whoever fixes it would publish them with every video, and a fix is plausible: the same mismatch is why the proof's public key is never published either.

`mobile/docs/IOS_PRIVACY_MANIFESTS.md` also said the options keep this data out of the proof, which was not true.

## Fix

- `Proof.swift` records the network fields only when `showMobileNetwork` is true. Divine passes `false`, so they are no longer written. They have to be left out when the proof is built: the file is signed as it is written, so removing fields afterwards would break verification.
- The privacy-manifest doc now says which fields each option gates. It lists this change in the LibProofMode vendor delta so a library refresh keeps it, and notes that publishing the proof CSV would be new data collection.

## Not changed

- Android. Its ProofMode library already leaves these fields out under Divine's settings: they sit behind its device-ID option, which is off by default and which Divine never turns on.
- The file-name mismatch in `NativeProofModeService.readProofMetadata`. Fixing it changes what Divine publishes, so it needs its own decision.
- Proof signing, the published tag, C2PA and attestation.

## Verification

- The new `LibProofModeNetworkFieldsTests` in `ios/RunnerTests/RunnerTests.swift` generates a real proof with Divine's options and checks the columns of the signed CSV. Against the unpatched library it fails once per field (IPv4, IPv6, Network, NetworkType, DataType). With the fix, the whole `RunnerTests` suite passes, 27 of 27, on an iOS 26.5 simulator (Xcode 26.6).
- No CI job builds iOS or runs `RunnerTests`, so that run was local. `check_privacy_manifest_coverage.sh`, `check_native_transport_security.sh` and `check_ios_shipping_versions.sh` also pass locally.

Closes #9073
