### PR TITLE
fix(dm): stop message restore from retrying forever

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2255,6 +2255,16 @@ class DmRepository {
     _drainRetryTimer?.cancel();
     _drainRetryTimer = null;
     if (_ingestSessionEnded(pubkey, generation)) return;
+    if (_automaticDrainRetryCount >=
+        DmHistoryDrainConfig.deferredRetryDelays.length) {
+      Log.warning(
+        'DM history drain for ${pubkeyForLogs(pubkey)} exhausted its '
+        'automatic no-progress retry budget; waiting for a manual retry or '
+        'a later session.',
+        category: LogCategory.system,
+      );
+      return;
+    }
     final lastConnected = <String>{
       for (final entry in _nostrClient.relayStatuses.entries)
         if (entry.value.isConnected) entry.key,
@@ -2291,23 +2301,20 @@ class DmRepository {
       );
       unawaited(backfillHistoryIfNeeded());
     });
-    if (_automaticDrainRetryCount <
-        DmHistoryDrainConfig.deferredRetryDelays.length) {
-      final delay =
-          DmHistoryDrainConfig.deferredRetryDelays[_automaticDrainRetryCount++];
-      _drainRetryTimer = Timer(delay, () {
-        _drainRetryTimer = null;
-        unawaited(_drainRelayReadySubscription?.cancel());
-        _drainRelayReadySubscription = null;
-        if (_ingestSessionEnded(pubkey, generation)) return;
-        Log.info(
-          'Resuming DM history drain for ${pubkeyForLogs(pubkey)} after the '
-          'bounded retry delay',
-          category: LogCategory.system,
-        );
-        unawaited(backfillHistoryIfNeeded());
-      });
-    }
+    final delay =
+        DmHistoryDrainConfig.deferredRetryDelays[_automaticDrainRetryCount++];
+    _drainRetryTimer = Timer(delay, () {
+      _drainRetryTimer = null;
+      unawaited(_drainRelayReadySubscription?.cancel());
+      _drainRelayReadySubscription = null;
+      if (_ingestSessionEnded(pubkey, generation)) return;
+      Log.info(
+        'Resuming DM history drain for ${pubkeyForLogs(pubkey)} after the '
+        'bounded retry delay',
+        category: LogCategory.system,
+      );
+      unawaited(backfillHistoryIfNeeded());
+    });
   }
 
   /// Stops listening for incoming DMs and tears this repository down.

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -8665,7 +8665,7 @@ void main() {
 
       test('automatic timer resumes stop at the session cap', () {
         fakeAsync((async) {
-          stubRelayStatus(
+          final relayStatus = stubRelayStatus(
             connectedNow: connected(['wss://silent.example']),
           );
           var giftWrapPages = 0;
@@ -8712,6 +8712,20 @@ void main() {
           );
           expect(syncState.drainCursorOverride, cursorBefore);
           expect(syncState.markedCompletePubkeys, isEmpty);
+          expect(
+            relayStatus.hasListener,
+            isFalse,
+            reason:
+                'relay reconnects must share the same no-progress budget as '
+                'timers instead of re-driving the drain forever',
+          );
+          relayStatus.add(connected(['wss://new-capacity.example']));
+          async.flushMicrotasks();
+          expect(
+            giftWrapPages,
+            (DmHistoryDrainConfig.deferredRetryDelays.length + 1) *
+                (DmHistoryDrainConfig.unsettledPageRetriesPerRun + 1),
+          );
         });
       });
 

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -1260,12 +1260,14 @@ class NostrClient {
       noRelays: noConnectedRelays || network.endedBy == QueryEnd.noRelay,
       timedOut:
           timedOutOverride ??
-          (network.endedBy == QueryEnd.deadline ||
-              // A read no relay took, ending at or after the deadline, had a
-              // relay still holding the REQ when the deadline fired.
-              (network.endedBy == QueryEnd.noRelay &&
-                  (requireAllRelaysSettled ||
-                      !DateTime.now().isBefore(deadline)))),
+          (requireAllRelaysSettled
+              ? !network.isComplete
+              : network.endedBy == QueryEnd.deadline ||
+                    // A read no relay took, ending at or after the deadline,
+                    // had a relay still holding the REQ when the deadline
+                    // fired.
+                    (network.endedBy == QueryEnd.noRelay &&
+                        !DateTime.now().isBefore(deadline))),
     );
   }
 

--- a/mobile/packages/nostr_client/test/src/nostr_client_read_events_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_read_events_test.dart
@@ -229,6 +229,44 @@ void main() {
     });
 
     test(
+      'keeps a prompt CLOSED inconclusive for strict legacy callers',
+      () async {
+        final nostr = _newNostr();
+        final relay = _ScriptedRelay('wss://refuses.example');
+        expect(await nostr.relayPool.add(relay), isTrue);
+        final client = _clientOver(
+          nostr,
+          connectedRelays: ['wss://refuses.example'],
+        );
+
+        final pending = client.queryEventsDetailed(
+          [_textNotes()],
+          useCache: false,
+          timeout: const Duration(seconds: 2),
+          requireAllRelaysSettled: true,
+        );
+        final subId = await relay.awaitReq(0);
+        await relay.deliver([
+          'CLOSED',
+          subId,
+          'error: unsupported filter',
+        ]);
+
+        final result = await pending;
+
+        expect(result.events, isEmpty);
+        expect(
+          result.timedOut,
+          isTrue,
+          reason:
+              'prompt transport completion must not make a refusal '
+              'authoritative for compatibility callers',
+        );
+        expect(result.noRelays, isFalse);
+      },
+    );
+
+    test(
       'reports a relay skipped past the settle window as settledEarly',
       () async {
         final nostr = _newNostr();

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -578,7 +578,7 @@ class Nostr {
       // hold and keeps its prompt empty answer.
       timedOut:
           read.endedAtDeadline ||
-          (requireAllRelaysSettled && noRelaysParticipated),
+          (requireAllRelaysSettled && !read.result.isComplete),
       noRelaysParticipated: noRelaysParticipated,
     );
   }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1177,11 +1177,12 @@ class RelayPool {
     }
 
     // Nothing is pending — but for a full-settlement caller that only means
-    // the query is finished if some relay actually answered it, and no relay
-    // refused to answer. A relay that `CLOSED` the REQ has made no data claim,
-    // and a relay that stayed silent may still be about to speak, so a caller
-    // about to replace what it read waits both out rather than read an empty
-    // box as "every relay says there is nothing".
+    // the query is complete if some relay actually answered it and no relay
+    // became stranded. A relay that `CLOSED` the REQ has made no data claim,
+    // but it has terminated its copy of the request: waiting cannot turn that
+    // refusal into an answer. Complete the transport promptly and let the
+    // query outcome report `relayClosed`, which strict compatibility callers
+    // map back to an inconclusive result.
     //
     // A fan-out no relay took is the one shape that cannot improve by waiting
     // — see [_queryReachedNoRelay] — and `sentTo` already tells the caller the
@@ -1192,9 +1193,7 @@ class RelayPool {
     // leaves no relay holding the query, so nothing can be stranded on one.
     if (_queriesRequiringFullSettlement.contains(subId) &&
         !_queryReachedNoRelay.contains(subId) &&
-        (!_queryAnswered.contains(subId) ||
-            _queryClosedWithoutAnswer.contains(subId) ||
-            strandedOnBlockedRelay)) {
+        (!_queryAnswered.contains(subId) || strandedOnBlockedRelay)) {
       return;
     }
 

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
@@ -904,6 +904,7 @@ void main() {
           final refusing = _SilentRelay('wss://refuses-req.example');
           expect(await nostr.relayPool.add(refusing), isTrue);
 
+          var completed = false;
           final pending = nostr.queryEventsDetailed(
             [
               {
@@ -921,6 +922,15 @@ void main() {
             'error: too many concurrent REQs',
           ]);
 
+          pending.then((_) => completed = true);
+          await pumpEventQueue();
+          expect(
+            completed,
+            isTrue,
+            reason:
+                'CLOSED is terminal for this relay copy, so waiting out the '
+                'deadline cannot make the incomplete answer more complete',
+          );
           final result = await pending;
 
           expect(result.events, isEmpty);
@@ -946,6 +956,7 @@ void main() {
         expect(await nostr.relayPool.add(answering), isTrue);
         expect(await nostr.relayPool.add(refusing), isTrue);
 
+        var completed = false;
         final pending = nostr.queryEventsDetailed(
           [
             {
@@ -965,6 +976,15 @@ void main() {
           'error: too many concurrent REQs',
         ]);
 
+        pending.then((_) => completed = true);
+        await pumpEventQueue();
+        expect(
+          completed,
+          isTrue,
+          reason:
+              'the healthy relay answered and the refusing relay terminated '
+              'its copy, so no participant can still change this result',
+        );
         final result = await pending;
 
         expect(result.events, isEmpty);


### PR DESCRIPTION
## Description

Stops DM history restoration from retrying forever when a relay refuses a request. Refusals now finish promptly without being mistaken for complete history, while reconnect-triggered retries share the existing bounded retry budget.

**Related Issues:** Relates to #9046, closes #9081

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
