### PR TITLE
test(m3u8): remove a network check that could not fail

### DIFF
--- a/mobile/scripts/baseline/skip_test_ceilings.txt
+++ b/mobile/scripts/baseline/skip_test_ceilings.txt
@@ -16,6 +16,5 @@
 # Fix a skip rather than regenerating this file. Skip-debt epic: #4337 (WS-1).
 test/providers/video_events_provider_test.dart	1 # rewrite: stubs subscribe(named filters:), now a positional param (#4836)
 test/screens/video_editor/video_text_editor_screen_test.dart	3 # rewrite: layer path fetches anonymouspro via google_fonts (#4836)
-test/services/m3u8_resolver_service_test.dart	1 # quarantine: real http to stream.divine.video playlist (#4836)
 test/services/video_event_service_repost_test.dart	1 # rewrite: uses kind 6 reposts and kind 22 originals; both dropped (#4836)
 test/widgets/comprehensive_clickable_hashtag_text_test.dart	4 # rewrite: taps need a gorouter harness; style expects materialcolor (#4836)

--- a/mobile/test/services/m3u8_resolver_service_test.dart
+++ b/mobile/test/services/m3u8_resolver_service_test.dart
@@ -89,23 +89,5 @@ Random text here
 
       expect(variants, isEmpty);
     });
-
-    test(
-      'end-to-end: resolves m3u8 URL to MP4 URL',
-      () async {
-        const m3u8Url = 'https://stream.divine.video/abc123/playlist.m3u8';
-
-        // This test will use real HTTP requests
-        // Skip in CI if network is unavailable
-        final resolvedUrl = await service.resolveM3u8ToMp4(m3u8Url);
-
-        // We expect either a resolved URL or null (if network/server issues)
-        if (resolvedUrl != null) {
-          expect(resolvedUrl, contains('.mp4'));
-          expect(resolvedUrl, isNot(contains('.m3u8')));
-        }
-      },
-      skip: 'Network test - run manually',
-    );
   });
 }


### PR DESCRIPTION
## Description

The skipped M3U8 network case could pass without exercising an assertion whenever resolution returned `null`, which is the normal Flutter-test HTTP behavior. This removes only that non-failing case and shrinks the skip ratchet while retaining the six deterministic parser tests.

**Related Issue:** Part of #4836

## Out of Scope

The four remaining skipped-test files tracked by #4836 are intentionally unchanged.

## Verification

- `mise exec -- flutter test --no-pub test/services/m3u8_resolver_service_test.dart`
- `mise exec -- flutter analyze test/services/m3u8_resolver_service_test.dart`
- `mise exec -- bash scripts/check_skip_ceiling.sh`
- `mise exec -- dart format --output=none --set-exit-if-changed test/services/m3u8_resolver_service_test.dart`

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
