### PR TITLE
chore(ios): stop shipping Google's ads-measurement SDK in the iOS app

### DIFF
--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -437,6 +437,7 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
             r"(?:shorebird (?:release|patch) ios|flutter build ios(?! --config-only))"
         )
 
+        selected = []
         missing = []
         for name, workflow in resolved["workflows"].items():
             scripts = "\n".join(
@@ -446,10 +447,20 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
             )
             if not real_ios_build.search(scripts):
                 continue
+            selected.append(name)
             declared = set((workflow.get("environment") or {}).get("vars") or {})
             if "FIREBASE_ANALYTICS_WITHOUT_ADID" not in declared:
                 missing.append(name)
 
+        # Pin the selection itself. Without this the loop enforces nothing when
+        # the build commands move behind a helper script and the match set
+        # silently empties — and a new iOS lane must force a human to look.
+        self.assertEqual(
+            sorted(selected),
+            ["e2e-smoke-ios", "ios-build", "ios-patch", "ios-simulator-build"],
+            "the set of iOS-building workflows changed; update this pin and "
+            "confirm each lane still sets FIREBASE_ANALYTICS_WITHOUT_ADID (#7303)",
+        )
         self.assertEqual(
             missing,
             [],

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -424,6 +424,40 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
                 if re.search(rf"\${{?{variable}}}?\b", scripts):
                     self.assertIn(variable, declared, f"{name} reads ${variable} without declaring it")
 
+    def test_ios_build_workflows_select_the_ads_measurement_free_product(self) -> None:
+        # #7303: firebase_analytics links FirebaseAnalyticsCore — no IDFA
+        # support, no Google ads-measurement SDK — only while
+        # FIREBASE_ANALYTICS_WITHOUT_ADID is present as Xcode evaluates its
+        # Package.swift. Xcode reads the variable, never a workflow script, so
+        # no other check in this file sees it. Pin it on every workflow that
+        # builds the iOS product; one that builds without it silently ships the
+        # full FirebaseAnalytics product.
+        resolved = self._resolved_config()
+        real_ios_build = re.compile(
+            r"(?:shorebird (?:release|patch) ios|flutter build ios(?! --config-only))"
+        )
+
+        missing = []
+        for name, workflow in resolved["workflows"].items():
+            scripts = "\n".join(
+                step.get("script", "")
+                for step in workflow.get("scripts", [])
+                if isinstance(step, dict)
+            )
+            if not real_ios_build.search(scripts):
+                continue
+            declared = set((workflow.get("environment") or {}).get("vars") or {})
+            if "FIREBASE_ANALYTICS_WITHOUT_ADID" not in declared:
+                missing.append(name)
+
+        self.assertEqual(
+            missing,
+            [],
+            "iOS-building workflows must set FIREBASE_ANALYTICS_WITHOUT_ADID so "
+            "firebase_analytics links FirebaseAnalyticsCore (#7303): "
+            f"{missing}",
+        )
+
     def test_store_release_workflows_require_main_and_emit_provenance(self) -> None:
         for workflow_name in ("ios-build", "android-build"):
             workflow = self._workflow_block(workflow_name)

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -610,6 +610,12 @@ definitions:
         # Shorebird archive before later steps can promote its artifacts.
         bash scripts/check_privacy_manifest_coverage.sh \
           --archive build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app
+
+        # Prove FIREBASE_ANALYTICS_WITHOUT_ADID reached Swift package
+        # resolution: the archive must link FirebaseAnalyticsCore, not the
+        # ads-measurement SDK the default product carries (#7303).
+        bash scripts/check_ios_analytics_product.sh \
+          --app build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app
     - &patch_ios
       name: Patch iOS (Shorebird)
       script: |
@@ -694,6 +700,9 @@ definitions:
           --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN \
           --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
           --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS
+
+        bash scripts/check_ios_analytics_product.sh \
+          --app build/ios/iphonesimulator/Runner.app
     # GH_ACTIONS_PR_PREVIEW sets forceOpenOnboarding on the invite client
     # (main.dart), so getClientConfig() reports OnboardingMode.open and the
     # invite gate self-redirects to account creation. Without it every flow
@@ -977,6 +986,12 @@ workflows:
         IOS_EXTENSION_BUNDLE_IDS: >-
           co.openvine.app.NotificationServiceExtension
           co.openvine.app.CameraQuickActionWidget
+        # firebase_analytics links FirebaseAnalyticsCore — no IDFA support, no
+        # Google ads-measurement SDK — when this is present while Xcode
+        # evaluates its Package.swift (#7303). Presence is what counts, not the
+        # value. scripts/check_ios_analytics_product.sh proves it reached the
+        # build product.
+        FIREBASE_ANALYTICS_WITHOUT_ADID: "true"
       ios_signing:
         distribution_type: app_store
         bundle_identifier: co.openvine.app
@@ -1039,6 +1054,9 @@ workflows:
       groups:
         - zendesk_credentials
         - proofmode_credentials
+      vars:
+        # Same analytics product as ios-build (#7303); see the comment there.
+        FIREBASE_ANALYTICS_WITHOUT_ADID: "true"
     cache:
       cache_paths:
         - $HOME/Library/Caches/CocoaPods
@@ -1204,6 +1222,8 @@ workflows:
         IOS_EXTENSION_BUNDLE_IDS: >-
           co.openvine.app.NotificationServiceExtension
           co.openvine.app.CameraQuickActionWidget
+        # Same analytics product as ios-build (#7303); see the comment there.
+        FIREBASE_ANALYTICS_WITHOUT_ADID: "true"
       ios_signing:
         distribution_type: app_store
         bundle_identifier: co.openvine.app
@@ -1400,6 +1420,8 @@ workflows:
         # resolve and render playback chrome. Never replace this with a private
         # account credential or mutable search result.
         QA_VIDEO_EVENT_ID: dd6ba512d5c3ed9490db9cd15986fb5c88347cb4aeeef6220331e8b06ca3c510
+        # Same analytics product as ios-build (#7303); see the comment there.
+        FIREBASE_ANALYTICS_WITHOUT_ADID: "true"
     cache:
       cache_paths:
         - $HOME/Library/Caches/CocoaPods

--- a/docs/ANALYTICS_OBSERVABILITY.md
+++ b/docs/ANALYTICS_OBSERVABILITY.md
@@ -204,6 +204,14 @@ Use Firebase Performance to inspect:
 - network request traces for media/API domains
 - custom traces when the span represents a real user wait
 
+The iOS `NETWORK_REQUEST` export also carries the Google SDKs' own traffic —
+`app-analytics-services.com` is the upload path for every event above, at
+roughly 3.5 requests and 4 KB per app start. Its expected volume, host by
+host, is recorded in
+[Google SDK traffic in the export](../mobile/docs/NETWORK_PERFORMANCE_MONITORING.md#google-sdk-traffic-in-the-export)
+so it is read as SDK cost rather than as a finding; the same section says why
+the `*.app-ads-services.com` rows stop at the first store release after #7303.
+
 The existing `feed_load_*` traces are an exception: they measure subscription
 attempts, including background retries and re-subscriptions, rather than a
 user-visible surface load. Filter them by `completion` and follow the

--- a/mobile/docs/IOS_PRIVACY_MANIFESTS.md
+++ b/mobile/docs/IOS_PRIVACY_MANIFESTS.md
@@ -134,18 +134,26 @@ added to the App Store Connect answers by hand, from the vendor's guidance:
 
 - Shorebird (D7): the engine's privacy manifest is Flutter's stock one, which
   declares no collected data, and the updater ships no manifest.
-- Firebase Analytics (with GoogleAppMeasurement), Google's on-device
-  conversion measurement SDK (GoogleAdsOnDeviceConversion), Firebase
-  Performance and Firebase Sessions ship no privacy manifest. Google's
-  guidance is its
+- Firebase Analytics (with GoogleAppMeasurement), Firebase Performance and
+  Firebase Sessions ship no privacy manifest. Google's guidance is its
   [App Store data disclosure page](https://firebase.google.com/docs/ios/app-store-data-collection).
+  Google's on-device conversion measurement SDK
+  (GoogleAdsOnDeviceConversion) and the IDFA support library used to be in
+  this list; since #7303 the iOS build links `FirebaseAnalyticsCore`, which
+  carries neither, and `scripts/check_ios_analytics_product.sh` fails the
+  release archive if either comes back. See
+  [Google SDK traffic in the export](NETWORK_PERFORMANCE_MONITORING.md#google-sdk-traffic-in-the-export).
 
 The report does show one type that the Runner manifest does not repeat: Other
 Data Types, declared by Firebase Cloud Messaging (not linked, Analytics). It
 belongs on the label like any other SDK-declared type.
 
 Checked on 2026-09-11 against firebase-ios-sdk 12.12.0, GoogleAppMeasurement
-12.11.0 and Shorebird 1.6.120. Re-check whenever one of them changes.
+12.11.0 and Shorebird 1.6.120; the Firebase half re-checked on 2026-09-12
+against firebase-ios-sdk 12.18.0 and GoogleAppMeasurement 12.18.0 on a plain
+`flutter build ios --release` archive (same manifest set, minus the two
+libraries `FirebaseAnalyticsCore` drops). Re-check whenever one of them
+changes.
 
 ### Tracking posture before each candidate
 

--- a/mobile/docs/NETWORK_PERFORMANCE_MONITORING.md
+++ b/mobile/docs/NETWORK_PERFORMANCE_MONITORING.md
@@ -94,6 +94,97 @@ Everything below routes through `instrumentedHttpClientFactoryProvider`.
 If any of these becomes worth measuring, the decision to add it belongs in this
 file next to the reason it was left out.
 
+## Google SDK traffic in the export
+
+On iOS, Firebase Performance also instruments `NSURLSession` in-process, so
+the export carries every request the Google SDKs make for themselves. Android
+shows none of it — the Android SDK instruments OkHttp and `HttpURLConnection`,
+which neither the Dart stack nor the Firebase SDKs use — so a host-by-host
+comparison across platforms is not a finding. Read these rows as the cost of
+the SDKs, sized here so nobody re-derives it (#7303). Baseline: 1.0.20 store
+build, 2026-09-01 → 2026-09-07, 17,367 `_app_start` events.
+
+| Host | Owner | Per app start | Bytes / week | What it is |
+|---|---|---|---|---|
+| `app-analytics-services.com/a`, `region1.app-analytics-services.com/a` | `GoogleAppMeasurement` | 3.5 | ~74 MB **up** | Analytics event upload — the data `screen_view`, `surface_load` and the creator funnel arrive through. |
+| `app-analytics-services.com/config/app/*`, `/sdk-exp` | `GoogleAppMeasurement` | 1.4 | ~7 MB down | Analytics remote config and SDK experiments. |
+| `firebase-settings.crashlytics.com`, `crashlyticsreports-pa.googleapis.com` | Crashlytics | 0.9 | ~11 MB down, ~55 MB up | Settings fetch per launch; reports (~66 KB each) only when there is something to send. |
+| `firebaseinstallations.googleapis.com`, `device-provisioning.googleapis.com`, `fcmtoken.googleapis.com`, `firebaseremoteconfig.googleapis.com` | Installations / FCM / Remote Config | 1.4 | ~15 MB down | Installation identity, push token registration, remote config. |
+| `muf.`, `odf.`, `odm.app-ads-services.com` | `GoogleAdsOnDeviceConversion` | 4.0 | **~223 MB down** | Google Ads on-device conversion measurement. Absent from builds after #7303 — see below. |
+
+Attribution is by URL-format strings in the framework binaries, not by
+inference: every `*.app-ads-services.com` template lives in
+`GoogleAdsOnDeviceConversion.framework`, every `app-analytics-services.com`
+template in `GoogleAppMeasurement.framework`.
+
+Two shapes in the ads-measurement rows look like defects and are not:
+
+- **`odf.app-ads-services.com/odf/config` answers `403` for ~16% of requests.**
+  The rate is ~100% for devices in the EEA and the UK and ~0% elsewhere; the
+  body is 20 bytes and the SDK does not retry into it (1.9 requests per app
+  start there against 1.2 elsewhere). That is Google's regional gate on the
+  feature, applied server-side after the device has already asked.
+- **`muf/psm/groupids` and `odm/psm` download 8–18 KB per request.** Those are
+  the private-set-membership tables the conversion match runs against on the
+  device. They are the bulk of the 223 MB.
+
+### Why the ads-measurement rows disappear after #7303
+
+FlutterFire's default iOS product, `FirebaseAnalytics`, links
+`GoogleAppMeasurementIdentitySupport` (IDFA) and `GoogleAdsOnDeviceConversion`
+alongside the analytics SDK. Divine has no Google Ads account linked to its
+analytics property, personalized advertising off and no ATT prompt
+([iOS privacy manifests](IOS_PRIVACY_MANIFESTS.md), decision D1), and the
+Android manifest already strips `AD_ID` and the AdServices permissions — so on
+iOS the conversion SDK was measuring for nobody at ~4 requests and ~13 KB per
+app start. The iOS build now links `FirebaseAnalyticsCore` instead, which
+carries neither library. Three things hold that in place:
+
+1. `firebase_analytics`'s `Package.swift` picks `FirebaseAnalyticsCore` when
+   `FIREBASE_ANALYTICS_WITHOUT_ADID` is present in the environment while Xcode
+   evaluates it. Presence is what counts, not the value. Every iOS workflow in
+   `codemagic.yaml` sets it; a local store-candidate build needs it too:
+
+   ```bash
+   FIREBASE_ANALYTICS_WITHOUT_ADID=true flutter build ios --release
+   ```
+
+   Xcode caches the evaluated manifest in `build/ios/SourcePackages`, so
+   flipping the variable on a machine that has already resolved packages
+   needs `flutter clean` first — clearing the workspace's
+   `xcshareddata/swiftpm` directory alone leaves the old product selection
+   in place. Codemagic starts from an empty `build/` and wipes DerivedData
+   and the workspace state before every build.
+2. `scripts/check_ios_analytics_product.sh --app <Runner.app>` reads the
+   built product and fails when any binary in it references
+   `app-ads-services.com`, or when none references
+   `app-analytics-services.com`. It runs after the Shorebird release archive
+   and after the simulator build, because nothing else notices a resolution
+   that silently fell back to the full product: the build is green either way
+   and the difference only shows up in this export weeks later.
+3. The switch is a native change. It ships with a store release, never as a
+   Shorebird patch — Shorebird refuses the native diff, which is the right
+   answer.
+
+`Package.resolved` still pins `google-ads-on-device-conversion-ios-sdk`: SPM
+resolves the `GoogleAppMeasurement` package's dependencies whichever product
+is selected. Whether the library is *linked* is what the check above answers.
+The macOS target keeps the full product — the plugin's macOS manifest has no
+switch — and the conversion SDK is iOS-only, so nothing changes there.
+
+**Verification on the next store release**: `app-ads-services.com` must not
+appear in `NETWORK_REQUEST` for that build's `app_build_version`, while
+`app-analytics-services.com/a` keeps its ~3.5 requests per app start.
+
+```sql
+SELECT REGEXP_EXTRACT(event_name, r'^(?:https?://)?([^/]+)') AS host, COUNT(*) AS n
+FROM `openvine-co.firebase_performance.co_openvine_app_IOS`
+WHERE event_type = 'NETWORK_REQUEST'
+  AND app_display_version = '<release>' AND app_build_version = '<store build>'
+  AND (event_name LIKE '%app-ads-services.com%' OR event_name LIKE '%app-analytics-services.com%')
+GROUP BY 1 ORDER BY 2 DESC
+```
+
 ## URL patterns
 
 Firebase aggregates by URL and drops high-cardinality patterns, so an

--- a/mobile/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
-        "version" : "11.2.0"
+        "revision" : "3e33dd27dd4c69bd81c7c81fe61d8ccf58846902",
+        "version" : "11.3.1"
       }
     },
     {
@@ -68,17 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "d47760f97a853808be6a045d278fbd12abf546b6",
-        "version" : "12.12.0"
-      }
-    },
-    {
-      "identity" : "flutterfire",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/flutterfire",
-      "state" : {
-        "revision" : "05731e3fb091093546db363e379bff166f7286a3",
-        "version" : "4.4.0-firebase-core-swift"
+        "revision" : "346daa9f46316aa372b35b317e18224acc2e9063",
+        "version" : "12.18.0"
       }
     },
     {
@@ -86,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
       "state" : {
-        "revision" : "23fa6970874ec8f3ac0039b3778ca8d6545d50ee",
-        "version" : "3.4.2"
+        "revision" : "dc39082d8881109d35b94b1c122164c0e8d08a55",
+        "version" : "3.6.1"
       }
     },
     {
@@ -95,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "1657f705bc70255ff9d66dfcc697a85db164998f",
-        "version" : "12.11.0"
+        "revision" : "f04760d460296cc0fa430935a7be212e5bd67fc5",
+        "version" : "12.18.0"
       }
     },
     {
@@ -104,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
-        "version" : "10.1.0"
+        "revision" : "ba3358d3c3dbae8ef230b58a46b97ad65e84e974",
+        "version" : "10.1.1"
       }
     },
     {
@@ -113,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
-        "version" : "8.1.0"
+        "revision" : "92c8f6dc3ac375d6febdfcb3db68bc3d10633db3",
+        "version" : "8.1.3"
       }
     },
     {
@@ -131,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "0be208810d2e8b90fcd2464d1816723b47819fe7",
-        "version" : "5.2.0"
+        "revision" : "724a52eea6329b7e12d3ad8300d76ca9f3895fcc",
+        "version" : "5.3.1"
       }
     },
     {
@@ -158,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",
       "state" : {
-        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
-        "version" : "2.30910.0"
+        "revision" : "3851d94a41890dea16dc3db34caf60e585cb4163",
+        "version" : "2.30910.1"
       }
     },
     {
@@ -167,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
-        "version" : "2.4.0"
+        "revision" : "f4a19a3c313dc2616c70bb49d29a799fb16be837",
+        "version" : "2.4.1"
       }
     },
     {
@@ -185,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
-        "version" : "1.6.0"
+        "revision" : "d9a5b37470adc940d22c3bcd5ca6953a516b727f",
+        "version" : "1.7.2"
       }
     },
     {
@@ -194,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
-        "version" : "1.18.0"
+        "revision" : "c8aece90ea05f9866bd392a5bf13b5cae56c0e03",
+        "version" : "1.20.0"
       }
     },
     {

--- a/mobile/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
-        "version" : "11.2.0"
+        "revision" : "3e33dd27dd4c69bd81c7c81fe61d8ccf58846902",
+        "version" : "11.3.1"
       }
     },
     {
@@ -68,17 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "d47760f97a853808be6a045d278fbd12abf546b6",
-        "version" : "12.12.0"
-      }
-    },
-    {
-      "identity" : "flutterfire",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/flutterfire",
-      "state" : {
-        "revision" : "05731e3fb091093546db363e379bff166f7286a3",
-        "version" : "4.4.0-firebase-core-swift"
+        "revision" : "346daa9f46316aa372b35b317e18224acc2e9063",
+        "version" : "12.18.0"
       }
     },
     {
@@ -86,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
       "state" : {
-        "revision" : "23fa6970874ec8f3ac0039b3778ca8d6545d50ee",
-        "version" : "3.4.2"
+        "revision" : "dc39082d8881109d35b94b1c122164c0e8d08a55",
+        "version" : "3.6.1"
       }
     },
     {
@@ -95,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "1657f705bc70255ff9d66dfcc697a85db164998f",
-        "version" : "12.11.0"
+        "revision" : "f04760d460296cc0fa430935a7be212e5bd67fc5",
+        "version" : "12.18.0"
       }
     },
     {
@@ -104,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
-        "version" : "10.1.0"
+        "revision" : "ba3358d3c3dbae8ef230b58a46b97ad65e84e974",
+        "version" : "10.1.1"
       }
     },
     {
@@ -113,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
-        "version" : "8.1.0"
+        "revision" : "92c8f6dc3ac375d6febdfcb3db68bc3d10633db3",
+        "version" : "8.1.3"
       }
     },
     {
@@ -131,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "0be208810d2e8b90fcd2464d1816723b47819fe7",
-        "version" : "5.2.0"
+        "revision" : "724a52eea6329b7e12d3ad8300d76ca9f3895fcc",
+        "version" : "5.3.1"
       }
     },
     {
@@ -158,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",
       "state" : {
-        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
-        "version" : "2.30910.0"
+        "revision" : "3851d94a41890dea16dc3db34caf60e585cb4163",
+        "version" : "2.30910.1"
       }
     },
     {
@@ -167,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
-        "version" : "2.4.0"
+        "revision" : "f4a19a3c313dc2616c70bb49d29a799fb16be837",
+        "version" : "2.4.1"
       }
     },
     {
@@ -185,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
-        "version" : "1.6.0"
+        "revision" : "d9a5b37470adc940d22c3bcd5ca6953a516b727f",
+        "version" : "1.7.2"
       }
     },
     {
@@ -194,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
-        "version" : "1.18.0"
+        "revision" : "c8aece90ea05f9866bd392a5bf13b5cae56c0e03",
+        "version" : "1.20.0"
       }
     },
     {

--- a/mobile/packages/analytics/pubspec.yaml
+++ b/mobile/packages/analytics/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_analytics: ^12.1.2
-  firebase_crashlytics: ^5.0.7
+  firebase_analytics: ^12.5.0
+  firebase_crashlytics: ^5.3.0
   media_cache:
     path: ../media_cache
   models:

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: cd83f7d6bd4e4c0b0b4fef802e8796784032e1cc23d7b0e982cf5d05d9bbe182
+      sha256: f6966125633a34f82d9be2ee895b755cff3554087b1d00a9eb884e5947f4bca9
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.66"
+    version: "1.3.77"
   alchemist:
     dependency: "direct dev"
     description:
@@ -654,114 +654,114 @@ packages:
     dependency: transitive
     description:
       name: firebase_analytics
-      sha256: "07e0a82e9b045dbd14522a0b23764e2dbcc269720e785d63c6a021133ebb766a"
+      sha256: "0bf812fe5fecf395c07b673f40d951929f631749bd7513a31b8bfafa182d9a06"
       url: "https://pub.dev"
     source: hosted
-    version: "12.1.2"
+    version: "12.5.0"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
-      sha256: "62fd3f27f342c898bd819fb97fa87c0b971e9fbe03357477282c0e14e1a40c3c"
+      sha256: "5c3ab4b681c837afd71f0abf77c7485f51c7b645d4ae77b96f9ed54779ff4126"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.6"
+    version: "6.0.7"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
-      sha256: "8fc488bb008439fc3b850cfac892dec1ff4cd438eee44438919a14c5e61b9828"
+      sha256: "09eb4d0ce4c9a16efbc277ac709a90eb197d5512592215a73c6a302ab1ab6c3a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1+2"
+    version: "0.6.1+13"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "923085c881663ef685269b013e241b428e1fb03cdd0ebde265d9b40ff18abf80"
+      sha256: "2343710d8a164e3157a5e2fbb00663503c669be4aa06185311df48626760fdf1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "4.14.0"
   firebase_core_platform_interface:
     dependency: "direct dev"
     description:
       name: firebase_core_platform_interface
-      sha256: cccb4f572325dc14904c02fcc7db6323ad62ba02536833dddb5c02cac7341c64
+      sha256: "9bfbc85faca09346471ac56fbcee00757ebcfd85887c6f602764eff0001902d8"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "8.1.1"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "83e7356c704131ca4d8d8dd57e360d8acecbca38b1a3705c7ae46cc34c708084"
+      sha256: de1e678209a0c974d8aa4cff39f17d61d2dc263aa64993168360f9be4efb8e91
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0"
+    version: "3.11.0"
   firebase_crashlytics:
     dependency: "direct main"
     description:
       name: firebase_crashlytics
-      sha256: a6e6cb8b2ea1214533a54e4c1b11b19c40f6a29333f3ab0854a479fdc3237c5b
+      sha256: aca14d94150d50e3f9e0f5090008fa98232d924bc780689481056521d9dc25c9
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.7"
+    version: "5.3.0"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
-      sha256: fc6837c4c64c48fa94cab8a872a632b9194fa9208ca76a822f424b3da945584d
+      sha256: "8270dcdb1800db3e5f888ce30a2d5e8f92c379c461f022297c83b2c794aa1792"
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.17"
+    version: "3.9.0"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: "06fad40ea14771e969a8f2bbce1944aa20ee2f4f57f4eca5b3ba346b65f3f644"
+      sha256: "31feb5db1fcbdececefd0feb5520013b7cb5d362018008c2889e7ae7e0da4dcb"
       url: "https://pub.dev"
     source: hosted
-    version: "16.1.1"
+    version: "16.6.0"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: "6c49e901c77e6e10e86d98e32056a087eb1ca1b93acdf58524f1961e617657b7"
+      sha256: f9707e185b8ce1155d58e7e29348245072d99981f899fa8d3214abb2652c4ccb
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.6"
+    version: "4.10.0"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "2756f8fea583ffb9d294d15ddecb3a9ad429b023b70c9990c151fc92c54a32b3"
+      sha256: "311b16c75fc645c7a70c9ade38908abb12310dfce449fc3d3cee1771f196351e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.2"
+    version: "4.2.5"
   firebase_performance:
     dependency: "direct main"
     description:
       name: firebase_performance
-      sha256: "72b8800907e2f7a0c65c140324a6eb07b9e16a73874b032ce7e5cc79e6dac4e9"
+      sha256: "1b01a42b403eb3d5d4de71793447339666ca2e7f40d95215c97a11d6700a0f2b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1+4"
+    version: "0.11.5"
   firebase_performance_platform_interface:
     dependency: transitive
     description:
       name: firebase_performance_platform_interface
-      sha256: "6f59cb2fdcf5e42c709ff0ca3f74cae0b656a1c288c508c40da71929fca6f4f5"
+      sha256: b598cea7051fb9f3abd3eddbcabc7dd9d2c6a7ab06e264c8c2d2c935a20c12aa
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.6+4"
+    version: "0.2.0+7"
   firebase_performance_web:
     dependency: transitive
     description:
       name: firebase_performance_web
-      sha256: "1ee6d1f27f340f39adb3d8afdce579ead1ff6a3df424503d4ea272e0498f33b6"
+      sha256: "424d695ea235b4aad3902cabe66f7c6197b4a9e66f0f151c14850100fb4fa45d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.8+2"
+    version: "0.1.8+13"
   fixnum:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -352,10 +352,10 @@ dependencies:
 
   # Desktop window management for proper window sizing
   window_manager: ^0.5.1
-  firebase_core: ^4.4.0
-  firebase_crashlytics: ^5.0.7
-  firebase_messaging: ^16.1.1
-  firebase_performance: ^0.11.1+4
+  firebase_core: ^4.14.0
+  firebase_crashlytics: ^5.3.0
+  firebase_messaging: ^16.6.0
+  firebase_performance: ^0.11.5
   # 18.0.0 is the first go_router built on material_ui, and the floor is
   # load-bearing: earlier versions pick a page builder with
   # findAncestorWidgetOfExactType<MaterialApp>() against the framework class,
@@ -438,7 +438,7 @@ dev_dependencies:
 
   # Testing
   file: ^7.0.1
-  firebase_core_platform_interface: ^6.0.2
+  firebase_core_platform_interface: ^8.1.1
   fake_async: ^1.3.3
   mocktail: ^1.0.3
   bloc_test: ^10.0.0

--- a/mobile/scripts/check_ios_analytics_product.sh
+++ b/mobile/scripts/check_ios_analytics_product.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Fails when a built iOS app carries Google's ads-measurement code (#7303).
+#
+# Divine's analytics property has no Google Ads account linked, personalized
+# advertising is off and there is no ATT prompt (docs/IOS_PRIVACY_MANIFESTS.md,
+# decision D1). The default FlutterFire product, `FirebaseAnalytics`, still
+# links `GoogleAdsOnDeviceConversion` and `GoogleAppMeasurementIdentitySupport`
+# — on the 1.0.20 store population that SDK made ~4 requests and downloaded
+# ~13 KB per app start to `*.app-ads-services.com`, reporting to nobody.
+# `FirebaseAnalyticsCore` links neither. The plugin picks it only when
+# FIREBASE_ANALYTICS_WITHOUT_ADID is present in the environment while Xcode
+# evaluates `firebase_analytics`'s Package.swift, and nothing else notices
+# when that variable is missing: the build succeeds either way and the
+# difference shows up weeks later in the Performance export. This check reads
+# the product Xcode actually linked, so the fallback fails the build instead.
+#
+# Two assertions, both on the Mach-O binaries in the bundle (the executable,
+# any root-level dylib, and any embedded framework):
+#   • no binary references `app-ads-services.com` — the only hosts
+#     GoogleAdsOnDeviceConversion talks to;
+#   • at least one binary references `app-analytics-services.com` — the
+#     Analytics upload host. This proves analytics is still linked and that the
+#     scan looked at a real binary; without it a wrong --app path or a stripped
+#     stub would pass vacuously.
+#
+# Usage:
+#   bash scripts/check_ios_analytics_product.sh --app <path/to/Runner.app>
+#
+# Docs: docs/NETWORK_PERFORMANCE_MONITORING.md ("Google SDK traffic")
+set -euo pipefail
+
+app=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --app)
+      shift
+      app="${1:-}"
+      ;;
+    *)
+      echo "❌ Unknown argument: $1" >&2
+      echo "Usage: bash scripts/check_ios_analytics_product.sh --app <path/to/Runner.app>" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$app" ] || [ ! -d "$app" ]; then
+  echo "❌ --app must point at a built .app bundle (got: '${app:-<missing>}')." >&2
+  exit 2
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "❌ python3 not found. It is preinstalled on Codemagic macOS images and GitHub Actions runners." >&2
+  exit 2
+fi
+
+# plistlib rather than PlistBuddy so the guard, and its test, run on Linux too.
+executable="$(python3 -c 'import plistlib, sys; print(plistlib.load(open(sys.argv[1], "rb")).get("CFBundleExecutable", ""))' "$app/Info.plist" 2>/dev/null || true)"
+if [ -z "$executable" ] || [ ! -f "$app/$executable" ]; then
+  echo "❌ $app has no CFBundleExecutable binary." >&2
+  exit 2
+fi
+
+# A release build links the SDK's static frameworks into the executable; a
+# debug build puts the app code in Runner.debug.dylib beside a stub executable,
+# and the embedded Google*.framework bundles are 50 KB SPM stubs either way.
+binaries=("$app/$executable")
+for dylib in "$app"/*.dylib; do
+  [ -f "$dylib" ] && binaries+=("$dylib")
+done
+if [ -d "$app/Frameworks" ]; then
+  for fw in "$app"/Frameworks/*.framework; do
+    [ -d "$fw" ] || continue
+    name="$(basename "$fw" .framework)"
+    [ -f "$fw/$name" ] && binaries+=("$fw/$name")
+  done
+fi
+
+fail=0
+analytics_seen=0
+# grep -a on the file itself rather than `strings | grep -q`: under pipefail
+# grep -q closes the pipe on the first hit and strings exits on SIGPIPE, which
+# turns a match into a false condition.
+for bin in "${binaries[@]}"; do
+  if grep -a -q 'app-ads-services\.com' "$bin"; then
+    echo "❌ ${bin#"$app"/} links Google ads-measurement code (references app-ads-services.com)."
+    fail=1
+  fi
+  if grep -a -q 'app-analytics-services\.com' "$bin"; then
+    analytics_seen=1
+  fi
+done
+
+if [ "$analytics_seen" -eq 0 ]; then
+  echo "❌ No binary in $app references app-analytics-services.com — Firebase Analytics is not linked, or the scan did not reach the real binary."
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "   The iOS build must run with FIREBASE_ANALYTICS_WITHOUT_ADID set so firebase_analytics links FirebaseAnalyticsCore. Check the workflow's vars, then 'flutter clean' and rebuild — Xcode keeps the evaluated Package.swift in build/ios/SourcePackages, so setting the variable alone does not re-resolve."
+  exit 1
+fi
+
+echo "OK [ios_analytics_product]: FirebaseAnalyticsCore linked — app-analytics-services.com present, app-ads-services.com absent (${#binaries[@]} binaries scanned)."

--- a/mobile/test/services/firebase_initialization_test.dart
+++ b/mobile/test/services/firebase_initialization_test.dart
@@ -103,4 +103,13 @@ class _FakeFirebaseApp implements FirebaseApp {
 
   @override
   Future<void> setAutomaticResourceManagementEnabled(bool enabled) async {}
+
+  @override
+  T? getService<T extends FirebaseService>() => null;
+
+  @override
+  void registerService<T extends FirebaseService>(
+    T service, {
+    Future<void> Function(T service)? dispose,
+  }) {}
 }

--- a/mobile/test/tools/ios_analytics_product_guard_test.dart
+++ b/mobile/test/tools/ios_analytics_product_guard_test.dart
@@ -1,0 +1,186 @@
+// ABOUTME: Tests for the iOS analytics-product guard
+// ABOUTME: (scripts/check_ios_analytics_product.sh), which fails a build that
+// ABOUTME: links Google's ads-measurement SDK (#7303).
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Drives `scripts/check_ios_analytics_product.sh` against synthetic `.app`
+/// bundles, so the two assertions — no binary references
+/// `app-ads-services.com`, some binary references `app-analytics-services.com`
+/// — are pinned without a 160 MB build product.
+///
+/// The guard exists because `FIREBASE_ANALYTICS_WITHOUT_ADID` is read inside
+/// `firebase_analytics`'s Package.swift and nothing else notices when it is
+/// missing: the build is green either way, and the difference only shows up
+/// in the Performance export weeks later.
+void main() {
+  group('check_ios_analytics_product', () {
+    late Directory tmp;
+    late String scriptPath;
+
+    const analyticsHost = 'https://app-analytics-services.com/a';
+    const adsHost = 'https://odm.app-ads-services.com/odm/config?%@';
+
+    /// Writes a minimal bundle: an Info.plist naming [executable], the
+    /// executable itself containing [executableStrings], optional root-level
+    /// dylibs and optional embedded frameworks.
+    Directory bundle({
+      String executable = 'Runner',
+      List<String> executableStrings = const [],
+      Map<String, List<String>> dylibs = const {},
+      Map<String, List<String>> frameworks = const {},
+    }) {
+      final app = Directory(
+        '${tmp.path}/${DateTime.now().microsecondsSinceEpoch}/Runner.app',
+      )..createSync(recursive: true);
+      File('${app.path}/Info.plist').writeAsStringSync('''
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>$executable</string>
+</dict>
+</plist>
+''');
+      File('${app.path}/$executable').writeAsBytesSync([
+        ...'binary\x00'.codeUnits,
+        ...executableStrings.join('\x00').codeUnits,
+        0,
+      ]);
+      dylibs.forEach((name, strings) {
+        File('${app.path}/$name').writeAsStringSync(strings.join('\x00'));
+      });
+      frameworks.forEach((name, strings) {
+        final fw = Directory('${app.path}/Frameworks/$name.framework')
+          ..createSync(recursive: true);
+        File('${fw.path}/$name').writeAsStringSync(strings.join('\x00'));
+      });
+      return app;
+    }
+
+    ProcessResult run(List<String> args) =>
+        Process.runSync('bash', [scriptPath, ...args]);
+
+    setUp(() {
+      tmp = Directory.systemTemp.createTempSync('ios_analytics_product_');
+      scriptPath =
+          '${Directory.current.path}/scripts/check_ios_analytics_product.sh';
+    });
+
+    tearDown(() {
+      tmp.deleteSync(recursive: true);
+    });
+
+    test(
+      'passes when the executable links analytics but not ads measurement',
+      () {
+        final app = bundle(executableStrings: [analyticsHost]);
+
+        final result = run(['--app', app.path]);
+
+        expect(result.exitCode, 0, reason: '${result.stdout}${result.stderr}');
+        expect(result.stdout, contains('OK [ios_analytics_product]'));
+      },
+    );
+
+    test('fails when the executable references app-ads-services.com', () {
+      final app = bundle(executableStrings: [analyticsHost, adsHost]);
+
+      final result = run(['--app', app.path]);
+
+      expect(result.exitCode, 1);
+      expect(
+        result.stdout,
+        contains('Runner links Google ads-measurement code'),
+      );
+      expect(result.stdout, contains('FIREBASE_ANALYTICS_WITHOUT_ADID'));
+    });
+
+    test('fails when no binary references app-analytics-services.com', () {
+      // A wrong --app path or a stub binary must not pass vacuously.
+      final app = bundle(executableStrings: ['nothing relevant']);
+
+      final result = run(['--app', app.path]);
+
+      expect(result.exitCode, 1);
+      expect(
+        result.stdout,
+        contains(
+          'No binary in ${app.path} references app-analytics-services.com',
+        ),
+      );
+    });
+
+    test('scans root-level dylibs, where a debug build keeps the app code', () {
+      final app = bundle(
+        executableStrings: ['stub'],
+        dylibs: {
+          'Runner.debug.dylib': [analyticsHost, adsHost],
+        },
+      );
+
+      final result = run(['--app', app.path]);
+
+      expect(result.exitCode, 1);
+      expect(
+        result.stdout,
+        contains('Runner.debug.dylib links Google ads-measurement code'),
+      );
+    });
+
+    test('scans embedded frameworks', () {
+      final app = bundle(
+        executableStrings: [analyticsHost],
+        frameworks: {
+          'GoogleAdsOnDeviceConversion': [adsHost],
+        },
+      );
+
+      final result = run(['--app', app.path]);
+
+      expect(result.exitCode, 1);
+      expect(
+        result.stdout,
+        contains(
+          'Frameworks/GoogleAdsOnDeviceConversion.framework/'
+          'GoogleAdsOnDeviceConversion links Google ads-measurement code',
+        ),
+      );
+    });
+
+    test('accepts analytics linked from an embedded framework', () {
+      final app = bundle(
+        executableStrings: ['stub'],
+        frameworks: {
+          'FirebaseAnalytics': [analyticsHost],
+        },
+      );
+
+      final result = run(['--app', app.path]);
+
+      expect(result.exitCode, 0, reason: '${result.stdout}${result.stderr}');
+    });
+
+    test('exits 2 on a missing bundle or an unknown argument', () {
+      expect(run(['--app', '${tmp.path}/missing.app']).exitCode, 2);
+      expect(run(['--archive', tmp.path]).exitCode, 2);
+      expect(run([]).exitCode, 2);
+    });
+
+    test('exits 2 when Info.plist names no executable', () {
+      final app = bundle(executableStrings: [analyticsHost]);
+      File('${app.path}/Info.plist').writeAsStringSync('''
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict></dict></plist>
+''');
+
+      final result = run(['--app', app.path]);
+
+      expect(result.exitCode, 2);
+      expect(result.stderr, contains('has no CFBundleExecutable binary'));
+    });
+  });
+}


### PR DESCRIPTION
## Description

The iOS app has been shipping Google's Ads on-device conversion measurement SDK (`GoogleAdsOnDeviceConversion`) and IDFA support, because FlutterFire's default iOS product `FirebaseAnalytics` links both alongside the analytics SDK. Nobody consumes what that SDK measures: no Google Ads account is linked to the analytics property, personalized advertising is off and there is no ATT prompt (`mobile/docs/IOS_PRIVACY_MANIFESTS.md`, decision D1), and the Android manifest already strips `AD_ID` and the AdServices permissions. On the 1.0.20 store population the conversion SDK still made ~4 requests and downloaded ~13 KB per app start — ~70k requests and ~223 MB a week to `*.app-ads-services.com`, nearly as many bytes as `media.divine.video` serves over the same instrumentation path. That is what #7303 asked to account for.

**What changes.** The iOS build links `FirebaseAnalyticsCore`, which carries neither library. `firebase_analytics` selects it when `FIREBASE_ANALYTICS_WITHOUT_ADID` is present in the environment while Xcode evaluates its `Package.swift`; that switch exists from plugin 12.2.0, so the FlutterFire set moves to `firebase_core` 4.14.0 in lockstep — analytics 12.5.0, crashlytics 5.3.0, messaging 16.6.0, performance 0.11.5; firebase-ios-sdk 12.12.0 → 12.18.0, Android BOM 34.7.0 → 34.18.0. The variable is set on every iOS workflow in `codemagic.yaml` (release, patch, simulator, E2E), so patch builds link the same graph as the release they patch.

**Why a guard.** The variable is read inside a package manifest and nothing else notices when it is missing: the build is green either way and the difference only shows up in the Performance export weeks later. `mobile/scripts/check_ios_analytics_product.sh` reads the built product after the Shorebird release archive and after the simulator build, and fails when any binary references `app-ads-services.com` (the only hosts the conversion SDK talks to) or when none references `app-analytics-services.com` (proves analytics is still linked and that the scan reached a real binary). Its Dart test drives it against synthetic bundles, including the debug layout where the app code sits in `Runner.debug.dylib`.

**Why the docs move too.** The expected per-host volume of the Google SDK traffic — analytics upload, Crashlytics, Installations/FCM/Remote Config, and the conversion SDK — is recorded in `mobile/docs/NETWORK_PERFORMANCE_MONITORING.md` next to the `NETWORK_REQUEST` documentation, with a pointer from `docs/ANALYTICS_OBSERVABILITY.md`, so the next reader of the export treats those rows as SDK cost rather than a finding. It also records that the 16% `odf/config` 403s are Google's EEA/UK gate applied server-side after the device has already asked (98–100% in EEA countries, ~0% elsewhere, no retry), and that `Package.resolved` keeps pinning the conversion package because SPM resolves package-level dependencies regardless of which product is linked. `IOS_PRIVACY_MANIFESTS.md` drops the two libraries from its "ships no manifest" list and records the re-check against 12.18.0.

`firebase_core` 4.14.0 added `registerService`/`getService` to `FirebaseApp`; the fake in `firebase_initialization_test.dart` implements them as no-ops.

**Related Issue:** Closes #7303

## Out of Scope

- This is a native change and ships with a store release; Shorebird refuses the native diff as a patch, which is the right answer.
- macOS keeps the full product: the plugin's macOS manifest has no switch, and the conversion SDK is iOS-only.
- The two side findings in the #7302 re-read (`apps.divine.video/v1/apps` answering 404 for every user; `video_upload_enqueue` failing with `authUnavailable` on 6.9% of Android enqueues) are deliberately not filed here.
- Verifying the effect on the export needs the first store release that carries this — 1.0.22 is not in the stores. The query is in the doc section.

## Verification

- iOS release build **with** `FIREBASE_ANALYTICS_WITHOUT_ADID` (`flutter build ios --release --no-codesign`): embedded Google frameworks are `FirebaseAnalytics` and `GoogleAppMeasurement` only; no binary in the bundle references `app-ads-services.com`; guard passes.
- Control build of the same plugin set **without** the variable, `build/ios/SourcePackages`, DerivedData and workspace SPM state wiped first: `GoogleAdsOnDeviceConversion` and `GoogleAppMeasurementIdentitySupport` come back, the executable references `app-ads-services.com`, guard fails. (Wiping only the workspace's `xcshareddata/swiftpm` was not enough — Xcode keeps the evaluated manifest under `build/ios/SourcePackages`; the doc and the guard's failure hint say `flutter clean`.)
- `scripts/check_privacy_manifest_coverage.sh --archive <Core build>` passes; same manifest set as the 2026-09-11 check minus the two dropped libraries; FCM still declares Other Data Types. `FPRConfigurations.m` in 12.18.0 keeps the deactivation-before-cache-before-plist order #7158 relies on.
- `flutter analyze lib test integration_test` clean; `flutter test` on the Firebase-adjacent app suites (147 tests), `packages/analytics` (82), `test/tools/codemagic_groups_test.dart`, `detect_mobile_ci_scope_test.dart`, `maestro_pr_smoke_contract_test.dart` and the new guard test (8) — all green. `shellcheck` clean on the guard.
- `check_dependency_provenance.sh`, `check_package_flutter_boundary.sh`, `check_codemagic_groups.sh` green. Lockfile diff is the Firebase set plus `_flutterfire_internals` only.
- `flutter build apk --debug` with BOM 34.18.0 builds.
- Android device test on an SM-S942B (Galaxy S25, staging debug build): Firebase Core, Crashlytics 20.1.0 and App Measurement initialize on BOM 34.18.0, `AnalyticsService initialized (enabled: true)`, `PushNotifications initialized in 119ms`, screen tracking and the feed load, no plugin exceptions, no crash across two launches. The debug-only Riverpod asserts in the log (`CircularDependencyError` on `analyticsServiceProvider` from the view-event retry sweep, #8795) predate this change and are outside its diff.

## Type of Change

- [x] ✅ Build configuration change
- [x] 📝 Documentation
- [x] 🗑️ Chore
