### PR TITLE
fix(nostr): stop a feed subscription waiting behind other subscriptions' replays

### DIFF
--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -652,13 +652,15 @@ class Nostr {
     final now = DateTime.now();
     if (!deadline.isAfter(now)) {
       // The pool files a completion line for every read it sees; this one
-      // it never will, so the line is filed here.
+      // it never will, so the line is filed here — under [clientScope],
+      // which exists so a layer above the pool cannot spend the pool's
+      // rate-limit budget on reads no relay was asked about.
       emitRelayDiagnostic(
         _pool.diagnosticsSink,
         RelayDiagnostic(
           site: RelayDiagnosticSite.queryCompletion,
           level: RelayDiagnosticLevel.warning,
-          relayUrl: RelayDiagnostic.poolScope,
+          relayUrl: RelayDiagnostic.clientScope,
           message:
               'Query $subscriptionId ended deadline before any REQ was '
               'written: the deadline had already passed by '

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -634,6 +634,13 @@ class Nostr {
     required DateTime deadline,
     required bool requireAllRelaysSettled,
   }) async {
+    // [RelayPool.query] rejects an empty filter list, and the deadline branch
+    // below returns before it is ever called. Validate here so a read is
+    // rejected the same way whichever path it takes.
+    if (filters.isEmpty) {
+      throw ArgumentError('No filters given', 'filters');
+    }
+
     // A deadline that has already passed ends the read before it starts. The
     // client's query pool can hand a slot over with the caller's budget fully
     // spent by the wait; a REQ written then was unsubscribed a few

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -665,11 +665,13 @@ class Nostr {
               '${now.difference(deadline).inMilliseconds}ms',
         ),
       );
+      // Growable, like every other exit: the normal path hands back
+      // [EventMemBox.all], which callers are free to sort or append to.
       return (
-        result: const QueryResult(events: [], endedBy: QueryEnd.deadline),
+        result: QueryResult(events: <Event>[], endedBy: QueryEnd.deadline),
         endedAtDeadline: true,
-        relays: const <QueryRelaySummary>[],
-        cappedWithoutEvents: const <String>[],
+        relays: <QueryRelaySummary>[],
+        cappedWithoutEvents: <String>[],
         sentTo: null,
       );
     }

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -634,8 +634,40 @@ class Nostr {
     required DateTime deadline,
     required bool requireAllRelaysSettled,
   }) async {
-    final eventBox = EventMemBox(sortAfterAdd: false);
+    // A deadline that has already passed ends the read before it starts. The
+    // client's query pool can hand a slot over with the caller's budget fully
+    // spent by the wait; a REQ written then was unsubscribed a few
+    // milliseconds later, and the pool read those milliseconds of silence as
+    // every relay having swallowed the request (#7301). Nothing is asked of
+    // the relays, so the outcome is the deadline's with no relay in it — the
+    // same answer the timer below would have given.
     final subscriptionId = id ?? StringUtil.rndNameStr(16);
+    final now = DateTime.now();
+    if (!deadline.isAfter(now)) {
+      // The pool files a completion line for every read it sees; this one
+      // it never will, so the line is filed here.
+      emitRelayDiagnostic(
+        _pool.diagnosticsSink,
+        RelayDiagnostic(
+          site: RelayDiagnosticSite.queryCompletion,
+          level: RelayDiagnosticLevel.warning,
+          relayUrl: RelayDiagnostic.poolScope,
+          message:
+              'Query $subscriptionId ended deadline before any REQ was '
+              'written: the deadline had already passed by '
+              '${now.difference(deadline).inMilliseconds}ms',
+        ),
+      );
+      return (
+        result: const QueryResult(events: [], endedBy: QueryEnd.deadline),
+        endedAtDeadline: true,
+        relays: const <QueryRelaySummary>[],
+        cappedWithoutEvents: const <String>[],
+        sentTo: null,
+      );
+    }
+
+    final eventBox = EventMemBox(sortAfterAdd: false);
     final ended = Completer<QueryOutcome>();
     var endedAtDeadline = false;
 

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -352,7 +352,9 @@ class Nostr {
   /// deadline rather than completing on the relays that answered first.
   ///
   /// A read that ends any other way than a complete, uncapped answer gets one
-  /// [RelayDiagnosticSite.queryCompletion] line, from the pool.
+  /// [RelayDiagnosticSite.queryCompletion] line: from the pool for a read it
+  /// saw, and from here under [RelayDiagnostic.clientScope] for one whose
+  /// deadline had already passed, which never reaches the pool.
   ///
   /// Throws [ArgumentError] when [filters] is empty.
   Future<QueryResult> readEvents(

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1671,19 +1671,18 @@ class RelayPool {
     // completing on CLOSED out of order would drop the events already in
     // flight. Frames of different subscriptions carry no ordering obligation
     // toward each other and run on independent chains (#7301). A frame whose
-    // subscription id is not a string is malformed; it takes the relay-wide
-    // chain so [_dispatchTypedFrame] can log and drop it in turn. With no
+    // subscription id is not a string is malformed and belongs to no chain;
+    // [_dispatchTypedFrame] logs and drops it without awaiting. With no
     // worker the original synchronous path runs unchanged.
     if (_verifyWorker != null &&
+        json.length > 1 &&
+        json[1] is String &&
         (messageType == 'EVENT' ||
             messageType == 'EOSE' ||
             messageType == 'CLOSED')) {
-      final subId = json.length > 1 && json[1] is String
-          ? json[1] as String
-          : '';
       return _enqueueOrdered(
         relay,
-        subId,
+        json[1] as String,
         () => _dispatchTypedFrame(relay, json, messageType),
       );
     }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -89,15 +89,12 @@ class RelayPool {
   /// order once verify becomes asynchronous (an EOSE must not complete a query
   /// before its preceding events finish verifying).
   ///
-  /// One entry per (relay, subscription id), not per relay. Only frames of the
-  /// same subscription need ordering, and one shared per-relay chain made a
-  /// live feed subscription wait behind every other subscription's stored
-  /// replay on that socket — thousands of one-shot query events at ~20–40 ms
-  /// of Schnorr verify each, on device — which is how a profile feed the relay
-  /// had answered in 300 ms reached the app 16 s later and ran into the 30 s
-  /// feed-load fuse on slower Android hardware (#7301). Entries are removed
-  /// once their chain drains, so the map stays bounded by the subscriptions
-  /// that are mid-delivery. Only used when [_verifyWorker] is set.
+  /// One entry per (relay, subscription id), not per relay: only frames of the
+  /// same subscription need ordering, and a shared per-relay chain made a live
+  /// feed wait behind every other subscription's stored replay on that socket
+  /// (#7301). Entries are removed once their chain drains, so the map stays
+  /// bounded by the subscriptions that are mid-delivery. Only used when
+  /// [_verifyWorker] is set.
   final Map<(String, String), Future<void>> _orderedFrameTails = {};
 
   // subscription
@@ -391,21 +388,16 @@ class RelayPool {
   /// is treated as evidence against the socket.
   ///
   /// [_repairRelaysThatNeverAnswered] assumed a query is only released once
-  /// its caller gave up waiting. Two release paths never waited at all: a
-  /// read whose deadline had already passed when its slot in the client's
-  /// query pool arrived was written to the relays and unsubscribed a few
-  /// milliseconds later, and a query the settle window completed on the
-  /// first relay's EOSE released the slower relays about a second after the
-  /// REQ. Neither says anything about the socket, but both pass the
-  /// silence test trivially — no relay answers inside 7 ms — so every relay
-  /// that was otherwise idle got force-cycled and replayed its whole stored
-  /// window for every subscription it carried. On device that was a
-  /// three-relay cycle and thousands of frames of replay per profile visit,
-  /// all of it queued ahead of the feed the user was looking at (#7301).
+  /// its caller gave up waiting. Two release paths never waited at all: a read
+  /// whose deadline had already passed when its query-pool slot arrived, and a
+  /// query the settle window completed on the first relay's EOSE. Neither says
+  /// anything about the socket, yet both pass the silence test trivially, so
+  /// every otherwise-idle relay got force-cycled and replayed its whole stored
+  /// window for every subscription it carried (#7301).
   ///
-  /// The default is below the SDK's 5 s default read timeout, so a caller
-  /// that waited its whole budget still gets the repair, and above any
-  /// settle-window completion. Injectable so tests need no wall-clock wait.
+  /// The default is below the SDK's 5 s default read timeout, so a caller that
+  /// waited its whole budget still gets the repair, and above
+  /// [querySettleWindow]. Injectable so tests need no wall-clock wait.
   Duration minQueryAgeBeforeRepair;
 
   /// How long after a subscription's REQ fan-out the pool checks whether any
@@ -1710,13 +1702,10 @@ class RelayPool {
         if (subId == null) return;
 
         // Nothing is listening for [subId] any more: the query was released
-        // or the subscription torn down while the relay was still streaming
-        // its replay. Every check below decides whether the event may be
-        // delivered, and with no recipient there is nothing to decide — the
-        // Schnorr verify it would spend is what the live subscriptions behind
-        // it are waiting on (#7301). Same outcome as the post-verify lookup
-        // below, which stays because the recipient can go away during the
-        // await.
+        // or the subscription torn down mid-replay. The verify this frame
+        // would spend is what the live subscriptions behind it are waiting on
+        // (#7301). The post-verify lookup below stays, because the recipient
+        // can also go away during the await.
         if (_subscriptions[subId] == null &&
             relay.getRequestSubscription(subId) == null) {
           return;

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -85,11 +85,20 @@ class RelayPool {
 
   set eventVerifyWorker(EventVerifyWorker? worker) => _verifyWorker = worker;
 
-  /// Per-relay serial tail used to keep EVENT/EOSE frames in order once verify
-  /// becomes asynchronous (an EOSE must not complete a query before its
-  /// preceding events finish verifying). One entry per relay url; only used
-  /// when [_verifyWorker] is set.
-  final Map<String, Future<void>> _orderedFrameTails = {};
+  /// Serial tails that keep a subscription's EVENT/EOSE/CLOSED frames in
+  /// order once verify becomes asynchronous (an EOSE must not complete a query
+  /// before its preceding events finish verifying).
+  ///
+  /// One entry per (relay, subscription id), not per relay. Only frames of the
+  /// same subscription need ordering, and one shared per-relay chain made a
+  /// live feed subscription wait behind every other subscription's stored
+  /// replay on that socket — thousands of one-shot query events at ~20–40 ms
+  /// of Schnorr verify each, on device — which is how a profile feed the relay
+  /// had answered in 300 ms reached the app 16 s later and ran into the 30 s
+  /// feed-load fuse on slower Android hardware (#7301). Entries are removed
+  /// once their chain drains, so the map stays bounded by the subscriptions
+  /// that are mid-delivery. Only used when [_verifyWorker] is set.
+  final Map<(String, String), Future<void>> _orderedFrameTails = {};
 
   // subscription
   final Map<String, Subscription> _subscriptions = {};
@@ -264,6 +273,7 @@ class RelayPool {
     this.signatureVerificationPolicy = SignatureVerificationPolicy.all,
     this.silentRepairCooldown = const Duration(seconds: 60),
     this.minSubscriptionAgeBeforeRepair = const Duration(seconds: 10),
+    this.minQueryAgeBeforeRepair = const Duration(seconds: 4),
     this.subscriptionSilenceProbe = const Duration(seconds: 8),
     this.tempRelayIdleTimeout = const Duration(seconds: 120),
     this.tempRelaySweepInterval = const Duration(seconds: 60),
@@ -376,6 +386,27 @@ class RelayPool {
   /// deadline, so a caller that actually waited still gets the repair.
   /// Injectable so tests need no wall-clock wait.
   Duration minSubscriptionAgeBeforeRepair;
+
+  /// How long a one-shot query must have gone unanswered before its release
+  /// is treated as evidence against the socket.
+  ///
+  /// [_repairRelaysThatNeverAnswered] assumed a query is only released once
+  /// its caller gave up waiting. Two release paths never waited at all: a
+  /// read whose deadline had already passed when its slot in the client's
+  /// query pool arrived was written to the relays and unsubscribed a few
+  /// milliseconds later, and a query the settle window completed on the
+  /// first relay's EOSE released the slower relays about a second after the
+  /// REQ. Neither says anything about the socket, but both pass the
+  /// silence test trivially — no relay answers inside 7 ms — so every relay
+  /// that was otherwise idle got force-cycled and replayed its whole stored
+  /// window for every subscription it carried. On device that was a
+  /// three-relay cycle and thousands of frames of replay per profile visit,
+  /// all of it queued ahead of the feed the user was looking at (#7301).
+  ///
+  /// The default is below the SDK's 5 s default read timeout, so a caller
+  /// that waited its whole budget still gets the repair, and above any
+  /// settle-window completion. Injectable so tests need no wall-clock wait.
+  Duration minQueryAgeBeforeRepair;
 
   /// How long after a subscription's REQ fan-out the pool checks whether any
   /// relay has answered, and repairs the ones that have not.
@@ -1089,15 +1120,29 @@ class RelayPool {
     }
   }
 
-  /// Runs [work] after the previous EVENT/EOSE frame from the same relay,
-  /// preserving per-relay in-order delivery once verify is asynchronous. Errors
-  /// are swallowed on the retained tail so one bad frame can't wedge the chain;
-  /// the returned future still surfaces them to the immediate caller.
-  Future<void> _enqueueOrdered(Relay relay, Future<void> Function() work) {
-    final key = relay.url;
+  /// Runs [work] after the previous EVENT/EOSE/CLOSED frame that [relay] sent
+  /// for [subId], preserving per-subscription in-order delivery once verify is
+  /// asynchronous. Errors are swallowed on the retained tail so one bad frame
+  /// can't wedge the chain; the returned future still surfaces them to the
+  /// immediate caller.
+  Future<void> _enqueueOrdered(
+    Relay relay,
+    String subId,
+    Future<void> Function() work,
+  ) {
+    final key = (relay.url, subId);
     final prev = _orderedFrameTails[key] ?? Future<void>.value();
     final next = prev.then((_) => work());
-    _orderedFrameTails[key] = next.catchError((Object _) {});
+    final tail = next.catchError((Object _) {});
+    _orderedFrameTails[key] = tail;
+    // Only the chain's last link removes the entry; a link that finished
+    // while a later frame was already queued behind it leaves that frame's
+    // tail in place.
+    tail.whenComplete(() {
+      if (identical(_orderedFrameTails[key], tail)) {
+        _orderedFrameTails.remove(key);
+      }
+    });
     return next;
   }
 
@@ -1426,9 +1471,11 @@ class RelayPool {
   /// Force-cycles the relays that never produced a terminal frame for the
   /// abandoned query [subId].
   ///
-  /// A caller only abandons a query by timing out, so any relay still holding
-  /// it demonstrably did not answer. When that same connection also received no
-  /// inbound frame of any kind since the REQ was written, it is the half-open
+  /// A caller that abandons a query after waiting at least
+  /// [minQueryAgeBeforeRepair] has given every relay still holding it a fair
+  /// chance to answer, so those relays demonstrably did not. When such a
+  /// connection also received no inbound frame of any kind since the REQ was
+  /// written, it is the half-open
   /// zombie [_repairSilentRelays] already remediates on the publish side — a
   /// socket that still reports `connected` to every health gate while silently
   /// swallowing everything written to it. Without this, queries never trigger
@@ -1437,6 +1484,11 @@ class RelayPool {
   void _repairRelaysThatNeverAnswered(String subId) {
     final sentAt = _querySentAt.remove(subId);
     if (sentAt == null) return;
+    // A query released before [minQueryAgeBeforeRepair] proves nothing about
+    // the socket; see that field for the two paths that release one early.
+    if (DateTime.now().difference(sentAt) < minQueryAgeBeforeRepair) {
+      return;
+    }
     final silent = [
       for (final relay in [
         ..._relaysSnapshot(),
@@ -1612,18 +1664,26 @@ class RelayPool {
     }
 
     // #5863: when an off-main verify worker is wired, serialize the frames
-    // that carry or terminate a query per relay so the asynchronous verify
-    // preserves in-order delivery — a terminal frame must not complete a query
-    // before its preceding events finish verifying. CLOSED is terminal too: a
-    // relay may stream part of a stored replay and then abandon it, so
+    // that carry or terminate a query per subscription so the asynchronous
+    // verify preserves in-order delivery — a terminal frame must not complete
+    // a query before its preceding events finish verifying. CLOSED is terminal
+    // too: a relay may stream part of a stored replay and then abandon it, so
     // completing on CLOSED out of order would drop the events already in
-    // flight. With no worker the original synchronous path runs unchanged.
+    // flight. Frames of different subscriptions carry no ordering obligation
+    // toward each other and run on independent chains (#7301). A frame whose
+    // subscription id is not a string is malformed; it takes the relay-wide
+    // chain so [_dispatchTypedFrame] can log and drop it in turn. With no
+    // worker the original synchronous path runs unchanged.
     if (_verifyWorker != null &&
         (messageType == 'EVENT' ||
             messageType == 'EOSE' ||
             messageType == 'CLOSED')) {
+      final subId = json.length > 1 && json[1] is String
+          ? json[1] as String
+          : '';
       return _enqueueOrdered(
         relay,
+        subId,
         () => _dispatchTypedFrame(relay, json, messageType),
       );
     }
@@ -1649,6 +1709,19 @@ class RelayPool {
       try {
         final subId = _stringAt(relay, json, 1, 'EVENT subscription id');
         if (subId == null) return;
+
+        // Nothing is listening for [subId] any more: the query was released
+        // or the subscription torn down while the relay was still streaming
+        // its replay. Every check below decides whether the event may be
+        // delivered, and with no recipient there is nothing to decide — the
+        // Schnorr verify it would spend is what the live subscriptions behind
+        // it are waiting on (#7301). Same outcome as the post-verify lookup
+        // below, which stays because the recipient can go away during the
+        // await.
+        if (_subscriptions[subId] == null &&
+            relay.getRequestSubscription(subId) == null) {
+          return;
+        }
 
         final eventJson = _mapAt(relay, json, 2, 'EVENT payload');
         if (eventJson == null) {

--- a/mobile/packages/nostr_sdk/test/unit/nostr_read_events_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nostr_read_events_test.dart
@@ -536,6 +536,13 @@ void main() {
           expect(completionLines(), hasLength(1));
           expect(completionLines().single.level, RelayDiagnosticLevel.warning);
           expect(
+            completionLines().single.relayUrl,
+            RelayDiagnostic.clientScope,
+            reason:
+                'a read the pool never saw must not share the pool key, or '
+                'it spends the rate-limit budget real pool warnings need',
+          );
+          expect(
             completionLines().single.message,
             contains('ended deadline before any REQ was written'),
           );

--- a/mobile/packages/nostr_sdk/test/unit/nostr_read_events_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nostr_read_events_test.dart
@@ -525,6 +525,14 @@ void main() {
           );
           expect(result.endedBy, QueryEnd.deadline);
           expect(result.events, isEmpty);
+          final extra = await signedEvents(1);
+          expect(
+            () => result.events.addAll(extra),
+            returnsNormally,
+            reason:
+                'every other exit returns the growable list [EventMemBox.all] '
+                'builds, so a caller may sort or append to this one too',
+          );
           expect(completionLines(), hasLength(1));
           expect(completionLines().single.level, RelayDiagnosticLevel.warning);
           expect(

--- a/mobile/packages/nostr_sdk/test/unit/nostr_read_events_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nostr_read_events_test.dart
@@ -495,10 +495,9 @@ void main() {
           expect(completionLines().single.message, contains('ended deadline'));
         });
 
-        test('returns the outcome the pool delivered while a deadline already '
-            'past was still pending, and lets that deadline go', () async {
-          final relay = await addRelay('wss://send-fails.example');
-          relay.sendSucceeds = false;
+        test('ends a read whose deadline had already passed before any REQ '
+            'is written (#7301)', () async {
+          final relay = await addRelay('wss://answers.example');
           final hold = _DeadlineHold();
 
           final result = await hold
@@ -509,35 +508,29 @@ void main() {
                   deadline: DateTime.now().subtract(const Duration(seconds: 1)),
                 ),
               )
-              .timeout(
-                _guard,
-                onTimeout: () => fail('the pool never completed the read'),
-              );
+              .timeout(_guard, onTimeout: () => fail('the read never ended'));
 
-          final deadline = hold.timer!;
           expect(
-            deadline.duration.isNegative,
-            isTrue,
+            relay.sentMessages,
+            isEmpty,
             reason:
-                'the timer held back is the deadline, already past when the '
-                'read began',
+                'a REQ the deadline would unsubscribe on the next event-loop '
+                'turn is never written; it only made every relay look like '
+                'it had swallowed the request',
           );
           expect(
-            result.endedBy,
-            QueryEnd.noRelay,
-            reason:
-                'the pool completed the read as its fan-out ended, while the '
-                'deadline was still pending',
+            hold.timer,
+            isNull,
+            reason: 'no deadline timer is armed for a read that never starts',
           );
-          expect(
-            deadline.isActive,
-            isFalse,
-            reason:
-                'once the pool has answered, the read cancels its deadline, '
-                'so a deadline already due can no longer end it',
-          );
+          expect(result.endedBy, QueryEnd.deadline);
+          expect(result.events, isEmpty);
           expect(completionLines(), hasLength(1));
-          expect(completionLines().single.message, contains('ended noRelay'));
+          expect(completionLines().single.level, RelayDiagnosticLevel.warning);
+          expect(
+            completionLines().single.message,
+            contains('ended deadline before any REQ was written'),
+          );
         });
       });
 

--- a/mobile/packages/nostr_sdk/test/unit/nostr_read_events_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nostr_read_events_test.dart
@@ -541,6 +541,23 @@ void main() {
             throwsArgumentError,
           );
         });
+
+        test(
+          'still rejects empty filters when the deadline has passed',
+          () async {
+            // The expired-deadline branch returns before [RelayPool.query] can
+            // raise this, so without its own guard the read answers an empty
+            // result for a call that was never valid (#7301).
+            await expectLater(
+              nostr.readEvents(
+                const [],
+                id: _readId,
+                deadline: DateTime.now().subtract(const Duration(seconds: 1)),
+              ),
+              throwsArgumentError,
+            );
+          },
+        );
       });
     });
 

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_offmain_verify_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_offmain_verify_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Tests RelayPool's off-main verify integration (#5863 P2).
-// ABOUTME: Worker verify, per-relay ordering, and inline fallback.
+// ABOUTME: Worker verify, per-subscription ordering, and inline fallback.
 
 import 'dart:async';
 
@@ -77,7 +77,7 @@ Nostr _nostr() => Nostr(
   (url) => RelayBase(url, RelayStatus(url)),
 );
 
-List<Event> _subscribe(Nostr nostr) {
+List<Event> _subscribe(Nostr nostr, {String id = 'sub'}) {
   final delivered = <Event>[];
   nostr.subscribe(
     [
@@ -86,7 +86,7 @@ List<Event> _subscribe(Nostr nostr) {
       },
     ],
     delivered.add,
-    id: 'sub',
+    id: id,
   );
   return delivered;
 }
@@ -144,7 +144,7 @@ void main() {
     });
 
     test(
-      'preserves per-relay delivery order despite out-of-order verify',
+      'preserves per-subscription delivery order despite out-of-order verify',
       () async {
         final nostr = _nostr();
         final gate = Completer<void>();
@@ -171,5 +171,60 @@ void main() {
         expect(delivered.map((e) => e.content), ['A', 'B']);
       },
     );
+
+    test('delivers one subscription while another on the same relay is still '
+        'verifying (#7301)', () async {
+      final nostr = _nostr();
+      final gate = Completer<void>();
+      // The stored replay of a one-shot query verifies slowly; the feed
+      // subscription's own event must not wait behind it. Before #7301 the
+      // chain was per relay, so a feed the relay answered in 300ms reached
+      // the app only after every other subscription's replay on that
+      // socket had been verified — 16s on a flagship, past the app's 30s
+      // feed-load fuse on slower hardware.
+      nostr.relayPool.eventVerifyWorker = _FakeVerifyWorker((json) async {
+        if (json['content'] == 'replay') await gate.future;
+        return true;
+      });
+      final relay = _FakeRelay('wss://relay.a');
+      expect(await nostr.relayPool.add(relay), isTrue);
+      final replayDelivered = _subscribe(nostr, id: 'query');
+      final feedDelivered = _subscribe(nostr, id: 'feed');
+
+      final replay = await _signedEvent('replay');
+      final feed = await _signedEvent('feed');
+      final dReplay = relay.deliver(['EVENT', 'query', replay.toJson()]);
+      final dFeed = relay.deliver(['EVENT', 'feed', feed.toJson()]);
+      await dFeed;
+
+      expect(feedDelivered.map((e) => e.content), ['feed']);
+      expect(replayDelivered, isEmpty, reason: 'still gated');
+      gate.complete();
+      await dReplay;
+      expect(replayDelivered.map((e) => e.content), ['replay']);
+    });
+
+    test('does not spend a verify on a frame no subscription is listening to '
+        '(#7301)', () async {
+      final nostr = _nostr();
+      final worker = _FakeVerifyWorker((_) => true);
+      nostr.relayPool.eventVerifyWorker = worker;
+      final relay = _FakeRelay('wss://relay.a');
+      expect(await nostr.relayPool.add(relay), isTrue);
+      final delivered = _subscribe(nostr);
+
+      // A relay keeps streaming a stored replay after the query it answers
+      // was released; every one of those frames used to be verified and
+      // then dropped, ahead of the live subscriptions queued behind them.
+      final orphan = await _signedEvent('orphan');
+      await relay.deliver(['EVENT', 'released-query', orphan.toJson()]);
+      expect(worker.calls, 0);
+      expect(delivered, isEmpty);
+
+      final live = await _signedEvent('live');
+      await relay.deliver(['EVENT', 'sub', live.toJson()]);
+      expect(worker.calls, 1);
+      expect(delivered.map((e) => e.content), ['live']);
+    });
   });
 }

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_offmain_verify_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_offmain_verify_test.dart
@@ -7,6 +7,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostr_sdk/relay/client_connected.dart';
 
+/// Ceiling for a delivery this test expects to complete. Without it a
+/// regression makes the awaited future hang to the framework's own timeout,
+/// which reports a bare timeout instead of naming what stalled.
+const _guard = Duration(seconds: 3);
+
 class _FakeRelay extends Relay {
   _FakeRelay(String url) : super(url, RelayStatus(url));
 
@@ -195,7 +200,13 @@ void main() {
       final feed = await _signedEvent('feed');
       final dReplay = relay.deliver(['EVENT', 'query', replay.toJson()]);
       final dFeed = relay.deliver(['EVENT', 'feed', feed.toJson()]);
-      await dFeed;
+      await dFeed.timeout(
+        _guard,
+        onTimeout: () => fail(
+          'the feed subscription was not delivered while another '
+          'subscription on the same relay was still verifying',
+        ),
+      );
 
       expect(feedDelivered.map((e) => e.content), ['feed']);
       expect(replayDelivered, isEmpty, reason: 'still gated');

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_outcome_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_outcome_test.dart
@@ -478,7 +478,10 @@ void main() {
         ]);
 
         // Abandoning another query the zombie never answered starts the
-        // force-cycle, which stays in flight until the gate completes.
+        // force-cycle, which stays in flight until the gate completes. The
+        // release comes at once here, so the floor that keeps a hasty
+        // release from counting as evidence is lifted for this test.
+        nostr.relayPool.minQueryAgeBeforeRepair = Duration.zero;
         await nostr.relayPool.query(
           [
             {

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_zombie_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_zombie_test.dart
@@ -96,7 +96,7 @@ void main() {
       expect(result.timedOut, isTrue);
 
       // Remediation runs asynchronously once the caller abandons the query.
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await pumpEventQueue();
       expect(
         factory.createdChannels,
         hasLength(2),
@@ -115,7 +115,7 @@ void main() {
       final result = await pending;
       expect(result.timedOut, isFalse);
 
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await pumpEventQueue();
       expect(
         factory.createdChannels,
         hasLength(1),
@@ -154,7 +154,7 @@ void main() {
         final result = await pending;
         expect(result.timedOut, isFalse);
 
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
         expect(
           factory.createdChannels,
           hasLength(2),
@@ -180,7 +180,7 @@ void main() {
         hasLength(1),
       );
 
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await pumpEventQueue();
       expect(
         factory.createdChannels,
         hasLength(1),
@@ -188,6 +188,19 @@ void main() {
             'a relay that went unanswered for 100ms has not been shown to '
             'be a zombie; cycling it would replay every subscription it '
             'carries',
+      );
+
+      // Positive control. The assertion above is a negative, which no amount
+      // of waiting can establish on its own: a repair that simply never runs
+      // looks identical to one the floor suppressed. Drop the floor and the
+      // same silent socket is cycled, so the green above is the floor's doing.
+      ignoreQueryAgeFloor();
+      await queryOnce();
+      await pumpEventQueue();
+      expect(
+        factory.createdChannels,
+        hasLength(2),
+        reason: 'only the floor was holding the repair back',
       );
     });
 
@@ -223,11 +236,22 @@ void main() {
         final result = await pending;
         expect(result.timedOut, isFalse);
 
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
         expect(
           factory.createdChannels,
           hasLength(1),
           reason: 'the slower relay keeps its socket and its subscriptions',
+        );
+
+        // Positive control, as above: prove the force-cycle is still
+        // observable here and only the floor suppressed it.
+        ignoreQueryAgeFloor();
+        await queryOnce();
+        await pumpEventQueue();
+        expect(
+          factory.createdChannels,
+          hasLength(2),
+          reason: 'only the floor was holding the repair back',
         );
       },
     );
@@ -246,7 +270,7 @@ void main() {
       final result = await pending;
       expect(result.timedOut, isTrue);
 
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await pumpEventQueue();
       expect(
         factory.createdChannels,
         hasLength(1),

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_zombie_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_zombie_test.dart
@@ -36,6 +36,10 @@ void main() {
         channelFactory: factory,
       );
       await nostr.relayPool.add(relay);
+      // These tests exercise the repair itself with a 100ms read budget; the
+      // floor that keeps a hasty release from counting as evidence is pinned
+      // separately below.
+      nostr.relayPool.minQueryAgeBeforeRepair = Duration.zero;
     });
 
     Future<({List<Event> events, bool timedOut, bool noRelaysParticipated})>
@@ -125,6 +129,75 @@ void main() {
           factory.createdChannels,
           hasLength(2),
           reason: 'the relay that swallowed the REQ is still the zombie',
+        );
+      },
+    );
+
+    test('a query released before minQueryAgeBeforeRepair is not evidence '
+        'against the socket (#7301)', () async {
+      // The read below waits 100ms, far short of the floor: a caller that
+      // gave the relay no real chance to answer proves nothing about the
+      // socket, however silent the relay was inside that window.
+      nostr.relayPool.minQueryAgeBeforeRepair = const Duration(seconds: 4);
+      final zombieChannel = factory.createdChannels.single;
+
+      final result = await queryOnce();
+      expect(result.timedOut, isTrue);
+      expect(
+        zombieChannel.sentMessages
+            .map((m) => jsonDecode(m as String) as List<dynamic>)
+            .where((m) => m.first == 'REQ'),
+        hasLength(1),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(
+        factory.createdChannels,
+        hasLength(1),
+        reason:
+            'a relay that went unanswered for 100ms has not been shown to '
+            'be a zombie; cycling it would replay every subscription it '
+            'carries',
+      );
+    });
+
+    test(
+      'a straggler the settle window abandons inside minQueryAgeBeforeRepair '
+      'is left alone (#7301)',
+      () async {
+        // A second relay answers at once, so the settle window releases the
+        // straggler about a second after the REQ — routine for a relay that
+        // is merely slower than its peer, and no evidence of a dead socket.
+        nostr.relayPool.minQueryAgeBeforeRepair = const Duration(seconds: 4);
+        const answeringUrl = 'wss://answers.example';
+        final answeringFactory = FakeWebSocketChannelFactory();
+        await nostr.relayPool.add(
+          RelayBase(
+            answeringUrl,
+            RelayStatus(answeringUrl),
+            channelFactory: answeringFactory,
+          ),
+        );
+        final answeringChannel = answeringFactory.createdChannels.single;
+
+        final pending = nostr.queryEventsDetailed([
+          {
+            'kinds': [1],
+          },
+        ], timeout: const Duration(seconds: 4));
+        await Future<void>.delayed(Duration.zero);
+        answeringChannel.simulateMessage(
+          jsonEncode(['EOSE', _lastReqSubId(answeringChannel)]),
+        );
+
+        final result = await pending;
+        expect(result.timedOut, isFalse);
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(
+          factory.createdChannels,
+          hasLength(1),
+          reason: 'the slower relay keeps its socket and its subscriptions',
         );
       },
     );

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_zombie_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_zombie_test.dart
@@ -36,11 +36,15 @@ void main() {
         channelFactory: factory,
       );
       await nostr.relayPool.add(relay);
-      // These tests exercise the repair itself with a 100ms read budget; the
-      // floor that keeps a hasty release from counting as evidence is pinned
-      // separately below.
-      nostr.relayPool.minQueryAgeBeforeRepair = Duration.zero;
     });
+
+    /// Removes the age floor so a 100ms read can exercise the repair itself.
+    ///
+    /// Called per test rather than from [setUp]: a group-wide override leaves
+    /// the shipped default exercised by nothing, and silently applies to every
+    /// test added here later.
+    void ignoreQueryAgeFloor() =>
+        nostr.relayPool.minQueryAgeBeforeRepair = Duration.zero;
 
     Future<({List<Event> events, bool timedOut, bool noRelaysParticipated})>
     queryOnce() {
@@ -51,8 +55,32 @@ void main() {
       ], timeout: const Duration(milliseconds: 100));
     }
 
+    test('the shipped age floor sits between the settle window and the '
+        'default read timeout', () {
+      // Every other test here runs the knob at zero or at a value chosen to
+      // suppress the repair, so the shipped default is the one value nothing
+      // exercises -- and its dartdoc leans on both of these bounds.
+      final floor = nostr.relayPool.minQueryAgeBeforeRepair;
+      expect(
+        floor,
+        greaterThan(RelayPool.querySettleWindow),
+        reason:
+            'a query the settle window completed on the first relay\'s EOSE '
+            'says nothing about the slower ones, so it must fall under the '
+            'floor rather than force-cycle them',
+      );
+      expect(
+        floor,
+        lessThan(const Duration(seconds: 5)),
+        reason:
+            'a caller that spent the SDK default read timeout in full waited '
+            'long enough for the silence to be evidence',
+      );
+    });
+
     test('a relay that accepts the REQ and never sends a terminal frame is '
         'force-reconnected', () async {
+      ignoreQueryAgeFloor();
       expect(factory.createdChannels, hasLength(1));
       final zombieChannel = factory.createdChannels.single;
 
@@ -77,6 +105,7 @@ void main() {
     });
 
     test('a relay that answers the REQ is left alone', () async {
+      ignoreQueryAgeFloor();
       final channel = factory.createdChannels.single;
 
       final pending = queryOnce();
@@ -97,6 +126,7 @@ void main() {
     test(
       'a straggler the settle window abandons is still force-reconnected',
       () async {
+        ignoreQueryAgeFloor();
         // A second relay answers, so the caller is released by the settle
         // window rather than by the timeout. Remediation keys off the query
         // being abandoned, not off how the caller was released.
@@ -204,6 +234,7 @@ void main() {
 
     test('a relay that stays inbound-active is left alone — silence '
         'discriminates zombie from slow', () async {
+      ignoreQueryAgeFloor();
       final channel = factory.createdChannels.single;
 
       final pending = queryOnce();


### PR DESCRIPTION
## Description

**Related Issue:** Closes #7301

### The problem

On 1.0.20 store builds since 2026-08-17, `feed_load_profile` ends in `timeout` on 3.4% of Android loads (n=62,457) against 1.3% on iOS (n=134,072). The split survives controlling for country (US 2.6% vs 1.3%, JP 2.6% vs 0.8%, GB 4.8% vs 1.6%), is not a few bad devices or carriers (816 of 3,610 device/OS/country/carrier groups carry timeouts), and is not late-firing timers after a process freeze (0.13%). It is a clean gradient by Android API level — API 37 1.1% (iOS parity), 36 2.7%, 35 4.6%, 34 7.8%, 31 9.1%, 29 13.7% — while the relay's own answer latency is the same on both platforms (US p50 352 vs 332 ms). Android does not get slower answers; it more often gets no usable answer inside 30 s.

Timing probes on a Galaxy S25 Ultra (profile build, eight profile visits) showed where the 30 s go. relay.divine.video answered every profile REQ in 300–1600 ms. The first frame then waited **14–26 s in the client** before the app saw it: the relay pool serialised every inbound frame *per relay* through the off-main Schnorr verify (`_enqueueOrdered`, #5863), and each EVENT costs 20–40 ms of pure-Dart verify on this device. The profile's 50 events queued behind 800–1,500 frames of other subscriptions' stored replays on the same socket — one-shot queries returning 500–920 events each, the DM drain, the notification subscriptions. 16.8 s on a flagship is past the 30 s fuse on the mid-range and older hardware that makes up the Android tail, and iPhones are uniformly fast enough to mostly stay under it. That is the platform split.

Two release paths made the backlog worse by force-cycling relays on no evidence. A read whose deadline had already passed when its query-pool slot arrived was still written to the relays and unsubscribed 4–13 ms later; `_repairRelaysThatNeverAnswered` read those milliseconds of silence as a zombie socket and cycled every relay that had been idle, each of which then replayed its whole stored window for every subscription it carried. A settle-window completion did the same to whichever relay was a second slower than its peers. Over eight profile visits that was 15 force-cycles and 13 reconnects of the three main relays.

### The fix

- **Order frames per (relay, subscription), not per relay.** Only frames of the same subscription need ordering — that is what #5863 requires (an EOSE must not complete a query before its own events finish verifying). Different subscriptions run on independent chains, so a live feed no longer waits behind another subscription's replay. Entries are removed once their chain drains.
- **Drop frames nothing is listening to before verifying them.** A relay keeps streaming a replay after the query it answers was released; those frames were verified and then discarded, ahead of everything queued behind them.
- **`minQueryAgeBeforeRepair` (4 s).** A query released before it is not evidence against the socket. The default is below the SDK's 5 s read timeout, so a caller that waited its whole budget still gets the repair, and above any settle-window completion. Mirrors `minSubscriptionAgeBeforeRepair`.
- **A read whose deadline has already passed writes no REQ.** It ends as `deadline` at once and files its own `queryCompletion` line, since the pool never sees it.

### Measured on device, same eight profiles

| | before | after |
|---|---|---|
| `first_relay_event` per profile (ms) | 353 · 543 · 147 · 658 · **3138** · **7023** · 451 · **16809** | 244 · 699 · 402 · 458 · 188 · 97 · 140 · 1163 |
| client-side wait before the profile's first frame (relay.divine.video) | up to **26,475 ms** | 0 ms on all eight |
| relay force-cycles | 15 | 0 |
| reconnects of the three main relays | 13 | 0 |
| relay answer latency | 300–1600 ms | unchanged |

### Why this and not the fuse or the relay

The 30 s fuse and the relay are both doing their job: the relay answered, the app was not listening yet. Shortening the fuse would only tear down subscriptions that are about to be served. Trust-gating relay.divine.video to skip verification would also help but is a security decision #5863 explicitly kept behind an explicit call, so it is not made here.

A caveat on the issue's framing: `feed_load_profile` and `feed_load_hashtag` time only the relay subscription. Both screens load REST-first (`getAuthorFeed`, `getHashtagFeedVideos`) with the relay as the realtime layer, so a `timeout` there is a relay-path failure, not necessarily an empty screen.

## Out of Scope

- **Verify throughput itself.** Each event still costs 20–40 ms of pure-Dart Schnorr in one isolate; after this change a feed no longer waits behind other subscriptions, but the total work is unchanged. Parallel verify workers or a native secp256k1 are their own change.
- **`eose_empty` (12.7% Android, 12.3% iOS).** Identical on both platforms and, per the issue, a copy and retry-affordance problem rather than a networking one. Needs its own task.
- The 30 s fuse in `VideoEventService` and the size of the one-shot queries the profile screen issues.

## Verification

- New tests, all red on `main`: `relay_pool_offmain_verify_test.dart` — a subscription is delivered while another on the same relay is still verifying; a frame with no listener spends no verify. `relay_pool_query_zombie_test.dart` — a query released before `minQueryAgeBeforeRepair` does not cycle the socket, nor does a straggler the settle window abandons inside it. `nostr_read_events_test.dart` — a read whose deadline already passed writes no REQ and files its completion line.
- Existing zombie-repair tests pin `minQueryAgeBeforeRepair = Duration.zero` where the repair itself is under test; the per-relay ordering test is now the per-subscription one (same subscription, unchanged assertion).
- `flutter test` in `packages/nostr_sdk` (903) and `packages/nostr_client` (429) green; `flutter analyze` and `dart format` clean; every `mobile/scripts/check_*.sh` ratchet green apart from three environment-only checks (iOS extension signing env, store-URL Ruby locale, coordinator route probe) that this diff does not touch.
- Tested on a real Samsung Galaxy (SM-S942B, profile build): cold start, eight profile visits, feed browsing — numbers above.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
