### PR TITLE
fix(perf): keep local release builds out of the Firebase Performance dataset

### DIFF
--- a/mobile/android/app/src/debug/AndroidManifest.xml
+++ b/mobile/android/app/src/debug/AndroidManifest.xml
@@ -44,7 +44,8 @@
              re-enabling is impossible while this is set. To collect
              performance data from a local build - e.g. to verify new
              instrumentation - comment this block out for that run AND flip
-             `PerformanceMonitoringService.collectionEnabled` to `true`.
+             `PerformanceMonitoringService.collectionEnabled` to `true` AND
+             `PerformanceMonitoringService.distributedBuildsOnly` to `false`.
              Commenting this out alone does nothing: that gate re-asserts
              `false` on every launch and the SDK persists it, so resolution
              just falls through to the cache it wrote. -->

--- a/mobile/docs/FEED_LOAD_TRACES.md
+++ b/mobile/docs/FEED_LOAD_TRACES.md
@@ -19,12 +19,14 @@ The implementation lives in
 [`FeedLoadTrace`](../lib/services/feed_load_trace.dart) owns the first-wins
 completion behavior.
 
-Only **release** builds report them. `PerformanceMonitoringService`
-gates on `kReleaseMode` in Dart and debug/profile builds are additionally
-deactivated natively, so a local run produces no samples at all and that is not
-a bug. Opting one run back in takes both halves of the recipe in
+Only **distributed release** builds report them. `PerformanceMonitoringService`
+gates on `kReleaseMode` in Dart, debug/profile builds are additionally
+deactivated natively, and since #7302 a release build must also carry the
+Shorebird engine (`shorebird release`) or a Zapstore installer — so a local
+run, `flutter run --release` included, produces no samples at all and that is
+not a bug. Opting one run back in takes every half of the recipe in
 [Network performance monitoring](NETWORK_PERFORMANCE_MONITORING.md#verifying-a-change) —
-either alone leaves collection off.
+any one alone leaves collection off.
 
 One sampling gap is worth knowing about, because it is silent.
 `startOperationTrace` hands back a no-op handle until

--- a/mobile/docs/NETWORK_PERFORMANCE_MONITORING.md
+++ b/mobile/docs/NETWORK_PERFORMANCE_MONITORING.md
@@ -147,10 +147,15 @@ slow; check the cheap things first.
    opt that one run back in: undo the native deactivation for your platform
    (`android/app/src/debug/AndroidManifest.xml`, or
    `FIREBASE_PERFORMANCE_COLLECTION_DEACTIVATED=NO` in `ios/Flutter/Debug.xcconfig`)
-   **and** flip `PerformanceMonitoringService.collectionEnabled` to `true` —
-   either alone leaves collection off. Revert both before committing; a debug
-   run that reports lands `http://localhost:<port>/…` patterns in the
-   production project under a build number no store build uses — exactly the
+   **and** flip `PerformanceMonitoringService.collectionEnabled` to `true`
+   **and** `PerformanceMonitoringService.distributedBuildsOnly` to `false` —
+   any one alone leaves collection off. A `flutter run --release` needs only
+   the last flip: release mode passes the first two gates, and the third is
+   what keeps a local release build out (#7302) — the Shorebird engine that
+   only `shorebird release` links, or a Zapstore installer, is what marks a
+   build as distributed. Revert every flip before committing; a run that
+   reports lands `http://localhost:<port>/…` patterns in the production
+   project under a build number no store build uses — exactly the
    contamination that skewed #7123.
 3. Console: **Performance → Network Requests**, filtered to `divine.video` /
    `dvines.org`. Confirm requests appear from **both** platforms and that each

--- a/mobile/ios/Flutter/Debug.xcconfig
+++ b/mobile/ios/Flutter/Debug.xcconfig
@@ -9,7 +9,8 @@
 // that trace is captured natively before Dart runs.
 //
 // To collect from a local build, set this to NO AND flip
-// `PerformanceMonitoringService.collectionEnabled` to `true`. Changing this
-// alone does nothing: that gate re-asserts `false` on every launch and the SDK
-// persists it, so resolution just falls through to the cache it wrote.
+// `PerformanceMonitoringService.collectionEnabled` to `true` AND
+// `PerformanceMonitoringService.distributedBuildsOnly` to `false`. Changing
+// this alone does nothing: that gate re-asserts `false` on every launch and
+// the SDK persists it, so resolution just falls through to the cache it wrote.
 FIREBASE_PERFORMANCE_COLLECTION_DEACTIVATED=YES

--- a/mobile/lib/providers/device_scope.dart
+++ b/mobile/lib/providers/device_scope.dart
@@ -14,6 +14,7 @@ import 'package:openvine/providers/documents_path_provider.dart';
 import 'package:openvine/providers/install_source_provider.dart';
 import 'package:openvine/providers/log_message_batcher_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/shorebird_availability_provider.dart';
 import 'package:openvine/providers/startup_performance_provider.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/database_corruption_service.dart';
@@ -61,6 +62,7 @@ class DeviceScope {
     this.dbCipherKey,
     this.databaseCorruptionService,
     this.installSource = InstallSource.sideload,
+    this.shorebirdAvailable = false,
     this.accountOverrides = const [],
   });
 
@@ -122,6 +124,11 @@ class DeviceScope {
   /// in-app review gate and `AppUpdateRepository` see the same value.
   final InstallSource installSource;
 
+  /// Whether the build carries the Shorebird updater engine, i.e. came out of
+  /// `shorebird release`. Sampled once at startup from the updater the patch
+  /// check constructs; `false` for a plain `flutter build` or `flutter run`.
+  final bool shorebirdAvailable;
+
   /// Extra overrides applied to every account container.
   ///
   /// Production leaves this empty. Tests use it for container-wide fakes that
@@ -140,6 +147,7 @@ class DeviceScope {
       databaseCorruptionService,
     ),
     installSourceProvider.overrideWithValue(installSource),
+    shorebirdAvailableProvider.overrideWithValue(shorebirdAvailable),
     startupPerformanceServiceProvider.overrideWithValue(startupPerformance),
     crashReportingServiceProvider.overrideWithValue(crashReporting),
     logMessageBatcherProvider.overrideWithValue(logMessageBatcher),

--- a/mobile/lib/providers/shorebird_availability_provider.dart
+++ b/mobile/lib/providers/shorebird_availability_provider.dart
@@ -1,0 +1,21 @@
+// ABOUTME: Riverpod provider for whether this build carries the Shorebird
+// ABOUTME: updater engine — true only for artifacts built by `shorebird release`.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Whether the running build was produced by `shorebird release`.
+///
+/// Sampled once at startup from the updater `main.dart` constructs for the
+/// recovery-critical patch check, and injected into every account container
+/// via `DeviceScope.overrides`. A plain `flutter build` or `flutter run
+/// --release` has no Shorebird engine and reads `false`, which is what lets
+/// `PerformanceMonitoringService` keep local release builds out of the
+/// production dataset (#7302).
+///
+/// Throws by default; `main.dart` overrides it before `runApp`. Reading it
+/// before that is a programmer error, not a runtime condition to handle.
+final shorebirdAvailableProvider = Provider<bool>(
+  (ref) => throw StateError(
+    'shorebirdAvailableProvider must be overridden at container creation',
+  ),
+);

--- a/mobile/lib/services/performance_monitoring_service.dart
+++ b/mobile/lib/services/performance_monitoring_service.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Performance monitoring service for tracking app performance metrics
 // ABOUTME: Uses Firebase Performance Monitoring to track screen transitions, network requests, and custom operations
 
+import 'package:app_update_repository/app_update_repository.dart';
 import 'package:firebase_performance/firebase_performance.dart';
 import 'package:flutter/foundation.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -141,6 +142,32 @@ class PerformanceMonitoringService implements PerformanceTraceMonitor {
   @visibleForTesting
   static const bool collectionEnabled = kReleaseMode;
 
+  /// Whether a release build must also be a distributed one to report.
+  ///
+  /// [collectionEnabled] cannot tell a store build from `flutter run
+  /// --release` on a developer's phone: both are release mode, and the local
+  /// one still reached the dataset under the `pubspec.yaml` build number —
+  /// 449 rows from four devices in the month after #7158 shipped (#7302).
+  /// [isDistributedBuild] is the runtime half: the Shorebird engine that only
+  /// `shorebird release` links, or an installer we recognise. Flip this to
+  /// `false` for a local run that should report; revert before committing.
+  @visibleForTesting
+  static const bool distributedBuildsOnly = true;
+
+  /// Whether this build reached the device through a channel real users use.
+  ///
+  /// Every store and TestFlight artifact comes out of `shorebird release` and
+  /// carries the updater engine, so [shorebirdAvailable] alone covers Play,
+  /// the App Store and TestFlight. Zapstore installs the split APKs Codemagic
+  /// builds with plain `flutter build`, which have no engine, so its installer
+  /// package is accepted on its own. A GitHub-release APK installed by hand is
+  /// indistinguishable from a local build by either signal and is excluded
+  /// with it — the only population this loses.
+  static bool isDistributedBuild({
+    required bool shorebirdAvailable,
+    required InstallSource installSource,
+  }) => shorebirdAvailable || installSource == InstallSource.zapstore;
+
   late final FirebasePerformance _performance;
   bool _initialized = false;
 
@@ -151,10 +178,15 @@ class PerformanceMonitoringService implements PerformanceTraceMonitor {
   /// before [initialize] resolves.
   bool get isEnabled => _initialized;
 
-  /// Initialize performance monitoring
-  Future<void> initialize() async {
+  /// Initialize performance monitoring.
+  ///
+  /// [distributedBuild] is [isDistributedBuild] evaluated by the caller, which
+  /// has the container; it only matters when [distributedBuildsOnly] holds.
+  Future<void> initialize({required bool distributedBuild}) async {
     if (_initialized) return;
 
+    final collect =
+        collectionEnabled && (!distributedBuildsOnly || distributedBuild);
     try {
       _performance = FirebasePerformance.instance;
 
@@ -162,12 +194,13 @@ class PerformanceMonitoringService implements PerformanceTraceMonitor {
       // is off: the SDK persists it across launches, so a device that ran an
       // earlier build — which enabled collection unconditionally — keeps
       // reporting until something actively sets it back to false.
-      await _performance.setPerformanceCollectionEnabled(collectionEnabled);
+      await _performance.setPerformanceCollectionEnabled(collect);
 
       _initialized = true;
       Log.info(
         'Performance monitoring initialized successfully '
-        '(collection enabled: $collectionEnabled)',
+        '(collection enabled: $collect, release: $collectionEnabled, '
+        'distributed build: $distributedBuild)',
         name: 'PerformanceMonitoring',
       );
     } catch (e) {

--- a/mobile/lib/startup/app_bootstrap.dart
+++ b/mobile/lib/startup/app_bootstrap.dart
@@ -653,6 +653,11 @@ Future<void> startOpenVineApp({
     dbCipherKey: dbCipherKey,
     databaseCorruptionService: databaseCorruptionService,
     installSource: installSource,
+    // The updater the recovery-critical patch check constructed above; its
+    // availability is what tells a `shorebird release` artifact apart from a
+    // local release build for performance collection (#7302).
+    shorebirdAvailable:
+        (startupShorebirdUpdater ??= ShorebirdUpdater()).isAvailable,
     accountOverrides: [
       // Screenshot mode: lead the 01_classics OG-Viner row with returning
       // Vine OGs who all have avatars, so the marketing shot has no

--- a/mobile/lib/startup/startup_coordinator_factory.dart
+++ b/mobile/lib/startup/startup_coordinator_factory.dart
@@ -13,13 +13,16 @@ import 'package:openvine/notifications/notification_tap_router.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/crash_reporting_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/install_source_provider.dart';
 import 'package:openvine/providers/log_message_batcher_provider.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/shorebird_availability_provider.dart';
 import 'package:openvine/providers/startup_performance_provider.dart';
 import 'package:openvine/services/bandwidth_tracker_service.dart';
 import 'package:openvine/services/notification_helpers.dart'
     show parseFcmPayload;
+import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/video_format_preference.dart';
 import 'package:openvine/startup/app_bootstrap.dart';
 import 'package:openvine/startup/startup_phases.dart';
@@ -150,12 +153,21 @@ StartupCoordinator createStartupCoordinator(ProviderContainer container) {
     name: 'PerformanceMonitoring',
     phase: StartupPhase.critical,
     initialize: () async {
+      // Read here rather than at registration: both providers are
+      // override-only, and the coordinator is also built in tests that never
+      // run this phase.
+      final distributedBuild = PerformanceMonitoringService.isDistributedBuild(
+        shorebirdAvailable: container.read(shorebirdAvailableProvider),
+        installSource: container.read(installSourceProvider),
+      );
       await runTimedStartupTask(
         startupPerformance: startupPerformance,
         crashReporting: crashReporting,
         phaseName: 'performance_monitoring',
         initializationStep: 'Initializing performance monitoring',
-        task: container.read(performanceMonitoringServiceProvider).initialize,
+        task: () => container
+            .read(performanceMonitoringServiceProvider)
+            .initialize(distributedBuild: distributedBuild),
       );
     },
     optional: true,

--- a/mobile/test/providers/device_scope_test.dart
+++ b/mobile/test/providers/device_scope_test.dart
@@ -13,6 +13,7 @@ import 'package:openvine/providers/documents_path_provider.dart';
 import 'package:openvine/providers/install_source_provider.dart';
 import 'package:openvine/providers/log_message_batcher_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/shorebird_availability_provider.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/startup_performance_service.dart';
 import 'package:openvine/utils/log_message_batcher.dart';
@@ -43,6 +44,7 @@ void main() {
       documentsPath: '/documents',
       logMessageBatcher: logMessageBatcher,
       installSource: InstallSource.playStore,
+      shorebirdAvailable: true,
     );
   });
 
@@ -79,6 +81,16 @@ void main() {
 
       expect(a.read(installSourceProvider), InstallSource.playStore);
       expect(b.read(installSourceProvider), InstallSource.playStore);
+    });
+
+    test('every container reads the same Shorebird availability override', () {
+      final a = buildAccountContainer(deviceScope);
+      addTearDown(a.dispose);
+      final b = buildAccountContainer(deviceScope);
+      addTearDown(b.dispose);
+
+      expect(a.read(shorebirdAvailableProvider), isTrue);
+      expect(b.read(shorebirdAvailableProvider), isTrue);
     });
 
     test('every container reads the same documents path override', () {

--- a/mobile/test/services/performance_monitoring_service_test.dart
+++ b/mobile/test/services/performance_monitoring_service_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:app_update_repository/app_update_repository.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
@@ -40,6 +41,61 @@ void main() {
       // manufacture a release-over-release regression that the release code
       // did not contain.
       expect(PerformanceMonitoringService.collectionEnabled, isFalse);
+    });
+  });
+
+  group('PerformanceMonitoringService.distributedBuildsOnly', () {
+    test('holds, so a local release build does not report', () {
+      // #7302: `kReleaseMode` cannot tell `flutter run --release` on a
+      // developer's phone from a store build. Four such devices put 449 rows
+      // under the pubspec build number in the month after #7158 shipped.
+      expect(PerformanceMonitoringService.distributedBuildsOnly, isTrue);
+    });
+  });
+
+  group('PerformanceMonitoringService.isDistributedBuild', () {
+    test('accepts any build that carries the Shorebird engine', () {
+      // Every Play, App Store and TestFlight artifact comes out of
+      // `shorebird release`, whatever installer the OS reports for it.
+      for (final source in InstallSource.values) {
+        expect(
+          PerformanceMonitoringService.isDistributedBuild(
+            shorebirdAvailable: true,
+            installSource: source,
+          ),
+          isTrue,
+          reason: source.name,
+        );
+      }
+    });
+
+    test('accepts a Zapstore install without the engine', () {
+      // Zapstore ships the split APKs Codemagic builds with plain
+      // `flutter build`, so the installer package is the only signal.
+      expect(
+        PerformanceMonitoringService.isDistributedBuild(
+          shorebirdAvailable: false,
+          installSource: InstallSource.zapstore,
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects a build with neither signal', () {
+      // A local `flutter build` reports sideload on Android and, installed
+      // through Xcode, a sandbox receipt on iOS — so neither store-looking
+      // installer is enough on its own.
+      for (final source in InstallSource.values) {
+        if (source == InstallSource.zapstore) continue;
+        expect(
+          PerformanceMonitoringService.isDistributedBuild(
+            shorebirdAvailable: false,
+            installSource: source,
+          ),
+          isFalse,
+          reason: source.name,
+        );
+      }
     });
   });
 
@@ -142,7 +198,7 @@ void main() {
       // because initialize() was called and swallowed a failure.
       expect(service.isEnabled, isFalse);
 
-      await service.initialize();
+      await service.initialize(distributedBuild: true);
 
       expect(service.isEnabled, isFalse);
     });
@@ -150,7 +206,7 @@ void main() {
     test(
       'startOperationTrace returns a handle that tags and stops cleanly',
       () async {
-        await service.initialize();
+        await service.initialize(distributedBuild: true);
 
         final trace = service.startOperationTrace('test_operation');
 


### PR DESCRIPTION
## Description

Developer devices still reach the production Firebase Performance dataset. #7158 gated collection on `kReleaseMode` and deactivated debug and profile builds natively, which removed the 9.5%-of-sample, 9× slower cold starts that skewed #7123. What it cannot do is tell a store build from `flutter run --release` on a developer's phone — both are release mode — and the re-read of 1.0.20 store data on #7302 found exactly that population: 449 rows from four devices under the `pubspec.yaml` build number in the month after #7158 shipped, continuing into 1.0.21 and 1.0.22 with the same number.

**What changes.** A release build now also has to be a *distributed* one before `PerformanceMonitoringService` turns collection on. Every Play, App Store and TestFlight artifact comes out of `shorebird release` and carries the updater engine, which a plain `flutter build` or `flutter run` never has, so `ShorebirdUpdater.isAvailable` covers the stores on its own. Zapstore installs the split APKs Codemagic builds *without* Shorebird (the `+2000` build numbers), so its installer package is accepted as the second signal. The availability is sampled once at startup from the updater the recovery-critical patch check already constructs — no second FFI probe — and reaches the service through `DeviceScope`, the same way the install source does.

**Why the startup coordinator reads the facts inside the `initialize` closure** rather than at registration: both providers are override-only and throw otherwise, and `createStartupCoordinator` is also built in tests that never run the critical phase.

**Why not the install source alone.** On iOS a build installed through Xcode carries a `sandboxReceipt` path and resolves to `testFlight`, so an installer-based gate would let the 331 iOS rows through; on Android a sideloaded GitHub-release APK and a local build both report no installer. The Shorebird engine is the one signal a local build cannot fake.

**Related Issue:** Closes #7302

## Out of Scope

- A GitHub-release APK installed by hand is indistinguishable from a local build by either signal and is excluded with it — the only real-user population this loses, and a small one (Zapstore, which installs the same APKs, is kept).
- The native `_app_start` trace precedes Dart, so a local release build's very first launch can still land one row before the persisted flag turns collection off; every later launch is silent. Store-build filtering (`app_build_version`) stays the documented rule for any comparison.
- The other two #7302 criteria are closed on the issue, not here: `feed_load_*` coverage of the feeds users see is already measured by the Analytics `feed_load_*` events per `feed_type` (`FEED_INTERACTIVE_LATENCY.md`; on 1.0.20 store data every visible feed reports), and the six `SubscriptionType` values without a Performance trace have no production entry point (`FEED_LOAD_TRACES.md` records zero as the correct reading). `video_upload` vs `transfer_ms` is documented as non-comparable and dropped.

## Verification

- `flutter analyze lib test integration_test` clean; `flutter test` on `performance_monitoring_service_test.dart` (now pins `distributedBuildsOnly` and the three `isDistributedBuild` cases), `device_scope_test.dart` (Shorebird availability reaches every account container), `main_startup_registration_test.dart`, `startup_diagnostics_test.dart`, `app_startup_test.dart` — 41 tests green. The pre-push hook's changed-file run: 22 green.
- Ratchets: `check_layer_direction.sh`, `check_untested_services_floor.sh`, `check_test_unit_structure.sh`, `check_ungrouped_tests.sh`, `check_placeholder_tests.sh` green.
- Android device (SM-S942B, staging debug build installed over adb): startup logs `Performance monitoring initialized successfully (collection enabled: false, release: false, distributed build: false)` — the new providers resolve inside the critical phase and the gate reads a local build as not distributed. The `true` branch is exercised by the store artifact itself; it cannot be produced locally, which is the point.
- The opt-in recipe for verifying instrumentation from a local run is updated in `NETWORK_PERFORMANCE_MONITORING.md`, `FEED_LOAD_TRACES.md`, the debug Android manifest and `Debug.xcconfig`: a `flutter run --release` now needs only `distributedBuildsOnly` flipped.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation
