### PR TITLE
fix(video-editor): preserve native export causes in crash reports

### DIFF
--- a/mobile/lib/services/pro_video_editor_log_forwarder.dart
+++ b/mobile/lib/services/pro_video_editor_log_forwarder.dart
@@ -7,14 +7,13 @@ import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Forwards native diagnostics emitted by `pro_video_editor` (the renderer,
-/// thumbnail, metadata and audio operations) into the app's [UnifiedLogger],
-/// so video-editor problems — e.g. a render that fails after many short clips
-/// (#4801) — are captured for bug reports.
+/// thumbnail, metadata and audio operations) into the app's [UnifiedLogger].
+/// Warnings and errors also become sanitized crash-report breadcrumbs, so
+/// video-editor failures retain native diagnostic context.
 ///
 /// Native forwarding is gated per call by the `nativeLogLevel` argument passed
-/// to each operation; this forwarder just pipes whatever the plugin emits into
-/// the unified log under [LogCategory.video]. The plugin's stream stays empty
-/// on Web, Windows, and Linux.
+/// to each operation. The plugin's stream stays empty on Web, Windows, and
+/// Linux.
 class ProVideoEditorLogForwarder {
   ProVideoEditorLogForwarder._();
 
@@ -43,7 +42,7 @@ class ProVideoEditorLogForwarder {
     _subscription = null;
   }
 
-  /// Maps a single [NativeLogEntry] onto the [UnifiedLogger].
+  /// Forwards one [NativeLogEntry] to local and crash-report logging.
   @visibleForTesting
   static void forwardEntry(
     NativeLogEntry entry, {

--- a/mobile/lib/services/pro_video_editor_log_forwarder.dart
+++ b/mobile/lib/services/pro_video_editor_log_forwarder.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:openvine/observability/crash_reporter.dart';
+import 'package:openvine/observability/reportable_error.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -21,11 +23,18 @@ class ProVideoEditorLogForwarder {
   /// Starts forwarding `pro_video_editor` native logs into [UnifiedLogger].
   ///
   /// Idempotent — a second call while a subscription is active is a no-op.
+  /// Warnings and errors also become sanitized [crashReporter] breadcrumbs,
+  /// preserving native causes that method-channel exceptions omit.
   /// [proVideoEditor] is injectable for tests.
-  static void start({ProVideoEditor? proVideoEditor}) {
+  static void start({
+    ProVideoEditor? proVideoEditor,
+    CrashReporter crashReporter = const SilentCrashReporter(),
+  }) {
     if (_subscription != null) return;
     final editor = proVideoEditor ?? ProVideoEditor.instance;
-    _subscription = editor.logStream.listen(forwardEntry);
+    _subscription = editor.logStream.listen(
+      (entry) => forwardEntry(entry, crashReporter: crashReporter),
+    );
   }
 
   /// Stops forwarding and releases the subscription. Mainly for tests.
@@ -36,11 +45,26 @@ class ProVideoEditorLogForwarder {
 
   /// Maps a single [NativeLogEntry] onto the [UnifiedLogger].
   @visibleForTesting
-  static void forwardEntry(NativeLogEntry entry) {
+  static void forwardEntry(
+    NativeLogEntry entry, {
+    CrashReporter crashReporter = const SilentCrashReporter(),
+  }) {
     if (entry.message.isEmpty) return;
     final name = (entry.tag?.isNotEmpty ?? false)
         ? entry.tag!
         : 'ProVideoEditorNative';
+    // The final render owns the non-fatal report. Native fallback attempts
+    // contribute context without each becoming a separate crash issue.
+    if (entry.level == NativeLogLevel.warning ||
+        entry.level == NativeLogLevel.error) {
+      final stack = entry.stackTrace;
+      crashReporter.log(
+        sanitizeForCrashReport(
+          '[$name] ${entry.message}'
+          '${stack == null || stack.isEmpty ? '' : '\n$stack'}',
+        ),
+      );
+    }
     switch (entry.level) {
       case NativeLogLevel.error:
         Log.error(

--- a/mobile/lib/startup/app_bootstrap.dart
+++ b/mobile/lib/startup/app_bootstrap.dart
@@ -319,9 +319,9 @@ Future<void> startOpenVineApp({
   }
 
   // Forward pro_video_editor native diagnostics (renderer, thumbnail, audio)
-  // into the unified log so video-editor/render problems land in bug reports
-  // (#4801). Gated per call by the nativeLogLevel passed to each operation.
-  ProVideoEditorLogForwarder.start();
+  // into bug-report logs and sanitized warning/error crash breadcrumbs.
+  // Gated per call by the nativeLogLevel passed to each operation.
+  ProVideoEditorLogForwarder.start(crashReporter: crashReporting);
 
   // Store original debugPrint to avoid recursion
   final originalDebugPrint = debugPrint;

--- a/mobile/test/services/pro_video_editor_log_forwarder_test.dart
+++ b/mobile/test/services/pro_video_editor_log_forwarder_test.dart
@@ -2,11 +2,19 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openvine/observability/crash_reporter.dart';
 import 'package:openvine/services/pro_video_editor_log_forwarder.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 class _MockProVideoEditor extends Mock implements ProVideoEditor {}
+
+class _RecordingCrashReporter extends Fake implements CrashReporter {
+  final breadcrumbs = <String>[];
+
+  @override
+  void log(String message) => breadcrumbs.add(message);
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -36,6 +44,75 @@ void main() {
   });
 
   group('ProVideoEditorLogForwarder.forwardEntry', () {
+    test('preserves native failure and cause chain in crash breadcrumbs', () {
+      final reporter = _RecordingCrashReporter();
+      const stack =
+          'androidx.media3.transformer.ExportException: '
+          'Video frame processing error\n'
+          'Caused by: androidx.media3.common.VideoFrameProcessingException: '
+          'GL_OUT_OF_MEMORY';
+
+      ProVideoEditorLogForwarder.forwardEntry(
+        entry(
+          NativeLogLevel.error,
+          'Error rendering video: Video frame processing error',
+          tag: 'RenderVideo',
+          stackTrace: stack,
+        ),
+        crashReporter: reporter,
+      );
+
+      expect(reporter.breadcrumbs, hasLength(1));
+      expect(reporter.breadcrumbs.single, contains('RenderVideo'));
+      expect(reporter.breadcrumbs.single, contains(stack));
+    });
+
+    test('sanitizes the message, tag and cause before crash reporting', () {
+      final reporter = _RecordingCrashReporter();
+      // Synthetic identifiers exercise the shared crash-report sanitizer.
+      final publicKey = 'npub1${List.filled(58, 'q').join()}';
+      final secretKey = 'nsec1${List.filled(58, 'q').join()}';
+      ProVideoEditorLogForwarder.forwardEntry(
+        entry(
+          NativeLogLevel.error,
+          'Error for $publicKey',
+          tag: secretKey,
+          stackTrace: 'Caused by: failed for creator@example.com',
+        ),
+        crashReporter: reporter,
+      );
+
+      expect(reporter.breadcrumbs, hasLength(1));
+      final breadcrumb = reporter.breadcrumbs.single;
+      expect(breadcrumb, isNot(contains(publicKey)));
+      expect(breadcrumb, isNot(contains(secretKey)));
+      expect(breadcrumb, isNot(contains('creator@example.com')));
+      expect(breadcrumb, contains('npub1<redacted>'));
+      expect(breadcrumb, contains('nsec1<redacted>'));
+      expect(breadcrumb, contains('Caused by:'));
+    });
+
+    test(
+      'keeps warnings but excludes routine native logs and empty messages',
+      () {
+        final reporter = _RecordingCrashReporter();
+        for (final level in NativeLogLevel.values) {
+          ProVideoEditorLogForwarder.forwardEntry(
+            entry(level, 'native-${level.name}'),
+            crashReporter: reporter,
+          );
+        }
+        ProVideoEditorLogForwarder.forwardEntry(
+          entry(NativeLogLevel.error, ''),
+          crashReporter: reporter,
+        );
+
+        expect(reporter.breadcrumbs, hasLength(2));
+        expect(reporter.breadcrumbs.join(), contains('native-warning'));
+        expect(reporter.breadcrumbs.join(), contains('native-error'));
+      },
+    );
+
     test('forwards an error with stack trace under the video category', () {
       const message = 'pve-fwd-error-unique';
       ProVideoEditorLogForwarder.forwardEntry(
@@ -133,12 +210,17 @@ void main() {
       final controller = StreamController<NativeLogEntry>.broadcast();
       when(() => mock.logStream).thenAnswer((_) => controller.stream);
 
-      ProVideoEditorLogForwarder.start(proVideoEditor: mock);
+      final reporter = _RecordingCrashReporter();
+      ProVideoEditorLogForwarder.start(
+        proVideoEditor: mock,
+        crashReporter: reporter,
+      );
 
       const live = 'pve-stream-live-unique';
       controller.add(entry(NativeLogLevel.warning, live));
       await Future<void>.delayed(Duration.zero);
       expect(latestWithMessage(live), isNotNull);
+      expect(reporter.breadcrumbs.single, contains(live));
 
       await ProVideoEditorLogForwarder.stop();
 
@@ -146,6 +228,7 @@ void main() {
       controller.add(entry(NativeLogLevel.warning, afterStop));
       await Future<void>.delayed(Duration.zero);
       expect(latestWithMessage(afterStop), isNull);
+      expect(reporter.breadcrumbs, hasLength(1));
 
       await controller.close();
     });


### PR DESCRIPTION
## Description

When Android video rendering fails, Crashlytics can show only a generic frame-processing or muxer error. The native plugin already emits its throwable and cause chain, but Divine was keeping those details only in local bug-report logs.

Send native warning/error messages and their stack traces to sanitized crash breadcrumbs through the existing injected `CrashReporter`. The final-render watchdog still owns the non-fatal report, so native fallback attempts contribute context without creating extra crash issues. Routine native messages stay in the local log. Bootstrap now supplies the crash reporter when subscribing.

**Related Issue:** Relates to #9100.

## Out of Scope

This fixes the missing diagnostic evidence. It does not establish or fix the underlying Android rendering failure, change rendering/retry behavior, or update the native editor dependency. #9100 remains open for a recurrence or device reproduction with the preserved cause chain.

## Verification

- Regression tests failed before implementation because crash breadcrumbs were empty.
- 34 tests passed across the native-log forwarder, shared crash-report sanitizer, and render watchdog.
- CI analysis targets (`lib`, `test`, `integration_test`, `tools`) passed with no issues.
- Reviewed the plugin's native error path: it emits the throwable and cause chain through the log channel before returning the generic method-channel error.
- Device verification of a new Crashlytics event remains pending; the original media and native cause were unavailable.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

```text
Agent-Model: openai/gpt-6
Agent-Effort: unknown
Agent-Harness: codex/unknown
Agent-Context: forked
Initiated-By: @rabble
```

Closes #9190
