### PR TITLE
fix(auth): keep forgot-password controls above the keyboard

### DIFF
--- a/mobile/lib/widgets/auth/forgot_password_dialog.dart
+++ b/mobile/lib/widgets/auth/forgot_password_dialog.dart
@@ -33,6 +33,17 @@ void showForgotPasswordDialog({
           enableDrag: false,
           showDragHandle: false,
           title: Text(context.l10n.forgotPasswordTitle),
+          contentWrapper: (sheetContext, child) => Padding(
+            padding: EdgeInsets.only(
+              bottom: MediaQuery.viewInsetsOf(sheetContext).bottom,
+            ),
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              excludeFromSemantics: true,
+              onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+              child: child,
+            ),
+          ),
           body: _ForgotPasswordSheetContent(
             initialEmail: initialEmail,
             onSendResetEmail: onSendResetEmail,
@@ -137,99 +148,103 @@ class _ForgotPasswordSheetContentState
     final validationMessages = AuthValidationMessages.fromL10n(context.l10n);
     return PopScope(
       canPop: !_isSubmitting,
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
-        child: Form(
-          key: _formKey,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                context.l10n.forgotPasswordDescription,
-                style: VineTheme.bodyMediumFont(
-                  color: context.vineColors.secondaryText,
-                ),
-              ),
-              const SizedBox(height: 20),
-              TextFormField(
-                controller: _emailController,
-                keyboardType: TextInputType.emailAddress,
-                autocorrect: false,
-                onChanged: (_) {
-                  if (_sendFailed) {
-                    setState(() => _sendFailed = false);
-                  }
-                },
-                style: VineTheme.bodyLargeFont(
-                  color: context.vineColors.primaryText,
-                ),
-                decoration: InputDecoration(
-                  labelText: context.l10n.forgotPasswordEmailLabel,
-                  labelStyle: VineTheme.bodyLargeFont(
-                    color: context.vineColors.mutedText,
-                  ),
-                  prefixIcon: DivineIcon(
-                    icon: DivineIconName.envelope,
-                    color: context.vineColors.mutedText,
-                  ),
-                  enabledBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: BorderSide(color: context.vineColors.outline),
-                  ),
-                  focusedBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: const BorderSide(
-                      color: VineTheme.vineGreen,
-                      width: 2,
-                    ),
-                  ),
-                ),
-                validator: (value) => Validators.validateEmail(
-                  value,
-                  messages: validationMessages,
-                ),
-              ),
-              if (_sendFailed) ...[
-                const SizedBox(height: 16),
+      child: SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
                 Text(
-                  context.l10n.authFailedToSendResetEmail,
+                  context.l10n.forgotPasswordDescription,
                   style: VineTheme.bodyMediumFont(
-                    color: context.vineColors.onErrorContainer,
+                    color: context.vineColors.secondaryText,
                   ),
                 ),
-              ],
-              const SizedBox(height: 24),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  TextButton(
-                    onPressed: _isSubmitting ? null : () => context.pop(),
-                    child: Text(
-                      context.l10n.forgotPasswordCancel,
-                      style: VineTheme.labelLargeFont(
-                        color: context.vineColors.onSurfaceMuted,
+                const SizedBox(height: 20),
+                TextFormField(
+                  controller: _emailController,
+                  keyboardType: TextInputType.emailAddress,
+                  autocorrect: false,
+                  onChanged: (_) {
+                    if (_sendFailed) {
+                      setState(() => _sendFailed = false);
+                    }
+                  },
+                  style: VineTheme.bodyLargeFont(
+                    color: context.vineColors.primaryText,
+                  ),
+                  decoration: InputDecoration(
+                    labelText: context.l10n.forgotPasswordEmailLabel,
+                    labelStyle: VineTheme.bodyLargeFont(
+                      color: context.vineColors.mutedText,
+                    ),
+                    prefixIcon: DivineIcon(
+                      icon: DivineIconName.envelope,
+                      color: context.vineColors.mutedText,
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide(color: context.vineColors.outline),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: const BorderSide(
+                        color: VineTheme.vineGreen,
+                        width: 2,
                       ),
                     ),
                   ),
-                  const SizedBox(width: 8),
-                  ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: VineTheme.vineGreen,
-                      foregroundColor: context.vineColors.background,
-                    ),
-                    onPressed: _isSubmitting ? null : _submit,
-                    child: Text(
-                      _isSubmitting
-                          ? context.l10n.authSending
-                          : _sendFailed
-                          ? context.l10n.authTryAgain
-                          : context.l10n.forgotPasswordSendLink,
+                  validator: (value) => Validators.validateEmail(
+                    value,
+                    messages: validationMessages,
+                  ),
+                ),
+                if (_sendFailed) ...[
+                  const SizedBox(height: 16),
+                  Text(
+                    context.l10n.authFailedToSendResetEmail,
+                    style: VineTheme.bodyMediumFont(
+                      color: context.vineColors.onErrorContainer,
                     ),
                   ),
                 ],
-              ),
-            ],
+                const SizedBox(height: 24),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    TextButton(
+                      onPressed: _isSubmitting ? null : () => context.pop(),
+                      child: Text(
+                        context.l10n.forgotPasswordCancel,
+                        style: VineTheme.labelLargeFont(
+                          color: context.vineColors.onSurfaceMuted,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: VineTheme.vineGreen,
+                        foregroundColor: context.vineColors.background,
+                      ),
+                      onPressed: _isSubmitting ? null : _submit,
+                      child: Text(
+                        _isSubmitting
+                            ? context.l10n.authSending
+                            : _sendFailed
+                            ? context.l10n.authTryAgain
+                            : context.l10n.forgotPasswordSendLink,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/mobile/test/widgets/auth/forgot_password_dialog_test.dart
+++ b/mobile/test/widgets/auth/forgot_password_dialog_test.dart
@@ -23,11 +23,12 @@ void main() {
       String initialEmail = '',
       Future<bool> Function(String email)? onSendResetEmail,
       VoidCallback? onResetAccepted,
+      TargetPlatform? platform,
     }) {
       return MaterialApp.router(
         localizationsDelegates: appLocalizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        theme: VineTheme.theme,
+        theme: VineTheme.theme.copyWith(platform: platform),
         routerConfig: GoRouter(
           routes: [
             GoRoute(
@@ -116,6 +117,94 @@ void main() {
     });
 
     group('interactions', () {
+      testWidgets('keeps the form controls above the keyboard', (tester) async {
+        const viewport = Size(430, 932);
+        const keyboardExtent = 336.0;
+        tester.view.devicePixelRatio = 1;
+        tester.view.physicalSize = viewport;
+        addTearDown(tester.view.reset);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+        await openDialog(tester);
+
+        await tester.tap(find.byType(TextFormField));
+        tester.view.viewInsets = const FakeViewPadding(
+          bottom: keyboardExtent,
+        );
+        await tester.pumpAndSettle();
+
+        final visibleBottom = viewport.height - keyboardExtent;
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final controls = {
+          'email field': find.byType(TextFormField),
+          'reset action': find.widgetWithText(
+            ElevatedButton,
+            l10n.forgotPasswordSendLink,
+          ),
+        };
+        for (final entry in controls.entries) {
+          expect(entry.value, findsOneWidget);
+          expect(
+            tester.getRect(entry.value).bottom,
+            lessThanOrEqualTo(visibleBottom),
+            reason: '${entry.key} must stay above the keyboard',
+          );
+        }
+      });
+
+      testWidgets('tapping instructional text dismisses field focus', (
+        tester,
+      ) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+        await openDialog(tester);
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        final editable = find.byType(EditableText);
+        await tester.tap(editable);
+        await tester.pump();
+        expect(
+          tester.widget<EditableText>(editable).focusNode.hasFocus,
+          isTrue,
+        );
+
+        await tester.tap(find.text(l10n.forgotPasswordDescription));
+        await tester.pump();
+
+        expect(
+          tester.widget<EditableText>(editable).focusNode.hasFocus,
+          isFalse,
+        );
+      });
+
+      testWidgets('dragging the form dismisses field focus on iOS', (
+        tester,
+      ) async {
+        await tester.pumpWidget(createTestWidget(platform: TargetPlatform.iOS));
+        await tester.pumpAndSettle();
+        await openDialog(tester);
+
+        final editable = find.byType(EditableText);
+        await tester.tap(editable);
+        await tester.pump();
+        expect(
+          tester.widget<EditableText>(editable).focusNode.hasFocus,
+          isTrue,
+        );
+
+        await tester.drag(
+          find.byType(SingleChildScrollView),
+          const Offset(0, -80),
+        );
+        await tester.pump();
+
+        expect(
+          tester.widget<EditableText>(editable).focusNode.hasFocus,
+          isFalse,
+        );
+      });
+
       testWidgets('Cancel closes dialog', (tester) async {
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();


### PR DESCRIPTION
## Description

The forgot-password sheet could open behind the software keyboard: the email field and the reset action sat below the visible area, tapping the sheet did not release field focus, and the sheet could not be dragged.

This change keeps the email field and the reset action above the keyboard. Tapping non-interactive sheet content releases focus, and dragging the form dismisses the keyboard on iOS. Dismissing the keyboard by tap or drag leaves the sheet open, so the reset flow continues without reopening it.

## Related Issue

Closes #8625

## Out of Scope

Other sheets and auth surfaces keep their current keyboard handling.

## Verification

- `flutter test test/widgets/auth/forgot_password_dialog_test.dart` (19 passed)
- `flutter test test/l10n/arb_consistency_test.dart` (13 passed)
- `flutter analyze lib test integration_test tools`
- `dart format --output=none --set-exit-if-changed lib test integration_test tools`

The affected static ratchets passed. The full sharded test suite, goldens, and CI-only checks have not run locally; CI covers them.

Not tested on a physical iOS device. Drag-to-dismiss on non-scrolling content relies on iOS scroll physics; tap-to-dismiss works on every platform.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
