### PR TITLE
fix(auth): stop rebuilding reactive auth providers on state changes

### DIFF
--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -242,20 +242,16 @@ Future<void> persistFollowingPrefetchForAuthRedirect({
 /// Widgets should watch this instead of authService.authState directly
 /// to get automatic rebuilds when authentication state changes.
 @Riverpod(keepAlive: true)
-AuthState currentAuthState(Ref ref) {
-  final authService = ref.watch(authServiceProvider);
-
-  // Listen to auth state changes and invalidate this provider when they occur
-  final subscription = authService.authStateStream.listen((_) {
-    // Invalidate to trigger rebuild with new state
-    ref.invalidateSelf();
-  });
-
-  // Clean up subscription when provider is disposed
-  ref.onDispose(subscription.cancel);
-
-  // Return current state
-  return authService.authState;
+class CurrentAuthState extends _$CurrentAuthState {
+  @override
+  AuthState build() {
+    final authService = ref.watch(authServiceProvider);
+    final subscription = authService.authStateStream.listen((authState) {
+      state = authState;
+    });
+    ref.onDispose(subscription.cancel);
+    return authService.authState;
+  }
 }
 
 /// Boundary-safe auth helper for recorder exits.
@@ -300,16 +296,18 @@ class RecorderExitAuthGate {
 /// Widgets and repositories should watch this instead of polling
 /// [AuthService.authRpcCapability] directly.
 @Riverpod(keepAlive: true)
-AuthRpcCapability currentAuthRpcCapability(Ref ref) {
-  final authService = ref.watch(authServiceProvider);
-
-  final subscription = authService.authRpcCapabilityStream.listen((_) {
-    ref.invalidateSelf();
-  });
-
-  ref.onDispose(subscription.cancel);
-
-  return authService.authRpcCapability;
+class CurrentAuthRpcCapability extends _$CurrentAuthRpcCapability {
+  @override
+  AuthRpcCapability build() {
+    final authService = ref.watch(authServiceProvider);
+    final subscription = authService.authRpcCapabilityStream.listen((
+      capability,
+    ) {
+      state = capability;
+    });
+    ref.onDispose(subscription.cancel);
+    return authService.authRpcCapability;
+  }
 }
 
 /// Provider that fetches the list of known accounts from the auth service.

--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -238,9 +238,12 @@ Future<void> persistFollowingPrefetchForAuthRedirect({
   await markFollowingPrefetchComplete(prefs, pubkeyHex);
 }
 
-/// Provider that returns current auth state and rebuilds when it changes.
-/// Widgets should watch this instead of authService.authState directly
-/// to get automatic rebuilds when authentication state changes.
+/// Current auth state, kept in sync with [AuthService.authStateStream].
+///
+/// Widgets should watch this instead of `authService.authState` directly
+/// so they rebuild when authentication state changes. Each streamed value
+/// becomes the notifier's state; the provider itself is not rebuilt, so its
+/// stream subscription survives every auth transition.
 @Riverpod(keepAlive: true)
 class CurrentAuthState extends _$CurrentAuthState {
   @override
@@ -291,10 +294,12 @@ class RecorderExitAuthGate {
   }
 }
 
-/// Provider that returns current RPC capability and rebuilds on changes.
+/// Current RPC capability, kept in sync with
+/// [AuthService.authRpcCapabilityStream].
 ///
 /// Widgets and repositories should watch this instead of polling
-/// [AuthService.authRpcCapability] directly.
+/// [AuthService.authRpcCapability] directly. Each streamed value becomes the
+/// notifier's state; the provider itself is not rebuilt on a change.
 @Riverpod(keepAlive: true)
 class CurrentAuthRpcCapability extends _$CurrentAuthRpcCapability {
   @override

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -393,21 +393,30 @@ final class AuthServiceProvider
 
 String _$authServiceHash() => r'040363ef2aa7f763b519f11e70bb77eb28a2abe7';
 
-/// Provider that returns current auth state and rebuilds when it changes.
-/// Widgets should watch this instead of authService.authState directly
-/// to get automatic rebuilds when authentication state changes.
+/// Current auth state, kept in sync with [AuthService.authStateStream].
+///
+/// Widgets should watch this instead of `authService.authState` directly
+/// so they rebuild when authentication state changes. Each streamed value
+/// becomes the notifier's state; the provider itself is not rebuilt, so its
+/// stream subscription survives every auth transition.
 
 @ProviderFor(CurrentAuthState)
 final currentAuthStateProvider = CurrentAuthStateProvider._();
 
-/// Provider that returns current auth state and rebuilds when it changes.
-/// Widgets should watch this instead of authService.authState directly
-/// to get automatic rebuilds when authentication state changes.
+/// Current auth state, kept in sync with [AuthService.authStateStream].
+///
+/// Widgets should watch this instead of `authService.authState` directly
+/// so they rebuild when authentication state changes. Each streamed value
+/// becomes the notifier's state; the provider itself is not rebuilt, so its
+/// stream subscription survives every auth transition.
 final class CurrentAuthStateProvider
     extends $NotifierProvider<CurrentAuthState, AuthState> {
-  /// Provider that returns current auth state and rebuilds when it changes.
-  /// Widgets should watch this instead of authService.authState directly
-  /// to get automatic rebuilds when authentication state changes.
+  /// Current auth state, kept in sync with [AuthService.authStateStream].
+  ///
+  /// Widgets should watch this instead of `authService.authState` directly
+  /// so they rebuild when authentication state changes. Each streamed value
+  /// becomes the notifier's state; the provider itself is not rebuilt, so its
+  /// stream subscription survives every auth transition.
   CurrentAuthStateProvider._()
     : super(
         from: null,
@@ -437,9 +446,12 @@ final class CurrentAuthStateProvider
 
 String _$currentAuthStateHash() => r'20a8f224af5db07a98723431b2a8d9781949e553';
 
-/// Provider that returns current auth state and rebuilds when it changes.
-/// Widgets should watch this instead of authService.authState directly
-/// to get automatic rebuilds when authentication state changes.
+/// Current auth state, kept in sync with [AuthService.authStateStream].
+///
+/// Widgets should watch this instead of `authService.authState` directly
+/// so they rebuild when authentication state changes. Each streamed value
+/// becomes the notifier's state; the provider itself is not rebuilt, so its
+/// stream subscription survives every auth transition.
 
 abstract class _$CurrentAuthState extends $Notifier<AuthState> {
   AuthState build();
@@ -459,24 +471,30 @@ abstract class _$CurrentAuthState extends $Notifier<AuthState> {
   }
 }
 
-/// Provider that returns current RPC capability and rebuilds on changes.
+/// Current RPC capability, kept in sync with
+/// [AuthService.authRpcCapabilityStream].
 ///
 /// Widgets and repositories should watch this instead of polling
-/// [AuthService.authRpcCapability] directly.
+/// [AuthService.authRpcCapability] directly. Each streamed value becomes the
+/// notifier's state; the provider itself is not rebuilt on a change.
 
 @ProviderFor(CurrentAuthRpcCapability)
 final currentAuthRpcCapabilityProvider = CurrentAuthRpcCapabilityProvider._();
 
-/// Provider that returns current RPC capability and rebuilds on changes.
+/// Current RPC capability, kept in sync with
+/// [AuthService.authRpcCapabilityStream].
 ///
 /// Widgets and repositories should watch this instead of polling
-/// [AuthService.authRpcCapability] directly.
+/// [AuthService.authRpcCapability] directly. Each streamed value becomes the
+/// notifier's state; the provider itself is not rebuilt on a change.
 final class CurrentAuthRpcCapabilityProvider
     extends $NotifierProvider<CurrentAuthRpcCapability, AuthRpcCapability> {
-  /// Provider that returns current RPC capability and rebuilds on changes.
+  /// Current RPC capability, kept in sync with
+  /// [AuthService.authRpcCapabilityStream].
   ///
   /// Widgets and repositories should watch this instead of polling
-  /// [AuthService.authRpcCapability] directly.
+  /// [AuthService.authRpcCapability] directly. Each streamed value becomes the
+  /// notifier's state; the provider itself is not rebuilt on a change.
   CurrentAuthRpcCapabilityProvider._()
     : super(
         from: null,
@@ -507,10 +525,12 @@ final class CurrentAuthRpcCapabilityProvider
 String _$currentAuthRpcCapabilityHash() =>
     r'fa4b97ab80f61d43b789df8bffd32332acdbd8d0';
 
-/// Provider that returns current RPC capability and rebuilds on changes.
+/// Current RPC capability, kept in sync with
+/// [AuthService.authRpcCapabilityStream].
 ///
 /// Widgets and repositories should watch this instead of polling
-/// [AuthService.authRpcCapability] directly.
+/// [AuthService.authRpcCapability] directly. Each streamed value becomes the
+/// notifier's state; the provider itself is not rebuilt on a change.
 
 abstract class _$CurrentAuthRpcCapability extends $Notifier<AuthRpcCapability> {
   AuthRpcCapability build();

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -397,16 +397,14 @@ String _$authServiceHash() => r'040363ef2aa7f763b519f11e70bb77eb28a2abe7';
 /// Widgets should watch this instead of authService.authState directly
 /// to get automatic rebuilds when authentication state changes.
 
-@ProviderFor(currentAuthState)
+@ProviderFor(CurrentAuthState)
 final currentAuthStateProvider = CurrentAuthStateProvider._();
 
 /// Provider that returns current auth state and rebuilds when it changes.
 /// Widgets should watch this instead of authService.authState directly
 /// to get automatic rebuilds when authentication state changes.
-
 final class CurrentAuthStateProvider
-    extends $FunctionalProvider<AuthState, AuthState, AuthState>
-    with $Provider<AuthState> {
+    extends $NotifierProvider<CurrentAuthState, AuthState> {
   /// Provider that returns current auth state and rebuilds when it changes.
   /// Widgets should watch this instead of authService.authState directly
   /// to get automatic rebuilds when authentication state changes.
@@ -426,13 +424,7 @@ final class CurrentAuthStateProvider
 
   @$internal
   @override
-  $ProviderElement<AuthState> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(pointer);
-
-  @override
-  AuthState create(Ref ref) {
-    return currentAuthState(ref);
-  }
+  CurrentAuthState create() => CurrentAuthState();
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(AuthState value) {
@@ -443,29 +435,44 @@ final class CurrentAuthStateProvider
   }
 }
 
-String _$currentAuthStateHash() => r'41c987ffc8f661555bab3ebec9078180411f66eb';
+String _$currentAuthStateHash() => r'20a8f224af5db07a98723431b2a8d9781949e553';
+
+/// Provider that returns current auth state and rebuilds when it changes.
+/// Widgets should watch this instead of authService.authState directly
+/// to get automatic rebuilds when authentication state changes.
+
+abstract class _$CurrentAuthState extends $Notifier<AuthState> {
+  AuthState build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<AuthState, AuthState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AuthState, AuthState>,
+              AuthState,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}
 
 /// Provider that returns current RPC capability and rebuilds on changes.
 ///
 /// Widgets and repositories should watch this instead of polling
 /// [AuthService.authRpcCapability] directly.
 
-@ProviderFor(currentAuthRpcCapability)
+@ProviderFor(CurrentAuthRpcCapability)
 final currentAuthRpcCapabilityProvider = CurrentAuthRpcCapabilityProvider._();
 
 /// Provider that returns current RPC capability and rebuilds on changes.
 ///
 /// Widgets and repositories should watch this instead of polling
 /// [AuthService.authRpcCapability] directly.
-
 final class CurrentAuthRpcCapabilityProvider
-    extends
-        $FunctionalProvider<
-          AuthRpcCapability,
-          AuthRpcCapability,
-          AuthRpcCapability
-        >
-    with $Provider<AuthRpcCapability> {
+    extends $NotifierProvider<CurrentAuthRpcCapability, AuthRpcCapability> {
   /// Provider that returns current RPC capability and rebuilds on changes.
   ///
   /// Widgets and repositories should watch this instead of polling
@@ -486,14 +493,7 @@ final class CurrentAuthRpcCapabilityProvider
 
   @$internal
   @override
-  $ProviderElement<AuthRpcCapability> $createElement(
-    $ProviderPointer pointer,
-  ) => $ProviderElement(pointer);
-
-  @override
-  AuthRpcCapability create(Ref ref) {
-    return currentAuthRpcCapability(ref);
-  }
+  CurrentAuthRpcCapability create() => CurrentAuthRpcCapability();
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(AuthRpcCapability value) {
@@ -505,7 +505,30 @@ final class CurrentAuthRpcCapabilityProvider
 }
 
 String _$currentAuthRpcCapabilityHash() =>
-    r'cb273f3377e25d0c88104df14a38d2b502c3f7de';
+    r'fa4b97ab80f61d43b789df8bffd32332acdbd8d0';
+
+/// Provider that returns current RPC capability and rebuilds on changes.
+///
+/// Widgets and repositories should watch this instead of polling
+/// [AuthService.authRpcCapability] directly.
+
+abstract class _$CurrentAuthRpcCapability extends $Notifier<AuthRpcCapability> {
+  AuthRpcCapability build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<AuthRpcCapability, AuthRpcCapability>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AuthRpcCapability, AuthRpcCapability>,
+              AuthRpcCapability,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}
 
 /// Provider that fetches the list of known accounts from the auth service.
 ///

--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -449,7 +449,7 @@ String? appRouterRedirect(Ref ref, GoRouterState state) {
   // Only bounce to the loading screen on a true cold load (no value yet).
   // Riverpod keeps the previous value during a background refetch
   // (isLoading == true while hasValue == true), e.g. when
-  // currentAuthStateProvider re-invalidates on an authStateStream event.
+  // currentAuthStateProvider publishes a new auth state.
   // Treating those transient refetches as "loading" would redirect away
   // from the current route to the review loading screen and back, which
   // tears down and rebuilds the video feed.

--- a/mobile/test/providers/account_deletion_recovery_providers_test.dart
+++ b/mobile/test/providers/account_deletion_recovery_providers_test.dart
@@ -42,6 +42,11 @@ final _authStateProbe = NotifierProvider<_AuthStateProbe, AuthState>(
   _AuthStateProbe.new,
 );
 
+class _TestCurrentAuthState extends CurrentAuthState {
+  @override
+  AuthState build() => ref.watch(_authStateProbe);
+}
+
 class _TestNostrSession extends NostrSession {
   @override
   NostrSessionReadiness build() =>
@@ -410,9 +415,7 @@ void main() {
             overrides: [
               sharedPreferencesProvider.overrideWithValue(preferences),
               authServiceProvider.overrideWithValue(authService),
-              currentAuthStateProvider.overrideWith(
-                (ref) => ref.watch(_authStateProbe),
-              ),
+              currentAuthStateProvider.overrideWith(_TestCurrentAuthState.new),
               accountDeletionRecoveryRepositoryProvider.overrideWithValue(
                 repository,
               ),
@@ -530,9 +533,7 @@ void main() {
           overrides: [
             sharedPreferencesProvider.overrideWithValue(preferences),
             authServiceProvider.overrideWithValue(authService),
-            currentAuthStateProvider.overrideWith(
-              (ref) => ref.watch(_authStateProbe),
-            ),
+            currentAuthStateProvider.overrideWith(_TestCurrentAuthState.new),
             currentAuthRpcCapabilityProvider.overrideWithValue(
               AuthRpcCapability.rpcReady,
             ),
@@ -620,9 +621,7 @@ void main() {
         overrides: [
           sharedPreferencesProvider.overrideWithValue(preferences),
           authServiceProvider.overrideWithValue(authService),
-          currentAuthStateProvider.overrideWith(
-            (ref) => ref.watch(_authStateProbe),
-          ),
+          currentAuthStateProvider.overrideWith(_TestCurrentAuthState.new),
           currentAuthRpcCapabilityProvider.overrideWithValue(
             AuthRpcCapability.rpcReady,
           ),

--- a/mobile/test/providers/auth_providers_test.dart
+++ b/mobile/test/providers/auth_providers_test.dart
@@ -39,6 +39,10 @@ class _FakeExtension extends NostrExtension {
       'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
 }
 
+final _authStateMirrorProvider = Provider<AuthState>(
+  (ref) => ref.watch(currentAuthStateProvider),
+);
+
 class _RecordingAnalytics implements AnalyticsEventSink {
   final userIds = <String?>[];
 
@@ -261,44 +265,46 @@ void main() {
   });
 
   group('currentAuthStateProvider', () {
-    testWidgets('updates consumers without rebuilding its subscription', (
-      tester,
-    ) async {
-      final authStateController = StreamController<AuthState>.broadcast();
-      addTearDown(authStateController.close);
-      final authService = _MockAuthService();
-      var authState = AuthState.checking;
-      when(() => authService.authState).thenAnswer((_) => authState);
-      when(
-        () => authService.authStateStream,
-      ).thenAnswer((_) => authStateController.stream);
+    testWidgets(
+      'updates dependent providers without rebuilding its subscription',
+      (
+        tester,
+      ) async {
+        final authStateController = StreamController<AuthState>.broadcast();
+        addTearDown(authStateController.close);
+        final authService = _MockAuthService();
+        var authState = AuthState.checking;
+        when(() => authService.authState).thenAnswer((_) => authState);
+        when(
+          () => authService.authStateStream,
+        ).thenAnswer((_) => authStateController.stream);
 
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [authServiceProvider.overrideWithValue(authService)],
-          child: Consumer(
-            builder: (context, ref, child) {
-              return SizedBox(
-                key: ValueKey(ref.watch(currentAuthStateProvider)),
-              );
-            },
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [authServiceProvider.overrideWithValue(authService)],
+            child: Consumer(
+              builder: (context, ref, child) {
+                return SizedBox(
+                  key: ValueKey(ref.watch(_authStateMirrorProvider)),
+                );
+              },
+            ),
           ),
-        ),
-      );
-      expect(find.byKey(const ValueKey(AuthState.checking)), findsOneWidget);
+        );
+        expect(find.byKey(const ValueKey(AuthState.checking)), findsOneWidget);
 
-      authState = AuthState.authenticated;
-      authStateController.add(authState);
-      await tester.pump();
-      await tester.pump();
+        authState = AuthState.authenticated;
+        authStateController.add(authState);
+        await tester.pump();
+        await tester.pump();
 
-      expect(tester.takeException(), isNull);
-      expect(
-        find.byKey(const ValueKey(AuthState.authenticated)),
-        findsOneWidget,
-      );
-      verify(() => authService.authStateStream).called(1);
-    });
+        expect(
+          find.byKey(const ValueKey(AuthState.authenticated)),
+          findsOneWidget,
+        );
+        verify(() => authService.authStateStream).called(1);
+      },
+    );
   });
 
   group('currentAuthRpcCapabilityProvider', () {
@@ -337,7 +343,6 @@ void main() {
       await tester.pump();
       await tester.pump();
 
-      expect(tester.takeException(), isNull);
       expect(
         find.byKey(const ValueKey(AuthRpcCapability.rpcReady)),
         findsOneWidget,

--- a/mobile/test/providers/auth_providers_test.dart
+++ b/mobile/test/providers/auth_providers_test.dart
@@ -4,10 +4,12 @@
 import 'dart:async';
 
 import 'package:analytics/analytics.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/repository_providers.dart';
@@ -255,6 +257,92 @@ void main() {
       container.dispose();
 
       expect(service.isAuthenticated, isFalse);
+    });
+  });
+
+  group('currentAuthStateProvider', () {
+    testWidgets('updates consumers without rebuilding its subscription', (
+      tester,
+    ) async {
+      final authStateController = StreamController<AuthState>.broadcast();
+      addTearDown(authStateController.close);
+      final authService = _MockAuthService();
+      var authState = AuthState.checking;
+      when(() => authService.authState).thenAnswer((_) => authState);
+      when(
+        () => authService.authStateStream,
+      ).thenAnswer((_) => authStateController.stream);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [authServiceProvider.overrideWithValue(authService)],
+          child: Consumer(
+            builder: (context, ref, child) {
+              return SizedBox(
+                key: ValueKey(ref.watch(currentAuthStateProvider)),
+              );
+            },
+          ),
+        ),
+      );
+      expect(find.byKey(const ValueKey(AuthState.checking)), findsOneWidget);
+
+      authState = AuthState.authenticated;
+      authStateController.add(authState);
+      await tester.pump();
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(
+        find.byKey(const ValueKey(AuthState.authenticated)),
+        findsOneWidget,
+      );
+      verify(() => authService.authStateStream).called(1);
+    });
+  });
+
+  group('currentAuthRpcCapabilityProvider', () {
+    testWidgets('updates consumers without rebuilding its subscription', (
+      tester,
+    ) async {
+      final capabilityController =
+          StreamController<AuthRpcCapability>.broadcast();
+      addTearDown(capabilityController.close);
+      final authService = _MockAuthService();
+      when(
+        () => authService.authRpcCapability,
+      ).thenReturn(AuthRpcCapability.unavailable);
+      when(
+        () => authService.authRpcCapabilityStream,
+      ).thenAnswer((_) => capabilityController.stream);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [authServiceProvider.overrideWithValue(authService)],
+          child: Consumer(
+            builder: (context, ref, child) {
+              return SizedBox(
+                key: ValueKey(ref.watch(currentAuthRpcCapabilityProvider)),
+              );
+            },
+          ),
+        ),
+      );
+      expect(
+        find.byKey(const ValueKey(AuthRpcCapability.unavailable)),
+        findsOneWidget,
+      );
+
+      capabilityController.add(AuthRpcCapability.rpcReady);
+      await tester.pump();
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(
+        find.byKey(const ValueKey(AuthRpcCapability.rpcReady)),
+        findsOneWidget,
+      );
+      verify(() => authService.authRpcCapabilityStream).called(1);
     });
   });
 

--- a/mobile/test/providers/crossposting_providers_test.dart
+++ b/mobile/test/providers/crossposting_providers_test.dart
@@ -74,9 +74,7 @@ void main() {
       when(() => auth.isRegistered).thenReturn(true);
       return ProviderContainer(
         overrides: [
-          currentAuthStateProvider.overrideWith(
-            (ref) => AuthState.authenticated,
-          ),
+          currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
           authServiceProvider.overrideWithValue(auth),
           appOAuthSupportProvider.overrideWith((ref) async {
             if (!resolveSupport) {

--- a/mobile/test/providers/is_dm_restricted_provider_test.dart
+++ b/mobile/test/providers/is_dm_restricted_provider_test.dart
@@ -200,8 +200,8 @@ void main() {
         // extracted provider keeps a stale value into the next account's
         // session — and a stale `false` unrestricts a Keycast-backed account.
         //
-        // Uses the REAL currentAuthStateProvider (stream + invalidateSelf) over
-        // a mock AuthService so an auth transition propagates exactly as in
+        // Uses the real currentAuthStateProvider stream over a mock AuthService
+        // so an auth transition propagates exactly as in
         // production; overriding currentAuthStateProvider with a value would
         // hide the defect.
         const pubkeyA =

--- a/mobile/test/providers/list_providers_test.dart
+++ b/mobile/test/providers/list_providers_test.dart
@@ -252,8 +252,8 @@ void main() {
         ).called(1);
 
         // Sign out — auth service emits `unauthenticated`. The stream
-        // event invalidates `currentAuthStateProvider`, which rebuilds
-        // with a genuinely different enum value and propagates.
+        // event becomes `currentAuthStateProvider`'s new state, a genuinely
+        // different enum value, so dependents rebuild.
         when(
           () => mockAuthService.authState,
         ).thenReturn(AuthState.unauthenticated);

--- a/mobile/test/providers/list_providers_test.dart
+++ b/mobile/test/providers/list_providers_test.dart
@@ -192,8 +192,7 @@ void main() {
           () => mockAuthService.currentPublicKeyHex,
         ).thenReturn(_ownerA);
 
-        // Invalidating currentAuthStateProvider simulates the
-        // authStateStream listener firing inside currentAuthStateProvider.
+        // Invalidating currentAuthStateProvider simulates an auth-state change.
         container.invalidate(currentAuthStateProvider);
 
         await Future<void>.delayed(Duration.zero);

--- a/mobile/test/router/minor_account_review_router_test.dart
+++ b/mobile/test/router/minor_account_review_router_test.dart
@@ -761,9 +761,9 @@ void main() {
       'does not bounce to the loading gate during a background refetch',
       (tester) async {
         // Regression: the review status is a FutureProvider that (in prod)
-        // depends on currentAuthStateProvider, which invalidates itself on
-        // every authStateStream event. A re-run puts the provider into
-        // AsyncLoading while retaining its previous value. The router must
+        // depends on currentAuthStateProvider. An auth-state change starts a
+        // review-status refresh, putting the provider into AsyncLoading while
+        // retaining its previous value. The router must
         // NOT treat that transient refetch as a cold load and bounce to the
         // loading screen — that redirect is a navigation that tears down the
         // video feed, which manifested as videos stopping while swiping the

--- a/mobile/test/screens/settings/crossposting_settings_screen_test.dart
+++ b/mobile/test/screens/settings/crossposting_settings_screen_test.dart
@@ -33,6 +33,11 @@ final _testAuthStateProvider = StateProvider<AuthState>(
   (_) => AuthState.authenticated,
 );
 
+class _TestCurrentAuthState extends CurrentAuthState {
+  @override
+  AuthState build() => ref.watch(_testAuthStateProvider);
+}
+
 void main() {
   group(CrosspostingSettingsScreen, () {
     late _MockAuthService authService;
@@ -77,9 +82,7 @@ void main() {
       return ProviderScope(
         overrides: [
           authServiceProvider.overrideWithValue(authService),
-          currentAuthStateProvider.overrideWith(
-            (ref) => ref.watch(_testAuthStateProvider),
-          ),
+          currentAuthStateProvider.overrideWith(_TestCurrentAuthState.new),
           crosspostingRepositoryProvider.overrideWithValue(repository),
         ],
         child: MaterialApp.router(

--- a/mobile/test/screens/settings/support_center_screen_test.dart
+++ b/mobile/test/screens/settings/support_center_screen_test.dart
@@ -71,7 +71,7 @@ void main() {
           overrides: [
             sharedPreferencesProvider.overrideWithValue(sharedPreferences),
             authServiceProvider.overrideWithValue(authService),
-            currentAuthStateProvider.overrideWith((ref) => authState),
+            currentAuthStateProvider.overrideWithValue(authState),
             bugReportServiceProvider.overrideWithValue(bugReportService),
             accountDeletionServiceProvider.overrideWithValue(
               accountDeletionService,

--- a/mobile/test/widgets/nostr_settings_screen_test.dart
+++ b/mobile/test/widgets/nostr_settings_screen_test.dart
@@ -73,7 +73,7 @@ void main() {
         overrides: [
           sharedPreferencesProvider.overrideWithValue(sharedPreferences),
           authServiceProvider.overrideWithValue(mockAuthService),
-          currentAuthStateProvider.overrideWith((ref) => authState),
+          currentAuthStateProvider.overrideWithValue(authState),
           isFeatureEnabledProvider(
             FeatureFlag.advancedRelaySettings,
           ).overrideWith((ref) => advancedRelaySettingsEnabled),
@@ -420,9 +420,7 @@ void main() {
           overrides: [
             sharedPreferencesProvider.overrideWithValue(sharedPreferences),
             authServiceProvider.overrideWithValue(mockAuthService),
-            currentAuthStateProvider.overrideWith(
-              (ref) => AuthState.authenticated,
-            ),
+            currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
             isFeatureEnabledProvider(
               FeatureFlag.advancedRelaySettings,
             ).overrideWith((ref) => false),
@@ -479,9 +477,7 @@ void main() {
           overrides: [
             sharedPreferencesProvider.overrideWithValue(sharedPreferences),
             authServiceProvider.overrideWithValue(mockAuthService),
-            currentAuthStateProvider.overrideWith(
-              (ref) => AuthState.authenticated,
-            ),
+            currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
             isFeatureEnabledProvider(
               FeatureFlag.advancedRelaySettings,
             ).overrideWith((ref) => false),

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -474,9 +474,7 @@ void main() {
             return isAccountEnforced;
           }),
           badgeRepositoryProvider.overrideWithValue(badgeRepository),
-          currentAuthStateProvider.overrideWith(
-            (ref) => AuthState.authenticated,
-          ),
+          currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
           isFeatureEnabledProvider(
             FeatureFlag.curatedLists,
           ).overrideWith((ref) => curatedListsEnabled),
@@ -2849,8 +2847,8 @@ void main() {
                   ).overrideWith((ref) => const Stream.empty()),
                   authServiceProvider.overrideWithValue(authService),
                   badgeRepositoryProvider.overrideWithValue(badgeRepository),
-                  currentAuthStateProvider.overrideWith(
-                    (ref) => AuthState.authenticated,
+                  currentAuthStateProvider.overrideWithValue(
+                    AuthState.authenticated,
                   ),
                   isFeatureEnabledProvider(
                     FeatureFlag.curatedLists,
@@ -2966,8 +2964,8 @@ void main() {
                   ).overrideWith((ref) => const Stream.empty()),
                   authServiceProvider.overrideWithValue(authService),
                   badgeRepositoryProvider.overrideWithValue(badgeRepository),
-                  currentAuthStateProvider.overrideWith(
-                    (ref) => AuthState.authenticated,
+                  currentAuthStateProvider.overrideWithValue(
+                    AuthState.authenticated,
                   ),
                   isFeatureEnabledProvider(
                     FeatureFlag.curatedLists,

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -168,7 +168,7 @@ void main() {
           draftStorageServiceProvider.overrideWithValue(
             mockDraftStorageService,
           ),
-          currentAuthStateProvider.overrideWith((ref) => authState),
+          currentAuthStateProvider.overrideWithValue(authState),
           knownAccountsProvider.overrideWith((ref) async => knownAccounts),
           isAccountEnforcedProvider.overrideWithValue(
             enforcement?.isEnforced ?? false,
@@ -260,9 +260,7 @@ void main() {
             draftStorageServiceProvider.overrideWithValue(
               mockDraftStorageService,
             ),
-            currentAuthStateProvider.overrideWith(
-              (ref) => AuthState.authenticated,
-            ),
+            currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
             knownAccountsProvider.overrideWith((ref) async => const []),
             // No NIP-05, but a follower count from the REST profile. Social
             // proof must not stand in for the signed-in account's identifier.
@@ -463,8 +461,8 @@ void main() {
               draftStorageServiceProvider.overrideWithValue(
                 mockDraftStorageService,
               ),
-              currentAuthStateProvider.overrideWith(
-                (ref) => AuthState.authenticated,
+              currentAuthStateProvider.overrideWithValue(
+                AuthState.authenticated,
               ),
               knownAccountsProvider.overrideWith((ref) async => accounts),
               userProfileReactiveProvider.overrideWith(
@@ -581,9 +579,7 @@ void main() {
           draftStorageServiceProvider.overrideWithValue(
             mockDraftStorageService,
           ),
-          currentAuthStateProvider.overrideWith(
-            (ref) => AuthState.authenticated,
-          ),
+          currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
           userProfileReactiveProvider.overrideWith(
             (ref, pubkey) => Stream.value(null),
           ),
@@ -777,8 +773,8 @@ void main() {
               draftStorageServiceProvider.overrideWithValue(
                 mockDraftStorageService,
               ),
-              currentAuthStateProvider.overrideWith(
-                (ref) => AuthState.authenticated,
+              currentAuthStateProvider.overrideWithValue(
+                AuthState.authenticated,
               ),
               userProfileReactiveProvider.overrideWith(
                 (ref, pubkey) => Stream.value(null),
@@ -1049,8 +1045,8 @@ void main() {
               draftStorageServiceProvider.overrideWithValue(
                 mockDraftStorageService,
               ),
-              currentAuthStateProvider.overrideWith(
-                (ref) => AuthState.authenticated,
+              currentAuthStateProvider.overrideWithValue(
+                AuthState.authenticated,
               ),
               userProfileReactiveProvider.overrideWith(
                 (ref, pubkey) => Stream.value(null),


### PR DESCRIPTION
## Description

This is standalone subscription-churn hardening for the two providers that feed account-dependent widgets from the auth service. It was found while investigating #8121, but it is not a fix for that report (see below).

`currentAuthStateProvider` and `currentAuthRpcCapabilityProvider` subscribed to the auth streams and called `ref.invalidateSelf()` on every event. Every auth-state change therefore tore the provider down and rebuilt it — cancelling and re-creating its stream subscription — instead of just publishing the new value, and left the provider dirty until Riverpod's scheduler got to it.

This change removes those two concrete auth-provider self-invalidation paths.
Both providers are now keep-alive notifiers that assign the streamed value to their own state, so dependents update without the provider being invalidated and rebuilt.
Their synchronous value API and the existing auth-transition behavior are unchanged.

Relationship to #8121: the stack there shows Riverpod's implicit dependency invalidation (`Ref.watch`), not the manual `ref.invalidateSelf()` calls this change removes. This change does not claim the reported device exception is gone; #8121 stays open and the exception still needs re-verification on a branch build.

**Related Issue:** Refs #8121

## Out of Scope

- Other listener-driven self-invalidating providers (`environment_provider.dart`, `feature_flag_providers.dart`, `preferences_providers.dart`) are deliberately left alone as out of scope for this auth-specific change and tracked in #9149.
- The exact `UncontrolledProviderScope.markNeedsBuild` failure needs the authenticated app root and a device auth transition, so the new tests pin the subscription churn this change removes rather than the device symptom.

## Verification

With Flutter 3.47.2 / Dart 3.13.2, the version `mobile/mise.toml` pins:

- `flutter analyze lib test integration_test tools`: no issues.
- `flutter test` over the 11 modified test files: 295 passed.
- All 57 declared CI ratchet scripts: pass.
- `bash .codex/scripts/test-config.sh`: pass.
- `python3 -m unittest discover -s .github/scripts/tests`: 110 tests, OK.
- `dart run build_runner build` leaves `git status` clean.

Not verified: the reported device exception requires the authenticated app root and a device auth transition.
The unsharded local `very_good test` run is timing-sensitive in this environment and fails intermittently in files this branch does not touch; the same failures reproduce on clean `main` with the same seed, and CI's sharded run is the authoritative suite.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

Closes #9189
