### PR TITLE
fix(auth): tell people when sign-in is rate limited

### DIFF
--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -272,6 +272,8 @@ class DivineAuthCubit extends Cubit<DivineAuthState>
         return SignInFailureReason.emailNotVerified;
       case KeycastLoginFailure.invalidEmail:
         return SignInFailureReason.invalidEmail;
+      case KeycastLoginFailure.rateLimited:
+        return SignInFailureReason.rateLimited;
       case KeycastLoginFailure.network:
         return SignInFailureReason.network;
       case KeycastLoginFailure.unknown:

--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -321,7 +321,9 @@ class DivineAuthCubit extends Cubit<DivineAuthState>
           current.copyWith(
             isSubmitting: false,
             generalError: errorMsg,
-            showLoginOptionsRecovery: result.errorCode == 'CONFLICT',
+            showLoginOptionsRecovery:
+                result.errorCode == 'CONFLICT' ||
+                result.errorCode == 'EMAIL_ALREADY_EXISTS',
           ),
         );
       }
@@ -638,8 +640,10 @@ class DivineAuthCubit extends Cubit<DivineAuthState>
   ) {
     switch (errorCode) {
       case 'CONFLICT':
+      case 'EMAIL_ALREADY_EXISTS':
         return 'This email is already registered. Please sign in instead.';
       case 'invalid_email':
+      case 'INVALID_EMAIL':
         return 'Please enter a valid email address.';
       case 'weak_password':
         return 'Password is too weak. Please use a stronger password.';

--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -310,10 +310,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState>
       );
 
       // Convert server error codes to localized messages
-      final errorMsg = _getLocalizedRegistrationError(
-        result.errorCode,
-        result.errorDescription,
-      );
+      final errorMsg = _getLocalizedRegistrationError(result);
 
       final current = state;
       if (current is DivineAuthFormState) {
@@ -322,8 +319,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState>
             isSubmitting: false,
             generalError: errorMsg,
             showLoginOptionsRecovery:
-                result.errorCode == 'CONFLICT' ||
-                result.errorCode == 'EMAIL_ALREADY_EXISTS',
+                result.failure == KeycastRegisterFailure.emailAlreadyRegistered,
           ),
         );
       }
@@ -627,44 +623,32 @@ class DivineAuthCubit extends Cubit<DivineAuthState>
     }
   }
 
-  /// Convert server error codes to localized messages for registration errors.
-  ///
-  /// Known error codes from the server:
-  /// - 'email_exists': Email is already registered
-  /// - 'invalid_email': Email format is invalid
-  /// - 'weak_password': Password doesn't meet requirements
-  /// - 'registration_failed': Generic registration failure
-  String _getLocalizedRegistrationError(
-    String? errorCode,
-    String? serverDescription,
-  ) {
-    switch (errorCode) {
-      case 'CONFLICT':
-      case 'EMAIL_ALREADY_EXISTS':
+  /// Converts typed registration failures to user-facing messages.
+  String _getLocalizedRegistrationError(HeadlessRegisterResult result) {
+    switch (result.failure) {
+      case KeycastRegisterFailure.emailAlreadyRegistered:
         return 'This email is already registered. Please sign in instead.';
-      case 'invalid_email':
-      case 'INVALID_EMAIL':
+      case KeycastRegisterFailure.invalidEmail:
         return 'Please enter a valid email address.';
-      case 'weak_password':
-        return 'Password is too weak. Please use a stronger password.';
-      case 'rate_limited':
+      case KeycastRegisterFailure.rateLimited:
         return 'Too many attempts. Please try again later.';
-      case 'server_error':
+      case KeycastRegisterFailure.server:
         return 'Server error. Please try again later.';
-      case 'connection_error':
-      case 'network_error':
+      case KeycastRegisterFailure.network:
         return 'Cannot connect to server. Please check your internet connection.';
-      default:
+      case KeycastRegisterFailure.unknown:
         // For unknown error codes, log it so we can add handling later
-        if (errorCode != null && errorCode != 'registration_failed') {
+        if (result.errorCode != null &&
+            result.errorCode != 'registration_failed') {
           Log.info(
-            'Unhandled registration error code: $errorCode',
+            'Unhandled registration error code: ${result.errorCode}',
             name: 'DivineAuthCubit',
             category: LogCategory.auth,
           );
         }
         // Fall back to server description or generic message
-        return serverDescription ?? 'Registration failed. Please try again.';
+        return result.errorDescription ??
+            'Registration failed. Please try again.';
     }
   }
 }

--- a/mobile/lib/blocs/divine_auth/divine_auth_state.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_state.dart
@@ -19,6 +19,9 @@ enum SignInFailureReason {
   /// The submitted email was malformed.
   invalidEmail,
 
+  /// Too many sign-in attempts have been made for now.
+  rateLimited,
+
   /// A network/transport problem prevented a verdict.
   network,
 

--- a/mobile/lib/screens/auth/login_options_screen.dart
+++ b/mobile/lib/screens/auth/login_options_screen.dart
@@ -563,6 +563,8 @@ String _signInErrorMessage(BuildContext context, SignInFailureReason reason) {
       return l10n.authSignInErrorEmailNotVerified;
     case SignInFailureReason.invalidEmail:
       return l10n.authSignInErrorInvalidEmail;
+    case SignInFailureReason.rateLimited:
+      return l10n.accountCredentialsRateLimited;
     case SignInFailureReason.network:
       return l10n.authSignInErrorNetwork;
     case SignInFailureReason.unknown:

--- a/mobile/lib/screens/auth/secure_account_screen.dart
+++ b/mobile/lib/screens/auth/secure_account_screen.dart
@@ -166,7 +166,8 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
       // the raw server text: sign in for the recoverable case, contact support
       // for the ones we can't resolve in-app (duplicate or credential-less
       // accounts).
-      if (result.errorCode == 'CONFLICT') {
+      if (result.errorCode == 'CONFLICT' ||
+          result.errorCode == 'EMAIL_ALREADY_EXISTS') {
         if (!mounted) return;
         setState(() {
           _hasConflict = true;

--- a/mobile/lib/screens/auth/secure_account_screen.dart
+++ b/mobile/lib/screens/auth/secure_account_screen.dart
@@ -160,14 +160,12 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
     );
 
     if (!result.success) {
-      // CONFLICT means the key or the entered email already has an account
-      // (the common case is a registered key the app forgot after falling back
-      // to anonymous). Show recovery choices in place instead of dead-ending on
-      // the raw server text: sign in for the recoverable case, contact support
-      // for the ones we can't resolve in-app (duplicate or credential-less
-      // accounts).
-      if (result.errorCode == 'CONFLICT' ||
-          result.errorCode == 'EMAIL_ALREADY_EXISTS') {
+      // A registration conflict means the key or entered email already has an
+      // account (commonly a registered key forgotten after anonymous fallback).
+      // Show recovery choices in place instead of dead-ending on raw server
+      // text: sign in for the recoverable case, or contact support for duplicate
+      // or credential-less accounts.
+      if (result.failure == KeycastRegisterFailure.emailAlreadyRegistered) {
         if (!mounted) return;
         setState(() {
           _hasConflict = true;

--- a/mobile/packages/keycast_flutter/lib/src/oauth/headless_models.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/headless_models.dart
@@ -64,6 +64,9 @@ enum KeycastLoginFailure {
   /// The submitted email was malformed (HTTP 400).
   invalidEmail,
 
+  /// Too many sign-in attempts have been made for now (HTTP 429).
+  rateLimited,
+
   /// Transport failure (timeout / no connection) before a server verdict.
   network,
 
@@ -130,6 +133,10 @@ class HeadlessLoginResult {
         return KeycastLoginFailure.emailNotVerified;
       case 'INVALID_EMAIL':
         return KeycastLoginFailure.invalidEmail;
+      case 'TOO_MANY_ATTEMPTS':
+      case 'RATE_LIMITED':
+      case 'rate_limited':
+        return KeycastLoginFailure.rateLimited;
       case 'timeout':
       case 'connection_error':
       case 'network_error':

--- a/mobile/packages/keycast_flutter/lib/src/oauth/headless_models.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/headless_models.dart
@@ -134,8 +134,6 @@ class HeadlessLoginResult {
       case 'INVALID_EMAIL':
         return KeycastLoginFailure.invalidEmail;
       case 'TOO_MANY_ATTEMPTS':
-      case 'RATE_LIMITED':
-      case 'rate_limited':
         return KeycastLoginFailure.rateLimited;
       case 'timeout':
       case 'connection_error':

--- a/mobile/packages/keycast_flutter/lib/src/oauth/headless_models.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/headless_models.dart
@@ -1,6 +1,16 @@
 // ABOUTME: Response models for headless authentication API
 // ABOUTME: Supports native login/register flows without browser redirects
 
+/// Typed classification of a failed `POST /api/headless/register`.
+enum KeycastRegisterFailure {
+  emailAlreadyRegistered,
+  invalidEmail,
+  rateLimited,
+  server,
+  network,
+  unknown,
+}
+
 /// Result from POST /api/headless/register
 class HeadlessRegisterResult {
   HeadlessRegisterResult({
@@ -41,11 +51,31 @@ class HeadlessRegisterResult {
   final String? deviceCode;
   final String? email;
 
-  /// OAuth error code (e.g., 'email_exists', 'invalid_password')
+  /// Machine-readable server or client-generated failure code.
   final String? errorCode;
 
   /// Human-readable error description from server
   final String? errorDescription;
+
+  /// Typed classification of the failure, for handling outside the client.
+  KeycastRegisterFailure get failure {
+    switch (errorCode) {
+      case 'CONFLICT':
+      case 'EMAIL_ALREADY_EXISTS':
+        return KeycastRegisterFailure.emailAlreadyRegistered;
+      case 'INVALID_EMAIL':
+        return KeycastRegisterFailure.invalidEmail;
+      case 'rate_limited':
+        return KeycastRegisterFailure.rateLimited;
+      case 'server_error':
+        return KeycastRegisterFailure.server;
+      case 'connection_error':
+      case 'network_error':
+        return KeycastRegisterFailure.network;
+      default:
+        return KeycastRegisterFailure.unknown;
+    }
+  }
 }
 
 /// Typed classification of a failed `POST /api/headless/login`.

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -526,6 +526,28 @@ class KeycastOAuth {
         );
       }
 
+      // Keycast's login handler does not emit 429 today. Anything in front of
+      // it can, and waiting is the only useful action — do not flatten it.
+      if (response.statusCode == 429) {
+        String? message;
+        try {
+          final json = jsonDecode(response.body) as Map<String, dynamic>;
+          message =
+              json['error'] as String? ??
+              json['error_description'] as String? ??
+              json['message'] as String?;
+        } catch (_) {
+          // Proxy 429s are often non-JSON; status is enough to classify.
+        }
+        return (
+          HeadlessLoginResult.error(
+            message ?? 'Too many sign-in attempts',
+            code: 'TOO_MANY_ATTEMPTS',
+          ),
+          verifier,
+        );
+      }
+
       if (response.statusCode >= 500) {
         return (
           HeadlessLoginResult.error(

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -413,6 +413,28 @@ class KeycastOAuth {
         );
       }
 
+      // Keycast's register handler does not emit 429 today. Anything in front
+      // of it can, and waiting is the only useful action — do not flatten it.
+      if (response.statusCode == 429) {
+        String? message;
+        try {
+          final json = jsonDecode(response.body) as Map<String, dynamic>;
+          message =
+              json['error'] as String? ??
+              json['error_description'] as String? ??
+              json['message'] as String?;
+        } catch (_) {
+          // Proxy 429s are often non-JSON; status is enough to classify.
+        }
+        return (
+          HeadlessRegisterResult.error(
+            message ?? 'Too many attempts. Please try again later.',
+            code: 'rate_limited',
+          ),
+          verifier,
+        );
+      }
+
       if (response.statusCode >= 500) {
         return (
           HeadlessRegisterResult.error(

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -416,19 +416,10 @@ class KeycastOAuth {
       // Keycast's register handler does not emit 429 today. Anything in front
       // of it can, and waiting is the only useful action — do not flatten it.
       if (response.statusCode == 429) {
-        String? message;
-        try {
-          final json = jsonDecode(response.body) as Map<String, dynamic>;
-          message =
-              json['error'] as String? ??
-              json['error_description'] as String? ??
-              json['message'] as String?;
-        } catch (_) {
-          // Proxy 429s are often non-JSON; status is enough to classify.
-        }
         return (
           HeadlessRegisterResult.error(
-            message ?? 'Too many attempts. Please try again later.',
+            _errorMessageFrom(response) ??
+                'Too many attempts. Please try again later.',
             code: 'rate_limited',
           ),
           verifier,
@@ -551,19 +542,9 @@ class KeycastOAuth {
       // Keycast's login handler does not emit 429 today. Anything in front of
       // it can, and waiting is the only useful action — do not flatten it.
       if (response.statusCode == 429) {
-        String? message;
-        try {
-          final json = jsonDecode(response.body) as Map<String, dynamic>;
-          message =
-              json['error'] as String? ??
-              json['error_description'] as String? ??
-              json['message'] as String?;
-        } catch (_) {
-          // Proxy 429s are often non-JSON; status is enough to classify.
-        }
         return (
           HeadlessLoginResult.error(
-            message ?? 'Too many sign-in attempts',
+            _errorMessageFrom(response) ?? 'Too many sign-in attempts',
             code: 'TOO_MANY_ATTEMPTS',
           ),
           verifier,
@@ -1029,12 +1010,13 @@ class KeycastOAuth {
     return ResendVerificationError.declined;
   }
 
-  /// The server's own `message` (falling back to `error`) from a JSON error
-  /// body, or null when the body is absent or not JSON.
+  /// The server's own message from a JSON error body, or null when absent.
   static String? _errorMessageFrom(http.Response response) {
     try {
       final json = jsonDecode(response.body) as Map<String, dynamic>;
-      return json['message'] as String? ?? json['error'] as String?;
+      return json['message'] as String? ??
+          json['error'] as String? ??
+          json['error_description'] as String?;
     } catch (_) {
       return null;
     }

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -1013,10 +1013,9 @@ class KeycastOAuth {
   /// The server's own message from a JSON error body, or null when absent.
   static String? _errorMessageFrom(http.Response response) {
     try {
-      final json = jsonDecode(response.body) as Map<String, dynamic>;
-      return json['message'] as String? ??
-          json['error'] as String? ??
-          json['error_description'] as String?;
+      final json = _decodeJsonObject(response.body);
+      final message = _responseErrorMessage(json, '');
+      return message.isEmpty ? null : message;
     } catch (_) {
       return null;
     }

--- a/mobile/packages/keycast_flutter/test/headless_models_test.dart
+++ b/mobile/packages/keycast_flutter/test/headless_models_test.dart
@@ -217,8 +217,6 @@ void main() {
           err('TOO_MANY_ATTEMPTS').failure,
           KeycastLoginFailure.rateLimited,
         );
-        expect(err('RATE_LIMITED').failure, KeycastLoginFailure.rateLimited);
-        expect(err('rate_limited').failure, KeycastLoginFailure.rateLimited);
         expect(err('timeout').failure, KeycastLoginFailure.network);
         expect(err('connection_error').failure, KeycastLoginFailure.network);
         expect(err('INTERNAL_ERROR').failure, KeycastLoginFailure.unknown);

--- a/mobile/packages/keycast_flutter/test/headless_models_test.dart
+++ b/mobile/packages/keycast_flutter/test/headless_models_test.dart
@@ -95,6 +95,40 @@ void main() {
         expect(result.errorDescription, 'Registration failed');
       });
     });
+
+    group('failure classification', () {
+      test('maps each supported code and defaults unknown', () {
+        HeadlessRegisterResult error(String code) =>
+            HeadlessRegisterResult.error('message', code: code);
+
+        expect(
+          error('CONFLICT').failure,
+          KeycastRegisterFailure.emailAlreadyRegistered,
+        );
+        expect(
+          error('EMAIL_ALREADY_EXISTS').failure,
+          KeycastRegisterFailure.emailAlreadyRegistered,
+        );
+        expect(
+          error('INVALID_EMAIL').failure,
+          KeycastRegisterFailure.invalidEmail,
+        );
+        expect(
+          error('rate_limited').failure,
+          KeycastRegisterFailure.rateLimited,
+        );
+        expect(error('server_error').failure, KeycastRegisterFailure.server);
+        expect(
+          error('connection_error').failure,
+          KeycastRegisterFailure.network,
+        );
+        expect(error('network_error').failure, KeycastRegisterFailure.network);
+        expect(
+          error('registration_failed').failure,
+          KeycastRegisterFailure.unknown,
+        );
+      });
+    });
   });
 
   group('HeadlessLoginResult', () {

--- a/mobile/packages/keycast_flutter/test/headless_models_test.dart
+++ b/mobile/packages/keycast_flutter/test/headless_models_test.dart
@@ -213,6 +213,12 @@ void main() {
           KeycastLoginFailure.emailNotVerified,
         );
         expect(err('INVALID_EMAIL').failure, KeycastLoginFailure.invalidEmail);
+        expect(
+          err('TOO_MANY_ATTEMPTS').failure,
+          KeycastLoginFailure.rateLimited,
+        );
+        expect(err('RATE_LIMITED').failure, KeycastLoginFailure.rateLimited);
+        expect(err('rate_limited').failure, KeycastLoginFailure.rateLimited);
         expect(err('timeout').failure, KeycastLoginFailure.network);
         expect(err('connection_error').failure, KeycastLoginFailure.network);
         expect(err('INTERNAL_ERROR').failure, KeycastLoginFailure.unknown);

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -538,6 +538,37 @@ void main() {
         expect(result.errorDescription, contains('500'));
       });
 
+      test('classifies a 429 without a machine code', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response(jsonEncode({'error': 'Slow down'}), 429);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final (result, _) = await oauth.headlessRegister(
+          email: 'test@example.com',
+          password: 'password123',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, 'rate_limited');
+        expect(result.errorDescription, 'Slow down');
+      });
+
+      test('classifies a non-JSON 429', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response('rate limited', 429);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final (result, _) = await oauth.headlessRegister(
+          email: 'test@example.com',
+          password: 'password123',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, 'rate_limited');
+      });
+
       test('returns error on invalid JSON response', () async {
         final mockClient = MockClient((request) async {
           return http.Response('not valid json {{{', 200);

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -788,6 +788,40 @@ void main() {
         expect(result.failure, KeycastLoginFailure.rateLimited);
       });
 
+      test('classifies a 429 without a machine code', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response(
+            jsonEncode({'error': 'Slow down'}),
+            429,
+          );
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final (result, _) = await oauth.headlessLogin(
+          email: 'test@example.com',
+          password: 'password123',
+        );
+
+        expect(result.errorCode, 'TOO_MANY_ATTEMPTS');
+        expect(result.failure, KeycastLoginFailure.rateLimited);
+        expect(result.errorDescription, 'Slow down');
+      });
+
+      test('classifies a non-JSON 429', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response('rate limited', 429);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final (result, _) = await oauth.headlessLogin(
+          email: 'test@example.com',
+          password: 'password123',
+        );
+
+        expect(result.errorCode, 'TOO_MANY_ATTEMPTS');
+        expect(result.failure, KeycastLoginFailure.rateLimited);
+      });
+
       test('returns error on SocketException', () async {
         final mockClient = MockClient((request) async {
           throw const SocketException('Connection refused');

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -541,10 +541,7 @@ void main() {
       test('classifies a 429 without a machine code', () async {
         final mockClient = MockClient((request) async {
           return http.Response(
-            jsonEncode({
-              'error': 'rate_limited',
-              'message': 'Slow down',
-            }),
+            jsonEncode({'error': 'rate_limited', 'message': 'Slow down'}),
             429,
           );
         });
@@ -828,10 +825,7 @@ void main() {
       test('classifies a 429 without a machine code', () async {
         final mockClient = MockClient((request) async {
           return http.Response(
-            jsonEncode({
-              'error': 'rate_limited',
-              'message': 'Slow down',
-            }),
+            jsonEncode({'error': 'rate_limited', 'message': 'Slow down'}),
             429,
           );
         });
@@ -883,6 +877,26 @@ void main() {
           expect(result.errorDescription, 'Slow down for a bit');
         },
       );
+
+      test('prefers error_description over an OAuth error token', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response(
+            jsonEncode({
+              'error': 'temporarily_unavailable',
+              'error_description': 'Please try again shortly',
+            }),
+            429,
+          );
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final (result, _) = await oauth.headlessLogin(
+          email: 'test@example.com',
+          password: 'password123',
+        );
+
+        expect(result.errorDescription, 'Please try again shortly');
+      });
 
       test('returns error on SocketException', () async {
         final mockClient = MockClient((request) async {

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -767,6 +767,27 @@ void main() {
         expect(result.failure, KeycastLoginFailure.invalidEmail);
       });
 
+      test('classifies TOO_MANY_ATTEMPTS 429', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response(
+            jsonEncode({
+              'code': 'TOO_MANY_ATTEMPTS',
+              'error': 'Too many sign-in attempts',
+            }),
+            429,
+          );
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final (result, _) = await oauth.headlessLogin(
+          email: 'test@example.com',
+          password: 'password123',
+        );
+
+        expect(result.errorCode, 'TOO_MANY_ATTEMPTS');
+        expect(result.failure, KeycastLoginFailure.rateLimited);
+      });
+
       test('returns error on SocketException', () async {
         final mockClient = MockClient((request) async {
           throw const SocketException('Connection refused');

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -540,7 +540,13 @@ void main() {
 
       test('classifies a 429 without a machine code', () async {
         final mockClient = MockClient((request) async {
-          return http.Response(jsonEncode({'error': 'Slow down'}), 429);
+          return http.Response(
+            jsonEncode({
+              'error': 'rate_limited',
+              'message': 'Slow down',
+            }),
+            429,
+          );
         });
 
         final oauth = KeycastOAuth(config: config, httpClient: mockClient);
@@ -822,7 +828,10 @@ void main() {
       test('classifies a 429 without a machine code', () async {
         final mockClient = MockClient((request) async {
           return http.Response(
-            jsonEncode({'error': 'Slow down'}),
+            jsonEncode({
+              'error': 'rate_limited',
+              'message': 'Slow down',
+            }),
             429,
           );
         });

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -862,6 +862,28 @@ void main() {
         expect(result.failure, KeycastLoginFailure.rateLimited);
       });
 
+      test(
+        'uses error_description when no message or error is present',
+        () async {
+          final mockClient = MockClient((request) async {
+            return http.Response(
+              jsonEncode({'error_description': 'Slow down for a bit'}),
+              429,
+            );
+          });
+
+          final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+          final (result, _) = await oauth.headlessLogin(
+            email: 'test@example.com',
+            password: 'password123',
+          );
+
+          expect(result.errorCode, 'TOO_MANY_ATTEMPTS');
+          expect(result.failure, KeycastLoginFailure.rateLimited);
+          expect(result.errorDescription, 'Slow down for a bit');
+        },
+      );
+
       test('returns error on SocketException', () async {
         final mockClient = MockClient((request) async {
           throw const SocketException('Connection refused');

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -1401,6 +1401,51 @@ void main() {
           );
 
           blocTest<DivineAuthCubit, DivineAuthState>(
+            'maps EMAIL_ALREADY_EXISTS to the same recovery as CONFLICT',
+            setUp: () {
+              when(
+                () => mockOAuth.headlessRegister(
+                  email: any(named: 'email'),
+                  password: any(named: 'password'),
+                  scope: any(named: 'scope'),
+                ),
+              ).thenAnswer(
+                (_) async => (
+                  HeadlessRegisterResult.error(
+                    'Email already registered',
+                    code: 'EMAIL_ALREADY_EXISTS',
+                  ),
+                  testVerifier,
+                ),
+              );
+            },
+            build: buildCubit,
+            seed: () => const DivineAuthFormState(
+              email: testEmail,
+              password: testPassword,
+            ),
+            act: (cubit) => cubit.submit(),
+            expect: () => [
+              const DivineAuthFormState(
+                email: testEmail,
+                password: testPassword,
+                isSubmitting: true,
+              ),
+              isA<DivineAuthFormState>()
+                  .having(
+                    (s) => s.generalError,
+                    'generalError',
+                    contains('already registered'),
+                  )
+                  .having(
+                    (s) => s.showLoginOptionsRecovery,
+                    'showLoginOptionsRecovery',
+                    isTrue,
+                  ),
+            ],
+          );
+
+          blocTest<DivineAuthCubit, DivineAuthState>(
             'maps invalid_email error code to localized message',
             setUp: () {
               when(
@@ -1415,6 +1460,45 @@ void main() {
                   HeadlessRegisterResult.error(
                     'Bad email',
                     code: 'invalid_email',
+                  ),
+                  testVerifier,
+                ),
+              );
+            },
+            build: buildCubit,
+            seed: () => const DivineAuthFormState(
+              email: testEmail,
+              password: testPassword,
+            ),
+            act: (cubit) => cubit.submit(),
+            expect: () => [
+              const DivineAuthFormState(
+                email: testEmail,
+                password: testPassword,
+                isSubmitting: true,
+              ),
+              isA<DivineAuthFormState>().having(
+                (s) => s.generalError,
+                'generalError',
+                contains('valid email'),
+              ),
+            ],
+          );
+
+          blocTest<DivineAuthCubit, DivineAuthState>(
+            'maps INVALID_EMAIL error code to localized message',
+            setUp: () {
+              when(
+                () => mockOAuth.headlessRegister(
+                  email: any(named: 'email'),
+                  password: any(named: 'password'),
+                  scope: any(named: 'scope'),
+                ),
+              ).thenAnswer(
+                (_) async => (
+                  HeadlessRegisterResult.error(
+                    'Bad email',
+                    code: 'INVALID_EMAIL',
                   ),
                   testVerifier,
                 ),

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -1358,7 +1358,7 @@ void main() {
 
         group('registration error codes', () {
           blocTest<DivineAuthCubit, DivineAuthState>(
-            'maps email_exists error code to localized message',
+            'maps CONFLICT to localized recovery',
             setUp: () {
               when(
                 () => mockOAuth.headlessRegister(
@@ -1447,46 +1447,6 @@ void main() {
           );
 
           blocTest<DivineAuthCubit, DivineAuthState>(
-            'maps invalid_email error code to localized message',
-            setUp: () {
-              when(
-                () => mockOAuth.headlessRegister(
-                  email: any(named: 'email'),
-                  password: any(named: 'password'),
-                  scope: any(named: 'scope'),
-                  marketingConsent: any(named: 'marketingConsent'),
-                ),
-              ).thenAnswer(
-                (_) async => (
-                  HeadlessRegisterResult.error(
-                    'Bad email',
-                    code: 'invalid_email',
-                  ),
-                  testVerifier,
-                ),
-              );
-            },
-            build: buildCubit,
-            seed: () => const DivineAuthFormState(
-              email: testEmail,
-              password: testPassword,
-            ),
-            act: (cubit) => cubit.submit(),
-            expect: () => [
-              const DivineAuthFormState(
-                email: testEmail,
-                password: testPassword,
-                isSubmitting: true,
-              ),
-              isA<DivineAuthFormState>().having(
-                (s) => s.generalError,
-                'generalError',
-                contains('valid email'),
-              ),
-            ],
-          );
-
-          blocTest<DivineAuthCubit, DivineAuthState>(
             'maps INVALID_EMAIL error code to localized message',
             setUp: () {
               when(
@@ -1522,43 +1482,6 @@ void main() {
                 (s) => s.generalError,
                 'generalError',
                 contains('valid email'),
-              ),
-            ],
-          );
-
-          blocTest<DivineAuthCubit, DivineAuthState>(
-            'maps weak_password error code to localized message',
-            setUp: () {
-              when(
-                () => mockOAuth.headlessRegister(
-                  email: any(named: 'email'),
-                  password: any(named: 'password'),
-                  scope: any(named: 'scope'),
-                  marketingConsent: any(named: 'marketingConsent'),
-                ),
-              ).thenAnswer(
-                (_) async => (
-                  HeadlessRegisterResult.error('Weak', code: 'weak_password'),
-                  testVerifier,
-                ),
-              );
-            },
-            build: buildCubit,
-            seed: () => const DivineAuthFormState(
-              email: testEmail,
-              password: testPassword,
-            ),
-            act: (cubit) => cubit.submit(),
-            expect: () => [
-              const DivineAuthFormState(
-                email: testEmail,
-                password: testPassword,
-                isSubmitting: true,
-              ),
-              isA<DivineAuthFormState>().having(
-                (s) => s.generalError,
-                'generalError',
-                contains('too weak'),
               ),
             ],
           );

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -807,6 +807,49 @@ void main() {
         );
 
         blocTest<DivineAuthCubit, DivineAuthState>(
+          'emits rateLimited reason on a keycast 429',
+          setUp: () {
+            when(
+              () => mockOAuth.headlessLogin(
+                email: any(named: 'email'),
+                password: any(named: 'password'),
+                scope: any(named: 'scope'),
+              ),
+            ).thenAnswer(
+              (_) async => (
+                HeadlessLoginResult(
+                  success: false,
+                  errorCode: 'TOO_MANY_ATTEMPTS',
+                  errorDescription: 'Too many sign-in attempts',
+                ),
+                testVerifier,
+              ),
+            );
+          },
+          build: buildCubit,
+          seed: () => const DivineAuthFormState(
+            email: testEmail,
+            password: testPassword,
+            isSignIn: true,
+          ),
+          act: (cubit) => cubit.submit(),
+          expect: () => [
+            const DivineAuthFormState(
+              email: testEmail,
+              password: testPassword,
+              isSignIn: true,
+              isSubmitting: true,
+            ),
+            const DivineAuthFormState(
+              email: testEmail,
+              password: testPassword,
+              isSignIn: true,
+              signInFailureReason: SignInFailureReason.rateLimited,
+            ),
+          ],
+        );
+
+        blocTest<DivineAuthCubit, DivineAuthState>(
           'emits network reason and logs description on transport failure',
           setUp: () {
             when(

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -1408,6 +1408,7 @@ void main() {
                   email: any(named: 'email'),
                   password: any(named: 'password'),
                   scope: any(named: 'scope'),
+                  marketingConsent: any(named: 'marketingConsent'),
                 ),
               ).thenAnswer(
                 (_) async => (
@@ -1493,6 +1494,7 @@ void main() {
                   email: any(named: 'email'),
                   password: any(named: 'password'),
                   scope: any(named: 'scope'),
+                  marketingConsent: any(named: 'marketingConsent'),
                 ),
               ).thenAnswer(
                 (_) async => (

--- a/mobile/test/screens/auth/login_options_screen_test.dart
+++ b/mobile/test/screens/auth/login_options_screen_test.dart
@@ -544,6 +544,54 @@ void main() {
         },
       );
 
+      testWidgets('shows localized rate-limit copy on a 429 sign in', (
+        tester,
+      ) async {
+        when(
+          () => mockOAuth.headlessLogin(
+            email: any(named: 'email'),
+            password: any(named: 'password'),
+            scope: any(named: 'scope'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            HeadlessLoginResult(
+              success: false,
+              errorCode: 'TOO_MANY_ATTEMPTS',
+              errorDescription: 'Too many sign-in attempts',
+            ),
+            'test-verifier',
+          ),
+        );
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+        await tester.enterText(
+          find.descendant(
+            of: find.widgetWithText(DivineAuthTextField, 'Email'),
+            matching: find.byType(TextField),
+          ),
+          'user@example.com',
+        );
+        await tester.enterText(
+          find.descendant(
+            of: find.widgetWithText(DivineAuthTextField, 'Password'),
+            matching: find.byType(TextField),
+          ),
+          'Password123!',
+        );
+
+        await tester.tap(find.widgetWithText(DivineButton, 'Sign in'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.text(l10n.accountCredentialsRateLimited), findsOneWidget);
+        expect(find.text('Too many sign-in attempts'), findsNothing);
+        expect(find.text(l10n.authSignInErrorGeneric), findsNothing);
+      });
+
       testWidgets(
         'tapping the options hint opens the sign-in options sheet',
         (tester) async {

--- a/mobile/test/screens/auth/secure_account_screen_test.dart
+++ b/mobile/test/screens/auth/secure_account_screen_test.dart
@@ -682,7 +682,13 @@ void main() {
     });
 
     group('Key conflict recovery', () {
-      Future<GoRouter> pumpConflict(WidgetTester tester) async {
+      Future<GoRouter> pumpConflict(
+        WidgetTester tester, {
+        String errorCode = 'CONFLICT',
+        String errorDescription =
+            'This Nostr key is already registered. '
+            'Please log in instead or use a different key.',
+      }) async {
         await setRegistrationTestSurface(tester);
         when(
           () => mockOAuth.headlessRegister(
@@ -694,9 +700,8 @@ void main() {
         ).thenAnswer(
           (_) async => (
             HeadlessRegisterResult.error(
-              'This Nostr key is already registered. '
-              'Please log in instead or use a different key.',
-              code: 'CONFLICT',
+              errorDescription,
+              code: errorCode,
             ),
             'test-verifier',
           ),
@@ -812,6 +817,25 @@ void main() {
           expect(find.textContaining('Nostr key'), findsNothing);
         },
       );
+
+      testWidgets('offers recovery for an existing email', (tester) async {
+        await pumpConflict(
+          tester,
+          errorCode: 'EMAIL_ALREADY_EXISTS',
+          errorDescription: 'Email already registered',
+        );
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        expect(
+          find.text(l10n.authSecureAccountAlreadyRegistered),
+          findsOneWidget,
+        );
+        expect(
+          find.widgetWithText(DivineButton, l10n.authSignInButton),
+          findsOneWidget,
+        );
+        expect(find.text('Email already registered'), findsNothing);
+      });
 
       testWidgets('editing the email clears the conflict for a fresh retry', (
         tester,


### PR DESCRIPTION
## Description

A 429 during sign-in used to show the same generic "something went wrong" message as any other unrecognized failure, so there was no way to tell "wait and try again" apart from a real error. Sign-up had the same blind spot: a rate-limited registration collapsed into the generic registration failure, and an email that already had an account skipped the recovery options a key conflict gets.

This change classifies an HTTP 429 by status for sign-in and registration. Sign-in shows the existing `accountCredentialsRateLimited` copy in all 22 locales instead of adding a new string, and a duplicate-email sign-up opens the same sign-in recovery as a key conflict. A wrong password and a non-existent account remain indistinguishable, so nothing here reveals whether an account exists. Change-password, change-email and key export already surface rate limits this way; sign-in was the outlier.

**Related Issue:** Closes #8444

## Inventory

Every user-facing Keycast-backed flow, what the client models today, and what stays intentionally generic. The audit was split out of #8432; the server-side attempt-limiting half remains tracked in `divinevideo/keycast#403`.

| Flow | Client distinguishes | Intentionally generic |
| --- | --- | --- |
| Sign-in | 401 credentials, 403 unverified, 400 invalid email, HTTP 429, network | 5xx, malformed and unknown responses offer retry only. 401 does not distinguish a missing account. |
| Account creation | key conflict, email already exists, invalid email, HTTP 429, network/server | Other codes keep the server description. Registration copy is still hardcoded English. `weak_password` has no Keycast producer today. |
| Verification poll | complete/pending, duplicate email, expired, temporary (429 retried), network | 429 is retried automatically and never shown. Unknown becomes a generic poll failure. |
| Email-link verification | success, duplicate email, expired, temporary, network | Opaque terminal responses use invalid-link recovery. |
| PIN verification | success/already complete, invalid, expired, locked, unavailable, duplicate email, server, network | Complete. Retry grouping is intentional where the action is the same. |
| Resend verification | success, expired registration, endpoint unavailable, other 4xx, 5xx, network | Cooldown and missing or completed registrations all return success, to avoid leaking registration state. |
| Password-reset request | accepted vs HTTP/network failure | Accepted always shows neutral "if an account exists" copy. |
| Password reset | success vs failure message | Expired and invalid tokens carry no single stable machine code. |
| Change password | wrong password, expired session, weak password, 429, 5xx, network | Server and unknown share retry copy. |
| Change email | wrong password, expired session, invalid email, 429, 5xx, network | Same, and already-registered target addresses return success by design. |
| Key export | wrong password, expired session, unverified email, no key, 429, 5xx, network | Reference for the 429-by-status behavior. Network, server and unknown share reachability copy. |
| Token exchange (after verification) | 200 token response, non-200 JSON error, network/timeout | Known limitation, recorded and not fixed: the body is decoded before the status check, so a non-JSON 429/502 reaches the generic auth-completion failure and a JSON error shows the raw server `error_description`. Retry is the only action either way, and changing it would alter session-recovery semantics. |
| Account status | 200 vs null | Null is never read as "no account". |
| Session exchange, refresh, logout | structured OAuth error; refresh distinguishes a rejected token from a network failure | Session recovery owns this path, not the sign-in failure copy. |
| Direct Keycast deletion | success, reauthentication, missing account, server, network | No production app call site; deletion runs through the separate account-deletion flow. |

## Out of Scope

- Localizing registration errors. That needs a `SignUpFailureReason` enum.
- Server-side attempt limiting. This change classifies the client response; the server half is `divinevideo/keycast#403`.
- Retry-After display.
- A password-reset token taxonomy. The expired-token path is a `success:false` 200 body with no machine code, while an invalid token is a 401.
- Token-exchange error taxonomy and its raw `error_description` exposure, recorded in the inventory above.

## Verification

- `dart format --output=none --set-exit-if-changed lib test integration_test tools`: clean (repo-wide).
- `flutter analyze lib test integration_test tools`: no issues (repo-wide, the CI analyze job).
- `flutter analyze` and `flutter test` in `mobile/packages/keycast_flutter`: clean, 323 tests passed.
- `flutter test test/blocs/divine_auth/ test/screens/auth/`: 242 tests passed.

Not run locally: the full Mobile CI test job, which is a sharded multi-command script. A plain run over `mobile/test/` was stopped at a 900 second timeout under concurrent machine load, so the full-suite signal comes from CI. The generated-files ratchets and the package's coverage workflow are CI-only.

## Type of Change

- [x] Bug fix
