### PR TITLE
chore(audio): record timing details for missing sound reports

### DIFF
--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -1717,6 +1717,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     final audioTracks = buildRenderAudioTracks(
       metaTracks: audioEvents,
       selectedSound: soundTrack,
+      logName: 'VideoEditorNotifier',
     );
 
     // Surface the resolution result so a silent export (no audio) is

--- a/mobile/lib/services/video_editor/draft_render_parameters_service.dart
+++ b/mobile/lib/services/video_editor/draft_render_parameters_service.dart
@@ -99,6 +99,7 @@ class DraftRenderParametersService {
       // timeline track, so without this the same draft publishes with music
       // from the editor and silent from the library.
       selectedSound: draft.selectedSound,
+      logName: _logName,
     );
 
     final stickers = <StickerData>[];

--- a/mobile/lib/services/video_editor/video_editor_audio_render.dart
+++ b/mobile/lib/services/video_editor/video_editor_audio_render.dart
@@ -53,12 +53,16 @@ AudioTrack? audioTrackFromSoundForRender(AudioEvent sound) {
     );
     return null;
   }
-  return audioTrackFromMetaForRender(
+  final track = audioTrackFromMetaForRender(
     sound.copyWith(
       startTime: Duration.zero,
       endTime: Duration(milliseconds: durationMs),
     ),
   );
+  if (track != null) {
+    _logPreparedTrack(track, origin: 'selected-sound fallback');
+  }
+  return track;
 }
 
 /// Builds the render [AudioTrack] for a timeline audio [track] taken from the
@@ -103,6 +107,26 @@ AudioTrack? audioTrackFromMetaForRender(AudioEvent track) {
   );
 }
 
+/// Records the timing boundary between editor state and render parameters.
+///
+/// Source paths and URLs are deliberately omitted: local paths can contain
+/// user-identifying directory names, while the timing fields are sufficient
+/// to distinguish source-offset failures from composition-placement failures.
+void _logPreparedTrack(AudioTrack track, {required String origin}) {
+  Log.info(
+    'Prepared $origin audio track ${track.id}: '
+    'composition=[${_durationMs(track.startTime)}, '
+    '${_durationMs(track.endTime)}], '
+    'source=[${_durationMs(track.audioStartTime)}, '
+    '${_durationMs(track.audioEndTime)}]',
+    name: _logName,
+    category: LogCategory.video,
+  );
+}
+
+String _durationMs(Duration? duration) =>
+    duration == null ? 'unbounded' : '${duration.inMilliseconds}ms';
+
 /// Builds the render audio tracks for a session from its timeline
 /// [metaTracks], falling back to the recorder's [selectedSound].
 ///
@@ -119,11 +143,20 @@ AudioTrack? audioTrackFromMetaForRender(AudioEvent track) {
 List<AudioTrack> buildRenderAudioTracks({
   required List<AudioEvent> metaTracks,
   required AudioEvent? selectedSound,
-}) => [
-  for (final track in metaTracks) ?audioTrackFromMetaForRender(track),
-  if (metaTracks.isEmpty && selectedSound != null)
-    ?audioTrackFromSoundForRender(selectedSound),
-];
+}) {
+  final tracks = <AudioTrack>[];
+  for (final event in metaTracks) {
+    final track = audioTrackFromMetaForRender(event);
+    if (track == null) continue;
+    _logPreparedTrack(track, origin: 'timeline');
+    tracks.add(track);
+  }
+  if (metaTracks.isEmpty && selectedSound != null) {
+    final track = audioTrackFromSoundForRender(selectedSound);
+    if (track != null) tracks.add(track);
+  }
+  return tracks;
+}
 
 /// Clamps an audio composition window so it cannot extend past [videoDuration],
 /// or returns `null` when the window lies entirely past the video and the track
@@ -190,16 +223,24 @@ Future<List<VideoAudioTrack>> resolveRenderAudioTracks(
         continue;
       }
       final (:startTime, :endTime) = window;
-      audioTracks.add(
-        VideoAudioTrack(
-          path: audioPath,
-          startTime: startTime,
-          endTime: endTime,
-          audioStartTime: track.audioStartTime,
-          audioEndTime: track.audioEndTime,
-          loop: track.loop,
-          volume: track.volume,
-        ),
+      final resolvedTrack = VideoAudioTrack(
+        path: audioPath,
+        startTime: startTime,
+        endTime: endTime,
+        audioStartTime: track.audioStartTime,
+        audioEndTime: track.audioEndTime,
+        loop: track.loop,
+        volume: track.volume,
+      );
+      audioTracks.add(resolvedTrack);
+      Log.info(
+        'Resolved audio track ${track.id} for mux: '
+        'composition=[${_durationMs(startTime)}, ${_durationMs(endTime)}], '
+        'source=[${_durationMs(track.audioStartTime)}, '
+        '${_durationMs(track.audioEndTime)}], '
+        'videoDuration=${_durationMs(videoDuration)}',
+        name: logName,
+        category: LogCategory.video,
       );
     } catch (e, stackTrace) {
       Log.error(

--- a/mobile/lib/services/video_editor/video_editor_audio_render.dart
+++ b/mobile/lib/services/video_editor/video_editor_audio_render.dart
@@ -59,9 +59,6 @@ AudioTrack? audioTrackFromSoundForRender(AudioEvent sound) {
       endTime: Duration(milliseconds: durationMs),
     ),
   );
-  if (track != null) {
-    _logPreparedTrack(track, origin: 'selected-sound fallback');
-  }
   return track;
 }
 
@@ -112,14 +109,18 @@ AudioTrack? audioTrackFromMetaForRender(AudioEvent track) {
 /// Source paths and URLs are deliberately omitted: local paths can contain
 /// user-identifying directory names, while the timing fields are sufficient
 /// to distinguish source-offset failures from composition-placement failures.
-void _logPreparedTrack(AudioTrack track, {required String origin}) {
-  Log.info(
+void _logPreparedTrack(
+  AudioTrack track, {
+  required String origin,
+  required String logName,
+}) {
+  Log.warning(
     'Prepared $origin audio track ${track.id}: '
     'composition=[${_durationMs(track.startTime)}, '
     '${_durationMs(track.endTime)}], '
     'source=[${_durationMs(track.audioStartTime)}, '
     '${_durationMs(track.audioEndTime)}]',
-    name: _logName,
+    name: logName,
     category: LogCategory.video,
   );
 }
@@ -143,17 +144,25 @@ String _durationMs(Duration? duration) =>
 List<AudioTrack> buildRenderAudioTracks({
   required List<AudioEvent> metaTracks,
   required AudioEvent? selectedSound,
+  required String logName,
 }) {
   final tracks = <AudioTrack>[];
   for (final event in metaTracks) {
     final track = audioTrackFromMetaForRender(event);
     if (track == null) continue;
-    _logPreparedTrack(track, origin: 'timeline');
+    _logPreparedTrack(track, origin: 'timeline', logName: logName);
     tracks.add(track);
   }
   if (metaTracks.isEmpty && selectedSound != null) {
     final track = audioTrackFromSoundForRender(selectedSound);
-    if (track != null) tracks.add(track);
+    if (track != null) {
+      _logPreparedTrack(
+        track,
+        origin: 'selected-sound fallback',
+        logName: logName,
+      );
+      tracks.add(track);
+    }
   }
   return tracks;
 }
@@ -233,11 +242,12 @@ Future<List<VideoAudioTrack>> resolveRenderAudioTracks(
         volume: track.volume,
       );
       audioTracks.add(resolvedTrack);
-      Log.info(
+      Log.warning(
         'Resolved audio track ${track.id} for mux: '
-        'composition=[${_durationMs(startTime)}, ${_durationMs(endTime)}], '
-        'source=[${_durationMs(track.audioStartTime)}, '
-        '${_durationMs(track.audioEndTime)}], '
+        'composition=[${_durationMs(resolvedTrack.startTime)}, '
+        '${_durationMs(resolvedTrack.endTime)}], '
+        'source=[${_durationMs(resolvedTrack.audioStartTime)}, '
+        '${_durationMs(resolvedTrack.audioEndTime)}], '
         'videoDuration=${_durationMs(videoDuration)}',
         name: logName,
         category: LogCategory.video,

--- a/mobile/test/services/video_editor/draft_render_parameters_service_test.dart
+++ b/mobile/test/services/video_editor/draft_render_parameters_service_test.dart
@@ -144,6 +144,15 @@ void main() {
 
         expect(parameters!.audioTracks, hasLength(1));
         expect(parameters.audioTracks.single.id, equals('sound-1'));
+        expect(parameters.audioTracks.single.startTime, Duration.zero);
+        expect(
+          parameters.audioTracks.single.endTime,
+          const Duration(seconds: 6),
+        );
+        expect(
+          parameters.audioTracks.single.audioStartTime,
+          Duration.zero,
+        );
       },
     );
 

--- a/mobile/test/services/video_editor/video_editor_audio_render_test.dart
+++ b/mobile/test/services/video_editor/video_editor_audio_render_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Unit tests for resolveRenderAudioTracks.
-// ABOUTME: Covers resolution, per-track skip-on-failure, and empty fallback.
+// ABOUTME: Unit tests for building and resolving render audio tracks.
+// ABOUTME: Covers timing, diagnostics, skip-on-failure, and empty fallback.
 
 import 'dart:io';
 
@@ -56,6 +56,15 @@ AudioTrack _unresolvableTrack(String id) {
 }
 
 void main() {
+  late LogCaptureService capture;
+
+  setUp(() async {
+    capture = LogCaptureService();
+    await capture.clearAllLogs();
+  });
+
+  tearDown(() => capture.clearAllLogs());
+
   group('buildRenderAudioTracks', () {
     AudioEvent sound({
       Duration startOffset = Duration.zero,
@@ -81,12 +90,17 @@ void main() {
           startTime: const Duration(milliseconds: 1300),
           endTime: const Duration(seconds: 20),
         ),
+        logName: 'recorder-render',
       );
 
       expect(tracks, hasLength(1));
       expect(tracks.single.startTime, Duration.zero);
       expect(tracks.single.endTime, const Duration(seconds: 30));
       expect(tracks.single.audioStartTime, const Duration(seconds: 12));
+      final log = capture.getRecentLogs(limit: 1).single;
+      expect(log.name, 'recorder-render');
+      expect(log.level, LogLevel.warning);
+      expect(log.message, contains('Prepared selected-sound fallback'));
     });
 
     test('timeline timing wins over the recorder-selected fallback', () {
@@ -98,12 +112,17 @@ void main() {
           ),
         ],
         selectedSound: sound(startOffset: const Duration(seconds: 12)),
+        logName: 'timeline-render',
       );
 
       expect(tracks, hasLength(1));
       expect(tracks.single.startTime, const Duration(milliseconds: 1300));
       expect(tracks.single.endTime, const Duration(seconds: 20));
       expect(tracks.single.audioStartTime, Duration.zero);
+      final log = capture.getRecentLogs(limit: 1).single;
+      expect(log.name, 'timeline-render');
+      expect(log.level, LogLevel.warning);
+      expect(log.message, contains('Prepared timeline'));
     });
   });
 
@@ -200,6 +219,7 @@ void main() {
           duration: 30,
           startOffset: const Duration(seconds: 12),
         ),
+        logName: 'test',
       );
 
       final result = await resolveRenderAudioTracks(
@@ -217,9 +237,6 @@ void main() {
     test(
       'captures resolved timing without exposing the local source path',
       () async {
-        final capture = LogCaptureService();
-        await capture.clearAllLogs();
-
         await resolveRenderAudioTracks(
           [
             _fileTrack(
@@ -237,6 +254,7 @@ void main() {
 
         final log = capture.getRecentLogs(limit: 1).single;
         expect(log.name, 'test-audio-render');
+        expect(log.level, LogLevel.warning);
         expect(log.category, LogCategory.video);
         expect(
           log.message,

--- a/mobile/test/services/video_editor/video_editor_audio_render_test.dart
+++ b/mobile/test/services/video_editor/video_editor_audio_render_test.dart
@@ -4,8 +4,10 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
 import 'package:openvine/services/video_editor/video_editor_audio_render.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 /// An [EditorAudio] whose [safeFilePath] always fails, standing in for a track
 /// whose source cannot be resolved (e.g. a failed network download).
@@ -54,6 +56,57 @@ AudioTrack _unresolvableTrack(String id) {
 }
 
 void main() {
+  group('buildRenderAudioTracks', () {
+    AudioEvent sound({
+      Duration startOffset = Duration.zero,
+      Duration startTime = Duration.zero,
+      Duration? endTime,
+    }) => AudioEvent(
+      id: 'selected-sound',
+      pubkey: 'a' * 64,
+      createdAt: 1735689600,
+      url: '/tmp/selected-sound.mp3',
+      duration: 30,
+      startOffset: startOffset,
+      startTime: startTime,
+      endTime: endTime,
+    );
+
+    test('recorder-selected sound starts at composition zero while preserving '
+        'the chosen source offset', () {
+      final tracks = buildRenderAudioTracks(
+        metaTracks: const [],
+        selectedSound: sound(
+          startOffset: const Duration(seconds: 12),
+          startTime: const Duration(milliseconds: 1300),
+          endTime: const Duration(seconds: 20),
+        ),
+      );
+
+      expect(tracks, hasLength(1));
+      expect(tracks.single.startTime, Duration.zero);
+      expect(tracks.single.endTime, const Duration(seconds: 30));
+      expect(tracks.single.audioStartTime, const Duration(seconds: 12));
+    });
+
+    test('timeline timing wins over the recorder-selected fallback', () {
+      final tracks = buildRenderAudioTracks(
+        metaTracks: [
+          sound(
+            startTime: const Duration(milliseconds: 1300),
+            endTime: const Duration(seconds: 20),
+          ),
+        ],
+        selectedSound: sound(startOffset: const Duration(seconds: 12)),
+      );
+
+      expect(tracks, hasLength(1));
+      expect(tracks.single.startTime, const Duration(milliseconds: 1300));
+      expect(tracks.single.endTime, const Duration(seconds: 20));
+      expect(tracks.single.audioStartTime, Duration.zero);
+    });
+  });
+
   group('resolveRenderAudioTracks', () {
     test('returns an empty list for empty input', () async {
       final result = await resolveRenderAudioTracks(
@@ -132,6 +185,67 @@ void main() {
 
         expect(result.single.startTime, equals(Duration.zero));
         expect(result.single.endTime, equals(const Duration(seconds: 1)));
+      },
+    );
+
+    test('keeps source offset separate from composition placement for a short '
+        'stop-motion render', () async {
+      final built = buildRenderAudioTracks(
+        metaTracks: const [],
+        selectedSound: AudioEvent(
+          id: 'stop-motion-sound',
+          pubkey: 'b' * 64,
+          createdAt: 1735689600,
+          url: '/tmp/stop-motion-sound.mp3',
+          duration: 30,
+          startOffset: const Duration(seconds: 12),
+        ),
+      );
+
+      final result = await resolveRenderAudioTracks(
+        built,
+        logName: 'test',
+        videoDuration: const Duration(milliseconds: 1400),
+      );
+
+      expect(result, hasLength(1));
+      expect(result.single.startTime, Duration.zero);
+      expect(result.single.endTime, const Duration(milliseconds: 1400));
+      expect(result.single.audioStartTime, const Duration(seconds: 12));
+    });
+
+    test(
+      'captures resolved timing without exposing the local source path',
+      () async {
+        final capture = LogCaptureService();
+        await capture.clearAllLogs();
+
+        await resolveRenderAudioTracks(
+          [
+            _fileTrack(
+              id: 'diagnostic-track',
+              path: '/private/user-name/selected-sound.mp3',
+              startTime: Duration.zero,
+              endTime: const Duration(seconds: 30),
+              audioStartTime: const Duration(seconds: 12),
+              audioEndTime: const Duration(seconds: 20),
+            ),
+          ],
+          logName: 'test-audio-render',
+          videoDuration: const Duration(milliseconds: 1400),
+        );
+
+        final log = capture.getRecentLogs(limit: 1).single;
+        expect(log.name, 'test-audio-render');
+        expect(log.category, LogCategory.video);
+        expect(
+          log.message,
+          contains(
+            'composition=[0ms, 1400ms], source=[12000ms, 20000ms], '
+            'videoDuration=1400ms',
+          ),
+        );
+        expect(log.message, isNot(contains('/private/user-name')));
       },
     );
 


### PR DESCRIPTION
## Problem

A published video can contain an audio track while still sounding silent, and current support logs only explain why requested audio was dropped. They do not record whether a successful track came from recorder-selected sound state or editor timeline state, nor do they show the source and composition windows handed to the muxer. That leaves source-offset and composition-placement failures indistinguishable after publication.

## Why this change

This records the authoring path and both timing axes when an audio track is prepared, then records the final clamped window handed to the muxer. Local paths and source URLs are deliberately omitted because timing is sufficient for diagnosis and filesystem paths may contain user-identifying data.

The tests pin the existing intended behavior: recorder-selected sound starts at composition zero, preserves its chosen source offset, and clamps to a short stop-motion output without moving that source offset onto the composition axis. Draft restoration is covered too.

## Deliberately unchanged

This does not guess at the remaining cause of #9098, re-anchor late timeline audio, impose a minimum coverage threshold, or change transition timing. Late short windows remain valid for sound effects and voiceovers. The added evidence will distinguish the next reproduction at the render boundary.

## Verification

- `flutter test test/services/video_editor/video_editor_audio_render_test.dart test/services/video_editor/draft_render_parameters_service_test.dart`
- `flutter test test/services/video_editor` (381 tests)
- `flutter analyze lib test integration_test tools`
- repository pre-push checks

Refs #9098