### PR TITLE
fix(account): keep saved account caches warm when switching

### DIFF
--- a/mobile/lib/services/relay_discovery_service.dart
+++ b/mobile/lib/services/relay_discovery_service.dart
@@ -164,6 +164,9 @@ class RelayDiscoveryService {
   static const String _cachePrefix = 'relay_discovery_';
   static const Duration _cacheExpiry = Duration(hours: 24);
 
+  /// SharedPreferences key for the relay-discovery cache owned by [npub].
+  static String cacheStorageKey(String npub) => '$_cachePrefix$npub';
+
   /// Discover relay list for a given npub.
   ///
   /// Steps:
@@ -580,7 +583,7 @@ class RelayDiscoveryService {
   Future<void> _cacheRelays(String npub, List<DiscoveredRelay> relays) async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      final cacheKey = '$_cachePrefix$npub';
+      final cacheKey = cacheStorageKey(npub);
 
       final cacheData = {
         'relays': relays.map((r) => r.toJson()).toList(),
@@ -601,7 +604,7 @@ class RelayDiscoveryService {
   Future<List<DiscoveredRelay>?> _getCachedRelays(String npub) async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      final cacheKey = '$_cachePrefix$npub';
+      final cacheKey = cacheStorageKey(npub);
 
       final cacheJson = prefs.getString(cacheKey);
       if (cacheJson == null) return null;
@@ -641,7 +644,7 @@ class RelayDiscoveryService {
   Future<void> clearCache(String npub) async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      final cacheKey = '$_cachePrefix$npub';
+      final cacheKey = cacheStorageKey(npub);
       await prefs.remove(cacheKey);
     } catch (e) {
       Log.warning(

--- a/mobile/lib/services/user_data_cleanup_service.dart
+++ b/mobile/lib/services/user_data_cleanup_service.dart
@@ -3,12 +3,14 @@
 
 import 'package:bookmarks_repository/bookmarks_repository.dart';
 import 'package:creator_sync/creator_sync.dart';
+import 'package:follow_repository/follow_repository.dart';
 import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
 import 'package:openvine/blocs/dm/conversation_mute/conversation_mute_cubit.dart';
 import 'package:openvine/constants/terms_acceptance_keys.dart';
 import 'package:openvine/services/account_label_service.dart';
 import 'package:openvine/services/age_verification_service.dart';
 import 'package:openvine/services/audio_sharing_preference_service.dart';
+import 'package:openvine/services/auth/following_prefetch_marker.dart';
 import 'package:openvine/services/content_deletion_service.dart';
 import 'package:openvine/services/content_filter_service.dart';
 import 'package:openvine/services/content_reporting_service.dart';
@@ -17,6 +19,7 @@ import 'package:openvine/services/curated_list_service.dart';
 import 'package:openvine/services/divine_host_filter_service.dart';
 import 'package:openvine/services/language_preference_service.dart';
 import 'package:openvine/services/moderation_label_service.dart';
+import 'package:openvine/services/relay_discovery_service.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:openvine/services/seen_videos_service.dart';
 import 'package:openvine/services/sound_library_service.dart';
@@ -115,10 +118,11 @@ class UserDataCleanupService {
 
   static const String legacyDraftOwnerKey = 'vine_drafts_owner_pubkey_hex';
 
-  /// Key prefixes for dynamic user-specific data (keys that embed pubkey/npub).
-  /// Only cleared on identity change (different user), NOT on same-user logout.
-  /// These caches are keyed by pubkey so they can't leak between users, and the
-  /// redirect logic needs following_list_ at login time before relay responds.
+  /// Classified dynamic cache prefixes whose keys embed their account owner.
+  ///
+  /// The preference-key guard reads this list by name. Cleanup preserves these
+  /// families during identity changes because their scope prevents cross-user
+  /// leakage. Targeted destructive removal uses each owner's key helper.
   static const List<String> identityChangePrefixes = [
     'following_list_', // follow cache per pubkey
     'following_prefetch_complete_', // successful auth prefetch per pubkey
@@ -228,9 +232,9 @@ class UserDataCleanupService {
     for (final key in AgeVerificationService.accountKeys(userPubkey)) {
       await remove(key);
     }
-    await remove('following_list_$userPubkey');
-    await remove('following_prefetch_complete_$userPubkey');
-    await remove('relay_discovery_$userNpub');
+    await remove(FollowingCacheRecord.storageKey(userPubkey));
+    await remove(followingPrefetchMarkerKey(userPubkey));
+    await remove(RelayDiscoveryService.cacheStorageKey(userNpub));
 
     await onDatabaseCleanup?.call(
       userPubkey: userPubkey,
@@ -249,10 +253,8 @@ class UserDataCleanupService {
   /// Returns the number of keys that were cleared for tracking purposes.
   /// Clears user-specific data from SharedPreferences.
   ///
-  /// When [isIdentityChange] is true (different user logging in), also clears
-  /// dynamic pubkey-keyed caches (following_list_, relay/blossom discovery).
-  /// On same-user logout these are preserved so the redirect logic can use them
-  /// at login time before relay data is available.
+  /// Account-scoped caches are preserved across identity changes. Destructive
+  /// cleanup removes only the known account's pubkey-scoped entries.
   Future<int> clearUserSpecificData({
     String? reason,
     bool isIdentityChange = false,
@@ -265,8 +267,7 @@ class UserDataCleanupService {
       'identityChange: $isIdentityChange, '
       'deleteUserData: $deleteUserData, '
       'userPubkey: ${pubkeyForLogs(userPubkey, whenNull: "null")}, '
-      'checking ${userSpecificKeys.length} keys'
-      '${isIdentityChange ? ' + ${identityChangePrefixes.length} prefixes' : ''})',
+      'checking ${userSpecificKeys.length} keys)',
       name: 'UserDataCleanupService',
       category: LogCategory.auth,
     );
@@ -336,6 +337,17 @@ class UserDataCleanupService {
           clearedKeys.add(key);
         }
       }
+
+      for (final key in [
+        FollowingCacheRecord.storageKey(userPubkey),
+        followingPrefetchMarkerKey(userPubkey),
+      ]) {
+        if (_prefs.containsKey(key)) {
+          await _prefs.remove(key);
+          clearedCount++;
+          clearedKeys.add(key);
+        }
+      }
     }
 
     // Clear user-specific database tables (DMs, conversations, notifications,
@@ -364,23 +376,6 @@ class UserDataCleanupService {
         // best-effort unless it is explicitly destructive.
         if (deleteUserData || isIdentityChange) {
           rethrow;
-        }
-      }
-    }
-
-    // Clear prefix-matched dynamic keys only on identity change
-    // These are keyed by pubkey so they can't leak, and the redirect
-    // logic needs following_list_ at login time before relay responds
-    if (isIdentityChange) {
-      final allKeys = _prefs.getKeys();
-      for (final key in allKeys) {
-        for (final prefix in identityChangePrefixes) {
-          if (key.startsWith(prefix)) {
-            await _prefs.remove(key);
-            clearedCount++;
-            clearedKeys.add(key);
-            break;
-          }
         }
       }
     }

--- a/mobile/test/services/auth_service_create_anonymous_test.dart
+++ b/mobile/test/services/auth_service_create_anonymous_test.dart
@@ -83,19 +83,12 @@ void main() {
       expect(prefetchCalls, 0);
     });
 
-    test('createAnonymousAccount keeps its marker when a real '
-        'UserDataCleanupService sweeps the outgoing account', () async {
+    test('createAnonymousAccount preserves both account markers with a real '
+        'UserDataCleanupService', () async {
       // The mocked cleanup service above answers shouldClearDataForUser with
-      // false, so it can never sweep following_prefetch_complete_ keys. That
-      // sweep is the one thing standing between the marker and the pre-fetch
-      // it exists to skip, so drive the real collaborator through the state
-      // that triggers it: another account is still the stored identity, which
-      // is what an account switch leaves behind.
-      //
-      // Signing out first does not reproduce it — that clears
-      // current_user_pubkey_hex, so the incoming account reads as the same
-      // identity and nothing is swept. The marker has to be written after the
-      // sweep, and only this shape can tell whether it is.
+      // false, so use the real collaborator and leave the first account stored
+      // while creating the second. Both pubkey-scoped markers must survive the
+      // identity change so either account can skip prefetch when restored.
       final prefs = await SharedPreferences.getInstance();
       var prefetchCalls = 0;
       final first = buildTestAuthService(
@@ -118,8 +111,8 @@ void main() {
       expect(secondPubkey, isNot(equals(firstPubkey)));
       expect(
         hasFollowingPrefetchMarker(prefs, firstPubkey),
-        isFalse,
-        reason: 'the outgoing account must still be swept',
+        isTrue,
+        reason: 'the outgoing account marker remains safely pubkey-scoped',
       );
       expect(hasFollowingPrefetchMarker(prefs, secondPubkey), isTrue);
       expect(prefetchCalls, 0);

--- a/mobile/test/services/auth_service_identity_change_preservation_test.dart
+++ b/mobile/test/services/auth_service_identity_change_preservation_test.dart
@@ -191,30 +191,27 @@ void main() {
       },
     );
 
-    test(
-      'identity-change cleanup passes old pubkey as userPubkey',
-      () async {
-        // Ensure the old pubkey is correctly threaded through even when
-        // we are signing in as the new user.
-        await _ignoringDiscoveryErrors(authService.createNewIdentity);
+    test('identity-change cleanup passes old pubkey as userPubkey', () async {
+      // Ensure the old pubkey is correctly threaded through even when
+      // we are signing in as the new user.
+      await _ignoringDiscoveryErrors(authService.createNewIdentity);
 
-        final captured = verify(
-          () => mockCleanupService.clearUserSpecificData(
-            reason: 'identity_change',
-            isIdentityChange: true,
-            userPubkey: captureAny(named: 'userPubkey'),
-            // Explicit false is the identity-preservation regression guard.
-            // ignore: avoid_redundant_argument_values
-            deleteUserData: false, // regression guard: must NOT be true
-          ),
-        ).captured;
+      final captured = verify(
+        () => mockCleanupService.clearUserSpecificData(
+          reason: 'identity_change',
+          isIdentityChange: true,
+          userPubkey: captureAny(named: 'userPubkey'),
+          // Explicit false is the identity-preservation regression guard.
+          // ignore: avoid_redundant_argument_values
+          deleteUserData: false, // regression guard: must NOT be true
+        ),
+      ).captured;
 
-        // The old pubkey from SharedPreferences must be forwarded so
-        // per-user cache keys can be scoped correctly even though we do
-        // not delete the underlying data.
-        expect(captured.single, equals(oldPubkeyHex));
-      },
-    );
+      // The old pubkey from SharedPreferences must be forwarded so
+      // per-user cache keys can be scoped correctly even though we do
+      // not delete the underlying data.
+      expect(captured.single, equals(oldPubkeyHex));
+    });
 
     test(
       'remove-device signOut (deleteKeys: true) preserves user data by default',
@@ -311,27 +308,23 @@ void main() {
       },
     );
 
-    test(
-      'identity-change: isIdentityChange=true is still passed '
-      'so prefix-keyed caches are cleared',
-      () async {
-        // Prefix-keyed caches (following_list_, relay_discovery_, DM
-        // cursors) are not owner-scoped and can leak across accounts.
-        // They must still be cleared on identity change even though
-        // per-user DAO rows are preserved.
-        await _ignoringDiscoveryErrors(authService.createNewIdentity);
+    test('identity-change: isIdentityChange=true is still passed '
+        'so legacy and database cleanup stays fail-closed', () async {
+      // The identity-change flag still guards legacy unscoped state and
+      // makes database cleanup errors abort the account transition. Scoped
+      // following and relay caches are preserved independently.
+      await _ignoringDiscoveryErrors(authService.createNewIdentity);
 
-        verify(
-          () => mockCleanupService.clearUserSpecificData(
-            reason: 'identity_change',
-            isIdentityChange: true, // must still be true
-            userPubkey: any(named: 'userPubkey'),
-            // Explicit false is the identity-preservation regression guard.
-            // ignore: avoid_redundant_argument_values
-            deleteUserData: false, // regression guard: must NOT be true
-          ),
-        ).called(1);
-      },
-    );
+      verify(
+        () => mockCleanupService.clearUserSpecificData(
+          reason: 'identity_change',
+          isIdentityChange: true, // must still be true
+          userPubkey: any(named: 'userPubkey'),
+          // Explicit false is the identity-preservation regression guard.
+          // ignore: avoid_redundant_argument_values
+          deleteUserData: false, // regression guard: must NOT be true
+        ),
+      ).called(1);
+    });
   });
 }

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -2313,6 +2313,42 @@ void main() {
       });
     }
 
+    test('account switch uses the incoming account following cache', () async {
+      const previousPubkey =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      final incomingPubkey = testKeyContainer.publicKeyHex;
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'automatic',
+        'current_user_pubkey_hex': previousPubkey,
+        'following_list_$previousPubkey': jsonEncode(['previous-follow']),
+        'following_list_$incomingPubkey': jsonEncode(['incoming-follow']),
+        kKnownAccountsKey: '[]',
+      });
+      final prefs = await SharedPreferences.getInstance();
+      var prefetchCalls = 0;
+      authService = AuthService(
+        backgroundActivityManager: BackgroundActivityManager(),
+        userDataCleanupService: UserDataCleanupService(prefs),
+        keyStorage: mockKeyStorage,
+        flutterSecureStorage: mockSecureStorage,
+        preFetchFollowing: (_) async {
+          prefetchCalls++;
+        },
+      );
+
+      when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => true);
+      when(
+        () => mockKeyStorage.getKeyContainer(),
+      ).thenAnswer((_) async => testKeyContainer);
+
+      await _ignoringDiscoveryErrors(authService.initialize);
+
+      expect(authService.authState, AuthState.authenticated);
+      expect(prefetchCalls, 0);
+      expect(prefs.containsKey('following_list_$previousPubkey'), isTrue);
+      expect(prefs.containsKey('following_list_$incomingPubkey'), isTrue);
+    });
+
     test('prefetches following after publishing authenticated state', () async {
       final prefetchedPubkeys = <String>[];
       final prefetchStarted = Completer<void>();
@@ -2462,37 +2498,34 @@ void main() {
       ('Bunker', 'bunker_info'),
       ('OAuth', 'keycast_session'),
     ]) {
-      test(
-        'account deletion reports $signer archive cleanup failure after '
-        'teardown',
-        () async {
-          SharedPreferences.setMockInitialValues({
-            'authentication_source': AuthenticationSource.automatic.code,
-            kKnownAccountsKey: jsonEncode([
-              KnownAccount(
-                pubkeyHex: testKeyContainer.publicKeyHex,
-                authSource: AuthenticationSource.automatic,
-                addedAt: DateTime.now(),
-                lastUsedAt: DateTime.now(),
-              ).toJson(),
-            ]),
-          });
-          authService.debugSetCurrentKeyContainer(testKeyContainer);
-          final archiveKey =
-              '${archiveKeyPrefix}_${testKeyContainer.publicKeyHex}';
-          when(
-            () => mockSecureStorage.delete(key: archiveKey),
-          ).thenThrow(StateError('keychain unavailable'));
+      test('account deletion reports $signer archive cleanup failure after '
+          'teardown', () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': AuthenticationSource.automatic.code,
+          kKnownAccountsKey: jsonEncode([
+            KnownAccount(
+              pubkeyHex: testKeyContainer.publicKeyHex,
+              authSource: AuthenticationSource.automatic,
+              addedAt: DateTime.now(),
+              lastUsedAt: DateTime.now(),
+            ).toJson(),
+          ]),
+        });
+        authService.debugSetCurrentKeyContainer(testKeyContainer);
+        final archiveKey =
+            '${archiveKeyPrefix}_${testKeyContainer.publicKeyHex}';
+        when(
+          () => mockSecureStorage.delete(key: archiveKey),
+        ).thenThrow(StateError('keychain unavailable'));
 
-          await expectLater(
-            authService.signOut(deleteKeys: true, deleteLocalUserData: true),
-            throwsA(isA<SecureKeyStorageException>()),
-          );
+        await expectLater(
+          authService.signOut(deleteKeys: true, deleteLocalUserData: true),
+          throwsA(isA<SecureKeyStorageException>()),
+        );
 
-          verify(() => mockSecureStorage.delete(key: archiveKey)).called(1);
-          expect(authService.authState, AuthState.unauthenticated);
-        },
-      );
+        verify(() => mockSecureStorage.delete(key: archiveKey)).called(1);
+        expect(authService.authState, AuthState.unauthenticated);
+      });
     }
 
     test('named local deletion works after sign-out and preserves another '
@@ -2551,10 +2584,7 @@ void main() {
       final remaining =
           jsonDecode(prefs.getString(kKnownAccountsKey)!) as List<dynamic>;
       expect(remaining, hasLength(1));
-      expect(
-        remaining.single['pubkeyHex'],
-        remainingAccount.publicKeyHex,
-      );
+      expect(remaining.single['pubkeyHex'], remainingAccount.publicKeyHex);
     });
 
     test('named local deletion preserves an active account session', () async {

--- a/mobile/test/services/user_data_cleanup_service_test.dart
+++ b/mobile/test/services/user_data_cleanup_service_test.dart
@@ -93,35 +93,26 @@ void main() {
         },
       );
 
-      test(
-        'keeps preserved legacy drafts for same-user re-login',
-        () async {
-          const pubkey = 'same_user_pubkey';
-          await prefs.setString('vine_drafts', '[{"id":"draft1"}]');
-          await service.markOwnerScopedLegacyDataForUser(pubkey);
+      test('keeps preserved legacy drafts for same-user re-login', () async {
+        const pubkey = 'same_user_pubkey';
+        await prefs.setString('vine_drafts', '[{"id":"draft1"}]');
+        await service.markOwnerScopedLegacyDataForUser(pubkey);
 
-          expect(service.shouldClearDataForUser(pubkey), isFalse);
-        },
-      );
+        expect(service.shouldClearDataForUser(pubkey), isFalse);
+      });
 
-      test(
-        'clears preserved legacy drafts for a different user',
-        () async {
-          await prefs.setString('vine_drafts', '[{"id":"draft1"}]');
-          await service.markOwnerScopedLegacyDataForUser('old_user_pubkey');
+      test('clears preserved legacy drafts for a different user', () async {
+        await prefs.setString('vine_drafts', '[{"id":"draft1"}]');
+        await service.markOwnerScopedLegacyDataForUser('old_user_pubkey');
 
-          expect(service.shouldClearDataForUser('new_user_pubkey'), isTrue);
-        },
-      );
+        expect(service.shouldClearDataForUser('new_user_pubkey'), isTrue);
+      });
 
-      test(
-        'clears unmarked legacy drafts as orphaned data',
-        () async {
-          await prefs.setString('vine_drafts', '[{"id":"draft1"}]');
+      test('clears unmarked legacy drafts as orphaned data', () async {
+        await prefs.setString('vine_drafts', '[{"id":"draft1"}]');
 
-          expect(service.shouldClearDataForUser('any_pubkey'), isTrue);
-        },
-      );
+        expect(service.shouldClearDataForUser('any_pubkey'), isTrue);
+      });
     });
 
     group('clearUserSpecificData', () {
@@ -131,10 +122,7 @@ void main() {
       test('destructive delete purges only that account verification', () async {
         const otherPubkey =
             'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
-        await prefs.setBool(
-          'adult_content_verified_$verificationPubkey',
-          true,
-        );
+        await prefs.setBool('adult_content_verified_$verificationPubkey', true);
         await prefs.setBool('adult_content_verified_$otherPubkey', true);
 
         await service.clearUserSpecificData(
@@ -149,31 +137,47 @@ void main() {
         expect(prefs.getBool('adult_content_verified_$otherPubkey'), isTrue);
       });
 
-      test('destructive delete purges the following prefetch marker', () async {
-        await prefs.setBool(
-          'following_prefetch_complete_$verificationPubkey',
-          true,
-        );
-
-        await service.deleteAccountData(
-          verificationPubkey,
-          userNpub: 'verification-npub',
-          preserveActiveSession: true,
-        );
-
-        expect(
-          prefs.containsKey(
+      test(
+        'destructive sign-out purges only that account following cache',
+        () async {
+          const otherPubkey =
+              'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+          await prefs.setString(
+            'following_list_$verificationPubkey',
+            '["followed"]',
+          );
+          await prefs.setBool(
             'following_prefetch_complete_$verificationPubkey',
-          ),
-          isFalse,
-        );
-      });
+            true,
+          );
+          await prefs.setString('following_list_$otherPubkey', '["other"]');
+          await prefs.setBool('following_prefetch_complete_$otherPubkey', true);
+
+          await service.clearUserSpecificData(
+            deleteUserData: true,
+            userPubkey: verificationPubkey,
+          );
+
+          expect(
+            prefs.containsKey('following_list_$verificationPubkey'),
+            isFalse,
+          );
+          expect(
+            prefs.containsKey(
+              'following_prefetch_complete_$verificationPubkey',
+            ),
+            isFalse,
+          );
+          expect(prefs.getString('following_list_$otherPubkey'), '["other"]');
+          expect(
+            prefs.getBool('following_prefetch_complete_$otherPubkey'),
+            isTrue,
+          );
+        },
+      );
 
       test('account switch preserves scoped verification', () async {
-        await prefs.setBool(
-          'adult_content_verified_$verificationPubkey',
-          true,
-        );
+        await prefs.setBool('adult_content_verified_$verificationPubkey', true);
 
         await service.clearUserSpecificData(
           isIdentityChange: true,
@@ -374,100 +378,91 @@ void main() {
         expect(prefs.containsKey(bucketKey), isTrue);
       });
 
-      test(
-        'clears the creator-sync cursor alongside the saved-sounds bucket '
-        'on destructive account delete',
-        () async {
-          const pubkey =
-              'a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456';
-          final cursorKey = PrefsSyncStateStore.appliedStorageKey(
-            SyncItemKind.sound,
-            pubkey,
-          );
-          await prefs.setString(
-            cursorKey,
-            '{"divine:sync:sound:s1":'
-            '{"createdAt":1000,"bodyHash":"h"}}',
-          );
+      test('clears the creator-sync cursor alongside the saved-sounds bucket '
+          'on destructive account delete', () async {
+        const pubkey =
+            'a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456';
+        final cursorKey = PrefsSyncStateStore.appliedStorageKey(
+          SyncItemKind.sound,
+          pubkey,
+        );
+        await prefs.setString(
+          cursorKey,
+          '{"divine:sync:sound:s1":'
+          '{"createdAt":1000,"bodyHash":"h"}}',
+        );
 
-          await service.clearUserSpecificData(
-            deleteUserData: true,
-            userPubkey: pubkey,
-          );
+        await service.clearUserSpecificData(
+          deleteUserData: true,
+          userPubkey: pubkey,
+        );
 
-          expect(prefs.containsKey(cursorKey), isFalse);
-        },
-      );
+        expect(prefs.containsKey(cursorKey), isFalse);
+      });
 
-      test(
-        'keeps the creator-sync cursor on a plain account switch',
-        () async {
-          const pubkey =
-              'a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456';
-          final cursorKey = PrefsSyncStateStore.appliedStorageKey(
-            SyncItemKind.sound,
-            pubkey,
-          );
-          await prefs.setString(
-            cursorKey,
-            '{"divine:sync:sound:s1":'
-            '{"createdAt":1000,"bodyHash":"h"}}',
-          );
+      test('keeps the creator-sync cursor on a plain account switch', () async {
+        const pubkey =
+            'a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456';
+        final cursorKey = PrefsSyncStateStore.appliedStorageKey(
+          SyncItemKind.sound,
+          pubkey,
+        );
+        await prefs.setString(
+          cursorKey,
+          '{"divine:sync:sound:s1":'
+          '{"createdAt":1000,"bodyHash":"h"}}',
+        );
 
-          await service.clearUserSpecificData(
-            isIdentityChange: true,
-            userPubkey: pubkey,
-          );
+        await service.clearUserSpecificData(
+          isIdentityChange: true,
+          userPubkey: pubkey,
+        );
 
-          expect(prefs.containsKey(cursorKey), isTrue);
-        },
-      );
+        expect(prefs.containsKey(cursorKey), isTrue);
+      });
 
-      test(
-        'does not let a reconcile after destructive cleanup mistake a '
-        'wiped local cache for a mass delete',
-        () async {
-          const pubkey =
-              'a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456';
-          // This device had already fully synced a 3-sound library before
-          // the destructive cleanup below wipes its saved-sounds bucket.
-          await PrefsSyncStateStore(
-            prefs,
-            pubkeyHex: pubkey,
-          ).writeApplied(SyncItemKind.sound, {
+      test('does not let a reconcile after destructive cleanup mistake a '
+          'wiped local cache for a mass delete', () async {
+        const pubkey =
+            'a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456';
+        // This device had already fully synced a 3-sound library before
+        // the destructive cleanup below wipes its saved-sounds bucket.
+        await PrefsSyncStateStore(prefs, pubkeyHex: pubkey).writeApplied(
+          SyncItemKind.sound,
+          {
             for (final id in ['s1', 's2', 's3'])
               'divine:sync:sound:$id': SyncItemState(
                 createdAt: 1000,
                 bodyHash: syncBodyHash({'label': id}),
               ),
-          });
+          },
+        );
 
-          await service.clearUserSpecificData(
-            deleteUserData: true,
-            userPubkey: pubkey,
-          );
+        await service.clearUserSpecificData(
+          deleteUserData: true,
+          userPubkey: pubkey,
+        );
 
-          final index = _MockSyncIndexClient();
-          when(
-            () => index.fetch(SyncItemKind.sound, since: any(named: 'since')),
-          ).thenAnswer((_) async => []);
-          final repository = SoundSyncRepository(
-            index: index,
-            state: PrefsSyncStateStore(prefs, pubkeyHex: pubkey),
-            local: _EmptyLocalSoundStore(),
-          );
+        final index = _MockSyncIndexClient();
+        when(
+          () => index.fetch(SyncItemKind.sound, since: any(named: 'since')),
+        ).thenAnswer((_) async => []);
+        final repository = SoundSyncRepository(
+          index: index,
+          state: PrefsSyncStateStore(prefs, pubkeyHex: pubkey),
+          local: _EmptyLocalSoundStore(),
+        );
 
-          await repository.reconcile();
+        await repository.reconcile();
 
-          verifyNever(
-            () => index.publish(
-              any(),
-              any(),
-              latestKnownRemote: any(named: 'latestKnownRemote'),
-            ),
-          );
-        },
-      );
+        verifyNever(
+          () => index.publish(
+            any(),
+            any(),
+            latestKnownRemote: any(named: 'latestKnownRemote'),
+          ),
+        );
+      });
 
       test('marks legacy draft owner only when legacy drafts exist', () async {
         await service.markOwnerScopedLegacyDataForUser('abc123');
@@ -544,35 +539,39 @@ void main() {
         },
       );
 
-      test(
-        'clears shared dynamic caches but preserves scoped DM cursors',
-        () async {
-          // Set up dynamic pubkey-keyed caches
+      test('preserves every account-scoped cache on identity change', () async {
+        for (final account in ['abc123', 'def456']) {
           await prefs.setString(
-            'following_list_abc123',
+            'following_list_$account',
             '["pubkey1","pubkey2"]',
           );
-          await prefs.setString('relay_discovery_npub1abc', 'relay_data');
-          // DM sync cursors are cleared by DmSyncState for the leaving pubkey,
-          // not by this global prefix sweep.
-          await prefs.setInt('dm.newestSyncedAt.abc123', 1700000000);
-          await prefs.setInt('dm.oldestSyncedAt.abc123', 1699000000);
+          await prefs.setBool('following_prefetch_complete_$account', true);
+          await prefs.setString('relay_discovery_npub1$account', 'relay_data');
+        }
+        // DM sync cursors are cleared by DmSyncState for the leaving pubkey,
+        // not by preference cleanup.
+        await prefs.setInt('dm.newestSyncedAt.abc123', 1700000000);
+        await prefs.setInt('dm.oldestSyncedAt.abc123', 1699000000);
 
-          await service.clearUserSpecificData(
-            reason: 'identity_change',
-            isIdentityChange: true,
+        await service.clearUserSpecificData(
+          reason: 'identity_change',
+          isIdentityChange: true,
+        );
+
+        for (final account in ['abc123', 'def456']) {
+          expect(prefs.containsKey('following_list_$account'), isTrue);
+          expect(
+            prefs.containsKey('following_prefetch_complete_$account'),
+            isTrue,
           );
-
-          // Dynamic prefix keys should be cleared on identity change
-          expect(prefs.containsKey('following_list_abc123'), isFalse);
-          expect(prefs.containsKey('relay_discovery_npub1abc'), isFalse);
-          expect(prefs.containsKey('dm.newestSyncedAt.abc123'), isTrue);
-          expect(prefs.containsKey('dm.oldestSyncedAt.abc123'), isTrue);
-        },
-      );
+          expect(prefs.containsKey('relay_discovery_npub1$account'), isTrue);
+        }
+        expect(prefs.containsKey('dm.newestSyncedAt.abc123'), isTrue);
+        expect(prefs.containsKey('dm.oldestSyncedAt.abc123'), isTrue);
+      });
 
       test(
-        'returns correct count including prefix keys on identity change',
+        'does not include scoped cache keys in identity-change count',
         () async {
           await prefs.setStringList('curated_lists', ['list1']);
           await prefs.setString('vine_drafts', '{"drafts": []}');
@@ -584,26 +583,28 @@ void main() {
             isIdentityChange: true,
           );
 
-          // 1 static + 1 owner-scoped legacy key + 2 prefix keys
-          expect(count, equals(4));
+          // 1 static + 1 owner-scoped legacy key.
+          expect(count, equals(2));
+          expect(prefs.containsKey('following_list_abc123'), isTrue);
+          expect(prefs.containsKey('relay_discovery_npub1abc'), isTrue);
         },
       );
 
-      test('preserves non-matching prefix keys on identity change', () async {
-        // Set up a key that starts with a non-matching prefix
-        await prefs.setString('some_other_cache_abc', 'data');
-        await prefs.setString('following_list_abc123', '["pubkey1"]');
+      test(
+        'preserves scoped and unrelated caches on identity change',
+        () async {
+          await prefs.setString('some_other_cache_abc', 'data');
+          await prefs.setString('following_list_abc123', '["pubkey1"]');
 
-        await service.clearUserSpecificData(
-          reason: 'identity_change',
-          isIdentityChange: true,
-        );
+          await service.clearUserSpecificData(
+            reason: 'identity_change',
+            isIdentityChange: true,
+          );
 
-        // Non-matching prefix should remain
-        expect(prefs.containsKey('some_other_cache_abc'), isTrue);
-        // Matching prefix should be cleared
-        expect(prefs.containsKey('following_list_abc123'), isFalse);
-      });
+          expect(prefs.containsKey('some_other_cache_abc'), isTrue);
+          expect(prefs.containsKey('following_list_abc123'), isTrue);
+        },
+      );
 
       test(
         'passes userPubkey and deleteUserData to onDatabaseCleanup',
@@ -734,7 +735,15 @@ void main() {
             '[{"id":"other-sound"}]',
           );
           await prefs.setString('following_list_$deletedPubkey', '[]');
+          await prefs.setBool(
+            'following_prefetch_complete_$deletedPubkey',
+            true,
+          );
           await prefs.setString('relay_discovery_$deletedNpub', '{}');
+          final otherNpub = NostrKeyUtils.encodePubKey(otherPubkey);
+          await prefs.setString('following_list_$otherPubkey', '["other"]');
+          await prefs.setBool('following_prefetch_complete_$otherPubkey', true);
+          await prefs.setString('relay_discovery_$otherNpub', '{"other":true}');
 
           await service.deleteAccountData(
             deletedPubkey,
@@ -757,7 +766,20 @@ void main() {
             isTrue,
           );
           expect(prefs.containsKey('following_list_$deletedPubkey'), isFalse);
+          expect(
+            prefs.containsKey('following_prefetch_complete_$deletedPubkey'),
+            isFalse,
+          );
           expect(prefs.containsKey('relay_discovery_$deletedNpub'), isFalse);
+          expect(prefs.getString('following_list_$otherPubkey'), '["other"]');
+          expect(
+            prefs.getBool('following_prefetch_complete_$otherPubkey'),
+            isTrue,
+          );
+          expect(
+            prefs.getString('relay_discovery_$otherNpub'),
+            '{"other":true}',
+          );
         },
       );
 
@@ -900,7 +922,7 @@ void main() {
     });
 
     group('identityChangePrefixes', () {
-      test('contains only globally safe prefix categories', () {
+      test('contains only account-scoped cache categories', () {
         const prefixes = UserDataCleanupService.identityChangePrefixes;
 
         expect(prefixes, contains('following_list_'));


### PR DESCRIPTION
## Problem

Switching accounts discarded the warm following and relay-discovery caches for every saved account. The cleanup ran before login redirect preparation, so returning to an account temporarily lost its local following state and triggered an avoidable network prefetch.

## Why this fix

Those cache keys already include their owning pubkey or npub, so preserving them cannot expose one account's state to another. This removes the global prefix sweep while retaining identity-change cleanup for genuinely unscoped legacy state and fail-closed database cleanup.

Destructive removal remains targeted: both account-deletion paths now remove only the departing account's following cache and prefetch marker, and the existing targeted relay cleanup remains intact. Cache key construction also uses the helpers owned by the writing services so future key changes fail at compile time instead of silently drifting.

## Deliberately unchanged

- Unscoped preferences still clear during identity changes.
- Database cleanup errors still abort identity changes.
- Relay discovery expiry and network behavior are unchanged.
- Ordinary sign-out's separate relay-cache policy is unchanged.

## Verification

- Red/green regression cycle covering identity-change preservation, destructive cleanup, and login redirect cache use
- `flutter test` for the affected auth, cleanup, and relay-discovery suites (212 tests)
- `flutter analyze lib test integration_test`
- `scripts/check_prefs_key_classification.sh`
- Pre-push analyzer and changed-file tests

Closes #9129
