### PR TITLE
fix(analytics): prevent duplicate and unbalanced shell events

### DIFF
--- a/docs/ANALYTICS_OBSERVABILITY.md
+++ b/docs/ANALYTICS_OBSERVABILITY.md
@@ -3,8 +3,9 @@
 Status: Current contract with semantic route screen views, comments sheet
 surface load instrumentation, authenticated identity, and creator funnel
 instrumentation live.
-Baseline validated against: `mobile/lib/services/screen_analytics_service.dart`,
-`mobile/lib/services/page_load_observer.dart`,
+Baseline validated against:
+`mobile/packages/analytics/lib/src/screen_analytics_service.dart`,
+`mobile/packages/analytics/lib/src/page_load_observer.dart`,
 `mobile/lib/screens/comments/comments_screen.dart`.
 
 Current code still contains legacy `screen_load` and `screen_data_loaded`
@@ -61,6 +62,30 @@ Required parameters:
 - `screen_name`
 - `entry_point`
 - `route_name`
+
+#### Bottom-navigation shell
+
+The root navigation observers see the shell as one full-screen route. On a
+cold start they receive one push named for the initial branch, such as `home`,
+and emit one corresponding `screen_view`. A route pushed above the shell, such
+as settings or video detail, is also observed normally.
+
+Branch navigators do not notify the root observers. Switching tabs, returning
+to an already-mounted tab, and replacing one route with another inside a tab
+therefore emit no root `screen_view` or page-load lifecycle events. Analytics
+owned by an individual surface remains independent of this observer contract.
+
+This isolation is deliberate. A stateful shell keeps branch navigators alive,
+so their events describe navigator lifecycle rather than user arrival:
+
+- the initial branch and shell both push at startup, duplicating the event;
+- another branch pushes only on its first mount, not on later visits;
+- a sibling route change produces a push plus a remove, while
+  `PageLoadObserver` ends sessions only on pop.
+
+For that reason the shell permanently sets `notifyRootObserver: false`.
+`mobile/test/router/shell_route_analytics_test.dart` pins both the production
+setting and the representative observer sequences.
 
 ### `surface_load`
 

--- a/mobile/lib/router/routes/shell.dart
+++ b/mobile/lib/router/routes/shell.dart
@@ -30,13 +30,9 @@ List<RouteBase> shellRoutes() {
     // pageContextProvider per branch so each tab sees *its own* route context
     // (not the active tab's) and keeps rendering real content while inactive.
     StatefulShellRoute(
-      // go_router 17 started notifying the root observers from inside a
-      // shell's branch navigators, and its 18.x line is what the
-      // material_ui migration needs (#8916). Taking the new default would
-      // make root observers emit screen-view and page-load events for every
-      // in-branch push. That is a product-analytics decision, not a side
-      // effect of a design-system migration, so behaviour is pinned here
-      // until #9079 is decided deliberately.
+      // Branch events are navigator lifecycle rather than reliable user
+      // arrivals, so root analytics deliberately observes only the shell page
+      // and routes above it; see docs/ANALYTICS_OBSERVABILITY.md.
       notifyRootObserver: false,
       // Transition-free on purpose: the shell replaces `/welcome` on the root
       // navigator when the authenticated redirect lands (startup restore,

--- a/mobile/scripts/baseline/l10n_delegates.txt
+++ b/mobile/scripts/baseline/l10n_delegates.txt
@@ -29,7 +29,6 @@ test/router/flat_route_cold_entry_back_test.dart	1
 test/router/fullscreen_feed_redirect_test.dart	1
 test/router/invite_availability_redirect_test.dart	3
 test/router/routes/restored_route_extras_test.dart	1
-test/router/shell_route_analytics_test.dart	1
 test/router/shell_transition_test.dart	1
 test/utils/await_push_transition_test.dart	2
 test/utils/clipboard_utils_test.dart	1

--- a/mobile/test/router/shell_route_analytics_test.dart
+++ b/mobile/test/router/shell_route_analytics_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Characterizes root-observer events from StatefulShellRoute.
 // ABOUTME: Pins branch navigation isolation so analytics stays deterministic.
 
+import 'dart:async';
+
 import 'package:analytics/analytics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -88,7 +90,7 @@ void main() {
         (action: _ObserverAction.push, name: 'home'),
       ]);
 
-      router.push('/details');
+      unawaited(router.push('/details'));
       await tester.pump();
 
       expect(observer.events, [

--- a/mobile/test/router/shell_route_analytics_test.dart
+++ b/mobile/test/router/shell_route_analytics_test.dart
@@ -1,63 +1,212 @@
-// ABOUTME: Regression coverage for shell route names reaching observers.
-// ABOUTME: Prevents normal home navigation from reporting unknown_route.
+// ABOUTME: Characterizes root-observer events from StatefulShellRoute.
+// ABOUTME: Pins branch navigation isolation so analytics stays deterministic.
 
 import 'package:analytics/analytics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:openvine/router/go_router_page_name.dart';
-import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:openvine/router/routes/shell.dart';
+
+enum _ObserverAction { push, pop, remove, replace }
+
+typedef _ObserverEvent = ({_ObserverAction action, String? name});
 
 class _RecordingNavigatorObserver extends NavigatorObserver {
-  final pushedNames = <String?>[];
+  final events = <_ObserverEvent>[];
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPush(route, previousRoute);
-    pushedNames.add(route.settings.name);
+    events.add((action: _ObserverAction.push, name: route.settings.name));
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPop(route, previousRoute);
+    events.add((action: _ObserverAction.pop, name: route.settings.name));
+  }
+
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didRemove(route, previousRoute);
+    events.add((action: _ObserverAction.remove, name: route.settings.name));
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    events.add((
+      action: _ObserverAction.replace,
+      name: newRoute?.settings.name,
+    ));
   }
 }
 
 void main() {
   group('shell route analytics', () {
-    testWidgets('shell home route pushes a named root route for analytics', (
+    test('production shell keeps branch events away from root observers', () {
+      final route = shellRoutes().single as StatefulShellRoute;
+
+      expect(route.notifyRootObserver, isFalse);
+    });
+
+    testWidgets('branch navigation stays isolated from root observers', (
       tester,
     ) async {
       final observer = _RecordingNavigatorObserver();
-      final router = GoRouter(
-        initialLocation: VideoFeedPage.path,
-        observers: [observer],
-        routes: [
-          StatefulShellRoute.indexedStack(
-            pageBuilder: (_, state, navigationShell) => NoTransitionPage<void>(
-              key: state.pageKey,
-              name: goRouterPageName(state),
-              child: navigationShell,
-            ),
-            branches: [
-              StatefulShellBranch(
-                routes: [
-                  GoRoute(
-                    path: VideoFeedPage.path,
-                    name: VideoFeedPage.routeName,
-                    builder: (_, _) => const SizedBox.shrink(),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ],
+      final router = _buildRouter(
+        observer: observer,
+        notifyRootObserver: false,
       );
       addTearDown(router.dispose);
 
       await tester.pumpWidget(MaterialApp.router(routerConfig: router));
       await tester.pump();
 
-      expect(observer.pushedNames, contains(VideoFeedPage.routeName));
+      expect(observer.events, [
+        (action: _ObserverAction.push, name: 'home'),
+      ]);
       expect(
-        AnalyticsSurface.routeSurfaceName(VideoFeedPage.routeName),
+        AnalyticsSurface.routeSurfaceName(observer.events.single.name),
         AnalyticsSurface.homeFeed,
       );
+
+      for (final location in [
+        '/explore',
+        '/home',
+        '/explore',
+        '/explore/tab/comedy',
+        '/profile/synthetic-user',
+        '/profile/synthetic-user/1',
+      ]) {
+        router.go(location);
+        await tester.pump();
+      }
+
+      expect(observer.events, [
+        (action: _ObserverAction.push, name: 'home'),
+      ]);
+
+      router.push('/details');
+      await tester.pump();
+
+      expect(observer.events, [
+        (action: _ObserverAction.push, name: 'home'),
+        (action: _ObserverAction.push, name: 'details'),
+      ]);
+
+      router.pop();
+      await tester.pump();
+
+      expect(observer.events.last, (
+        action: _ObserverAction.pop,
+        name: 'details',
+      ));
+    });
+
+    testWidgets('forwarding branch events produces lifecycle-dependent data', (
+      tester,
+    ) async {
+      final observer = _RecordingNavigatorObserver();
+      final router = _buildRouter(observer: observer, notifyRootObserver: true);
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pump();
+
+      expect(observer.events, [
+        (action: _ObserverAction.push, name: 'home'),
+        (action: _ObserverAction.push, name: 'home'),
+      ]);
+
+      router.go('/explore');
+      await tester.pump();
+      expect(observer.events.last, (
+        action: _ObserverAction.push,
+        name: 'explore',
+      ));
+
+      final firstExploreVisitCount = observer.events.length;
+      router.go('/home');
+      await tester.pump();
+      router.go('/explore');
+      await tester.pump();
+      expect(observer.events, hasLength(firstExploreVisitCount));
+
+      router.go('/explore/tab/comedy');
+      await tester.pump();
+
+      expect(observer.events, [
+        (action: _ObserverAction.push, name: 'home'),
+        (action: _ObserverAction.push, name: 'home'),
+        (action: _ObserverAction.push, name: 'explore'),
+        (action: _ObserverAction.push, name: '/explore/tab/:name'),
+        (action: _ObserverAction.remove, name: 'explore'),
+      ]);
     });
   });
+}
+
+GoRouter _buildRouter({
+  required NavigatorObserver observer,
+  required bool notifyRootObserver,
+}) {
+  return GoRouter(
+    initialLocation: '/home',
+    observers: [observer],
+    routes: [
+      StatefulShellRoute.indexedStack(
+        notifyRootObserver: notifyRootObserver,
+        pageBuilder: (_, state, navigationShell) => NoTransitionPage<void>(
+          key: state.pageKey,
+          name: goRouterPageName(state),
+          child: navigationShell,
+        ),
+        branches: [
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: '/home',
+                name: 'home',
+                builder: (_, _) => const SizedBox.shrink(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: '/explore',
+                name: 'explore',
+                builder: (_, _) => const SizedBox.shrink(),
+              ),
+              GoRoute(
+                path: '/explore/tab/:name',
+                builder: (_, _) => const SizedBox.shrink(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            initialLocation: '/profile/synthetic-user',
+            routes: [
+              GoRoute(
+                path: '/profile/:user',
+                name: 'profile',
+                builder: (_, _) => const SizedBox.shrink(),
+              ),
+              GoRoute(
+                path: '/profile/:user/:index',
+                builder: (_, _) => const SizedBox.shrink(),
+              ),
+            ],
+          ),
+        ],
+      ),
+      GoRoute(
+        path: '/details',
+        name: 'details',
+        builder: (_, _) => const SizedBox.shrink(),
+      ),
+    ],
+  );
 }

--- a/mobile/test/router/shell_route_analytics_test.dart
+++ b/mobile/test/router/shell_route_analytics_test.dart
@@ -7,6 +7,7 @@ import 'package:analytics/analytics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:material_ui/material_ui.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/router/go_router_page_name.dart';
 import 'package:openvine/router/routes/shell.dart';
 
@@ -63,7 +64,13 @@ void main() {
       );
       addTearDown(router.dispose);
 
-      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerConfig: router,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      );
       await tester.pump();
 
       expect(observer.events, [
@@ -114,7 +121,13 @@ void main() {
       final router = _buildRouter(observer: observer, notifyRootObserver: true);
       addTearDown(router.dispose);
 
-      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerConfig: router,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      );
       await tester.pump();
 
       expect(observer.events, [


### PR DESCRIPTION
## Problem

go_router can forward stateful-shell branch navigator events to the app's root observers. Those forwarded events do not represent consistent user arrivals: startup sends duplicate events, another tab emits only on its first mount, and a sibling route change sends a push plus a remove that the page-load observer does not balance. Enabling them would make screen-view and page-load data depend on navigator lifecycle.

## Why this fix

This keeps branch-to-root forwarding disabled and makes that a permanent analytics decision. Characterization tests record both configurations, pin the production setting, and cover startup, repeat tab visits, Explore and profile sibling routes, plus a route pushed and popped above the shell. The analytics contract now documents exactly which shell navigation reaches root observers.

## Deliberately unchanged

This does not add a second shell-specific screen-view reporter, change surface-owned analytics, or alter route-observer playback behavior. Root observers continue to record the initial shell surface and full-screen routes above it; tab switches and in-branch replacements remain silent.

## Verification

- `flutter analyze lib/router/routes/shell.dart test/router/shell_route_analytics_test.dart`
- `flutter test test/router/shell_route_analytics_test.dart test/services/page_load_observer_test.dart test/router/product_analytics_navigation_observer_test.dart`
- Pre-push diff analyzer and changed-file tests

Closes #9079