### PR TITLE
fix(account): let users cancel stale deletion attempts

### DIFF
--- a/mobile/lib/repositories/account_deletion_recovery_repository.dart
+++ b/mobile/lib/repositories/account_deletion_recovery_repository.dart
@@ -23,6 +23,7 @@ class AccountDeletionRecoveryException implements Exception {
     this.statusCode,
     this.isTransportFailure = false,
     this.indicatesMissingCoordinatorRoute = false,
+    this.attempt,
   });
 
   final String message;
@@ -31,6 +32,7 @@ class AccountDeletionRecoveryException implements Exception {
   final int? statusCode;
   final bool isTransportFailure;
   final bool indicatesMissingCoordinatorRoute;
+  final AccountDeletionAttempt? attempt;
 
   /// Whether only the username release is unsupported by this deployment.
   ///
@@ -123,9 +125,10 @@ class AccountDeletionRecoveryRepository {
   ) async {
     final username = attempt.username;
     if (username == null) {
-      throw const AccountDeletionRecoveryException(
+      throw AccountDeletionRecoveryException(
         'Preparing username attempt did not include a username',
         stage: AccountDeletionRecoveryStage.usernamePreparation,
+        attempt: attempt,
       );
     }
     if (attempt.status == AccountDeletionAttemptStatus.recoverable) {

--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -728,6 +728,22 @@ Future<void> executeAccountDeletion({
           category: LogCategory.auth,
         );
       } on AccountDeletionRecoveryException catch (error) {
+        final staleAttempt = error.attempt;
+        if (staleAttempt != null) {
+          Log.warning(
+            'Account deletion preparation found an existing attempt that '
+            'must be cancelled before retrying',
+            name: screenName,
+            category: LogCategory.auth,
+          );
+          deletionAttempt = staleAttempt;
+          usernamePrepared = staleAttempt.username != null;
+          dismissProgressSheet();
+          if (context.mounted) {
+            showDurableDeletionOutcome(deletionIncompleteText);
+          }
+          return;
+        }
         // Release is mandatory, so a name-release failure fails the whole
         // deletion closed (nothing deleted). The unavailable 503 and the
         // missing-coordinator route both mean deletion is unavailable right now

--- a/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_cubit_test.dart
+++ b/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_cubit_test.dart
@@ -67,6 +67,10 @@ const _preparing = AccountDeletionAttempt(
   status: AccountDeletionAttemptStatus.preparing,
   username: 'alice',
 );
+const _preparingWithoutUsername = AccountDeletionAttempt(
+  id: 'attempt-id',
+  status: AccountDeletionAttemptStatus.preparing,
+);
 const _recoverable = AccountDeletionAttempt(
   id: 'attempt-id',
   status: AccountDeletionAttemptStatus.recoverable,
@@ -449,6 +453,24 @@ void main() {
   });
 
   group('cancel', () {
+    test('username-free preparing attempt cancels without resuming', () async {
+      when(
+        repository.fetchCurrent,
+      ).thenAnswer((_) async => _preparingWithoutUsername);
+      when(
+        () => repository.cancel(attemptId: 'attempt-id'),
+      ).thenAnswer((_) async => _cancelled);
+      final cubit = buildCubit();
+      await cubit.load();
+
+      await cubit.cancel();
+
+      verifyNever(() => repository.resumePreparation(any()));
+      verify(() => repository.cancel(attemptId: 'attempt-id')).called(1);
+      expect(cubit.state.status, AccountDeletionRecoveryStatus.resolved);
+      await cubit.close();
+    });
+
     test(
       'preparing username completes handshake before 200 cancellation',
       () async {

--- a/mobile/test/repositories/account_deletion_recovery_repository_test.dart
+++ b/mobile/test/repositories/account_deletion_recovery_repository_test.dart
@@ -425,6 +425,36 @@ void main() {
       );
     });
 
+    test('username-free stale attempt is retained for recovery', () {
+      expect(
+        () => repository(
+          MockClient(
+            (_) async => http.Response(
+              jsonEncode({
+                'id': 'stale-attempt',
+                'status': 'preparing',
+                'operation': 'none',
+              }),
+              200,
+            ),
+          ),
+        ).prepare(username: 'alice'),
+        throwsA(
+          isA<AccountDeletionRecoveryException>()
+              .having(
+                (error) => error.stage,
+                'stage',
+                AccountDeletionRecoveryStage.usernamePreparation,
+              )
+              .having(
+                (error) => error.attempt?.id,
+                'recoverable attempt id',
+                'stale-attempt',
+              ),
+        ),
+      );
+    });
+
     test('coordinator confirmation failure has its own stage', () {
       expect(
         () => repository(

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -54,6 +54,16 @@ const _completedAttemptWithoutUsername = AccountDeletionAttempt(
   status: AccountDeletionAttemptStatus.completed,
 );
 
+const _stalePreparingAttemptWithoutUsername = AccountDeletionAttempt(
+  id: 'stale-attempt',
+  status: AccountDeletionAttemptStatus.preparing,
+);
+
+const _cancelledStaleAttempt = AccountDeletionAttempt(
+  id: 'stale-attempt',
+  status: AccountDeletionAttemptStatus.cancelled,
+);
+
 const _pubkeyHex =
     '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
 
@@ -1387,6 +1397,66 @@ void main() {
         ),
         findsOneWidget,
       );
+    });
+
+    testWidgets('stale username-free attempt offers immediate cancellation', (
+      tester,
+    ) async {
+      final deletionService = _MockAccountDeletionService();
+      final authService = _MockAuthService();
+      final recoveryRepository = _MockAccountDeletionRecoveryRepository();
+      when(
+        authService.checkAccountDeletionReadiness,
+      ).thenAnswer((_) async => AccountDeletionReadiness.ready);
+      when(() => recoveryRepository.prepare(username: 'alice')).thenThrow(
+        const AccountDeletionRecoveryException(
+          'Preparing username attempt did not include a username',
+          stage: AccountDeletionRecoveryStage.usernamePreparation,
+          attempt: _stalePreparingAttemptWithoutUsername,
+        ),
+      );
+      when(
+        () => recoveryRepository.cancelAndWait(attemptId: 'stale-attempt'),
+      ).thenAnswer((_) async => _cancelledStaleAttempt);
+
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        _wrapWithRouter(
+          Builder(
+            builder: (context) {
+              capturedContext = context;
+              return const Scaffold(body: SizedBox.shrink());
+            },
+          ),
+        ),
+      );
+
+      await runDeletion(
+        context: capturedContext,
+        deletionService: deletionService,
+        authService: authService,
+        deletionRecoveryRepository: recoveryRepository,
+        lookup: const DivineUsernameFound(name: 'alice', canonical: 'alice'),
+      );
+      await tester.pumpAndSettle();
+
+      final l10n = _englishL10n();
+      expect(find.text(l10n.deleteAccountDeletionIncomplete), findsOneWidget);
+      expect(find.text(l10n.accountDeletionCancelAttempt), findsOneWidget);
+      verifyNever(
+        () => deletionService.deleteAccount(
+          onProgress: any(named: 'onProgress'),
+          expectedPubkey: any(named: 'expectedPubkey'),
+        ),
+      );
+
+      await tester.tap(find.text(l10n.accountDeletionCancelAttempt));
+      await tester.pump();
+      await tester.pump();
+
+      verify(
+        () => recoveryRepository.cancelAndWait(attemptId: 'stale-attempt'),
+      ).called(1);
     });
 
     testWidgets('coordinator outage explains deletion is unavailable', (


### PR DESCRIPTION
## Description

Preserves an existing username-free deletion attempt when name preparation cannot resume, allowing the account-deletion flow to offer its durable cancellation action immediately. This prevents users who later claim a Divine name from becoming trapped behind an attempt the app cannot otherwise clear.

**Related Issue:** Closes #9139

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore